### PR TITLE
Track player shelf events

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -163,15 +163,15 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         binding.playerActions.setOnClickListener { onMoreClicked() }
         binding.podcast.setOnClickListener { showPodcast() }
         binding.played.setOnClickListener {
-            trackShelfAction(ShelfItem.ShelfItemId.PLAYED.analyticsValue)
+            trackShelfAction(ShelfItem.Played.analyticsValue)
             viewModel.markCurrentlyPlayingAsPlayed(requireContext())?.show(childFragmentManager, "mark_as_played")
         }
         binding.archive.setOnClickListener {
-            trackShelfAction(ShelfItem.ShelfItemId.ARCHIVE.analyticsValue)
+            trackShelfAction(ShelfItem.Archive.analyticsValue)
             viewModel.archiveCurrentlyPlaying(resources)?.show(childFragmentManager, "archive")
         }
         binding.download.setOnClickListener {
-            trackShelfAction(ShelfItem.ShelfItemId.DOWNLOAD.analyticsValue)
+            trackShelfAction(ShelfItem.Download.analyticsValue)
             viewModel.downloadCurrentlyPlaying()
         }
         binding.videoView.playbackManager = playbackManager
@@ -180,7 +180,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         CastButtonFactory.setUpMediaRouteButton(binding.root.context, binding.castButton)
         binding.castButton.setAlwaysVisible(true)
         binding.castButton.updateColor(ThemeColor.playerContrast03(theme.activeTheme))
-        binding.castButton.setOnClickListener { trackShelfAction(ShelfItem.ShelfItemId.CAST.analyticsValue) }
+        binding.castButton.setOnClickListener { trackShelfAction(ShelfItem.Cast.analyticsValue) }
 
         setupUpNextDrag(view, binding.topView)
 
