### PR TITLE
Proposal: Use different app icon for debug builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,7 @@ android {
             def (gitTag, versionBuild, gitHash, gitDirty) = gitLongVersion.tokenize('-')
 
             manifestPlaceholders = [
+                    appIcon: "@mipmap/ic_launcher_radioactive",
                     gitHash: gitHash + (gitDirty ? ("-" + gitDirty) : "")
             ]
         }
@@ -57,6 +58,7 @@ android {
 
         release {
             manifestPlaceholders = [
+                    appIcon: "@mipmap/ic_launcher",
                     gitHash: ""
             ]
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
     <application
             android:name=".PocketcastsApplication"
             android:hardwareAccelerated="true"
-            android:icon="@mipmap/ic_launcher"
+            android:icon="${appIcon}"
             android:label="@string/app_name"
             android:largeHeap="true"
             android:allowBackup="true"


### PR DESCRIPTION
# Description

I love how we can have both debug and release builds on a device at the same time, but I sometimes get confused about which is which and open the wrong one. I thought it might be nice to have a different default icon for our debug builds. I picked the radioactive icon since it has that console look and feels dev-y to me, but I have no strong feelings.

![image](https://user-images.githubusercontent.com/4656348/183686632-90d85727-94bb-4700-84a9-1fc8092fddbd.png)


# Checklist

- [x] Should this change be included in the release notes? If yes, please add a line in RELEASE-NOTES.md
- [x] Have you tested in landscape?
- [x] Have you tested accessibility with TalkBack?
- [x] Have you tested in different themes?
- [x] Does the change work with a large display font?
- [x] Are all the strings localized?
- [x] Could you have written any new tests?
- [x] Did you include Compose previews with any components?