### PR TITLE
Update the maxLines property of Discover collection title

### DIFF
--- a/modules/features/discover/src/main/res/layout/row_collection_list.xml
+++ b/modules/features/discover/src/main/res/layout/row_collection_list.xml
@@ -76,7 +76,7 @@
         android:layout_marginTop="3dp"
         android:layout_marginEnd="16dp"
         android:ellipsize="end"
-        android:maxLines="1"
+        android:maxLines="2"
         android:textColor="?attr/primary_text_01"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
# Description

Just updated the `maxLines` to 2, Fixes #48 

### Before & After
<img width="150" alt="Screen Shot 2022-10-04 at 23 09 41" src="https://user-images.githubusercontent.com/47274419/193919782-0261b85c-96da-4551-b7b2-61053a4d427d.png"> -> <img width="150" alt="Screen Shot 2022-10-04 at 23 10 12" src="https://user-images.githubusercontent.com/47274419/193919999-b0f41fc3-b5fa-4377-8ebd-152df9b15a20.png">


# Checklist

- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [x] Have you tested in landscape?
- [x] Have you tested accessibility with TalkBack?
- [x] Have you tested in different themes?
- [x] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?