### PR TITLE
Fix the discover section collection header

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridFragment.kt
@@ -1,8 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.discover.view
 
-import android.graphics.Color
-import android.graphics.ColorMatrix
-import android.graphics.ColorMatrixColorFilter
 import android.graphics.Rect
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -19,13 +16,9 @@ import au.com.shiftyjelly.pocketcasts.servers.model.DisplayStyle
 import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyle
 import au.com.shiftyjelly.pocketcasts.servers.model.ListFeed
 import au.com.shiftyjelly.pocketcasts.servers.model.ListType
-import au.com.shiftyjelly.pocketcasts.ui.images.ThemedImageTintTransformation
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
-import au.com.shiftyjelly.pocketcasts.views.activity.WebViewActivity
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
-import coil.load
-import coil.transform.CircleCropTransformation
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 
@@ -73,52 +66,18 @@ class PodcastGridFragment : PodcastGridListFragment() {
                             } else {
                                 binding.headerLayout.visibility = View.VISIBLE
 
-                                binding.toolbar.title = it.subtitle
-                                binding.toolbar.menu.findItem(R.id.share_list)?.isVisible = curated
-
-                                binding.lblSubtitle.text = it.subtitle?.uppercase()
-                                binding.lblTitle.text = it.title
-                                binding.lblBody.text = it.description
-
-                                it.webLinkTitle?.let { linkTitle ->
-                                    it.webLinkUrl?.let { linkUrl ->
-                                        binding.linkLayout.visibility = View.VISIBLE
-                                        binding.lblLinkTitle.text = linkTitle
-                                        binding.linkLayout.setOnClickListener {
-                                            WebViewActivity.show(context, linkTitle, linkUrl)
-                                        }
-                                    }
-                                }
-
-                                val colorMatrix = ColorMatrix().apply { setSaturation(0.0f) }
-                                binding.imgPodcast.colorFilter = ColorMatrixColorFilter(colorMatrix)
-
-                                context?.let { context ->
-                                    it.collageImages?.let { images ->
-                                        if (images.isNotEmpty()) {
-                                            val backgroundUrl = images[0].imageUrl
-                                            binding.imgPodcast.load(backgroundUrl) {
-                                                transformations(ThemedImageTintTransformation(context))
-                                            }
-                                        }
-                                    }
-
-                                    it.tintColors?.let { tintColors ->
-                                        val tintColor: Int
-                                        try {
-                                            tintColor = if (theme.isDarkTheme) Color.parseColor(tintColors.darkTintColor) else Color.parseColor(tintColors.lightTintColor)
-                                            binding.lblSubtitle.setTextColor(tintColor)
-                                            binding.imgTint.setBackgroundColor(tintColor)
-                                        } catch (e: Exception) {
-                                        }
-                                    }
-
-                                    it.collectionImageUrl?.let { url ->
-                                        binding.highlightImage.load(url) {
-                                            transformations(ThemedImageTintTransformation(context), CircleCropTransformation())
-                                        }
-                                    }
-                                }
+                                updateCollectionHeaderView(
+                                    listFeed = it,
+                                    headshotImageView = binding.highlightImage,
+                                    headerImageView = binding.imgPodcast,
+                                    tintImageView = binding.imgTint,
+                                    titleTextView = binding.lblTitle,
+                                    subTitleTextView = binding.lblSubtitle,
+                                    bodyTextView = binding.lblBody,
+                                    linkView = binding.linkLayout,
+                                    linkTextView = binding.lblLinkTitle,
+                                    toolbar = binding.toolbar
+                                )
                             }
                         }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridListFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridListFragment.kt
@@ -1,12 +1,19 @@
 package au.com.shiftyjelly.pocketcasts.discover.view
 
 import android.content.Intent
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
 import android.os.Bundle
 import android.view.MenuItem
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.discover.R
 import au.com.shiftyjelly.pocketcasts.discover.viewmodel.PodcastListViewModel
+import au.com.shiftyjelly.pocketcasts.localization.helper.tryToLocalise
 import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastFragment
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -15,10 +22,18 @@ import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverEpisode
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
 import au.com.shiftyjelly.pocketcasts.servers.model.DisplayStyle
 import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyle
+import au.com.shiftyjelly.pocketcasts.servers.model.ListFeed
 import au.com.shiftyjelly.pocketcasts.servers.model.ListType
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
+import au.com.shiftyjelly.pocketcasts.ui.images.ThemedImageTintTransformation
 import au.com.shiftyjelly.pocketcasts.utils.AnalyticsHelper
+import au.com.shiftyjelly.pocketcasts.views.activity.WebViewActivity
+import au.com.shiftyjelly.pocketcasts.views.extensions.hide
+import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import coil.load
+import coil.transform.CircleCropTransformation
+import timber.log.Timber
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -121,5 +136,81 @@ open class PodcastGridListFragment : BaseFragment(), Toolbar.OnMenuItemClickList
             return true
         }
         return false
