### PR TITLE
Fix for different background in Compose theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
         ([#415](https://github.com/Automattic/pocket-casts-android/pull/415)).
     *   Fixed skip backwards settings
         ([#425](https://github.com/Automattic/pocket-casts-android/pull/425)).
+    *   Fixed background color for screens using the compose theme
+        ([#432](https://github.com/Automattic/pocket-casts-android/pull/432)).
 
 7.25
 -----

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/Theme.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/Theme.kt
@@ -104,7 +104,7 @@ private fun buildMaterialColors(colors: ThemeColors, isLight: Boolean): Colors {
         primaryVariant = colors.primaryInteractive01,
         secondary = colors.primaryInteractive01,
         secondaryVariant = colors.primaryInteractive01,
-        background = colors.primaryUi04,
+        background = colors.primaryUi01,
         surface = colors.primaryUi01,
         error = colors.support05,
         onPrimary = colors.primaryInteractive02,


### PR DESCRIPTION
Background color in the compose theme was slightly different to the background color used in non-compose screens

Fixes #251 

Attached matching screenshots from the ones seen in the linked issue with the correct background color:

![Screenshot_20221020_171321](https://user-images.githubusercontent.com/22520267/197002507-df27a6ae-59b8-4f61-aa95-49a348583cff.png)
![Screenshot_20221020_171301](https://user-images.githubusercontent.com/22520267/197002512-625c13a2-0a18-48ee-bbe5-1c8352e5c4a0.png)
