### PR TITLE
Update podcasts_tab_opened key to be plural

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1082,7 +1082,7 @@ class MainActivity :
 
     private fun trackTabOpened(tab: Int, isInitial: Boolean = false) {
         val event: AnalyticsEvent? = when (tab) {
-            VR.id.navigation_podcasts -> AnalyticsEvent.PODCAST_TAB_OPENED
+            VR.id.navigation_podcasts -> AnalyticsEvent.PODCASTS_TAB_OPENED
             VR.id.navigation_filters -> AnalyticsEvent.FILTERS_TAB_OPENED
             VR.id.navigation_discover -> AnalyticsEvent.DISCOVER_TAB_OPENED
             VR.id.navigation_profile -> AnalyticsEvent.PROFILE_TAB_OPENED

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -92,7 +92,7 @@ enum class AnalyticsEvent(val key: String) {
     PODCASTS_LIST_BADGES_CHANGED("podcasts_list_badges_changed"),
 
     /* Tab bar items */
-    PODCAST_TAB_OPENED("podcast_tab_opened"),
+    PODCASTS_TAB_OPENED("podcasts_tab_opened"),
     FILTERS_TAB_OPENED("filters_tab_opened"),
     DISCOVER_TAB_OPENED("discover_tab_opened"),
     PROFILE_TAB_OPENED("profile_tab_opened"),


### PR DESCRIPTION
# Description

This changes `podcast_tab_opened` to analytics key to be plural (`podcasts_tab_opened`) since this tab relates to multiple podcasts, not just one.

To test
1. Tap on the Podcasts tab
1. ✅ Verify you see `🔵 Tracked: podcasts_tab_opened {...}` in console

Related iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/268

# Checklist

- [X] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [X] Are all the strings localized?
- [X] Could you have written any new tests?
- [X] Did you include Compose previews with any components?