+    }
+
+    protected fun updateCollectionHeaderView(
+        listFeed: ListFeed,
+        headshotImageView: ImageView,
+        headerImageView: ImageView,
+        tintImageView: ImageView,
+        titleTextView: TextView,
+        subTitleTextView: TextView,
+        bodyTextView: TextView,
+        linkView: ConstraintLayout,
+        linkTextView: TextView,
+        toolbar: Toolbar
+    ) {
+        toolbar.title = listFeed.subtitle?.tryToLocalise(resources)
+        toolbar.menu.findItem(R.id.share_list)?.isVisible = curated
+
+        subTitleTextView.text = listFeed.subtitle?.uppercase()
+        titleTextView.text = listFeed.title
+        bodyTextView.text = listFeed.description
+
+        // website
+        val linkTitle = listFeed.webLinkTitle
+        val linkUrl = listFeed.webLinkUrl
+        if (linkTitle != null && linkUrl != null) {
+            linkView.visibility = View.VISIBLE
+            linkTextView.text = linkTitle
+            linkView.setOnClickListener {
+                WebViewActivity.show(context, linkTitle, linkUrl)
+            }
+        }
+
+        // circular headshot image
+        val headshotImageUrl = listFeed.collectionImageUrl
+        headshotImageView.apply {
+            if (headshotImageUrl == null) {
+                hide()
+            } else {
+                show()
+                load(headshotImageUrl) {
+                    transformations(ThemedImageTintTransformation(context), CircleCropTransformation())
+                }
+            }
+        }
+
+        val headerImageUrl = listFeed.headerImageUrl
+        if (headerImageUrl == null) {
+            // use the background collage image if background hasn't been manually added
+            val backgroundImageUrl = listFeed.collageImages?.find { collage -> collage.key == "mobile" }?.imageUrl
+            if (backgroundImageUrl != null) {
+                headerImageView.load(backgroundImageUrl) {
+                    transformations(ThemedImageTintTransformation(headerImageView.context))
+                }
+            }
+            // tint the header background image if there is also a headshot
+            headerImageView.colorFilter = if (headshotImageUrl == null) {
+                null
+            } else {
+                val colorMatrix = ColorMatrix().apply { setSaturation(0.0f) }
+                ColorMatrixColorFilter(colorMatrix)
+            }
+        } else {
+            headerImageView.load(headerImageUrl)
+            headerImageView.alpha = 1f
+            tintImageView.hide()
+        }
+
+        listFeed.tintColors?.let { tintColors ->
+            try {
+                val tintColor = tintColors.tintColorInt(theme.isDarkTheme) ?: return@let
+                subTitleTextView.setTextColor(tintColor)
+                tintImageView.setBackgroundColor(tintColor)
+            } catch (e: Exception) {
+                Timber.e(e)
+            }
+        }
     }
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastListFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastListFragment.kt
@@ -1,7 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.discover.view
 
-import android.graphics.ColorMatrix
-import android.graphics.ColorMatrixColorFilter
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -23,14 +21,8 @@ import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyle
 import au.com.shiftyjelly.pocketcasts.servers.model.ListFeed
 import au.com.shiftyjelly.pocketcasts.servers.model.ListType
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.images.ThemedImageTintTransformation
 import au.com.shiftyjelly.pocketcasts.utils.AnalyticsHelper
