### PR TITLE
Tracks for filters part 5 (filter_edit_dismissed)

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterFragment.kt
@@ -237,6 +237,11 @@ class CreateFilterFragment : BaseFragment(), CoroutineScope {
         }
     }
 
+    override fun onBackPressed(): Boolean {
+        viewModel.onBackPressed(isCreate)
+        return super.onBackPressed()
+    }
+
     private fun setupIconViews() {
         val context = context ?: return
         val binding = binding ?: return

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -217,6 +217,7 @@ enum class AnalyticsEvent(val key: String) {
     FILTER_AUTO_DOWNLOAD_LIMIT_UPDATED("filter_auto_download_limit_updated"),
     FILTER_AUTO_DOWNLOAD_UPDATED("filter_auto_download_updated"),
     FILTER_DELETED("filter_deleted"),
+    FILTER_EDIT_DISMISSED("filter_edit_dismissed"),
     FILTER_LIST_SHOWN("filter_list_shown"),
     FILTER_SHOWN("filter_shown"),
     FILTER_SORT_BY_CHANGED("filter_sort_by_changed"),


### PR DESCRIPTION
| 📘 Project: #261 | 🛫 Depends on: #387  |
| --- | --- |

Adding the `filter_edit_dismissed` event.

## To Test

For each of these tests, start by:
1. From the filters tab, tap on a filter
2. From the overflow menu, select "Filter Settings"

### 1. No changes
1. Immediately exit from the Filter Settings screen without making any changes by tapping on the navigation arrow
2. ✅  Observe that a `filter_edit_dismissed` event is fired, but all of the setting properties are false (did_change_auto_download, did_change_episode_count, did_change_icon, did_change_name, did_change_color)
3. Reopen the Filter Settings screen
4. Exit from the Filter Settings screen without making any changes by using a back gesture
5. 2. ✅  Observe that a `filter_edit_dismissed` event is fired, but all of the setting properties are false

### 2. Change all Settings
1. Change the Filter's name, icon, color, auto download and auto download limit settings (note that the auto download and auto download limit change will fire their own events immediately when those settings are changed)
2. Exit the Filter Settings screen
3. ✅  Observe that a `filter_edit_dismissed` event is fired, and all of the setting properties are true (did_change_auto_download, did_change_episode_count, did_change_icon, did_change_name, did_change_color)
4. Reopen the Filter Settings screen
5. Again, change all of the filter's settings
6. Rotate the device so that a configuration change occurs
7. Exit the Filter settings screen
8. ✅  Again, observe that a `filter_edit_dismissed` event is fired, and all of the setting properties are true even though the changes occurred before the configuration change (did_change_auto_download, did_change_episode_count, did_change_icon, did_change_name, did_change_color)

# Checklist

- [X] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [X] Are all the strings localized?
- [X] Could you have written any new tests?
- [X] Did you include Compose previews with any components?