### PR TITLE
The latest GlotPress translation import.

### DIFF
--- a/modules/services/localization/src/main/res/values-ar/strings.xml
+++ b/modules/services/localization/src/main/res/values-ar/strings.xml
@@ -341,7 +341,6 @@ Language: ar
 	<string name="settings_title_storage">التخزين واستخدام البيانات</string>
 	<string name="settings_title_playback">عام</string>
 	<string name="settings_title_notifications">التنبيهات</string>
-	<string name="settings_title_manage_downloads">إدارة التنزيلات</string>
 	<string name="settings_title_import_export">استيراد وتصدير OPML</string>
 	<string name="settings_title_help">المساعدة والملاحظات</string>
 	<string name="settings_title_excluded_podcasts">البث الصوتي المُستبعد</string>
@@ -357,7 +356,6 @@ Language: ar
 	<string name="settings_storage_move_podcasts">جارٍ نقل البث الصوتي...</string>
 	<string name="settings_storage_move_message">سيقوم هذا بنقل ملفات البث الصوتي إلى هذا الموقع الجديد.</string>
 	<string name="settings_storage_move">نقل</string>
-	<string name="settings_storage_manage_downloads">إدارة الملفات التي تم تنزيلها</string>
 	<string name="settings_storage_folder_write_failed">يتعذر الكتابة على هذا المجلد.</string>
 	<string name="settings_storage_folder_not_found">يتعذر العثور على المجلد أو إنشاؤه.</string>
 	<string name="settings_storage_folder_change_failed">يتعذر التغيير إلى مجلد مخصص.</string>
@@ -505,7 +503,6 @@ Language: ar
 	<string name="plus_renews_automatically_yearly">يتم التجديد سنويًا تلقائيًا</string>
 	<string name="plus_best_value">أفضل قيمة</string>
 	<string name="plus_select_payment_frequency">تحديد وتيرة الدفع</string>
-	<string name="plus_year_month_price">⁦%1$s⁩ في السنة / ⁦%2$s⁩ في الشهر</string>
 	<string name="plus_upgrade_to_pocket_casts_plus">الترقية إلى Pocket Casts Plus</string>
 	<string name="plus_trial_finished_locked">سيتم قفل الوصول إلى ميزات Pocket Casts Plus</string>
 	<string name="plus_trial_finished_files_removed">ستتم إزالة الملفات التي تم رفعها إلى حسابك بعد أسبوع</string>
@@ -515,8 +512,6 @@ Language: ar
 	<string name="plus_themes_icons_body">أظهر معدنك الحقيقي. أيقونات وقوالب حصرية لنادي plus فقط.</string>
 	<string name="plus_themes_icons">القوالب والأيقونات</string>
 	<string name="plus_thanks_for_your_support_bang">شكرًا لك على دعمك!</string>
-	<string name="plus_per_month">%s / شهريًا</string>
-	<string name="plus_month_price">%s في الشهر</string>
 	<string name="plus_lifetime_member">عضو مدى الحياة</string>
 	<string name="plus_learn_more_button">أعرف أكثر</string>
 	<string name="plus_learn_more_about_plus">معرفة المزيد حول Pocket Casts Plus</string>
@@ -622,7 +617,6 @@ Language: ar
 	<string name="profile_payment_failed_detail">يبدو أنه كانت مشكلة في معالجة عملية الدفع الخاصة بك. الرجاء المحاولة مرة أخرى.</string>
 	<string name="profile_payment_failed">فشلت عملية الدفع</string>
 	<string name="profile_payment_cancelled">تم إلغاء عملية الدفع</string>
-	<string name="profile_pay_now">الدفع الآن</string>
 	<string name="profile_password_changed_successful">تم بنجاح!</string>
 	<string name="profile_password_changed">تم تغيير كلمة المرور</string>
 	<string name="profile_password">كلمة المرور</string>
@@ -750,7 +744,6 @@ Language: ar
 	<string name="profile_account_created">تم إنشاء حساب</string>
 	<string name="profile_access_ends">ينتهي الوصول: %s</string>
 	<string name="profile_access_ended">انتهى الوصول: %s</string>
-	<string name="profile_1_year_free">عام واحد مجانًا</string>
 	<string name="profile">الملف الشخصي</string>
 	<string name="filters_warning_delete_summary">يتعذر التراجع عن هذه العملية.</string>
 	<string name="filters_title_new_releases">إصدارات جديدة</string>
@@ -1007,7 +1000,6 @@ Language: ar
 	<string name="player_up_next_empty_desc">يمكنك إدراج الحلقات في قائمة الانتظار لتشغيلها بعد ذلك عن طريق التمرير إلى اليمين في صفوف الحلقة أو النقر على الأيقونة الموجودة على بطاقة الحلقة.</string>
 	<string name="player_up_next_empty">لا يوجد شيء في التالي</string>
 	<string name="player_up_next_clear_queue_button">مسح التالي</string>
-	<string name="player_up_next_clear_queue_summary">يتعذر التراجع عن مسح قائمتك التالية</string>
 	<string name="player_up_next_clear_queue">مسح قائمة الانتظار</string>
 	<string name="player_trim_silence_detail">يقلل طول الحلقة عن طريق إزالة السكوت في المحادثات.</string>
 	<string name="player_time_saved_no_hour">تهانينا! إنك توفِّر الوقت وتحصل على مزيد من البث الصوتي.</string>
@@ -1032,7 +1024,6 @@ Language: ar
 	<string name="player_notification_skip_back">الرجوع %d من الثواني</string>
 	<string name="player_more_actions">المزيد من الإجراءات</string>
 	<string name="player_full_screen">وضع ملء الشاشة</string>
-	<string name="player_end_playback_clear_up_next">نهاية التشغيل ومسح التالي</string>
 	<string name="player_effects_volume_boost">تعزيز الصوت</string>
 	<string name="player_effects_voices_sound_louder">تبدو الأصوات أعلى</string>
 	<string name="player_effects_trim_silence">إزالة السكوت</string>

--- a/modules/services/localization/src/main/res/values-de/strings.xml
+++ b/modules/services/localization/src/main/res/values-de/strings.xml
@@ -1,11 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2022-08-09 11:54:03+0000
+Translation-Revision-Date: 2022-08-23 11:54:04+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/2.4.0-alpha
 Language: de
 -->
 <resources>
+	<string name="settings_storage_section_heading_mobile_data">Mobile Daten</string>
+	<string name="settings_storage_section_heading_usage">Nutzung</string>
+	<string name="settings_storage_downloaded_files">Heruntergeladene Dateien</string>
+	<string name="settings_storage_downloaded_bytes">%d Byte</string>
+	<string name="plus_per_month">%s pro Monat</string>
+	<string name="plus_day">Tag</string>
+	<string name="plus_month_year_price">%1$s pro Monat/%2$s pro Jahr</string>
+	<string name="plus_trial_then_slash_year">%1$s kostenlos, dann %2$s/Jahr</string>
+	<string name="plus_trial_then_slash_month">%1$s kostenlos, dann %2$s/Monat</string>
+	<string name="plus_then_slash_year">dann %s/Jahr</string>
+	<string name="plus_then_slash_month">dann %s/Monat</string>
+	<string name="plus_slash_year">%s/Jahr</string>
+	<string name="plus_per_year">%s pro Jahr</string>
+	<string name="plus_trial_duration_free">%s KOSTENLOS</string>
+	<string name="profile_start_free_trial">Gratis-Test starten</string>
+	<string name="profile_per_year">Pro Jahr</string>
+	<string name="profile_feature_try_trial_secondary_info">Jetzt keine Zahlungen – jederzeit kündbar</string>
+	<string name="profile_feature_try_trial">Teste Pocket Casts Plus kostenlos für %s</string>
+	<string name="player_up_next_clear_episodes_plural">%1$d Episoden löschen</string>
+	<string name="player_up_next_clear_queue_summary">Bist du sicher, dass du deine „Als Nächstes“-Warteschlange löschen möchtest?</string>
+	<string name="player_end_playback_clear_up_next">„Als Nächstes“ schließen und löschen</string>
 	<string name="player_open_full_size_player">Aktivieren, um Vollbild-Player zu öffnen</string>
 	<string name="settings_downloads_clean_up">Bereinigen</string>
 	<string name="podcasts_share_failed_description">Beim Erstellen deiner Teilen-Seite ist etwas schiefgelaufen.</string>
@@ -351,7 +372,6 @@ Language: de
 	<string name="settings_title_storage">Speicher und Datennutzung</string>
 	<string name="settings_title_playback">Allgemein</string>
 	<string name="settings_title_notifications">Benachrichtigungen</string>
-	<string name="settings_title_manage_downloads">Downloads verwalten</string>
 	<string name="settings_title_import_export">OPML-Import/Export</string>
 	<string name="settings_title_help">Hilfe &amp; Feedback</string>
 	<string name="settings_title_excluded_podcasts">Ausgeschlossene Podcasts</string>
@@ -367,7 +387,6 @@ Language: de
 	<string name="settings_storage_move_podcasts">Podcasts werden verschoben ...</string>
 	<string name="settings_storage_move_message">Dadurch werden bestehende Podcast-Dateien an diesen neuen Speicherort verschoben.</string>
 	<string name="settings_storage_move">Verschieben</string>
-	<string name="settings_storage_manage_downloads">Heruntergeladene Dateien verwalten</string>
 	<string name="settings_storage_folder_write_failed">In diesen Ordner kann nicht geschrieben werden.</string>
 	<string name="settings_storage_folder_not_found">Der Ordner kann nicht gefunden oder erstellt werden.</string>
 	<string name="settings_storage_folder_change_failed">Kann nicht in individuellen Ordner geändert werden.</string>
@@ -515,7 +534,6 @@ Language: de
 	<string name="plus_renews_automatically_yearly">Wird jedes Jahr automatisch verlängert</string>
 	<string name="plus_best_value">BESTES PREIS-LEISTUNGSVERHÄLTNIS</string>
 	<string name="plus_select_payment_frequency">Zahlungshäufigkeit auswählen</string>
-	<string name="plus_year_month_price">%1$s pro Jahr/%2$s pro Monat</string>
 	<string name="plus_upgrade_to_pocket_casts_plus">Auf Pocket Casts Plus upgraden</string>
 	<string name="plus_trial_finished_locked">Der Zugriff auf Pocket Casts Plus-Funktionen wird gesperrt</string>
 	<string name="plus_trial_finished_files_removed">Dateien, die in dein Konto hochgeladen wurden, werden nach einer Woche gelöscht</string>
@@ -525,8 +543,7 @@ Language: de
 	<string name="plus_themes_icons_body">Bekenne Farbe mit den exklusiven Icons und Themes nur für Plus-Abonnenten.</string>
 	<string name="plus_themes_icons">Themes und Icons</string>
 	<string name="plus_thanks_for_your_support_bang">Danke für deine Unterstützung!</string>
-	<string name="plus_slash_month">%s /Monat</string>
-	<string name="plus_per_month">%s pro Monat</string>
+	<string name="plus_slash_month">%s/Monat</string>
 	<string name="plus_lifetime_member">Lebenslange Mitgliedschaft</string>
 	<string name="plus_learn_more_button">Weitere Informationen</string>
 	<string name="plus_learn_more_about_plus">Weitere Informationen zu Pocket Casts Plus</string>
@@ -632,7 +649,6 @@ Language: de
 	<string name="profile_payment_failed_detail">Bei der Bearbeitung deiner Zahlung ist anscheinend ein Fehler aufgetreten. Bitte versuch es noch einmal.</string>
 	<string name="profile_payment_failed">Zahlung fehlgeschlagen</string>
 	<string name="profile_payment_cancelled">Zahlung storniert</string>
-	<string name="profile_pay_now">Jetzt bezahlen</string>
 	<string name="profile_password_changed_successful">Erfolgreich!</string>
 	<string name="profile_password_changed">Passwort geändert</string>
 	<string name="profile_password">Passwort</string>
@@ -760,7 +776,6 @@ Language: de
 	<string name="profile_account_created">Konto erstellt</string>
 	<string name="profile_access_ends">Zugriff endet: %s</string>
 	<string name="profile_access_ended">Zugriff beendet: %s</string>
-	<string name="profile_1_year_free">1 Jahr kostenlos</string>
 	<string name="profile">Profil</string>
 	<string name="filters_warning_delete_summary">Dies kann nicht rückgängig gemacht werden.</string>
 	<string name="filters_title_new_releases">Neuerscheinungen</string>
@@ -1017,7 +1032,6 @@ Language: de
 	<string name="player_up_next_empty_desc">Du kannst eine Folge zur Warteschlange hinzufügen, indem du in der Folgenliste nach rechts wischst oder in einer Folgenkarte das Warteschlangen-Icon antippst.</string>
 	<string name="player_up_next_empty">Die Warteschlange ist leer.</string>
 	<string name="player_up_next_clear_queue_button">Warteschlange löschen</string>
-	<string name="player_up_next_clear_queue_summary">Das Löschen deiner Warteschlange kann nicht rückgängig gemacht werden.</string>
 	<string name="player_up_next_clear_queue">Warteschlange löschen</string>
 	<string name="player_trim_silence_detail">Reduziert die Länge einer Folge, indem Stille in Unterhaltungen gekürzt wird.</string>
 	<string name="player_time_saved_no_hour">Glückwunsch! Du sparst Zeit und schaffst mehr Podcasts.</string>
@@ -1042,7 +1056,6 @@ Language: de
 	<string name="player_notification_skip_back">%d Sek. zurück</string>
 	<string name="player_more_actions">Weitere Aktionen</string>
 	<string name="player_full_screen">Vollbild</string>
-	<string name="player_end_playback_clear_up_next">Wiedergabe beenden und Warteschlange löschen</string>
 	<string name="player_effects_volume_boost">Lautstärke-Booster</string>
 	<string name="player_effects_voices_sound_louder">Stimmen hören sich lauter an</string>
 	<string name="player_effects_trim_silence">Stille kürzen</string>

