### PR TITLE
Disable unused Android Gradle Plugin features

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,12 @@
 android.nonTransitiveRClass=true
 android.useAndroidX=true
 
+# Disable unused Android Gradle Plugin features
+android.defaults.buildfeatures.aidl=false
+android.defaults.buildfeatures.renderscript=false
+android.defaults.buildfeatures.resvalues=false
+android.defaults.buildfeatures.shaders=false
+
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx8048M
 org.gradle.parallel=true


### PR DESCRIPTION
# Description

Disable unused Android Gradle Plugin features to speed up builds

Defaults are documented here:
https://developer.android.com/reference/tools/gradle-api/7.3/com/android/build/api/dsl/BuildFeatures?hl=en
