### PR TITLE
Added Automotive setting to show played.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
         ([#335](https://github.com/Automattic/pocket-casts-android/pull/335)).
     *   Allow select text in show notes from episode details view.
         ([#372](https://github.com/Automattic/pocket-casts-android/pull/372)).
+    *   Added Automotive OS setting to show played episodes.
+        ([#389](https://github.com/Automattic/pocket-casts-android/pull/389)).
 
 7.24
 -----

--- a/automotive/build.gradle
+++ b/automotive/build.gradle
@@ -49,17 +49,17 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     // Commented out the Automotive library as it clashes with the Material library and we don't use it. Duplicate value for resource attr/navigationIconTint.
     //implementation 'androidx.car:car:1.0.0-alpha7'
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'com.google.android.material:material:1.5.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    implementation 'com.mikepenz:aboutlibraries-core:10.4.0'
-    implementation 'com.mikepenz:aboutlibraries-compose:10.4.0'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    implementation project(':modules:services:localization')
+    implementation androidLibs.appCompat
+    implementation androidLibs.ktx
+    implementation androidLibs.design
+    implementation androidLibs.constraintLayout
+    implementation libs.aboutLibrariesCore
+    implementation libs.aboutLibrariesCompose
+    testImplementation libs.junit
+    androidTestImplementation androidLibs.junitExt
+    androidTestImplementation androidLibs.testEspressoCore
 
+    implementation project(':modules:services:localization')
     implementation project(':modules:services:preferences')
     implementation project(':modules:services:utils')
     implementation project(':modules:services:model')

--- a/automotive/src/main/res/xml/preferences_auto.xml
+++ b/automotive/src/main/res/xml/preferences_auto.xml
@@ -14,6 +14,11 @@
             android:title="@string/settings_subscribe_to_played"
             android:defaultValue="true"
             android:summary="@string/settings_subscribe_to_played_summary" />
+        <SwitchPreference
+            android:key="autoShowPlayed"
+            android:title="@string/settings_show_played"
+            android:defaultValue="false"
+            android:summary="@string/settings_show_played_summary" />
     </PreferenceCategory>
     <EditTextPreference
         android:id="@+id/edit_text_skip_forward"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -234,7 +234,10 @@ project.ext {
             sentryBom: 'io.sentry:sentry-bom:6.4.2',
             sentry: 'io.sentry:sentry-android',
             sentryFragment: 'io.sentry:sentry-android-fragment',
-            sentryTimber: 'io.sentry:sentry-android-timber'
+            sentryTimber: 'io.sentry:sentry-android-timber',
+            // AboutLibraries - https://github.com/mikepenz/AboutLibraries
+            aboutLibrariesCore: 'com.mikepenz:aboutlibraries-core:10.5.0',
+            aboutLibrariesCompose: 'com.mikepenz:aboutlibraries-compose:10.5.0'
     ]
 
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
@@ -9,7 +9,6 @@ import androidx.fragment.app.viewModels
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.Preference
-import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralSeconds

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1087,6 +1087,8 @@
     <string name="settings_storage_sorry">Sorry</string>
     <string name="settings_storage_store_on">Store podcasts on</string>
     <string name="settings_subscribe_to_played">Subscribe to played podcasts</string>
+    <string name="settings_show_played">Show played episodes</string>
+    <string name="settings_show_played_summary">Episodes that you have finished playing will still be displayed</string>
     <string name="settings_theme">Theme</string>
     <string name="settings_title">Title</string>
     <string name="settings_title_about">About</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -92,6 +92,7 @@ interface Settings {
 
         const val PREFERENCE_AUTO_PLAY_ON_EMPTY = "autoUpNextEmpty"
         const val PREFERENCE_AUTO_SUBSCRIBE_ON_PLAY = "autoSubscribeToPlayed"
+        const val PREFERENCE_AUTO_SHOW_PLAYED = "autoShowPlayed"
 
         const val PREFERENCE_DISCOVERY_COUNTRY_CODE = "discovery_country_code"
         const val PREFERENCE_POPULAR_PODCAST_COUNTRY_CODE = "popular_podcast_country_code"
@@ -514,6 +515,7 @@ interface Settings {
     fun setTrialFinishedSeen(seen: Boolean)
     fun getTrialFinishedSeen(): Boolean
     fun getAutoSubscribeToPlayed(): Boolean
+    fun getAutoShowPlayed(): Boolean
     fun getAutoPlayNextEpisodeOnEmpty(): Boolean
     fun defaultShowArchived(): Boolean
     fun setDefaultShowArchived(value: Boolean)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -491,7 +491,11 @@ class SettingsImpl @Inject constructor(
     }
 
     override fun getAutoSubscribeToPlayed(): Boolean {
-        return getBoolean(Settings.PREFERENCE_AUTO_SUBSCRIBE_ON_PLAY, false)
+        return getBoolean(Settings.PREFERENCE_AUTO_SUBSCRIBE_ON_PLAY, true)
+    }
+
+    override fun getAutoShowPlayed(): Boolean {
+        return getBoolean(Settings.PREFERENCE_AUTO_SHOW_PLAYED, false)
     }
 
     override fun canDuckAudioWithNotifications(): Boolean {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -524,7 +524,13 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
         } else {
             val podcastFound = podcastManager.findPodcastByUuidSuspend(parentId) ?: podcastManager.findOrDownloadPodcastRx(parentId).toMaybe().onErrorComplete().awaitSingleOrNull()
             podcastFound?.let { podcast ->
-                val episodes = episodeManager.findEpisodesByPodcastOrdered(podcast).filterNot { it.isFinished || it.isArchived }.take(EPISODE_LIMIT).toMutableList()
+
+                val showPlayed = settings.getAutoShowPlayed()
+                val episodes = episodeManager
+                    .findEpisodesByPodcastOrdered(podcast)
+                    .filterNot { !showPlayed && (it.isFinished || it.isArchived) }
+                    .take(EPISODE_LIMIT)
+                    .toMutableList()
                 if (!podcast.isSubscribed) {
                     episodes.sortBy { it.episodeType !is Episode.EpisodeType.Trailer } // Bring trailers to the top
                 }


### PR DESCRIPTION
This change adds a setting to allow Automotive OS users to show played episodes.

Fixes https://github.com/Automattic/pocket-casts-android/issues/379

Other changes are:

- Moved the Automotive library dependency versions from the build.gradle to dependencies.gradle.
- Upgraded AboutLibraries from 10.4.0 to 10.5.0
  https://github.com/mikepenz/AboutLibraries/releases/tag/v10.5.0

**Test Steps**

1. Install the Automotive app on an emulator
2. Start playing an episode
3. On the full screen play mark the episode as played
4. ✅ Verify you don't see the episode in the list
5. Open the settings page and turn on "Show played episodes"
6. ✅ Verify you do see the episode in the list

![Screenshot_20221010_132421](https://user-images.githubusercontent.com/308331/194794975-0d7a26eb-397b-4b20-af51-beb1195b41fe.png)