--- a/modules/services/localization/src/main/res/values-en-rGB/strings.xml
+++ b/modules/services/localization/src/main/res/values-en-rGB/strings.xml
@@ -340,7 +340,6 @@ Language: en_GB
 	<string name="settings_title_storage">Storage &amp; data use</string>
 	<string name="settings_title_playback">General</string>
 	<string name="settings_title_notifications">Notifications</string>
-	<string name="settings_title_manage_downloads">Manage downloads</string>
 	<string name="settings_title_import_export">Import &amp; export OPML</string>
 	<string name="settings_title_help">Help &amp; feedback</string>
 	<string name="settings_title_excluded_podcasts">Excluded Podcasts</string>
@@ -356,7 +355,6 @@ Language: en_GB
 	<string name="settings_storage_move_podcasts">Moving podcasts…</string>
 	<string name="settings_storage_move_message">This will move existing podcast files to this new location.</string>
 	<string name="settings_storage_move">Move</string>
-	<string name="settings_storage_manage_downloads">Manage downloaded files</string>
 	<string name="settings_storage_folder_write_failed">This folder cannot be written to.</string>
 	<string name="settings_storage_folder_not_found">The folder cannot be found or created.</string>
 	<string name="settings_storage_folder_change_failed">Unable to change to custom folder.</string>
@@ -504,7 +502,6 @@ Language: en_GB
 	<string name="plus_renews_automatically_yearly">Renews automatically yearly</string>
 	<string name="plus_best_value">BEST VALUE</string>
 	<string name="plus_select_payment_frequency">Select Payment Frequency</string>
-	<string name="plus_year_month_price">%1$s per year / %2$s per month</string>
 	<string name="plus_upgrade_to_pocket_casts_plus">Upgrade to Pocket Casts Plus</string>
 	<string name="plus_trial_finished_locked">Access to Pocket Casts Plus features will be locked</string>
 	<string name="plus_trial_finished_files_removed">Files uploaded to your account will be removed after a week</string>
@@ -514,8 +511,6 @@ Language: en_GB
 	<string name="plus_themes_icons_body">Show your true colours. Exclusive icons and themes for the plus club only.</string>
 	<string name="plus_themes_icons">Themes and Icons</string>
 	<string name="plus_thanks_for_your_support_bang">Thanks for your support!</string>
-	<string name="plus_per_month">%s / month</string>
-	<string name="plus_month_price">%s per month</string>
 	<string name="plus_lifetime_member">Lifetime Member</string>
 	<string name="plus_learn_more_button">Learn More</string>
 	<string name="plus_learn_more_about_plus">Learn more about Pocket Casts Plus</string>
@@ -621,7 +616,6 @@ Language: en_GB
 	<string name="profile_payment_failed_detail">It looks like there was a problem processing your payment. Please try again.</string>
 	<string name="profile_payment_failed">Payment Failed</string>
 	<string name="profile_payment_cancelled">Payment Cancelled</string>
-	<string name="profile_pay_now">Pay Now</string>
 	<string name="profile_password_changed_successful">Successful!</string>
 	<string name="profile_password_changed">Password Changed</string>
 	<string name="profile_password">Password</string>
@@ -749,7 +743,6 @@ Language: en_GB
 	<string name="profile_account_created">Account Created</string>
 	<string name="profile_access_ends">Access ends: %s</string>
 	<string name="profile_access_ended">Access ended: %s</string>
-	<string name="profile_1_year_free">1 Year Free</string>
 	<string name="profile">Profile</string>
 	<string name="filters_warning_delete_summary">This cannot be undone.</string>
 	<string name="filters_title_new_releases">New Releases</string>
@@ -1006,7 +999,6 @@ Language: en_GB
 	<string name="player_up_next_empty_desc">You can queue episodes to play next by swiping right on episode rows or tapping the icon on an episode card.</string>
 	<string name="player_up_next_empty">Nothing in Up Next</string>
 	<string name="player_up_next_clear_queue_button">Clear Up Next</string>
-	<string name="player_up_next_clear_queue_summary">Clearing your Up Next list cannot be undone</string>
 	<string name="player_up_next_clear_queue">Clear Queue</string>
 	<string name="player_trim_silence_detail">Reduces the length of an episode by trimming silence in conversations.</string>
 	<string name="player_time_saved_no_hour">Congrats! You\'re saving time and getting through more podcasts.</string>
@@ -1031,7 +1023,6 @@ Language: en_GB
 	<string name="player_notification_skip_back">Back %d secs</string>
 	<string name="player_more_actions">More actions</string>
 	<string name="player_full_screen">Full screen</string>
-	<string name="player_end_playback_clear_up_next">End playback &amp; clear Up Next</string>
 	<string name="player_effects_volume_boost">Volume Boost</string>
 	<string name="player_effects_voices_sound_louder">Voices sound louder</string>
 	<string name="player_effects_trim_silence">Trim Silence</string>

--- a/modules/services/localization/src/main/res/values-es-rMX/strings.xml
+++ b/modules/services/localization/src/main/res/values-es-rMX/strings.xml
@@ -6,6 +6,27 @@ Generator: GlotPress/2.4.0-alpha
 Language: es_MX
 -->
 <resources>
+	<string name="settings_storage_section_heading_mobile_data">Datos móviles</string>
+	<string name="settings_storage_section_heading_usage">Uso</string>
+	<string name="settings_storage_downloaded_files">Archivos descargados</string>
+	<string name="settings_storage_downloaded_bytes">%d bytes</string>
+	<string name="plus_per_month">%s al mes</string>
+	<string name="plus_day">día</string>
+	<string name="plus_month_year_price">%1$s al mes / %2$s al año</string>
+	<string name="plus_trial_then_slash_year">%1$s gratis y, después, %2$s/año</string>
+	<string name="plus_trial_then_slash_month">%1$s gratis y, después, %2$s/mes</string>
+	<string name="plus_then_slash_year">después, %s/año</string>
+	<string name="plus_then_slash_month">después, %s/mes</string>
+	<string name="plus_slash_year">%s/año</string>
+	<string name="plus_per_year">%s al año</string>
+	<string name="plus_trial_duration_free">%s GRATIS</string>
+	<string name="profile_start_free_trial">Iniciar prueba gratuita</string>
+	<string name="profile_per_year">Al año</string>
+	<string name="profile_feature_try_trial_secondary_info">Sin pago por adelantado, cancela en cualquier momento</string>
+	<string name="profile_feature_try_trial">Prueba Pocket Casts Plus gratis durante %s</string>
+	<string name="player_up_next_clear_episodes_plural">Borrar %1$d episodios</string>
+	<string name="player_up_next_clear_queue_summary">¿Seguro que quieres borrar tu lista de A continuación?</string>
+	<string name="player_end_playback_clear_up_next">Cerrar y borrar A continuación</string>
 	<string name="player_open_full_size_player">Activar para abrir el reproductor a tamaño completo</string>
 	<string name="settings_downloads_clean_up">Vaciar</string>
 	<string name="podcasts_share_failed_description">Se ha producido un error al crear tu página compartida.</string>
@@ -351,7 +372,6 @@ Language: es_MX
 	<string name="settings_title_storage">Almacenamiento y uso de datos</string>
 	<string name="settings_title_playback">General</string>
 	<string name="settings_title_notifications">Notificaciones</string>
-	<string name="settings_title_manage_downloads">Administrar descargas</string>
 	<string name="settings_title_import_export">Importar y exportar OPML</string>
 	<string name="settings_title_help">Ayuda y comentarios</string>
 	<string name="settings_title_excluded_podcasts">Podcasts excluidos</string>
@@ -367,7 +387,6 @@ Language: es_MX
 	<string name="settings_storage_move_podcasts">Moviendo podcasts…</string>
 	<string name="settings_storage_move_message">Esto moverá los archivos de podcasts existentes a esta nueva ubicación.</string>
 	<string name="settings_storage_move">Mover</string>
-	<string name="settings_storage_manage_downloads">Administrar archivos descargados</string>
 	<string name="settings_storage_folder_write_failed">No es posible escribir en esta carpeta.</string>
 	<string name="settings_storage_folder_not_found">No es posible encontrar o crear la carpeta.</string>
 	<string name="settings_storage_folder_change_failed">No es posible cambiar a la carpeta personalizada.</string>
@@ -515,7 +534,6 @@ Language: es_MX
 	<string name="plus_renews_automatically_yearly">Se renueva automáticamente una vez al año</string>
 	<string name="plus_best_value">MEJOR OFERTA</string>
 	<string name="plus_select_payment_frequency">Selecciona la frecuencia de pago</string>
-	<string name="plus_year_month_price">%1$s por año / %2$s por mes</string>
 	<string name="plus_upgrade_to_pocket_casts_plus">Actualizar a Pocket Casts Plus</string>
 	<string name="plus_trial_finished_locked">Se bloqueará el acceso a las funciones de Pocket Casts Plus</string>
 	<string name="plus_trial_finished_files_removed">Los archivos subidos a tu cuenta se eliminarán después de una semana</string>
@@ -525,8 +543,7 @@ Language: es_MX
 	<string name="plus_themes_icons_body">Muestra tus verdaderos colores. Iconos y temas exclusivos solo para el club Plus.</string>
 	<string name="plus_themes_icons">Temas e iconos</string>
 	<string name="plus_thanks_for_your_support_bang">¡Gracias por tu apoyo!</string>
-	<string name="plus_slash_month">%s  / mes</string>
-	<string name="plus_per_month">%s por mes</string>
+	<string name="plus_slash_month">%s/mes</string>
 	<string name="plus_lifetime_member">Miembro vitalicio</string>
 	<string name="plus_learn_more_button">Más información</string>
 	<string name="plus_learn_more_about_plus">Obtén más información sobre Pocket Casts Plus</string>
@@ -632,7 +649,6 @@ Language: es_MX
 	<string name="profile_payment_failed_detail">Parece que hubo un problema al procesar tu pago. Vuelve al intentarlo.</string>
 	<string name="profile_payment_failed">Error al realizar el pago</string>
 	<string name="profile_payment_cancelled">Pago cancelado</string>
-	<string name="profile_pay_now">Pagar ahora</string>
 	<string name="profile_password_changed_successful">¡Listo!</string>
 	<string name="profile_password_changed">Se modificó la contraseña.</string>
 	<string name="profile_password">Contraseña</string>
@@ -760,7 +776,6 @@ Language: es_MX
 	<string name="profile_account_created">Cuenta creada</string>
 	<string name="profile_access_ends">El acceso finaliza: %s</string>
 	<string name="profile_access_ended">Acceso finalizado: %s</string>
-	<string name="profile_1_year_free">1 año gratis</string>
 	<string name="profile">Perfil</string>
 	<string name="filters_warning_delete_summary">Esto no se puede deshacer.</string>
 	<string name="filters_title_new_releases">Nuevos lanzamientos</string>
@@ -1017,7 +1032,6 @@ Language: es_MX
 	<string name="player_up_next_empty_desc">Puedes poner los episodios en cola para reproducirlos a continuación deslizando los episodios de las filas hacia la derecha o tocando el icono en una tarjeta de episodio.</string>
 	<string name="player_up_next_empty">Ningún episodio en A continuación</string>
 	<string name="player_up_next_clear_queue_button">Borrar A continuación</string>
-	<string name="player_up_next_clear_queue_summary">La acción de borrar la lista de A continuación no se puede deshacer</string>
 	<string name="player_up_next_clear_queue">Borra cola</string>
 	<string name="player_trim_silence_detail">Recorta el silencio en las conversaciones para reducir la duración de un episodio.</string>
 	<string name="player_time_saved_no_hour">¡Felicitaciones! Estás ahorrando tiempo y obteniendo más podcasts.</string>
@@ -1042,7 +1056,6 @@ Language: es_MX
 	<string name="player_notification_skip_back">Atrasar %d s</string>
 	<string name="player_more_actions">Mas acciones</string>
 	<string name="player_full_screen">Pantalla completa</string>
-	<string name="player_end_playback_clear_up_next">Finalizar reproducción y borrar A continuación</string>
 	<string name="player_effects_volume_boost">Aumento de volumen</string>
 	<string name="player_effects_voices_sound_louder">Aumenta el volumen de las voces</string>
 	<string name="player_effects_trim_silence">Recortar silencio</string>

--- a/modules/services/localization/src/main/res/values-es/strings.xml
+++ b/modules/services/localization/src/main/res/values-es/strings.xml
@@ -1,11 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2022-08-09 09:54:16+0000
+Translation-Revision-Date: 2022-08-23 14:54:03+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/2.4.0-alpha
 Language: es
 -->
 <resources>
+	<string name="settings_storage_section_heading_mobile_data">Datos móviles</string>
+	<string name="settings_storage_section_heading_usage">Uso</string>
+	<string name="settings_storage_downloaded_files">Archivos descargados</string>
+	<string name="settings_storage_downloaded_bytes">%d bytes</string>
+	<string name="plus_per_month">%s al mes</string>
+	<string name="plus_day">día</string>
+	<string name="plus_month_year_price">%1$s al mes / %2$s al año</string>
+	<string name="plus_trial_then_slash_year">%1$s gratis y, después, %2$s/año</string>
+	<string name="plus_trial_then_slash_month">%1$s gratis y, después, %2$s/mes</string>
+	<string name="plus_then_slash_year">después, %s/año</string>
+	<string name="plus_then_slash_month">después, %s/mes</string>
+	<string name="plus_slash_year">%s/año</string>
+	<string name="plus_per_year">%s al año</string>
+	<string name="plus_trial_duration_free">%s GRATIS</string>
+	<string name="profile_start_free_trial">Iniciar prueba gratuita</string>
+	<string name="profile_per_year">Al año</string>
+	<string name="profile_feature_try_trial_secondary_info">Sin pago por adelantado, cancela en cualquier momento</string>
+	<string name="profile_feature_try_trial">Prueba Pocket Casts Plus gratis durante %s</string>
+	<string name="player_up_next_clear_episodes_plural">Borrar %1$d episodios</string>
+	<string name="player_up_next_clear_queue_summary">¿Seguro que quieres borrar tu lista de A continuación?</string>
+	<string name="player_end_playback_clear_up_next">Cerrar y borrar A continuación</string>
 	<string name="player_open_full_size_player">Activar para abrir el reproductor a tamaño completo</string>
 	<string name="settings_downloads_clean_up">Vaciar</string>
 	<string name="podcasts_share_failed_description">Se ha producido un error al crear tu página compartida.</string>
