### PR TITLE
Organize dependency declarations

### DIFF
--- a/modules/features/account/build.gradle
+++ b/modules/features/account/build.gradle
@@ -13,17 +13,20 @@ android {
 }
 
 dependencies {
-    implementation project(':modules:services:localization')
-    implementation project(':modules:services:preferences')
-    implementation project(':modules:services:utils')
-    implementation project(':modules:services:images')
-    implementation project(':modules:services:ui')
-    implementation project(':modules:services:compose')
-    implementation project(':modules:services:views')
-    implementation project(':modules:services:repositories')
-    implementation project(':modules:services:servers')
-    implementation project(':modules:services:model')
-    implementation project(':modules:services:analytics')
+    // features
     implementation project(':modules:features:cartheme')
     implementation project(':modules:features:settings')
+
+    // services
+    implementation project(':modules:services:analytics')
+    implementation project(':modules:services:compose')
+    implementation project(':modules:services:images')
+    implementation project(':modules:services:localization')
+    implementation project(':modules:services:model')
+    implementation project(':modules:services:preferences')
+    implementation project(':modules:services:repositories')
+    implementation project(':modules:services:servers')
+    implementation project(':modules:services:ui')
+    implementation project(':modules:services:utils')
+    implementation project(':modules:services:views')
 }

--- a/modules/features/discover/build.gradle
+++ b/modules/features/discover/build.gradle
@@ -10,18 +10,21 @@ android {
 }
 
 dependencies {
-    implementation project(':modules:services:localization')
-    implementation project(':modules:services:preferences')
-    implementation project(':modules:services:utils')
-    implementation project(':modules:services:images')
-    implementation project(':modules:services:ui')
-    implementation project(':modules:services:compose')
-    implementation project(':modules:services:views')
-    implementation project(':modules:services:servers')
-    implementation project(':modules:services:repositories')
-    implementation project(':modules:services:model')
-    implementation project(':modules:services:analytics')
+    // features
+    implementation project(':modules:features:account')
     implementation project(':modules:features:podcasts')
     implementation project(':modules:features:search')
-    implementation project(':modules:features:account')
+
+    // services
+    implementation project(':modules:services:analytics')
+    implementation project(':modules:services:compose')
+    implementation project(':modules:services:localization')
+    implementation project(':modules:services:images')
+    implementation project(':modules:services:model')
+    implementation project(':modules:services:preferences')
+    implementation project(':modules:services:repositories')
+    implementation project(':modules:services:servers')
+    implementation project(':modules:services:utils')
+    implementation project(':modules:services:ui')
+    implementation project(':modules:services:views')
 }

--- a/modules/features/filters/build.gradle
+++ b/modules/features/filters/build.gradle
@@ -10,15 +10,18 @@ android {
 }
 
 dependencies {
-    implementation project(':modules:services:localization')
-    implementation project(':modules:services:preferences')
-    implementation project(':modules:services:utils')
-    implementation project(':modules:services:images')
-    implementation project(':modules:services:ui')
-    implementation project(':modules:services:compose')
-    implementation project(':modules:services:views')
-    implementation project(':modules:services:repositories')
-    implementation project(':modules:services:model')
-    implementation project(':modules:services:analytics')
+    // features
     implementation project(':modules:features:podcasts')
+
+    // services
+    implementation project(':modules:services:analytics')
+    implementation project(':modules:services:compose')
+    implementation project(':modules:services:images')
+    implementation project(':modules:services:localization')
+    implementation project(':modules:services:model')
+    implementation project(':modules:services:preferences')
+    implementation project(':modules:services:repositories')
+    implementation project(':modules:services:utils')
+    implementation project(':modules:services:ui')
+    implementation project(':modules:services:views')
 }

--- a/modules/features/podcasts/build.gradle
+++ b/modules/features/podcasts/build.gradle
@@ -10,18 +10,21 @@ android {
 }
 
 dependencies {
-    implementation project(':modules:services:localization')
-    implementation project(':modules:services:preferences')
-    implementation project(':modules:services:utils')
-    implementation project(':modules:services:images')
-    implementation project(':modules:services:ui')
-    implementation project(':modules:services:compose')
-    implementation project(':modules:services:views')
-    implementation project(':modules:services:servers')
-    implementation project(':modules:services:repositories')
-    implementation project(':modules:services:model')
-    implementation project(':modules:services:analytics')
+    // features
+    implementation project(':modules:features:account')
     implementation project(':modules:features:search')
     implementation project(':modules:features:settings')
-    implementation project(':modules:features:account')
+
+    // services
+    implementation project(':modules:services:analytics')
+    implementation project(':modules:services:compose')
+    implementation project(':modules:services:images')
+    implementation project(':modules:services:model')
+    implementation project(':modules:services:localization')
+    implementation project(':modules:services:preferences')
+    implementation project(':modules:services:repositories')
+    implementation project(':modules:services:servers')
+    implementation project(':modules:services:utils')
+    implementation project(':modules:services:ui')
+    implementation project(':modules:services:views')
 }

