### PR TITLE
Android Grade Plugin upgrade

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,6 +9,8 @@ apply from: "../base.gradle"
 apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 
 android {
+    namespace 'au.com.shiftyjelly.pocketcasts'
+
     defaultConfig {
         applicationId project.applicationId
         multiDexEnabled true
@@ -22,10 +24,6 @@ android {
         viewBinding true
         dataBinding = true
         compose true
-    }
-
-    lintOptions {
-        abortOnError false
     }
 
     buildTypes {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools" package="au.com.shiftyjelly.pocketcasts">
+          xmlns:tools="http://schemas.android.com/tools">
 
     <supports-screens
             android:largeScreens="true"

--- a/automotive/build.gradle
+++ b/automotive/build.gradle
@@ -8,6 +8,8 @@ plugins {
 apply from: "../base.gradle"
 
 android {
+    namespace 'au.com.shiftyjelly.pocketcasts'
+
     defaultConfig {
         applicationId project.applicationId
         minSdkVersion 28

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts"
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature

--- a/base.gradle
+++ b/base.gradle
@@ -32,8 +32,10 @@ android {
         vectorDrawables.useSupportLibrary = true
     }
 
-    lintOptions {
+    lint {
         abortOnError false
+        disable 'AppCompatResource', 'ContentDescription', 'DiffUtilEquals'
+        xmlReport true
     }
 
     compileOptions {
@@ -64,12 +66,16 @@ android {
     }
 
     packagingOptions {
-        exclude 'META-INF/rxjava.properties'
-        exclude 'META-INF/AL2.0'
-        exclude 'META-INF/LGPL2.1'
-        exclude 'META-INF/licenses/ASM'
-        // Fixes issue running './gradlew connectedDebugAndroidTest' with clashing testing libraries.
-        exclude '**/attach_hotspot_windows.dll'
+        resources {
+            excludes += [
+                'META-INF/rxjava.properties',
+                'META-INF/AL2.0',
+                'META-INF/LGPL2.1',
+                'META-INF/licenses/ASM',
+                // Fixes issue running './gradlew connectedDebugAndroidTest' with clashing testing libraries.
+                '**/attach_hotspot_windows.dll'
+            ]
+        }
     }
 
     if (canSignRelease) {
@@ -139,10 +145,6 @@ android {
         }
     }
 
-    lintOptions {
-        disable 'AppCompatResource', 'ContentDescription', 'DiffUtilEquals'
-        xmlReport true
-    }
 }
 
 dependencies {

--- a/modules/features/account/build.gradle
+++ b/modules/features/account/build.gradle
@@ -3,6 +3,15 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.account'
+    buildFeatures {
+        viewBinding true
+        dataBinding = true
+        compose true
+    }
+}
+
 dependencies {
     implementation project(':modules:services:localization')
     implementation project(':modules:services:preferences')
@@ -17,12 +26,4 @@ dependencies {
     implementation project(':modules:services:analytics')
     implementation project(':modules:features:cartheme')
     implementation project(':modules:features:settings')
-}
-
-android {
-    buildFeatures {
-        viewBinding true
-        dataBinding = true
-        compose true
-    }
 }

--- a/modules/features/account/src/main/AndroidManifest.xml
+++ b/modules/features/account/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.account">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/modules/features/cartheme/build.gradle
+++ b/modules/features/cartheme/build.gradle
@@ -2,6 +2,10 @@ apply from: "../../modules.gradle"
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.cartheme'
+}
+
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation androidLibs.appCompat

--- a/modules/features/cartheme/src/main/AndroidManifest.xml
+++ b/modules/features/cartheme/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.cartheme" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/modules/features/discover/build.gradle
+++ b/modules/features/discover/build.gradle
@@ -1,5 +1,14 @@
 apply from: "../../modules.gradle"
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.discover'
+    buildFeatures {
+        viewBinding true
+        dataBinding = true
+        compose true
+    }
+}
+
 dependencies {
     implementation project(':modules:services:localization')
     implementation project(':modules:services:preferences')
@@ -15,12 +24,4 @@ dependencies {
     implementation project(':modules:features:podcasts')
     implementation project(':modules:features:search')
     implementation project(':modules:features:account')
-}
-
-android {
-    buildFeatures {
-        viewBinding true
-        dataBinding = true
-        compose true
-    }
 }

--- a/modules/features/discover/src/main/AndroidManifest.xml
+++ b/modules/features/discover/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.discover" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/modules/features/filters/build.gradle
+++ b/modules/features/filters/build.gradle
@@ -1,5 +1,14 @@
 apply from: "../../modules.gradle"
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.filters'
+    buildFeatures {
+        viewBinding true
+        dataBinding = true
+        compose true
+    }
+}
+
 dependencies {
     implementation project(':modules:services:localization')
     implementation project(':modules:services:preferences')
@@ -12,12 +21,4 @@ dependencies {
     implementation project(':modules:services:model')
     implementation project(':modules:services:analytics')
     implementation project(':modules:features:podcasts')
-}
-
-android {
-    buildFeatures {
-        viewBinding true
-        dataBinding = true
-        compose true
-    }
 }

--- a/modules/features/filters/src/main/AndroidManifest.xml
+++ b/modules/features/filters/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.filters" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/modules/features/navigation/build.gradle
+++ b/modules/features/navigation/build.gradle
@@ -1,5 +1,9 @@
 apply from: "../../modules.gradle"
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.navigation'
+}
+
 dependencies {
     implementation "com.github.akarnokd:rxjava2-extensions:0.20.10"
 }

--- a/modules/features/navigation/src/main/AndroidManifest.xml
+++ b/modules/features/navigation/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.navigation">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/modules/features/player/build.gradle
+++ b/modules/features/player/build.gradle
@@ -1,5 +1,14 @@
 apply from: "../../modules.gradle"
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.player'
+    buildFeatures {
+        viewBinding true
+        dataBinding = true
+        compose true
+    }
+}
+
 dependencies {
     implementation project(':modules:services:localization')
     implementation project(':modules:services:preferences')
@@ -12,12 +21,4 @@ dependencies {
     implementation project(':modules:services:repositories')
     implementation project(':modules:services:model')
     implementation project(':modules:services:analytics')
-}
-
-android {
-    buildFeatures {
-        viewBinding true
-        dataBinding = true
-        compose true
-    }
 }

--- a/modules/features/player/src/main/AndroidManifest.xml
+++ b/modules/features/player/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="au.com.shiftyjelly.pocketcasts.player">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application>
         <activity

--- a/modules/features/podcasts/build.gradle
+++ b/modules/features/podcasts/build.gradle
@@ -1,5 +1,14 @@
 apply from: "../../modules.gradle"
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.podcasts'
+    buildFeatures {
+        viewBinding true
+        dataBinding = true
+        compose true
+    }
+}
+
 dependencies {
     implementation project(':modules:services:localization')
     implementation project(':modules:services:preferences')
@@ -15,12 +24,4 @@ dependencies {
     implementation project(':modules:features:search')
     implementation project(':modules:features:settings')
     implementation project(':modules:features:account')
-}
-
-android {
-    buildFeatures {
-        viewBinding true
-        dataBinding = true
-        compose true
-    }
 }

--- a/modules/features/podcasts/src/main/AndroidManifest.xml
+++ b/modules/features/podcasts/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.podcasts" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <activity android:name=".view.share.ShareListCreateActivity" />

--- a/modules/features/profile/build.gradle
+++ b/modules/features/profile/build.gradle
@@ -3,6 +3,15 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.profile'
+    buildFeatures {
+        viewBinding true
+        dataBinding = true
+        compose true
+    }
+}
+
 dependencies {
     implementation project(':modules:services:localization')
     implementation project(':modules:services:preferences')
@@ -20,12 +29,4 @@ dependencies {
     implementation project(':modules:features:podcasts')
     implementation project(':modules:features:cartheme')
     implementation project(':modules:features:account')
-}
-
-android {
-    buildFeatures {
-        viewBinding true
-        dataBinding = true
-        compose true
-    }
 }

--- a/modules/features/profile/src/main/AndroidManifest.xml
+++ b/modules/features/profile/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.profile">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <activity android:name=".cloud.AddFileActivity"

--- a/modules/features/search/build.gradle
+++ b/modules/features/search/build.gradle
@@ -1,5 +1,14 @@
 apply from: "../../modules.gradle"
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.search'
+    buildFeatures {
+        viewBinding true
+        dataBinding = true
+        compose true
+    }
+}
+
 dependencies {
     implementation project(':modules:services:localization')
     implementation project(':modules:services:preferences')
@@ -11,12 +20,4 @@ dependencies {
     implementation project(':modules:services:servers')
     implementation project(':modules:services:repositories')
     implementation project(':modules:services:model')
-}
-
-android {
-    buildFeatures {
-        viewBinding true
-        dataBinding = true
-        compose true
-    }
 }

--- a/modules/features/search/src/main/AndroidManifest.xml
+++ b/modules/features/search/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.search" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/modules/features/settings/build.gradle
+++ b/modules/features/settings/build.gradle
@@ -1,5 +1,14 @@
 apply from: "../../modules.gradle"
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.settings'
+    buildFeatures {
+        viewBinding true
+        dataBinding = true
+        compose true
+    }
+}
+
 dependencies {
     implementation project(':modules:services:localization')
     implementation project(':modules:services:preferences')
@@ -12,12 +21,4 @@ dependencies {
     implementation project(':modules:services:repositories')
     implementation project(':modules:services:model')
     implementation project(':modules:services:analytics')
-}
-
-android {
-    buildFeatures {
-        viewBinding true
-        dataBinding = true
-        compose true
-    }
 }

--- a/modules/features/settings/src/main/AndroidManifest.xml
+++ b/modules/features/settings/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.settings">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 
 </manifest>

--- a/modules/services/analytics/build.gradle
+++ b/modules/services/analytics/build.gradle
@@ -1,6 +1,10 @@
 apply from: "../../modules.gradle"
 apply plugin: 'kotlin-android'
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.analytics'
+}
+
 dependencies {
     implementation libs.automatticTracks
     implementation project(':modules:services:utils')

--- a/modules/services/analytics/src/main/AndroidManifest.xml
+++ b/modules/services/analytics/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="au.com.shiftyjelly.pocketcasts.analytics"/>
+<manifest />

--- a/modules/services/compose/build.gradle
+++ b/modules/services/compose/build.gradle
@@ -2,6 +2,13 @@ apply from: "../../modules.gradle"
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.compose'
+    buildFeatures {
+        compose true
+    }
+}
+
 dependencies {
     implementation project(':modules:services:localization')
     implementation project(':modules:services:preferences')
@@ -10,10 +17,4 @@ dependencies {
     implementation project(':modules:services:images')
     implementation project(':modules:services:repositories')
     implementation project(':modules:services:model')
-}
-
-android {
-    buildFeatures {
-        compose true
-    }
 }

--- a/modules/services/compose/src/main/AndroidManifest.xml
+++ b/modules/services/compose/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.compose">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/modules/services/images/build.gradle
+++ b/modules/services/images/build.gradle
@@ -1,3 +1,7 @@
 apply from: "../../modules.gradle"
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
+
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.images'
+}

--- a/modules/services/images/src/main/AndroidManifest.xml
+++ b/modules/services/images/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.images">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/modules/services/localization/build.gradle
+++ b/modules/services/localization/build.gradle
@@ -2,3 +2,6 @@ apply from: "../../modules.gradle"
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.localization'
+}

--- a/modules/services/localization/src/main/AndroidManifest.xml
+++ b/modules/services/localization/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.localization">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/modules/services/model/build.gradle
+++ b/modules/services/model/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
+    namespace 'au.com.shiftyjelly.pocketcasts.model'
     defaultConfig {
         javaCompileOptions {
             annotationProcessorOptions {

--- a/modules/services/model/src/main/AndroidManifest.xml
+++ b/modules/services/model/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.model">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/modules/services/preferences/build.gradle
+++ b/modules/services/preferences/build.gradle
@@ -2,6 +2,10 @@ apply from: "../../modules.gradle"
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.preferences'
+}
+
 dependencies {
     implementation project(':modules:services:localization')
     implementation project(':modules:services:utils')

--- a/modules/services/preferences/src/main/AndroidManifest.xml
+++ b/modules/services/preferences/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.preferences">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/modules/services/repositories/build.gradle
+++ b/modules/services/repositories/build.gradle
@@ -2,6 +2,10 @@ apply from: "../../modules.gradle"
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.repositories'
+}
+
 dependencies {
     implementation project(':modules:services:localization')
     implementation project(':modules:services:utils')

--- a/modules/services/repositories/src/main/AndroidManifest.xml
+++ b/modules/services/repositories/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.repositories">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:usesCleartextTraffic="true">

--- a/modules/services/servers/build.gradle
+++ b/modules/services/servers/build.gradle
@@ -2,6 +2,10 @@ apply from: "../../modules.gradle"
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.servers'
+}
+
 dependencies {
     implementation project(':modules:services:localization')
     implementation project(':modules:services:utils')

--- a/modules/services/servers/src/main/AndroidManifest.xml
+++ b/modules/services/servers/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.servers">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/modules/services/ui/build.gradle
+++ b/modules/services/ui/build.gradle
@@ -2,6 +2,10 @@ apply from: "../../modules.gradle"
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.ui'
+}
+
 dependencies {
     implementation project(':modules:services:localization')
     implementation project(':modules:services:preferences')

--- a/modules/services/ui/src/main/AndroidManifest.xml
+++ b/modules/services/ui/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.ui">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/modules/services/utils/build.gradle
+++ b/modules/services/utils/build.gradle
@@ -3,3 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 // utils should have no other module dependencies
+
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.helper'
+}

--- a/modules/services/utils/src/main/AndroidManifest.xml
+++ b/modules/services/utils/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.helper">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/modules/services/views/build.gradle
+++ b/modules/services/views/build.gradle
@@ -3,6 +3,15 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
 
+android {
+    namespace 'au.com.shiftyjelly.pocketcasts.views'
+    buildFeatures {
+        viewBinding true
+        dataBinding = true
+        compose true
+    }
+}
+
 dependencies {
     implementation project(':modules:services:localization')
     implementation project(':modules:services:utils')
@@ -14,12 +23,4 @@ dependencies {
     implementation project(':modules:services:servers')
     implementation project(':modules:services:repositories')
     implementation project(':modules:services:analytics')
-}
-
-android {
-    buildFeatures {
-        viewBinding true
-        dataBinding = true
-        compose true
-    }
 }

--- a/modules/services/views/src/main/AndroidManifest.xml
+++ b/modules/services/views/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="au.com.shiftyjelly.pocketcasts.views">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:usesCleartextTraffic="true">


### PR DESCRIPTION
This change upgrades the Gradle files for the latest Android Gradle Plugin 7.3.0. I didn't realise this can be done in Android Studio from the menu option 'Tools' -> 'AGP Upgrade Assistant...'.

Running `./gradlew :app:assembleRelease` output the following error.

```
package="au.com.shiftyjelly.pocketcasts.discover" found in source AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: 
https://developer.android.com/studio/build/configure-app-module#set-namespace
This migration can be done automatically using the AGP Upgrade Assistant, please refer to 
https://developer.android.com/studio/build/agp-upgrade-assistant for more information.
```