@@ -351,7 +372,6 @@ Language: es
 	<string name="settings_title_storage">Almacenamiento y uso de datos</string>
 	<string name="settings_title_playback">General</string>
 	<string name="settings_title_notifications">Avisos</string>
-	<string name="settings_title_manage_downloads">Gestionar descargas</string>
 	<string name="settings_title_import_export">Importar y exportar OPML</string>
 	<string name="settings_title_help">Ayuda y comentarios</string>
 	<string name="settings_title_excluded_podcasts">Podcasts excluidos</string>
@@ -367,7 +387,6 @@ Language: es
 	<string name="settings_storage_move_podcasts">Moviendo podcasts…</string>
 	<string name="settings_storage_move_message">Se moverán los archivos existentes de podcasts a esta nueva ubicación.</string>
 	<string name="settings_storage_move">Mover</string>
-	<string name="settings_storage_manage_downloads">Gestionar archivos descargados</string>
 	<string name="settings_storage_folder_write_failed">No se puede añadir nada a esta carpeta ni modificarla.</string>
 	<string name="settings_storage_folder_not_found">No se ha podido encontrar la carpeta o no se ha podido crear.</string>
 	<string name="settings_storage_folder_change_failed">No se ha podido cambiar a la carpeta personalizada.</string>
@@ -515,7 +534,6 @@ Language: es
 	<string name="plus_renews_automatically_yearly">Se renueva automáticamente cada año</string>
 	<string name="plus_best_value">Mejor relación calidad-precio</string>
 	<string name="plus_select_payment_frequency">Seleccionar frecuencia de pago</string>
-	<string name="plus_year_month_price">%1$s al año o %2$s al mes</string>
 	<string name="plus_upgrade_to_pocket_casts_plus">Mejorar a Pocket Casts Plus</string>
 	<string name="plus_trial_finished_locked">El acceso a las funciones de Pocket Casts Plus estará bloqueado</string>
 	<string name="plus_trial_finished_files_removed">Los archivos subidos a tu cuenta se eliminarán tras una semana</string>
@@ -525,8 +543,7 @@ Language: es
 	<string name="plus_themes_icons_body">Muéstrate tal y como eres. Iconos y temas exclusivos solo para miembros plus.</string>
 	<string name="plus_themes_icons">Temas e iconos</string>
 	<string name="plus_thanks_for_your_support_bang">¡Gracias por tu apoyo!</string>
-	<string name="plus_slash_month">%s /mes</string>
-	<string name="plus_per_month">%s al mes</string>
+	<string name="plus_slash_month">%s/mes</string>
 	<string name="plus_lifetime_member">Miembro vitalicio</string>
 	<string name="plus_learn_more_button">Aprender más</string>
 	<string name="plus_learn_more_about_plus">Obtén más información sobre Pocket Casts Plus</string>
@@ -632,7 +649,6 @@ Language: es
 	<string name="profile_payment_failed_detail">Parece que se ha producido un error al procesar el pago. Inténtalo de nuevo.</string>
 	<string name="profile_payment_failed">Pago fallido</string>
 	<string name="profile_payment_cancelled">Pago cancelado</string>
-	<string name="profile_pay_now">Pagar ahora</string>
 	<string name="profile_password_changed_successful">¡Correcto!</string>
 	<string name="profile_password_changed">Contraseña cambiada</string>
 	<string name="profile_password">Contraseña</string>
@@ -760,7 +776,6 @@ Language: es
 	<string name="profile_account_created">Cuenta creada</string>
 	<string name="profile_access_ends">El acceso termina: %s</string>
 	<string name="profile_access_ended">El acceso terminó: %s</string>
-	<string name="profile_1_year_free">1 año gratis</string>
 	<string name="profile">Perfil</string>
 	<string name="filters_warning_delete_summary">Esta acción no se puede deshacer.</string>
 	<string name="filters_title_new_releases">Novedades</string>
@@ -1017,7 +1032,6 @@ Language: es
 	<string name="player_up_next_empty_desc">Puedes poner en cola los episodios para que se reproduzcan a continuación si deslizas hacia la derecha en las filas de los episodios o si tocas el icono en la tarjeta del episodio.</string>
 	<string name="player_up_next_empty">No hay nada en A continuación</string>
 	<string name="player_up_next_clear_queue_button">Borrar A continuación</string>
-	<string name="player_up_next_clear_queue_summary">No podrás deshacer la acción si borras la lista A continuación</string>
 	<string name="player_up_next_clear_queue">Borrar cola</string>
 	<string name="player_trim_silence_detail">Reduce la duración de un episodio al recortar el silencio en las conversaciones.</string>
 	<string name="player_time_saved_no_hour">¡Enhorabuena! Estás ahorrando tiempo y terminando más podcasts.</string>
@@ -1042,7 +1056,6 @@ Language: es
 	<string name="player_notification_skip_back">Volver atrás %d segundos</string>
 	<string name="player_more_actions">Más acciones</string>
 	<string name="player_full_screen">Pantalla completa</string>
-	<string name="player_end_playback_clear_up_next">Terminar reproducción y borrar A continuación</string>
 	<string name="player_effects_volume_boost">Subir volumen</string>
 	<string name="player_effects_voices_sound_louder">Las voces suenan más alto</string>
 	<string name="player_effects_trim_silence">Recortar silencio</string>

--- a/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
@@ -6,6 +6,27 @@ Generator: GlotPress/2.4.0-alpha
 Language: fr_CA
 -->
 <resources>
+	<string name="settings_storage_section_heading_mobile_data">Données mobiles</string>
+	<string name="settings_storage_section_heading_usage">Utilisation</string>
+	<string name="settings_storage_downloaded_files">Fichiers téléchargés</string>
+	<string name="settings_storage_downloaded_bytes">%d octets</string>
+	<string name="plus_per_month">%s par mois</string>
+	<string name="plus_day">jour</string>
+	<string name="plus_month_year_price">%1$s par mois / %2$s par an</string>
+	<string name="plus_trial_then_slash_year">%1$s gratuit puis %2$s /an</string>
+	<string name="plus_trial_then_slash_month">%1$s gratuit puis %2$s /mois</string>
+	<string name="plus_then_slash_year">puis %s /an</string>
+	<string name="plus_then_slash_month">puis %s /mois</string>
+	<string name="plus_slash_year">%s /an</string>
+	<string name="plus_per_year">%s par an</string>
+	<string name="plus_trial_duration_free">%s GRATUIT</string>
+	<string name="profile_start_free_trial">Démarrez votre essai gratuit</string>
+	<string name="profile_per_year">Par an</string>
+	<string name="profile_feature_try_trial_secondary_info">Aucun paiement pour le moment – Annulation à tout moment</string>
+	<string name="profile_feature_try_trial">Essayez Pocket Casts Plus gratuitement pour %s</string>
+	<string name="player_up_next_clear_episodes_plural">Effacer %1$d épisodes</string>
+	<string name="player_up_next_clear_queue_summary">Voulez-vous vraiment effacer votre file d’attente ?</string>
+	<string name="player_end_playback_clear_up_next">Fermer et effacer la file d’attente</string>
 	<string name="player_open_full_size_player">Activer pour ouvrir le lecteur grand format</string>
 	<string name="settings_downloads_clean_up">Nettoyer</string>
 	<string name="podcasts_share_failed_description">Un problème est survenu lors de la création de votre page de partage.</string>
@@ -351,7 +372,6 @@ Language: fr_CA
 	<string name="settings_title_storage">Stockage et utilisation des données</string>
 	<string name="settings_title_playback">Généralités</string>
 	<string name="settings_title_notifications">Notifications</string>
-	<string name="settings_title_manage_downloads">Gérer les téléchargements</string>
 	<string name="settings_title_import_export">Importer et exporter OPML</string>
 	<string name="settings_title_help">Aide et commentaires</string>
 	<string name="settings_title_excluded_podcasts">Balados exclus</string>
@@ -367,7 +387,6 @@ Language: fr_CA
 	<string name="settings_storage_move_podcasts">Déplacement des balados...</string>
 	<string name="settings_storage_move_message">Vos fichiers balados existants seront déplacés à un nouvel emplacement.</string>
 	<string name="settings_storage_move">Déplacer</string>
-	<string name="settings_storage_manage_downloads">Gérer les fichiers téléchargés</string>
 	<string name="settings_storage_folder_write_failed">Ce dossier ne peut être en écriture.</string>
 	<string name="settings_storage_folder_not_found">Ce dossier est introuvable ou ne peut pas être créé.</string>
 	<string name="settings_storage_folder_change_failed">Impossible de changer pour le dossier personnalisé.</string>
@@ -515,7 +534,6 @@ Language: fr_CA
 	<string name="plus_renews_automatically_yearly">Se renouvelle automatiquement chaque année</string>
 	<string name="plus_best_value">VALEUR OPTIMALE</string>
 	<string name="plus_select_payment_frequency">Sélectionner la fréquence de paiement</string>
-	<string name="plus_year_month_price">%1$s par année/%2$s par mois</string>
 	<string name="plus_upgrade_to_pocket_casts_plus">Mis à niveau à Pocket Casts Plus</string>
 	<string name="plus_trial_finished_locked">L’accès aux fonctionnalités Pocket Casts Plus sera verrouillé.</string>
 	<string name="plus_trial_finished_files_removed">Les fichiers téléversés dans votre compte seront supprimés après une semaine.</string>
@@ -525,8 +543,7 @@ Language: fr_CA
 	<string name="plus_themes_icons_body">Affichez vos vraies couleurs. Des icônes et des thèmes exclusifs uniquement pour le club plus.</string>
 	<string name="plus_themes_icons">Thèmes et icônes</string>
 	<string name="plus_thanks_for_your_support_bang">Merci de votre soutien!</string>
-	<string name="plus_slash_month">%s/mois</string>
-	<string name="plus_per_month">%s par mois</string>
+	<string name="plus_slash_month">%s /mois</string>
 	<string name="plus_lifetime_member">Membre à vie</string>
 	<string name="plus_learn_more_button">En savoir plus</string>
 	<string name="plus_learn_more_about_plus">En savoir plus sur Pocket Casts Plus</string>
@@ -632,7 +649,6 @@ Language: fr_CA
 	<string name="profile_payment_failed_detail">Il semble qu’un problème est survenu lors du traitement de votre paiement. Veuillez réessayer.</string>
 	<string name="profile_payment_failed">Échec du paiement</string>
 	<string name="profile_payment_cancelled">Paiement annulé</string>
-	<string name="profile_pay_now">Payer maintenant</string>
 	<string name="profile_password_changed_successful">Réussite!</string>
 	<string name="profile_password_changed">Mot de passe changé</string>
 	<string name="profile_password">Mot de passe</string>
@@ -760,7 +776,6 @@ Language: fr_CA
 	<string name="profile_account_created">Compte créé</string>
 	<string name="profile_access_ends">Fin de l’accès : %s</string>
 	<string name="profile_access_ended">L’accès a pris fin : %s</string>
-	<string name="profile_1_year_free">1 an gratuit</string>
 	<string name="profile">Profil</string>
 	<string name="filters_warning_delete_summary">Ceci ne peut pas être annulé.</string>
 	<string name="filters_title_new_releases">Nouvelles sorties</string>
@@ -1017,7 +1032,6 @@ Language: fr_CA
 	<string name="player_up_next_empty_desc">Vous pouvez mettre des épisodes dans la file d’attente de lecture en balayant la ligne de l’épisode vers la droite ou en appuyant sur l’icône dans la fiche d’un épisode.</string>
 	<string name="player_up_next_empty">Aucun épisode dans la file d’attente Prochains épisodes</string>
 	<string name="player_up_next_clear_queue_button">Effacer la file d’attente Prochains épisodes</string>
-	<string name="player_up_next_clear_queue_summary">L’effacement de votre file d’attente Prochains épisodes est définitif.</string>
 	<string name="player_up_next_clear_queue">Effacer la file d’attente</string>
 	<string name="player_trim_silence_detail">Cette fonctionnalité réduit la durée d’un épisode en coupant le silence dans les conversations.</string>
 	<string name="player_time_saved_no_hour">Félicitations! Vous gagnez du temps et écoutez plus de balados.</string>
@@ -1042,7 +1056,6 @@ Language: fr_CA
 	<string name="player_notification_skip_back">Reculer %d s</string>
 	<string name="player_more_actions">Plus d’actions</string>
 	<string name="player_full_screen">Plein écran</string>
-	<string name="player_end_playback_clear_up_next">Terminer la lecture et effacer la file d’attente Prochains épisodes</string>
 	<string name="player_effects_volume_boost">Amplification du volume</string>
 	<string name="player_effects_voices_sound_louder">Le volume des voix est plus élevé</string>
 	<string name="player_effects_trim_silence">Couper le silence</string>

--- a/modules/services/localization/src/main/res/values-fr/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr/strings.xml
@@ -1,11 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2022-08-09 16:54:17+0000
+Translation-Revision-Date: 2022-08-23 09:54:03+0000
 Plural-Forms: nplurals=2; plural=n > 1;
 Generator: GlotPress/2.4.0-alpha
 Language: fr
 -->
 <resources>
