### PR TITLE
Fix dark theme background color

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,8 @@
 *   Bug Fixes:    
     *   Fix the mini player's play icon showing the wrong icon.
         ([#208](https://github.com/Automattic/pocket-casts-android/pull/208)).
+    *   Fix dark theme background color.
+        ([#206](https://github.com/Automattic/pocket-casts-android/issues/206)).
     *   Fix embedded artwork not showing on player screen.
         ([#16](https://github.com/Automattic/pocket-casts-android/issues/16)).
     *   Fixes folder mapping at the time of folders full sync.

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseFragment.kt
@@ -38,7 +38,7 @@ open class BaseFragment : Fragment(), CoroutineScope, HasBackstack {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         if (view.background == null) {
-            view.setBackgroundColor(view.context.getThemeColor(UR.attr.primary_ui_01))
+            view.setBackgroundColor(view.context.getThemeColor(UR.attr.primary_ui_04))
         }
         view.isClickable = true
         view.isFocusable = true


### PR DESCRIPTION
The dark theme background color was changed to match iOS but this was a mistake as iOS uses it differently.

| Android Before | iOS | Android After |
| --- | --- | --- |
| ![Screenshot_20220808_212652](https://user-images.githubusercontent.com/308331/183415285-67ff47f7-fcae-4dd9-aee0-b8ba117b117d.png) | ![Simulator Screen Shot - iPhone 12 - 2022-08-08 at 21 26 12](https://user-images.githubusercontent.com/308331/183415303-24e46fda-1337-43ab-ace0-33d8879cd051.png) | ![Screenshot_20220808_214401](https://user-images.githubusercontent.com/308331/183415392-76a6be39-96a0-40ea-a5d1-05d4a64fb072.png) |

Fixes https://github.com/Automattic/pocket-casts-android/issues/206
