### PR TITLE
Fix embedded artwork not showing on player screen.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,8 @@
 *   Bug Fixes:    
     *   Fix the mini player's play icon showing the wrong icon.
         ([#208](https://github.com/Automattic/pocket-casts-android/pull/208)).
+    *   Fix embedded artwork not showing on player screen.
+        ([#16](https://github.com/Automattic/pocket-casts-android/issues/16)).
 
 ### 7.20.2
 


### PR DESCRIPTION
This change fixes the issue with embedded artwork not showing on the player screen. For some podcasts it seems to be the case we can't convert the embedded artwork to a bitmap. When this happens the full screen player shows the fallback image instead of the podcast artwork. The code that extracts the embedded artwork now checks it can decode the bitmap successfully.

Included in this change I have cleaned up some of the code.

Fixes https://github.com/Automattic/pocket-casts-android/issues/16

**Steps to test failing artwork**
1. Open the podcast "The Rewatchables"
2. Download the episode "‘Hard to Kill’ With Bill Simmons and Kyle Brandt"
3. Play the episode
4. Open the full screen player

It should show the podcast artwork and not the fallback error image.

**Steps to test successful artwork**
1. Open the podcast "Upgrade" (From Relay FM)
2. Download the episode "Cocktail of Headwinds"
3. Play the episode
4. Open the full screen player

It should show the embedded episode artwork instead of the podcast artwork.
