### PR TITLE
Fix Chromecast not taking over playback after connection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 *   Bug Fixes:
     *   Fix playing on Chromecast always shows buffering.
         ([#254](https://github.com/Automattic/pocket-casts-android/pull/254)).
+    *   Fix Chromecast not taking over playback after connection.
 
 ### 7.21.0
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/CastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/CastManagerImpl.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.chromecast
 
 import android.content.Context
+import androidx.core.content.ContextCompat
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.google.android.gms.cast.framework.CastContext
 import com.google.android.gms.cast.framework.Session
@@ -23,7 +24,10 @@ class CastManagerImpl @Inject constructor(@ApplicationContext private val contex
     override val isConnectedObservable = BehaviorRelay.create<Boolean>().apply { accept(false) }
 
     init {
-        getSessionManager()?.addSessionManagerListener(sessionManagerListener)
+        val executor = ContextCompat.getMainExecutor(context)
+        CastContext.getSharedInstance(context, executor)
+            .addOnFailureListener { e -> LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Failed to init CastContext shared instance ${e.message}") }
+            .addOnSuccessListener { castContext -> castContext.sessionManager.addSessionManagerListener(sessionManagerListener) }
     }
 
     override suspend fun isAvailable(): Boolean {


### PR DESCRIPTION
The Chromecast integration was broken after I upgraded the library. In the `init` method of `CastManagerImpl` the `CastContext` was returned as null. Because of this, the cast listener wasn't set up correctly and the app wasn't notified about Chromecast connections. 

Thanks @ashiagr for solving this.

**Test steps**
1. Play an episode
2. Tap the Chromecast icon
3. Tap the device to connect to

The episode should stop playing on the device and play through the Chromecast device.