### PR TITLE
Update feature request issue template label

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature suggestion
 description: Propose a feature in the Pocket Casts Android app
-labels: ["feature", "triage"]
+labels: ["feature request", "triage"]
 body:
 
     - type: markdown


### PR DESCRIPTION
I updated the label's name from "feature" to "feature request" to make it more descriptive in GitHub, and that seems broke this template so that it no longer adds the "feature"/"feature request" label. I assume this change will fix that.