### PR TITLE
Tracks for Filters part 4 (filter_sort_by_changed)

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -478,23 +478,23 @@ class FilterEpisodeListFragment : BaseFragment() {
                 .setTitle(getString(LR.string.sort_by))
                 .addCheckedOption(
                     titleId = LR.string.episode_sort_newest_to_oldest,
-                    click = { viewModel.changeSort(Playlist.PLAYLIST_SORT_NEWEST_TO_OLDEST) },
-                    checked = (it.sortId == Playlist.PLAYLIST_SORT_NEWEST_TO_OLDEST)
+                    click = { viewModel.changeSort(Playlist.SortOrder.NEWEST_TO_OLDEST) },
+                    checked = (it.sortOrder() == Playlist.SortOrder.NEWEST_TO_OLDEST)
                 )
                 .addCheckedOption(
                     titleId = LR.string.episode_sort_oldest_to_newest,
-                    click = { viewModel.changeSort(Playlist.PLAYLIST_SORT_OLDEST_TO_NEWEST) },
-                    checked = (it.sortId == Playlist.PLAYLIST_SORT_OLDEST_TO_NEWEST)
+                    click = { viewModel.changeSort(Playlist.SortOrder.OLDEST_TO_NEWEST) },
+                    checked = (it.sortOrder() == Playlist.SortOrder.OLDEST_TO_NEWEST)
                 )
                 .addCheckedOption(
                     titleId = LR.string.episode_sort_short_to_long,
-                    click = { viewModel.changeSort(Playlist.PLAYLIST_SORT_SHORTEST_TO_LONGEST) },
-                    checked = (it.sortId == Playlist.PLAYLIST_SORT_SHORTEST_TO_LONGEST)
+                    click = { viewModel.changeSort(Playlist.SortOrder.SHORTEST_TO_LONGEST) },
+                    checked = (it.sortOrder() == Playlist.SortOrder.SHORTEST_TO_LONGEST)
                 )
                 .addCheckedOption(
                     titleId = LR.string.episode_sort_long_to_short,
-                    click = { viewModel.changeSort(Playlist.PLAYLIST_SORT_LONGEST_TO_SHORTEST) },
-                    checked = (it.sortId == Playlist.PLAYLIST_SORT_LONGEST_TO_SHORTEST)
+                    click = { viewModel.changeSort(Playlist.SortOrder.LONGEST_TO_SHORTEST) },
+                    checked = (it.sortOrder() == Playlist.SortOrder.LONGEST_TO_SHORTEST)
                 )
             dialog.show(parentFragmentManager, "sort_options")
         }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -135,13 +135,13 @@ class FilterEpisodeListViewModel @Inject constructor(
         }
     }
 
-    fun changeSort(sortOrder: Int) {
+    fun changeSort(sortOrder: Playlist.SortOrder) {
         launch {
             playlist.value?.let { playlist ->
-                playlist.sortId = sortOrder
+                playlist.sortId = sortOrder.value
 
                 val userPlaylistUpdate = UserPlaylistUpdate(
-                    listOf(PlaylistProperty.Sort),
+                    listOf(PlaylistProperty.Sort(sortOrder)),
                     PlaylistUpdateSource.FILTER_EPISODE_LIST
                 )
                 playlistManager.update(playlist, userPlaylistUpdate)

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -219,6 +219,7 @@ enum class AnalyticsEvent(val key: String) {
     FILTER_DELETED("filter_deleted"),
     FILTER_LIST_SHOWN("filter_list_shown"),
     FILTER_SHOWN("filter_shown"),
+    FILTER_SORT_BY_CHANGED("filter_sort_by_changed"),
     FILTER_UPDATED("filter_updated"),
 
     /* Discover */

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Playlist.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Playlist.kt
@@ -33,7 +33,7 @@ data class Playlist(
     @ColumnInfo(name = "autoDownload") var autoDownload: Boolean = false,
     @ColumnInfo(name = "autoDownloadWifiOnly") var autoDownloadUnmeteredOnly: Boolean = false,
     @ColumnInfo(name = "autoDownloadPowerOnly") var autoDownloadPowerOnly: Boolean = false,
-    @ColumnInfo(name = "sortId") var sortId: Int = PLAYLIST_SORT_NEWEST_TO_OLDEST,
+    @ColumnInfo(name = "sortId") var sortId: Int = SortOrder.NEWEST_TO_OLDEST.value,
     @ColumnInfo(name = "iconId") var iconId: Int = 0,
     @ColumnInfo(name = "filterHours") var filterHours: Int = 0,
     @ColumnInfo(name = "starred") var starred: Boolean = false,
@@ -54,12 +54,6 @@ data class Playlist(
         const val AUDIO_VIDEO_FILTER_ALL = 0
         const val AUDIO_VIDEO_FILTER_AUDIO_ONLY = 1
         const val AUDIO_VIDEO_FILTER_VIDEO_ONLY = 2
-
-        const val PLAYLIST_SORT_NEWEST_TO_OLDEST = 0
-        const val PLAYLIST_SORT_OLDEST_TO_NEWEST = 1
-        const val PLAYLIST_SORT_SHORTEST_TO_LONGEST = 2
-        const val PLAYLIST_SORT_LONGEST_TO_SHORTEST = 3
-        const val PLAYLIST_SORT_LAST_DOWNLOAD_ATTEMPT_DATE = 100
 
         const val SYNC_STATUS_NOT_SYNCED = 0
         const val SYNC_STATUS_SYNCED = 1
@@ -156,4 +150,19 @@ data class Playlist(
 
     val isAllEpisodes: Boolean
         get() = unplayed && partiallyPlayed && finished && notDownloaded && downloaded && audioVideo == AUDIO_VIDEO_FILTER_ALL && allPodcasts && !filterDuration && filterHours == 0 && !starred
+
+    fun sortOrder() = SortOrder.fromInt(sortId)
+
+    enum class SortOrder(val value: Int) {
+        NEWEST_TO_OLDEST(0),
+        OLDEST_TO_NEWEST(1),
+        SHORTEST_TO_LONGEST(2),
+        LONGEST_TO_SHORTEST(3),
+        LAST_DOWNLOAD_ATTEMPT_DATE(100);
+
+        companion object {
+            fun fromInt(value: Int) =
+                SortOrder.values().find { it.value == value }
+        }
+    }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistProperty.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistProperty.kt
@@ -1,5 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
+import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
+
 sealed interface FilterUpdatedEvent {
     val groupValue: String
 }
@@ -40,7 +42,7 @@ sealed class PlaylistProperty {
         override val groupValue = "release_date"
     }
 
-    object Sort : PlaylistProperty()
+    data class Sort(val sortOrder: Playlist.SortOrder) : PlaylistProperty()
 
     object Starred : PlaylistProperty(), FilterUpdatedEvent {
         override val groupValue = "starred"


### PR DESCRIPTION
| 📘 Project: #261 | 🛫 Depends on: #386 |
| --- | --- |

Adding the `filter_sort_by_changed` event.

## To Test

1. Open the filters tab
2. Tap on a filter
3. From the overflow menu, select "Sort By"
4. Dismiss the sort modal without selecting anything
5. ✅  Observe that there is no `filter_sort_by_changed` event fired
6. Reopen the "Sort By" modal
7. Tap on any sorting option
8. ✅  Observe that a `filter_sort_by_changed` event is fired with an appropriate "sort_order" property of either "newest_to_oldest", "oldest_to_newest", "shortest_to_longest", or "longest_to_shortest"

# Checklist

- [X] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [X] Are all the strings localized?
- [X] Could you have written any new tests?
- [X] Did you include Compose previews with any components?