### PR TITLE
fix When no podcasts were selected in filter, 'all your podcasts' chip should be visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
     *   Fixed Help & Feedback buttons being hidden when using text zoom.
         ([#446](https://github.com/Automattic/pocket-casts-android/pull/446)).
     *   Fixed When no podcasts were selected for a filter, change the chip to 'All Your Podcasts'
-        ([#75])(https://github.com/Automattic/pocket-casts-android/issues/75)
+        ([#75](https://github.com/Automattic/pocket-casts-android/issues/75)).
 
 7.25
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 *   Bug Fixes:
     *   Fixed Help & Feedback buttons being hidden when using text zoom.
         ([#446](https://github.com/Automattic/pocket-casts-android/pull/446)).
+    *   Fixed When no podcasts were selected for a filter, change the chip to 'All Your Podcasts'
+        ([#75])(https://github.com/Automattic/pocket-casts-android/issues/75)
 
 7.25
 -----

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
@@ -117,7 +117,7 @@ class PodcastOptionsFragment : BaseFragment(), PodcastSelectFragment.Listener, C
         btnSave.setOnClickListener {
             playlist?.let { playlist ->
                 playlist.podcastUuidList = podcastSelection
-                playlist.allPodcasts = switchAllPodcasts.isChecked
+                playlist.allPodcasts = switchAllPodcasts.isChecked || podcastSelection.isEmpty()
                 launch(Dispatchers.Default) {
                     playlist.syncStatus = Playlist.SYNC_STATUS_NOT_SYNCED
 


### PR DESCRIPTION
# Description

fixed bug When no podcasts were selected in filter fragment, all podcasts selected should have been visible in chips instead of 0 podcasts.
bug was in the update playlist logic, there was no check if podcastSelection was empty or not.

Fixes #75

# Checklist

- [x] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [ ] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [ ] Have you tested in different themes?
- [ ] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?