### PR TITLE
Remove no-op `Dir.chdir('.')`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -98,13 +98,11 @@ platform :android do
     build_dir = "artifacts/"
 
     # Build
-    Dir.chdir(".") do
-      gradle(task: "clean")
-      UI.message("Running lint...")
-      gradle(task: ":#{app}:preBundleLint")
-      UI.message("Building #{version["name"]} / #{version["code"]} - #{aab_artifact_path}...")
-      gradle(task: ":#{app}:bundle", build_type: "Release")
-    end
+    gradle(task: "clean")
+    UI.message("Running lint...")
+    gradle(task: ":#{app}:preBundleLint")
+    UI.message("Building #{version["name"]} / #{version["code"]} - #{aab_artifact_path}...")
+    gradle(task: ":#{app}:bundle", build_type: "Release")
 
     Dir.chdir("..") do
       sh("mkdir -p #{build_dir} && cp -v #{bundle_output_path(app)} #{aab_artifact_path}")


### PR DESCRIPTION
# Description

What it says on the title. (Supersedes #242.)

# Checklist

- [x] Should this change be included in the release notes? If yes, please add a line in RELEASE-NOTES.md – N.A.
- [x] Have you tested in landscape? – N.A.
- [x] Have you tested accessibility with TalkBack? – N.A.
- [x] Have you tested in different themes? – N.A.
- [x] Does the change work with a large display font? – N.A.
- [x] Are all the strings localized? – N.A.
- [x] Could you have written any new tests? – N.A.
- [x] Did you include Compose previews with any components? – N.A.