### PR TITLE
Adding formatting check to CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,12 @@ steps:
       ./gradlew testDebugUnitTest
     plugins: *common_plugins
 
+  - label: 'Spotless formatting check'
+    command: |
+      echo "--- 🔎 Checking formatting with Spotless"
+      ./gradlew spotlessCheck
+    plugins: *common_plugins
+
   - label: 'Lint'
     command: |
       echo "--- 🧹 Linting"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ We always try to avoid duplicating efforts, so if you decide to work on an issue
 
 If the change is trivial, feel free to send a pull request without notifying us.
 
+We use [Spotless](https://github.com/diffplug/spotless) to maintain a consistent code style consistent. Please run the `spotlessCheck` gradle task to check for any issues with your code (which can be fixed with `spotlessApply`).
+
 ### Pull Requests and Code Reviews
 
 All code contributions pass through pull requests. If you haven't created a pull request before, we recommend this free video series, [How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github).
@@ -40,4 +42,4 @@ Note: If you are part of the org and have the permissions on the repo, don't for
 
 * PRs require one reviewer to approve the PR before it can be merged to the base branch
 * We keep the PR git history when merging (merge via "merge commit")
-* The reviewer who approved the PR will merge it right after approval (without waiting for the PR author) if all checks are green.
+* The reviewer who approved the PR may merge it right after approval (without waiting for the PR author) if all checks are green.

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/ComposableBase.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/ComposableBase.kt
@@ -108,7 +108,7 @@ fun <T> ComposableTaskerInputField(content: TaskerInputFieldState.Content<T>) {
                     }
                 }
             )
-            val dropdownMaxHeight = screenSize.height / 6 * 2 //at most dropdown can be 2/6 of the screen size so it doesn't draw over its parent
+            val dropdownMaxHeight = screenSize.height / 6 * 2 // at most dropdown can be 2/6 of the screen size so it doesn't draw over its parent
             if (hasTaskerVariables) {
                 DropdownMenu(
                     modifier = Modifier.requiredSizeIn(maxHeight = dropdownMaxHeight),

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/Extensions.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/Extensions.kt
@@ -14,7 +14,7 @@ fun <T> tryOrNull(handleError: ((Throwable) -> T?)? = null, block: () -> T?): T?
 
 val screenSize
     @Composable
-    get() :DpSize {
+    get(): DpSize {
         val configuration = LocalConfiguration.current
 
         val screenHeight = configuration.screenHeightDp.dp

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/ViewModelBase.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/ViewModelBase.kt
@@ -8,7 +8,6 @@ import com.joaomgcd.taskerpluginlibrary.action.TaskerPluginRunnerActionNoOutput
 import com.joaomgcd.taskerpluginlibrary.config.TaskerPluginConfig
 import com.joaomgcd.taskerpluginlibrary.config.TaskerPluginConfigHelperNoOutput
 import com.joaomgcd.taskerpluginlibrary.input.TaskerInput
-import kotlinx.coroutines.flow.MutableStateFlow
 
 abstract class ViewModelBase<TInput : Any, THelper : TaskerPluginConfigHelperNoOutput<TInput, out TaskerPluginRunnerActionNoOutput<TInput>>>(application: Application) : AndroidViewModel(application), TaskerPluginConfig<TInput> {
     override val context get() = getApplication<Application>()

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/config/ViewModelConfigControlPlayback.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/config/ViewModelConfigControlPlayback.kt
@@ -6,8 +6,8 @@ import au.com.shiftyjelly.pocketcasts.taskerplugin.controlplayback.ActionHelperC
 import au.com.shiftyjelly.pocketcasts.taskerplugin.controlplayback.InputControlPlayback
 import com.joaomgcd.taskerpluginlibrary.config.TaskerPluginConfig
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
+import javax.inject.Inject
 
 @HiltViewModel
 class ViewModelConfigControlPlayback @Inject constructor(
@@ -59,24 +59,21 @@ class ViewModelConfigControlPlayback @Inject constructor(
             optionalFields.forEach { it.updateAskForState() }
         }
 
-
     val availableCommands get() = InputControlPlayback.PlaybackCommand.values()
 
     /*Chapter To skip to*/
     val shouldAskForChapter get() = optionalFieldChapterToSkipTo.shouldAskForState
     val chapterToSkipTo get() = optionalFieldChapterToSkipTo.valueState
-    fun setChapterToSkipTo(value:String){
+    fun setChapterToSkipTo(value: String) {
         optionalFieldChapterToSkipTo.value = value
     }
     /*End chapter To skip to*/
 
-
     /*Time To skip to*/
     val showAskForTime get() = optionalFieldTimeToSkipTo.shouldAskForState
     val timeToSkipTo get() = optionalFieldTimeToSkipTo.valueState
-    fun setTimeToSkipTo(value:String){
+    fun setTimeToSkipTo(value: String) {
         optionalFieldTimeToSkipTo.value = value
     }
     /*End time To skip to*/
-
 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/TimberDebugTree.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/TimberDebugTree.kt
@@ -2,9 +2,9 @@ package au.com.shiftyjelly.pocketcasts.utils
 
 import android.os.Build
 import android.util.Log
+import timber.log.Timber
 import java.util.regex.Pattern
 import kotlin.math.min
-import timber.log.Timber
 
 class TimberDebugTree : Timber.Tree() {
 


### PR DESCRIPTION
# Description

Have CI start running Spotless so that our formatting conventions are enforced even if a contributor does not have [our pre-commit hook](https://github.com/Automattic/pocket-casts-android/blob/main/scripts/git-hooks/pre-commit.sh) installed.

You can see the formatting check job failing on CI for this branch until I added [709d3fc](https://github.com/Automattic/pocket-casts-android/pull/473/commits/709d3fcdce0afdbea7d262923ce08fe3ac9fa950) to the branch, which fixes the formatting issues currently on `main`: https://buildkite.com/automattic/pocket-casts-android/builds?branch=update%2Fspotless-on-ci

I am a bit concerned that, as I understand it, external contributors cannot see the logs for the Spotless check because they would need access to our Buildkite org. I could see that leading to some confusion about what is going wrong. I added a line to our contributing guide to help with this a bit, but I doubt that's enough to avoid confusion.

> **Note**
> Once this is merged. I think we should wait a bit of time so this change has a chance to make it to most contributor's branches—then let's add this as a required check from within GitHub.

# Checklist

- [X] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [X] Have you tested in landscape?
- [X] Have you tested accessibility with TalkBack?
- [X] Have you tested in different themes?
- [X] Does the change work with a large display font?
- [X] Are all the strings localized?
- [X] Could you have written any new tests?
- [X] Did you include Compose previews with any components?