### PR TITLE
Remove ad id permission for automotive

### DIFF
--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -22,6 +22,8 @@
         android:name="android.hardware.camera"
         android:required="false" />
 
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
+
     <application
         android:name=".AutomotiveApplication"
         android:allowBackup="true"
@@ -74,6 +76,9 @@
                 android:value="androidx.startup"
                 tools:node="remove" />
         </provider>
+
+        <!-- Disable Advertising ID collection -->
+        <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false"/>
 
         <meta-data
             android:name="pocketcasts_automotive"


### PR DESCRIPTION
# Description

This PR removes advertising ID permission and disables its collection for the automotive app. 

While creating beta release for the mobile app, publishing failed with the below error:

```
[2022-10-06T06:41:51Z] [!] Google Api Error: Invalid request - This release includes the com.google.android.gms.permission.AD_ID permission but your declaration on Play Console says your app doesn't use advertising ID. You must update your advertising ID declaration.
```

Noticed that advertising ID permission was included for the automotive app in the merged manifest that blocked publishing for the mobile app as well:

<img width="1086" alt="Screenshot 2022-10-06 at 12 27 31 PM" src="https://user-images.githubusercontent.com/1405144/194235164-4c24e620-1a41-4873-ad6f-a27f87b8ca19.png">

# Checklist

- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [ ] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [ ] Have you tested in different themes?
- [ ] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?