### PR TITLE
Add token info to user.env-example

### DIFF
--- a/fastlane/env/user.env-example
+++ b/fastlane/env/user.env-example
@@ -3,5 +3,5 @@ GITHUB_TOKEN=<GitHub access token>
 
 # Requires:
 #   Organizations: 'Automattic',
-#   REST Scopes: 'read_repos', 'write_repos'
+#   REST Scopes: 'write_builds'
 BUILDKITE_TOKEN=<Buildkite Personal Access Token>

--- a/fastlane/env/user.env-example
+++ b/fastlane/env/user.env-example
@@ -1,3 +1,7 @@
+# Requires: 'repo'
 GITHUB_TOKEN=<GitHub access token>
 
+# Requires:
+#   Organizations: 'Automattic',
+#   REST Scopes: 'read_repos', 'write_repos'
 BUILDKITE_TOKEN=<Buildkite Personal Access Token>


### PR DESCRIPTION
## Description

Adds some info about the kind of token needed to the example user env file so the user knows what kind of tokens they need to add. If you think there's a better place to provide this information, please feel free to just update this PR directly.

I do not know if these are the correct token permissions, but I was able to successfully run the `new_beta_release` script with them. I based these permissions on https://github.com/woocommerce/woocommerce-android/blob/trunk/scripts/release-management-prechecks.sh#L53-L55.

## Checklist

- [X] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [X] Are all the strings localized?
- [X] Could you have written any new tests?
- [X] Did you include Compose previews with any components?