### PR TITLE
Upgrading Firebase

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -67,7 +67,7 @@ project.ext {
             cast: "com.google.android.gms:play-services-cast-framework:21.0.1",
             desugarJdk: "com.android.tools:desugar_jdk_libs:1.1.5",
             // Firebase BoM (Bill of Materials enables you to manage all your Firebase library versions by specifying only one version)
-            firebaseBom: "com.google.firebase:firebase-bom:30.2.0",
+            firebaseBom: "com.google.firebase:firebase-bom:30.3.1",
             firebaseCrashlytics: "com.google.firebase:firebase-crashlytics-ktx",
             firebaseAnalytics: "com.google.firebase:firebase-analytics-ktx",
             firebaseConfig: "com.google.firebase:firebase-config-ktx",


### PR DESCRIPTION
This change upgrades Firebase to the latest version and is recommended by Google Play due to a critical issue.

```
 - com.google.firebase:firebase-analytics-ktx [21.0.0 -> 21.1.0]
 - com.google.firebase:firebase-bom [30.2.0 -> 30.3.1]
 - com.google.firebase:firebase-config-ktx [21.1.0 -> 21.1.1]
 - com.google.firebase:firebase-crashlytics-ktx [18.2.11 -> 18.2.12]
```

Fixes https://github.com/Automattic/pocket-casts-android/issues/179