--- a/modules/features/profile/build.gradle
+++ b/modules/features/profile/build.gradle
@@ -13,20 +13,22 @@ android {
 }
 
 dependencies {
-    implementation project(':modules:services:localization')
-    implementation project(':modules:services:preferences')
-    implementation project(':modules:services:utils')
-    implementation project(':modules:services:analytics')
-    implementation project(':modules:services:images')
-    implementation project(':modules:services:ui')
-    implementation project(':modules:services:compose')
-    implementation project(':modules:services:views')
-    implementation project(':modules:services:servers')
-    implementation project(':modules:services:repositories')
-    implementation project(':modules:services:model')
-    implementation project(':modules:services:analytics')
-    implementation project(':modules:features:settings')
-    implementation project(':modules:features:podcasts')
-    implementation project(':modules:features:cartheme')
+    // features
     implementation project(':modules:features:account')
+    implementation project(':modules:features:cartheme')
+    implementation project(':modules:features:podcasts')
+    implementation project(':modules:features:settings')
+
+    // services
+    implementation project(':modules:services:analytics')
+    implementation project(':modules:services:compose')
+    implementation project(':modules:services:images')
+    implementation project(':modules:services:localization')
+    implementation project(':modules:services:model')
+    implementation project(':modules:services:preferences')
+    implementation project(':modules:services:repositories')
+    implementation project(':modules:services:servers')
+    implementation project(':modules:services:ui')
+    implementation project(':modules:services:utils')
+    implementation project(':modules:services:views')
 }

--- a/modules/services/compose/build.gradle
+++ b/modules/services/compose/build.gradle
@@ -10,11 +10,11 @@ android {
 }
 
 dependencies {
-    implementation project(':modules:services:localization')
-    implementation project(':modules:services:preferences')
-    implementation project(':modules:services:utils')
-    implementation project(':modules:services:ui')
     implementation project(':modules:services:images')
-    implementation project(':modules:services:repositories')
+    implementation project(':modules:services:localization')
     implementation project(':modules:services:model')
+    implementation project(':modules:services:preferences')
+    implementation project(':modules:services:repositories')
+    implementation project(':modules:services:ui')
+    implementation project(':modules:services:utils')
 }

--- a/modules/services/preferences/build.gradle
+++ b/modules/services/preferences/build.gradle
@@ -7,8 +7,8 @@ android {
 }
 
 dependencies {
-    implementation project(':modules:services:localization')
-    implementation project(':modules:services:utils')
-    implementation project(':modules:services:model')
     implementation project(':modules:services:images')
+    implementation project(':modules:services:localization')
+    implementation project(':modules:services:model')
+    implementation project(':modules:services:utils')
 }

--- a/modules/services/repositories/build.gradle
+++ b/modules/services/repositories/build.gradle
@@ -7,11 +7,11 @@ android {
 }
 
 dependencies {
-    implementation project(':modules:services:localization')
-    implementation project(':modules:services:utils')
+    implementation project(':modules:services:analytics')
     implementation project(':modules:services:images')
+    implementation project(':modules:services:localization')
+    implementation project(':modules:services:model')
     implementation project(':modules:services:preferences')
     implementation project(':modules:services:servers')
-    implementation project(':modules:services:model')
-    implementation project(':modules:services:analytics')
+    implementation project(':modules:services:utils')
 }

--- a/modules/services/servers/build.gradle
+++ b/modules/services/servers/build.gradle
@@ -7,9 +7,9 @@ android {
 }
 
 dependencies {
-    implementation project(':modules:services:localization')
-    implementation project(':modules:services:utils')
     implementation project(':modules:services:analytics')
-    implementation project(':modules:services:preferences')
+    implementation project(':modules:services:localization')
     implementation project(':modules:services:model')
+    implementation project(':modules:services:preferences')
+    implementation project(':modules:services:utils')
 }

--- a/modules/services/ui/build.gradle
+++ b/modules/services/ui/build.gradle
@@ -7,10 +7,10 @@ android {
 }
 
 dependencies {
-    implementation project(':modules:services:localization')
-    implementation project(':modules:services:preferences')
-    implementation project(':modules:services:utils')
     implementation project(':modules:services:images')
-    implementation project(':modules:services:repositories')
+    implementation project(':modules:services:localization')
     implementation project(':modules:services:model')
+    implementation project(':modules:services:preferences')
+    implementation project(':modules:services:repositories')
+    implementation project(':modules:services:utils')
 }

--- a/modules/services/views/build.gradle
+++ b/modules/services/views/build.gradle
@@ -13,14 +13,14 @@ android {
 }
 
 dependencies {
-    implementation project(':modules:services:localization')
-    implementation project(':modules:services:utils')
-    implementation project(':modules:services:preferences')
-    implementation project(':modules:services:model')
-    implementation project(':modules:services:ui')
+    implementation project(':modules:services:analytics')
     implementation project(':modules:services:compose')
     implementation project(':modules:services:images')
-    implementation project(':modules:services:servers')
+    implementation project(':modules:services:localization')
+    implementation project(':modules:services:model')
+    implementation project(':modules:services:preferences')
     implementation project(':modules:services:repositories')
-    implementation project(':modules:services:analytics')
+    implementation project(':modules:services:servers')
+    implementation project(':modules:services:ui')
+    implementation project(':modules:services:utils')
 }


### PR DESCRIPTION
# Description

Just a tiny bit of cleanup to make it easier to see whether a specific module dependency is already declared.

The only change here that is more than moving lines around is the removal of a duplicate declaration of the analytics dependency inside the profile module.

# Checklist

- [N/A] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [N/A] Have you tested in landscape?
- [N/A] Have you tested accessibility with TalkBack?
- [N/A] Have you tested in different themes?
- [N/A] Does the change work with a large display font?
- [N/A] Are all the strings localized?
- [N/A] Could you have written any new tests?
- [N/A] Did you include Compose previews with any components?