### PR TITLE
Add BasePreferenceFragment and Implement in PodcastSettingsFragment

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
@@ -29,6 +29,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.extensions.setInputAsSeconds
 import au.com.shiftyjelly.pocketcasts.views.extensions.updateColors
+import au.com.shiftyjelly.pocketcasts.views.fragments.BasePreferenceFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.FilterSelectFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.HasBackstack
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
@@ -48,7 +49,7 @@ import au.com.shiftyjelly.pocketcasts.settings.R as SR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @AndroidEntryPoint
-class PodcastSettingsFragment : PreferenceFragmentCompat(), CoroutineScope, FilterSelectFragment.Listener, HasBackstack {
+class PodcastSettingsFragment : BasePreferenceFragment(), CoroutineScope, FilterSelectFragment.Listener, HasBackstack {
     @Inject lateinit var theme: Theme
     @Inject lateinit var podcastManager: PodcastManager
 
@@ -120,6 +121,7 @@ class PodcastSettingsFragment : PreferenceFragmentCompat(), CoroutineScope, Filt
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        showLoading()
 
         view.setBackgroundColor(view.context.getThemeColor(UR.attr.primary_ui_01))
         view.isClickable = true
@@ -172,6 +174,8 @@ class PodcastSettingsFragment : PreferenceFragmentCompat(), CoroutineScope, Filt
             preferenceFilters?.icon = context.getTintedDrawable(IR.drawable.ic_filters, colors.iconColor)
 
             preferenceUnsubscribe?.isVisible = podcast.isSubscribed
+
+            hideLoading()
         }
 
         viewModel.includedFilters.observe(viewLifecycleOwner) {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BasePreferenceFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BasePreferenceFragment.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.ProgressBar
 import androidx.preference.PreferenceFragmentCompat
-import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 
 abstract class BasePreferenceFragment : PreferenceFragmentCompat() {
@@ -24,17 +23,6 @@ abstract class BasePreferenceFragment : PreferenceFragmentCompat() {
         progressBar = createProgressBar()
         root.addView(progressBar)
         return root
-    }
-
-    override fun onCreateRecyclerView(
-        inflater: LayoutInflater,
-        parent: ViewGroup,
-        savedInstanceState: Bundle?
-    ): RecyclerView {
-        return super.onCreateRecyclerView(inflater, parent, savedInstanceState).apply {
-            // itemAnimator = null
-            // layoutAnimation = null
-        }
     }
 
     fun showLoading() {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BasePreferenceFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BasePreferenceFragment.kt
@@ -1,0 +1,61 @@
+package au.com.shiftyjelly.pocketcasts.views.fragments
+
+import android.os.Bundle
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.ProgressBar
+import androidx.preference.PreferenceFragmentCompat
+import androidx.recyclerview.widget.RecyclerView
+import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+
+abstract class BasePreferenceFragment : PreferenceFragmentCompat() {
+
+    private var progressBar: ProgressBar? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val root = super.onCreateView(inflater, container, savedInstanceState) as ViewGroup
+        progressBar = createProgressBar()
+        root.addView(progressBar)
+        return root
+    }
+
+    override fun onCreateRecyclerView(
+        inflater: LayoutInflater,
+        parent: ViewGroup,
+        savedInstanceState: Bundle?
+    ): RecyclerView {
+        return super.onCreateRecyclerView(inflater, parent, savedInstanceState).apply {
+            // itemAnimator = null
+            // layoutAnimation = null
+        }
+    }
+
+    fun showLoading() {
+        listView.visibility = View.GONE
+        progressBar?.visibility = View.VISIBLE
+    }
+
+    fun hideLoading() {
+        listView.visibility = View.VISIBLE
+        progressBar?.visibility = View.GONE
+    }
+
+    private fun createProgressBar(): ProgressBar {
+        return ProgressBar(requireContext()).apply {
+            isIndeterminate = true
+            layoutParams = FrameLayout.LayoutParams(
+                24.dpToPx(requireContext()),
+                24.dpToPx(requireContext())
+            ).apply {
+                gravity = Gravity.CENTER
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description

Add `BasePreferenceFragment` and Implemented in `PodcastSettingsFragment` to handle loading state changes. I created a base Fragment to handle this logic because I saw other problems that implements Preferences like this one.

Also when I disabled the RecyclerView animation that handles ListPreference's childeren animations, It still has a small flicker. (not the switches only the child items) Which implementation is better in your opinion @geekygecko 

https://user-images.githubusercontent.com/47274419/194526328-74bbb803-426b-4179-b9ec-67a68f941ea9.mp4 

https://user-images.githubusercontent.com/47274419/194526340-1645ef59-81b5-42b0-9b54-e17e09f91d6f.mp4

Fixes #73 

# Checklist

- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?