### PR TITLE
Sets textZoom to 100 for webview

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
@@ -89,6 +89,7 @@ class HelpFragment : Fragment(), HasBackstack, Toolbar.OnMenuItemClickListener {
             webViewClient = SupportWebViewClient()
             loadUrl(loadedUrl ?: "https://support.pocketcasts.com/android/?device=android")
             settings.javaScriptEnabled = true
+            settings.textZoom = 100
         }
         loadingView = view.findViewById(VR.id.progress_circle)
         layoutError = view.findViewById(VR.id.layoutLoadingError)


### PR DESCRIPTION
# Description

The webview in the Help & Feedback section was affected by the user's display size settings, which was causing the buttons in the Get in touch modal to overlap. Setting the textZoom to 100 will alleviate the problem on that particular webview. 

Fixes # (Help & Feedback: Get in touch: Buttons overlap out of the container #114)

# Checklist

- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [X] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [ ] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?

![Screenshot (Oct 21, 2022 3 41 18 PM)](https://user-images.githubusercontent.com/85636562/197276624-f4a3d9dd-d10a-45fc-8c64-05d5fd7bf4f1.png)