### PR TITLE
Fix issue with full screen video player not closing on the first time

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -266,7 +266,6 @@ class MainActivity :
         if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
             if (!videoPlayerShown && playbackManager.getCurrentEpisode()?.isVideo == true && playbackManager.isPlaybackLocal() && playbackManager.isPlaying() && viewModel.isPlayerOpen) {
                 openFullscreenViewPlayer()
-                videoPlayerShown = true
             } else {
                 videoPlayerShown = false
             }
@@ -274,6 +273,7 @@ class MainActivity :
     }
 
     private fun openFullscreenViewPlayer() {
+        videoPlayerShown = true
         startActivity(VideoActivity.buildIntent(context = this))
     }
 


### PR DESCRIPTION
# Description

Video player in the full screen module (landscape) was not closing on the first time we clicked on 'X' button, because MainActivity didn't update videoPlayerShown value when we clicked play/pause button

moved videoPlayerShown updating logic in the openFullscreenViewPlayer, because its called in 2 places and it's better to have one place to assing value, rather than in 2 places

Fixes #463 

# Checklist

- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [ ] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [ ] Have you tested in different themes?
- [ ] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?