+	<string name="settings_storage_section_heading_mobile_data">Données mobiles</string>
+	<string name="settings_storage_section_heading_usage">Utilisation</string>
+	<string name="settings_storage_downloaded_files">Fichiers téléchargés</string>
+	<string name="settings_storage_downloaded_bytes">%d octets</string>
+	<string name="plus_per_month">%s par mois</string>
+	<string name="plus_day">jour</string>
+	<string name="plus_month_year_price">%1$s par mois / %2$s par an</string>
+	<string name="plus_trial_then_slash_year">%1$s gratuit puis %2$s /an</string>
+	<string name="plus_trial_then_slash_month">%1$s gratuit puis %2$s /mois</string>
+	<string name="plus_then_slash_year">puis %s /an</string>
+	<string name="plus_then_slash_month">puis %s /mois</string>
+	<string name="plus_slash_year">%s /an</string>
+	<string name="plus_per_year">%s par an</string>
+	<string name="plus_trial_duration_free">%s GRATUIT</string>
+	<string name="profile_start_free_trial">Démarrez votre essai gratuit</string>
+	<string name="profile_per_year">Par an</string>
+	<string name="profile_feature_try_trial_secondary_info">Aucun paiement pour le moment – Annulation à tout moment</string>
+	<string name="profile_feature_try_trial">Essayez Pocket Casts Plus gratuitement pour %s</string>
+	<string name="player_up_next_clear_episodes_plural">Effacer %1$d épisodes</string>
+	<string name="player_up_next_clear_queue_summary">Voulez-vous vraiment effacer votre file d’attente ?</string>
+	<string name="player_end_playback_clear_up_next">Fermer et effacer la file d’attente</string>
 	<string name="player_open_full_size_player">Activer pour ouvrir le lecteur grand format</string>
 	<string name="settings_downloads_clean_up">Nettoyer</string>
 	<string name="podcasts_share_failed_description">Un problème est survenu lors de la création de votre page de partage.</string>
@@ -351,7 +372,6 @@ Language: fr
 	<string name="settings_title_storage">Stockage et utilisation des données</string>
 	<string name="settings_title_playback">Général</string>
 	<string name="settings_title_notifications">Notifications</string>
-	<string name="settings_title_manage_downloads">Gérer les téléchargements</string>
 	<string name="settings_title_import_export">Importation et exportation OPML</string>
 	<string name="settings_title_help">Aide et commentaires</string>
 	<string name="settings_title_excluded_podcasts">Podcasts exclus</string>
@@ -367,7 +387,6 @@ Language: fr
 	<string name="settings_storage_move_podcasts">Déplacement des podcasts en cours…</string>
 	<string name="settings_storage_move_message">Cela déplacera les fichiers de podcast existants vers ce nouvel emplacement.</string>
 	<string name="settings_storage_move">Déplacer</string>
-	<string name="settings_storage_manage_downloads">Gérer les fichiers téléchargés</string>
 	<string name="settings_storage_folder_write_failed">Écriture impossible sur ce dossier.</string>
 	<string name="settings_storage_folder_not_found">Le dossier est introuvable ou ne peut pas être créé.</string>
 	<string name="settings_storage_folder_change_failed">Impossible de passer au dossier personnalisé.</string>
@@ -515,7 +534,6 @@ Language: fr
 	<string name="plus_renews_automatically_yearly">Renouvellement annuel automatique</string>
 	<string name="plus_best_value">MEILLEURE VALEUR</string>
 	<string name="plus_select_payment_frequency">Sélectionner une fréquence de paiement</string>
-	<string name="plus_year_month_price">%1$s par an / %2$s par mois</string>
 	<string name="plus_upgrade_to_pocket_casts_plus">Mettre à niveau vers Pocket Casts Plus</string>
 	<string name="plus_trial_finished_locked">L’accès aux fonctionnalités de Pocket Casts Plus sera verrouillé</string>
 	<string name="plus_trial_finished_files_removed">Les fichiers chargés sur votre compte seront supprimés au bout d’une semaine</string>
@@ -526,7 +544,6 @@ Language: fr
 	<string name="plus_themes_icons">Thèmes et icônes</string>
 	<string name="plus_thanks_for_your_support_bang">Merci pour votre soutien !</string>
 	<string name="plus_slash_month">%s /mois</string>
-	<string name="plus_per_month">%s par mois</string>
 	<string name="plus_lifetime_member">Membre à vie</string>
 	<string name="plus_learn_more_button">En savoir plus</string>
 	<string name="plus_learn_more_about_plus">En savoir plus sur Pocket Casts Plus</string>
@@ -632,7 +649,6 @@ Language: fr
 	<string name="profile_payment_failed_detail">Il semble qu’un problème soit survenu lors du traitement de votre paiement. Veuillez réessayer.</string>
 	<string name="profile_payment_failed">Échec du paiement</string>
 	<string name="profile_payment_cancelled">Paiement annulé</string>
-	<string name="profile_pay_now">Payer Maintenant</string>
 	<string name="profile_password_changed_successful">C’est réussi !</string>
 	<string name="profile_password_changed">Mot de passe modifié</string>
 	<string name="profile_password">Mot de passe</string>
@@ -760,7 +776,6 @@ Language: fr
 	<string name="profile_account_created">Compte créé</string>
 	<string name="profile_access_ends">Expiration de l’accès le : %s</string>
 	<string name="profile_access_ended">Accès expiré le : %s</string>
-	<string name="profile_1_year_free">1 an gratuit</string>
 	<string name="profile">Profil</string>
 	<string name="filters_warning_delete_summary">Cette action ne peut pas être annulée.</string>
 	<string name="filters_title_new_releases">Nouvelles versions</string>
@@ -1017,7 +1032,6 @@ Language: fr
 	<string name="player_up_next_empty_desc">Vous pouvez mettre en file d’attente des épisodes à lire par la suite en faisant glisser les lignes d’épisodes vers la droite ou en appuyant sur l’icône d’une carte d’épisode.</string>
 	<string name="player_up_next_empty">Rien dans la file d\'attente </string>
 	<string name="player_up_next_clear_queue_button">Effacer la file d\'attente</string>
-	<string name="player_up_next_clear_queue_summary">L’effacement de votre file d\'attente ne peut pas être annulé</string>
 	<string name="player_up_next_clear_queue">Effacer la file d’attente</string>
 	<string name="player_trim_silence_detail">Réduit la longueur d’un épisode en coupant les silences dans les conversations.</string>
 	<string name="player_time_saved_no_hour">Félicitations ! Vous gagnez du temps et obtenez plus de podcasts.</string>
@@ -1042,7 +1056,6 @@ Language: fr
 	<string name="player_notification_skip_back">Reculer de %d s</string>
 	<string name="player_more_actions">Plus d’actions</string>
 	<string name="player_full_screen">Plein écran</string>
-	<string name="player_end_playback_clear_up_next">Terminer la lecture et effacer la file d\'attente</string>
 	<string name="player_effects_volume_boost">Augmenter le volume</string>
 	<string name="player_effects_voices_sound_louder">Les voix sont plus fortes</string>
 	<string name="player_effects_trim_silence">Couper les silences</string>

--- a/modules/services/localization/src/main/res/values-it/strings.xml
+++ b/modules/services/localization/src/main/res/values-it/strings.xml
@@ -1,11 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2022-08-09 09:54:15+0000
+Translation-Revision-Date: 2022-08-22 13:54:03+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/2.4.0-alpha
 Language: it
 -->
 <resources>
+	<string name="settings_storage_section_heading_mobile_data">Dati dispositivi mobili</string>
+	<string name="settings_storage_section_heading_usage">Utilizzo</string>
+	<string name="settings_storage_downloaded_files">File scaricati</string>
+	<string name="settings_storage_downloaded_bytes">%d byte</string>
+	<string name="plus_per_month">%s al mese</string>
+	<string name="plus_day">giorno</string>
+	<string name="plus_month_year_price">%1$s al mese/%2$s all\'anno</string>
+	<string name="plus_trial_then_slash_year">%1$s gratuito poi %2$s/all\'anno</string>
+	<string name="plus_trial_then_slash_month">%1$s gratuito poi %2$s/al mese</string>
+	<string name="plus_then_slash_year">poi %s/all\'anno</string>
+	<string name="plus_then_slash_month">poi %s/al mese</string>
+	<string name="plus_slash_year">%s all\'anno</string>
+	<string name="plus_per_year">%s all\'anno</string>
+	<string name="plus_trial_duration_free">%s GRATUITO</string>
+	<string name="profile_start_free_trial">Inizia la prova gratuita</string>
+	<string name="profile_per_year">All\'anno</string>
+	<string name="profile_feature_try_trial_secondary_info">Nessun pagamento ora. Cancellazione in qualsiasi momento</string>
+	<string name="profile_feature_try_trial">Prova Pocket Casts Plus gratis per %s</string>
+	<string name="player_up_next_clear_episodes_plural">Cancella %1$d episodi</string>
+	<string name="player_up_next_clear_queue_summary">Desideri cancellare la tua coda Successivo?</string>
+	<string name="player_end_playback_clear_up_next">Chiudi e cancella Successivo</string>
 	<string name="player_open_full_size_player">Attivare per aprire il lettore a grandezza naturale</string>
 	<string name="settings_downloads_clean_up">Cancella</string>
 	<string name="podcasts_share_failed_description">Si è verificato un problema durante la creazione della tua pagina di condivisione.</string>
@@ -351,7 +372,6 @@ Language: it
 	<string name="settings_title_storage">Archiviazione e utilizzo dei dati</string>
 	<string name="settings_title_playback">Generale</string>
 	<string name="settings_title_notifications">Notifiche</string>
-	<string name="settings_title_manage_downloads">Gestisci i file scaricati</string>
 	<string name="settings_title_import_export">Importa ed esporta OPML</string>
 	<string name="settings_title_help">Supporto e feedback</string>
 	<string name="settings_title_excluded_podcasts">Podcast esclusi</string>
@@ -367,7 +387,6 @@ Language: it
 	<string name="settings_storage_move_podcasts">Spostamento dei podcast in corso...</string>
 	<string name="settings_storage_move_message">Questa opzione sposterà i file dei podcast esistenti in questa nuova posizione.</string>
 	<string name="settings_storage_move">Sposta</string>
-	<string name="settings_storage_manage_downloads">Gestisci i file scaricati</string>
 	<string name="settings_storage_folder_write_failed">Questa cartella non può essere scritta.</string>
 	<string name="settings_storage_folder_not_found">Questa cartella non può essere cercata o creata.</string>
 	<string name="settings_storage_folder_change_failed">Impossibile cambiare in cartella personalizzata.</string>
@@ -515,7 +534,6 @@ Language: it
 	<string name="plus_renews_automatically_yearly">Si rinnova automaticamente ogni anno</string>
 	<string name="plus_best_value">VALORE MIGLIORE</string>
 	<string name="plus_select_payment_frequency">Seleziona la frequenza di pagamento</string>
-	<string name="plus_year_month_price">%1$s all\'anno/%2$s al mese</string>
 	<string name="plus_upgrade_to_pocket_casts_plus">Aggiorna a Pocket Casts Plus</string>
 	<string name="plus_trial_finished_locked">L\'accesso alle funzionalità di Pocket Casts Plus verrà bloccato</string>
 	<string name="plus_trial_finished_files_removed">I file caricati sul tuo account verranno rimossi dopo una settimana</string>
@@ -525,8 +543,7 @@ Language: it
 	<string name="plus_themes_icons_body">Mostra i tuoi reali colori. Icone e temi esclusivi solo per chi fa parte del club Plus.</string>
 	<string name="plus_themes_icons">Temi e icone</string>
 	<string name="plus_thanks_for_your_support_bang">Grazie per il supporto.</string>
-	<string name="plus_slash_month">%s al mese</string>
-	<string name="plus_per_month">%s al mese</string>
+	<string name="plus_slash_month">%s/al mese</string>
 	<string name="plus_lifetime_member">Membro a vita</string>
 	<string name="plus_learn_more_button">Scopri di più</string>
 	<string name="plus_learn_more_about_plus">Scopri di più su Pocket Casts Plus</string>
@@ -632,7 +649,6 @@ Language: it
 	<string name="profile_payment_failed_detail">Sembra che si sia verificato un problema durante l\'elaborazione del pagamento. Riprova.</string>
 	<string name="profile_payment_failed">Pagamento non riuscito</string>
 	<string name="profile_payment_cancelled">Pagamento annullato</string>
-	<string name="profile_pay_now">Paga ora</string>
 	<string name="profile_password_changed_successful">Operazione completata.</string>
 	<string name="profile_password_changed">Password modificata</string>
 	<string name="profile_password">Password</string>
@@ -760,7 +776,6 @@ Language: it
 	<string name="profile_account_created">Account creato</string>
 	<string name="profile_access_ends">L\'accesso termina: %s</string>
 	<string name="profile_access_ended">L\'accesso è terminato: %s</string>
-	<string name="profile_1_year_free">1 anno gratis</string>
 	<string name="profile">Profilo</string>
 	<string name="filters_warning_delete_summary">Questa operazione non può essere annullata.</string>
 	<string name="filters_title_new_releases">Nuovi episodi</string>
@@ -1017,7 +1032,6 @@ Language: it
 	<string name="player_up_next_empty_desc">Puoi mettere in coda gli episodi per la riproduzione scorrendo verso destra sulle righe degli episodi o toccando l\'icona sulla scheda di un episodio.</string>
 	<string name="player_up_next_empty">Lista Prossimo vuota</string>
 	<string name="player_up_next_clear_queue_button">Cancella Prossimo</string>
-	<string name="player_up_next_clear_queue_summary">La cancellazione dell\'elenco Prossimo non può essere annullata</string>
 	<string name="player_up_next_clear_queue">Cancella la coda</string>
 	<string name="player_trim_silence_detail">Riduce la durata di un episodio tagliando il silenzio durante le conversazioni.</string>
 	<string name="player_time_saved_no_hour">Congratulazioni! Stai risparmiando tempo e ascoltando più podcast.</string>
@@ -1042,7 +1056,6 @@ Language: it
 	<string name="player_notification_skip_back">Indietro di %d secondi</string>
 	<string name="player_more_actions">Altre azioni</string>
 	<string name="player_full_screen">Schermo intero</string>
-	<string name="player_end_playback_clear_up_next">Interrompi la riproduzione e cancella Prossimo</string>
 	<string name="player_effects_volume_boost">Aumenta il volume</string>
 	<string name="player_effects_voices_sound_louder">Volume più alto del solito</string>
 	<string name="player_effects_trim_silence">Taglia i silenzi</string>

