### PR TITLE
Fixes OPML import not working

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,8 +1,15 @@
 # Release notes
 
-### 7.20.1
+### 7.20.2
 
 *   Bug Fixes:    
+    *   Fix OPML import.
+
+### 7.20.1
+
+*   New Features:
+    *   Add localizations for English (UK), Arabic, and Norwegian.
+*   Bug Fixes:
     *   Fix an issue where the podcasts order was being changed after migrating to the latest version.
 
 ### 7.20.0

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
@@ -5,6 +5,7 @@ import android.app.NotificationManager
 import android.content.Context
 import android.net.Uri
 import android.widget.Toast
+import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
@@ -18,6 +19,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.servers.refresh.ImportOpmlResponse
 import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshServerManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
@@ -32,7 +35,14 @@ import javax.xml.parsers.SAXParserFactory
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-class OpmlImportTask(context: Context, parameters: WorkerParameters) : CoroutineWorker(context, parameters) {
+@HiltWorker
+class OpmlImportTask @AssistedInject constructor(
+    @Assisted val context: Context,
+    @Assisted val parameters: WorkerParameters,
+    var podcastManager: PodcastManager,
+    var refreshServerManager: RefreshServerManager,
+    var notificationHelper: NotificationHelper
+) : CoroutineWorker(context, parameters) {
 
     companion object {
         const val INPUT_URI = "INPUT_URI"
@@ -53,10 +63,6 @@ class OpmlImportTask(context: Context, parameters: WorkerParameters) : Coroutine
             Toast.makeText(context, context.getString(LR.string.settings_import_opml_toast), Toast.LENGTH_LONG).show()
         }
     }
-
-    lateinit var podcastManager: PodcastManager
-    lateinit var refreshServerManager: RefreshServerManager
-    lateinit var notificationHelper: NotificationHelper
 
     private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 


### PR DESCRIPTION
This change fixes the OPML import not working. It wasn't working with any files as the dependency injection seemed to be broken. 

Fixes https://github.com/Automattic/pocket-casts-android/issues/196

**Steps to test**
1. Tap the Profile tab
2. Tap the setting cog
3. Tap "Import & export OPML"
4. Tap "Select file"
5. Find an OPML file to import

It should start importing the OPML file but instead it was crashing. 