### PR TITLE
Fix pr template link

### DIFF
--- a/docs/pull-request-guidelines.md
+++ b/docs/pull-request-guidelines.md
@@ -27,6 +27,6 @@ All released versions are tagged with the version number. For example, the 7.19.
 
 When you are ready, please, spend time crafting a good Pull Request, since it will have a huge impact on the work of reviewers, release managers and testers.
 
-We have a [Pull Request template](.github/pull_request_template.md) to help. 
+We have a [Pull Request template](../.github/pull_request_template.md) to help. 
 
 _Thank you very much for contributing to Pocket Casts Android!_


### PR DESCRIPTION
# Description

- Fixes the link for pull request template in `pull-request-guidelines.md`
- Without the fix, the link doesn't redirect to the correct page

# Checklist

- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [ ] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [ ] Have you tested in different themes?
- [ ] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?