### PR TITLE
Fix status bar colors

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -177,6 +177,7 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
         binding?.recyclerView?.scrollToPosition(0)
     }
 
+    @Suppress("DEPRECATION")
     override fun setUserVisibleHint(visible: Boolean) {
         super.setUserVisibleHint(visible)
         if (visible) {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -120,6 +120,7 @@ class FiltersFragment : BaseFragment(), CoroutineScope, Toolbar.OnMenuItemClickL
         }
     }
 
+    @Suppress("DEPRECATION")
     override fun setUserVisibleHint(visible: Boolean) {
         super.setUserVisibleHint(visible)
         if (visible && isAdded) {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseFragment.kt
@@ -43,19 +43,24 @@ open class BaseFragment : Fragment(), CoroutineScope, HasBackstack {
         view.isFocusable = true
     }
 
-    @Suppress("DEPRECATION")
-    override fun setUserVisibleHint(visible: Boolean) {
-        super.setUserVisibleHint(visible)
+    override fun onResume() {
+        super.onResume()
 
         // Need to make sure we are the top fragment before updating the status bar
-        val backstack = activity?.supportFragmentManager?.backStackEntryCount
-        if (visible && (backstack == 0 || activity?.supportFragmentManager?.fragments?.last() == this)) {
+        val fragmentManager = activity?.supportFragmentManager
+        if (fragmentManager != null && (fragmentManager.backStackEntryCount == 0 || fragmentManager.fragments.last() == this)) {
             updateStatusBar()
         }
     }
 
     fun updateStatusBar() {
-        (activity as? FragmentHostListener)?.updateStatusBar()
+        val activity = activity ?: return
+
+        if (activity is FragmentHostListener) {
+            activity.updateStatusBar()
+        } else {
+            theme.updateWindowStatusBar(window = activity.window, statusBarColor = statusBarColor, context = activity)
+        }
     }
 
     fun updateStatusBarColor(@ColorInt color: Int) {


### PR DESCRIPTION
This change fixes the issue on the light theme that the status bar icons are hidden because they are the same color as the bar. I noticed this when I was working on the Google Sign In but it also affects the share podcasts page. 

| Before | After |
| --- | --- |
| ![Screenshot_20221017_152738](https://user-images.githubusercontent.com/308331/196094534-54c02649-f2c9-48cc-9dd9-5db672651cc0.png) | ![Screenshot_20221017_153316](https://user-images.githubusercontent.com/308331/196094550-3bcec50c-226e-48c4-a859-2cbce651987d.png) |
| ![Screenshot_20221017_152745](https://user-images.githubusercontent.com/308331/196094614-a8881b94-7509-4b52-b145-92e39a68342c.png) | ![Screenshot_20221017_153323](https://user-images.githubusercontent.com/308331/196094584-f4e5bd70-6fda-4c3b-ab61-b53a7a6801f2.png) |
| ![Screenshot_20221017_152757](https://user-images.githubusercontent.com/308331/196094636-46079a99-9732-4f1b-8e45-a9517c9357f0.png) | ![Screenshot_20221017_153245](https://user-images.githubusercontent.com/308331/196094604-109144a6-4cdd-4345-9e08-a7ff73103e94.png) |
