### PR TITLE
Turn off Tracks for release builds

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTracker.kt
@@ -28,8 +28,10 @@ object AnalyticsTracker {
     }
 
     fun track(event: AnalyticsEvent, properties: Map<String, Any> = emptyMap()) {
-        // TODO don't send usage stats for debug builds
-        if (sendUsageStats) {
+        // TODO only sending usage stats for debug builds while this feature is in development. Once we're
+        // ready to release this, we should reverse this and default to _only_ sending usage stats when
+        // it is _not_ a debug build (or do more checks when setting the `sendUsageStats` variable).
+        if (sendUsageStats && BuildConfig.DEBUG) {
             trackers.forEach { it.track(event, properties) }
         }
     }


### PR DESCRIPTION
## Description

Turns off Tracks for release builds in preparation for us cutting the 7.22.0 release.

## To Test

Verify that tracks are only sent for debug builds.

# Checklist

- [X] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [X] Are all the strings localized?
- [X] Could you have written any new tests?
- [X] Did you include Compose previews with any components?