### PR TITLE
Fixing quotes in localisation string.

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -79,7 +79,7 @@
     <string name="retry">Retry</string>
     <string name="queue_for_later">Queue for later</string>
     <string name="youre_not_on_wifi">You\'re not on WiFi</string>
-    <string name="youre_on_metered_wifi">"You\'re on metered WiFi"</string>
+    <string name="youre_on_metered_wifi">You\'re on metered WiFi</string>
     <string name="delete_download">Delete download</string>
     <string name="chromecast">Chromecast</string>
     <string name="rearrange_actions">Rearrange Actions</string>


### PR DESCRIPTION
The GlotPress translations are getting confused with the double quotes. These aren't needed so I'm going to remove them.

```
    <string name="youre_on_metered_wifi">"You\'re on metered WiFi"</string>
```
Has become
```
	<string name="youre_on_metered_wifi">„Du nutzt eine getaktete WLAN-Verbindung“</string>
	<string name="youre_on_metered_wifi">「従量制の Wi-Fi に接続しています」</string>
```

<img  width="300" src="https://user-images.githubusercontent.com/308331/177540809-dd166b10-d95c-4d76-a849-0ba93e04fe8d.jpg" /> | <img  width="300" src="https://user-images.githubusercontent.com/308331/177540789-35ce64c0-cc83-49cc-8691-9603b3c13225.jpg" />