--- a/modules/services/localization/src/main/res/values-ja/strings.xml
+++ b/modules/services/localization/src/main/res/values-ja/strings.xml
@@ -1,11 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2022-07-26 09:54:03+0000
+Translation-Revision-Date: 2022-08-25 09:54:03+0000
 Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/2.4.0-alpha
 Language: ja_JP
 -->
 <resources>
+	<string name="settings_storage_section_heading_mobile_data">モバイルデータ</string>
+	<string name="settings_storage_section_heading_usage">使用量</string>
+	<string name="settings_storage_downloaded_files">ダウンロード済みファイル</string>
+	<string name="settings_storage_downloaded_bytes">%dバイト</string>
+	<string name="plus_per_month">%s / 月</string>
+	<string name="plus_day">日</string>
+	<string name="plus_month_year_price">月額%1$s / 年額%2$s</string>
+	<string name="plus_trial_then_slash_year">%1$s 無料の後 %2$s / 年</string>
+	<string name="plus_trial_then_slash_month">%1$s 無料の後 %2$s / 月</string>
+	<string name="plus_then_slash_year">後 %s / 年</string>
+	<string name="plus_then_slash_month">後 %s/ 年</string>
+	<string name="plus_slash_year">後 %s / 年</string>
+	<string name="plus_per_year">%s / 年</string>
+	<string name="plus_trial_duration_free">%s無料</string>
+	<string name="profile_start_free_trial">無料お試しを開始する</string>
+	<string name="profile_per_year">/年</string>
+	<string name="profile_feature_try_trial_secondary_info">無料でお試ししていつでもキャンセル可能</string>
+	<string name="profile_feature_try_trial">%s で Pocket Casts Plus を無料でお試し</string>
+	<string name="player_up_next_clear_episodes_plural">%1$d件のエピソードをクリア</string>
+	<string name="player_up_next_clear_queue_summary">次のエピソード待機リストをクリアしてもよろしいですか ?</string>
+	<string name="player_end_playback_clear_up_next">閉じて次をクリア</string>
+	<string name="player_open_full_size_player">有効化してプレーヤーをフルサイズで開く</string>
 	<string name="settings_downloads_clean_up">クリーンアップ</string>
 	<string name="podcasts_share_failed_description">共有ページの作成中に問題が発生しました。</string>
 	<string name="podcasts_share_failed">共有に失敗</string>
@@ -350,7 +372,6 @@ Language: ja_JP
 	<string name="settings_title_storage">ストレージとデータ使用量</string>
 	<string name="settings_title_playback">全般</string>
 	<string name="settings_title_notifications">通知</string>
-	<string name="settings_title_manage_downloads">ダウンロードを管理</string>
 	<string name="settings_title_import_export">OPML をインポート / エクスポート</string>
 	<string name="settings_title_help">ヘルプ &amp; フィードバック</string>
 	<string name="settings_title_excluded_podcasts">除外されたポッドキャスト</string>
@@ -366,7 +387,6 @@ Language: ja_JP
 	<string name="settings_storage_move_podcasts">ポッドキャストを移動しています…</string>
 	<string name="settings_storage_move_message">既存のポッドキャストファイルがこちらの新しい場所に移動します。</string>
 	<string name="settings_storage_move">移動</string>
-	<string name="settings_storage_manage_downloads">ダウンロード済みファイルを管理</string>
 	<string name="settings_storage_folder_write_failed">このフォルダーには書き込めません。</string>
 	<string name="settings_storage_folder_not_found">フォルダーが見つからないか作成できません。</string>
 	<string name="settings_storage_folder_change_failed">カスタムフォルダーに変更できません。</string>
@@ -514,7 +534,6 @@ Language: ja_JP
 	<string name="plus_renews_automatically_yearly">毎年自動更新</string>
 	<string name="plus_best_value">最高の価値</string>
 	<string name="plus_select_payment_frequency">支払頻度を選択</string>
-	<string name="plus_year_month_price">年額%1$s / 月額%2$s</string>
 	<string name="plus_upgrade_to_pocket_casts_plus">Pocket Casts Plus にアップグレード</string>
 	<string name="plus_trial_finished_locked">Pocket Casts Plus の機能が利用できなくなります</string>
 	<string name="plus_trial_finished_files_removed">アカウントにアップロードされたファイルは1週間後に削除されます</string>
@@ -525,7 +544,6 @@ Language: ja_JP
 	<string name="plus_themes_icons">テーマとアイコン</string>
 	<string name="plus_thanks_for_your_support_bang">ご支援いただきありがとうございます。</string>
 	<string name="plus_slash_month">%s / 月</string>
-	<string name="plus_per_month">%s / 月</string>
 	<string name="plus_lifetime_member">無期限メンバー</string>
 	<string name="plus_learn_more_button">もっと詳しく知る</string>
 	<string name="plus_learn_more_about_plus">Pocket Casts Plus の詳細</string>
@@ -631,7 +649,6 @@ Language: ja_JP
 	<string name="profile_payment_failed_detail">支払の処理で問題が発生したようです。 もう一度お試しください。</string>
 	<string name="profile_payment_failed">支払いに失敗しました</string>
 	<string name="profile_payment_cancelled">支払いをキャンセル済み</string>
-	<string name="profile_pay_now">今すぐ払う</string>
 	<string name="profile_password_changed_successful">成功しました !</string>
 	<string name="profile_password_changed">パスワードを変更済み</string>
 	<string name="profile_password">パスワード</string>
@@ -759,7 +776,6 @@ Language: ja_JP
 	<string name="profile_account_created">アカウントを作成済み</string>
 	<string name="profile_access_ends">アクセス権終了予定日: %s</string>
 	<string name="profile_access_ended">アクセス権終了日: %s</string>
-	<string name="profile_1_year_free">1年間無料</string>
 	<string name="profile">プロフィール</string>
 	<string name="filters_warning_delete_summary">この操作は元に戻すことができません。</string>
 	<string name="filters_title_new_releases">新規リリース</string>
@@ -1016,7 +1032,6 @@ Language: ja_JP
 	<string name="player_up_next_empty_desc">エピソード行を右にスワイプするか、エピソードカードのアイコンをタップすることで、次に再生するエピソードを待機リストに追加できます。</string>
 	<string name="player_up_next_empty">次のエピソードには何もありません</string>
 	<string name="player_up_next_clear_queue_button">次のエピソードをクリア</string>
-	<string name="player_up_next_clear_queue_summary">次のエピソードリストのクリアは元に戻すことができません</string>
 	<string name="player_up_next_clear_queue">待機リストをクリア</string>
 	<string name="player_trim_silence_detail">会話の間にある沈黙時間をカットしてエピソードを短縮します。</string>
 	<string name="player_time_saved_no_hour">おめでとうございます ! 時間を節約してより多くのポッドキャストを聴いています。</string>
@@ -1041,7 +1056,6 @@ Language: ja_JP
 	<string name="player_notification_skip_back">%d秒巻き戻し</string>
 	<string name="player_more_actions">その他の操作</string>
 	<string name="player_full_screen">フルスクリーン表示</string>
-	<string name="player_end_playback_clear_up_next">再生を終了して次のエピソードをクリア</string>
 	<string name="player_effects_volume_boost">ボリュームブースト</string>
 	<string name="player_effects_voices_sound_louder">音声のボリュームをアップ</string>
 	<string name="player_effects_trim_silence">無音時間をカット</string>

--- a/modules/services/localization/src/main/res/values-nb/strings.xml
+++ b/modules/services/localization/src/main/res/values-nb/strings.xml
@@ -341,7 +341,6 @@ Language: nb_NO
 	<string name="settings_title_storage">Lagring og databruk</string>
 	<string name="settings_title_playback">Generelt</string>
 	<string name="settings_title_notifications">Varslinger</string>
-	<string name="settings_title_manage_downloads">Administrer nedlastinger</string>
 	<string name="settings_title_import_export">Importer og eksporter OPML</string>
 	<string name="settings_title_help">Hjelp og tilbakemeldinger</string>
 	<string name="settings_title_excluded_podcasts">Utelatte podcaster</string>
@@ -357,7 +356,6 @@ Language: nb_NO
 	<string name="settings_storage_move_podcasts">Flytter podcaster …</string>
 	<string name="settings_storage_move_message">Dette vil flytte eksisterende podcast-filer til den nye plasseringen.</string>
 	<string name="settings_storage_move">Flytt</string>
-	<string name="settings_storage_manage_downloads">Administrer nedlastede filer</string>
 	<string name="settings_storage_folder_write_failed">Denne mappen kan ikke skrives til.</string>
 	<string name="settings_storage_folder_not_found">Finner ikke mappen, eller den kan ikke opprettes.</string>
 	<string name="settings_storage_folder_change_failed">Kan ikke bytte til egendefinert mappe.</string>
@@ -505,7 +503,6 @@ Language: nb_NO
 	<string name="plus_renews_automatically_yearly">Fornyes automatisk per år</string>
 	<string name="plus_best_value">BESTE VERDI</string>
 	<string name="plus_select_payment_frequency">Velg betalingshyppighet</string>
-	<string name="plus_year_month_price">%1$s per år / %2$s per måned</string>
 	<string name="plus_upgrade_to_pocket_casts_plus">Oppgrader til Pocket Casts Plus</string>
 	<string name="plus_trial_finished_locked">Tilgang til Pocket Casts Plus-funksjoner blir sperret</string>
 	<string name="plus_trial_finished_files_removed">Filer lastet opp til kontoen din blir fjernet etter en uke</string>
@@ -515,8 +512,6 @@ Language: nb_NO
 	<string name="plus_themes_icons_body">Vis ditt sanne jeg. Eksklusive ikoner og temaer kun for Plus-klubben.</string>
 	<string name="plus_themes_icons">Temaer og ikoner</string>
 	<string name="plus_thanks_for_your_support_bang">Takk for støtten!</string>
-	<string name="plus_per_month">%s / måned</string>
-	<string name="plus_month_price">%s per måned</string>
 	<string name="plus_lifetime_member">Livstidsmedlem</string>
 	<string name="plus_learn_more_button">Finn ut mer</string>
 	<string name="plus_learn_more_about_plus">Finn ut mer om Pocket Casts Plus</string>
@@ -622,7 +617,6 @@ Language: nb_NO
 	<string name="profile_payment_failed_detail">Det virker som det oppstod et problem under behandling av betalingen. Prøv på nytt.</string>
 	<string name="profile_payment_failed">Betaling mislyktes</string>
 	<string name="profile_payment_cancelled">Betaling kansellert</string>
-	<string name="profile_pay_now">Betal nå</string>
 	<string name="profile_password_changed_successful">Vellykket!</string>
 	<string name="profile_password_changed">Passord endret</string>
 	<string name="profile_password">Passord</string>
@@ -750,7 +744,6 @@ Language: nb_NO
 	<string name="profile_account_created">Konto opprettet</string>
 	<string name="profile_access_ends">Tilgang avsluttes: %s</string>
 	<string name="profile_access_ended">Tilgang avsluttet: %s</string>
-	<string name="profile_1_year_free">1 år gratis</string>
 	<string name="profile">Profil</string>
 	<string name="filters_warning_delete_summary">Dette kan ikke angres.</string>
 	<string name="filters_title_new_releases">Nye utgivelser</string>
@@ -1007,7 +1000,6 @@ Language: nb_NO
 	<string name="player_up_next_empty_desc">Du kan sette episoder i kø for avspilling ved å sveipe til høyre på episoderader eller ved å trykke på ikonet på et episodekort.</string>
 	<string name="player_up_next_empty">Ingenting i Neste</string>
 	<string name="player_up_next_clear_queue_button">Tøm Neste</string>
-	<string name="player_up_next_clear_queue_summary">Tømming av Neste-listen kan ikke angres</string>
 	<string name="player_up_next_clear_queue">Tøm kø</string>
 	<string name="player_trim_silence_detail">Reduserer lengden på en episode ved å kutte bort stillhet i samtaler.</string>
 	<string name="player_time_saved_no_hour">Gratulerer! Du sparer tid og kan gå gjennom flere podcaster.</string>
@@ -1032,7 +1024,6 @@ Language: nb_NO
 	<string name="player_notification_skip_back">Tilbake %d sekunder</string>
 	<string name="player_more_actions">Flere handlinger</string>
 	<string name="player_full_screen">Full skjerm</string>
-	<string name="player_end_playback_clear_up_next">Avslutt avspilling og tøm Neste</string>
 	<string name="player_effects_volume_boost">Volumøkning</string>
 	<string name="player_effects_voices_sound_louder">Stemmer blir høyere</string>
 	<string name="player_effects_trim_silence">Kutt av stillhet</string>

--- a/modules/services/localization/src/main/res/values-nl/strings.xml
+++ b/modules/services/localization/src/main/res/values-nl/strings.xml
@@ -1,11 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2022-08-09 14:54:03+0000
+Translation-Revision-Date: 2022-08-23 14:54:03+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/2.4.0-alpha
 Language: nl
 -->
 <resources>
+	<string name="settings_storage_section_heading_mobile_data">Mobiele data</string>
+	<string name="settings_storage_section_heading_usage">Gebruik</string>
+	<string name="settings_storage_downloaded_files">Gedownloade bestanden</string>
+	<string name="settings_storage_downloaded_bytes">%d bytes</string>
+	<string name="plus_per_month">%s per maand</string>
+	<string name="plus_day">dag</string>
+	<string name="plus_month_year_price">%1$s per jaar/%2$s per maand</string>
+	<string name="plus_trial_then_slash_year">%1$s gratis, daarna %2$s per jaar</string>
+	<string name="plus_trial_then_slash_month">%1$s gratis, daarna %2$s per maand</string>
+	<string name="plus_then_slash_year">daarna %s per jaar</string>
+	<string name="plus_then_slash_month">daarna %s per maand</string>
+	<string name="plus_slash_year">%s per jaar</string>
+	<string name="plus_per_year">%s per jaar</string>
+	<string name="plus_trial_duration_free">%s GRATIS</string>
+	<string name="profile_start_free_trial">Gratis proefversie starten</string>
+	<string name="profile_per_year">Per jaar</string>
+	<string name="profile_feature_try_trial_secondary_info">Nu geen betalingen - Annuleer wanneer je wilt</string>
+	<string name="profile_feature_try_trial">Probeer Pocket Casts Plus gratis voor %s</string>
+	<string name="player_up_next_clear_episodes_plural">%1$d afleveringen wissen</string>
+	<string name="player_up_next_clear_queue_summary">Weet je zeker dat je je wachtrij Hierna wilt wissen?</string>
+	<string name="player_end_playback_clear_up_next">Sluit en wis Hierna</string>
 	<string name="player_open_full_size_player">Activeer om de speler op volledige grootte te openen</string>
 	<string name="settings_downloads_clean_up">Opschonen</string>
 	<string name="podcasts_share_failed_description">Er is iets verkeerd gegaan tijdens het aanmaken van je deelpagina.</string>
