### PR TITLE
Allow select text in show notes from episode details view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 -----
 
 *   Bug Fixes:
-    *   Allow Discover feed collection titles to wrap
+    *   Allow Discover feed collection titles to wrap.
         ([#335](https://github.com/Automattic/pocket-casts-android/pull/335)).
+    *   Allow select text in show notes from episode details view.
+        ([#372](https://github.com/Automattic/pocket-casts-android/pull/372)).
 
 7.24
 -----

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -490,10 +490,6 @@ class EpisodeFragment : BaseDialogFragment() {
                             return true
                         }
                     }
-                    // turn off text selection in the web view
-                    setOnLongClickListener { true }
-                    isLongClickable = false
-                    isHapticFeedbackEnabled = false
                 }
                 binding?.webViewShowNotes?.addView(webView, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
             } catch (e: Exception) {


### PR DESCRIPTION
This change allows the user to select text from the show notes on the full-screen episode details view.

Thanks to @karacca for looking into this issue.

Fixes https://github.com/Automattic/pocket-casts-android/issues/143

**Test steps**
1. Tap on the "Podcasts" tab
2. Tap on a podcast
3. Tap on an episode
4. Long press on the show notes to select text

You should be allowed to copy text from the show notes.

<img  width="300" src="https://user-images.githubusercontent.com/308331/194156506-a7050486-1169-415b-ada0-5cb0200b7879.png" />

