### PR TITLE
Add margin to Tasker plugin UI

### DIFF
--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/ComposableBase.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/ComposableBase.kt
@@ -164,7 +164,9 @@ fun ComposableTaskerInputFieldList(
     fieldContents: List<TaskerInputFieldState.Content<*>>,
     onFinish: () -> Unit
 ) {
-    Box(modifier = Modifier.fillMaxHeight()) {
+    Box(modifier = Modifier
+            .padding(8.dp)
+            .fillMaxHeight()) {
         LazyColumn {
             fieldContents.forEach { content ->
                 item {


### PR DESCRIPTION
# Description

As the first time I've ever run an Android application locally or touched a Kotlin file, I'll call this a win.

I plan to follow up on additional improvements to this UI to make it resemble the filters tab, however, that will likely take me a bit as a novice mobile developer so I wanted to push this minor tweak first :)

Related to #471 (does not close)

# Checklist

- [x] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md (no)
- [x] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [ ] Have you tested in different themes?
- [ ] Does the change work with a large display font?
- [ ] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?