### PR TITLE
Hide next episode date if unknown

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -401,7 +401,6 @@
     <string name="podcast_group_unplayed" translatable="false">@string/unplayed</string>
     <string name="podcast_hide_archived">Hide archived</string>
     <string name="podcast_load_error">There was an error loading the podcast.</string>
-    <string name="podcast_next_episode" translatable="false">@string/next_episode</string>
     <string name="podcast_next_episode_any_day_now">Next episode any day now</string>
     <string name="podcast_next_episode_today">Next episode today</string>
     <string name="podcast_next_episode_tomorrow">Next episode tomorrow</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
@@ -195,18 +195,18 @@ data class Podcast(
     }
 
     @Suppress("DEPRECATION")
-    fun displayableNextEpisodeDate(resources: Resources): String {
-        val expectedDate = estimatedNextEpisode ?: return resources.getString(LR.string.podcast_next_episode)
+    fun displayableNextEpisodeDate(resources: Resources): String? {
+        val expectedDate = estimatedNextEpisode ?: return null
         val expectedTime = expectedDate.time
         if (expectedTime <= 0) {
-            return resources.getString(LR.string.podcast_next_episode)
+            return null
         }
         val sevenDaysInMs = 7 * DateUtils.DAY_IN_MILLIS
         val now = System.currentTimeMillis()
         val sevenDaysAgo = now - sevenDaysInMs
         val sevenDaysFuture = now + sevenDaysInMs
         return when {
-            expectedTime < sevenDaysAgo -> resources.getString(LR.string.podcast_next_episode)
+            expectedTime < sevenDaysAgo -> null
             DateUtils.isToday(expectedTime) -> resources.getString(LR.string.podcast_next_episode_today)
             DateUtils.isToday(expectedTime - DateUtils.DAY_IN_MILLIS) -> resources.getString(LR.string.podcast_next_episode_tomorrow)
             expectedTime in sevenDaysAgo..now -> resources.getString(LR.string.podcast_next_episode_any_day_now)


### PR DESCRIPTION
Some podcasts don't have an expected next episode date. This happens for shows with an inconsistent release schedule. Previously it would show "Next episode" with no date. Now that section is completely hidden.

Before:
<img width="444" alt="Screen Shot 2022-10-19 at 10 18 59 PM" src="https://user-images.githubusercontent.com/6628497/196841568-6b4e617b-980d-489b-b0eb-0913fedf4cc3.png">

After:
<img width="443" alt="Screen Shot 2022-10-19 at 10 16 59 PM" src="https://user-images.githubusercontent.com/6628497/196841611-2be5945d-3c8d-4be2-b84a-61e9e0dfee08.png">

For context, this is what it looks like for episodes where the next date is predicted (both before and after this change)

<img width="443" alt="Screen Shot 2022-10-19 at 10 22 46 PM" src="https://user-images.githubusercontent.com/6628497/196841807-91cdb65d-9762-43e2-a1f0-e346b7666307.png">