### PR TITLE
Improve the readme logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
-# Pocket Casts Android
+<p align="center">
+    <img src="https://user-images.githubusercontent.com/308331/194037473-41ad7eba-8602-4be5-be73-49e3c0c48c12.svg#gh-light-mode-only" />
+    <img src="https://user-images.githubusercontent.com/308331/194041226-4c6d8181-cafa-4ea8-8735-1d8106f5e5f6.svg#gh-dark-mode-only" />
+</p>
+
+<p align="center">
+    <a href="https://buildkite.com/automattic/pocket-casts-android"><img src="https://badge.buildkite.com/dc67ef3537ad6cf097ff193b28063347418205a341d55f9940.svg?branch=main" /></a>
+    <a href="https://github.com/Automattic/pocket-casts-android/blob/main/LICENSE.md"><img src="https://img.shields.io/badge/license-MPL-black" /></a>
+</p>
+
+<p align="center">
+    Pocket Casts is the world's most powerful podcast platform, an app by listeners, for listeners.
+</p>
+
+## Install
 
 If you're just looking to install Pocket Casts Android, you can find it on [Google Play](https://play.google.com/store/apps/details?id=au.com.shiftyjelly.pocketcasts). If you're a developer wanting to contribute, read on.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
     <a href="https://buildkite.com/automattic/pocket-casts-android"><img src="https://badge.buildkite.com/dc67ef3537ad6cf097ff193b28063347418205a341d55f9940.svg?branch=main" /></a>
-    <a href="https://github.com/Automattic/pocket-casts-android/blob/main/LICENSE.md"><img src="https://img.shields.io/badge/license-MPL-black" /></a>
+    <a href="https://github.com/Automattic/pocket-casts-android/blob/main/LICENSE.md"><img src="https://img.shields.io/badge/license-MPL-blue" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Improving the readme header to keep up with iOS, but this version supports dark mode too!

<img width="970" alt="Screen Shot 2022-10-05 at 9 10 02 pm" src="https://user-images.githubusercontent.com/308331/194041907-3ee4373b-b177-4937-b02f-239be928ba68.png">
<img width="998" alt="Screen Shot 2022-10-05 at 9 10 12 pm" src="https://user-images.githubusercontent.com/308331/194041915-11421f63-45c8-4818-abd9-5849e52fde9e.png">
