### PR TITLE
Fix the position of the discover collection headshot on the grid layout

### DIFF
--- a/modules/features/discover/src/main/res/layout/podcast_grid_fragment.xml
+++ b/modules/features/discover/src/main/res/layout/podcast_grid_fragment.xml
@@ -76,9 +76,10 @@
                     android:layout_width="80dp"
                     android:layout_height="80dp"
                     android:background="@drawable/circle"
+                    android:layout_marginTop="100dp"
                     android:padding="4dp"
                     android:translationZ="5dp"
-                    app:layout_constraintBottom_toTopOf="@id/lblSubtitle"
+                    app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent" />
 


### PR DESCRIPTION
With the last change I fixed the padding of the titles on the full page discover collection view when using a grid. But I broke it for when there is a headshot. 🤦‍♂️ This change fixes that!

| Before | After |
| --- | --- |
| ![Screenshot_20221002_084205](https://user-images.githubusercontent.com/308331/193430521-bd567dad-a9b9-4bb0-8dc1-5ea3ab035846.png) | ![Screenshot_20221002_085304](https://user-images.githubusercontent.com/308331/193430505-a86b963d-5736-4778-922e-9e72bde6b1ce.png) |
| ![Screenshot_20221002_084220](https://user-images.githubusercontent.com/308331/193430517-c4ce4c10-fbd0-4e46-b174-a01d96c9eaf9.png) | ![Screenshot_20221002_085312](https://user-images.githubusercontent.com/308331/193430503-3963d687-4076-4396-be18-d8c62b34995b.png) |
| ![Screenshot_20221002_084234](https://user-images.githubusercontent.com/308331/193430511-08a23b51-4c2e-48d7-9da0-ad768e7d9013.png) | ![Screenshot_20221002_085323](https://user-images.githubusercontent.com/308331/193430501-dbf5f51b-22e0-4ca1-b2af-6b703efccb41.png) |