### PR TITLE
Identify and skip/track few unknown playback sources

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -686,14 +686,13 @@ class MainActivity :
     }
 
     override fun onPlayClicked() {
-        playbackManager.playbackSource = PlaybackSource.MINIPLAYER
         if (playbackManager.shouldWarnAboutPlayback()) {
             launch {
                 // show the stream warning if the episode isn't downloaded
                 playbackManager.getCurrentEpisode()?.let { episode ->
                     launch(Dispatchers.Main) {
                         if (episode.isDownloaded) {
-                            playbackManager.playQueue()
+                            playbackManager.playQueue(PlaybackSource.MINIPLAYER)
                             warningsHelper.showBatteryWarningSnackbarIfAppropriate()
                         } else {
                             warningsHelper.streamingWarningDialog(episode)
@@ -703,24 +702,21 @@ class MainActivity :
                 }
             }
         } else {
-            playbackManager.playQueue()
+            playbackManager.playQueue(PlaybackSource.MINIPLAYER)
             warningsHelper.showBatteryWarningSnackbarIfAppropriate()
         }
     }
 
     override fun onPauseClicked() {
-        playbackManager.playbackSource = PlaybackSource.MINIPLAYER
-        playbackManager.pause()
+        playbackManager.pause(playbackSource = PlaybackSource.MINIPLAYER)
     }
 
     override fun onSkipBackwardClicked() {
-        playbackManager.playbackSource = PlaybackSource.MINIPLAYER
-        playbackManager.skipBackward()
+        playbackManager.skipBackward(playbackSource = PlaybackSource.MINIPLAYER)
     }
 
     override fun onSkipForwardClicked() {
-        playbackManager.playbackSource = PlaybackSource.MINIPLAYER
-        playbackManager.skipForward()
+        playbackManager.skipForward(playbackSource = PlaybackSource.MINIPLAYER)
     }
 
     override fun addFragment(fragment: Fragment, onTop: Boolean) {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -695,7 +695,7 @@ class MainActivity :
                             playbackManager.playQueue(PlaybackSource.MINIPLAYER)
                             warningsHelper.showBatteryWarningSnackbarIfAppropriate()
                         } else {
-                            warningsHelper.streamingWarningDialog(episode)
+                            warningsHelper.streamingWarningDialog(episode = episode, playbackSource = PlaybackSource.MINIPLAYER)
                                 .show(supportFragmentManager, "streaming dialog")
                         }
                     }

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
@@ -20,6 +20,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.EXTRA_CONTENT_STYLE_
 import au.com.shiftyjelly.pocketcasts.repositories.playback.FOLDER_ROOT_PREFIX
 import au.com.shiftyjelly.pocketcasts.repositories.playback.MEDIA_ID_ROOT
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PODCASTS_ROOT
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackService
 import au.com.shiftyjelly.pocketcasts.repositories.playback.auto.AutoConverter
 import au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsTask
@@ -72,7 +73,7 @@ class AutoPlaybackService : PlaybackService() {
         super.onDestroy()
         Log.d(Settings.LOG_TAG_AUTO, "Auto playback service destroyed")
 
-        playbackManager.pause(transientLoss = false)
+        playbackManager.pause(transientLoss = false, playbackSource = PlaybackSource.AUTO_PAUSE)
     }
 
     override fun onLoadChildren(parentId: String, result: Result<List<MediaBrowserCompat.MediaItem>>) {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -162,13 +162,11 @@ class DiscoverViewModel @Inject constructor(
     }
 
     fun playEpisode(episode: Episode) {
-        playbackManager.playbackSource = PlaybackSource.DISCOVER
-        playbackManager.playNow(episode, forceStream = true)
+        playbackManager.playNow(episode = episode, forceStream = true, playbackSource = PlaybackSource.DISCOVER)
     }
 
     fun stopPlayback() {
-        playbackManager.playbackSource = PlaybackSource.DISCOVER
-        playbackManager.stopAsync()
+        playbackManager.stopAsync(playbackSource = PlaybackSource.DISCOVER)
     }
 }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -41,6 +41,7 @@ class DiscoverViewModel @Inject constructor(
     val userManager: UserManager
 ) : ViewModel() {
     private val disposables = CompositeDisposable()
+    private val playbackSource = PlaybackSource.DISCOVER
     val state = MutableLiveData<DiscoverState>().apply { value = DiscoverState.Loading }
     var currentRegionCode: String? = settings.getDiscoveryCountryCode()
     var replacements = emptyMap<String, String>()
@@ -162,11 +163,11 @@ class DiscoverViewModel @Inject constructor(
     }
 
     fun playEpisode(episode: Episode) {
-        playbackManager.playNow(episode = episode, forceStream = true, playbackSource = PlaybackSource.DISCOVER)
+        playbackManager.playNow(episode = episode, forceStream = true, playbackSource = playbackSource)
     }
 
     fun stopPlayback() {
-        playbackManager.stopAsync(playbackSource = PlaybackSource.DISCOVER)
+        playbackManager.stopAsync(playbackSource = playbackSource)
     }
 }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/PodcastListViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/PodcastListViewModel.kt
@@ -151,13 +151,11 @@ class PodcastListViewModel @Inject constructor(
     }
 
     fun playEpisode(episode: Episode) {
-        playbackManager.playbackSource = PlaybackSource.DISCOVER_PODCAST_LIST
-        playbackManager.playNow(episode, forceStream = true)
+        playbackManager.playNow(episode, forceStream = true, playbackSource = PlaybackSource.DISCOVER_PODCAST_LIST)
     }
 
     fun stopPlayback() {
-        playbackManager.playbackSource = PlaybackSource.DISCOVER_PODCAST_LIST
-        playbackManager.stopAsync()
+        playbackManager.stopAsync(playbackSource = PlaybackSource.DISCOVER_PODCAST_LIST)
     }
 }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeAction
