### PR TITLE
Ignore "the" when sorting filter podcast list

### DIFF
--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/PodcastSelectFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/PodcastSelectFragment.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralPodcastsSelected
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImageLoader
 import au.com.shiftyjelly.pocketcasts.repositories.images.into
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -92,12 +93,12 @@ class PodcastSelectFragment : BaseFragment() {
         }
         podcastManager.findSubscribedRx()
             .zipWith(Single.fromCallable { listener.podcastSelectFragmentGetCurrentSelection() })
-            .map {
-                val podcasts = it.first
-                val selected = it.second
-                return@map podcasts.map {
-                    SelectablePodcast(it, selected.contains(it.uuid))
-                }
+            .map { pair ->
+                val podcasts = pair.first
+                val selected = pair.second
+                return@map podcasts
+                    .sortedBy { PodcastsSortType.cleanStringForSort(it.title) }
+                    .map { SelectablePodcast(it, selected.contains(it.uuid)) }
             }
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeOn(Schedulers.io())


### PR DESCRIPTION
# Description

Use smart sort (ignore "the") when sorting the podcast list for a filter.

Fixes https://github.com/Automattic/pocket-casts-android/issues/17

| Before | After |
| --- | --- |
| ![Screenshot_20220630](https://user-images.githubusercontent.com/4656348/176741479-1a31afe1-a2da-4a8e-88b4-6c487159c16f.png) | ![Screenshot_20220630_134225](https://user-images.githubusercontent.com/4656348/176742838-e57c2316-84a2-4263-9ef4-37ceaaab2c84.png) | 

# Checklist

- [ ] Should this change be included in the release notes? If yes, please add a line in RELEASE-NOTES.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [X] Are all the strings localized?
- [ ] Could you have written any new tests?
- [X] Did you include Compose previews with any components?