### PR TITLE
Update ResetPasswordFragment to use NavController

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/ResetPasswordFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/ResetPasswordFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
+import androidx.navigation.findNavController
 import au.com.shiftyjelly.pocketcasts.account.databinding.FragmentResetPasswordBinding
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.ResetPasswordError
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.ResetPasswordState
@@ -86,7 +87,7 @@ class ResetPasswordFragment : BaseFragment() {
                             getString(LR.string.profile_reset_password_check_email),
                             onComplete = {
                                 if (isAdded) {
-                                    parentFragmentManager.popBackStack()
+                                    view.findNavController().popBackStack()
                                 }
                             }
                         )


### PR DESCRIPTION
# Description

Update ResetPasswordFragment to use NavController instead of FragmetManager. 

Fixes #290

https://user-images.githubusercontent.com/47274419/194166412-6da10a03-fc07-45ec-b868-99fc0e0652cf.mp4

# Checklist

- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [x] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [x] Have you tested in different themes?
- [x] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?