### PR TITLE
Remove empty overflowmenu in profile-starred screen

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -227,7 +227,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             navigationIcon = BackArrow,
             activity = activity,
             theme = theme,
-            menu = R.menu.menu_profile_list
+            menu = if (mode.showMenu) R.menu.menu_profile_list else null
         )
         toolbar.setOnMenuItemClickListener(this)
     }


### PR DESCRIPTION
# Description

Only adding the overflow menu when the `mode.showMenu` is true.

Fixes https://github.com/Automattic/pocket-casts-android/issues/10

# Checklist

- [X] Should this change be included in the release notes? If yes, please add a line in RELEASE-NOTES.md
- [X] Have you tested in landscape?
- [N/A] Have you tested accessibility with TalkBack?
- [N/A] Have you tested in different themes?
- [N/A] Does the change work with a large display font?
- [N/A] Are all the strings localized?
- [ ] Could you have written any new tests?
- [N/A] Did you include Compose previews with any components?