### PR TITLE
Remove default price of 0

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateFrequencyFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateFrequencyFragment.kt
@@ -80,7 +80,6 @@ class CreateFrequencyFragment : BaseFragment() {
             if (frequency != null) {
                 val product = frequency.product
                 AnalyticsHelper.plusPlanChosen(sku = product.productId, title = product.title, price = product.priceDouble, currency = product.priceCurrencyCode)
-
                 it.findNavController().navigate(R.id.action_createFrequencyFragment_to_createTOSFragment)
             }
         }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/AnalyticsHelper.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/AnalyticsHelper.kt
@@ -229,7 +229,7 @@ object AnalyticsHelper {
         logEvent("select_sign_in_account")
     }
 
-    fun plusPlanChosen(sku: String, title: String, price: Double, currency: String) {
+    fun plusPlanChosen(sku: String, title: String, price: Double?, currency: String?) {
         val plan = bundleOf(
             Param.ITEM_ID to sku,
             Param.ITEM_NAME to title,

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/ProductDetails.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/ProductDetails.kt
@@ -8,14 +8,14 @@ val ProductDetails.shortTitle: String
 val ProductDetails.firstSubscriptionPricingPhase: ProductDetails.PricingPhase?
     get() = subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()
 
-val ProductDetails.price: String
-    get() = firstSubscriptionPricingPhase?.formattedPrice ?: "0"
+val ProductDetails.price: String?
+    get() = firstSubscriptionPricingPhase?.formattedPrice
 
-val ProductDetails.priceDouble: Double
-    get() = (firstSubscriptionPricingPhase?.priceAmountMicros ?: 0) * 1_000_000.0
+val ProductDetails.priceDouble: Double?
+    get() = firstSubscriptionPricingPhase?.priceAmountMicros?.let { it * 1_000_000.0 }
 
-val ProductDetails.priceCurrencyCode: String
-    get() = firstSubscriptionPricingPhase?.priceCurrencyCode ?: ""
+val ProductDetails.priceCurrencyCode: String?
+    get() = firstSubscriptionPricingPhase?.priceCurrencyCode
 
 val ProductDetails.billingPeriod: String?
     get() = firstSubscriptionPricingPhase?.billingPeriod


### PR DESCRIPTION
# Description

This was something I meant to include in the [PR updating the billing library](https://github.com/Automattic/pocket-casts-android/pull/180), but I just forgot. I thought it would be good not to have these default price and currency values. It looks like we already handle `null` values everywhere except for analytics, and I think the `null` would be more informative in the analytics. I'm just worried about having us opened up to accidentally presenting the user with a price of 0 or something.

Let me know what you think.

# Checklist

- [X] Should this change be included in the release notes? If yes, please add a line in RELEASE-NOTES.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [X] Are all the strings localized?
- [X] Could you have written any new tests?
- [X] Did you include Compose previews with any components?