### PR TITLE
Fixes the status page send button crash

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -71,7 +71,9 @@ class Support @Inject constructor(
 
     @Suppress("DEPRECATION")
     suspend fun sendEmail(subject: String, intro: String, context: Context): Intent {
-        val dialog = android.app.ProgressDialog.show(context, context.getString(R.string.loading), this.context.getString(R.string.settings_support_please_wait), true)
+        val dialog = withContext(Dispatchers.Main) {
+            android.app.ProgressDialog.show(context, context.getString(R.string.loading), context.getString(R.string.settings_support_please_wait), true)
+        }
         val intent = Intent(Intent.ACTION_SEND)
 
         withContext(Dispatchers.IO) {


### PR DESCRIPTION
The status page is crashing when you tap the send button.

```
java.lang.RuntimeException: Can't create handler inside thread Thread[DefaultDispatcher-worker-10,5,main] that has not called Looper.prepare()
   at android.os.Handler.<init>(Handler.java:227)
   at android.os.Handler.<init>(Handler.java:129)
   at android.app.Dialog.<init>(Dialog.java:173)
   at android.app.AlertDialog.<init>(AlertDialog.java:204)
   at android.app.AlertDialog.<init>(AlertDialog.java:200)
   at android.app.AlertDialog.<init>(AlertDialog.java:145)
   at android.app.ProgressDialog.<init>(ProgressDialog.java:118)
   at android.app.ProgressDialog.show(ProgressDialog.java:223)
   at android.app.ProgressDialog.show(ProgressDialog.java:186)
   at au.com.shiftyjelly.pocketcasts.repositories.support.Support.sendEmail(Support.kt:74)
```

**Steps to test**
1. Tap on the Profile tab
2. Tap on the settings icon
3. Tap on Help & feedback
4. Tap on the status page icon in the toolbar
5. Tap "Run now"
6. Tap "Send report"

It shouldn't crash but instead open a share sheet to send the report as an email.