### PR TITLE
Trust user certificates on debug builds

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,7 @@
             android:supportsRtl="false"
             tools:replace="android:supportsRtl"
             android:theme="@style/ThemeDark"
+            android:networkSecurityConfig="@xml/network_security_config"
             tools:ignore="UnusedAttribute">
 
         <meta-data android:name="com.google.android.gms.car.application"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+<debug-overrides>
+    <trust-anchors>
+        <!-- Trust user added CAs while debuggable only -->
+        <certificates src="user" />
+    </trust-anchors>
+</debug-overrides>
+</network-security-config>


### PR DESCRIPTION
## Description

Makes it easier to use something like Charles proxy to inspect our https calls on debug builds.

I followed the instructions from these two sources:
- [Android documationation](https://developer.android.com/training/articles/security-config#TrustingDebugCa)
- [Charles Proxy documentation](https://www.charlesproxy.com/documentation/using-charles/ssl-certificates/)

When testing this on release builds I did get [this crash](https://sentry.io/organizations/a8c/issues/3693580607/?project=6711064&referrer=release-issue-stream) a couple of times, but then it went away and I couldn't recreate it. Not sure if I was just doing something weird with my build or what was going on there.

#### To Test

##### Debug Build
1. Follow instructions for installing Charles certificate on your device
2. Set your device up to proxy through Charles (as part of this, make sure you install the Charles SSL cert on your device)
4. Turn on SSL proxying for one of the app's https calls
5. Have the app make that call
6. Confirm that you can inspect the call through Charles

##### Release Build
1. Follow steps 1 through 4 above
2. Observe that the app crashes because we don't trust the Charles certificate on release builds (I was a bit surprised to see the app crash here, I thought we just wouldn't be able to inspect the call. I think I'm doing everything right though).
3. Set your device up to _not_ proxy through Charles
4. Have the app make an https call
5. Confirm that you cannot inspect the call in Charles. _I had one release build that crashed in this scenario, but I can't recreate it, so I think I just did something weird with that build. Definitely worth keeping an eye out for though._

# Checklist

- [X] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [X] Are all the strings localized?
- [X] Could you have written any new tests?
- [X] Did you include Compose previews with any components?