### PR TITLE
Improve Automotive OS tab order

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -440,7 +440,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
         return arrayListOf(AutoConverter.convertEpisodeToMediaItem(this, upNext, parentPodcast))
     }
 
-    open fun loadRootChildren(): ArrayList<MediaBrowserCompat.MediaItem> {
+    open suspend fun loadRootChildren(): List<MediaBrowserCompat.MediaItem> {
         val rootItems = ArrayList<MediaBrowserCompat.MediaItem>()
 
         // podcasts


### PR DESCRIPTION
This change switches the Automotive OS opening tab between "Podcasts" and "Discover". If the user doesn't have any podcasts it starts with the "Discover" so they aren't presented with an empty screen. Otherwise, the user is shown their podcast collection as the first tab.

Fixes https://github.com/Automattic/pocket-casts-android/issues/347

**Test steps**
1. Open the Automotive app

The "Discover" tab should open first.

2. Tap on a podcast
3. Play an episode
4. Leave the app, open the Settings app
5. Open the Apps section
6. If the Pocket Casts app and Force stop the app
7. Open the Bluetooth Audio app
8. Open the Pocket Casts app

The "Podcasts" tab should open first.

![Screenshot_20221004_143345](https://user-images.githubusercontent.com/308331/193731763-2e5afcc7-b815-4c92-bb84-7cd6604b6956.png)
![Screenshot_20221004_143306](https://user-images.githubusercontent.com/308331/193731767-9b3c5c24-7e10-4e88-811c-dc1c7fda6c7b.png)

