### PR TITLE
Fix for fullscreen player button not animating

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -185,7 +185,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
             val headerViewModel = it.podcastHeader
             binding.viewModel = headerViewModel
 
-            binding.largePlayButton.setPlaying(isPlaying = headerViewModel.isPlaying, animate = false)
+            binding.largePlayButton.setPlaying(isPlaying = headerViewModel.isPlaying, animate = true)
 
             val playerContrast1 = ThemeColor.playerContrast01(headerViewModel.theme)
             binding.largePlayButton.setCircleTintColor(playerContrast1)


### PR DESCRIPTION
# Description

Setting animate to true so the animation is played when isPlaying changes state

Fixes #207 