### PR TITLE
filter_created Tracks event

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterViewModel.kt
@@ -108,7 +108,7 @@ class CreateFilterViewModel @Inject constructor(
         userChangedFilterName.changedSinceFilterUpdated = false
         userChangedIcon.changedSinceFilterUpdated = false
 
-        playlistManager.update(playlist, userPlaylistUpdate)
+        playlistManager.update(playlist, userPlaylistUpdate, isCreatingFilter = true)
     }
 
     fun updateAutodownload(autoDownload: Boolean) {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -214,11 +214,13 @@ enum class AnalyticsEvent(val key: String) {
     ANALYTICS_OPT_OUT("analytics_opt_out"),
     SETTINGS_SHOW_PRIVACY_POLICY("settings_show_privacy_policy"),
 
-    /* Filters screen */
+    /* Filters */
     FILTER_AUTO_DOWNLOAD_LIMIT_UPDATED("filter_auto_download_limit_updated"),
     FILTER_AUTO_DOWNLOAD_UPDATED("filter_auto_download_updated"),
+    FILTER_CREATED("filter_created"),
     FILTER_DELETED("filter_deleted"),
     FILTER_EDIT_DISMISSED("filter_edit_dismissed"),
+    FILTER_LIST_REORDERED("filter_list_reordered"),
     FILTER_LIST_SHOWN("filter_list_shown"),
     FILTER_SHOWN("filter_shown"),
     FILTER_SORT_BY_CHANGED("filter_sort_by_changed"),
@@ -276,7 +278,6 @@ enum class AnalyticsEvent(val key: String) {
     PLAYBACK_EFFECT_TRIM_SILENCE_TOGGLED("playback_effect_trim_silence_toggled"),
     PLAYBACK_EFFECT_TRIM_SILENCE_AMOUNT_CHANGED("playback_effect_trim_silence_amount_changed"),
     PLAYBACK_EFFECT_VOLUME_BOOST_TOGGLED("playback_effect_volume_boost_toggled"),
-    FILTER_LIST_REORDERED("filter_list_reordered"),
 
     /* Player - Shelf */
     PLAYER_SHELF_ACTION_TAPPED("player_shelf_action_tapped"),

--- a/modules/services/repositories/build.gradle
+++ b/modules/services/repositories/build.gradle
@@ -15,3 +15,4 @@ dependencies {
     implementation project(':modules:services:model')
     implementation project(':modules:services:analytics')
 }
+

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
@@ -31,7 +31,7 @@ interface PlaylistManager {
     fun createPlaylist(name: String, iconId: Int, draft: Boolean): Playlist
 
     fun create(playlist: Playlist): Long
-    fun update(playlist: Playlist, userPlaylistUpdate: UserPlaylistUpdate?)
+    fun update(playlist: Playlist, userPlaylistUpdate: UserPlaylistUpdate?, isCreatingFilter: Boolean = false)
 
     fun updateAutoDownloadStatus(playlist: Playlist, autoDownloadEnabled: Boolean, unmeteredOnly: Boolean, powerOnly: Boolean)
     fun rxUpdateAutoDownloadStatus(playlist: Playlist, autoDownloadEnabled: Boolean, unmeteredOnly: Boolean, powerOnly: Boolean): Completable

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -2,8 +2,6 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import android.content.Context
 import android.os.Build
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
@@ -13,8 +11,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.calculateCombinedIconId
-import au.com.shiftyjelly.pocketcasts.repositories.extensions.colorIndex
-import au.com.shiftyjelly.pocketcasts.repositories.extensions.drawableId
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.shortcuts.PocketCastsShortcuts
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -30,7 +26,6 @@ import java.util.Date
 import java.util.UUID
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
-import au.com.shiftyjelly.pocketcasts.images.R as IR
 
 private const val NEWRELEASE_UUID = "2797DCF8-1C93-4999-B52A-D1849736FA2C"
 private const val INPROGRESS_UUID = "D89A925C-5CE1-41A4-A879-2751838CE5CE"
@@ -39,58 +34,10 @@ private const val CREATED_DEFAULT_PLAYLISTS = "createdDefaultPlaylists"
 class PlaylistManagerImpl @Inject constructor(
     private val settings: Settings,
     private val downloadManager: DownloadManager,
-    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val playlistUpdateAnalytics: PlaylistUpdateAnalytics,
     @ApplicationContext private val context: Context,
     appDatabase: AppDatabase
 ) : PlaylistManager, CoroutineScope {
-
-    companion object {
-        private object AnalyticsProp {
-            object Key {
-                const val ALL_PODCASTS = "all_podcasts"
-                const val COLOR = "color"
-                const val DOWNLOADED = "downloaded"
-                const val DURATION = "duration"
-                const val ENABLED = "enabled"
-                const val GROUP = "group"
-                const val ICON_NAME = "icon_name"
-                const val LIMIT = "limit"
-                const val EPISODE_STATUS_IN_PROGRESS = "expisode_status_in_progress"
-                const val EPISODE_STATUS_PLAYED = "episode_status_played"
-                const val EPISODE_STATUS_UNPLAYED = "episode_status_unplayed"
-                const val MEDIA_TYPE = "media_type"
-                const val RELEASE_DATE = "release_date"
-                const val SORT_ORDER = "sort_order"
-                const val SOURCE = "source"
-                const val STARRED = "starred"
-            }
-            object Value {
-                object Icon {
-                    const val CLOCK = "filter_clock"
-                    const val DOWNLOADED = "filter_downloaded"
-                    const val HEADPHONES = "filter_headphones"
-                    const val LIST = "filter_list"
-                    const val PLAY = "filter_play"
-                    const val STARRED = "filter_starred"
-                    const val VOLUME = "filter_volume"
-                    const val VIDEO = "filter_video"
-                }
-                object MediaType {
-                    const val ALL = "all"
-                    const val AUDIO = "audio"
-                    const val VIDEO = "video"
-                }
-                object ReleaseDate {
-                    const val ANYTIME = "anytime"
-                    const val TWENTY_FOUR_HOURS = "24 hours"
-                    const val THREE_DAYS = "3 days"
-                    const val WEEK = "Last Week"
-                    const val TWO_WEEKS = "Last 2 Weeks"
-                    const val MONTH = "Last Month"
-                }
-            }
-        }
-    }
 
     private val playlistDao = appDatabase.playlistDao()
 
@@ -255,7 +202,7 @@ class PlaylistManagerImpl @Inject constructor(
         isCreatingFilter: Boolean
     ) {
         playlistDao.update(playlist)
-        sendPlaylistUpdateAnalytics(playlist, userPlaylistUpdate, isCreatingFilter)
+        playlistUpdateAnalytics.update(playlist, userPlaylistUpdate, isCreatingFilter)
     }
 
     override fun updateAll(playlists: List<Playlist>) {
@@ -384,140 +331,6 @@ class PlaylistManagerImpl @Inject constructor(
 
     override fun findPlaylistsToSync(): List<Playlist> {
         return playlistDao.findNotSynced()
-    }
-
-    private fun sendPlaylistUpdateAnalytics(
-        playlist: Playlist,
-        userPlaylistUpdate: UserPlaylistUpdate?,
-        isCreatingFilter: Boolean
-    ) {
-
-        if (isCreatingFilter) {
-            val properties = buildMap<String, Any> {
-
-                val icon = when (playlist.drawableId) {
-
-                    IR.drawable.ic_filters_list,
-                    IR.drawable.auto_filter_list,
-                    IR.drawable.automotive_filter_list -> AnalyticsProp.Value.Icon.LIST
-
-                    IR.drawable.ic_filters_headphones,
-                    IR.drawable.auto_filter_headphones,
-                    IR.drawable.automotive_filter_headphones -> AnalyticsProp.Value.Icon.HEADPHONES
-
-                    IR.drawable.ic_filters_clock,
-                    IR.drawable.auto_filter_clock,
-                    IR.drawable.automotive_filter_clock -> AnalyticsProp.Value.Icon.CLOCK
-
-                    IR.drawable.ic_filters_download,
-                    IR.drawable.auto_filter_downloaded,
-                    IR.drawable.automotive_filter_downloaded -> AnalyticsProp.Value.Icon.DOWNLOADED
-
-                    IR.drawable.ic_filters_play,
-                    IR.drawable.auto_filter_play,
-                    IR.drawable.automotive_filter_play -> AnalyticsProp.Value.Icon.PLAY
-
-                    IR.drawable.ic_filters_volume,
-                    IR.drawable.auto_filter_volume,
-                    IR.drawable.automotive_filter_volume -> AnalyticsProp.Value.Icon.VOLUME
-
-                    IR.drawable.ic_filters_video,
-                    IR.drawable.auto_filter_video,
-                    IR.drawable.automotive_filter_video -> AnalyticsProp.Value.Icon.VIDEO
-
-                    IR.drawable.ic_filters_star,
-                    IR.drawable.auto_filter_star,
-                    IR.drawable.automotive_filter_star -> AnalyticsProp.Value.Icon.STARRED
-
-                    else -> {
-                        Timber.e("No matching icon found")
-                        null
-                    }
-                }
-
-                val mediaType = when (playlist.audioVideo) {
-                    0 -> AnalyticsProp.Value.MediaType.ALL
-                    1 -> AnalyticsProp.Value.MediaType.AUDIO
-                    2 -> AnalyticsProp.Value.MediaType.VIDEO
-                    else -> {
-                        Timber.e("No match found for audioVideo Int")
-                        null
-                    }
-                }
-
-                val releaseDate = when (playlist.filterHours) {
-                    Playlist.ANYTIME -> AnalyticsProp.Value.ReleaseDate.ANYTIME
-                    Playlist.LAST_24_HOURS -> AnalyticsProp.Value.ReleaseDate.TWENTY_FOUR_HOURS
-                    Playlist.LAST_3_DAYS -> AnalyticsProp.Value.ReleaseDate.THREE_DAYS
-                    Playlist.LAST_WEEK -> AnalyticsProp.Value.ReleaseDate.WEEK
-                    Playlist.LAST_2_WEEKS -> AnalyticsProp.Value.ReleaseDate.TWO_WEEKS
-                    Playlist.LAST_MONTH -> AnalyticsProp.Value.ReleaseDate.MONTH
-                    else -> {
-                        Timber.e("Unexpected filter hours value")
-                        null
-                    }
-                }
-
-                put(AnalyticsProp.Key.ALL_PODCASTS, playlist.allPodcasts)
-                put(AnalyticsProp.Key.COLOR, playlist.colorIndex)
-                put(AnalyticsProp.Key.DOWNLOADED, playlist.downloaded)
-                put(AnalyticsProp.Key.DURATION, playlist.filterDuration)
-                put(AnalyticsProp.Key.EPISODE_STATUS_IN_PROGRESS, playlist.partiallyPlayed)
-                put(AnalyticsProp.Key.EPISODE_STATUS_PLAYED, playlist.finished)
-                put(AnalyticsProp.Key.EPISODE_STATUS_UNPLAYED, playlist.unplayed)
-                icon?.let { put(AnalyticsProp.Key.ICON_NAME, it) }
-                mediaType?.let { put(AnalyticsProp.Key.MEDIA_TYPE, it) }
-                put(AnalyticsProp.Key.STARRED, playlist.starred)
-                releaseDate?.let { put(AnalyticsProp.Key.RELEASE_DATE, it) }
-            }
-
-            analyticsTracker.track(AnalyticsEvent.FILTER_CREATED, properties)
-
-            // If the playlist is a draft, then we are in the filter creation flow and
-            // we don't want to send update events
-        } else if (!playlist.draft) {
-            userPlaylistUpdate?.properties?.map { playlistProperty ->
-                when (playlistProperty) {
-
-                    is FilterUpdatedEvent -> {
-                        val properties = mapOf(
-                            AnalyticsProp.Key.GROUP to playlistProperty.groupValue,
-                            AnalyticsProp.Key.SOURCE to userPlaylistUpdate.source.analyticsValue
-                        )
-                        analyticsTracker.track(AnalyticsEvent.FILTER_UPDATED, properties)
-                    }
-
-                    is PlaylistProperty.AutoDownload -> {
-                        val properties = mapOf(
-                            AnalyticsProp.Key.SOURCE to userPlaylistUpdate.source.analyticsValue,
-                            AnalyticsProp.Key.ENABLED to playlistProperty.enabled
-                        )
-                        analyticsTracker.track(AnalyticsEvent.FILTER_AUTO_DOWNLOAD_UPDATED, properties)
-                    }
-
-                    is PlaylistProperty.AutoDownloadLimit -> {
-                        val properties = mapOf(AnalyticsProp.Key.LIMIT to playlistProperty.limit)
-                        analyticsTracker.track(AnalyticsEvent.FILTER_AUTO_DOWNLOAD_LIMIT_UPDATED, properties)
-                    }
-
-                    is PlaylistProperty.Sort -> {
-                        val sortOrderString = when (playlistProperty.sortOrder) {
-                            Playlist.SortOrder.NEWEST_TO_OLDEST -> "newest_to_oldest"
-                            Playlist.SortOrder.OLDEST_TO_NEWEST -> "oldest_to_newest"
-                            Playlist.SortOrder.SHORTEST_TO_LONGEST -> "shortest_to_longest"
-                            Playlist.SortOrder.LONGEST_TO_SHORTEST -> "longest_to_shortest"
-                            Playlist.SortOrder.LAST_DOWNLOAD_ATTEMPT_DATE -> "last_download_attempt_date"
-                        }
-                        val properties = mapOf(AnalyticsProp.Key.SORT_ORDER to sortOrderString)
-                        analyticsTracker.track(AnalyticsEvent.FILTER_SORT_BY_CHANGED, properties)
-                    }
-
-                    PlaylistProperty.Color,
-                    PlaylistProperty.FilterName,
-                    PlaylistProperty.Icon -> { /* Do nothing. These are handled by the filter_edit_dismissed event. */ }
-                }
-            }
-        }
     }
 
     /**

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistUpdateAnalytics.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistUpdateAnalytics.kt
@@ -20,99 +20,118 @@ class PlaylistUpdateAnalytics @Inject constructor(
     ) {
 
         when {
-            isCreatingFilter -> {
-                sendPlaylistCreatedEvent(playlist)
-            }
+            isCreatingFilter -> sendPlaylistCreatedEvent(playlist)
 
             // If the playlist is a draft, then we are in the middle of the filter creation flow and
             // we don't want to send update events
-            !playlist.draft -> {
-                sendPlaylistUpdateEvent(userPlaylistUpdate)
-            }
+            !playlist.draft -> sendPlaylistUpdateEvent(userPlaylistUpdate)
         }
     }
 
     private fun sendPlaylistCreatedEvent(playlist: Playlist) {
         val properties = buildMap<String, Any> {
 
-            val icon = when (playlist.drawableId) {
-
-                IR.drawable.ic_filters_list,
-                IR.drawable.auto_filter_list,
-                IR.drawable.automotive_filter_list -> AnalyticsProp.Value.Icon.LIST
-
-                IR.drawable.ic_filters_headphones,
-                IR.drawable.auto_filter_headphones,
-                IR.drawable.automotive_filter_headphones -> AnalyticsProp.Value.Icon.HEADPHONES
-
-                IR.drawable.ic_filters_clock,
-                IR.drawable.auto_filter_clock,
-                IR.drawable.automotive_filter_clock -> AnalyticsProp.Value.Icon.CLOCK
-
-                IR.drawable.ic_filters_download,
-                IR.drawable.auto_filter_downloaded,
-                IR.drawable.automotive_filter_downloaded -> AnalyticsProp.Value.Icon.DOWNLOADED
-
-                IR.drawable.ic_filters_play,
-                IR.drawable.auto_filter_play,
-                IR.drawable.automotive_filter_play -> AnalyticsProp.Value.Icon.PLAY
-
-                IR.drawable.ic_filters_volume,
-                IR.drawable.auto_filter_volume,
-                IR.drawable.automotive_filter_volume -> AnalyticsProp.Value.Icon.VOLUME
-
-                IR.drawable.ic_filters_video,
-                IR.drawable.auto_filter_video,
-                IR.drawable.automotive_filter_video -> AnalyticsProp.Value.Icon.VIDEO
-
-                IR.drawable.ic_filters_star,
-                IR.drawable.auto_filter_star,
-                IR.drawable.automotive_filter_star -> AnalyticsProp.Value.Icon.STARRED
-
-                else -> {
-                    Timber.e("No matching icon found")
-                    null
-                }
+            put(Key.ALL_PODCASTS, playlist.allPodcasts)
+            colorAnalyticsValue(playlist)?.let {
+                put(Key.COLOR, it)
             }
-
-            val mediaType = when (playlist.audioVideo) {
-                0 -> AnalyticsProp.Value.MediaType.ALL
-                1 -> AnalyticsProp.Value.MediaType.AUDIO
-                2 -> AnalyticsProp.Value.MediaType.VIDEO
-                else -> {
-                    Timber.e("No match found for audioVideo Int")
-                    null
-                }
+            put(Key.DOWNLOADED, playlist.downloaded)
+            put(Key.DURATION, playlist.filterDuration)
+            put(Key.EPISODE_STATUS_IN_PROGRESS, playlist.partiallyPlayed)
+            put(Key.EPISODE_STATUS_PLAYED, playlist.finished)
+            put(Key.EPISODE_STATUS_UNPLAYED, playlist.unplayed)
+            iconAnalayticsValue(playlist)?.let {
+                put(Key.ICON_NAME, it)
             }
-
-            val releaseDate = when (playlist.filterHours) {
-                Playlist.ANYTIME -> AnalyticsProp.Value.ReleaseDate.ANYTIME
-                Playlist.LAST_24_HOURS -> AnalyticsProp.Value.ReleaseDate.TWENTY_FOUR_HOURS
-                Playlist.LAST_3_DAYS -> AnalyticsProp.Value.ReleaseDate.THREE_DAYS
-                Playlist.LAST_WEEK -> AnalyticsProp.Value.ReleaseDate.WEEK
-                Playlist.LAST_2_WEEKS -> AnalyticsProp.Value.ReleaseDate.TWO_WEEKS
-                Playlist.LAST_MONTH -> AnalyticsProp.Value.ReleaseDate.MONTH
-                else -> {
-                    Timber.e("Unexpected filter hours value")
-                    null
-                }
+            mediaTypeAnalyticsValue(playlist)?.let {
+                put(Key.MEDIA_TYPE, it)
             }
-
-            put(AnalyticsProp.Key.ALL_PODCASTS, playlist.allPodcasts)
-            put(AnalyticsProp.Key.COLOR, playlist.colorIndex)
-            put(AnalyticsProp.Key.DOWNLOADED, playlist.downloaded)
-            put(AnalyticsProp.Key.DURATION, playlist.filterDuration)
-            put(AnalyticsProp.Key.EPISODE_STATUS_IN_PROGRESS, playlist.partiallyPlayed)
-            put(AnalyticsProp.Key.EPISODE_STATUS_PLAYED, playlist.finished)
-            put(AnalyticsProp.Key.EPISODE_STATUS_UNPLAYED, playlist.unplayed)
-            icon?.let { put(AnalyticsProp.Key.ICON_NAME, it) }
-            mediaType?.let { put(AnalyticsProp.Key.MEDIA_TYPE, it) }
-            put(AnalyticsProp.Key.STARRED, playlist.starred)
-            releaseDate?.let { put(AnalyticsProp.Key.RELEASE_DATE, it) }
+            put(Key.STARRED, playlist.starred)
+            releaseDateAnalyticsValue(playlist)?.let {
+                put(Key.RELEASE_DATE, it)
+            }
         }
 
         analyticsTracker.track(AnalyticsEvent.FILTER_CREATED, properties)
     }
+
+    private fun iconAnalayticsValue(playlist: Playlist) =
+        when (playlist.drawableId) {
+            IR.drawable.ic_filters_list,
+            IR.drawable.auto_filter_list,
+            IR.drawable.automotive_filter_list -> Value.IconName.LIST
+
+            IR.drawable.ic_filters_headphones,
+            IR.drawable.auto_filter_headphones,
+            IR.drawable.automotive_filter_headphones -> Value.IconName.HEADPHONES
+
+            IR.drawable.ic_filters_clock,
+            IR.drawable.auto_filter_clock,
+            IR.drawable.automotive_filter_clock -> Value.IconName.CLOCK
+
+            IR.drawable.ic_filters_download,
+            IR.drawable.auto_filter_downloaded,
+            IR.drawable.automotive_filter_downloaded -> Value.IconName.DOWNLOADED
+
+            IR.drawable.ic_filters_play,
+            IR.drawable.auto_filter_play,
+            IR.drawable.automotive_filter_play -> Value.IconName.PLAY
+
+            IR.drawable.ic_filters_volume,
+            IR.drawable.auto_filter_volume,
+            IR.drawable.automotive_filter_volume -> Value.IconName.VOLUME
+
+            IR.drawable.ic_filters_video,
+            IR.drawable.auto_filter_video,
+            IR.drawable.automotive_filter_video -> Value.IconName.VIDEO
+
+            IR.drawable.ic_filters_star,
+            IR.drawable.auto_filter_star,
+            IR.drawable.automotive_filter_star -> Value.IconName.STARRED
+
+            else -> {
+                Timber.e("No matching analytics icon found")
+                null
+            }
+        }
+
+    private fun mediaTypeAnalyticsValue(playlist: Playlist) =
+        when (playlist.audioVideo) {
+            0 -> Value.MediaType.ALL
+            1 -> Value.MediaType.AUDIO
+            2 -> Value.MediaType.VIDEO
+            else -> {
+                Timber.e("No match found for audioVideo Int")
+                null
+            }
+        }
+
+    private fun releaseDateAnalyticsValue(playlist: Playlist) =
+        when (playlist.filterHours) {
+            Playlist.ANYTIME -> Value.ReleaseDate.ANYTIME
+            Playlist.LAST_24_HOURS -> Value.ReleaseDate.TWENTY_FOUR_HOURS
+            Playlist.LAST_3_DAYS -> Value.ReleaseDate.THREE_DAYS
+            Playlist.LAST_WEEK -> Value.ReleaseDate.WEEK
+            Playlist.LAST_2_WEEKS -> Value.ReleaseDate.TWO_WEEKS
+            Playlist.LAST_MONTH -> Value.ReleaseDate.MONTH
+            else -> {
+                Timber.e("Unexpected filter hours value")
+                null
+            }
+        }
+
+    private fun colorAnalyticsValue(playlist: Playlist) =
+        when (playlist.colorIndex) {
+            0 -> Value.Color.RED
+            1 -> Value.Color.BLUE
+            2 -> Value.Color.GREEN
+            3 -> Value.Color.PURPLE
+            4 -> Value.Color.YELLOW
+            else -> {
+                Timber.e("No matching analytics color found")
+                null
+            }
+        }
 
     private fun sendPlaylistUpdateEvent(userPlaylistUpdate: UserPlaylistUpdate?) {
         userPlaylistUpdate?.properties?.map { playlistProperty ->
@@ -120,22 +139,22 @@ class PlaylistUpdateAnalytics @Inject constructor(
 
                 is FilterUpdatedEvent -> {
                     val properties = mapOf(
-                        AnalyticsProp.Key.GROUP to playlistProperty.groupValue,
-                        AnalyticsProp.Key.SOURCE to userPlaylistUpdate.source.analyticsValue
+                        Key.GROUP to playlistProperty.groupValue,
+                        Key.SOURCE to userPlaylistUpdate.source.analyticsValue
                     )
                     analyticsTracker.track(AnalyticsEvent.FILTER_UPDATED, properties)
                 }
 
                 is PlaylistProperty.AutoDownload -> {
                     val properties = mapOf(
-                        AnalyticsProp.Key.SOURCE to userPlaylistUpdate.source.analyticsValue,
-                        AnalyticsProp.Key.ENABLED to playlistProperty.enabled
+                        Key.SOURCE to userPlaylistUpdate.source.analyticsValue,
+                        Key.ENABLED to playlistProperty.enabled
                     )
                     analyticsTracker.track(AnalyticsEvent.FILTER_AUTO_DOWNLOAD_UPDATED, properties)
                 }
 
                 is PlaylistProperty.AutoDownloadLimit -> {
-                    val properties = mapOf(AnalyticsProp.Key.LIMIT to playlistProperty.limit)
+                    val properties = mapOf(Key.LIMIT to playlistProperty.limit)
                     analyticsTracker.track(AnalyticsEvent.FILTER_AUTO_DOWNLOAD_LIMIT_UPDATED, properties)
                 }
 
@@ -147,7 +166,7 @@ class PlaylistUpdateAnalytics @Inject constructor(
                         Playlist.SortOrder.LONGEST_TO_SHORTEST -> "longest_to_shortest"
                         Playlist.SortOrder.LAST_DOWNLOAD_ATTEMPT_DATE -> "last_download_attempt_date"
                     }
-                    val properties = mapOf(AnalyticsProp.Key.SORT_ORDER to sortOrderString)
+                    val properties = mapOf(Key.SORT_ORDER to sortOrderString)
                     analyticsTracker.track(AnalyticsEvent.FILTER_SORT_BY_CHANGED, properties)
                 }
 
@@ -159,52 +178,58 @@ class PlaylistUpdateAnalytics @Inject constructor(
     }
 
     companion object {
-        private object AnalyticsProp {
-            object Key {
-                const val ALL_PODCASTS = "all_podcasts"
-                const val COLOR = "color"
-                const val DOWNLOADED = "downloaded"
-                const val DURATION = "duration"
-                const val ENABLED = "enabled"
-                const val GROUP = "group"
-                const val ICON_NAME = "icon_name"
-                const val LIMIT = "limit"
-                const val EPISODE_STATUS_IN_PROGRESS = "expisode_status_in_progress"
-                const val EPISODE_STATUS_PLAYED = "episode_status_played"
-                const val EPISODE_STATUS_UNPLAYED = "episode_status_unplayed"
-                const val MEDIA_TYPE = "media_type"
-                const val RELEASE_DATE = "release_date"
-                const val SORT_ORDER = "sort_order"
-                const val SOURCE = "source"
-                const val STARRED = "starred"
+        private object Key {
+            const val ALL_PODCASTS = "all_podcasts"
+            const val COLOR = "color"
+            const val DOWNLOADED = "downloaded"
+            const val DURATION = "duration"
+            const val ENABLED = "enabled"
+            const val GROUP = "group"
+            const val ICON_NAME = "icon_name"
+            const val LIMIT = "limit"
+            const val EPISODE_STATUS_IN_PROGRESS = "expisode_status_in_progress"
+            const val EPISODE_STATUS_PLAYED = "episode_status_played"
+            const val EPISODE_STATUS_UNPLAYED = "episode_status_unplayed"
+            const val MEDIA_TYPE = "media_type"
+            const val RELEASE_DATE = "release_date"
+            const val SORT_ORDER = "sort_order"
+            const val SOURCE = "source"
+            const val STARRED = "starred"
+        }
+
+        private object Value {
+            object IconName {
+                const val CLOCK = "filter_clock"
+                const val DOWNLOADED = "filter_downloaded"
+                const val HEADPHONES = "filter_headphones"
+                const val LIST = "filter_list"
+                const val PLAY = "filter_play"
+                const val STARRED = "filter_starred"
+                const val VOLUME = "filter_volume"
+                const val VIDEO = "filter_video"
             }
 
-            object Value {
-                object Icon {
-                    const val CLOCK = "filter_clock"
-                    const val DOWNLOADED = "filter_downloaded"
-                    const val HEADPHONES = "filter_headphones"
-                    const val LIST = "filter_list"
-                    const val PLAY = "filter_play"
-                    const val STARRED = "filter_starred"
-                    const val VOLUME = "filter_volume"
-                    const val VIDEO = "filter_video"
-                }
+            object MediaType {
+                const val ALL = "all"
+                const val AUDIO = "audio"
+                const val VIDEO = "video"
+            }
 
-                object MediaType {
-                    const val ALL = "all"
-                    const val AUDIO = "audio"
-                    const val VIDEO = "video"
-                }
+            object ReleaseDate {
+                const val ANYTIME = "anytime"
+                const val TWENTY_FOUR_HOURS = "24_hours"
+                const val THREE_DAYS = "3_days"
+                const val WEEK = "last_week"
+                const val TWO_WEEKS = "last_2_Weeks"
+                const val MONTH = "last_month"
+            }
 
-                object ReleaseDate {
-                    const val ANYTIME = "anytime"
-                    const val TWENTY_FOUR_HOURS = "24 hours"
-                    const val THREE_DAYS = "3 days"
-                    const val WEEK = "Last Week"
-                    const val TWO_WEEKS = "Last 2 Weeks"
-                    const val MONTH = "Last Month"
-                }
+            object Color {
+                const val RED = "red"
+                const val BLUE = "blue"
+                const val GREEN = "green"
+                const val PURPLE = "purple"
+                const val YELLOW = "yellow"
             }
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistUpdateAnalytics.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistUpdateAnalytics.kt
@@ -1,0 +1,211 @@
+package au.com.shiftyjelly.pocketcasts.repositories.podcast
+
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
+import au.com.shiftyjelly.pocketcasts.repositories.extensions.colorIndex
+import au.com.shiftyjelly.pocketcasts.repositories.extensions.drawableId
+import timber.log.Timber
+import javax.inject.Inject
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+
+class PlaylistUpdateAnalytics @Inject constructor(
+    private val analyticsTracker: AnalyticsTrackerWrapper
+) {
+
+    fun update(
+        playlist: Playlist,
+        userPlaylistUpdate: UserPlaylistUpdate?,
+        isCreatingFilter: Boolean
+    ) {
+
+        when {
+            isCreatingFilter -> {
+                sendPlaylistCreatedEvent(playlist)
+            }
+
+            // If the playlist is a draft, then we are in the middle of the filter creation flow and
+            // we don't want to send update events
+            !playlist.draft -> {
+                sendPlaylistUpdateEvent(userPlaylistUpdate)
+            }
+        }
+    }
+
+    private fun sendPlaylistCreatedEvent(playlist: Playlist) {
+        val properties = buildMap<String, Any> {
+
+            val icon = when (playlist.drawableId) {
+
+                IR.drawable.ic_filters_list,
+                IR.drawable.auto_filter_list,
+                IR.drawable.automotive_filter_list -> AnalyticsProp.Value.Icon.LIST
+
+                IR.drawable.ic_filters_headphones,
+                IR.drawable.auto_filter_headphones,
+                IR.drawable.automotive_filter_headphones -> AnalyticsProp.Value.Icon.HEADPHONES
+
+                IR.drawable.ic_filters_clock,
+                IR.drawable.auto_filter_clock,
+                IR.drawable.automotive_filter_clock -> AnalyticsProp.Value.Icon.CLOCK
+
+                IR.drawable.ic_filters_download,
+                IR.drawable.auto_filter_downloaded,
+                IR.drawable.automotive_filter_downloaded -> AnalyticsProp.Value.Icon.DOWNLOADED
+
+                IR.drawable.ic_filters_play,
+                IR.drawable.auto_filter_play,
+                IR.drawable.automotive_filter_play -> AnalyticsProp.Value.Icon.PLAY
+
+                IR.drawable.ic_filters_volume,
+                IR.drawable.auto_filter_volume,
+                IR.drawable.automotive_filter_volume -> AnalyticsProp.Value.Icon.VOLUME
+
+                IR.drawable.ic_filters_video,
+                IR.drawable.auto_filter_video,
+                IR.drawable.automotive_filter_video -> AnalyticsProp.Value.Icon.VIDEO
+
+                IR.drawable.ic_filters_star,
+                IR.drawable.auto_filter_star,
+                IR.drawable.automotive_filter_star -> AnalyticsProp.Value.Icon.STARRED
+
+                else -> {
+                    Timber.e("No matching icon found")
+                    null
+                }
+            }
+
+            val mediaType = when (playlist.audioVideo) {
+                0 -> AnalyticsProp.Value.MediaType.ALL
+                1 -> AnalyticsProp.Value.MediaType.AUDIO
+                2 -> AnalyticsProp.Value.MediaType.VIDEO
+                else -> {
+                    Timber.e("No match found for audioVideo Int")
+                    null
+                }
+            }
+
+            val releaseDate = when (playlist.filterHours) {
+                Playlist.ANYTIME -> AnalyticsProp.Value.ReleaseDate.ANYTIME
+                Playlist.LAST_24_HOURS -> AnalyticsProp.Value.ReleaseDate.TWENTY_FOUR_HOURS
+                Playlist.LAST_3_DAYS -> AnalyticsProp.Value.ReleaseDate.THREE_DAYS
+                Playlist.LAST_WEEK -> AnalyticsProp.Value.ReleaseDate.WEEK
+                Playlist.LAST_2_WEEKS -> AnalyticsProp.Value.ReleaseDate.TWO_WEEKS
+                Playlist.LAST_MONTH -> AnalyticsProp.Value.ReleaseDate.MONTH
+                else -> {
+                    Timber.e("Unexpected filter hours value")
+                    null
+                }
+            }
+
+            put(AnalyticsProp.Key.ALL_PODCASTS, playlist.allPodcasts)
+            put(AnalyticsProp.Key.COLOR, playlist.colorIndex)
+            put(AnalyticsProp.Key.DOWNLOADED, playlist.downloaded)
+            put(AnalyticsProp.Key.DURATION, playlist.filterDuration)
+            put(AnalyticsProp.Key.EPISODE_STATUS_IN_PROGRESS, playlist.partiallyPlayed)
+            put(AnalyticsProp.Key.EPISODE_STATUS_PLAYED, playlist.finished)
+            put(AnalyticsProp.Key.EPISODE_STATUS_UNPLAYED, playlist.unplayed)
+            icon?.let { put(AnalyticsProp.Key.ICON_NAME, it) }
+            mediaType?.let { put(AnalyticsProp.Key.MEDIA_TYPE, it) }
+            put(AnalyticsProp.Key.STARRED, playlist.starred)
+            releaseDate?.let { put(AnalyticsProp.Key.RELEASE_DATE, it) }
+        }
+
+        analyticsTracker.track(AnalyticsEvent.FILTER_CREATED, properties)
+    }
+
+    private fun sendPlaylistUpdateEvent(userPlaylistUpdate: UserPlaylistUpdate?) {
+        userPlaylistUpdate?.properties?.map { playlistProperty ->
+            when (playlistProperty) {
+
+                is FilterUpdatedEvent -> {
+                    val properties = mapOf(
+                        AnalyticsProp.Key.GROUP to playlistProperty.groupValue,
+                        AnalyticsProp.Key.SOURCE to userPlaylistUpdate.source.analyticsValue
+                    )
+                    analyticsTracker.track(AnalyticsEvent.FILTER_UPDATED, properties)
+                }
+
+                is PlaylistProperty.AutoDownload -> {
+                    val properties = mapOf(
+                        AnalyticsProp.Key.SOURCE to userPlaylistUpdate.source.analyticsValue,
+                        AnalyticsProp.Key.ENABLED to playlistProperty.enabled
+                    )
+                    analyticsTracker.track(AnalyticsEvent.FILTER_AUTO_DOWNLOAD_UPDATED, properties)
+                }
+
+                is PlaylistProperty.AutoDownloadLimit -> {
+                    val properties = mapOf(AnalyticsProp.Key.LIMIT to playlistProperty.limit)
+                    analyticsTracker.track(AnalyticsEvent.FILTER_AUTO_DOWNLOAD_LIMIT_UPDATED, properties)
+                }
+
+                is PlaylistProperty.Sort -> {
+                    val sortOrderString = when (playlistProperty.sortOrder) {
+                        Playlist.SortOrder.NEWEST_TO_OLDEST -> "newest_to_oldest"
+                        Playlist.SortOrder.OLDEST_TO_NEWEST -> "oldest_to_newest"
+                        Playlist.SortOrder.SHORTEST_TO_LONGEST -> "shortest_to_longest"
+                        Playlist.SortOrder.LONGEST_TO_SHORTEST -> "longest_to_shortest"
+                        Playlist.SortOrder.LAST_DOWNLOAD_ATTEMPT_DATE -> "last_download_attempt_date"
+                    }
+                    val properties = mapOf(AnalyticsProp.Key.SORT_ORDER to sortOrderString)
+                    analyticsTracker.track(AnalyticsEvent.FILTER_SORT_BY_CHANGED, properties)
+                }
+
+                PlaylistProperty.Color,
+                PlaylistProperty.FilterName,
+                PlaylistProperty.Icon -> { /* Do nothing. These are handled by the filter_edit_dismissed event. */ }
+            }
+        }
+    }
+
+    companion object {
+        private object AnalyticsProp {
+            object Key {
+                const val ALL_PODCASTS = "all_podcasts"
+                const val COLOR = "color"
+                const val DOWNLOADED = "downloaded"
+                const val DURATION = "duration"
+                const val ENABLED = "enabled"
+                const val GROUP = "group"
+                const val ICON_NAME = "icon_name"
+                const val LIMIT = "limit"
+                const val EPISODE_STATUS_IN_PROGRESS = "expisode_status_in_progress"
+                const val EPISODE_STATUS_PLAYED = "episode_status_played"
+                const val EPISODE_STATUS_UNPLAYED = "episode_status_unplayed"
+                const val MEDIA_TYPE = "media_type"
+                const val RELEASE_DATE = "release_date"
+                const val SORT_ORDER = "sort_order"
+                const val SOURCE = "source"
+                const val STARRED = "starred"
+            }
+
+            object Value {
+                object Icon {
+                    const val CLOCK = "filter_clock"
+                    const val DOWNLOADED = "filter_downloaded"
+                    const val HEADPHONES = "filter_headphones"
+                    const val LIST = "filter_list"
+                    const val PLAY = "filter_play"
+                    const val STARRED = "filter_starred"
+                    const val VOLUME = "filter_volume"
+                    const val VIDEO = "filter_video"
+                }
+
+                object MediaType {
+                    const val ALL = "all"
+                    const val AUDIO = "audio"
+                    const val VIDEO = "video"
+                }
+
+                object ReleaseDate {
+                    const val ANYTIME = "anytime"
+                    const val TWENTY_FOUR_HOURS = "24 hours"
+                    const val THREE_DAYS = "3 days"
+                    const val WEEK = "Last Week"
+                    const val TWO_WEEKS = "Last 2 Weeks"
+                    const val MONTH = "Last Month"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds the filter_created event

## To Test

Just do this a few times with the different possible filter configurations:
1. Create a new filter
2. Observe that a `filter_created` event is fired with the appropriate properties for these keys:
    1. all_podcasts
    2. color
    3. downloaded
    4. duration
    5. episode_status_played
    6. episode_status_in_progress
    7. episode_status_unplayed
    8. icon_name
    9. media_type
    10. release_date
    11. starred

# Checklist

- [X] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [X] Are all the strings localized?
- [X] Could you have written any new tests?
- [X] Did you include Compose previews with any components?