### PR TITLE
Fix subscription renew labels

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
@@ -56,12 +56,12 @@ class CreateAccountViewModel
                             // need to check subscriptionPeriod code types
                             if (skuDetail.subscriptionPeriod.contains("M")) {
                                 period = LR.string.plus_month
-                                renews = LR.string.plus_renews_automatically_yearly
+                                renews = LR.string.plus_renews_automatically_monthly
                                 isMonth = true
                             } else if (skuDetail.subscriptionPeriod.contains("Y")) {
                                 period = LR.string.plus_year
                                 hint = LR.string.plus_best_value
-                                renews = LR.string.plus_renews_automatically_monthly
+                                renews = LR.string.plus_renews_automatically_yearly
                                 isMonth = false
                             }
 


### PR DESCRIPTION
# Description

Fixes renew labels for subscriptions.


Monthy | Yearly
--------|------
![monthly](https://user-images.githubusercontent.com/1405144/181508817-56dcf465-6fab-43b7-9966-2d1785d51ddd.png) | ![yearly](https://user-images.githubusercontent.com/1405144/181508911-533485ee-4167-4cac-a5fc-211a3c4e517d.png)


# Checklist

- [x] Should this change be included in the release notes? If yes, please add a line in RELEASE-NOTES.md
- [x] Have you tested in landscape?
- [x] Have you tested accessibility with TalkBack?
- [x] Have you tested in different themes?
- [x] Does the change work with a large display font?
- [x] Are all the strings localized?
- [x] Could you have written any new tests?
- [x] Did you include Compose previews with any components?