### PR TITLE
Fixes the Automotive issue of the podcast title repeating on the player screen

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -286,11 +286,14 @@ class MediaSessionManager(
         val safeCharacterPodcastTitle = podcastTitle.replace("%", "pct")
         var nowPlayingBuilder = MediaMetadataCompat.Builder()
             .putString(MediaMetadataCompat.METADATA_KEY_MEDIA_ID, episode.uuid)
-            .putString(MediaMetadataCompat.METADATA_KEY_ALBUM, safeCharacterPodcastTitle)
             .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, safeCharacterPodcastTitle)
             .putLong(MediaMetadataCompat.METADATA_KEY_DURATION, episode.durationMs.toLong())
             .putString(MediaMetadataCompat.METADATA_KEY_GENRE, "Podcast")
             .putString(MediaMetadataCompat.METADATA_KEY_TITLE, episode.title)
+
+        if (podcast != null && podcast.author.isNotEmpty()) {
+            nowPlayingBuilder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM, podcast.author)
+        }
 
         val nowPlaying = nowPlayingBuilder.build()
         Timber.i("MediaSession metadata. Episode: ${episode.uuid} ${episode.title} Duration: ${episode.durationMs.toLong()}")


### PR DESCRIPTION
We have had reports from an Android Automotive partner that the podcast title repeats on the player page.

<img  width="300" src="https://user-images.githubusercontent.com/308331/186351147-2800578e-593f-41e4-a537-561468c808d3.png" />

To fix this the author's name is used in the Media Session album tag. Here is the result in some of the locations the Media Session is used. I was going to use the artist tag but that seems to get used in less places than the album tag and having the podcast title visible instead of the author seemed correct.

<img  width="300" src="https://user-images.githubusercontent.com/308331/186351745-012aacf3-8219-4b1d-be20-504c0441c068.png" />

<img  width="300" src="https://user-images.githubusercontent.com/308331/186351768-7f5057bf-ac8e-44f2-88a2-03bf759d53e2.png" />
<img  width="300" src="https://user-images.githubusercontent.com/308331/186351800-3725e16b-4c5f-4b2d-8b5e-41377aaab78a.png" />
<img  width="300" src="https://user-images.githubusercontent.com/308331/186351813-dfa98d46-39c3-486f-9422-57b5e399f897.png" />
<img  width="300" src="https://user-images.githubusercontent.com/308331/186351907-1f6489de-6a83-4ae3-8085-1641924c14b8.jpg" />
<img  width="300" src="https://user-images.githubusercontent.com/308331/186351928-ca6d806b-cb3c-4bd9-bd80-2a793e94ea8e.jpg" />
<img  width="300" src="https://user-images.githubusercontent.com/308331/186351935-7abfde19-320c-46b4-b924-80ec49268795.jpg" />


