### PR TITLE
Upgrade libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,9 @@ buildscript {
     // Gradle Plugins
     dependencies {
         // Android - https://developer.android.com/studio/releases/gradle-plugin
-        classpath 'com.android.tools.build:gradle:7.2.2'
-
+        classpath 'com.android.tools.build:gradle:7.3.0'
         // Google Services - https://developers.google.com/android/guides/google-services-plugin
-        classpath "com.google.gms:google-services:4.3.13"
+        classpath "com.google.gms:google-services:4.3.14"
         // Kotlin
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // Open source licenses plugin

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -100,7 +100,7 @@ project.ext {
             cast: "com.google.android.gms:play-services-cast-framework:21.1.0",
             desugarJdk: "com.android.tools:desugar_jdk_libs:1.1.5",
             // Firebase BoM (Bill of Materials enables you to manage all your Firebase library versions by specifying only one version)
-            firebaseBom: "com.google.firebase:firebase-bom:30.3.2",
+            firebaseBom: "com.google.firebase:firebase-bom:30.5.0",
             firebaseAnalytics: "com.google.firebase:firebase-analytics-ktx",
             firebaseConfig: "com.google.firebase:firebase-config-ktx",
             constraintLayout: "androidx.constraintlayout:constraintlayout:2.1.4",
@@ -219,7 +219,7 @@ project.ext {
             // Automattic Tracks
             automatticTracks: "com.automattic:Automattic-Tracks-Android:$versionTracks",
             // Sentry
-            sentryBom: 'io.sentry:sentry-bom:6.4.1',
+            sentryBom: 'io.sentry:sentry-bom:6.4.2',
             sentry: 'io.sentry:sentry-android',
             sentryFragment: 'io.sentry:sentry-android-fragment',
             sentryTimber: 'io.sentry:sentry-android-timber'


### PR DESCRIPTION
This change upgrades some of the core libraries.

Upgraded **Android build tools** from 7.2.2 to 7.3.0
https://developer.android.com/studio/releases/gradle-plugin#7-3-0

---

Upgraded **Sentry** from 6.4.1 to 6.4.2
https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#642

- Fixed AbstractMethodError when getting Lifecycle 
- Missing unit fields for Android measurements 
- Avoid sending empty profiles
- Fix file descriptor leak in FileIO instrumentation 

---

Upgraded **Firebase BOM** from 30.3.2 to 30.5.0
Which upgrades Firebase Analytics from 21.1.0 to 21.1.1
https://firebase.google.com/support/release-notes/android#2022-09-01

- Fixed a bug where GoogleTagManager (transitively included from the Tag Manager SDK) would rapidly retry DNS lookups whenever it fails.
- Updated dependencies.

---

Upgraded **Google Service Gradle plugin** from 4.3.13 to 4.3.14
https://firebase.google.com/support/release-notes/android#google-services_plugin_v4-3-14

- Improved task caching and awareness of changes in google-services.json files.

