### PR TITLE
Add POST_NOTIFICATIONS permission to 7.24.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 7.25
 -----
 
+7.24.2
+-----
 
-7.24
+*   Bug Fixes:
+    *   Add missing POST_NOTIFICATIONS permission for Android 13
+        ([#330](https://github.com/Automattic/pocket-casts-android/pull/436)).
+
+7.24.0
 -----
 
 *   Bug Fixes:

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
     <uses-permission android:name="com.android.vending.BILLING" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 


### PR DESCRIPTION
# Description

I missed adding the `POST_NOTIFICATIONS` permission when I [updated us to target Android 13](https://github.com/Automattic/pocket-casts-android/pull/312). That meant that our app wouldn't be allowed to post notifications on Android 13 devices 😞 

> **Warning**
> I think this should be a new hotfix, so I created a `release/7.24.2` branch and am targeting that with this PR. I created a separate PR to pull this change into `release/7.25` for a 7.25 betafix release.

Fixes #430 

## To Test

1. Install on a device running Android 13
2. Verify that if you go into the systems app settings for Pocket Casts that the notifications toggle can be turned on

## Checklist

- [x] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [x] Have you tested in landscape?
- [x] Have you tested accessibility with TalkBack?
- [x] Have you tested in different themes?
- [x] Does the change work with a large display font?
- [x] Are all the strings localized?
- [x] Could you have written any new tests?
- [x] Did you include Compose previews with any components?