### PR TITLE
Track mini player and up next events

### DIFF
--- a/app/src/debug/res/xml/shortcuts.xml
+++ b/app/src/debug/res/xml/shortcuts.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <shortcut android:icon="@drawable/shortcut_grid" android:enabled="true" android:shortcutId="shortcut-podcasts" android:shortcutShortLabel="@string/podcasts">
+        <intent android:targetPackage="au.com.shiftyjelly.pocketcasts.debug"
+                android:targetClass="au.com.shiftyjelly.pocketcasts.ui.MainActivity"
+                android:action="android.intent.action.VIEW">
+            <extra android:name="launch-page" android:value="podcasts" />
+        </intent>
+    </shortcut>
+
+    <shortcut android:icon="@drawable/shortcut_search" android:enabled="true" android:shortcutId="shortcut-search" android:shortcutShortLabel="@string/search">
+        <intent android:targetPackage="au.com.shiftyjelly.pocketcasts.debug"
+                android:targetClass="au.com.shiftyjelly.pocketcasts.ui.MainActivity"
+                android:action="android.intent.action.VIEW">
+            <extra android:name="launch-page" android:value="search" />
+        </intent>
+    </shortcut>
+
+    <shortcut android:icon="@drawable/shortcut_upnext" android:enabled="true" android:shortcutId="shortcut-up-next" android:shortcutShortLabel="@string/up_next">
+        <intent android:targetPackage="au.com.shiftyjelly.pocketcasts.debug"
+                android:targetClass="au.com.shiftyjelly.pocketcasts.ui.MainActivity"
+                android:action="android.intent.action.VIEW">
+            <extra android:name="launch-page" android:value="upnext" />
+        </intent>
+    </shortcut>
+
+</shortcuts>

--- a/app/src/debugProd/res/xml/shortcuts.xml
+++ b/app/src/debugProd/res/xml/shortcuts.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <shortcut android:icon="@drawable/shortcut_grid" android:enabled="true" android:shortcutId="shortcut-podcasts" android:shortcutShortLabel="@string/podcasts">
+        <intent android:targetPackage="au.com.shiftyjelly.pocketcasts.debug"
+                android:targetClass="au.com.shiftyjelly.pocketcasts.ui.MainActivity"
+                android:action="android.intent.action.VIEW">
+            <extra android:name="launch-page" android:value="podcasts" />
+        </intent>
+    </shortcut>
+
+    <shortcut android:icon="@drawable/shortcut_search" android:enabled="true" android:shortcutId="shortcut-search" android:shortcutShortLabel="@string/search">
+        <intent android:targetPackage="au.com.shiftyjelly.pocketcasts.debug"
+                android:targetClass="au.com.shiftyjelly.pocketcasts.ui.MainActivity"
+                android:action="android.intent.action.VIEW">
+            <extra android:name="launch-page" android:value="search" />
+        </intent>
+    </shortcut>
+
+    <shortcut android:icon="@drawable/shortcut_upnext" android:enabled="true" android:shortcutId="shortcut-up-next" android:shortcutShortLabel="@string/up_next">
+        <intent android:targetPackage="au.com.shiftyjelly.pocketcasts.debug"
+                android:targetClass="au.com.shiftyjelly.pocketcasts.ui.MainActivity"
+                android:action="android.intent.action.VIEW">
+            <extra android:name="launch-page" android:value="upnext" />
+        </intent>
+    </shortcut>
+
+</shortcuts>

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -435,7 +435,7 @@ class MainActivity :
     }
 
     override fun onMiniPlayerLongClick() {
-        MiniPlayerDialog(playbackManager, podcastManager, episodeManager, supportFragmentManager).show(this)
+        MiniPlayerDialog(playbackManager, podcastManager, episodeManager, supportFragmentManager, analyticsTracker).show(this)
     }
 
     @OptIn(DelicateCoroutinesApi::class)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -433,16 +433,16 @@ class MainActivity :
     }
 
     override fun onUpNextClicked() {
-        analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHOWN, mapOf(SOURCE_KEY to UpNextSource.MINI_PLAYER.analyticsValue))
-        showUpNextFragment()
+        showUpNextFragment(UpNextSource.MINI_PLAYER)
     }
 
     override fun onMiniPlayerLongClick() {
         MiniPlayerDialog(playbackManager, podcastManager, episodeManager, supportFragmentManager, analyticsTracker).show(this)
     }
 
-    private fun showUpNextFragment() {
-        showBottomSheet(UpNextFragment())
+    private fun showUpNextFragment(source: UpNextSource) {
+        analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHOWN, mapOf(SOURCE_KEY to source.analyticsValue))
+        showBottomSheet(UpNextFragment.newInstance(source = source))
     }
 
     @OptIn(DelicateCoroutinesApi::class)
@@ -586,9 +586,8 @@ class MainActivity :
         // Handle up next shortcut
         if (intent.getStringExtra(INTENT_EXTRA_PAGE) == "upnext") {
             intent.putExtra(INTENT_EXTRA_PAGE, null as String?)
-            analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHOWN, mapOf(SOURCE_KEY to UpNextSource.UP_NEXT_SHORTCUT.analyticsValue))
             binding.playerBottomSheet.openPlayer()
-            showUpNextFragment()
+            showUpNextFragment(UpNextSource.UP_NEXT_SHORTCUT)
         }
     }
 

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -654,6 +654,8 @@ class MainActivity :
         binding.frameBottomSheet.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
     }
 
