### PR TITLE
Proposal: Switch codeowners to use Automattic/pocket-casts-android

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @geekygecko @mchowning @ashiagr
+* @Automattic/pocket-casts-android 


### PR DESCRIPTION
Thought this would make it easier for us to maintain/update the codeowners. I haven't bounced this idea off of either of you yet though, so don't hesitate to let me know if you think this might not be a good idea.