### PR TITLE
Changing the GitHub Actions to the main branch

### DIFF
--- a/.github/workflows/release_to_internal.yml
+++ b/.github/workflows/release_to_internal.yml
@@ -4,7 +4,7 @@ name: Release to Internal
 on:
   push:
     branches:
-      - develop
+      - main
 
 jobs:
   deployment:

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     types: [review_requested, ready_for_review]
     branches:
-      - develop
+      - main
 
 jobs:
   tests:


### PR DESCRIPTION
Now the project uses `main` instead of `develop` as the working branch the GitHub Actions need to be changed.