+    override fun isUpNextShowing() = bottomSheetTag == UpNextFragment::class.java.name
+
     private fun removeBottomSheetFragment(fragment: Fragment) {
         val tag = fragment::class.java.name
         supportFragmentManager.findFragmentByTag(tag)?.let {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -58,6 +58,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -125,6 +126,7 @@ class MainActivity :
 
     companion object {
         private const val INITIAL_KEY = "initial"
+        private const val SOURCE_KEY = "source"
         init {
             AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
         }
@@ -431,11 +433,16 @@ class MainActivity :
     }
 
     override fun onUpNextClicked() {
-        showBottomSheet(UpNextFragment())
+        analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHOWN, mapOf(SOURCE_KEY to UpNextSource.MINI_PLAYER.analyticsValue))
+        showUpNextFragment()
     }
 
     override fun onMiniPlayerLongClick() {
         MiniPlayerDialog(playbackManager, podcastManager, episodeManager, supportFragmentManager, analyticsTracker).show(this)
+    }
+
+    private fun showUpNextFragment() {
+        showBottomSheet(UpNextFragment())
     }
 
     @OptIn(DelicateCoroutinesApi::class)
@@ -579,8 +586,9 @@ class MainActivity :
         // Handle up next shortcut
         if (intent.getStringExtra(INTENT_EXTRA_PAGE) == "upnext") {
             intent.putExtra(INTENT_EXTRA_PAGE, null as String?)
+            analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHOWN, mapOf(SOURCE_KEY to UpNextSource.UP_NEXT_SHORTCUT.analyticsValue))
             binding.playerBottomSheet.openPlayer()
-            onUpNextClicked()
+            showUpNextFragment()
         }
     }
 

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -529,6 +529,7 @@ class MainActivity :
 
                 override fun onStateChanged(bottomSheet: View, newState: Int) {
                     if (newState == BottomSheetBehavior.STATE_COLLAPSED) {
+                        analyticsTracker.track(AnalyticsEvent.UP_NEXT_DISMISSED)
                         supportFragmentManager.findFragmentByTag(bottomSheetTag)?.let {
                             removeBottomSheetFragment(it)
                         }

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
@@ -130,4 +130,8 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
 
     override fun overrideNextRefreshTimer() {
     }
+
+    override fun isUpNextShowing(): Boolean {
+        return false
+    }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -17,12 +17,15 @@ import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.RecyclerView.SCROLL_STATE_IDLE
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentPlayerContainerBinding
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -42,6 +45,7 @@ import au.com.shiftyjelly.pocketcasts.views.R as VR
 @AndroidEntryPoint
 class PlayerContainerFragment : BaseFragment(), HasBackstack {
     @Inject lateinit var settings: Settings
+    @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     lateinit var upNextBottomSheetBehavior: BottomSheetBehavior<View>
 
@@ -139,7 +143,10 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
             binding.upNextButton.setImageDrawable(upNextDrawable)
             binding.countText.text = if (upNextCount == 0) "" else upNextCount.toString()
 
-            binding.upNextButton.setOnClickListener { openUpNext() }
+            binding.upNextButton.setOnClickListener {
+                analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHOWN, mapOf(SOURCE_KEY to UpNextSource.PLAYER.analyticsValue))
+                openUpNext()
+            }
 
             view.setBackgroundColor(it.podcastHeader.backgroundColor)
         }
@@ -196,6 +203,10 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
         } else {
             false
         }
+    }
+
+    companion object {
+        private const val SOURCE_KEY = "source"
     }
 }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -68,7 +68,7 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
 
         adapter = ViewPagerAdapter(childFragmentManager, viewLifecycleOwner.lifecycle)
 
-        val upNextFragment = UpNextFragment.newInstance(embedded = true)
+        val upNextFragment = UpNextFragment.newInstance(embedded = true, source = UpNextSource.PLAYER)
         childFragmentManager.beginTransaction().replace(R.id.upNextFrameBottomSheet, upNextFragment).commitAllowingStateLoss()
 
         val binding = binding ?: return

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -68,7 +68,7 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
 
         adapter = ViewPagerAdapter(childFragmentManager, viewLifecycleOwner.lifecycle)
 
-        val upNextFragment = UpNextFragment.newInstance(embedded = true, source = UpNextSource.PLAYER)
+        val upNextFragment = UpNextFragment.newInstance(embedded = true, source = UpNextSource.NOW_PLAYING)
         childFragmentManager.beginTransaction().replace(R.id.upNextFrameBottomSheet, upNextFragment).commitAllowingStateLoss()
 
         val binding = binding ?: return
