### PR TITLE
Initial value for skip backwards setting uses the skip forwards value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 *   New Features:
     *   Added a Halloween icon.
         ([#415](https://github.com/Automattic/pocket-casts-android/pull/415)).
+    *   Fixed skip backwards settings
+        ([#425](https://github.com/Automattic/pocket-casts-android/pull/425)).
 
 7.25
 -----

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -150,7 +150,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                     SkipTime(
                         primaryText = stringResource(LR.string.settings_skip_back_time),
                         saved = settings.skipBackwardInSecsObservable
-                            .subscribeAsState(settings.getSkipForwardInSecs())
+                            .subscribeAsState(settings.getSkipBackwardInSecs())
                             .value,
                         onSave = settings::setSkipBackwardInSec
                     )


### PR DESCRIPTION
Just spotted this minor issue, looks like a bad copy paste maybe 😄

The initial value for the skip backwards setting was using the skip forwards value instead of the skip backwards value.