@@ -351,7 +372,6 @@ Language: nl
 	<string name="settings_title_storage">Gebruik van opslag en data</string>
 	<string name="settings_title_playback">Algemeen</string>
 	<string name="settings_title_notifications">Meldingen</string>
-	<string name="settings_title_manage_downloads">Downloads beheren</string>
 	<string name="settings_title_import_export">OPML importeren/exporteren</string>
 	<string name="settings_title_help">Hulp en feedback</string>
 	<string name="settings_title_excluded_podcasts">Uitgesloten podcasts</string>
@@ -367,7 +387,6 @@ Language: nl
 	<string name="settings_storage_move_podcasts">Podcasts verplaatsen...</string>
 	<string name="settings_storage_move_message">Hierdoor worden bestaande podcastbestanden verplaatst naar deze nieuwe locatie.</string>
 	<string name="settings_storage_move">Verplaats</string>
-	<string name="settings_storage_manage_downloads">Gedownloade bestanden beheren</string>
 	<string name="settings_storage_folder_write_failed">Er kan niet naar deze map geschreven worden.</string>
 	<string name="settings_storage_folder_not_found">De map kan niet gevonden of aangemaakt worden.</string>
 	<string name="settings_storage_folder_change_failed">Kan niet wijzigen naar aangepaste map.</string>
@@ -515,7 +534,6 @@ Language: nl
 	<string name="plus_renews_automatically_yearly">Automatisch jaarlijks verlengen</string>
 	<string name="plus_best_value">BESTE KOOP</string>
 	<string name="plus_select_payment_frequency">Selecteer betaalfrequentie</string>
-	<string name="plus_year_month_price">%1$s per jaar/%2$s per maand</string>
 	<string name="plus_upgrade_to_pocket_casts_plus">Upgraden naar Pocket Casts Plus</string>
 	<string name="plus_trial_finished_locked">Toegang tot Pocket Casts Plus-functies worden vergrendeld</string>
 	<string name="plus_trial_finished_files_removed">Bestanden die worden geüpload naar uw account worden na een week verwijderd</string>
@@ -526,7 +544,6 @@ Language: nl
 	<string name="plus_themes_icons">Thema\'s en pictogrammen</string>
 	<string name="plus_thanks_for_your_support_bang">Bedankt voor je ondersteuning!</string>
 	<string name="plus_slash_month">%s / maand</string>
-	<string name="plus_per_month">%s per maand</string>
 	<string name="plus_lifetime_member">Levenslang lid</string>
 	<string name="plus_learn_more_button">Meer weten</string>
 	<string name="plus_learn_more_about_plus">Bekijk meer informatie over Pocket Casts Plus</string>
@@ -632,7 +649,6 @@ Language: nl
 	<string name="profile_payment_failed_detail">Het lijkt erop dat er een probleem is opgetreden bij het verwerken van je betaling. Probeer het nog eens.</string>
 	<string name="profile_payment_failed">Betaling mislukt.</string>
 	<string name="profile_payment_cancelled">Betaling geannuleerd</string>
-	<string name="profile_pay_now">Nu betalen</string>
 	<string name="profile_password_changed_successful">Gelukt!</string>
 	<string name="profile_password_changed">Wachtwoord veranderd</string>
 	<string name="profile_password">Wachtwoord</string>
@@ -760,7 +776,6 @@ Language: nl
 	<string name="profile_account_created">Account aangemaakt.</string>
 	<string name="profile_access_ends">Toegang eindigt: %s</string>
 	<string name="profile_access_ended">Toegang beëindigd: %s</string>
-	<string name="profile_1_year_free">1 jaar gratis</string>
 	<string name="profile">Profiel</string>
 	<string name="filters_warning_delete_summary">Deze actie kan niet ongedaan worden gemaakt.</string>
 	<string name="filters_title_new_releases">Nieuwe uitgaven</string>
@@ -1017,7 +1032,6 @@ Language: nl
 	<string name="player_up_next_empty_desc">U kunt afleveringen in de wachtrij zetten door naar rechts te swipen in afleveringrijen of door op het pictogram op een afleveringkaart te tikken.</string>
 	<string name="player_up_next_empty">Niets in Hierna</string>
 	<string name="player_up_next_clear_queue_button">Hierna wissen</string>
-	<string name="player_up_next_clear_queue_summary">Het wissen van je Hierna-lijst kan niet ongedaan gemaakt worden</string>
 	<string name="player_up_next_clear_queue">Wachtrij wissen</string>
 	<string name="player_trim_silence_detail">Vermindert de duur van een aflevering door stilte in gesprekken weg te filteren.</string>
 	<string name="player_time_saved_no_hour">Gefeliciteerd! Je bespaart tijd en kunt meer podcasts luisteren.</string>
@@ -1042,7 +1056,6 @@ Language: nl
 	<string name="player_notification_skip_back">%d seconden terugspoelen</string>
 	<string name="player_more_actions">Meer acties</string>
 	<string name="player_full_screen">Volledig scherm</string>
-	<string name="player_end_playback_clear_up_next">Afspelen beëindigen en Hierna wissen</string>
 	<string name="player_effects_volume_boost">Volumeboost</string>
 	<string name="player_effects_voices_sound_louder">Stemmen klinken luider</string>
 	<string name="player_effects_trim_silence">Stiltes wegfilteren</string>

--- a/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
+++ b/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
@@ -1,11 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2022-08-08 15:54:03+0000
+Translation-Revision-Date: 2022-08-22 15:54:03+0000
 Plural-Forms: nplurals=2; plural=(n > 1);
 Generator: GlotPress/2.4.0-alpha
 Language: pt_BR
 -->
 <resources>
+	<string name="settings_storage_section_heading_mobile_data">Dados móveis</string>
+	<string name="settings_storage_section_heading_usage">Uso</string>
+	<string name="settings_storage_downloaded_files">Arquivos baixados</string>
+	<string name="settings_storage_downloaded_bytes">%d bytes</string>
+	<string name="plus_per_month">%s por mês</string>
+	<string name="plus_day">dia</string>
+	<string name="plus_month_year_price">%1$s por mês/%2$s por ano</string>
+	<string name="plus_trial_then_slash_year">%1$s grátis; depois, %2$s/ano</string>
+	<string name="plus_trial_then_slash_month">%1$s grátis; depois, %2$s/mês</string>
+	<string name="plus_then_slash_year">depois, %s/ano</string>
+	<string name="plus_then_slash_month">depois, %s/mês</string>
+	<string name="plus_slash_year">%s/ano</string>
+	<string name="plus_per_year">%s por ano</string>
+	<string name="plus_trial_duration_free">%s GRÁTIS</string>
+	<string name="profile_start_free_trial">Iniciar teste gratuito</string>
+	<string name="profile_per_year">Por ano</string>
+	<string name="profile_feature_try_trial_secondary_info">Sem pagamento por enquanto, cancele quando quiser</string>
+	<string name="profile_feature_try_trial">Experimente o Pocket Casts Plus de graça por %s</string>
+	<string name="player_up_next_clear_episodes_plural">Apagar %1$d episódios</string>
+	<string name="player_up_next_clear_queue_summary">Tem certeza de que deseja limpar sua fila Próximos?</string>
+	<string name="player_end_playback_clear_up_next">Fechar e limpar Próximos</string>
 	<string name="player_open_full_size_player">Ative para abrir o reprodutor no tamanho original</string>
 	<string name="settings_downloads_clean_up">Limpar</string>
 	<string name="podcasts_share_failed_description">Ocorreu um erro ao criar sua página de compartilhamento.</string>
@@ -351,7 +372,6 @@ Language: pt_BR
 	<string name="settings_title_storage">Armazenamento e uso de dados</string>
 	<string name="settings_title_playback">Geral</string>
 	<string name="settings_title_notifications">Notificações</string>
-	<string name="settings_title_manage_downloads">Gerenciar downloads</string>
 	<string name="settings_title_import_export">Importar/exportar OPML</string>
 	<string name="settings_title_help">Ajuda e feedback</string>
 	<string name="settings_title_excluded_podcasts">Podcasts excluídos</string>
@@ -367,7 +387,6 @@ Language: pt_BR
 	<string name="settings_storage_move_podcasts">Movendo podcasts…</string>
 	<string name="settings_storage_move_message">Isso moverá os arquivos de podcasts existentes para este novo local.</string>
 	<string name="settings_storage_move">Mover</string>
-	<string name="settings_storage_manage_downloads">Gerenciar arquivos baixados</string>
 	<string name="settings_storage_folder_write_failed">Não é possível gravar nesta pasta.</string>
 	<string name="settings_storage_folder_not_found">Não é possível encontrar ou criar a pasta.</string>
 	<string name="settings_storage_folder_change_failed">Não foi possível trocar para pasta personalizada.</string>
@@ -515,7 +534,6 @@ Language: pt_BR
 	<string name="plus_renews_automatically_yearly">Renovado automaticamente todo ano</string>
 	<string name="plus_best_value">MELHOR VALOR</string>
 	<string name="plus_select_payment_frequency">Selecione a frequência de pagamento</string>
-	<string name="plus_year_month_price">%1$s por ano / %2$s por mês</string>
 	<string name="plus_upgrade_to_pocket_casts_plus">Fazer upgrade para Pocket Casts Plus</string>
 	<string name="plus_trial_finished_locked">O acesso às funcionalidades do Pocket Casts Plus será bloqueado</string>
 	<string name="plus_trial_finished_files_removed">Os arquivos enviados para a sua conta serão removidos após uma semana</string>
@@ -525,8 +543,7 @@ Language: pt_BR
 	<string name="plus_themes_icons_body">Expresse sua individualidade. Temas e ícones exclusivos para o Plus.</string>
 	<string name="plus_themes_icons">Temas e ícones</string>
 	<string name="plus_thanks_for_your_support_bang">Obrigado pelo apoio!</string>
-	<string name="plus_slash_month">%s / mês</string>
-	<string name="plus_per_month">%s por mês</string>
+	<string name="plus_slash_month">%s/mês</string>
 	<string name="plus_lifetime_member">Membro vitalício</string>
 	<string name="plus_learn_more_button">Saiba mais</string>
 	<string name="plus_learn_more_about_plus">Saiba mais sobre o Pocket Casts Plus</string>
@@ -632,7 +649,6 @@ Language: pt_BR
 	<string name="profile_payment_failed_detail">Houve um problema no processamento do pagamento. Tente novamente.</string>
 	<string name="profile_payment_failed">Falha no pagamento</string>
 	<string name="profile_payment_cancelled">Pagamento cancelado</string>
-	<string name="profile_pay_now">Pagar agora</string>
 	<string name="profile_password_changed_successful">Sucesso!</string>
 	<string name="profile_password_changed">Senha alterada</string>
 	<string name="profile_password">Senha</string>
@@ -760,7 +776,6 @@ Language: pt_BR
 	<string name="profile_account_created">Conta criada</string>
 	<string name="profile_access_ends">O acesso termina em: %s</string>
 	<string name="profile_access_ended">O acesso terminou em: %s</string>
-	<string name="profile_1_year_free">1 ano grátis</string>
 	<string name="profile">Perfil</string>
 	<string name="filters_warning_delete_summary">Essa ação não pode ser desfeita.</string>
 	<string name="filters_title_new_releases">Lançamentos</string>
@@ -1017,7 +1032,6 @@ Language: pt_BR
 	<string name="player_up_next_empty_desc">Você pode enfileirar episódios para serem reproduzidos arrastando para a direita nas linhas de episódios ou tocando no ícone no cartão de um episódio.</string>
 	<string name="player_up_next_empty">Nada na fila de Próximos</string>
 	<string name="player_up_next_clear_queue_button">Limpar Próximos</string>
-	<string name="player_up_next_clear_queue_summary">A ação de limpar sua lista de Próximos não pode ser desfeita</string>
 	<string name="player_up_next_clear_queue">Limpar fila</string>
 	<string name="player_trim_silence_detail">Reduza a duração do episódio cortando os momentos de silêncio nas conversas.</string>
 	<string name="player_time_saved_no_hour">Parabéns! Você está economizando tempo e ouvindo mais podcasts.</string>
@@ -1042,7 +1056,6 @@ Language: pt_BR
 	<string name="player_notification_skip_back">Voltar %ds</string>
 	<string name="player_more_actions">Mais ações</string>
 	<string name="player_full_screen">Tela cheia</string>
-	<string name="player_end_playback_clear_up_next">Terminar reprodução e limpar Próximos</string>
 	<string name="player_effects_volume_boost">Aumentar volume</string>
 	<string name="player_effects_voices_sound_louder">Vozes mais altas</string>
 	<string name="player_effects_trim_silence">Cortar momentos de silêncio</string>

--- a/modules/services/localization/src/main/res/values-ru/strings.xml
+++ b/modules/services/localization/src/main/res/values-ru/strings.xml
@@ -1,11 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2022-08-08 13:54:02+0000
+Translation-Revision-Date: 2022-08-23 09:54:03+0000
 Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);
 Generator: GlotPress/2.4.0-alpha
 Language: ru
 -->
 <resources>
