### PR TITLE
Removes Configure Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,6 @@ buildscript {
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.5'
         // Hilt dependency injection
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
-
-        // Configure plugin: https://github.com/Automattic/configure/
-        classpath 'com.automattic.android:configure:0.6.2'
     }
 
     // Force proguard to the new version to fix "proguard.ParseException: Use of generics not allowed for java type at '<1>_<2>_<3>JsonAdapter' in line 31 of file '/Users/philip/.gradle/caches/transforms-2/files-2.1/d5ca2d039e1d32e9ba6bfd6a67df5151/META-INF/proguard/moshi.pro'"
@@ -53,7 +50,6 @@ plugins {
 apply plugin: 'base'
 apply from: rootProject.file('dependencies.gradle')
 apply from: 'scripts/git-hooks/install.gradle'
-apply plugin: 'com.automattic.android.configure'
 
 apply plugin: 'com.diffplug.spotless'
 spotless {


### PR DESCRIPTION
# Description

I've recently learned that we should not be mixing the [`configure` Gradle plugin](https://github.com/Automattic/configure/) with the `fastlane` configuration actions such as `configure_update`.

Even though we'd prefer not to require the `Ruby` toolchain from developers to apply the configuration, the `configure` plugin still have several bugs. At least for the moment, I think it makes more sense to rely on the `fastlane` actions especially in repositories where we have `fastlane` release management. This decision is also consistent with rest of projects where we have preferred `fastlane` actions over the `configure` plugin.

* No testing is required

# Checklist

- [x] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [x] Have you tested in landscape?
- [x] Have you tested accessibility with TalkBack?
- [x] Have you tested in different themes?
- [x] Does the change work with a large display font?
- [x] Are all the strings localized?
- [x] Could you have written any new tests?
- [x] Did you include Compose previews with any components?