### PR TITLE
Update CHANGELOG file format to work with our release notes tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
-# Release notes
-
-### 7.22.0
+7.22.0
+-----
 
 *   Bug Fixes:
     *   Fix playing on Chromecast always shows buffering.
         ([#254](https://github.com/Automattic/pocket-casts-android/pull/254)).
 
-### 7.21.0
+7.21.0
+-----
 
 *   Bug Fixes:    
     *   Fix the mini player's play icon showing the wrong icon.
@@ -30,27 +30,31 @@
     *   Fix episode row buffering state.
         ([#53](https://github.com/Automattic/pocket-casts-android/issues/53)).
 
-### 7.20.3
+7.20.3
+-----
 
 *   Bug Fixes:
     *   Fixes folder mapping at the time of folders full sync.
         ([#214](https://github.com/Automattic/pocket-casts-android/pull/214)).
 
-### 7.20.2
+7.20.2
+-----
 
 *   Bug Fixes:    
     *   Fix OPML import.
     *   Fix podcasts and folders rearrange crash.
         ([#200](https://github.com/Automattic/pocket-casts-android/issues/200)).
 
-### 7.20.1
+7.20.1
+-----
 
 *   New Features:
     *   Add localizations for English (UK), Arabic, and Norwegian.
 *   Bug Fixes:
     *   Fix an issue where the podcasts order was being changed after migrating to the latest version.
 
-### 7.20.0
+7.20.0
+-----
 
 *   New Features:
     *   Folders!
@@ -113,7 +117,8 @@
     *   Improve manage downloads screen
         ([#117](https://github.com/Automattic/pocket-casts-android/pull/117)).
 
-### 7.19.2 (2022-02-11)
+7.19.2 (2022-02-11)
+-----
 
 *   New Features:
     *   Add support for episode lists in the discover section.


### PR DESCRIPTION
This PR updates the format of `CHANGELOG.md` so we can extract the release notes during code freeze. The rendered version looks very similar to the version from `main` with the main difference being that it no longer has the `Release notes` title. Considering the name of the file is `CHANGELOG.md`, I think this is a negligible change.

It's also worth noting that this is the same format [Pocket Casts iOS is using](https://github.com/Automattic/pocket-casts-ios/blob/trunk/CHANGELOG.md) presumably for the [same reason](https://github.com/Automattic/pocket-casts-ios/blob/trunk/fastlane/Fastfile#L16).

# Checklist

- [x] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [x] Have you tested in landscape?
- [x] Have you tested accessibility with TalkBack?
- [x] Have you tested in different themes?
- [x] Does the change work with a large display font?
- [x] Are all the strings localized?
- [x] Could you have written any new tests?
- [x] Did you include Compose previews with any components?