-import au.com.shiftyjelly.pocketcasts.views.activity.WebViewActivity
-import au.com.shiftyjelly.pocketcasts.views.extensions.hide
-import au.com.shiftyjelly.pocketcasts.views.extensions.showIf
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
-import coil.load
-import coil.transform.CircleCropTransformation
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
@@ -121,63 +113,18 @@ class PodcastListFragment : PodcastGridListFragment() {
 
         binding.headerLayout.visibility = View.VISIBLE
 
-        binding.toolbar.title = feed.subtitle?.tryToLocalise(resources)
-        binding.lblSubtitle.text = feed.subtitle?.uppercase()
-        binding.lblTitle.text = feed.title
-        binding.lblBody.text = feed.description
-
-        val linkTitle = feed.webLinkTitle
-        val linkUrl = feed.webLinkUrl
-        if (linkTitle != null && linkUrl != null) {
-            binding.linkLayout.visibility = View.VISIBLE
-            binding.lblLinkTitle.text = linkTitle
-            binding.linkLayout.setOnClickListener {
-                WebViewActivity.show(context, linkTitle, linkUrl)
-            }
-        }
-
-        // circular headshot image
-        val headshotImage = feed.collectionImageUrl
-        binding.highlightImage.apply {
-            showIf(headshotImage != null)
-            load(headshotImage) {
-                transformations(ThemedImageTintTransformation(context), CircleCropTransformation())
-            }
-        }
-
-        // tint the header background image if there is also a headshot
-        binding.imagePodcast.colorFilter = if (headshotImage == null) {
-            null
-        } else {
-            val colorMatrix = ColorMatrix().apply { setSaturation(0.0f) }
-            ColorMatrixColorFilter(colorMatrix)
-        }
-
-        // header background image
-        val headerImage = feed.headerImageUrl
-        if (headerImage == null) {
-            // use the background collage image if background hasn't been manually added
-            val backgroundImageUrl = feed.collageImages?.find { collage -> collage.key == "mobile" }?.imageUrl
-            if (backgroundImageUrl != null) {
-                binding.imagePodcast.load(backgroundImageUrl) {
-                    transformations(ThemedImageTintTransformation(binding.imagePodcast.context))
-                }
-            }
-        } else {
-            binding.imagePodcast.load(headerImage)
-            binding.imagePodcast.alpha = 1f
-            binding.imageTint.hide()
-        }
-
-        feed.tintColors?.let { tintColors ->
-            try {
-                val tintColor = tintColors.tintColorInt(theme.isDarkTheme) ?: return@let
-                binding.lblSubtitle.setTextColor(tintColor)
-                binding.imageTint.setBackgroundColor(tintColor)
-            } catch (e: Exception) {
-                Timber.e(e)
-            }
-        }
+        updateCollectionHeaderView(
+            listFeed = feed,
+            headshotImageView = binding.highlightImage,
+            headerImageView = binding.imagePodcast,
+            tintImageView = binding.imageTint,
+            titleTextView = binding.lblTitle,
+            subTitleTextView = binding.lblSubtitle,
+            bodyTextView = binding.lblBody,
+            linkView = binding.linkLayout,
+            linkTextView = binding.lblLinkTitle,
+            toolbar = binding.toolbar
+        )
     }
 
     override fun onDestroyView() {

--- a/modules/features/discover/src/main/res/layout/podcast_grid_fragment.xml
+++ b/modules/features/discover/src/main/res/layout/podcast_grid_fragment.xml
@@ -64,6 +64,13 @@
 
                 </androidx.cardview.widget.CardView>
 
+                <View
+                    android:id="@+id/cardImageSpacer"
+                    android:layout_width="0dp"
+                    android:layout_height="8dp"
+                    app:layout_constraintTop_toBottomOf="@+id/cardImage"
+                    app:layout_constraintStart_toStartOf="parent" />
+
                 <ImageView
                     android:id="@+id/highlightImage"
                     android:layout_width="80dp"
@@ -75,12 +82,18 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent" />
 
+                <androidx.constraintlayout.widget.Barrier
+                    android:id="@+id/barrierContent"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:barrierDirection="bottom"
+                    app:constraint_referenced_ids="cardImageSpacer,highlightImage" />
+
                 <TextView
                     android:id="@+id/lblSubtitle"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="16dp"
-                    android:layout_marginTop="32dp"
                     android:layout_marginEnd="16dp"
                     android:gravity="center_horizontal"
                     android:paddingTop="8dp"
@@ -89,7 +102,7 @@
                     android:textColor="?attr/support_03"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/cardImage"
+                    app:layout_constraintTop_toBottomOf="@id/barrierContent"
                     tools:text="Subtitle" />
 
                 <TextView


### PR DESCRIPTION
Em pointed out there was an issue with the full-page grid style, the custom images she uploaded weren't being displayed. But it was working when the full-page style was plain list. 

<img width="199" alt="Screen Shot 2022-09-30 at 8 12 01 pm" src="https://user-images.githubusercontent.com/308331/193253118-93133af5-ecec-49fc-a884-10fd59abaf88.png">
<img width="151" alt="Screen Shot 2022-09-30 at 8 11 54 pm" src="https://user-images.githubusercontent.com/308331/193253134-821e6cc5-db37-4826-b032-102b485141a4.png">
<img width="218" alt="Screen Shot 2022-09-30 at 8 12 53 pm" src="https://user-images.githubusercontent.com/308331/193253250-e2416f3d-337b-467d-b8b2-c5063a224d97.png">

Ideally, I would have created a shared component but as a temporary fix I have just shared the fragment logic so any changes are shared across the plain list and grid view.

**Test steps**
1. Load the development version of the apk so it points to the staging servers
2. Go to the discover tab
3. Work through the test lists I have added to the top for the different combinations

If there is a custom image there should be no tint layer on top.
If there isn't a custom image there it should use the podcast collage and have a tint layer on top.

| Grid, Headshot, Custom Image | Grid, Custom Image | Grid, Headshot |
| --- | --- | --- |
| ![Screenshot_20220930_193750](https://user-images.githubusercontent.com/308331/193250609-9b2452f4-b5a4-44bb-8428-8f398787bb60.png) | ![Screenshot_20220930_195236](https://user-images.githubusercontent.com/308331/193250632-9808906a-b968-4762-9db6-3b00ac4abdb7.png) | ![Screenshot_20220930_193812](https://user-images.githubusercontent.com/308331/193250645-8024eae4-344e-40d6-8ac0-9fd91a96f6b8.png)

| Plain List, Headshot, Custom Image | Plain List, Custom Image | Plain List, Headshot |
| --- | --- | --- |
| ![Screenshot_20220930_194623](https://user-images.githubusercontent.com/308331/193250658-64f99662-80ef-4b99-b4ce-888a5f65607b.png) | ![Screenshot_20220930_194635](https://user-images.githubusercontent.com/308331/193250676-dc51c61a-777d-470f-a583-c5362bb7419b.png) | ![Screenshot_20220930_194643](https://user-images.githubusercontent.com/308331/193250698-3b7b1a5b-18b6-42f8-907b-4dada904aaa4.png) |