@@ -118,7 +119,7 @@ class FilterEpisodeListViewModel @Inject constructor(
             if (startIndex > -1) {
                 playbackManager.upNextQueue.removeAll()
                 val count = min(episodes.size - startIndex, settings.getMaxUpNextEpisodes())
-                playbackManager.playEpisodes(episodes = episodes.subList(startIndex, startIndex + count), playbackSource = PlaybackManager.PlaybackSource.FILTERS)
+                playbackManager.playEpisodes(episodes = episodes.subList(startIndex, startIndex + count), playbackSource = PlaybackSource.FILTERS)
             }
         }
     }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -118,7 +118,7 @@ class FilterEpisodeListViewModel @Inject constructor(
             if (startIndex > -1) {
                 playbackManager.upNextQueue.removeAll()
                 val count = min(episodes.size - startIndex, settings.getMaxUpNextEpisodes())
-                playbackManager.playEpisodes(episodes.subList(startIndex, startIndex + count))
+                playbackManager.playEpisodes(episodes = episodes.subList(startIndex, startIndex + count), playbackSource = PlaybackManager.PlaybackSource.FILTERS)
             }
         }
     }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -123,15 +123,6 @@ class FilterEpisodeListViewModel @Inject constructor(
         }
     }
 
-    fun playAll() {
-        launch {
-            val episodes = episodesList.value ?: emptyList()
-            if (episodes.isNotEmpty()) {
-                onPlayAllFromHere(episodes.first())
-            }
-        }
-    }
-
     fun changeSort(sortOrder: Int) {
         launch {
             playlist.value?.let { playlist ->

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -74,7 +74,6 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
     lateinit var imageLoader: PodcastImageLoaderThemed
     private val viewModel: PlayerViewModel by activityViewModels()
     private var binding: AdapterPlayerHeaderBinding? = null
-    private val playbackSource = PlaybackSource.PLAYER
     private var skippedFirstTouch: Boolean = false
     private var hasReceivedOnTouchDown = false
 
@@ -100,12 +99,10 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         binding.viewModel = PlayerViewModel.PlayerHeader()
 
         binding.skipBack.setOnClickListener {
-            playbackManager.playbackSource = playbackSource
             onSkipBack()
             (it as LottieAnimationView).playAnimation()
         }
         binding.skipForward.setOnClickListener {
-            playbackManager.playbackSource = playbackSource
             onSkipForward()
             (it as LottieAnimationView).playAnimation()
         }
@@ -476,10 +473,9 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
     }
 
     override fun onPlayClicked() {
-        playbackManager.playbackSource = playbackSource
         if (playbackManager.isPlaying()) {
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Pause clicked in player")
-            playbackManager.pause()
+            playbackManager.pause(playbackSource = PlaybackSource.PLAYER)
         } else {
             if (playbackManager.shouldWarnAboutPlayback()) {
                 launch {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -76,6 +76,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
     private var binding: AdapterPlayerHeaderBinding? = null
     private var skippedFirstTouch: Boolean = false
     private var hasReceivedOnTouchDown = false
+    private val playbackSource = PlaybackSource.PLAYER
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = AdapterPlayerHeaderBinding.inflate(inflater, container, false)
@@ -475,7 +476,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
     override fun onPlayClicked() {
         if (playbackManager.isPlaying()) {
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Pause clicked in player")
-            playbackManager.pause(playbackSource = PlaybackSource.PLAYER)
+            playbackManager.pause(playbackSource = playbackSource)
         } else {
             if (playbackManager.shouldWarnAboutPlayback()) {
                 launch {
@@ -486,7 +487,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
                                 viewModel.play()
                                 warningsHelper.showBatteryWarningSnackbarIfAppropriate(snackbarParentView = view)
                             } else {
-                                warningsHelper.streamingWarningDialog(episode = episode, snackbarParentView = view, playbackSource = PlaybackSource.PLAYER)
+                                warningsHelper.streamingWarningDialog(episode = episode, snackbarParentView = view, playbackSource = playbackSource)
                                     .show(parentFragmentManager, "streaming dialog")
                             }
                         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -486,7 +486,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
                                 viewModel.play()
                                 warningsHelper.showBatteryWarningSnackbarIfAppropriate(snackbarParentView = view)
                             } else {
-                                warningsHelper.streamingWarningDialog(episode, snackbarParentView = view)
+                                warningsHelper.streamingWarningDialog(episode = episode, snackbarParentView = view, playbackSource = PlaybackSource.PLAYER)
                                     .show(parentFragmentManager, "streaming dialog")
                             }
                         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -24,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentUpnextBinding
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
@@ -69,6 +70,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     lateinit var adapter: UpNextAdapter
+    private val playbackSource = PlaybackSource.UP_NEXT
     private val playerViewModel: PlayerViewModel by activityViewModels()
     private var userRearrangingFrom: Int? = null
     private var playingEpisodeAtStartOfDrag: String? = null
@@ -288,7 +290,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
 
     override fun onEpisodeActionsClick(episodeUuid: String, podcastUuid: String?) {
         if (settings.getTapOnUpNextShouldPlay()) {
-            playerViewModel.playEpisode(uuid = episodeUuid, playbackSource = PlaybackManager.PlaybackSource.UP_NEXT)
+            playerViewModel.playEpisode(uuid = episodeUuid, playbackSource = playbackSource)
         } else {
             (activity as? FragmentHostListener)?.openEpisodeDialog(episodeUuid, podcastUuid, forceDark = true)
         }
@@ -298,7 +300,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
         if (settings.getTapOnUpNextShouldPlay()) {
             (activity as? FragmentHostListener)?.openEpisodeDialog(episodeUuid, podcastUuid, forceDark = true)
         } else {
-            playerViewModel.playEpisode(uuid = episodeUuid, playbackSource = PlaybackManager.PlaybackSource.UP_NEXT)
+            playerViewModel.playEpisode(uuid = episodeUuid, playbackSource = playbackSource)
         }
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -288,7 +288,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
 
     override fun onEpisodeActionsClick(episodeUuid: String, podcastUuid: String?) {
         if (settings.getTapOnUpNextShouldPlay()) {
-            playerViewModel.playEpisode(episodeUuid)
+            playerViewModel.playEpisode(uuid = episodeUuid, playbackSource = PlaybackManager.PlaybackSource.UP_NEXT)
         } else {
             (activity as? FragmentHostListener)?.openEpisodeDialog(episodeUuid, podcastUuid, forceDark = true)
         }
@@ -298,7 +298,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
         if (settings.getTapOnUpNextShouldPlay()) {
             (activity as? FragmentHostListener)?.openEpisodeDialog(episodeUuid, podcastUuid, forceDark = true)
         } else {
-            playerViewModel.playEpisode(episodeUuid)
+            playerViewModel.playEpisode(uuid = episodeUuid, playbackSource = PlaybackManager.PlaybackSource.UP_NEXT)
         }
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoActivity.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoActivity.kt
@@ -17,7 +17,6 @@ import androidx.media.session.MediaButtonReceiver
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.SimplePlayer
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import dagger.hilt.android.AndroidEntryPoint
@@ -57,8 +56,6 @@ class VideoActivity : AppCompatActivity() {
         window.navigationBarColor = color
 
         setContentView(R.layout.activity_video)
-
-        playbackManager.playbackSource = PlaybackSource.FULL_SCREEN_VIDEO
 
         if (savedInstanceState == null) {
             supportFragmentManager.beginTransaction()

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -149,7 +149,7 @@ class PlayerViewModel @Inject constructor(
     ) {
         fun isSameChapter(chapter: Chapter) = currentChapter?.let { it.index == chapter.index } ?: false
     }
-
+    private val playbackSource = PlaybackSource.PLAYER
     private val _showPlayerFlow = MutableSharedFlow<Unit>()
     val showPlayerFlow: SharedFlow<Unit> = _showPlayerFlow
 
@@ -368,10 +368,10 @@ class PlayerViewModel @Inject constructor(
 
     fun play() {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Play clicked in player")
-        playbackManager.playQueue(playbackSource = PlaybackSource.PLAYER)
+        playbackManager.playQueue(playbackSource = playbackSource)
     }
 
-    fun playEpisode(uuid: String, playbackSource: PlaybackManager.PlaybackSource = PlaybackManager.PlaybackSource.UNKNOWN) {
+    fun playEpisode(uuid: String, playbackSource: PlaybackSource = PlaybackSource.UNKNOWN) {
         launch {
             val episode = episodeManager.findPlayableByUuid(uuid) ?: return@launch
             playbackManager.playNow(episode = episode, playbackSource = playbackSource)
@@ -379,11 +379,11 @@ class PlayerViewModel @Inject constructor(
     }
 
     fun skipBackward() {
-        playbackManager.skipBackward(playbackSource = PlaybackSource.PLAYER)
+        playbackManager.skipBackward(playbackSource = playbackSource)
     }
 
     fun skipForward() {
-        playbackManager.skipForward(playbackSource = PlaybackSource.PLAYER)
+        playbackManager.skipForward(playbackSource = playbackSource)
     }
 
     fun longSkipForwardOptionsDialog(): OptionsDialog {
@@ -395,7 +395,7 @@ class PlayerViewModel @Inject constructor(
         }
         if (playbackManager.upNextQueue.queueEpisodes.isNotEmpty()) {
             optionsDialogBuilder = optionsDialogBuilder.addTextOption(titleId = LR.string.next_episode) {
-                playbackManager.playNextInQueue(playbackSource = PlaybackManager.PlaybackSource.PLAYER)
+                playbackManager.playNextInQueue(playbackSource = playbackSource)
             }
         }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -27,6 +27,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getUrlForArtwork
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.saveToGlobalSettings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.SleepTimer
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
@@ -367,7 +368,7 @@ class PlayerViewModel @Inject constructor(
 
     fun play() {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Play clicked in player")
-        playbackManager.playQueue()
+        playbackManager.playQueue(playbackSource = PlaybackSource.PLAYER)
     }
 
     fun playEpisode(uuid: String) {
@@ -382,11 +383,11 @@ class PlayerViewModel @Inject constructor(
     }
 
     fun skipBackward() {
-        playbackManager.skipBackward()
+        playbackManager.skipBackward(playbackSource = PlaybackSource.PLAYER)
     }
 
     fun skipForward() {
-        playbackManager.skipForward()
+        playbackManager.skipForward(playbackSource = PlaybackSource.PLAYER)
     }
 
     fun longSkipForwardOptionsDialog(): OptionsDialog {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -378,10 +378,6 @@ class PlayerViewModel @Inject constructor(
         }
     }
 
-    fun pause() {
-        playbackManager.pause()
-    }
-
     fun skipBackward() {
         playbackManager.skipBackward(playbackSource = PlaybackSource.PLAYER)
     }
@@ -572,10 +568,6 @@ class PlayerViewModel @Inject constructor(
 
     fun previousChapter() {
         playbackManager.skipToPreviousChapter()
-    }
-
-    fun playPause() {
-        playbackManager.playPause()
     }
 
     fun onChapterClick(chapter: Chapter) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -399,7 +399,7 @@ class PlayerViewModel @Inject constructor(
         }
         if (playbackManager.upNextQueue.queueEpisodes.isNotEmpty()) {
             optionsDialogBuilder = optionsDialogBuilder.addTextOption(titleId = LR.string.next_episode) {
-                playbackManager.playNextInQueue()
+                playbackManager.playNextInQueue(playbackSource = PlaybackManager.PlaybackSource.PLAYER)
             }
         }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -371,10 +371,10 @@ class PlayerViewModel @Inject constructor(
         playbackManager.playQueue(playbackSource = PlaybackSource.PLAYER)
     }
 
-    fun playEpisode(uuid: String) {
+    fun playEpisode(uuid: String, playbackSource: PlaybackManager.PlaybackSource = PlaybackManager.PlaybackSource.UNKNOWN) {
         launch {
             val episode = episodeManager.findPlayableByUuid(uuid) ?: return@launch
-            playbackManager.playNow(episode)
+            playbackManager.playNow(episode = episode, playbackSource = playbackSource)
         }
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/VideoViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/VideoViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.BackpressureStrategy
@@ -29,21 +30,21 @@ class VideoViewModel @Inject constructor(
     val controlsVisible: LiveData<Boolean> get() = controlsVisibleMutable
 
     fun play() {
-        playbackManager.playQueue()
+        playbackManager.playQueue(playbackSource = PlaybackSource.FULL_SCREEN_VIDEO)
         startHideControlsTimer()
     }
 
     fun pause() {
-        playbackManager.pause()
+        playbackManager.pause(playbackSource = PlaybackSource.FULL_SCREEN_VIDEO)
     }
 
     fun skipBackward() {
-        playbackManager.skipBackward()
+        playbackManager.skipBackward(playbackSource = PlaybackSource.FULL_SCREEN_VIDEO)
         startHideControlsTimer()
     }
 
     fun skipForward() {
-        playbackManager.skipForward()
+        playbackManager.skipForward(playbackSource = PlaybackSource.FULL_SCREEN_VIDEO)
         startHideControlsTimer()
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/VideoViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/VideoViewModel.kt
@@ -27,24 +27,25 @@ class VideoViewModel @Inject constructor(
     private var lastTimeHidingControls = 0L
 
     private var controlsVisibleMutable = MutableLiveData(true)
+    private val playbackSource = PlaybackSource.FULL_SCREEN_VIDEO
     val controlsVisible: LiveData<Boolean> get() = controlsVisibleMutable
 
     fun play() {
-        playbackManager.playQueue(playbackSource = PlaybackSource.FULL_SCREEN_VIDEO)
+        playbackManager.playQueue(playbackSource = playbackSource)
         startHideControlsTimer()
     }
 
     fun pause() {
-        playbackManager.pause(playbackSource = PlaybackSource.FULL_SCREEN_VIDEO)
+        playbackManager.pause(playbackSource = playbackSource)
     }
 
     fun skipBackward() {
-        playbackManager.skipBackward(playbackSource = PlaybackSource.FULL_SCREEN_VIDEO)
+        playbackManager.skipBackward(playbackSource = playbackSource)
         startHideControlsTimer()
     }
 
     fun skipForward() {
-        playbackManager.skipForward(playbackSource = PlaybackSource.FULL_SCREEN_VIDEO)
+        playbackManager.skipForward(playbackSource = playbackSource)
         startHideControlsTimer()
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
@@ -42,7 +42,7 @@ class PlayButtonListener @Inject constructor(
                         if (episode.isDownloaded) {
                             play(episode)
                         } else if (activity is AppCompatActivity) {
-                            warningsHelper.streamingWarningDialog(episode)
+                            warningsHelper.streamingWarningDialog(episode = episode, playbackSource = playbackSource)
                                 .show(activity.supportFragmentManager, "streaming dialog")
                         }
                     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
@@ -54,14 +54,12 @@ class PlayButtonListener @Inject constructor(
     }
 
     private fun play(episode: Playable, force: Boolean = true) {
-        playbackManager.playbackSource = playbackSource
-        playbackManager.playNow(episode, force)
+        playbackManager.playNow(episode = episode, forceStream = force, playbackSource = playbackSource)
         warningsHelper.showBatteryWarningSnackbarIfAppropriate()
     }
 
     override fun onPauseClicked() {
-        playbackManager.playbackSource = playbackSource
-        playbackManager.pause()
+        playbackManager.pause(playbackSource = playbackSource)
     }
 
     override fun onPlayedClicked(episodeUuid: String) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
@@ -8,6 +8,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.components.PlayButton
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -30,7 +31,7 @@ class PlayButtonListener @Inject constructor(
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
 
-    override var playbackSource = PlaybackManager.PlaybackSource.UNKNOWN
+    override var playbackSource = PlaybackSource.UNKNOWN
 
     override fun onPlayClicked(episodeUuid: String) {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "In app play button pushed for $episodeUuid")

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -55,6 +55,7 @@ class EpisodeFragmentViewModel @Inject constructor(
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
 
+    private val playbackSource = PlaybackSource.EPISODE_DETAILS
     lateinit var state: LiveData<EpisodeFragmentState>
     val showNotes: MutableLiveData<String> = MutableLiveData()
     lateinit var inUpNext: LiveData<Boolean>
@@ -244,14 +245,14 @@ class EpisodeFragmentViewModel @Inject constructor(
     ): Boolean {
         episode?.let { episode ->
             if (isPlaying.value == true) {
-                playbackManager.pause(playbackSource = PlaybackSource.EPISODE_DETAILS)
+                playbackManager.pause(playbackSource = playbackSource)
                 return false
             } else {
                 fromListUuid?.let {
                     FirebaseAnalyticsTracker.podcastEpisodePlayedFromList(it, episode.podcastUuid)
                     analyticsTracker.track(AnalyticsEvent.DISCOVER_LIST_EPISODE_PLAY, mapOf(LIST_ID_KEY to it, PODCAST_ID_KEY to episode.podcastUuid))
                 }
-                playbackManager.playNow(episode, forceStream = force, playbackSource = PlaybackSource.EPISODE_DETAILS)
+                playbackManager.playNow(episode, forceStream = force, playbackSource = playbackSource)
                 warningsHelper.showBatteryWarningSnackbarIfAppropriate()
                 return true
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -243,16 +243,15 @@ class EpisodeFragmentViewModel @Inject constructor(
         fromListUuid: String? = null
     ): Boolean {
         episode?.let { episode ->
-            playbackManager.playbackSource = PlaybackSource.EPISODE_DETAILS
             if (isPlaying.value == true) {
-                playbackManager.pause()
+                playbackManager.pause(playbackSource = PlaybackSource.EPISODE_DETAILS)
                 return false
             } else {
                 fromListUuid?.let {
                     FirebaseAnalyticsTracker.podcastEpisodePlayedFromList(it, episode.podcastUuid)
                     analyticsTracker.track(AnalyticsEvent.DISCOVER_LIST_EPISODE_PLAY, mapOf(LIST_ID_KEY to it, PODCAST_ID_KEY to episode.podcastUuid))
                 }
-                playbackManager.playNow(episode, force)
+                playbackManager.playNow(episode, forceStream = force, playbackSource = PlaybackSource.EPISODE_DETAILS)
                 warningsHelper.showBatteryWarningSnackbarIfAppropriate()
                 return true
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.viewModels
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralSeconds

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
@@ -9,7 +9,6 @@ import androidx.fragment.app.viewModels
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.Preference
-import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralSeconds

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.containsUuid
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -120,12 +121,12 @@ class CloudBottomSheetViewModel @Inject constructor(
     }
 
     fun playNow(episode: UserEpisode, forceStream: Boolean) {
-        playbackManager.playNow(episode, forceStream)
+        playbackManager.playNow(episode = episode, forceStream = forceStream, playbackSource = PlaybackSource.FILES)
         analyticsTracker.track(AnalyticsEvent.USER_FILE_PLAY_PAUSE_BUTTON_TAPPED, mapOf(OPTION_KEY to PLAY))
     }
 
     fun pause() {
-        playbackManager.pause()
+        playbackManager.pause(playbackSource = PlaybackSource.FILES)
         analyticsTracker.track(AnalyticsEvent.USER_FILE_PLAY_PAUSE_BUTTON_TAPPED, mapOf(OPTION_KEY to PAUSE))
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -442,7 +442,7 @@ class MediaSessionManager(
                 playPauseTimer = null
 
                 logEvent("skip forwards from headset hook")
-                playbackManager.skipForward()
+                playbackManager.skipForward(playbackSource = PlaybackSource.MEDIA_BUTTON_BROADCAST_ACTION)
             }
         }
 
@@ -480,7 +480,7 @@ class MediaSessionManager(
             logEvent("stop")
             launch {
                 // note: the stop event is called from cars when they only want to pause, this is less destructive and doesn't cause issues if they try to play again
-                playbackManager.pause()
+                playbackManager.pause(playbackSource = PlaybackSource.MEDIA_BUTTON_BROADCAST_ACTION)
             }
         }
 
@@ -512,7 +512,7 @@ class MediaSessionManager(
                 val autoMediaId = AutoMediaId.fromMediaId(mediaId)
                 val playableId = autoMediaId.playableId
                 episodeManager.findPlayableByUuid(playableId)?.let { episode ->
-                    playbackManager.playNow(episode)
+                    playbackManager.playNow(episode, playbackSource = PlaybackSource.MEDIA_BUTTON_BROADCAST_ACTION)
 
                     playbackManager.lastLoadedFromPodcastOrPlaylistUuid = autoMediaId.sourceId
                 }
@@ -537,7 +537,7 @@ class MediaSessionManager(
             if (state is UpNextQueue.State.Loaded) {
                 state.queue.find { it.adapterId == id }?.let { episode ->
                     logEvent("play from skip to queue item")
-                    playbackManager.playNow(episode)
+                    playbackManager.playNow(episode, playbackSource = PlaybackSource.MEDIA_BUTTON_BROADCAST_ACTION)
                 }
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -390,7 +390,6 @@ class MediaSessionManager(
                     @Suppress("DEPRECATION")
                     mediaButtonEvent.getParcelableExtra(Intent.EXTRA_KEY_EVENT)
                 } ?: return false
-                playbackManager.playbackSource = PlaybackSource.MEDIA_BUTTON_BROADCAST_ACTION
                 if (keyEvent.action == KeyEvent.ACTION_DOWN) {
                     when (keyEvent.keyCode) {
                         KeyEvent.KEYCODE_HEADSETHOOK -> {
@@ -430,7 +429,7 @@ class MediaSessionManager(
                         object : TimerTask() {
                             override fun run() {
                                 logEvent("play from headset hook", inSessionCallback = false)
-                                playbackManager.playPause()
+                                playbackManager.playPause(PlaybackSource.MEDIA_BUTTON_BROADCAST_ACTION)
                                 playPauseTimer = null
                             }
                         },
@@ -461,12 +460,12 @@ class MediaSessionManager(
 
         override fun onPlay() {
             logEvent("play")
-            playbackManager.playQueue()
+            playbackManager.playQueue(playbackSource = PlaybackSource.MEDIA_BUTTON_BROADCAST_ACTION)
         }
 
         override fun onPause() {
             logEvent("pause")
-            playbackManager.pause()
+            playbackManager.pause(playbackSource = PlaybackSource.MEDIA_BUTTON_BROADCAST_ACTION)
         }
 
         override fun onPlayFromSearch(query: String?, extras: Bundle?) {
@@ -487,12 +486,12 @@ class MediaSessionManager(
 
         override fun onSkipToPrevious() {
             logEvent("skip backwards")
-            playbackManager.skipBackward()
+            playbackManager.skipBackward(playbackSource = PlaybackSource.MEDIA_BUTTON_BROADCAST_ACTION)
         }
 
         override fun onSkipToNext() {
             logEvent("skip forwards")
-            playbackManager.skipForward()
+            playbackManager.skipForward(playbackSource = PlaybackSource.MEDIA_BUTTON_BROADCAST_ACTION)
         }
 
         override fun onSetRating(rating: RatingCompat?) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -707,7 +707,7 @@ class MediaSessionManager(
             return
         }
 
-        playbackManager.playEpisodes(episodes)
+        playbackManager.playEpisodes(episodes = episodes, playbackSource = PlaybackSource.MEDIA_BUTTON_BROADCAST_SEARCH_ACTION)
     }
 
     private suspend fun playPodcast(podcast: Podcast) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -633,9 +633,10 @@ class MediaSessionManager(
 
         Timber.i("performPlayFromSearch query: $query")
 
+        val playbackSource = PlaybackSource.MEDIA_BUTTON_BROADCAST_SEARCH_ACTION
         launch {
             if (query.startsWith("up next")) {
-                playbackManager.playQueue()
+                playbackManager.playQueue(playbackSource = playbackSource)
                 return@launch
             }
 
@@ -652,7 +653,7 @@ class MediaSessionManager(
                 val matchingPodcast: Podcast? = podcastManager.searchPodcastByTitle(option)
                 if (matchingPodcast != null) {
                     LogBuffer.i(LogBuffer.TAG_PLAYBACK, "User played podcast from search %s.", option)
-                    playPodcast(matchingPodcast)
+                    playPodcast(podcast = matchingPodcast, playbackSource = playbackSource)
                     return@launch
                 }
             }
@@ -660,7 +661,7 @@ class MediaSessionManager(
             for (option in options) {
                 val matchingEpisode = episodeManager.findFirstBySearchQuery(option) ?: continue
                 LogBuffer.i(LogBuffer.TAG_PLAYBACK, "User played episode from search %s.", option)
-                playbackManager.playNow(matchingEpisode)
+                playbackManager.playNow(episode = matchingEpisode, playbackSource = playbackSource)
                 return@launch
             }
 
@@ -710,9 +711,9 @@ class MediaSessionManager(
         playbackManager.playEpisodes(episodes = episodes, playbackSource = PlaybackSource.MEDIA_BUTTON_BROADCAST_SEARCH_ACTION)
     }
 
-    private suspend fun playPodcast(podcast: Podcast) {
+    private suspend fun playPodcast(podcast: Podcast, playbackSource: PlaybackSource = PlaybackSource.UNKNOWN) {
         val latestEpisode = withContext(Dispatchers.Default) { episodeManager.findLatestUnfinishedEpisodeByPodcast(podcast) } ?: return
-        playbackManager.playNow(latestEpisode)
+        playbackManager.playNow(episode = latestEpisode, playbackSource = playbackSource)
     }
 
     // there's an issue on Samsung phones that if you don't say you support ACTION_SKIP_TO_PREVIOUS and ACTION_SKIP_TO_NEXT then the skip buttons on the lock screen are disabled.

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1864,6 +1864,7 @@ open class PlaybackManager @Inject constructor(
         PLAYER("player"),
         NOTIFICATION("notification"),
         FULL_SCREEN_VIDEO("full_screen_video"),
+        UP_NEXT("up_next"),
         MEDIA_BUTTON_BROADCAST_ACTION("media_button_broadcast_action"),
         CHROMECAST("chromecast"),
         AUTO_PLAY("auto_play"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1850,9 +1850,6 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    private fun PlaybackSource.skipTracking() =
-        this in listOf(PlaybackSource.AUTO_PLAY, PlaybackSource.AUTO_PAUSE)
-
     enum class PlaybackSource(val analyticsValue: String) {
         PODCAST_SCREEN("podcast_screen"),
         FILTERS("filters"),
@@ -1874,6 +1871,8 @@ open class PlaybackManager @Inject constructor(
         CHROMECAST("chromecast"),
         AUTO_PLAY("auto_play"),
         AUTO_PAUSE("auto_pause"),
-        UNKNOWN("unknown"),
+        UNKNOWN("unknown");
+
+        fun skipTracking() = this in listOf(AUTO_PLAY, AUTO_PAUSE)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -206,7 +206,7 @@ open class PlaybackManager @Inject constructor(
         withContext(Dispatchers.Default) {
             upNextQueue.playNext(autoPlayEpisode, downloadManager) {
                 launch {
-                    loadCurrentEpisode(autoPlay)
+                    loadCurrentEpisode(play = autoPlay, playbackSource = PlaybackSource.AUTO_PLAY)
                 }
             }
         }
@@ -999,7 +999,7 @@ open class PlaybackManager @Inject constructor(
                 shutdown()
             }
         } else {
-            loadCurrentEpisode(autoPlay)
+            loadCurrentEpisode(play = autoPlay, playbackSource = PlaybackSource.AUTO_PLAY)
         }
     }
 
@@ -1845,7 +1845,9 @@ open class PlaybackManager @Inject constructor(
         if (playbackSource == PlaybackSource.UNKNOWN) {
             Timber.w("Found unknown playback source.")
         }
-        analyticsTracker.track(event, mapOf(KEY_SOURCE to playbackSource.analyticsValue))
+        if (playbackSource != PlaybackSource.AUTO_PLAY) {
+            analyticsTracker.track(event, mapOf(KEY_SOURCE to playbackSource.analyticsValue))
+        }
     }
 
     enum class PlaybackSource(val analyticsValue: String) {
@@ -1863,6 +1865,7 @@ open class PlaybackManager @Inject constructor(
         NOTIFICATION("notification"),
         FULL_SCREEN_VIDEO("full_screen_video"),
         MEDIA_BUTTON_BROADCAST_ACTION("media_button_broadcast_action"),
+        AUTO_PLAY("auto_play"),
         UNKNOWN("unknown"),
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -753,7 +753,7 @@ open class PlaybackManager @Inject constructor(
         upNextQueue.currentEpisode ?: return
         launch {
             if (isPlayerSwitchRequired()) {
-                loadCurrentEpisode(true)
+                loadCurrentEpisode(true, playbackSource = PlaybackSource.CHROMECAST)
             }
         }
     }
@@ -766,7 +766,7 @@ open class PlaybackManager @Inject constructor(
             stop()
 
             if (isPlayerSwitchRequired()) {
-                loadCurrentEpisode(false)
+                loadCurrentEpisode(false, playbackSource = PlaybackSource.CHROMECAST)
             }
         }
     }
@@ -1865,6 +1865,7 @@ open class PlaybackManager @Inject constructor(
         NOTIFICATION("notification"),
         FULL_SCREEN_VIDEO("full_screen_video"),
         MEDIA_BUTTON_BROADCAST_ACTION("media_button_broadcast_action"),
+        CHROMECAST("chromecast"),
         AUTO_PLAY("auto_play"),
         UNKNOWN("unknown"),
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -711,7 +711,7 @@ open class PlaybackManager @Inject constructor(
                 upNextQueue.removeEpisode(episodeToRemove)
 
                 if (isCurrentEpisode) {
-                    loadCurrentEpisode(isPlaying)
+                    loadCurrentEpisode(play = isPlaying, playbackSource = PlaybackSource.AUTO_PLAY)
                 }
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1870,6 +1870,7 @@ open class PlaybackManager @Inject constructor(
         UP_NEXT("up_next"),
         MEDIA_BUTTON_BROADCAST_ACTION("media_button_broadcast_action"),
         MEDIA_BUTTON_BROADCAST_SEARCH_ACTION("media_button_broadcast_search_action"),
+        PLAYER_BROADCAST_ACTION("player_broadcast_action"),
         CHROMECAST("chromecast"),
         AUTO_PLAY("auto_play"),
         AUTO_PAUSE("auto_pause"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -399,14 +399,14 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    fun playEpisodes(episodes: List<Playable>) {
+    fun playEpisodes(episodes: List<Playable>, playbackSource: PlaybackSource = PlaybackSource.UNKNOWN) {
         if (episodes.isEmpty()) {
             return
         }
 
         launch {
             val topEpisode = episodes.first()
-            playNowSync(topEpisode)
+            playNowSync(episode = topEpisode, playbackSource = playbackSource)
             if (episodes.size > 1) {
                 upNextQueue.clearAndPlayAll(episodes.slice(1 until min(episodes.size, settings.getMaxUpNextEpisodes())), downloadManager)
             }
@@ -1866,6 +1866,7 @@ open class PlaybackManager @Inject constructor(
         FULL_SCREEN_VIDEO("full_screen_video"),
         UP_NEXT("up_next"),
         MEDIA_BUTTON_BROADCAST_ACTION("media_button_broadcast_action"),
+        MEDIA_BUTTON_BROADCAST_SEARCH_ACTION("media_button_broadcast_search_action"),
         CHROMECAST("chromecast"),
         AUTO_PLAY("auto_play"),
         UNKNOWN("unknown"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -578,10 +578,10 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    fun playNextInQueue() {
+    fun playNextInQueue(playbackSource: PlaybackSource = PlaybackSource.UNKNOWN) {
         launch {
             upNextQueue.queueEpisodes.getOrNull(0)?.let {
-                playNowSync(it)
+                playNowSync(episode = it, playbackSource = playbackSource)
             }
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiver.kt
@@ -28,6 +28,7 @@ class PlayerBroadcastReceiver : BroadcastReceiver() {
 
     @Inject lateinit var podcastManager: PodcastManager
     @Inject lateinit var playbackManager: PlaybackManager
+    private val playbackSource = PlaybackSource.PLAYER_BROADCAST_ACTION
 
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action == INTENT_ACTION_REFRESH_PODCASTS) {
@@ -52,26 +53,26 @@ class PlayerBroadcastReceiver : BroadcastReceiver() {
     }
 
     private fun skipBackward() {
-        playbackManager.skipBackward(playbackSource = PlaybackSource.PLAYER_BROADCAST_ACTION)
+        playbackManager.skipBackward(playbackSource = playbackSource)
     }
 
     private fun skipForward() {
-        playbackManager.skipForward(playbackSource = PlaybackSource.PLAYER_BROADCAST_ACTION)
+        playbackManager.skipForward(playbackSource = playbackSource)
     }
 
     private fun pause() {
-        playbackManager.pause(playbackSource = PlaybackSource.PLAYER_BROADCAST_ACTION)
+        playbackManager.pause(playbackSource = playbackSource)
     }
 
     private fun play() {
-        playbackManager.playQueue(playbackSource = PlaybackSource.PLAYER_BROADCAST_ACTION)
+        playbackManager.playQueue(playbackSource = playbackSource)
     }
 
     private fun playNext() {
-        playbackManager.playNextInQueue(playbackSource = PlaybackSource.PLAYER_BROADCAST_ACTION)
+        playbackManager.playNextInQueue(playbackSource = playbackSource)
     }
 
     private fun stop() {
-        playbackManager.stopAsync(playbackSource = PlaybackSource.PLAYER_BROADCAST_ACTION)
+        playbackManager.stopAsync(playbackSource = playbackSource)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiver.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.AndroidEntryPoint
@@ -51,26 +52,26 @@ class PlayerBroadcastReceiver : BroadcastReceiver() {
     }
 
     private fun skipBackward() {
-        playbackManager.skipBackward()
+        playbackManager.skipBackward(playbackSource = PlaybackSource.PLAYER_BROADCAST_ACTION)
     }
 
     private fun skipForward() {
-        playbackManager.skipForward()
+        playbackManager.skipForward(playbackSource = PlaybackSource.PLAYER_BROADCAST_ACTION)
     }
 
     private fun pause() {
-        playbackManager.pause()
+        playbackManager.pause(playbackSource = PlaybackSource.PLAYER_BROADCAST_ACTION)
     }
 
     private fun play() {
-        playbackManager.playQueue()
+        playbackManager.playQueue(playbackSource = PlaybackSource.PLAYER_BROADCAST_ACTION)
     }
 
     private fun playNext() {
-        playbackManager.playNextInQueue()
+        playbackManager.playNextInQueue(playbackSource = PlaybackSource.PLAYER_BROADCAST_ACTION)
     }
 
     private fun stop() {
-        playbackManager.stopAsync()
+        playbackManager.stopAsync(playbackSource = PlaybackSource.PLAYER_BROADCAST_ACTION)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerReceiver.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -16,7 +17,7 @@ class SleepTimerReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Paused from sleep timer.")
         Toast.makeText(context, "Sleep timer stopped your podcast.\nNight night!", Toast.LENGTH_LONG).show()
-        playbackManager.pause()
+        playbackManager.pause(playbackSource = PlaybackSource.AUTO_PAUSE)
         playbackManager.updateSleepTimerStatus(running = false)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/NotificationBroadcastReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/NotificationBroadcastReceiver.kt
@@ -27,6 +27,8 @@ class NotificationBroadcastReceiver : BroadcastReceiver(), CoroutineScope {
     @Inject lateinit var downloadManager: DownloadManager
     @Inject lateinit var playbackManager: PlaybackManager
 
+    private val playbackSource = PlaybackSource.NOTIFICATION
+
     companion object {
 
         const val NOTIFICATION_ID = 541251
@@ -90,7 +92,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver(), CoroutineScope {
     private fun playNow(episodeUuid: String, forceStream: Boolean) {
         launch {
             episodeManager.findPlayableByUuid(episodeUuid)?.let { episode ->
-                playbackManager.playNow(episode, forceStream = forceStream, playbackSource = PlaybackSource.NOTIFICATION)
+                playbackManager.playNow(episode, forceStream = forceStream, playbackSource = playbackSource)
             }
         }
     }
@@ -132,7 +134,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver(), CoroutineScope {
             episodeManager.findPlayableByUuid(episodeUuid)?.let { episode ->
                 playbackManager.playLast(episode)
                 if (playNext) {
-                    playbackManager.playNextInQueue(playbackSource = PlaybackManager.PlaybackSource.NOTIFICATION)
+                    playbackManager.playNextInQueue(playbackSource = playbackSource)
                 }
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/NotificationBroadcastReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/NotificationBroadcastReceiver.kt
@@ -132,7 +132,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver(), CoroutineScope {
             episodeManager.findPlayableByUuid(episodeUuid)?.let { episode ->
                 playbackManager.playLast(episode)
                 if (playNext) {
-                    playbackManager.playNextInQueue()
+                    playbackManager.playNextInQueue(playbackSource = PlaybackManager.PlaybackSource.NOTIFICATION)
                 }
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/NotificationBroadcastReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/NotificationBroadcastReceiver.kt
@@ -8,6 +8,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import dagger.hilt.android.AndroidEntryPoint
@@ -60,7 +61,6 @@ class NotificationBroadcastReceiver : BroadcastReceiver(), CoroutineScope {
             return
         }
 
-        playbackManager.playbackSource = PlaybackManager.PlaybackSource.NOTIFICATION
         // remove the notification
         val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         val notificationTag = bundle.getString(INTENT_EXTRA_NOTIFICATION_TAG, null)
@@ -90,7 +90,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver(), CoroutineScope {
     private fun playNow(episodeUuid: String, forceStream: Boolean) {
         launch {
             episodeManager.findPlayableByUuid(episodeUuid)?.let { episode ->
-                playbackManager.playNow(episode, forceStream)
+                playbackManager.playNow(episode, forceStream = forceStream, playbackSource = PlaybackSource.NOTIFICATION)
             }
         }
     }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
@@ -40,11 +40,12 @@ class WarningsHelper @Inject constructor(
     @OptIn(DelicateCoroutinesApi::class)
     fun streamingWarningDialog(
         episode: Playable,
-        snackbarParentView: View? = null
+        snackbarParentView: View? = null,
+        playbackSource: PlaybackManager.PlaybackSource
     ): ConfirmationDialog {
         return streamingWarningDialog(onConfirm = {
             GlobalScope.launch {
-                playbackManager.playNow(episode, true)
+                playbackManager.playNow(episode = episode, forceStream = true, playbackSource = playbackSource)
                 showBatteryWarningSnackbarIfAppropriate(snackbarParentView)
             }
         })


### PR DESCRIPTION
| 📘 Project: #261 | 📘 Continuation of: #343) |
|:---:|:---:|

> **Warning**
> The PR targets release/7.24 branch

This PR 
1. Explicitly passes `PlaybackSource` instead of setting it on the `PlaybackManager` so that we're sure of where those sources are coming from - da6367c3555639746a7cfad0bd4760ed256e684d
2. Explicitly passes `PlaybackSource` from `warningsHelper.streamingWarningDialg(...)` as suggested in https://github.com/Automattic/pocket-casts-android/pull/343#discussion_r983907170
3. Identifies a few `unknown` playback sources: `up_next`, `media_button_broadcast_search_action`, `chromecast`, `auto_play`, `auto_pause`. 
    - `auto_play`,  `auto_pause` sources are skipped from tracking.
    -  For `chromecast`, I'm only tracking the cast-connected scenario. Current screen source is tracked irrespective of whether the player is a simple player or a cast player. I can take it up separately if we decide to track it differently.

These changes might not eliminate all the unknowns. Hopefully, it is a step forward in identifying some of the missing ones. 

#### Test-1 Refactoring 
- Go through the testing steps from https://github.com/Automattic/pocket-casts-android/pull/343
- ✅ Verify that events are tracked as before

#### Test-2 Streaming Warning Dialog 
- Disable wifi and enable mobile network
- Make sure warn before using data is enabled in Profile -> Settings -> Storage & data use
- Play an episode so that `You're not on WiFi` alert is displayed
- Tap on `Stream Anyway` 
- ✅ Verify that the current screen source is tracked
- Re-enable wifi 

#### Test-3.1 Up Next
- Disable Profile -> Settings -> Play Up Next episode on tap 
- Play an episode
- Add a few episodes to the `Up Next` queue
- Long press on one of the episodes in `Up Next` queue
- ✅ Verify that the selected episode starts playing and is tracked with the source `up_next`
- Enable Profile -> Settings -> Play Up Next episode on tap 
- Tap on one of the episodes in `Up Next` queue 
- ✅ Verify that the selected episode starts playing and is tracked with the source `up_next`

#### Test-3.2 media_button_broadcast_search_action
- Close the application
- Test the search using the following terminal command
  `adb shell am start -a android.media.action.MEDIA_PLAY_FROM_SEARCH -p au.com.shiftyjelly.pocketcasts.debug --es query "The\ Daily"`
- ✅ Verify that an episode from a podcast title starting with "The\ Daily" starts playing and is tracked with the source `media_button_broadcast_search_action`

#### Test-3.3 Multiple episodes - play all
- Go to filters tab
- Select a filter having episodes
- Select options drop down in the tool bar and tap on Play all
- Tap Play x episodes from the "Play all" confirmation dialog
-  ✅ Verify that an episode starts playing and is tracked with the source `filters`

#### Test-4 Auto-play/ auto-pause skip tracking
- Add few episodes to up-next queue
- Play an episode
- Long press on the mini-player
- Tap on Mark played
- ✅ Verify that no playback event is tracked
- Expand the mini player 
- Drag the seek-bar to the end so that next episode is played
- ✅ Verify that no playback event is tracked
- While the episode is playing, background the app and play a song from another app
- Reopen the app
- ✅ Verify that the episode that was playing is paused and no playback event is tracked

# Checklist
N/A
- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [ ] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [ ] Have you tested in different themes?
- [ ] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?