### PR TITLE
Fix crash when swiping to open Up Next queue

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -61,7 +61,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private const val UPNEXT_DRAG_DISTANCE_MULTIPLIER = 1.85f // Open up next at a different rate than we are dragging
 private const val UPNEXT_HEIGHT_OPEN_THRESHOLD = 0.15f // We only have an open threshold because we only control swipe up, swipe down is the standard bottom sheet behaviour
-private const val UPNEXT_OUTLIER_THRESHOLD = 150.0f // Sometimes we get a random large delta, it seems better to filter them out or else you get random jumps
+private const val UPNEXT_OUTLIER_THRESHOLD = 400.0f // Sometimes we get a random large delta, it seems better to filter them out or else you get random jumps
 
 @AndroidEntryPoint
 class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -167,7 +167,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         binding.castButton.setAlwaysVisible(true)
         binding.castButton.updateColor(ThemeColor.playerContrast03(theme.activeTheme))
 
-        setupUpNextDrag(view)
+        setupUpNextDrag(view, binding.topView)
 
         viewModel.listDataLive.observe(viewLifecycleOwner) {
             val headerViewModel = it.podcastHeader
@@ -258,7 +258,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         }
     }
 
-    private fun setupUpNextDrag(view: View) {
+    private fun setupUpNextDrag(view: View, topView: View?) {
         val context = context ?: return
         val swipeGesture = GestureDetectorCompat(
             context,
@@ -298,6 +298,18 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
                 }
             }
         )
+
+        @Suppress("ClickableViewAccessibility")
+        topView?.setOnTouchListener { _, event ->
+            // Check for down events from the top view because sometimes they don't make it to
+            // the NestedScrollView's OnTouchListener and the first event we pass to our
+            // swipe gesture handler must be a down event
+            if (!hasReceivedOnTouchDown && event.actionMasked == MotionEvent.ACTION_DOWN) {
+                swipeGesture.onTouchEvent(event)
+                hasReceivedOnTouchDown = true
+            }
+            false
+        }
 
         view.setOnTouchListener { _, event ->
             if ((activity as? FragmentHostListener)?.getPlayerBottomSheetState() != BottomSheetBehavior.STATE_EXPANDED) {

--- a/modules/features/player/src/main/res/layout/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout/adapter_player_header.xml
@@ -449,6 +449,16 @@
 
             </LinearLayout>
 
+               <View
+                android:id="@+id/topView"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
## Description

Fixes #370 by adding a top level view to capture the down events that for some reason don't seem to always make it down to the `NestedScrollView` (which results in a crash). 

_h/t to @geekygecko for coming up with this solution. 🙇_

> **Warning**
> I am targeting the `release/7.24` branch because I think we should do a betafix for this. It is a regression in the 7.24 release (probably because of [bumping our target SDK to 33](https://github.com/Automattic/pocket-casts-android/pull/312)) and has a pretty high number of occurrences in Sentry considering it only just started with the 7.24-rc-1 release we put out earlier this week. Let me know if you disagree (or if you think that targeting the release branch like this isn't the right way to proceed with a beta release).

## Test steps

This crash is very hard to reproduce, and I don't have any clear test steps to cause the crash. For some reason I seem to be able to get it pretty consistently on my Pixel 3 test device running Android 12, but it seems like all the crashes in Sentry are with Android 13. 🤷  TLDR: You may not be able to reproduce this crash locally.

1. Open app
2. Open full screen player
3. Swipe up to open the Up Next queue
4. ✅  Verfiy there is no crash

# Checklist

- [X] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [X] Are all the strings localized?
- [X] Could you have written any new tests?
- [X] Did you include Compose previews with any components?