### PR TITLE
Track player sleep timer events

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -250,4 +250,9 @@ enum class AnalyticsEvent(val key: String) {
     UP_NEXT_MULTI_SELECT_EXITED("up_next_multi_select_exited"),
     UP_NEXT_QUEUE_REORDERED("up_next_queue_reordered"),
     UP_NEXT_DISMISSED("up_next_dismissed"),
+
+    /* Player - Sleep Timer */
+    PLAYER_SLEEP_TIMER_ENABLED("player_sleep_timer_enabled"),
+    PLAYER_SLEEP_TIMER_EXTENDED("player_sleep_timer_extended"),
+    PLAYER_SLEEP_TIMER_CANCELLED("player_sleep_timer_cancelled"),
 }


### PR DESCRIPTION
| 📘 Project: #261 |
|:---:|

Corresponding iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/290

This adds events for the sleep timer:

- `player_sleep_timer_enabled`: When the sleep timer is enabled
- `player_sleep_timer_extended`: When the user extends the sleep timer duration
- `player_sleep_timer_cancelled`: When the user cancels the sleep timer

## To test

1. Play an episode if you don't have one playing already
2. Open the full screen player
3. Tap the ZZZ icon to show the sleep timer options
4. Tap the 5 minutes option
5. ✅ Verify you see: `🔵 Tracked: player_sleep_timer_enabled ["time": 300]` in console
6. Tap each of the other items except end of episode
7. ✅ Verify the `time` property in the log corresponds with the item you selected
8. Tap the end of episode item
9. ✅ Verify you see `🔵 Tracked: player_sleep_timer_enabled ["time": "end_of_episode"]` in console 
10. Tap the Zzz icon again and tap then cancel button
11. ✅  `🔵 Tracked: player_sleep_timer_cancelled`
12. Enable the 5 minute sleep timer
13. Tap the ZZZ icon again
14. Tap the `+ 5 Minutes` button
15. ✅ `🔵 Tracked: player_sleep_timer_extended ["amount": 300]`
16. Tap the End of Episode button
17. ✅ Verify you see `🔵 Tracked: player_sleep_timer_extended ["amount": "end_of_episode"]`
18. Tap cancel again

# Checklist
N/A

- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [ ] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [ ] Have you tested in different themes?
- [ ] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?