+	<string name="settings_storage_section_heading_mobile_data">Мобильные данные</string>
+	<string name="settings_storage_section_heading_usage">Использование</string>
+	<string name="settings_storage_downloaded_files">Скачанные файлы</string>
+	<string name="settings_storage_downloaded_bytes">%d байтов</string>
+	<string name="plus_per_month">%s за месяц</string>
+	<string name="plus_day">день</string>
+	<string name="plus_month_year_price">%1$s в месяц/%2$s в год</string>
+	<string name="plus_trial_then_slash_year">%1$s бесплатно, затем %2$s в год</string>
+	<string name="plus_trial_then_slash_month">%1$s бесплатно, затем %2$s в месяц</string>
+	<string name="plus_then_slash_year">затем %s в год</string>
+	<string name="plus_then_slash_month">затем %s в месяц</string>
+	<string name="plus_slash_year">%s в год</string>
+	<string name="plus_per_year">%s в год</string>
+	<string name="plus_trial_duration_free">%s БЕСПЛАТНО</string>
+	<string name="profile_start_free_trial">Запустить бесплатную пробную версию</string>
+	<string name="profile_per_year">В год</string>
+	<string name="profile_feature_try_trial_secondary_info">Пользуйтесь бесплатно или отмените в любой момент</string>
+	<string name="profile_feature_try_trial">Испытайте Pocket Casts Plus бесплатно в течение %s</string>
+	<string name="player_up_next_clear_episodes_plural">Удалить выпуски (%1$d)</string>
+	<string name="player_up_next_clear_queue_summary">Очистить очередь \"Следующие\"?</string>
+	<string name="player_end_playback_clear_up_next">Закрыть и очистить очередь</string>
 	<string name="player_open_full_size_player">Активируйте, чтобы открыть плеер в полном размере</string>
 	<string name="settings_downloads_clean_up">Очистить</string>
 	<string name="podcasts_share_failed_description">При создании общей страницы произошла ошибка.</string>
@@ -351,7 +372,6 @@ Language: ru
 	<string name="settings_title_storage">Использование хранилища и данных</string>
 	<string name="settings_title_playback">Общие</string>
 	<string name="settings_title_notifications">Уведомления</string>
-	<string name="settings_title_manage_downloads">Управлять скачиваниями</string>
 	<string name="settings_title_import_export">Импорт и экспорт OPML</string>
 	<string name="settings_title_help">Помощь и отзывы</string>
 	<string name="settings_title_excluded_podcasts">Исключенные подкасты</string>
@@ -367,7 +387,6 @@ Language: ru
 	<string name="settings_storage_move_podcasts">Переношу подкасты…</string>
 	<string name="settings_storage_move_message">Это приведёт к перемещению существующих файлов подкастов в указанное новое место.</string>
 	<string name="settings_storage_move">Переместить</string>
-	<string name="settings_storage_manage_downloads">Управление скачанными файлами</string>
 	<string name="settings_storage_folder_write_failed">Запись в эту папку невозможна.</string>
 	<string name="settings_storage_folder_not_found">Невозможно найти или создать папку.</string>
 	<string name="settings_storage_folder_change_failed">Не удаётся перейти в пользовательскую папку.</string>
@@ -515,7 +534,6 @@ Language: ru
 	<string name="plus_renews_automatically_yearly">Ежегодное автоматическое продление</string>
 	<string name="plus_best_value">ЛУЧШАЯ ЦЕНА</string>
 	<string name="plus_select_payment_frequency">Выбрать срок оплаты</string>
-	<string name="plus_year_month_price">%1$s в год/%2$s в месяц</string>
 	<string name="plus_upgrade_to_pocket_casts_plus">Обновить до Pocket Casts Plus</string>
 	<string name="plus_trial_finished_locked">Доступ к функциям Pocket Casts Plus будет заблокирован</string>
 	<string name="plus_trial_finished_files_removed">Файлы, загруженные в вашу учётную запись, будут удалены через неделю</string>
@@ -526,7 +544,6 @@ Language: ru
 	<string name="plus_themes_icons">Темы и значки</string>
 	<string name="plus_thanks_for_your_support_bang">Спасибо за вашу поддержку!</string>
 	<string name="plus_slash_month">%s в месяц</string>
-	<string name="plus_per_month">%s за месяц</string>
 	<string name="plus_lifetime_member">Пожизненное членство</string>
 	<string name="plus_learn_more_button">Подробнее</string>
 	<string name="plus_learn_more_about_plus">Подробнее о Pocket Casts Plus</string>
@@ -632,7 +649,6 @@ Language: ru
 	<string name="profile_payment_failed_detail">Похоже, что при обработке вашего платежа возникла проблема. Повторите попытку.</string>
 	<string name="profile_payment_failed">Не удалось оплатить.</string>
 	<string name="profile_payment_cancelled">Оплата отменена</string>
-	<string name="profile_pay_now">Оплатить сейчас</string>
 	<string name="profile_password_changed_successful">Успешно!</string>
 	<string name="profile_password_changed">Пароль изменен</string>
 	<string name="profile_password">Пароль</string>
@@ -760,7 +776,6 @@ Language: ru
 	<string name="profile_account_created">Учетная запись создана</string>
 	<string name="profile_access_ends">Доступ прекращается: %s</string>
 	<string name="profile_access_ended">Доступ прекращён: %s</string>
-	<string name="profile_1_year_free">1 год бесплатно</string>
 	<string name="profile">Профиль</string>
 	<string name="filters_warning_delete_summary">Это действие нельзя отменить.</string>
 	<string name="filters_title_new_releases">Новые выпуски</string>
@@ -1017,7 +1032,6 @@ Language: ru
 	<string name="player_up_next_empty_desc">Вы можете поместить выпуски в очередь для последующего воспроизведения, проведя пальцем вправо по строкам выпусков или коснувшись значка на карточке выпуска.</string>
 	<string name="player_up_next_empty">Очередь пуста</string>
 	<string name="player_up_next_clear_queue_button">Очистить «Следующие»</string>
-	<string name="player_up_next_clear_queue_summary">Очистку списка «Следующие» отменить невозможно.</string>
 	<string name="player_up_next_clear_queue">Очистить очередь</string>
 	<string name="player_trim_silence_detail">Сокращает длину выпуска, вырезая паузы в разговорах.</string>
 	<string name="player_time_saved_no_hour">Поздравляем! Вы экономите время и успеваете прослушать больше подкастов.</string>
@@ -1042,7 +1056,6 @@ Language: ru
 	<string name="player_notification_skip_back">Назад на %d с.</string>
 	<string name="player_more_actions">Другие действия</string>
 	<string name="player_full_screen">Полноэкранный режим</string>
-	<string name="player_end_playback_clear_up_next">Завершить воспроизведение и очистить очередь «Следующие»</string>
 	<string name="player_effects_volume_boost">Усилитель звука</string>
 	<string name="player_effects_voices_sound_louder">Голоса звучат громче</string>
 	<string name="player_effects_trim_silence">Удалить паузы</string>

--- a/modules/services/localization/src/main/res/values-sv/strings.xml
+++ b/modules/services/localization/src/main/res/values-sv/strings.xml
@@ -1,11 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2022-08-09 14:54:03+0000
+Translation-Revision-Date: 2022-08-23 11:54:03+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/2.4.0-alpha
 Language: sv_SE
 -->
 <resources>
+	<string name="settings_storage_section_heading_mobile_data">Mobildata</string>
+	<string name="settings_storage_section_heading_usage">Användning</string>
+	<string name="settings_storage_downloaded_files">Nedladdade filer</string>
+	<string name="settings_storage_downloaded_bytes">%d byte</string>
+	<string name="plus_per_month">%s per månad</string>
+	<string name="plus_day">dag</string>
+	<string name="plus_month_year_price">%1$s per månad/%2$s per år</string>
+	<string name="plus_trial_then_slash_year">%1$s gratis, därefter %2$s/år</string>
+	<string name="plus_trial_then_slash_month">%1$s gratis, därefter %2$s/månad</string>
+	<string name="plus_then_slash_year">därefter %s/år</string>
+	<string name="plus_then_slash_month">därefter %s/månad</string>
+	<string name="plus_slash_year">%s/år</string>
+	<string name="plus_per_year">%s per år</string>
+	<string name="plus_trial_duration_free">%s GRATIS</string>
+	<string name="profile_start_free_trial">Starta kostnadsfri testperiod</string>
+	<string name="profile_per_year">Per år</string>
+	<string name="profile_feature_try_trial_secondary_info">Ingen betalning nu — Avbryt när som helst</string>
+	<string name="profile_feature_try_trial">Prova Pocket Casts Plus gratis i %s</string>
+	<string name="player_up_next_clear_episodes_plural">Rensa %1$d avsnitt</string>
+	<string name="player_up_next_clear_queue_summary">Är du säker på att du vill rensa din Nästa-kö?</string>
+	<string name="player_end_playback_clear_up_next">Stäng och rensa Nästa</string>
 	<string name="player_open_full_size_player">Aktivera för att öppna spelare i full storlek</string>
 	<string name="settings_downloads_clean_up">Rensa</string>
 	<string name="podcasts_share_failed_description">Något gick fel när din delningssida skulle skapas.</string>
@@ -351,7 +372,6 @@ Language: sv_SE
 	<string name="settings_title_storage">Lagrings- och dataanvändning</string>
 	<string name="settings_title_playback">Allmänt</string>
 	<string name="settings_title_notifications">Aviseringar</string>
-	<string name="settings_title_manage_downloads">Hantera nedladdningar</string>
 	<string name="settings_title_import_export">Importera och exportera OPML</string>
 	<string name="settings_title_help">Hjälp och feedback</string>
 	<string name="settings_title_excluded_podcasts">Exkluderade podcasts</string>
@@ -367,7 +387,6 @@ Language: sv_SE
 	<string name="settings_storage_move_podcasts">Flyttar podcasts …</string>
 	<string name="settings_storage_move_message">Detta kommer flytta befintliga podcastfiler till denna nya plats.</string>
 	<string name="settings_storage_move">Flytta</string>
-	<string name="settings_storage_manage_downloads">Hantera nedladdade filer</string>
 	<string name="settings_storage_folder_write_failed">Det går inte att skriva till den här mappen.</string>
 	<string name="settings_storage_folder_not_found">Det går inte att hitta eller skapa mappen.</string>
 	<string name="settings_storage_folder_change_failed">Det gick inte att ändra till anpassad mapp.</string>
@@ -515,7 +534,6 @@ Language: sv_SE
 	<string name="plus_renews_automatically_yearly">Förnyas automatiskt årligen</string>
 	<string name="plus_best_value">MEST PRISVÄRT</string>
 	<string name="plus_select_payment_frequency">Välj betalningsfrekvens</string>
-	<string name="plus_year_month_price">%1$s per år / %2$s per månad</string>
 	<string name="plus_upgrade_to_pocket_casts_plus">Uppgradera till Pocket Casts Plus</string>
 	<string name="plus_trial_finished_locked">Åtkomst till Pocket Casts Plus-funktioner kommer att låsas</string>
 	<string name="plus_trial_finished_files_removed">Filer uppladdade till ditt konto kommer att tas bort efter en vecka</string>
@@ -525,8 +543,7 @@ Language: sv_SE
 	<string name="plus_themes_icons_body">Välj dina egna färger. Exklusiva ikoner och teman för Plus-medlemmar.</string>
 	<string name="plus_themes_icons">Teman och ikoner</string>
 	<string name="plus_thanks_for_your_support_bang">Tack för ditt stöd!</string>
-	<string name="plus_slash_month">%s /månad</string>
-	<string name="plus_per_month">%s per månad</string>
+	<string name="plus_slash_month">%s/månad</string>
 	<string name="plus_lifetime_member">Livstidsmedlem</string>
 	<string name="plus_learn_more_button">Lär dig mer</string>
 	<string name="plus_learn_more_about_plus">Läs mer om Pocket Casts Plus</string>
@@ -632,7 +649,6 @@ Language: sv_SE
 	<string name="profile_payment_failed_detail">Det verkar som att det uppstod ett problem när din betalning behandlades. Försök igen.</string>
 	<string name="profile_payment_failed">Betalningen misslyckades</string>
 	<string name="profile_payment_cancelled">Betalningen har avbrutits</string>
-	<string name="profile_pay_now">Betala nu</string>
 	<string name="profile_password_changed_successful">Det lyckades!</string>
 	<string name="profile_password_changed">Lösenord ändrat</string>
 	<string name="profile_password">Lösenord</string>
@@ -760,7 +776,6 @@ Language: sv_SE
 	<string name="profile_account_created">Konto skapat.</string>
 	<string name="profile_access_ends">Åtkomst upphör: %s</string>
 	<string name="profile_access_ended">Åtkomst upphörde: %s</string>
-	<string name="profile_1_year_free">1 år gratis</string>
 	<string name="profile">Profil</string>
 	<string name="filters_warning_delete_summary">Det här går inte att ångra.</string>
 	<string name="filters_title_new_releases">Nya släpp</string>
@@ -1017,7 +1032,6 @@ Language: sv_SE
 	<string name="player_up_next_empty_desc">Du kan placera avsnitt i kö för uppspelning genom att svepa åt höger på avsnittsraden, eller genom att trycka på ikonen på ett avsnittskort.</string>
 	<string name="player_up_next_empty">Inget i Nästa</string>
 	<string name="player_up_next_clear_queue_button">Rensa Nästa</string>
-	<string name="player_up_next_clear_queue_summary">Rensning av din Nästa-lista går inte att ångra</string>
 	<string name="player_up_next_clear_queue">Rensa kö</string>
 	<string name="player_trim_silence_detail">Minskar längden på ett avsnitt genom att trimma tystnad i konversationer.</string>
 	<string name="player_time_saved_no_hour">Grattis! Du sparar tid och hinner gå igenom fler podcasts.</string>
@@ -1042,7 +1056,6 @@ Language: sv_SE
 	<string name="player_notification_skip_back">Bakåt %d sekunder</string>
 	<string name="player_more_actions">Fler åtgärder</string>
 	<string name="player_full_screen">Fullskärm</string>
-	<string name="player_end_playback_clear_up_next">Avsluta uppspelning och rensa Nästa</string>
 	<string name="player_effects_volume_boost">Volymökning</string>
 	<string name="player_effects_voices_sound_louder">Röster låter starkare</string>
 	<string name="player_effects_trim_silence">Trimma tystnad</string>

