### PR TITLE
Tracks for filters part 6 (filter_list_reordered)

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -101,8 +101,8 @@ class FiltersFragment : BaseFragment(), CoroutineScope, Toolbar.OnMenuItemClickL
         val touchHelperCallback = FiltersListItemTouchCallback({ from, to ->
             val newList = viewModel.movePlaylist(from, to)
             adapter.submitList(newList)
-        }) {
-            viewModel.commitMoves()
+        }) { from, to ->
+            viewModel.commitMoves(from != to)
         }
         val itemTouchHelper = ItemTouchHelper(touchHelperCallback)
         itemTouchHelper.attachToRecyclerView(recyclerView)
@@ -166,17 +166,33 @@ class FiltersFragment : BaseFragment(), CoroutineScope, Toolbar.OnMenuItemClickL
     }
 }
 
-private class FiltersListItemTouchCallback(val onMoveListener: (Int, Int) -> Unit, val onFinish: () -> Unit) : ItemTouchHelper.SimpleCallback(ItemTouchHelper.UP.or(ItemTouchHelper.DOWN), 0) {
+private class FiltersListItemTouchCallback(
+    val onMoveListener: (from: Int, to: Int) -> Unit,
+    val onFinish: (from: Int?, to: Int?) -> Unit
+) : ItemTouchHelper.SimpleCallback(ItemTouchHelper.UP.or(ItemTouchHelper.DOWN), 0) {
+    private var moveFrom: Int? = null
+    private var moveTo: Int? = null
+
     override fun onMove(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder, target: RecyclerView.ViewHolder): Boolean {
+
+        // Onlu update moveFrom if it is not initialized because it represents the position where the move started
+        if (moveFrom == null) {
+            moveFrom = viewHolder.bindingAdapterPosition
+        }
+
+        // Always update moveTo because it represents the final position
+        moveTo = target.bindingAdapterPosition
+
         onMoveListener(viewHolder.bindingAdapterPosition, target.bindingAdapterPosition)
         return true
     }
 
-    override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
-    }
+    override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {}
 
     override fun clearView(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder) {
         super.clearView(recyclerView, viewHolder)
-        onFinish()
+        onFinish(moveFrom, moveTo)
+        moveFrom = null
+        moveTo = null
     }
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -175,7 +175,7 @@ private class FiltersListItemTouchCallback(
 
     override fun onMove(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder, target: RecyclerView.ViewHolder): Boolean {
 
-        // Onlu update moveFrom if it is not initialized because it represents the position where the move started
+        // Only update moveFrom if it is not initialized because it represents the position where the move started
         if (moveFrom == null) {
             moveFrom = viewHolder.bindingAdapterPosition
         }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
@@ -57,7 +57,7 @@ class FiltersFragmentViewModel @Inject constructor(
         return adapterState.toList()
     }
 
-    fun commitMoves() {
+    fun commitMoves(moved: Boolean) {
         val playlists = adapterState
 
         playlists.forEachIndexed { index, playlist ->
@@ -65,7 +65,12 @@ class FiltersFragmentViewModel @Inject constructor(
             playlist.syncStatus = Playlist.SYNC_STATUS_NOT_SYNCED
         }
 
-        runBlocking(Dispatchers.Default) { playlistManager.updateAll(playlists) }
+        runBlocking(Dispatchers.Default) {
+            playlistManager.updateAll(playlists)
+            if (moved) {
+                analyticsTracker.track(AnalyticsEvent.FILTER_LIST_REORDERED)
+            }
+        }
     }
 
     fun onFragmentPause(isChangingConfigurations: Boolean?) {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -267,4 +267,5 @@ enum class AnalyticsEvent(val key: String) {
     PLAYBACK_EFFECT_TRIM_SILENCE_TOGGLED("playback_effect_trim_silence_toggled"),
     PLAYBACK_EFFECT_TRIM_SILENCE_AMOUNT_CHANGED("playback_effect_trim_silence_amount_changed"),
     PLAYBACK_EFFECT_VOLUME_BOOST_TOGGLED("playback_effect_volume_boost_toggled"),
+    FILTER_LIST_REORDERED("filter_list_reordered"),
 }


### PR DESCRIPTION
| 📘 Project: #261 |
| --- |

## Description

Adds the `filter_list_reordered` event.

## To Test

1. Open the filters tab
2. Long press on one of the filters and then move it to a new position
3. ✅  Observe that a `filter_list_reordered` event is fired
4. Long press on one of the filters but leave it in the same position
5. ✅ Observe that a `filter_list_reordered` event is _not_ fired


# Checklist

- [X] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [X] Are all the strings localized?
- [X] Could you have written any new tests?
- [X] Did you include Compose previews with any components?