@@ -80,6 +80,7 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
 
             override fun onStateChanged(bottomSheet: View, newState: Int) {
                 if (newState == BottomSheetBehavior.STATE_EXPANDED) {
+                    analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHOWN, mapOf(SOURCE_KEY to UpNextSource.NOW_PLAYING.analyticsValue))
                     upNextBottomSheetBehavior.setPeekHeight(0, false)
                     updateUpNextVisibility(true)
 
@@ -92,6 +93,7 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
 
                     FirebaseAnalyticsTracker.openedUpNext()
                 } else if (newState == BottomSheetBehavior.STATE_COLLAPSED) {
+                    analyticsTracker.track(AnalyticsEvent.UP_NEXT_DISMISSED, mapOf(SOURCE_KEY to UpNextSource.NOW_PLAYING.analyticsValue))
                     updateUpNextVisibility(false)
 
                     (activity as? FragmentHostListener)?.updateSystemColors()

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -164,7 +164,7 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
     }
 
     fun openUpNext() {
-        val upNextFragment = UpNextFragment()
+        val upNextFragment = UpNextFragment.newInstance(source = UpNextSource.PLAYER)
         (activity as? FragmentHostListener)?.showBottomSheet(upNextFragment)
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -93,7 +93,7 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
 
                     FirebaseAnalyticsTracker.openedUpNext()
                 } else if (newState == BottomSheetBehavior.STATE_COLLAPSED) {
-                    analyticsTracker.track(AnalyticsEvent.UP_NEXT_DISMISSED, mapOf(SOURCE_KEY to UpNextSource.NOW_PLAYING.analyticsValue))
+                    analyticsTracker.track(AnalyticsEvent.UP_NEXT_DISMISSED)
                     updateUpNextVisibility(false)
 
                     (activity as? FragmentHostListener)?.updateSystemColors()

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -61,7 +61,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private const val UPNEXT_DRAG_DISTANCE_MULTIPLIER = 1.85f // Open up next at a different rate than we are dragging
 private const val UPNEXT_HEIGHT_OPEN_THRESHOLD = 0.15f // We only have an open threshold because we only control swipe up, swipe down is the standard bottom sheet behaviour
-private const val UPNEXT_OUTLIER_THRESHOLD = 150.0f // Sometimes we get a random large delta, it seems better to filter them out or else you get random jumps
+private const val UPNEXT_OUTLIER_THRESHOLD = 400.0f // Sometimes we get a random large delta, it seems better to filter them out or else you get random jumps
 
 @AndroidEntryPoint
 class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -167,7 +167,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         binding.castButton.setAlwaysVisible(true)
         binding.castButton.updateColor(ThemeColor.playerContrast03(theme.activeTheme))
 
-        setupUpNextDrag(view)
+        setupUpNextDrag(view, binding.topView)
 
         viewModel.listDataLive.observe(viewLifecycleOwner) {
             val headerViewModel = it.podcastHeader
@@ -258,7 +258,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         }
     }
 
-    private fun setupUpNextDrag(view: View) {
+    private fun setupUpNextDrag(view: View, topView: View?) {
         val context = context ?: return
         val swipeGesture = GestureDetectorCompat(
             context,
@@ -298,6 +298,18 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
                 }
             }
         )
