### PR TITLE
Fix issue when system bar didn't disappear on full screen video player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 *   Bug Fixes:
     *   Fixed Help & Feedback buttons being hidden when using text zoom.
         ([#446](https://github.com/Automattic/pocket-casts-android/pull/446)).
+    *   Fixed when system bar didn't disappear on full screen video player
+        ([#461](https://github.com/Automattic/pocket-casts-android/pull/461)).
 
 7.25
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
@@ -136,10 +136,12 @@ class VideoFragment : Fragment(), PlayerSeekBar.OnUserSeekListener {
 
     private fun hideSystemUi() {
         getInsetsController()?.hide(WindowInsetsCompat.Type.statusBars())
+        getInsetsController()?.hide(WindowInsetsCompat.Type.navigationBars())
     }
 
     private fun showSystemUi() {
         getInsetsController()?.show(WindowInsetsCompat.Type.statusBars())
+        getInsetsController()?.show(WindowInsetsCompat.Type.navigationBars())
     }
 
     private fun getInsetsController(): WindowInsetsControllerCompat? {


### PR DESCRIPTION
# Description
System bar wasn't disapearing on full screen after when user tapped on screen

Fixes #115

# Checklist

- [x] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [x] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [ ] Have you tested in different themes?
- [ ] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?