### PR TITLE
Adds free trial feature flag

### DIFF
--- a/base.gradle
+++ b/base.gradle
@@ -31,6 +31,8 @@ android {
         buildConfigField "String", "SETTINGS_ENCRYPT_SECRET", "\"${project.properties["pocketcastsSettingsEncryptSecret"] ?: ""}\""
         buildConfigField "String", "SHARING_SERVER_SECRET", "\"${project.properties["pocketcastsSharingServerSecret"] ?: ""}\""
 
+        buildConfigField "boolean", "ENABLE_FREE_TRIAL", "false"
+
         testInstrumentationRunner project.testInstrumentationRunner
         testApplicationId "au.com.shiftyjelly.pocketcasts.test" + project.name.replace("-", "_")
         vectorDrawables.useSupportLibrary = true

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.BuildConfig
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager.Companion.MONTHLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager.Companion.TEST_FREE_TRIAL_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager.Companion.YEARLY_PRODUCT_ID
@@ -326,7 +327,7 @@ class SubscriptionManagerImpl @Inject constructor(private val syncServerManager:
 
     override fun isEligibleForFreeTrial(): Boolean {
         /* TODO: Add server check */
-        return true
+        return BuildConfig.ENABLE_FREE_TRIAL
     }
 
     override fun getDefaultSubscription(subscriptions: List<Subscription>): Subscription? {


### PR DESCRIPTION
Project https://github.com/Automattic/pocket-casts-android/issues/190

# Description

This PR adds a feature flag to disable the free trial.

### Test Steps

1. Launch the app
2. Sign out if you're signed in
3. Tap on the Podcast tab
4. Tap on the add folder button
5. ✅  You do not see the free trial
6. Set `ENABLE_FREE_TRIAL` feature flag to true
7. Repeat the above steps
8. ✅ You see the free trial

# Checklist

N/A

- Should this change be included in the release notes? If yes, please add a line in RELEASE-NOTES.md
- Have you tested in landscape?
- Have you tested accessibility with TalkBack?
- Have you tested in different themes?
- Does the change work with a large display font?
- Are all the strings localized?
- Could you have written any new tests?
- Did you include Compose previews with any components?