### PR TITLE
Track playback effect events 

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
@@ -49,8 +49,7 @@ class EffectsFragment : BaseDialogFragment(), CompoundButton.OnCheckedChangeList
     private lateinit var imageLoader: PodcastImageLoaderThemed
     private var binding: FragmentEffectsBinding? = null
     private val trimToggleGroupButtonIds = arrayOf(R.id.trimLow, R.id.trimMedium, R.id.trimHigh)
-    private var isSpeedChanged = false
-    private var finalSpeed: Double = 1.0
+    private var updatedSpeed: Double? = null
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -158,11 +157,10 @@ class EffectsFragment : BaseDialogFragment(), CompoundButton.OnCheckedChangeList
     private fun changePlaybackSpeed(effects: PlaybackEffects, podcast: Podcast, amount: Double) {
         val binding = binding ?: return
 
-        isSpeedChanged = true
         // val speed = (amount.clipToRange(0.5, 3.0) * 10.0).toInt() / 10.0
         val speed = round(amount.clipToRange(0.5, 3.0) * 10.0) / 10.0
         effects.playbackSpeed = speed
-        finalSpeed = speed
+        updatedSpeed = speed
         binding.playbackSpeedString = String.format("%.1fx", effects.playbackSpeed)
         viewModel.saveEffects(effects, podcast)
 
@@ -250,10 +248,7 @@ class EffectsFragment : BaseDialogFragment(), CompoundButton.OnCheckedChangeList
     }
 
     private fun trackSpeedChangeIfNeeded() {
-        if (isSpeedChanged) {
-            trackPlaybackEffectsEvent(AnalyticsEvent.PLAYBACK_EFFECT_SPEED_CHANGED, mapOf(PlaybackManager.SPEED_KEY to finalSpeed))
-            isSpeedChanged = false
-        }
+        updatedSpeed?.let { trackPlaybackEffectsEvent(AnalyticsEvent.PLAYBACK_EFFECT_SPEED_CHANGED, mapOf(PlaybackManager.SPEED_KEY to it)) }
     }
 
     private fun trackPlaybackEffectsEvent(event: AnalyticsEvent, props: Map<String, Any> = emptyMap()) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastEffectsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastEffectsFragment.kt
@@ -9,10 +9,12 @@ import androidx.fragment.app.viewModels
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.podcasts.R
 import au.com.shiftyjelly.pocketcasts.podcasts.view.components.PlaybackSpeedPreference
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastEffectsViewModel
+import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastEffectsViewModel.Companion.ENABLED_KEY
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getTintedDrawable
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
@@ -116,6 +118,7 @@ class PodcastEffectsFragment : PreferenceFragmentCompat() {
         }
 
         preferenceTrimSilence?.setOnPreferenceChangeListener { _, newValue ->
+            viewModel.trackPlaybackEffectsEvent(AnalyticsEvent.PLAYBACK_EFFECT_TRIM_SILENCE_TOGGLED, mapOf(ENABLED_KEY to newValue))
             viewModel.updateTrimSilence(if (newValue as? Boolean == true) TrimMode.LOW else TrimMode.OFF)
             true
         }
@@ -127,6 +130,7 @@ class PodcastEffectsFragment : PreferenceFragmentCompat() {
         }
 
         preferenceBoostVolume?.setOnPreferenceChangeListener { _, newValue ->
+            viewModel.trackPlaybackEffectsEvent(AnalyticsEvent.PLAYBACK_EFFECT_VOLUME_BOOST_TOGGLED, mapOf(ENABLED_KEY to newValue))
             viewModel.updateBoostVolume(newValue as Boolean)
             true
         }
