### PR TITLE
improve nullability of OpmlExporter when sharing files

### DIFF
--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/FileUtil.java
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/FileUtil.java
@@ -5,6 +5,8 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+
+import androidx.annotation.NonNull;
 import androidx.core.content.FileProvider;
 import java.io.BufferedReader;
 import java.io.File;
@@ -179,7 +181,7 @@ public class FileUtil {
     }
 
 
-    public static Uri createUriWithReadPermissions(File file, Intent intent, Context context) {
+    public static Uri createUriWithReadPermissions(@NonNull File file, @NonNull Intent intent, @NonNull Context context) {
         Uri uri = FileProvider.getUriForFile(context, context.getApplicationContext().getPackageName() + ".fileprovider", file);
         // give the email clients read access
         List<ResolveInfo> resInfoList = context.getPackageManager().queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/OpmlExporter.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/OpmlExporter.kt
@@ -110,7 +110,7 @@ class OpmlExporter(private val fragment: PreferenceFragmentCompat, private val s
                             UiUtil.hideProgressDialog(progressDialog)
                             val opmlFile = opmlFile
                             if (opmlFile != null && opmlFile.exists()) {
-                                if (sendAsEmail) sendIntentEmail() else sendIntentFile()
+                                if (sendAsEmail) sendIntentEmail(opmlFile) else sendIntentFile(opmlFile)
                             }
                         } catch (e: Exception) {
                             UiUtil.hideProgressDialog(progressDialog)
@@ -122,11 +122,11 @@ class OpmlExporter(private val fragment: PreferenceFragmentCompat, private val s
         }
     }
 
-    private fun sendIntentFile() {
+    private fun sendIntentFile(file: File) {
         try {
             val intent = Intent(Intent.ACTION_SEND)
             intent.type = "text/xml"
-            val uri = FileUtil.createUriWithReadPermissions(opmlFile, intent, fragment.activity)
+            val uri = FileUtil.createUriWithReadPermissions(file, intent, fragment.requireActivity())
             intent.putExtra(Intent.EXTRA_STREAM, uri)
             try {
                 context.startActivity(intent)
@@ -139,7 +139,7 @@ class OpmlExporter(private val fragment: PreferenceFragmentCompat, private val s
         }
     }
 
-    private fun sendIntentEmail() {
+    private fun sendIntentEmail(file: File) {
         try {
             val intent = Intent(Intent.ACTION_SEND)
             intent.type = "text/html"
@@ -151,7 +151,7 @@ class OpmlExporter(private val fragment: PreferenceFragmentCompat, private val s
 
             intent.putExtra(Intent.EXTRA_SUBJECT, context.getString(LR.string.settings_opml_email_subject))
             intent.putExtra(Intent.EXTRA_TEXT, HtmlCompat.fromHtml(context.getString(LR.string.settings_opml_email_body), HtmlCompat.FROM_HTML_MODE_COMPACT))
-            val uri = FileUtil.createUriWithReadPermissions(opmlFile, intent, fragment.activity)
+            val uri = FileUtil.createUriWithReadPermissions(file, intent, fragment.requireActivity())
             intent.putExtra(Intent.EXTRA_STREAM, uri)
             try {
                 context.startActivity(intent)


### PR DESCRIPTION
# Description

Improve nullability of OpmlExporter by using the already null-checked file instead of global var when sharing files - this is in preparation of converting `FileUtil` to Kotlin.

Fixes # (issue)

# Checklist

- [x] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [x] Have you tested in landscape?
- [x] Have you tested accessibility with TalkBack?
- [x] Have you tested in different themes?
- [x] Does the change work with a large display font?
- [x] Are all the strings localized?
- [x] Could you have written any new tests?
- [x] Did you include Compose previews with any components?