### PR TITLE
The pocketcasts.com web path '/get' should open the app.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -224,11 +224,18 @@
                 <data android:scheme="https" android:host="lists.pocketcasts.com"/>
             </intent-filter>
 
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https" android:host="pocketcasts.com" android:path="/get" />
+            </intent-filter>
+
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="pocket-casts-main-development.mystagingwebsite.com" android:path="/get" />
             </intent-filter>
 
             <meta-data

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
+import androidx.core.app.ActivityCompat.startActivityForResult
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
@@ -66,6 +67,7 @@ import au.com.shiftyjelly.pocketcasts.servers.ServerCallback
 import au.com.shiftyjelly.pocketcasts.servers.ServerManager
 import au.com.shiftyjelly.pocketcasts.servers.discover.PodcastSearch
 import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewFragment
+import au.com.shiftyjelly.pocketcasts.ui.MainActivity.Companion.PROMOCODE_REQUEST_CODE
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -834,6 +836,9 @@ class MainActivity :
                             }
                         }
                     }
+                } else if (IntentUtil.isPocketCastsWebsite(intent)) {
+                    // when the user goes to https://pocketcasts.com/get it should either open the play store or the user's app
+                    return
                 } else if (IntentUtil.isPodloveUrl(intent)) {
                     openPodcastUrl(IntentUtil.getPodloveUrl(intent))
                     return

--- a/base.gradle
+++ b/base.gradle
@@ -88,7 +88,7 @@ android {
             buildConfigField "String", "SERVER_STATIC_URL", "\"https://static.pocketcasts.net\""
             buildConfigField "String", "SERVER_SHARING_URL", "\"https://sharing.pocketcasts.net\""
             buildConfigField "String", "SERVER_SHORT_URL", "\"https://pcast.pocketcasts.net\""
-            buildConfigField "String", "WEB_BASE_HOST", "\"pocketcasts.net\""
+            buildConfigField "String", "WEB_BASE_HOST", "\"pocket-casts-main-development.mystagingwebsite.com\""
             buildConfigField "String", "SERVER_LIST_URL", "\"https://lists.pocketcasts.net\""
             buildConfigField "String", "SERVER_LIST_HOST", "\"lists.pocketcasts.net\""
         }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.appcompat.app.AlertDialog
+import au.com.shiftyjelly.pocketcasts.preferences.BuildConfig
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.utils.StringUtil
 import java.io.UnsupportedEncodingException
@@ -13,6 +14,10 @@ import java.util.Arrays
 import java.util.regex.Matcher
 
 object IntentUtil {
+
+    fun isPocketCastsWebsite(intent: Intent): Boolean {
+        return intent.data?.host == BuildConfig.WEB_BASE_HOST
+    }
 
     fun isPodloveUrl(intent: Intent): Boolean {
         val scheme = intent.scheme


### PR DESCRIPTION
Visiting pocketcasts.com/get should open the app if it's installed.

Fixes https://github.com/Automattic/pocket-casts-android/issues/136

https://user-images.githubusercontent.com/308331/180156147-1f4a0574-f9dc-4bf7-88ba-d5fe5b4410ed.mov

To test if the URLs are verified on your device run the following:
```
adb shell pm get-app-links au.com.shiftyjelly.pocketcasts.debug
    Domain verification state:
      lists.pocketcasts.com: legacy_failure
      pocket-casts-main-development.mystagingwebsite.com: verified
      pocketcasts.com: verified
```
https://developer.android.com/training/app-links/verify-site-associations