### PR TITLE
Track playback seek

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -120,6 +120,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         binding.seekBar.changeListener = object : PlayerSeekBar.OnUserSeekListener {
             override fun onSeekPositionChangeStop(progress: Int, seekComplete: () -> Unit) {
                 viewModel.seekToMs(progress, seekComplete)
+                playbackManager.trackPlaybackSeek(progress, PlaybackSource.PLAYER)
             }
 
             override fun onSeekPositionChanging(progress: Int) {}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
@@ -16,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.player.view.PlayerSeekBar
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.VideoViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.SimplePlayer
 import au.com.shiftyjelly.pocketcasts.views.extensions.hide
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
@@ -156,6 +157,7 @@ class VideoFragment : Fragment(), PlayerSeekBar.OnUserSeekListener {
 
     override fun onSeekPositionChangeStop(progress: Int, seekComplete: () -> Unit) {
         viewModel.seekToMs(progress)
+        playbackManager.trackPlaybackSeek(progress, PlaybackSource.FULL_SCREEN_VIDEO)
         seekComplete()
     }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -206,6 +206,7 @@ enum class AnalyticsEvent(val key: String) {
     PLAYBACK_SKIP_BACK("playback_skip_back"),
     PLAYBACK_SKIP_FORWARD("playback_skip_forward"),
     PLAYBACK_STOP("playback_stop"),
+    PLAYBACK_SEEK("playback_seek"),
 
     /* Privacy */
     PRIVACY_SETTINGS_SHOWN("privacy_settings_shown"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -548,6 +548,7 @@ class MediaSessionManager(
             seeking = true
             launch {
                 playbackManager.seekToTimeMs(pos.toInt())
+                playbackManager.trackPlaybackSeek(pos.toInt(), PlaybackSource.MEDIA_BUTTON_BROADCAST_ACTION)
             }
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -108,6 +108,8 @@ open class PlaybackManager @Inject constructor(
         private const val MAX_TIME_WITHOUT_FOCUS_FOR_RESUME = (MAX_TIME_WITHOUT_FOCUS_FOR_RESUME_MINUTES * 60 * 1000).toLong()
         private const val PAUSE_TIMER_DELAY = ((MAX_TIME_WITHOUT_FOCUS_FOR_RESUME_MINUTES + 1) * 60 * 1000).toLong()
         private const val SOURCE_KEY = "source"
+        private const val SEEK_TO_PERCENT_KEY = "seek_to_percent"
+        private const val SEEK_FROM_PERCENT_KEY = "seek_from_percent"
         const val SPEED_KEY = "speed"
         const val AMOUNT_KEY = "amount"
         const val ENABLED_KEY = "enabled"
@@ -1850,6 +1852,28 @@ open class PlaybackManager @Inject constructor(
         }
         analyticsTracker.track(event, mapOf(SOURCE_KEY to playbackSource.analyticsValue))
         playbackSource = PlaybackSource.UNKNOWN
+    }
+
+    fun trackPlaybackSeek(
+        positionMs: Int,
+        playbackSource: PlaybackSource
+    ) {
+        val episode = getCurrentEpisode()
+        episode?.let {
+            val fromPositionMs = episode.playedUpToMs.toDouble()
+            val durationMs = episode.duration * 1000
+            val seekFromPercent = ((fromPositionMs / durationMs) * 100).toInt()
+            val seekToPercent = ((positionMs / durationMs) * 100).toInt()
+
+            analyticsTracker.track(
+                AnalyticsEvent.PLAYBACK_SEEK,
+                mapOf(
+                    SOURCE_KEY to playbackSource.analyticsValue,
+                    SEEK_FROM_PERCENT_KEY to seekFromPercent,
+                    SEEK_TO_PERCENT_KEY to seekToPercent
+                )
+            )
+        }
     }
 
     fun trackPlaybackEffectsEvent(


### PR DESCRIPTION
| 📘 Project: #261 | 🛫 Depends on: #383 |
|:---:|:---:|

Corresponding iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/292

This adds an event when the user changes the playback position in the player:

- `playback_seek`: When the user changes the playback position in the player

### Note
Tracking is added for seeking from 
- `OnUserSeekListener` - I could find only two sources for seek by user: `player` and `full_screen_video`. 
- Notification drawer/ lock screen - I reused `media_button_broadcast_action` source for it. 

## To test

1. Play an episode if you're not already
2. Open the full screen player
3. Drag the slider to about half way 
4. ✅ Verify you see the following in console ` 🔵 Tracked: playback_seek ["source": "player", "seek_from_percent": 0, "seek_to_percent": PERCENT]` - Where PERCENT is near 50% 
4. Drag the slider to the another position
5. ✅ `🔵 Tracked: playback_seek ["seek_from_percent": FROM, "source": "player", "seek_to_percent": TO]`
- Where FROM is the value that you slid to in the above step
- And TO is the new value
6. Repeat above steps for full screen video player 
    - Play an episode from "TED Talks Daily (HD video)" podcast
    - On the Now Playing tab, tap on the video 
    - Seek from the full screen video player 
8. ✅ Verify that source is now `full_screen_video`
9. Repeat above steps for seek from notification drawer/ lock screen 
10. ✅ Verify that source is now `media_button_broadcast_action`

# Checklist
N/A

- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [ ] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [ ] Have you tested in different themes?
- [ ] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?