### PR TITLE
Fix strings resource warnings

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -887,8 +887,8 @@
     <string name="plus_slash_year">%s / year</string>
     <string name="plus_then_slash_month">then %s / month</string>
     <string name="plus_then_slash_year">then %s / year</string>
-    <string name="plus_trial_then_slash_month">%s free then %s / month</string>
-    <string name="plus_trial_then_slash_year">%s free then %s / year</string>
+    <string name="plus_trial_then_slash_month">%1$s free then %2$s / month</string>
+    <string name="plus_trial_then_slash_year">%1$s free then %2$s / year</string>
     <string name="plus_thanks_for_your_support_bang">Thanks for your support!</string>
     <string name="plus_themes_icons">Themes and Icons</string>
     <string name="plus_themes_icons_body">Fly your true colors. Exclusive icons and themes for the plus club only.</string>


### PR DESCRIPTION
Fixes string resources warnings: 

` Multiple substitutions specified in non-positional format of string resource string/plus_trial_then_slash_month. Did you mean to add the formatted="false" attribute?`

for the strings:

```
<string name="plus_trial_then_slash_month">%s free then %s / month</string>
<string name="plus_trial_then_slash_year">%s free then %s / year</string>
```

# Checklist

- [ ] Should this change be included in the release notes? If yes, please add a line in RELEASE-NOTES.md
- [ ] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [ ] Have you tested in different themes?
- [ ] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?