### PR TITLE
Add google-services.json for debug builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,3 +93,20 @@ dependencies {
 task appStart(type: Exec, dependsOn: 'installDebug') {
     commandLine 'adb', 'shell', 'am', 'start', '-n', 'au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.ui.MainActivity'
 }
+
+task useGoogleServicesDebugFile {
+    description 'Copies the debug google-services.json file if file is missing.'
+    doLast {
+        def googleServicesFile = "google-services.json"
+        if (!file("${project.projectDir}/$googleServicesFile").exists()) {
+            def debugOnlyFile = "google-services.json_debug-only"
+            println "$googleServicesFile file is missing. Copying $debugOnlyFile"
+            copy {
+                from "${project.projectDir}/$debugOnlyFile"
+                into project.projectDir
+                rename { googleServicesFile }
+            }
+        }
+    }
+}
+preBuild.dependsOn(useGoogleServicesDebugFile)

--- a/app/google-services.json_debug-only
+++ b/app/google-services.json_debug-only
@@ -1,0 +1,39 @@
+{
+  "project_info": {
+    "project_number": "219484810371",
+    "project_id": "pocket-casts-debug",
+    "storage_bucket": "pocket-casts-debug.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:219484810371:android:7502b372956eb312fc3fb6",
+        "android_client_info": {
+          "package_name": "au.com.shiftyjelly.pocketcasts.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "219484810371-dq2i74pgo8p71n072hjj1fk63mt1vap4.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBguqVfwriVWjnSqRg50XPfZZH5r1VumNM"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "219484810371-dq2i74pgo8p71n072hjj1fk63mt1vap4.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/automotive/build.gradle
+++ b/automotive/build.gradle
@@ -7,6 +7,7 @@ apply from: "../base.gradle"
 
 android {
     defaultConfig {
+        applicationId project.applicationId
         minSdkVersion 28
     }
 
@@ -22,9 +23,12 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix '.debug'
+        }
+
         debugProd {
             initWith debug
-
             debuggable true
         }
 
@@ -81,3 +85,20 @@ dependencies {
 
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'
+
+task useGoogleServicesDebugFile {
+    description 'Copies the debug google-services.json file if file is missing.'
+    doLast {
+        def googleServicesFile = "google-services.json"
+        if (!file("${project.projectDir}/$googleServicesFile").exists()) {
+            def debugOnlyFile = "google-services.json_debug-only"
+            println "$googleServicesFile file is missing. Copying $debugOnlyFile"
+            copy {
+                from "${project.projectDir}/$debugOnlyFile"
+                into project.projectDir
+                rename { googleServicesFile }
+            }
+        }
+    }
+}
+preBuild.dependsOn(useGoogleServicesDebugFile)

--- a/automotive/google-services.json_debug-only
+++ b/automotive/google-services.json_debug-only
@@ -1,0 +1,39 @@
+{
+  "project_info": {
+    "project_number": "219484810371",
+    "project_id": "pocket-casts-debug",
+    "storage_bucket": "pocket-casts-debug.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:219484810371:android:7502b372956eb312fc3fb6",
+        "android_client_info": {
+          "package_name": "au.com.shiftyjelly.pocketcasts.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "219484810371-dq2i74pgo8p71n072hjj1fk63mt1vap4.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBguqVfwriVWjnSqRg50XPfZZH5r1VumNM"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "219484810371-dq2i74pgo8p71n072hjj1fk63mt1vap4.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/automotive/src/debug/res/values/titles.xml
+++ b/automotive/src/debug/res/values/titles.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Pocket Debug</string>
+</resources>

--- a/automotive/src/debugProd/res/values/titles.xml
+++ b/automotive/src/debugProd/res/values/titles.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Pocket Debug</string>
+</resources>

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -48,20 +48,17 @@
             </intent-filter>
         </service>
 
-        <!-- services which are user triggered, eg: run in the foreground -->
-        <service android:name="au.com.shiftyjelly.pocketcasts.ui.tasks.RefreshArtworkTask"/>
-
         <!-- services which are periodic or trigerred by the app automatically triggered, eg: can run in the background -->
-        <service android:name="au.com.shiftyjelly.pocketcasts.repositories.download.UpdateEpisodeDetailsJob"
+        <service android:name=".repositories.download.UpdateEpisodeDetailsJob"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="true"/>
-        <service android:name="au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsJob"
+        <service android:name=".repositories.refresh.RefreshPodcastsJob"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="true"/>
-        <service android:name="au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsJob"
+        <service android:name=".repositories.jobs.VersionMigrationsJob"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="true"/>
-        <service android:name="au.com.shiftyjelly.pocketcasts.repositories.sync.UpNextSyncJob"
+        <service android:name=".repositories.sync.UpNextSyncJob"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="true"/>
 


### PR DESCRIPTION
# Description

Add a `google-services.json-debug` file that can be used to build the debug version of the app without needing either our production `google-services.json` file or to create your own firebase project. 

This debug file will automatically get used if there isn't a `google-services.json` file, but if there is already a `google-services.json` file, that will be used instead of the debug file.

# Checklist

- [N/A] Should this change be included in the release notes? If yes, please add a line in RELEASE-NOTES.md
- [N/A] Have you tested in landscape?
- [N/A] Have you tested accessibility with TalkBack?
- [N/A] Have you tested in different themes?
- [N/A] Does the change work with a large display font?
- [N/A] Are all the strings localized?
- [N/A] Could you have written any new tests?
- [N/A] Did you include Compose previews with any components?