### PR TITLE
fix When no podcasts were selected in filter, all podcasts selected chip should be visible

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
@@ -117,7 +117,7 @@ class PodcastOptionsFragment : BaseFragment(), PodcastSelectFragment.Listener, C
         btnSave.setOnClickListener {
             playlist?.let { playlist ->
                 playlist.podcastUuidList = podcastSelection
-                playlist.allPodcasts = switchAllPodcasts.isChecked
+                playlist.allPodcasts = switchAllPodcasts.isChecked || playlist.podcastUuidList.isEmpty()
                 launch(Dispatchers.Default) {
                     playlist.syncStatus = Playlist.SYNC_STATUS_NOT_SYNCED
 


### PR DESCRIPTION
# Description

fixed bug When no podcasts were selected in filter fragment, all podcasts selected should have been visible in chips instead of 0 podcasts.

Fixes #75 

# Checklist

- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [ ] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [ ] Have you tested in different themes?
- [ ] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?