--- a/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
@@ -1,11 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2022-08-09 09:54:16+0000
+Translation-Revision-Date: 2022-08-23 11:54:04+0000
 Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/2.4.0-alpha
 Language: zh_TW
 -->
 <resources>
+	<string name="settings_storage_section_heading_mobile_data">行動數據</string>
+	<string name="settings_storage_section_heading_usage">使用方式</string>
+	<string name="settings_storage_downloaded_files">已下載的檔案</string>
+	<string name="settings_storage_downloaded_bytes">%d 位元</string>
+	<string name="plus_per_month">每月 %s</string>
+	<string name="plus_day">天</string>
+	<string name="plus_month_year_price">每月 %1$s/每年 %2$s</string>
+	<string name="plus_trial_then_slash_year">免費使用%1$s，之後每年 %2$s</string>
+	<string name="plus_trial_then_slash_month">免費使用%1$s，之後每月 %2$s</string>
+	<string name="plus_then_slash_year">之後每年 %s</string>
+	<string name="plus_then_slash_month">之後每月 %s</string>
+	<string name="plus_slash_year">%s /年</string>
+	<string name="plus_per_year">每年 %s</string>
+	<string name="plus_trial_duration_free">免費使用%s</string>
+	<string name="profile_start_free_trial">開始免費試用</string>
+	<string name="profile_per_year">每年</string>
+	<string name="profile_feature_try_trial_secondary_info">現在無需付費，可隨時取消</string>
+	<string name="profile_feature_try_trial">免費試用 Pocket Casts Plus %s</string>
+	<string name="player_up_next_clear_episodes_plural">清除 %1$d 集</string>
+	<string name="player_up_next_clear_queue_summary">你確定要清除「接下來播放」佇列嗎？</string>
+	<string name="player_end_playback_clear_up_next">關閉並清除「接下來播放」</string>
 	<string name="player_open_full_size_player">啟用以開啟全尺寸播放器</string>
 	<string name="settings_downloads_clean_up">清理</string>
 	<string name="podcasts_share_failed_description">建立分享頁面時發生問題。</string>
@@ -351,7 +372,6 @@ Language: zh_TW
 	<string name="settings_title_storage">儲存空間和數據使用</string>
 	<string name="settings_title_playback">一般</string>
 	<string name="settings_title_notifications">通知</string>
-	<string name="settings_title_manage_downloads">管理下載項目</string>
 	<string name="settings_title_import_export">匯入/匯出 OPML</string>
 	<string name="settings_title_help">說明與意見反應</string>
 	<string name="settings_title_excluded_podcasts">排除 Podcast</string>
@@ -367,7 +387,6 @@ Language: zh_TW
 	<string name="settings_storage_move_podcasts">正在移動 Podcast…</string>
 	<string name="settings_storage_move_message">這會將現有的 Podcast 檔案移到這個新位置。</string>
 	<string name="settings_storage_move">移動</string>
-	<string name="settings_storage_manage_downloads">管理下載的檔案</string>
 	<string name="settings_storage_folder_write_failed">無法寫入此資料夾。</string>
 	<string name="settings_storage_folder_not_found">找不到或無法建立此資料夾。</string>
 	<string name="settings_storage_folder_change_failed">無法變更為自訂資料夾。</string>
@@ -515,7 +534,6 @@ Language: zh_TW
 	<string name="plus_renews_automatically_yearly">每年自動續訂</string>
 	<string name="plus_best_value">最划算的價格</string>
 	<string name="plus_select_payment_frequency">選取付款頻率</string>
-	<string name="plus_year_month_price">每年 %1$s/每月 %2$s</string>
 	<string name="plus_upgrade_to_pocket_casts_plus">升級到 Pocket Casts Plus</string>
 	<string name="plus_trial_finished_locked">Pocket Casts Plus 功能使用權限將會鎖定</string>
 	<string name="plus_trial_finished_files_removed">上傳到帳號的檔案將在一週後移除</string>
@@ -525,8 +543,7 @@ Language: zh_TW
 	<string name="plus_themes_icons_body">展現你最真實的色彩。 僅供 Plus 社群使用的獨家圖示和主題。</string>
 	<string name="plus_themes_icons">佈景主題與圖示</string>
 	<string name="plus_thanks_for_your_support_bang">感謝你的支持！</string>
-	<string name="plus_slash_month">%s / 月</string>
-	<string name="plus_per_month">%s 每月</string>
+	<string name="plus_slash_month">%s /月</string>
 	<string name="plus_lifetime_member">終身會員</string>
 	<string name="plus_learn_more_button">瞭解詳情</string>
 	<string name="plus_learn_more_about_plus">深入瞭解 Pocket Casts Plus</string>
@@ -632,7 +649,6 @@ Language: zh_TW
 	<string name="profile_payment_failed_detail">處理你的付款時似乎發生問題。 請再試一次。</string>
 	<string name="profile_payment_failed">付款失敗</string>
 	<string name="profile_payment_cancelled">付款已取消</string>
-	<string name="profile_pay_now">立即付款</string>
 	<string name="profile_password_changed_successful">成功！</string>
 	<string name="profile_password_changed">密碼已變更</string>
 	<string name="profile_password">密碼</string>
@@ -760,7 +776,6 @@ Language: zh_TW
 	<string name="profile_account_created">已建立帳號</string>
 	<string name="profile_access_ends">使用權預計結束時間：%s</string>
 	<string name="profile_access_ended">使用權結束時間：%s</string>
-	<string name="profile_1_year_free">1 年免費</string>
 	<string name="profile">個人檔案</string>
 	<string name="filters_warning_delete_summary">此動作無法復原。</string>
 	<string name="filters_title_new_releases">最新上架</string>
@@ -1017,7 +1032,6 @@ Language: zh_TW
 	<string name="player_up_next_empty_desc">在單集列向右滑動或點選單集卡片上的圖示，即可將單集排入佇列接著播放。</string>
 	<string name="player_up_next_empty">「接下來播放」中沒有任何單集</string>
 	<string name="player_up_next_clear_queue_button">清除「接下來播放」</string>
-	<string name="player_up_next_clear_queue_summary">清除「接下來播放」清單即無法復原</string>
 	<string name="player_up_next_clear_queue">清除佇列</string>
 	<string name="player_trim_silence_detail">透過剪輯對話中無聲的部分，減少單集的長度。</string>
 	<string name="player_time_saved_no_hour">恭喜！ 你已省下時間，並收聽更多 Podcast。</string>
@@ -1042,7 +1056,6 @@ Language: zh_TW
 	<string name="player_notification_skip_back">倒退 %d 秒</string>
 	<string name="player_more_actions">更多動作</string>
 	<string name="player_full_screen">全螢幕</string>
-	<string name="player_end_playback_clear_up_next">結束播放並清除「接下來播放」</string>
 	<string name="player_effects_volume_boost">音量增強</string>
 	<string name="player_effects_voices_sound_louder">音量更大聲</string>
 	<string name="player_effects_trim_silence">無聲剪輯</string>

--- a/modules/services/localization/src/main/res/values-zh/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh/strings.xml
@@ -1,11 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2022-08-09 09:54:15+0000
+Translation-Revision-Date: 2022-08-23 09:54:03+0000
 Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/2.4.0-alpha
 Language: zh_CN
 -->
 <resources>
+	<string name="settings_storage_section_heading_mobile_data">移动数据</string>
+	<string name="settings_storage_section_heading_usage">使用情况</string>
+	<string name="settings_storage_downloaded_files">下载的文件</string>
+	<string name="settings_storage_downloaded_bytes">%d 字节</string>
+	<string name="plus_per_month">%s/月</string>
+	<string name="plus_day">日</string>
+	<string name="plus_month_year_price">%1$s/月或 %2$s/年</string>
+	<string name="plus_trial_then_slash_year">%1$s免费，之后 %2$s/年</string>
+	<string name="plus_trial_then_slash_month">%1$s免费，之后 %2$s/月</string>
+	<string name="plus_then_slash_year">之后 %s/年</string>
+	<string name="plus_then_slash_month">之后 %s/月</string>
+	<string name="plus_slash_year">%s/年</string>
+	<string name="plus_per_year">%s/年</string>
+	<string name="plus_trial_duration_free">%s免费！</string>
+	<string name="profile_start_free_trial">开始免费试用</string>
+	<string name="profile_per_year">每年</string>
+	<string name="profile_feature_try_trial_secondary_info">现在无需付款 - 可随时取消</string>
+	<string name="profile_feature_try_trial">免费试用 Pocket Casts Plus %s</string>
+	<string name="player_up_next_clear_episodes_plural">清除 %1$d 集 </string>
+	<string name="player_up_next_clear_queue_summary">是否确定要清除您的“接下来播放”队列？</string>
+	<string name="player_end_playback_clear_up_next">关闭并清除“接下来播放”</string>
 	<string name="player_open_full_size_player">启用以打开全尺寸播放器</string>
 	<string name="settings_downloads_clean_up">清理</string>
 	<string name="podcasts_share_failed_description">创建共享页面时出错。</string>
@@ -351,7 +372,6 @@ Language: zh_CN
 	<string name="settings_title_storage">存储和数据使用情况</string>
 	<string name="settings_title_playback">常规</string>
 	<string name="settings_title_notifications">通知</string>
-	<string name="settings_title_manage_downloads">管理下载</string>
 	<string name="settings_title_import_export">导入和导出 OPML</string>
 	<string name="settings_title_help">帮助和反馈</string>
 	<string name="settings_title_excluded_podcasts">不包括播客</string>
@@ -367,7 +387,6 @@ Language: zh_CN
 	<string name="settings_storage_move_podcasts">正在移动播客…</string>
 	<string name="settings_storage_move_message">这会将现有播客文件移动到此新位置。</string>
 	<string name="settings_storage_move">移动</string>
-	<string name="settings_storage_manage_downloads">管理下载的文件</string>
 	<string name="settings_storage_folder_write_failed">无法写入到此文件夹。</string>
 	<string name="settings_storage_folder_not_found">无法找到或创建文件夹。</string>
 	<string name="settings_storage_folder_change_failed">无法更改为自定义文件夹。</string>
@@ -515,7 +534,6 @@ Language: zh_CN
 	<string name="plus_renews_automatically_yearly">每年自动续订</string>
 	<string name="plus_best_value">最佳值</string>
 	<string name="plus_select_payment_frequency">选择付款频率</string>
-	<string name="plus_year_month_price">每年 %1$s/每月 %2$s</string>
 	<string name="plus_upgrade_to_pocket_casts_plus">升级到 Pocket Casts Plus</string>
 	<string name="plus_trial_finished_locked">对 Pocket Casts Plus 功能的访问将被锁定</string>
 	<string name="plus_trial_finished_files_removed">上传到您账户的文件将在一周后删除</string>
@@ -525,8 +543,7 @@ Language: zh_CN
 	<string name="plus_themes_icons_body">选择您的真实颜色。 仅面向 Plus 俱乐部的专属图标和主题。</string>
 	<string name="plus_themes_icons">主题和图标</string>
 	<string name="plus_thanks_for_your_support_bang">感谢您的支持！</string>
-	<string name="plus_slash_month">%s /月</string>
-	<string name="plus_per_month">%s 每个月</string>
+	<string name="plus_slash_month">%s/月</string>
 	<string name="plus_lifetime_member">终身会员</string>
 	<string name="plus_learn_more_button">了解更多</string>
 	<string name="plus_learn_more_about_plus">了解有关 Pocket Casts Plus 的更多信息</string>
@@ -632,7 +649,6 @@ Language: zh_CN
 	<string name="profile_payment_failed_detail">似乎在处理您的付款时出现问题。 请重试。</string>
 	<string name="profile_payment_failed">付款失败</string>
 	<string name="profile_payment_cancelled">付款已取消</string>
-	<string name="profile_pay_now">立即支付</string>
 	<string name="profile_password_changed_successful">成功！</string>
 	<string name="profile_password_changed">密码已更改</string>
 	<string name="profile_password">密码</string>
@@ -760,7 +776,6 @@ Language: zh_CN
 	<string name="profile_account_created">账户已创建</string>
 	<string name="profile_access_ends">访问结束：%s</string>
 	<string name="profile_access_ended">访问已结束：%s</string>
-	<string name="profile_1_year_free">1 年免费</string>
 	<string name="profile">个人资料</string>
 	<string name="filters_warning_delete_summary">此操作无法撤消。</string>
 	<string name="filters_title_new_releases">新发布</string>
@@ -1017,7 +1032,6 @@ Language: zh_CN
 	<string name="player_up_next_empty_desc">您可以向右滑动剧集行或点按剧集卡上的图标，将剧集排队以供接下来播放。</string>
 	<string name="player_up_next_empty">“接下来播放”列表无内容</string>
 	<string name="player_up_next_clear_queue_button">清除“接下来播放”</string>
-	<string name="player_up_next_clear_queue_summary">清除“接下来播放”列表不能撤消</string>
 	<string name="player_up_next_clear_queue">清除队列</string>
 	<string name="player_trim_silence_detail">通过剪裁对话中的静音来缩短剧集的长度。</string>
 	<string name="player_time_saved_no_hour">恭喜！ 您节省了时间，并浏览了更多播客。</string>
@@ -1042,7 +1056,6 @@ Language: zh_CN
 	<string name="player_notification_skip_back">后退 %d 秒</string>
 	<string name="player_more_actions">更多操作</string>
 	<string name="player_full_screen">全屏</string>
-	<string name="player_end_playback_clear_up_next">结束播放并清除“接下来播放”</string>
 	<string name="player_effects_volume_boost">音量增强</string>
 	<string name="player_effects_voices_sound_louder">声音会更大</string>
 	<string name="player_effects_trim_silence">剪裁静音</string>


### PR DESCRIPTION
# Description

This cherry picks string translations from commit 481355d2a109cc9db8412359c545077b701d5272

# Checklist

- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [ ] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [ ] Have you tested in different themes?
- [ ] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?