### PR TITLE
Increase the Android version number due to the accidental deploy

### DIFF
--- a/.github/workflows/release_to_internal.yml
+++ b/.github/workflows/release_to_internal.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Assemble Release
         run: ./gradlew :app:bundleRelease --no-daemon
         env:
-          VERSION_CODE_START: 8135
+          VERSION_CODE_START: 8840
       - name: Sign Release
         uses: r0adkll/sign-android-release@v1
         id: sign_app


### PR DESCRIPTION
While switching over to Buildkite the automatic deployments have uploaded a version of the wrong number. For us to be able to deploy over the top we will need to increase the version number to larger than 9001.