+
+        @Suppress("ClickableViewAccessibility")
+        topView?.setOnTouchListener { _, event ->
+            // Check for down events from the top view because sometimes they don't make it to
+            // the NestedScrollView's OnTouchListener and the first event we pass to our
+            // swipe gesture handler must be a down event
+            if (!hasReceivedOnTouchDown && event.actionMasked == MotionEvent.ACTION_DOWN) {
+                swipeGesture.onTouchEvent(event)
+                hasReceivedOnTouchDown = true
+            }
+            false
+        }
 
         view.setOnTouchListener { _, event ->
             if ((activity as? FragmentHostListener)?.getPlayerBottomSheetState() != BottomSheetBehavior.STATE_EXPANDED) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -11,6 +11,8 @@ import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
@@ -22,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getSummaryText
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImageLoader
 import au.com.shiftyjelly.pocketcasts.repositories.images.into
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
@@ -30,7 +33,17 @@ import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectHelper
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-class UpNextAdapter(context: Context, val imageLoader: PodcastImageLoader, val episodeManager: EpisodeManager, val listener: UpNextListener, val multiSelectHelper: MultiSelectHelper, val fragmentManager: FragmentManager) : ListAdapter<Any, RecyclerView.ViewHolder>(UPNEXT_ADAPTER_DIFF) {
+class UpNextAdapter(
+    context: Context,
+    val
+    imageLoader: PodcastImageLoader,
+    val episodeManager: EpisodeManager,
+    val listener: UpNextListener,
+    val multiSelectHelper: MultiSelectHelper,
+    val fragmentManager: FragmentManager,
+    val analyticsTracker: AnalyticsTrackerWrapper,
+    val upNextSource: UpNextSource
+) : ListAdapter<Any, RecyclerView.ViewHolder>(UPNEXT_ADAPTER_DIFF) {
     private val dateFormatter = RelativeDateFormatter(context)
 
     var isPlaying: Boolean = false
@@ -126,7 +139,10 @@ class UpNextAdapter(context: Context, val imageLoader: PodcastImageLoader, val e
         var loadedUuid: String? = null
 
         init {
-            binding.root.setOnClickListener { listener.onNowPlayingClick() }
+            binding.root.setOnClickListener {
+                analyticsTracker.track(AnalyticsEvent.UP_NEXT_NOW_PLAYING_TAPPED, mapOf(SOURCE_KEY to upNextSource))
+                listener.onNowPlayingClick()
+            }
         }
 
         fun bind(playingState: UpNextPlaying) {
@@ -150,6 +166,10 @@ class UpNextAdapter(context: Context, val imageLoader: PodcastImageLoader, val e
 
             binding.playingAnimation.isVisible = isPlaying
         }
+    }
+
+    companion object {
+        private const val SOURCE_KEY = "source"
     }
 }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -98,7 +98,7 @@ class UpNextAdapter(
             } else {
                 val podcastUuid = (item as? Episode)?.podcastUuid
                 val playOnTap = settings.getTapOnUpNextShouldPlay()
-                analyticsTracker.track(AnalyticsEvent.UP_NEXT_QUEUE_EPISODE_TAPPED, mapOf(SOURCE_KEY to upNextSource, WILL_PLAY_KEY to playOnTap))
+                trackUpNextEvent(AnalyticsEvent.UP_NEXT_QUEUE_EPISODE_TAPPED, mapOf(WILL_PLAY_KEY to playOnTap))
                 listener.onEpisodeActionsClick(episodeUuid = item.uuid, podcastUuid = podcastUuid)
             }
         }
@@ -108,7 +108,7 @@ class UpNextAdapter(
             } else {
                 val podcastUuid = (item as? Episode)?.podcastUuid
                 val playOnLongPress = !settings.getTapOnUpNextShouldPlay()
-                analyticsTracker.track(AnalyticsEvent.UP_NEXT_QUEUE_EPISODE_LONG_PRESSED, mapOf(SOURCE_KEY to upNextSource, WILL_PLAY_KEY to playOnLongPress))
+                trackUpNextEvent(AnalyticsEvent.UP_NEXT_QUEUE_EPISODE_LONG_PRESSED, mapOf(WILL_PLAY_KEY to playOnLongPress))
                 listener.onEpisodeActionsLongPress(episodeUuid = item.uuid, podcastUuid = podcastUuid)
             }
             true
@@ -146,7 +146,7 @@ class UpNextAdapter(
 
         init {
             binding.root.setOnClickListener {
-                analyticsTracker.track(AnalyticsEvent.UP_NEXT_NOW_PLAYING_TAPPED, mapOf(SOURCE_KEY to upNextSource))
+                trackUpNextEvent(AnalyticsEvent.UP_NEXT_NOW_PLAYING_TAPPED)
                 listener.onNowPlayingClick()
             }
         }
@@ -172,6 +172,13 @@ class UpNextAdapter(
 
             binding.playingAnimation.isVisible = isPlaying
         }
+    }
+
+    private fun trackUpNextEvent(event: AnalyticsEvent, props: Map<String, Any> = emptyMap()) {
+        val properties = HashMap<String, Any>()
+        properties[SOURCE_KEY] = upNextSource.analyticsValue
+        properties.putAll(props)
+        analyticsTracker.track(event, properties)
     }
 
     companion object {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -21,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.player.databinding.AdapterUpNextFooterBinding
 import au.com.shiftyjelly.pocketcasts.player.databinding.AdapterUpNextPlayingBinding
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getSummaryText
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImageLoader
 import au.com.shiftyjelly.pocketcasts.repositories.images.into
@@ -41,8 +42,9 @@ class UpNextAdapter(
     val listener: UpNextListener,
     val multiSelectHelper: MultiSelectHelper,
     val fragmentManager: FragmentManager,
-    val analyticsTracker: AnalyticsTrackerWrapper,
-    val upNextSource: UpNextSource
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val upNextSource: UpNextSource,
+    private val settings: Settings
 ) : ListAdapter<Any, RecyclerView.ViewHolder>(UPNEXT_ADAPTER_DIFF) {
     private val dateFormatter = RelativeDateFormatter(context)
 
@@ -95,6 +97,8 @@ class UpNextAdapter(
                 holder.binding.checkbox.isChecked = multiSelectHelper.toggle(item)
             } else {
                 val podcastUuid = (item as? Episode)?.podcastUuid
+                val playOnTap = settings.getTapOnUpNextShouldPlay()
+                analyticsTracker.track(AnalyticsEvent.UP_NEXT_QUEUE_EPISODE_TAPPED, mapOf(SOURCE_KEY to upNextSource, WILL_PLAY_KEY to playOnTap))
                 listener.onEpisodeActionsClick(episodeUuid = item.uuid, podcastUuid = podcastUuid)
             }
         }
@@ -103,6 +107,8 @@ class UpNextAdapter(
                 multiSelectHelper.defaultLongPress(episode = item, fragmentManager = fragmentManager)
             } else {
                 val podcastUuid = (item as? Episode)?.podcastUuid
+                val playOnLongPress = !settings.getTapOnUpNextShouldPlay()
+                analyticsTracker.track(AnalyticsEvent.UP_NEXT_QUEUE_EPISODE_LONG_PRESSED, mapOf(SOURCE_KEY to upNextSource, WILL_PLAY_KEY to playOnLongPress))
                 listener.onEpisodeActionsLongPress(episodeUuid = item.uuid, podcastUuid = podcastUuid)
             }
             true
@@ -170,6 +176,7 @@ class UpNextAdapter(
 
     companion object {
         private const val SOURCE_KEY = "source"
+        private const val WILL_PLAY_KEY = "will_play"
     }
 }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -156,7 +156,6 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
         val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
         toolbar.setTitle(LR.string.up_next)
         toolbar.setNavigationOnClickListener {
-            trackUpNextEvent(AnalyticsEvent.UP_NEXT_DISMISSED)
             close()
         }
         toolbar.navigationIcon?.setTint(ThemeColor.secondaryIcon01(overrideTheme))

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -205,7 +205,8 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
             multiSelectToolbar.isVisible = isMultiSelecting
             toolbar.isVisible = !isMultiSelecting
 
-            if (!isEmbedded) {
+            /* Track only if not embedded. If it is an embedded fragment, then track only when in expanded state */
+            if (!isEmbedded || isEmbeddedExpanded()) {
                 if (isMultiSelecting) {
                     trackUpNextEvent(AnalyticsEvent.UP_NEXT_MULTI_SELECT_ENTERED)
                 } else if (wasMultiSelecting) {
@@ -305,6 +306,9 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
             (parentFragment as? PlayerContainerFragment)?.upNextBottomSheetBehavior?.state = BottomSheetBehavior.STATE_COLLAPSED
         }
     }
+
+    private fun isEmbeddedExpanded() =
+        isEmbedded && (parentFragment as? PlayerContainerFragment)?.upNextBottomSheetBehavior?.state == BottomSheetBehavior.STATE_EXPANDED
 
     override fun onClearUpNext() {
         playerViewModel.clearUpNext(context = requireContext(), upNextSource = upNextSource)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -123,7 +123,8 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
             multiSelectHelper = multiSelectHelper,
             fragmentManager = childFragmentManager,
             analyticsTracker = analyticsTracker,
-            upNextSource = upNextSource
+            upNextSource = upNextSource,
+            settings = settings
         )
         adapter.theme = overrideTheme
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -165,7 +165,6 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
         toolbar.setOnMenuItemClickListener {
             when (it.itemId) {
                 R.id.menu_select -> {
-                    trackUpNextEvent(AnalyticsEvent.UP_NEXT_MULTI_SELECT_ENTERED)
                     multiSelectHelper.isMultiSelecting = true
                     true
                 }
@@ -201,12 +200,17 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
         (recyclerView.itemAnimator as? SimpleItemAnimator)?.changeDuration = 0
 
         val multiSelectToolbar = view.findViewById<MultiSelectToolbar>(R.id.multiSelectToolbar)
-        multiSelectHelper.isMultiSelectingLive.observe(viewLifecycleOwner) {
-            multiSelectToolbar.isVisible = it
-            toolbar.isVisible = !it
+        multiSelectHelper.isMultiSelectingLive.observe(viewLifecycleOwner) { isMultiSelecting ->
+            val wasMultiSelecting = multiSelectToolbar.isVisible
+            multiSelectToolbar.isVisible = isMultiSelecting
+            toolbar.isVisible = !isMultiSelecting
 
-            if (toolbar.isVisible) {
-                trackUpNextEvent(AnalyticsEvent.UP_NEXT_MULTI_SELECT_EXITED)
+            if (!isEmbedded) {
+                if (isMultiSelecting) {
+                    trackUpNextEvent(AnalyticsEvent.UP_NEXT_MULTI_SELECT_ENTERED)
+                } else if (wasMultiSelecting) {
+                    trackUpNextEvent(AnalyticsEvent.UP_NEXT_MULTI_SELECT_EXITED)
+                }
             }
 
             multiSelectToolbar.setNavigationIcon(IR.drawable.ic_arrow_back)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -303,7 +303,8 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
     }
 
     override fun onClearUpNext() {
-        playerViewModel.clearUpNext(requireContext()).showOrClear(parentFragmentManager)
+        playerViewModel.clearUpNext(context = requireContext(), upNextSource = upNextSource)
+            .showOrClear(parentFragmentManager)
     }
 
     override fun onUpNextEpisodeStartDrag(viewHolder: RecyclerView.ViewHolder) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -148,6 +148,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
         val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
         toolbar.setTitle(LR.string.up_next)
         toolbar.setNavigationOnClickListener {
+            trackUpNextEvent(AnalyticsEvent.UP_NEXT_DISMISSED)
             close()
         }
         toolbar.navigationIcon?.setTint(ThemeColor.secondaryIcon01(overrideTheme))

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextTouchCallback.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextTouchCallback.kt
@@ -15,7 +15,7 @@ class UpNextTouchCallback(
         fun onUpNextEpisodeMove(fromPosition: Int, toPosition: Int)
         fun onUpNextEpisodeRemove(position: Int)
         fun onUpNextEpisodeStartDrag(viewHolder: RecyclerView.ViewHolder)
-        fun onUpNextItemTouchHelperFinished()
+        fun onUpNextItemTouchHelperFinished(position: Int)
     }
 
     interface ItemTouchHelperViewHolder {
@@ -64,7 +64,7 @@ class UpNextTouchCallback(
         }
 
         viewHolder.setIsRecyclable(true)
-        adapter.onUpNextItemTouchHelperFinished()
+        adapter.onUpNextItemTouchHelperFinished(viewHolder.bindingAdapterPosition)
     }
 
     override fun isItemViewSwipeEnabled(): Boolean {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/dialog/ClearUpNextDialog.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/dialog/ClearUpNextDialog.kt
@@ -2,15 +2,26 @@ package au.com.shiftyjelly.pocketcasts.player.view.dialog
 
 import android.content.Context
 import androidx.fragment.app.FragmentManager
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
+import dagger.hilt.android.AndroidEntryPoint
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 /**
  * A dialog that shows a clear Up Next confirmation dialog if there are more than two episodes in the queue.
  */
-class ClearUpNextDialog(private val removeNowPlaying: Boolean, private val playbackManager: PlaybackManager, context: Context) : ConfirmationDialog() {
+@AndroidEntryPoint
+class ClearUpNextDialog(
+    private val source: UpNextSource = UpNextSource.UNKNOWN,
+    private val removeNowPlaying: Boolean,
+    private val playbackManager: PlaybackManager,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    context: Context
+) : ConfirmationDialog() {
 
     init {
         setTitle(context.getString(LR.string.player_up_next_clear_queue_button))
@@ -22,6 +33,7 @@ class ClearUpNextDialog(private val removeNowPlaying: Boolean, private val playb
     }
 
     private fun clear() {
+        analyticsTracker.track(AnalyticsEvent.UP_NEXT_QUEUE_CLEARED, mapOf(SOURCE_KEY to source.analyticsValue))
         if (removeNowPlaying) {
             playbackManager.endPlaybackAndClearUpNextAsync()
         } else {
@@ -36,5 +48,9 @@ class ClearUpNextDialog(private val removeNowPlaying: Boolean, private val playb
         } else {
             clear()
         }
+    }
+
+    companion object {
+        private const val SOURCE_KEY = "source"
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/dialog/MiniPlayerDialog.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/dialog/MiniPlayerDialog.kt
@@ -5,6 +5,7 @@ import androidx.fragment.app.FragmentManager
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
@@ -57,8 +58,14 @@ class MiniPlayerDialog(
     }
 
     private fun endPlaybackAndClearUpNext(context: Context) {
-        ClearUpNextDialog(removeNowPlaying = true, playbackManager = playbackManager, context = context)
-            .showOrClear(fragmentManager)
+        val dialog = ClearUpNextDialog(
+            source = UpNextSource.MINI_PLAYER,
+            removeNowPlaying = true,
+            playbackManager = playbackManager,
+            analyticsTracker = analyticsTracker,
+            context = context
+        )
+        dialog.showOrClear(fragmentManager)
     }
 
     private fun markAsPlayed() {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/dialog/MiniPlayerDialog.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/dialog/MiniPlayerDialog.kt
@@ -2,6 +2,8 @@ package au.com.shiftyjelly.pocketcasts.player.view.dialog
 
 import android.content.Context
 import androidx.fragment.app.FragmentManager
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -18,24 +20,39 @@ class MiniPlayerDialog(
     private val playbackManager: PlaybackManager,
     private val podcastManager: PodcastManager,
     private val episodeManager: EpisodeManager,
-    private val fragmentManager: FragmentManager
+    private val fragmentManager: FragmentManager,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
 ) {
-
+    private var isOptionClicked = false
     fun show(context: Context) {
+        analyticsTracker.track(AnalyticsEvent.MINI_PLAYER_LONG_PRESS_MENU_SHOWN)
         val dangerColor = context.getThemeColor(UR.attr.support_05)
         OptionsDialog()
             .addTextOption(
                 titleId = LR.string.mark_played,
                 imageId = IR.drawable.ic_markasplayed,
-                click = { markAsPlayed() }
+                click = {
+                    isOptionClicked = true
+                    analyticsTracker.track(AnalyticsEvent.MINI_PLAYER_LONG_PRESS_MENU_OPTION_TAPPED, mapOf(OPTION_KEY to MARK_PLAYED))
+                    markAsPlayed()
+                }
             )
             .addTextOption(
                 titleId = LR.string.player_end_playback_clear_up_next,
                 titleColor = dangerColor,
                 imageId = IR.drawable.ic_close,
                 imageColor = dangerColor,
-                click = { endPlaybackAndClearUpNext(context) }
+                click = {
+                    isOptionClicked = true
+                    analyticsTracker.track(AnalyticsEvent.MINI_PLAYER_LONG_PRESS_MENU_OPTION_TAPPED, mapOf(OPTION_KEY to CLOSE_AND_CLEAR_UP_NEXT))
+                    endPlaybackAndClearUpNext(context)
+                }
             )
+            .setOnDismiss {
+                if (!isOptionClicked) {
+                    analyticsTracker.track(AnalyticsEvent.MINI_PLAYER_LONG_PRESS_MENU_DISMISSED)
+                }
+            }
             .show(fragmentManager, "mini_player_dialog")
     }
 
@@ -47,5 +64,11 @@ class MiniPlayerDialog(
     private fun markAsPlayed() {
         val episode = playbackManager.upNextQueue.currentEpisode ?: return
         episodeManager.markAsPlayedAsync(episode, playbackManager, podcastManager)
+    }
+
+    companion object {
+        private const val OPTION_KEY = "option"
+        private const val MARK_PLAYED = "mark_played"
+        private const val CLOSE_AND_CLEAR_UP_NEXT = "close_and_clear_up_next"
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
@@ -30,6 +31,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.SleepTimer
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
@@ -73,7 +75,8 @@ class PlayerViewModel @Inject constructor(
     private val sleepTimer: SleepTimer,
     private val settings: Settings,
     private val theme: Theme,
-    @ApplicationContext private val context: Context
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    @ApplicationContext private val context: Context,
 ) : ViewModel(), CoroutineScope {
 
     override val coroutineContext: CoroutineContext
@@ -559,8 +562,14 @@ class PlayerViewModel @Inject constructor(
         }
     }
 
-    fun clearUpNext(context: Context): ClearUpNextDialog {
-        val dialog = ClearUpNextDialog(removeNowPlaying = false, playbackManager = playbackManager, context = context)
+    fun clearUpNext(context: Context, upNextSource: UpNextSource): ClearUpNextDialog {
+        val dialog = ClearUpNextDialog(
+            source = upNextSource,
+            removeNowPlaying = false,
+            playbackManager = playbackManager,
+            analyticsTracker = analyticsTracker,
+            context = context
+        )
         dialog.setForceDarkTheme(true)
         return dialog
     }

--- a/modules/features/player/src/main/res/layout/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout/adapter_player_header.xml
@@ -449,6 +449,16 @@
 
             </LinearLayout>
 
+               <View
+                android:id="@+id/topView"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.core.widget.NestedScrollView>

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -183,10 +183,12 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             binding?.toolbar?.isVisible = !isMultiSelecting
             binding?.multiSelectToolbar?.setNavigationIcon(R.drawable.ic_arrow_back)
 
-            if (isMultiSelecting) {
-                trackMultiSelectEntered()
-            } else if (wasMultiSelecting) {
-                trackMultiSelectExited()
+            if ((activity as? FragmentHostListener)?.isUpNextShowing() == false) {
+                if (isMultiSelecting) {
+                    trackMultiSelectEntered()
+                } else if (wasMultiSelecting) {
+                    trackMultiSelectExited()
+                }
             }
 
             adapter.notifyDataSetChanged()

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -246,7 +246,7 @@ enum class AnalyticsEvent(val key: String) {
     UP_NEXT_QUEUE_EPISODE_TAPPED("up_next_queue_episode_tapped"),
     UP_NEXT_QUEUE_EPISODE_LONG_PRESSED("up_next_queue_episode_long_pressed"),
     UP_NEXT_MULTI_SELECT_ENTERED("up_next_multi_select_entered"),
-    UP_NEXT_SELECT_ALL_BUTTON_TAPPED("up_next_select_all_button_tapped"),
+    UP_NEXT_SELECT_ALL_TAPPED("up_next_select_all_tapped"),
     UP_NEXT_MULTI_SELECT_EXITED("up_next_multi_select_exited"),
     UP_NEXT_QUEUE_REORDERED("up_next_queue_reordered"),
     UP_NEXT_DISMISSED("up_next_dismissed"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -238,4 +238,16 @@ enum class AnalyticsEvent(val key: String) {
     MINI_PLAYER_LONG_PRESS_MENU_SHOWN("mini_player_long_press_menu_shown"),
     MINI_PLAYER_LONG_PRESS_MENU_OPTION_TAPPED("mini_player_long_press_menu_option_tapped"),
     MINI_PLAYER_LONG_PRESS_MENU_DISMISSED("mini_player_long_press_menu_dismissed"),
+
+    /* Up Next */
+    UP_NEXT_SHOWN("up_next_shown"),
+    UP_NEXT_QUEUE_CLEARED("up_next_queue_cleared"),
+    UP_NEXT_NOW_PLAYING_TAPPED("up_next_now_playing_tapped"),
+    UP_NEXT_QUEUE_EPISODE_TAPPED("up_next_queue_episode_tapped"),
+    UP_NEXT_QUEUE_EPISODE_LONG_PRESSED("up_next_queue_episode_long_pressed"),
+    UP_NEXT_MULTI_SELECT_ENTERED("up_next_multi_select_entered"),
+    UP_NEXT_SELECT_ALL_BUTTON_TAPPED("up_next_select_all_button_tapped"),
+    UP_NEXT_MULTI_SELECT_EXITED("up_next_multi_select_exited"),
+    UP_NEXT_QUEUE_REORDERED("up_next_queue_reordered"),
+    UP_NEXT_DISMISSED("up_next_dismissed"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -233,4 +233,9 @@ enum class AnalyticsEvent(val key: String) {
     DISCOVER_SMALL_LIST_PAGE_CHANGED("discover_small_list_page_changed"),
     DISCOVER_REGION_CHANGED("discover_region_changed"),
     DISCOVER_COLLECTION_LINK_TAPPED("discover_collection_link_tapped"),
+
+    /* Mini Player */
+    MINI_PLAYER_LONG_PRESS_MENU_SHOWN("mini_player_long_press_menu_shown"),
+    MINI_PLAYER_LONG_PRESS_MENU_OPTION_TAPPED("mini_player_long_press_menu_option_tapped"),
+    MINI_PLAYER_LONG_PRESS_MENU_DISMISSED("mini_player_long_press_menu_dismissed"),
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
@@ -78,6 +78,11 @@ enum class UpNextSource(val analyticsValue: String) {
     MINI_PLAYER("mini_player"),
     PLAYER("player"),
     UP_NEXT_SHORTCUT("up_next_shortcut"),
+    UNKNOWN("unknown");
+
+    companion object {
+        fun fromString(string: String) = UpNextSource.values().find { it.analyticsValue == string } ?: UNKNOWN
+    }
 }
 
 fun Observable<UpNextQueue.State>.containsUuid(uuid: String): Observable<Boolean> {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
@@ -74,6 +74,12 @@ interface UpNextQueue {
     }
 }
 
+enum class UpNextSource(val analyticsValue: String) {
+    MINI_PLAYER("mini_player"),
+    PLAYER("player"),
+    UP_NEXT_SHORTCUT("up_next_shortcut"),
+}
+
 fun Observable<UpNextQueue.State>.containsUuid(uuid: String): Observable<Boolean> {
     return this.switchMap { state ->
         if (state is UpNextQueue.State.Loaded) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
@@ -77,6 +77,7 @@ interface UpNextQueue {
 enum class UpNextSource(val analyticsValue: String) {
     MINI_PLAYER("mini_player"),
     PLAYER("player"),
+    NOW_PLAYING("now_playing"),
     UP_NEXT_SHORTCUT("up_next_shortcut"),
     UNKNOWN("unknown");
 

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
@@ -26,4 +26,5 @@ interface FragmentHostListener {
     fun lockPlayerBottomSheet(locked: Boolean)
     fun updateSystemColors()
     fun overrideNextRefreshTimer()
+    fun isUpNextShowing(): Boolean
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/OptionsDialog.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/OptionsDialog.kt
@@ -119,4 +119,9 @@ class OptionsDialog : BottomSheetDialogFragment() {
             }
         }
     }
+
+    fun setOnDismiss(onDismiss: (() -> Unit)?): OptionsDialog {
+        this.onDismiss = onDismiss
+        return this
+    }
 }


### PR DESCRIPTION
| 📘 Project: #261  |
|:---:|

Adds events to the mini player and up next views

## To test

### Mini Player
1. Launch the app and play something if you have no miniplayer
2. Long press on the mini player
3. ✅ Verify you see `🔵 Tracked: mini_player_long_press_menu_shown`
4. Dismiss it without taking any action
5. ✅ Verify you see `🔵 Tracked: mini_player_long_press_menu_dismissed`
6. Long press again and select the mark played action
7. ✅ Verify you see `🔵 Tracked: mini_player_long_press_menu_option_tapped ["option": "mark_played"]`
8. Long press again and select the Close and Clear action
9. ✅ Verify you see `🔵 Tracked: mini_player_long_press_menu_option_tapped ["option": "close_and_clear_up_next"]`


### Up Next

#### Up Next Shown
1. Launch the app and add some items to your queue if you don't have any
2. Tap the up next queue button in the mini player
3. ✅  Verify you see `🔵 Tracked: up_next_shown ["source": "mini_player"]`
4. Dismiss it
5. Tap the mini player to show the full player
6. Tap the up next button in the player
7. ✅  Verify you see `🔵 Tracked: up_next_shown ["source": "player"]`
8. Dismiss it
9. Swipe up on the full player to show the up next view
10. ✅  Verify you see `🔵 Tracked: up_next_shown ["source": "now_playing"]` - I cherry-picked commits (c07d528...f3cf735) from https://github.com/Automattic/pocket-casts-android/pull/375 that fixes swipe up/ down crash so that I could track this event. 
11. Add up next shortcut to device home screen
12. Tap on the widget
13. ✅  Verify you see: `🔵 Tracked: up_next_shown ["source": "up_next_shortcut"]`

c7470b087b54af27da9ad19e362aeb874ed3f5f1 - `fixes shorcut not working for debug builds`

#### Episode tapping, long pressing, and multi select
1. Open the Up Next queue from anywhere
2. Tap on the episode that is currently playing
3. ✅  Verify you see `🔵 Tracked: up_next_now_playing_tapped ["source": "SOURCE"]` 
4. Open the Up Next queue again
5. Tap on an episode in the list
6. ✅  Verify you see `🔵 Tracked: up_next_queue_episode_tapped ["source": "SOURCE", "will_play": WILL_PLAY]`
   - WILL_PLAY - This should be false if the episode details is displayed, and true if it starts playing. This corresponds to the `Play Up Next On Tap` option in General settings
7. Open the General section in settings and toggle the Play Up Next On Tap switch
8. Open the Up Next queue and tap on an episode and verify the `will_play` value corresponds with your selection
9. Long press on an episode in the queue
10. ✅  Verify you see `🔵 Tracked: up_next_queue_episode_long_pressed ["will_play": WILL_PLAY, "source": "SOURCE"]`
   - A long press will do the opposite action as your play up next on tap. If the option is enabled then this will display episode details, if not it will play
15. Tap the Select button
16. ✅  Verify you see  ` 🔵 Tracked: up_next_multi_select_entered ["source": "SOURCE"]`
17. Tap the more option (vertical ellipses) and Select all
18. ✅  Verify you see `🔵 Tracked: up_next_select_all_tapped ["source": "SOURCE", "select_all": true]`
19. Tap the more option (vertical ellipses) and Select none
20.✅  Verify you see ` 🔵 Tracked: up_next_select_all_tapped ["source": "SOURCE", "select_all": false]`
21. Tap the back arrow button
22. ✅  Verify you see `🔵 Tracked: up_next_multi_select_exited ["source": "SOURCE"]`

#### Reordering
1. Add at least 10 items to your up next queue
2. Open the Up next Queue from anywhere
3. Press on the move handle and drag the episode up 1 slot
4. ✅  Verify you see `🔵 Tracked: up_next_queue_reordered ["direction": "up", "source": "SOURCE", "slots": 1, is_next: false]`
5. Move the episode down 5 slots
6. ✅  Verify you see `🔵 Tracked: up_next_queue_reordered ["direction": "down", "source": "SOURCE", "slots": 5, is_next: false]`
7. Move the episode to the top slot in the queue
8. ✅  Verify the is_next value is true: `🔵 Tracked: up_next_queue_reordered ["source": "mini_player", "is_next": true, "slots": 1, "direction": "up"]`

#### Clearing and Dismissing
1. Open the Up Next Queue
2. Tap the Clear Queue button
3. Confirm the clear
4. ✅  Verify you see  `🔵 Tracked: up_next_queue_cleared ["source": "SOURCE"]`
5. Dismiss the up next queue
6. ✅  Verify you see `🔵 Tracked: up_next_dismissed`  - `I'm not tracking the source here as it is a bit tricky to distinguish if it is collapsed for mini player or player source + it is always coupled with a corresponding  `up_next_shown` event which has a source set on it`

# Checklist
N/A
- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [ ] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [ ] Have you tested in different themes?
- [ ] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?