### PR TITLE
Only allow the Github action to run manually.

### DIFF
--- a/.github/workflows/release_to_internal.yml
+++ b/.github/workflows/release_to_internal.yml
@@ -1,8 +1,7 @@
 name: Release to Internal
 
 # Run the deployment manually
-on:
-  workflow_dispatch:
+on: [workflow_dispatch]
 
 jobs:
   deployment:


### PR DESCRIPTION
During the switch over to Buildkite we will disable automatically deploying to the Internal track. Hopefully this change means we can still run it manually when we require it.