@@ -443,27 +443,27 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
     }
 
     override fun onEffectsClick() {
-        trackShelfAction(ShelfItem.ShelfItemId.EFFECTS.analyticsValue)
+        trackShelfAction(ShelfItem.Effects.analyticsValue)
         EffectsFragment().show(parentFragmentManager, "effects_sheet")
     }
 
     override fun onSleepClick() {
-        trackShelfAction(ShelfItem.ShelfItemId.SLEEP.analyticsValue)
+        trackShelfAction(ShelfItem.Sleep.analyticsValue)
         SleepFragment().show(parentFragmentManager, "effects_sheet")
     }
 
     override fun onStarClick() {
-        trackShelfAction(ShelfItem.ShelfItemId.STAR.analyticsValue)
+        trackShelfAction(ShelfItem.Star.analyticsValue)
         viewModel.starToggle()
     }
 
     override fun onShareClick() {
-        trackShelfAction(ShelfItem.ShelfItemId.SHARE.analyticsValue)
+        trackShelfAction(ShelfItem.Share.analyticsValue)
         viewModel.shareDialog(context, childFragmentManager)?.show()
     }
 
     private fun showPodcast() {
-        trackShelfAction(ShelfItem.ShelfItemId.PODCAST.analyticsValue)
+        trackShelfAction(ShelfItem.Podcast.analyticsValue)
         val podcast = viewModel.podcast
         (activity as FragmentHostListener).closePlayer()
         if (podcast != null) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -24,7 +24,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.player.databinding.AdapterPlayerHeaderBinding
-import au.com.shiftyjelly.pocketcasts.player.view.ShelfBottomSheet.Companion.AnalyticsProp
+import au.com.shiftyjelly.pocketcasts.player.view.ShelfFragment.Companion.AnalyticsProp
 import au.com.shiftyjelly.pocketcasts.player.view.video.VideoActivity
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -492,6 +492,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         if (childFragmentManager.fragments.firstOrNull() is ShelfBottomSheet) {
             return
         }
+        analyticsTracker.track(AnalyticsEvent.PLAYER_SHELF_OVERFLOW_MENU_SHOWN)
         ShelfBottomSheet().show(childFragmentManager, "shelf_bottom_sheet")
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
@@ -18,6 +18,7 @@ import au.com.shiftyjelly.pocketcasts.views.extensions.applyColor
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import com.google.android.gms.cast.framework.CastButtonFactory
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -68,26 +69,20 @@ class ShelfBottomSheet : BaseDialogFragment() {
     }
 
     private fun onClick(item: ShelfItem) {
-        val analyticsAction: String
         when (item) {
             is ShelfItem.Effects -> {
-                analyticsAction = ShelfItem.ShelfItemId.EFFECTS.analyticsValue
                 EffectsFragment().show(parentFragmentManager, "effects")
             }
             is ShelfItem.Sleep -> {
-                analyticsAction = ShelfItem.ShelfItemId.SLEEP.analyticsValue
                 SleepFragment().show(parentFragmentManager, "sleep")
             }
             is ShelfItem.Star -> {
-                analyticsAction = ShelfItem.ShelfItemId.STAR.analyticsValue
                 playerViewModel.starToggle()
             }
             is ShelfItem.Share -> {
-                analyticsAction = ShelfItem.ShelfItemId.SHARE.analyticsValue
                 playerViewModel.shareDialog(context, parentFragmentManager)?.show()
             }
             is ShelfItem.Podcast -> {
-                analyticsAction = ShelfItem.ShelfItemId.PODCAST.analyticsValue
                 (activity as FragmentHostListener).closePlayer()
                 val podcast = playerViewModel.podcast
                 if (podcast != null) {
@@ -97,26 +92,23 @@ class ShelfBottomSheet : BaseDialogFragment() {
                 }
             }
             is ShelfItem.Cast -> {
-                analyticsAction = ShelfItem.ShelfItemId.CAST.analyticsValue
                 binding?.mediaRouteButton?.performClick()
             }
             is ShelfItem.Played -> {
-                analyticsAction = ShelfItem.ShelfItemId.PLAYED.analyticsValue
                 context?.let {
                     playerViewModel.markCurrentlyPlayingAsPlayed(it)?.show(parentFragmentManager, "mark_as_played")
                 }
             }
             is ShelfItem.Archive -> {
-                analyticsAction = ShelfItem.ShelfItemId.ARCHIVE.analyticsValue
                 playerViewModel.archiveCurrentlyPlaying(resources)?.show(parentFragmentManager, "archive")
             }
-            else -> {
-                analyticsAction = AnalyticsProp.Value.UNKNOWN
+            ShelfItem.Download -> {
+                Timber.e("Unexpected click on ShelfItem.Download")
             }
         }
         analyticsTracker.track(
             AnalyticsEvent.PLAYER_SHELF_ACTION_TAPPED,
-            mapOf(AnalyticsProp.Key.FROM to AnalyticsProp.Value.OVERFLOW_MENU, AnalyticsProp.Key.ACTION to analyticsAction)
+            mapOf(AnalyticsProp.Key.FROM to AnalyticsProp.Value.OVERFLOW_MENU, AnalyticsProp.Key.ACTION to item.analyticsValue)
         )
         dismiss()
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentShelfBottomSheetBinding
+import au.com.shiftyjelly.pocketcasts.player.view.ShelfFragment.Companion.AnalyticsProp
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
@@ -117,19 +118,5 @@ class ShelfBottomSheet : BaseDialogFragment() {
             mapOf(AnalyticsProp.Key.FROM to AnalyticsProp.Value.OVERFLOW_MENU, AnalyticsProp.Key.ACTION to analyticsAction)
         )
         dismiss()
-    }
-
-    companion object {
-        object AnalyticsProp {
-            object Key {
-                const val FROM = "from"
-                const val ACTION = "action"
-            }
-            object Value {
-                const val SHELF = "shelf"
-                const val OVERFLOW_MENU = "overflow_menu"
-                const val UNKNOWN = "unknown"
-            }
-        }
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
@@ -59,6 +59,7 @@ class ShelfBottomSheet : BaseDialogFragment() {
         }
 
         binding.btnEdit.setOnClickListener {
+            analyticsTracker.track(AnalyticsEvent.PLAYER_SHELF_OVERFLOW_MENU_REARRANGE_STARTED)
             (activity as FragmentHostListener).showModal(ShelfFragment())
             dismiss()
         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
@@ -77,7 +77,10 @@ class ShelfFragment : BaseFragment(), ShelfTouchCallback.ItemTouchHelperAdapter 
         val toolbar = binding.toolbar
         toolbar.setTitle(LR.string.rearrange_actions)
         toolbar.setTitleTextColor(toolbar.context.getThemeColor(UR.attr.player_contrast_01))
-        toolbar.setNavigationOnClickListener { (activity as? FragmentHostListener)?.closeModal(this) }
+        toolbar.setNavigationOnClickListener {
+            trackRearrangeFinishedEvent()
+            (activity as? FragmentHostListener)?.closeModal(this)
+        }
         toolbar.navigationIcon?.setTint(ThemeColor.playerContrast01(theme.activeTheme))
 
         val backgroundColor = theme.playerBackground2Color(playerViewModel.podcast)
@@ -110,6 +113,11 @@ class ShelfFragment : BaseFragment(), ShelfTouchCallback.ItemTouchHelperAdapter 
         playerViewModel.playingEpisodeLive.observe(viewLifecycleOwner) { (playable, _) ->
             adapter.playable = playable
         }
+    }
+
+    override fun onBackPressed(): Boolean {
+        trackRearrangeFinishedEvent()
+        return super.onBackPressed()
     }
 
     override fun onShelfItemMove(fromPosition: Int, toPosition: Int) {
@@ -175,6 +183,10 @@ class ShelfFragment : BaseFragment(), ShelfTouchCallback.ItemTouchHelperAdapter 
             )
             dragStartPosition = null
         }
+    }
+
+    private fun trackRearrangeFinishedEvent() {
+        analyticsTracker.track(AnalyticsEvent.PLAYER_SHELF_OVERFLOW_MENU_REARRANGE_FINISHED)
     }
 
     companion object {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
@@ -20,6 +20,8 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.player.R
@@ -46,6 +48,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 class ShelfFragment : BaseFragment(), ShelfTouchCallback.ItemTouchHelperAdapter {
     private var items = emptyList<Any>()
 
+    @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
     @Inject lateinit var settings: Settings
 
     private lateinit var itemTouchHelper: ItemTouchHelper
@@ -54,6 +57,7 @@ class ShelfFragment : BaseFragment(), ShelfTouchCallback.ItemTouchHelperAdapter 
     private val shortcutTitle = ShelfTitle(LR.string.player_rearrange_actions_shown)
     private val moreActionsTitle = ShelfTitle(LR.string.player_rearrange_actions_hidden)
     private var binding: FragmentShelfBinding? = null
+    private var dragStartPosition: Int? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentShelfBinding.inflate(inflater, container, false)
@@ -137,11 +141,57 @@ class ShelfFragment : BaseFragment(), ShelfTouchCallback.ItemTouchHelperAdapter 
     }
 
     override fun onShelfItemStartDrag(viewHolder: ShelfAdapter.ItemViewHolder) {
+        dragStartPosition = viewHolder.bindingAdapterPosition
         itemTouchHelper.startDrag(viewHolder)
     }
 
-    override fun onShelfItemTouchHelperFinished() {
+    override fun onShelfItemTouchHelperFinished(position: Int) {
+        trackShelfItemMovedEvent(position)
         settings.setShelfItems(items.filterIsInstance<ShelfItem>().map { it.id })
+    }
+
+    private fun sectionTitleAt(position: Int) =
+        if (position < items.indexOf(moreActionsTitle)) AnalyticsProp.Value.SHELF else AnalyticsProp.Value.OVERFLOW_MENU
+
+    private fun trackShelfItemMovedEvent(position: Int) {
+        dragStartPosition?.let {
+            val title = ShelfItem.ShelfItemId.fromId((items[position] as? ShelfItem)?.id)
+                ?.analyticsValue ?: AnalyticsProp.Value.UNKNOWN
+            val movedFrom = sectionTitleAt(it)
+            val movedTo = sectionTitleAt(position)
+            val newPosition = if (movedTo == AnalyticsProp.Value.SHELF) {
+                position - 1
+            } else {
+                position - (items.indexOf(moreActionsTitle) + 1)
+            }
+            analyticsTracker.track(
+                AnalyticsEvent.PLAYER_SHELF_OVERFLOW_MENU_REARRANGE_ACTION_MOVED,
+                mapOf(
+                    AnalyticsProp.Key.ACTION to title,
+                    AnalyticsProp.Key.POSITION to newPosition, // it is the new position in section it was moved to
+                    AnalyticsProp.Key.MOVED_FROM to movedFrom,
+                    AnalyticsProp.Key.MOVED_TO to movedTo
+                )
+            )
+            dragStartPosition = null
+        }
+    }
+
+    companion object {
+        object AnalyticsProp {
+            object Key {
+                const val FROM = "from"
+                const val ACTION = "action"
+                const val MOVED_FROM = "moved_from"
+                const val MOVED_TO = "moved_to"
+                const val POSITION = "position"
+            }
+            object Value {
+                const val SHELF = "shelf"
+                const val OVERFLOW_MENU = "overflow_menu"
+                const val UNKNOWN = "unknown"
+            }
+        }
     }
 }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
@@ -163,8 +163,8 @@ class ShelfFragment : BaseFragment(), ShelfTouchCallback.ItemTouchHelperAdapter 
 
     private fun trackShelfItemMovedEvent(position: Int) {
         dragStartPosition?.let {
-            val title = ShelfItem.ShelfItemId.fromId((items[position] as? ShelfItem)?.id)
-                ?.analyticsValue ?: AnalyticsProp.Value.UNKNOWN
+            val title = (items[position] as? ShelfItem)?.analyticsValue
+                ?: AnalyticsProp.Value.UNKNOWN
             val movedFrom = sectionTitleAt(it)
             val movedTo = sectionTitleAt(position)
             val newPosition = if (movedTo == AnalyticsProp.Value.SHELF) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfItem.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfItem.kt
@@ -19,49 +19,90 @@ object ShelfItems {
     }
 }
 
-sealed class ShelfItem(val id: String, var title: (Playable?) -> Int, var iconRes: (Playable?) -> Int, val shownWhen: Shown, @StringRes val subtitle: Int? = null) {
+sealed class ShelfItem(
+    val id: String,
+    var title: (Playable?) -> Int,
+    var iconRes: (Playable?) -> Int,
+    val shownWhen: Shown,
+    val analyticsValue: String,
+    @StringRes val subtitle: Int? = null
+) {
     sealed class Shown {
         object Always : Shown()
         object EpisodeOnly : Shown()
         object UserEpisodeOnly : Shown()
     }
 
-    object Effects : ShelfItem(ShelfItemId.EFFECTS.value, { LR.string.podcast_playback_effects }, { R.drawable.ic_effects_off }, Shown.Always)
+    object Effects : ShelfItem(
+        id = "effects",
+        title = { LR.string.podcast_playback_effects },
+        iconRes = { R.drawable.ic_effects_off },
+        shownWhen = Shown.Always,
+        analyticsValue = "playback_effects"
+    )
 
-    object Sleep : ShelfItem(ShelfItemId.SLEEP.value, { LR.string.player_sleep_timer }, { R.drawable.ic_sleep }, Shown.Always)
+    object Sleep : ShelfItem(
+        id = "sleep",
+        title = { LR.string.player_sleep_timer },
+        iconRes = { R.drawable.ic_sleep },
+        shownWhen = Shown.Always,
+        analyticsValue = "sleep_timer"
+    )
 
     object Star : ShelfItem(
-        ShelfItemId.STAR.value,
-        { if (it is Episode && it.isStarred) LR.string.unstar_episode else LR.string.star_episode },
-        { if (it is Episode && it.isStarred) IR.drawable.ic_star_filled else IR.drawable.ic_star },
-        Shown.EpisodeOnly,
-        LR.string.player_actions_hidden_for_custom
+        id = "star",
+        title = { if (it is Episode && it.isStarred) LR.string.unstar_episode else LR.string.star_episode },
+        subtitle = LR.string.player_actions_hidden_for_custom,
+        iconRes = { if (it is Episode && it.isStarred) IR.drawable.ic_star_filled else IR.drawable.ic_star },
+        shownWhen = Shown.EpisodeOnly,
+        analyticsValue = "star_episode"
     )
 
-    object Share : ShelfItem(ShelfItemId.SHARE.value, { LR.string.podcast_share_episode }, { IR.drawable.ic_share }, Shown.EpisodeOnly, LR.string.player_actions_hidden_for_custom)
+    object Share : ShelfItem(
+        id = "share",
+        title = { LR.string.podcast_share_episode },
+        subtitle = LR.string.player_actions_hidden_for_custom,
+        iconRes = { IR.drawable.ic_share },
+        shownWhen = Shown.EpisodeOnly,
+        analyticsValue = "share_episode"
+    )
 
     object Podcast : ShelfItem(
-        ShelfItemId.PODCAST.value,
-        { if (it is UserEpisode) LR.string.go_to_files else LR.string.go_to_podcast },
-        { R.drawable.ic_arrow_goto },
-        Shown.Always
+        id = "podcast",
+        title = { if (it is UserEpisode) LR.string.go_to_files else LR.string.go_to_podcast },
+        iconRes = { R.drawable.ic_arrow_goto },
+        shownWhen = Shown.Always,
+        analyticsValue = "go_to_podcast"
     )
 
-    object Cast : ShelfItem(ShelfItemId.CAST.value, { LR.string.chromecast }, { com.google.android.gms.cast.framework.R.drawable.quantum_ic_cast_connected_white_24 }, Shown.Always)
+    object Cast : ShelfItem(
+        id = "cast",
+        title = { LR.string.chromecast },
+        iconRes = { com.google.android.gms.cast.framework.R.drawable.quantum_ic_cast_connected_white_24 },
+        shownWhen = Shown.Always,
+        analyticsValue = "chromecast"
+    )
 
-    object Played : ShelfItem(ShelfItemId.PLAYED.value, { LR.string.mark_as_played }, { R.drawable.ic_markasplayed }, Shown.Always)
+    object Played : ShelfItem(
+        id = "played",
+        title = { LR.string.mark_as_played },
+        iconRes = { R.drawable.ic_markasplayed },
+        shownWhen = Shown.Always,
+        analyticsValue = "mark_as_played"
+    )
 
     object Archive : ShelfItem(
-        ShelfItemId.ARCHIVE.value,
-        { if (it is UserEpisode) LR.string.delete else LR.string.archive },
-        { if (it is UserEpisode) VR.drawable.ic_delete else IR.drawable.ic_archive },
-        Shown.Always,
-        LR.string.player_actions_show_as_delete_for_custom
+        id = "archive",
+        title = { if (it is UserEpisode) LR.string.delete else LR.string.archive },
+        subtitle = LR.string.player_actions_show_as_delete_for_custom,
+        iconRes = { if (it is UserEpisode) VR.drawable.ic_delete else IR.drawable.ic_archive },
+        shownWhen = Shown.Always,
+        analyticsValue = "archive"
     )
 
     object Download : ShelfItem(
-        ShelfItemId.DOWNLOAD.value,
-        {
+        id = "download",
+        title = {
             if (it?.isDownloaded == true) {
                 LR.string.delete_download
             } else if (it?.isDownloading == true) {
@@ -70,7 +111,7 @@ sealed class ShelfItem(val id: String, var title: (Playable?) -> Int, var iconRe
                 LR.string.download
             }
         },
-        {
+        iconRes = {
             if (it?.isDownloaded == true) {
                 VR.drawable.ic_delete
             } else if (it?.episodeStatus == EpisodeStatusEnum.DOWNLOADING || it?.episodeStatus == EpisodeStatusEnum.QUEUED) {
@@ -79,23 +120,7 @@ sealed class ShelfItem(val id: String, var title: (Playable?) -> Int, var iconRe
                 IR.drawable.ic_download
             }
         },
-        Shown.Always
+        shownWhen = Shown.Always,
+        analyticsValue = "download"
     )
-
-    enum class ShelfItemId(val value: String, val analyticsValue: String) {
-        EFFECTS("effects", "playback_effects"),
-        SLEEP("sleep", "sleep_timer"),
-        STAR("star", "star_episode"),
-        SHARE("share", "share_episode"),
-        PODCAST("podcast", "go_to_podcast"),
-        CAST("cast", "chromecast"),
-        PLAYED("played", "mark_as_played"),
-        ARCHIVE("archive", "archive"),
-        DOWNLOAD("download", "download");
-
-        companion object {
-            fun fromId(id: String?) =
-                ShelfItemId.values().find { it.value == id }
-        }
-    }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfItem.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfItem.kt
@@ -26,33 +26,33 @@ sealed class ShelfItem(val id: String, var title: (Playable?) -> Int, var iconRe
         object UserEpisodeOnly : Shown()
     }
 
-    object Effects : ShelfItem("effects", { LR.string.podcast_playback_effects }, { R.drawable.ic_effects_off }, Shown.Always)
+    object Effects : ShelfItem(ShelfItemId.EFFECTS.value, { LR.string.podcast_playback_effects }, { R.drawable.ic_effects_off }, Shown.Always)
 
-    object Sleep : ShelfItem("sleep", { LR.string.player_sleep_timer }, { R.drawable.ic_sleep }, Shown.Always)
+    object Sleep : ShelfItem(ShelfItemId.SLEEP.value, { LR.string.player_sleep_timer }, { R.drawable.ic_sleep }, Shown.Always)
 
     object Star : ShelfItem(
-        "star",
+        ShelfItemId.STAR.value,
         { if (it is Episode && it.isStarred) LR.string.unstar_episode else LR.string.star_episode },
         { if (it is Episode && it.isStarred) IR.drawable.ic_star_filled else IR.drawable.ic_star },
         Shown.EpisodeOnly,
         LR.string.player_actions_hidden_for_custom
     )
 
-    object Share : ShelfItem("share", { LR.string.podcast_share_episode }, { IR.drawable.ic_share }, Shown.EpisodeOnly, LR.string.player_actions_hidden_for_custom)
+    object Share : ShelfItem(ShelfItemId.SHARE.value, { LR.string.podcast_share_episode }, { IR.drawable.ic_share }, Shown.EpisodeOnly, LR.string.player_actions_hidden_for_custom)
 
     object Podcast : ShelfItem(
-        "podcast",
+        ShelfItemId.PODCAST.value,
         { if (it is UserEpisode) LR.string.go_to_files else LR.string.go_to_podcast },
         { R.drawable.ic_arrow_goto },
         Shown.Always
     )
 
-    object Cast : ShelfItem("cast", { LR.string.chromecast }, { com.google.android.gms.cast.framework.R.drawable.quantum_ic_cast_connected_white_24 }, Shown.Always)
+    object Cast : ShelfItem(ShelfItemId.CAST.value, { LR.string.chromecast }, { com.google.android.gms.cast.framework.R.drawable.quantum_ic_cast_connected_white_24 }, Shown.Always)
 
-    object Played : ShelfItem("played", { LR.string.mark_as_played }, { R.drawable.ic_markasplayed }, Shown.Always)
+    object Played : ShelfItem(ShelfItemId.PLAYED.value, { LR.string.mark_as_played }, { R.drawable.ic_markasplayed }, Shown.Always)
 
     object Archive : ShelfItem(
-        "archive",
+        ShelfItemId.ARCHIVE.value,
         { if (it is UserEpisode) LR.string.delete else LR.string.archive },
         { if (it is UserEpisode) VR.drawable.ic_delete else IR.drawable.ic_archive },
         Shown.Always,
@@ -60,7 +60,7 @@ sealed class ShelfItem(val id: String, var title: (Playable?) -> Int, var iconRe
     )
 
     object Download : ShelfItem(
-        "download",
+        ShelfItemId.DOWNLOAD.value,
         {
             if (it?.isDownloaded == true) {
                 LR.string.delete_download
@@ -81,4 +81,21 @@ sealed class ShelfItem(val id: String, var title: (Playable?) -> Int, var iconRe
         },
         Shown.Always
     )
+
+    enum class ShelfItemId(val value: String, val analyticsValue: String) {
+        EFFECTS("effects", "playback_effects"),
+        SLEEP("sleep", "sleep_timer"),
+        STAR("star", "star_episode"),
+        SHARE("share", "share_episode"),
+        PODCAST("podcast", "go_to_podcast"),
+        CAST("cast", "chromecast"),
+        PLAYED("played", "mark_as_played"),
+        ARCHIVE("archive", "archive"),
+        DOWNLOAD("download", "download");
+
+        companion object {
+            fun fromId(id: String?) =
+                ShelfItemId.values().find { it.value == id }
+        }
+    }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfTouchCallback.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfTouchCallback.kt
@@ -10,7 +10,7 @@ class ShelfTouchCallback(
     interface ItemTouchHelperAdapter {
         fun onShelfItemMove(fromPosition: Int, toPosition: Int)
         fun onShelfItemStartDrag(viewHolder: ShelfAdapter.ItemViewHolder)
-        fun onShelfItemTouchHelperFinished()
+        fun onShelfItemTouchHelperFinished(position: Int)
     }
 
     interface ItemTouchHelperViewHolder {
@@ -59,7 +59,7 @@ class ShelfTouchCallback(
         if (viewHolder is ItemTouchHelperViewHolder) {
             viewHolder.onItemClear()
         }
-        listener.onShelfItemTouchHelperFinished()
+        listener.onShelfItemTouchHelperFinished(viewHolder.bindingAdapterPosition)
     }
 
     override fun isItemViewSwipeEnabled(): Boolean {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -272,6 +272,7 @@ enum class AnalyticsEvent(val key: String) {
     /* Player - Shelf */
     PLAYER_SHELF_ACTION_TAPPED("player_shelf_action_tapped"),
     PLAYER_SHELF_OVERFLOW_MENU_SHOWN("player_shelf_overflow_menu_shown"),
+    PLAYER_SHELF_OVERFLOW_MENU_REARRANGE_STARTED("player_shelf_overflow_menu_rearrange_started"),
     PLAYER_SHELF_OVERFLOW_MENU_REARRANGE_ACTION_MOVED("player_shelf_overflow_menu_rearrange_action_moved"),
     PLAYER_SHELF_OVERFLOW_MENU_REARRANGE_FINISHED("player_shelf_overflow_menu_rearrange_finished"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -268,4 +268,7 @@ enum class AnalyticsEvent(val key: String) {
     PLAYBACK_EFFECT_TRIM_SILENCE_AMOUNT_CHANGED("playback_effect_trim_silence_amount_changed"),
     PLAYBACK_EFFECT_VOLUME_BOOST_TOGGLED("playback_effect_volume_boost_toggled"),
     FILTER_LIST_REORDERED("filter_list_reordered"),
+
+    /* Player - Shelf */
+    PLAYER_SHELF_ACTION_TAPPED("player_shelf_action_tapped"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -271,4 +271,6 @@ enum class AnalyticsEvent(val key: String) {
 
     /* Player - Shelf */
     PLAYER_SHELF_ACTION_TAPPED("player_shelf_action_tapped"),
+    PLAYER_SHELF_OVERFLOW_MENU_SHOWN("player_shelf_overflow_menu_shown"),
+    PLAYER_SHELF_OVERFLOW_MENU_REARRANGE_ACTION_MOVED("player_shelf_overflow_menu_rearrange_action_moved"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -273,4 +273,5 @@ enum class AnalyticsEvent(val key: String) {
     PLAYER_SHELF_ACTION_TAPPED("player_shelf_action_tapped"),
     PLAYER_SHELF_OVERFLOW_MENU_SHOWN("player_shelf_overflow_menu_shown"),
     PLAYER_SHELF_OVERFLOW_MENU_REARRANGE_ACTION_MOVED("player_shelf_overflow_menu_rearrange_action_moved"),
+    PLAYER_SHELF_OVERFLOW_MENU_REARRANGE_FINISHED("player_shelf_overflow_menu_rearrange_finished"),
 }


### PR DESCRIPTION
| 📘 Project: #261  | 
|:---:|

iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/293

This adds events for the "player shelf" actions:

- `player_shelf_action_tapped`: When the user taps on one of the actions located in the player shelf or overflow menu
- `player_shelf_overflow_menu_shown`: When the user taps on the vertical `...` button and the overflow menu is displayed
- `player_shelf_overflow_menu_rearrange_started`: When the user taps the Edit button and the overflow menu enters rearrange mode
- `player_shelf_overflow_menu_rearrange_action_moved`: When the user moves an action in during a rearrange
- `player_shelf_overflow_menu_rearrange_finished`: When the user exits the rearrange mode

## To test

1. Play an episode if you're not already
2. Open the full screen player
3. Tap each of the 4 actions located in the shelf at the bottom of the player view
4. ✅ Verify you see the following in console: `🔵 Tracked: player_shelf_action_tapped ["from": "shelf", "action": "NAME"]` - Where name is the name of the action that was tapped
5. Tap the ... to open the overflow menu
6. ✅ `🔵 Tracked: player_shelf_overflow_menu_shown`
7. Tap the actions located in the overflow menu
8. ✅ `🔵 Tracked: player_shelf_action_tapped ["from": "overflow_menu", "action": "NAME"]`
9. Open the overflow menu again
10. Tap the edit button
11. ✅ `🔵 Tracked: player_shelf_overflow_menu_rearrange_started`
12. Move an item out of the "Shortcut on player" section
13. ✅ `🔵 Tracked: player_shelf_overflow_menu_rearrange_action_moved ["action": "NAME", "moved_to": "overflow_menu", "moved_from": "shelf", "position": POSITION]`
- NAME: Is the name of the action that was moved
- POSITION is the new position in section it was moved to
14. Move an action from the "More actions" section to the "Shortcut on player" section
15. ✅ `🔵 Tracked: player_shelf_overflow_menu_rearrange_action_moved ["moved_from": "overflow_menu", "action": "NAME", "moved_to": "shelf", "position": POSITION]`
16. Move an item to a higher position in the Shortcut On player section
17. ✅ `🔵 Tracked: player_shelf_overflow_menu_rearrange_action_moved ["moved_from": "shelf", "action": "NAME", "moved_to": "shelf", "position": POSITION]`
18. Tap the Done button
19. ✅ `🔵 Tracked: player_shelf_overflow_menu_rearrange_finished`

# Checklist
N/A

- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [ ] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [ ] Have you tested in different themes?
- [ ] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?