### PR TITLE
Updating PocketCastsApplication name

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/ui/PlaybackServiceTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/ui/PlaybackServiceTest.kt
@@ -7,7 +7,7 @@ import android.support.v4.media.session.PlaybackStateCompat
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ServiceTestRule
-import au.com.shiftyjelly.pocketcasts.PocketcastsApplication
+import au.com.shiftyjelly.pocketcasts.PocketCastsApplication
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.NotificationId
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackService
@@ -37,7 +37,7 @@ class PlaybackServiceTest {
     @Test
     @Throws(TimeoutException::class)
     fun testPlaybackServiceEntersAndExitsForeground() {
-        val application = ApplicationProvider.getApplicationContext<PocketcastsApplication>()
+        val application = ApplicationProvider.getApplicationContext<PocketCastsApplication>()
         val testScheduler = SchedulerProvider.testScheduler
 
         // Create the service Intent.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 
     <application
-            android:name=".PocketcastsApplication"
+            android:name=".PocketCastsApplication"
             android:hardwareAccelerated="true"
             android:icon="${appIcon}"
             android:label="@string/app_name"

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/CastOptionsProvider.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/CastOptionsProvider.kt
@@ -12,7 +12,7 @@ import com.google.android.gms.cast.framework.media.NotificationOptions
 
 class CastOptionsProvider : OptionsProvider {
     override fun getCastOptions(context: Context): CastOptions {
-        val application = context as PocketcastsApplication
+        val application = context as PocketCastsApplication
         val buttonActions = listOf(
             MediaIntentReceiver.ACTION_REWIND,
             MediaIntentReceiver.ACTION_TOGGLE_PLAYBACK,

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -52,7 +52,7 @@ import java.util.concurrent.Executors
 import javax.inject.Inject
 
 @HiltAndroidApp
-class PocketcastsApplication : Application(), Configuration.Provider {
+class PocketCastsApplication : Application(), Configuration.Provider {
 
     @Inject lateinit var appLifecycleObserver: AppLifecycleObserver
     @Inject lateinit var statsManager: StatsManager
@@ -143,7 +143,7 @@ class PocketcastsApplication : Application(), Configuration.Provider {
         runBlocking {
             appIcon.enableSelectedAlias(appIcon.activeAppIcon)
 
-            AnalyticsHelper.setup(FirebaseAnalytics.getInstance(this@PocketcastsApplication))
+            AnalyticsHelper.setup(FirebaseAnalytics.getInstance(this@PocketCastsApplication))
             notificationHelper.setupNotificationChannels()
             appLifecycleObserver.setup()
 
@@ -164,16 +164,16 @@ class PocketcastsApplication : Application(), Configuration.Provider {
                 if (storageChoice == null) {
                     // the user doesn't have a storage choice, give them one
                     val storageOptions = StorageOptions()
-                    val locationsAvailable = storageOptions.getFolderLocations(this@PocketcastsApplication)
+                    val locationsAvailable = storageOptions.getFolderLocations(this@PocketCastsApplication)
                     if (locationsAvailable.size > 0) {
                         val folder = locationsAvailable[0]
                         settings.setStorageChoice(folder.filePath, folder.label)
                     } else {
-                        val location = this@PocketcastsApplication.filesDir
+                        val location = this@PocketCastsApplication.filesDir
                         settings.setStorageCustomFolder(location.absolutePath)
                     }
                 } else if (storageChoice.equals(Settings.LEGACY_STORAGE_ON_PHONE, ignoreCase = true)) {
-                    val location = this@PocketcastsApplication.filesDir
+                    val location = this@PocketCastsApplication.filesDir
                     settings.setStorageCustomFolder(location.absolutePath)
                 } else if (storageChoice.equals(Settings.LEGACY_STORAGE_ON_SD_CARD, ignoreCase = true)) {
                     val location = findExternalStorageDirectory()
@@ -201,7 +201,7 @@ class PocketcastsApplication : Application(), Configuration.Provider {
                     Timber.e(e, "Unable to create opml folder.")
                 }
 
-                VersionMigrationsJob.run(podcastManager = podcastManager, settings = settings, context = this@PocketcastsApplication)
+                VersionMigrationsJob.run(podcastManager = podcastManager, settings = settings, context = this@PocketCastsApplication)
 
                 // check that we have .nomedia files in existing folders
                 fileStorage.checkNoMediaDirs()
@@ -209,7 +209,7 @@ class PocketcastsApplication : Application(), Configuration.Provider {
                 // init the stats engine
                 statsManager.initStatsEngine()
 
-                subscriptionManager.connectToGooglePlay(this@PocketcastsApplication)
+                subscriptionManager.connectToGooglePlay(this@PocketCastsApplication)
             }
         }
 


### PR DESCRIPTION
# Description

Just knocking out one of our most important tasks... changing the capitalization of `PocketcastsApplication` to be `PocketCastsApplication`.

<img width="250px" src="https://media0.giphy.com/media/nTfdeBvfgzV26zjoFP/giphy.gif"/>

Ok, let me explain... every time I want to search for our Application class in Android Studio I search by typing "PCApp". When our application doesn't turn up I then stare at the computer confused for a few seconds before eventually remembering that the c isn't capitalized in that class. EVERY TIME!

This addresses that by capitalizing the c in Casts, which makes the capitalization of this class consistent with the other class names in the app that contain "PocketCasts".

##### _This obviously isn't a big deal at all. Please let me know if there's any reason you'd rather not make this change._

### Test Steps

1. Check out this branch
2. Search for a file in Android Studio by typing "PCApp"
3. 🙌  Rejoice upon seeing that the first result is "PocketCastsApplication"
4. Make sure the app builds and runs
