### PR TITLE
Add POST_NOTIFICATIONS permission to 7.25 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,15 @@
         ([#389](https://github.com/Automattic/pocket-casts-android/pull/389)).
     *   Added new episode lists to Automotive OS. Starred, Listening History, and Files.
         ([#403](https://github.com/Automattic/pocket-casts-android/pull/403)).
+    * 
+7.24.2
+-----
 
-7.24
+*   Bug Fixes:
+    *   Add missing POST_NOTIFICATIONS permission for Android 13
+        ([#330](https://github.com/Automattic/pocket-casts-android/pull/436)).
+
+7.24.0
 -----
 
 *   Bug Fixes:

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
     <uses-permission android:name="com.android.vending.BILLING" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 


### PR DESCRIPTION
# Description

See https://github.com/Automattic/pocket-casts-android/pull/436 for the description of this PR. This PR is just bringing that hotfix change into the 7.25 release.

> **Warning**
> Note that this is targeting the `release/7.25` branch.

# Checklist

- [X] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [X] Are all the strings localized?
- [X] Could you have written any new tests?
- [X] Did you include Compose previews with any components?