### PR TITLE
Enable creating local signed release builds

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -54,9 +54,21 @@ project.ext {
 
     // App Signing
     storeFile = file("$rootDir/${secretProperties.getProperty("signingKeyStoreFile", null)}")
-    storePassword = secretProperties.getProperty("signingKeyStorePassword", null)
-    keyAlias = secretProperties.getProperty("signingKeyAlias", null)
-    keyPassword = secretProperties.getProperty("signingKeyPassword", null)
+    if (storeFile.exists()) {
+        // Use secret properties
+        storePassword = secretProperties.getProperty("signingKeyStorePassword", null)
+        keyAlias = secretProperties.getProperty("signingKeyAlias", null)
+        keyPassword = secretProperties.getProperty("signingKeyPassword", null)
+    } else {
+        // Check local gradle properties
+        def keystoreFilePropertyKey = "pocketcastsKeyStoreFile"
+        if (project.hasProperty(keystoreFilePropertyKey)) {
+            storeFile = file(project.getProperty(keystoreFilePropertyKey))
+            storePassword = project.getProperty("pocketcastsKeyStorePassword")
+            keyAlias = project.getProperty("pocketcastsKeyStoreAlias")
+            keyPassword = project.getProperty("pocketcastsKeyStoreAliasPassword")
+        }
+    }
     canSignRelease = storeFile.exists()
 
     // Secrets


### PR DESCRIPTION
## Description

The ability to create a locally signed release build no longer works for me after the buildkite updates. This restores the previous behavior where the user can define the relevant information locally in a gradle.properties file (as described in the [README](https://github.com/Automattic/pocket-casts-android/blob/main/README.md#signing-a-release)).

## To Test

1. Set up a signing key and add the relevant properties to one of the gradle.properties files that this project will load
2. Create a release build and ensure that the app runs

# Checklist

- [X] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [X] Are all the strings localized?
- [X] Could you have written any new tests?
- [X] Did you include Compose previews with any components?