### PR TITLE
Add Tracks filter events for multiselect

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -214,12 +214,18 @@ enum class AnalyticsEvent(val key: String) {
     ANALYTICS_OPT_OUT("analytics_opt_out"),
     SETTINGS_SHOW_PRIVACY_POLICY("settings_show_privacy_policy"),
 
-    /* Filters screen */
+    /* Filters */
     FILTER_AUTO_DOWNLOAD_LIMIT_UPDATED("filter_auto_download_limit_updated"),
     FILTER_AUTO_DOWNLOAD_UPDATED("filter_auto_download_updated"),
     FILTER_DELETED("filter_deleted"),
     FILTER_EDIT_DISMISSED("filter_edit_dismissed"),
+    FILTER_LIST_REORDERED("filter_list_reordered"),
     FILTER_LIST_SHOWN("filter_list_shown"),
+    FILTER_MULTI_SELECT_ENTERED("filter_multi_select_entered"),
+    FILTER_MULTI_SELECT_EXITED("filter_multi_select_exited"),
+    FILTER_SELECT_ALL_BUTTON_TAPPED("filter_select_all_button_tapped"),
+    FILTER_SELECT_ALL_ABOVE("filter_select_all_above"),
+    FILTER_SELECT_ALL_BELOW("filter_select_all_below"),
     FILTER_SHOWN("filter_shown"),
     FILTER_SORT_BY_CHANGED("filter_sort_by_changed"),
     FILTER_UPDATED("filter_updated"),
@@ -276,7 +282,6 @@ enum class AnalyticsEvent(val key: String) {
     PLAYBACK_EFFECT_TRIM_SILENCE_TOGGLED("playback_effect_trim_silence_toggled"),
     PLAYBACK_EFFECT_TRIM_SILENCE_AMOUNT_CHANGED("playback_effect_trim_silence_amount_changed"),
     PLAYBACK_EFFECT_VOLUME_BOOST_TOGGLED("playback_effect_volume_boost_toggled"),
-    FILTER_LIST_REORDERED("filter_list_reordered"),
 
     /* Player - Shelf */
     PLAYER_SHELF_ACTION_TAPPED("player_shelf_action_tapped"),


### PR DESCRIPTION
## Description

Adding the following events:
* `filter_multi_select_entered`
* `filter_multi_select_exited`
* `filter_multi_select_all`
* `filter_multi_select_all_above`
* `filter_multi_select_all_below`

## To Test

1. Open the Filters tab and tap on Filter with multiple episodes to bring up the episode list
2. Long press on an episode to enter multiselect mode
3. ✅  Observe the event `filter_multi_select_entered`
4. Long-press on an episode to bring up the select above/below modal
5. Tap on "Select all above"
6. ✅ Observe the event `filter_multi_select_all_above`
7. Long-press on an episode to bring up the select above/below modal
8. Tap on "Select all below"
9. ✅ Observe the event `filter_multi_select_all_below`
10. Tap on the three-dots to open the overflow menu
11. Tap on "Select all"
12. ✅ Observe the event `filter_multi_select_all`
13. Tap the back arrow in the top-left of the screen to exit mult-select mode
14. ✅ Observe the event `filter_multi_select_exited`

# Checklist

- [X] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [X] Are all the strings localized?
- [X] Could you have written any new tests?
- [X] Did you include Compose previews with any components?