### PR TITLE
Update Wear to use the dark theme

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearAppTheme.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearAppTheme.kt
@@ -32,17 +32,17 @@ fun WearAppTheme(
 
 private fun buildWearMaterialColors(colors: ThemeColors): Colors {
     return Colors(
-        primary = colors.primaryInteractive01,
-        primaryVariant = colors.primaryInteractive01,
-        secondary = colors.primaryInteractive01,
-        secondaryVariant = colors.primaryInteractive01,
+        primary = colors.primaryText01,
+        primaryVariant = colors.primaryText01,
+        secondary = colors.primaryText02,
+        secondaryVariant = colors.primaryText02,
         background = colors.primaryUi04,
         surface = colors.primaryUi01,
         error = colors.support05,
         onPrimary = colors.primaryInteractive02,
         onSecondary = colors.primaryInteractive02,
         onBackground = colors.secondaryIcon01,
-        onSurface = colors.primaryInteractive01,
+        onSurface = colors.primaryText01,
         onError = colors.secondaryIcon01,
     )
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
@@ -119,7 +119,9 @@ private fun WatchListChip(
     val title = stringResource(titleRes)
     Chip(
         onClick = onClick,
-        colors = ChipDefaults.chipColors(),
+        colors = ChipDefaults.secondaryChipColors(
+            secondaryContentColor = MaterialTheme.theme.colors.primaryText02
+        ),
         label = {
             Text(title)
         },
@@ -146,7 +148,7 @@ private fun UpNextChip(navigateToRoute: (String) -> Unit, numInUpNext: Int) {
     val title = stringResource(LR.string.up_next)
     Chip(
         onClick = { navigateToRoute(UpNextScreen.route) },
-        colors = ChipDefaults.chipColors(),
+        colors = ChipDefaults.secondaryChipColors(),
         modifier = Modifier.fillMaxWidth()
     ) {
         Row(
@@ -181,6 +183,7 @@ private fun UpNextChip(navigateToRoute: (String) -> Unit, numInUpNext: Int) {
                 Text(
                     text = num,
                     textAlign = TextAlign.Center,
+                    color = MaterialTheme.theme.colors.primaryUi01,
                     modifier = Modifier.padding(horizontal = 6.dp)
                 )
             }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
@@ -45,7 +45,7 @@ fun PodcastsScreen(
 private fun PodcastChip(podcast: FolderItem.Podcast, onClick: (String) -> Unit, modifier: Modifier = Modifier) {
     Chip(
         onClick = { onClick(podcast.uuid) },
-        colors = ChipDefaults.chipColors(),
+        colors = ChipDefaults.secondaryChipColors(),
         label = {
             Text(podcast.title, maxLines = 1, overflow = TextOverflow.Ellipsis)
         },


### PR DESCRIPTION
This change updates the Wear OS app to use the dark theme colors to make it more similar to the Apple Watch version.

![Screenshot_20220916_153625](https://user-images.githubusercontent.com/308331/190568226-0e1f7044-dd0e-420a-871f-bd74174996bd.png)
![Screenshot_20220916_153633](https://user-images.githubusercontent.com/308331/190568219-79af6f3e-f829-45ac-bc84-8cea10b2bf71.png)
![Screenshot_20220916_153639](https://user-images.githubusercontent.com/308331/190568210-af60b352-390c-41bf-b92b-4d297d16c76e.png)