@@ -146,5 +150,10 @@ class PodcastEffectsFragment : PreferenceFragmentCompat() {
         preferencePlaybackSpeed?.icon = context.getTintedDrawable(R.drawable.ic_speed, tintColor)
         preferenceTrimSilence?.icon = context.getTintedDrawable(R.drawable.ic_silence, tintColor)
         preferenceBoostVolume?.icon = context.getTintedDrawable(R.drawable.ic_volumeboost, tintColor)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        viewModel.trackSpeedChangeIfNeeded()
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastEffectsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastEffectsFragment.kt
@@ -14,7 +14,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.podcasts.R
 import au.com.shiftyjelly.pocketcasts.podcasts.view.components.PlaybackSpeedPreference
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastEffectsViewModel
-import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastEffectsViewModel.Companion.ENABLED_KEY
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getTintedDrawable
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
@@ -118,7 +118,7 @@ class PodcastEffectsFragment : PreferenceFragmentCompat() {
         }
 
         preferenceTrimSilence?.setOnPreferenceChangeListener { _, newValue ->
-            viewModel.trackPlaybackEffectsEvent(AnalyticsEvent.PLAYBACK_EFFECT_TRIM_SILENCE_TOGGLED, mapOf(ENABLED_KEY to newValue))
+            viewModel.trackPlaybackEffectsEvent(AnalyticsEvent.PLAYBACK_EFFECT_TRIM_SILENCE_TOGGLED, mapOf(PlaybackManager.ENABLED_KEY to newValue))
             viewModel.updateTrimSilence(if (newValue as? Boolean == true) TrimMode.LOW else TrimMode.OFF)
             true
         }
@@ -130,7 +130,7 @@ class PodcastEffectsFragment : PreferenceFragmentCompat() {
         }
 
         preferenceBoostVolume?.setOnPreferenceChangeListener { _, newValue ->
-            viewModel.trackPlaybackEffectsEvent(AnalyticsEvent.PLAYBACK_EFFECT_VOLUME_BOOST_TOGGLED, mapOf(ENABLED_KEY to newValue))
+            viewModel.trackPlaybackEffectsEvent(AnalyticsEvent.PLAYBACK_EFFECT_VOLUME_BOOST_TOGGLED, mapOf(PlaybackManager.ENABLED_KEY to newValue))
             viewModel.updateBoostVolume(newValue as Boolean)
             true
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastEffectsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastEffectsFragment.kt
@@ -125,7 +125,9 @@ class PodcastEffectsFragment : PreferenceFragmentCompat() {
 
         preferenceTrimMode?.setOnPreferenceChangeListener { preference, newValue ->
             val index = (preference as ListPreference).findIndexOfValue(newValue as String)
-            viewModel.updateTrimSilence(TrimMode.values()[index + 1])
+            val trimMode = TrimMode.values()[index + 1]
+            viewModel.trackPlaybackEffectsEvent(AnalyticsEvent.PLAYBACK_EFFECT_TRIM_SILENCE_AMOUNT_CHANGED, mapOf(PlaybackManager.AMOUNT_KEY to trimMode.analyticsVale))
+            viewModel.updateTrimSilence(trimMode)
             true
         }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
@@ -10,7 +10,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.utils.extensions.clipToRange
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -57,7 +56,7 @@ class PodcastEffectsViewModel
         val podcast = this.podcast.value ?: return
         launch {
             podcastManager.updateTrimMode(podcast, trimMode)
-            trackPlaybackEffectsEvent(AnalyticsEvent.PLAYBACK_EFFECT_TRIM_SILENCE_AMOUNT_CHANGED, mapOf(AMOUNT_KEY to trimMode.analyticsVale))
+            trackPlaybackEffectsEvent(AnalyticsEvent.PLAYBACK_EFFECT_TRIM_SILENCE_AMOUNT_CHANGED, mapOf(PlaybackManager.AMOUNT_KEY to trimMode.analyticsVale))
             if (shouldUpdatePlaybackManager()) {
                 playbackManager.updatePlayerEffects(podcast.playbackEffects)
             }
@@ -109,22 +108,12 @@ class PodcastEffectsViewModel
 
     fun trackSpeedChangeIfNeeded() {
         if (isSpeedChanged) {
-            trackPlaybackEffectsEvent(AnalyticsEvent.PLAYBACK_EFFECT_SPEED_CHANGED, mapOf(SPEED_KEY to finalSpeed))
+            trackPlaybackEffectsEvent(AnalyticsEvent.PLAYBACK_EFFECT_SPEED_CHANGED, mapOf(PlaybackManager.SPEED_KEY to finalSpeed))
             isSpeedChanged = false
         }
     }
 
     fun trackPlaybackEffectsEvent(event: AnalyticsEvent, props: Map<String, Any> = emptyMap()) {
-        val properties = HashMap<String, Any>()
-        properties[SOURCE_KEY] = PlaybackSource.PODCAST_SETTINGS.analyticsValue
-        properties.putAll(props)
-        analyticsTracker.track(event, properties)
-    }
-
-    companion object {
-        private const val SOURCE_KEY = "source"
-        private const val SPEED_KEY = "speed"
-        private const val AMOUNT_KEY = "amount"
-        const val ENABLED_KEY = "enabled"
+        playbackManager.trackPlaybackEffectsEvent(event, props, PlaybackManager.PlaybackSource.PODCAST_SETTINGS)
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
@@ -27,7 +26,6 @@ class PodcastEffectsViewModel
     private val podcastManager: PodcastManager,
     private val playbackManager: PlaybackManager,
     private val settings: Settings,
-    private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ViewModel(), CoroutineScope {
 
     override val coroutineContext: CoroutineContext

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
@@ -53,7 +53,6 @@ class PodcastEffectsViewModel
         val podcast = this.podcast.value ?: return
         launch {
             podcastManager.updateTrimMode(podcast, trimMode)
-            trackPlaybackEffectsEvent(AnalyticsEvent.PLAYBACK_EFFECT_TRIM_SILENCE_AMOUNT_CHANGED, mapOf(PlaybackManager.AMOUNT_KEY to trimMode.analyticsVale))
             if (shouldUpdatePlaybackManager()) {
                 playbackManager.updatePlayerEffects(podcast.playbackEffects)
             }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -255,4 +255,10 @@ enum class AnalyticsEvent(val key: String) {
     PLAYER_SLEEP_TIMER_ENABLED("player_sleep_timer_enabled"),
     PLAYER_SLEEP_TIMER_EXTENDED("player_sleep_timer_extended"),
     PLAYER_SLEEP_TIMER_CANCELLED("player_sleep_timer_cancelled"),
+
+    /* Player - Playback effects */
+    PLAYBACK_EFFECT_SPEED_CHANGED("playback_effect_speed_changed"),
+    PLAYBACK_EFFECT_TRIM_SILENCE_TOGGLED("playback_effect_trim_silence_toggled"),
+    PLAYBACK_EFFECT_TRIM_SILENCE_AMOUNT_CHANGED("playback_effect_trim_silence_amount_changed"),
+    PLAYBACK_EFFECT_VOLUME_BOOST_TOGGLED("playback_effect_volume_boost_toggled"),
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/TrimMode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/TrimMode.kt
@@ -1,5 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.models.type
 
-enum class TrimMode {
-    OFF, LOW, MEDIUM, HIGH
+enum class TrimMode(val analyticsVale: String) {
+    OFF("off"),
+    LOW("mild"),
+    MEDIUM("medium"),
+    HIGH("mad_max"),
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1864,6 +1864,8 @@ open class PlaybackManager @Inject constructor(
         NOTIFICATION("notification"),
         FULL_SCREEN_VIDEO("full_screen_video"),
         MEDIA_BUTTON_BROADCAST_ACTION("media_button_broadcast_action"),
+        PLAYER_PLAYBACK_EFFECTS("player_playback_effects"),
+        PODCAST_SETTINGS("podcast_settings"),
         UNKNOWN("unknown"),
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -107,7 +107,10 @@ open class PlaybackManager @Inject constructor(
         private const val MAX_TIME_WITHOUT_FOCUS_FOR_RESUME_MINUTES = 30
         private const val MAX_TIME_WITHOUT_FOCUS_FOR_RESUME = (MAX_TIME_WITHOUT_FOCUS_FOR_RESUME_MINUTES * 60 * 1000).toLong()
         private const val PAUSE_TIMER_DELAY = ((MAX_TIME_WITHOUT_FOCUS_FOR_RESUME_MINUTES + 1) * 60 * 1000).toLong()
-        private const val KEY_SOURCE = "source"
+        private const val SOURCE_KEY = "source"
+        const val SPEED_KEY = "speed"
+        const val AMOUNT_KEY = "amount"
+        const val ENABLED_KEY = "enabled"
     }
 
     override val coroutineContext: CoroutineContext
@@ -1845,8 +1848,19 @@ open class PlaybackManager @Inject constructor(
         if (playbackSource == PlaybackSource.UNKNOWN) {
             Timber.w("Found unknown playback source.")
         }
-        analyticsTracker.track(event, mapOf(KEY_SOURCE to playbackSource.analyticsValue))
+        analyticsTracker.track(event, mapOf(SOURCE_KEY to playbackSource.analyticsValue))
         playbackSource = PlaybackSource.UNKNOWN
+    }
+
+    fun trackPlaybackEffectsEvent(
+        event: AnalyticsEvent,
+        props: Map<String, Any> = emptyMap(),
+        playbackSource: PlaybackSource
+    ) {
+        val properties = HashMap<String, Any>()
+        properties[SOURCE_KEY] = playbackSource.analyticsValue
+        properties.putAll(props)
+        analyticsTracker.track(event, properties)
     }
 
     enum class PlaybackSource(val analyticsValue: String) {


### PR DESCRIPTION
| 📘 Project: #261 | 🛫 Depends on: #381 |
|:---:|:---:|

Corresponding iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/291

This adds events for the playback effect settings
- `playback_effect_speed_changed`:  When the user changes the speed the podcast plays
- `playback_effect_trim_silence_toggled`:  When the user toggles the trim silence option
- `playback_effect_trim_silence_amount_changed`: When the user changes the trim select amount
- `playback_effect_volume_boost_toggled`: When the user toggles the volume boost option


## To test

1. Play an episode if you aren't already
2. Open the full screen player
3. Tap the dial icon to open the playback effects view
4. Tap the + button on the Speed option, then tap outside the playback effects view
5. ✅ Verify you see the following in console: `🔵 Tracked: playback_effect_speed_changed ["source": "player_playback_effects", "speed": 1.1]`
6. Tap the dial icon again to open the playback effects view, tap the - button, then tap outside the playback effects view
7. ✅ `🔵 Tracked: playback_effect_speed_changed ["source": "player_playback_effects", "speed": 1.0]`
8. Tap the dial icon again to open the playback effects view, then tap the middle option to cycle through predefined options,  then tap outside the playback effects view
9. ✅ Verify the `speed` property in console changes accordingly (speed changes are tracked when the playback effects view is destroyed to [match the behavior on iOS](https://github.com/Automattic/pocket-casts-ios/pull/291#discussion_r981633702))
10. Enable the Trim Silence option
11. ✅ `🔵 Tracked: playback_effect_trim_silence_toggled ["source": "player_playback_effects", "enabled": true]`
12. Change your trim silence setting to Medium
13. ✅ `🔵 Tracked: playback_effect_trim_silence_amount_changed ["amount": "medium", "source": "player_playback_effects"]`
14. Change to mad max
15. ✅ `🔵 Tracked: playback_effect_trim_silence_amount_changed ["source": "player_playback_effects", "amount": "mad_max"]`
16. Change back to mild
17. ✅ `🔵 Tracked: playback_effect_trim_silence_amount_changed ["source": "player_playback_effects", "amount": "mild"]`
18. Enable the Volume boost option
19. ✅ `🔵 Tracked: playback_effect_volume_boost_toggled ["source": "player_playback_effects", "enabled": true]`
20. Repeat above tests for subscribed podcast's playback effects settings which you can reach as follows:
     - Select a subscribed podcast
     - Tap on the gear icon on podcast screen 
     - Tap on "Playback effects" on podcasts settings
20. ✅ Verify that `"source": "podcast_settings"` is shown for these events

# Checklist
N/A 

- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [ ] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [ ] Have you tested in different themes?
- [ ] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?