### PR TITLE
Update custom media action order for mediastyle notification

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -353,8 +353,6 @@ class MediaSessionManager(
             stateBuilder.addCustomAction(APP_ACTION_CHANGE_SPEED, "Change speed", drawableId)
         }
 
-        addCustomAction(stateBuilder, APP_ACTION_MARK_AS_PLAYED, "Mark as played", IR.drawable.auto_markasplayed)
-
         if (currentEpisode is Episode) {
             if (currentEpisode.isStarred) {
                 addCustomAction(stateBuilder, APP_ACTION_UNSTAR, "Unstar", IR.drawable.auto_starred)
@@ -362,6 +360,8 @@ class MediaSessionManager(
                 addCustomAction(stateBuilder, APP_ACTION_STAR, "Star", IR.drawable.auto_star)
             }
         }
+
+        addCustomAction(stateBuilder, APP_ACTION_MARK_AS_PLAYED, "Mark as played", IR.drawable.auto_markasplayed)
     }
 
     private fun addCustomAction(stateBuilder: PlaybackStateCompat.Builder, action: String, name: CharSequence, @DrawableRes icon: Int) {


### PR DESCRIPTION
# Description

> **Warning**
> Targets release/7.24

Starting Android 13, there can be [more playback controls](https://developer.android.com/about/versions/13/behavior-changes-13#playback-controls) in the `mediastyle` notification. With the current set of custom actions, `mark_as_played` action has started displaying at the end of the notification. An accidental tap on it can mark the episode as played causing a poor user experience. 

This PR reorders `mark_as_played` action below the `star` action so that the `star` action takes precedence. 

Slack convo: p1665681166247159-slack-C02A333D8LQ

Before | After
-----| ----
![before](https://user-images.githubusercontent.com/1405144/195789346-aeec72f5-7559-4b30-a4d2-d432fe246bd1.png) | ![after](https://user-images.githubusercontent.com/1405144/195789363-ae83f5ca-b725-45f8-82a9-644896341275.png)



# Checklist
N/A
- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md - We changed app's target to Android 13 in 7.24. Since this is a beta fix, the change doesn't need to be included in the CHANGELOG.
- [ ] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [ ] Have you tested in different themes?
- [ ] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?