### PR TITLE
Enable gradle build cache when building pocket casts

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,4 @@ android.useAndroidX=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx8048M
 org.gradle.parallel=true
+org.gradle.caching=true


### PR DESCRIPTION
# Description

Build caching is off by default in Gradle

Details https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_enable

# Checklist

- [x] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [x] Have you tested in landscape?
- [x] Have you tested accessibility with TalkBack?
- [x] Have you tested in different themes?
- [x] Does the change work with a large display font?
- [x] Are all the strings localized?
- [x] Could you have written any new tests?
- [x] Did you include Compose previews with any components?