### PR TITLE
Fix release build without sentry.properties files.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,10 @@ android {
     }
 }
 
+sentry {
+    includeProguardMapping = file("$rootDir/sentry.properties").exists()
+}
+
 dependencies {
     implementation project(':modules:services:localization')
     implementation project(':modules:services:preferences')


### PR DESCRIPTION
Running a release build without the sentry.properties file fails. This change fixes this by skipping the Sentry mapping file upload if the file is missing.

Before the fix.
```
./gradlew :app:assembleRelease

> Task :app:uploadSentryProguardMappingsRelease FAILED
> compressing mappings
> uploading mappings
error: An organization slug is required (provide with --org)
```

After the fix with a sentry.properties file.
```
./gradlew :app:assembleRelease

> Task :app:uploadSentryProguardMappingsRelease
> compressing mappings
> uploading mappings
> Uploaded a total of 1 new mapping files
Newly uploaded debug symbols:

```

After the fix without a sentry.properties file.
```
./gradlew :app:assembleRelease

> Configure project :app
WARNING: Sentry configuration file 'sentry.properties' not found. The ProGuard mapping files won't be uploaded.

BUILD SUCCESSFUL in 6s
```
