### PR TITLE
Tracks for Filters part 3 (auto_download_*)

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterViewModel.kt
@@ -97,7 +97,7 @@ class CreateFilterViewModel @Inject constructor(val playlistManager: PlaylistMan
                 playlist.autoDownload = autoDownload
                 val userPlaylistUpdate = if (isAutoDownloadSwitchInitialized) {
                     UserPlaylistUpdate(
-                        listOf(PlaylistProperty.AutoDownload),
+                        listOf(PlaylistProperty.AutoDownload(autoDownload)),
                         PlaylistUpdateSource.FILTER_EPISODE_LIST
                     )
                 } else null
@@ -131,7 +131,7 @@ class CreateFilterViewModel @Inject constructor(val playlistManager: PlaylistMan
             playlist.autodownloadLimit = limit
 
             val userPlaylistUpdate = UserPlaylistUpdate(
-                listOf(PlaylistProperty.AutoDownloadLimit),
+                listOf(PlaylistProperty.AutoDownloadLimit(limit)),
                 PlaylistUpdateSource.FILTER_OPTIONS
             )
             playlistManager.update(playlist, userPlaylistUpdate)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -248,7 +248,7 @@ class AutoDownloadSettingsFragment :
 
                 val userPlaylistUpdate = if (userChanged) {
                     UserPlaylistUpdate(
-                        listOf(PlaylistProperty.AutoDownload),
+                        listOf(PlaylistProperty.AutoDownload(autoDownloadStatus)),
                         PlaylistUpdateSource.AUTO_DOWNLOAD_SETTINGS
                     )
                 } else null

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -214,9 +214,11 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_SHOW_PRIVACY_POLICY("settings_show_privacy_policy"),
 
     /* Filters screen */
+    FILTER_AUTO_DOWNLOAD_LIMIT_UPDATED("filter_auto_download_limit_updated"),
+    FILTER_AUTO_DOWNLOAD_UPDATED("filter_auto_download_updated"),
+    FILTER_DELETED("filter_deleted"),
     FILTER_LIST_SHOWN("filter_list_shown"),
     FILTER_SHOWN("filter_shown"),
-    FILTER_DELETED("filter_deleted"),
     FILTER_UPDATED("filter_updated"),
 
     /* Discover */

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -41,6 +41,13 @@ class PlaylistManagerImpl @Inject constructor(
     appDatabase: AppDatabase
 ) : PlaylistManager, CoroutineScope {
 
+    companion object {
+        const val ENABLED_KEY = "enabled"
+        const val LIMIT_KEY = "limit"
+        const val GROUP_KEY = "group"
+        const val SOURCE_KEY = "source"
+    }
+
     private val playlistDao = appDatabase.playlistDao()
 
     init {
@@ -331,14 +338,25 @@ class PlaylistManagerImpl @Inject constructor(
 
                     is FilterUpdatedEvent -> {
                         val properties = mapOf(
-                            "group" to playlistProperty.groupValue,
-                            "source" to userPlaylistUpdate.source.analyticsValue
+                            GROUP_KEY to playlistProperty.groupValue,
+                            SOURCE_KEY to userPlaylistUpdate.source.analyticsValue
                         )
                         analyticsTracker.track(AnalyticsEvent.FILTER_UPDATED, properties)
                     }
 
-                    PlaylistProperty.AutoDownload,
-                    PlaylistProperty.AutoDownloadLimit,
+                    is PlaylistProperty.AutoDownload -> {
+                        val properties = mapOf(
+                            SOURCE_KEY to userPlaylistUpdate.source.analyticsValue,
+                            ENABLED_KEY to playlistProperty.enabled
+                        )
+                        analyticsTracker.track(AnalyticsEvent.FILTER_AUTO_DOWNLOAD_UPDATED, properties)
+                    }
+
+                    is PlaylistProperty.AutoDownloadLimit -> {
+                        val properties = mapOf(LIMIT_KEY to playlistProperty.limit)
+                        analyticsTracker.track(AnalyticsEvent.FILTER_AUTO_DOWNLOAD_LIMIT_UPDATED, properties)
+                    }
+
                     PlaylistProperty.Color,
                     PlaylistProperty.FilterName,
                     PlaylistProperty.Icon,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistProperty.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistProperty.kt
@@ -6,9 +6,9 @@ sealed interface FilterUpdatedEvent {
 
 sealed class PlaylistProperty {
 
-    object AutoDownload : PlaylistProperty()
+    data class AutoDownload(val enabled: Boolean) : PlaylistProperty()
 
-    object AutoDownloadLimit : PlaylistProperty()
+    data class AutoDownloadLimit(val limit: Int) : PlaylistProperty()
 
     object Color : PlaylistProperty()
 


### PR DESCRIPTION
| 📘 Project: #261 | 🛫 Depends on: #385 |
| --- | --- |

Adds the `filter_auto_download_updated` and `filter_auto_download_limit_updated` events.

## To Test

### 1. Filter Options
1. Open the filters tab
2. Tap on a filter
3. From the overflow menu select "Filter Settings"
4. Toggle Auto Download  on
5. ✅  Observe the event `filter_auto_download_updated, {"source": "filters", "enabled": "true", ...}`
6. Change the number of episodes to Auto Download
7. ✅  Observe the event `filter_auto_download_limit_updated, {"limit": [SELECTED LIMIT], ...}`
8. Toggle Auto Download off
5. ✅  Observe the event `filter_auto_download_updated, {"source": "filters", "enabled": "false", ...}`

### 2. Auto Download Settings
1. Open the profile tab
2. Tap on the Settings cog
3. Tap on Auto download
4. Tap on the Filters setting
5. ✅  Tap the checkboxes for some of the filters and observe a`filter_auto_download_updated` event is fired with the appropriate "enabled" property and a "source" property of "auto_download_settings"
6. Tap on Select All/None
7. ✅  Observe that an appropriate `filter_auto_download_updated` event is fired for each filter that is updated. For example if you have 5 filters, but 2 of them are already set up to auto download, then tapping Select All should result in 3 events.

# Checklist

- [X] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [X] Are all the strings localized?
- [X] Could you have written any new tests?
- [X] Did you include Compose previews with any components?