### PR TITLE
Do not replace timeskip when it is in a URL

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/views/helper/ShowNotesHelperTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/views/helper/ShowNotesHelperTest.kt
@@ -31,5 +31,10 @@ class ShowNotesHelperTest {
         actual = ShowNotesHelper.convertTimesToLinks("<li><a href=\"https://overcast.fm/+BtuyYAAIQ/16:45\">Confirmation of John's prediction about face swipe timing</a></li>")
         expected = "<li><a href=\"https://overcast.fm/+BtuyYAAIQ/16:45\">Confirmation of John's prediction about face swipe timing</a></li>"
         assertEquals(actual, expected)
+
+        // Do not replace timeskip when it is in an URL - https://github.com/Automattic/pocket-casts-android/issues/145
+        actual = ShowNotesHelper.convertTimesToLinks("<li><a href=\"https://www.theverge.com/2021/12/21/22848957/lg-dualup-32-inch-4k-ultra-fine-monitors-announced-specs\">LG’s new 16:18 monitor looks like a multitasking powerhouse</a></li>")
+        expected = "<li><a href=\"https://www.theverge.com/2021/12/21/22848957/lg-dualup-32-inch-4k-ultra-fine-monitors-announced-specs\">LG’s new 16:18 monitor looks like a multitasking powerhouse</a></li>"
+        assertEquals(actual, expected)
     }
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ShowNotesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ShowNotesHelper.kt
@@ -3,6 +3,19 @@ package au.com.shiftyjelly.pocketcasts.views.helper
 object ShowNotesHelper {
 
     fun convertTimesToLinks(html: String): String {
-        return html.replace("(\\A|\\s|>|[^a-zsA-Z_0-9/])(\\d{0,2}:?\\d{1,2}:\\d{2})(<|\\s|\\z|[^a-zsA-Z_0-9\"])".toRegex(), "$1<a href=\"http://localhost/#playerJumpTo=$2\">$2</a>$3")
+        return html.replace("(\\A|\\s|>|[^a-zsA-Z_0-9/])(\\d{0,2}:?\\d{1,2}:\\d{2})(<|\\s|\\z|[^a-zsA-Z_0-9\"])".toRegex()) { match ->
+            return@replace if (matchIsInUrl(match, html)) {
+                match.value
+            } else {
+                val (prefix, timeskip, suffix) = match.destructured
+                "$prefix<a href=\"http://localhost/#playerJumpTo=$timeskip\">$timeskip</a>$suffix"
+            }
+        }
+    }
+
+    // searches for the first closing tag that comes after a potential timeskip and compares it to url closing tag (</a>)
+    private fun matchIsInUrl(match: MatchResult, html: String): Boolean {
+        val closingTagRegex = "</\\w+>".toRegex()
+        return closingTagRegex.find(html.substring(match.range.first))?.value == "</a>"
     }
 }


### PR DESCRIPTION
# Description
A bug occurs in the show notes when a URL contains a text formatted like a timeskip. In this scenario, the text should not be replaced, as it will break the URL.

Fixes #145

# What is done
I wrote a method that checks whether a potential timeskip is in a URL by finding the nearest HTML closing tag to the potential timeskip. 
I have also written a new test that checks the exact string the issue occurred on.

# Checklist

- [x] In "Rebuild - Tatsuhiko Miyagawa" episode 325 text formatted like timeskip is not replaced by timeskip
- [x] In "Foundation - True Ventures" episode 8, timeskips work properly
- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [x] Have you tested in landscape?
- [x] Have you tested accessibility with TalkBack?
- [x] Have you tested in different themes?
- [ ] Does the change work with a large display font?
- [ ] ~Are all the strings localized?~ I havent touched any string resources
- [x] Could you have written any new tests?
- [ ] ~Did you include Compose previews with any components?~ I havent used compose

Video:

https://user-images.githubusercontent.com/116375788/197280193-75359b20-fa41-480e-b8ab-e389556aa872.mp4

