### PR TITLE
Fix long podcast website links overflowing

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,7 +9,9 @@
         ([#206](https://github.com/Automattic/pocket-casts-android/issues/206)).
     *   Fix embedded artwork not showing on player screen.
         ([#16](https://github.com/Automattic/pocket-casts-android/issues/16)).
-    
+    *   Fix long podcast website links overflowing.
+        ([#230](https://github.com/Automattic/pocket-casts-android/issues/230)).
+
 ### 7.20.3
 
 *   Bug Fixes:

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_bottom.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_bottom.xml
@@ -131,6 +131,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
+            android:layout_marginEnd="24dp"
             android:ellipsize="end"
             android:gravity="center_vertical"
             android:includeFontPadding="false"
@@ -144,6 +145,7 @@
             app:showIfPresent="@{podcast.shortUrl}"
             app:layout_constraintBottom_toBottomOf="@+id/link_image"
             app:layout_constraintStart_toEndOf="@+id/link_image"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@+id/link_image"
             tools:text="@tools:sample/lorem" />
 


### PR DESCRIPTION
The podcast website link was overflowing if it was too long. The fix for this was to anchor the end of the view to the edge of the screen.

Fixes https://github.com/Automattic/pocket-casts-android/issues/230

**Test Steps**
1. Change `Podcast.getShortUrl()` to return a long website such as "areallylongwebaddressthatwontfitonthescreencanifixityesican.com.au"
2. Tap the Podcasts tab
3. Tap on a podcast
4. Tap the expand arrow icon 

The podcast website link shouldn't overflow the edge of the page.

<img  width="300" src="https://user-images.githubusercontent.com/308331/183887906-cc9c968d-1837-418b-be02-c7bed160ea57.png" />

