### PR TITLE
Update IntentUtilTest

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtilTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtilTest.kt
@@ -26,11 +26,11 @@ class IntentUtilTest {
     @Test
     fun testSubscribeUrlWithParams() {
         val intent = Intent(Intent.ACTION_VIEW)
-        val url = "pktc://subscribe/theincomparable.memberfulcontent.com/rss/6618?someKey=someValue"
+        val url = "pktc://subscribe/mypodcast.memberfulcontent.com/rss/6618?someKey=someValue"
         intent.data = Uri.parse(url)
 
         val parsed = IntentUtil.getPodloveUrl(intent)
-        assertEquals("http://theincomparable.memberfulcontent.com/rss/6618?someKey=someValue", parsed)
+        assertEquals("http://mypodcast.memberfulcontent.com/rss/6618?someKey=someValue", parsed)
     }
 
     @Test
@@ -46,11 +46,11 @@ class IntentUtilTest {
     @Test
     fun testSubscribeUrlWithParamsHttps() {
         val intent = Intent(Intent.ACTION_VIEW)
-        val url = "pktc://subscribehttps/theincomparable.memberfulcontent.com/rss/6618?someKey=someValue"
+        val url = "pktc://subscribehttps/mypodcast.memberfulcontent.com/rss/6618?someKey=someValue"
         intent.data = Uri.parse(url)
 
         val parsed = IntentUtil.getPodloveUrl(intent)
-        assertEquals("https://theincomparable.memberfulcontent.com/rss/6618?someKey=someValue", parsed)
+        assertEquals("https://mypodcast.memberfulcontent.com/rss/6618?someKey=someValue", parsed)
     }
 
     @Test


### PR DESCRIPTION
# Description

Just doing some cleanup to make it obvious that the `IntentUtilTest` is testing generic urls and not a specific URL.

p1663588458037529-slack-C028JAG44VD

# Checklist

- [X] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [X] Are all the strings localized?
- [X] Could you have written any new tests?
- [X] Did you include Compose previews with any components?