### PR TITLE
Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,25 @@
-# Description
+## Description
+<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
 
-Please include a summary of the changes and the related issue.
+Fixes # <!-- issue number, if applicable -->
 
-Fixes # (issue)
+## Testing Instructions
+<!-- Please include step by step instructions on how to test this PR. -->
+<!-- 1. Tap on the Filters tab -->
+<!-- 2. Tap on a filter -->
+<!-- 3. etc. -->
 
-# Checklist
+## Screenshots or Screencast 
+<!-- if applicable -->
 
-- [ ] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
-- [ ] Have you tested in landscape?
-- [ ] Have you tested accessibility with TalkBack?
-- [ ] Have you tested in different themes?
-- [ ] Does the change work with a large display font?
-- [ ] Are all the strings localized?
-- [ ] Could you have written any new tests?
-- [ ] Did you include Compose previews with any components?
+## Checklist
+- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
+- [ ] I have considered whether it makes sense to add tests for my changes
+- [ ] Any jetpack compose components I added or changed are covered by compose previews
+ 
+#### I have tested any UI changes...
+<!-- If this PR does not contain UI changes, ignore these items -->
+- [ ] with different themes
+- [ ] with a landscape orientation
+- [ ] with the device set to have a large display and font size
+- [ ] for accessibility with TalkBack

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,7 @@ Fixes # <!-- issue number, if applicable -->
 ## Checklist
 - [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
 - [ ] I have considered whether it makes sense to add tests for my changes
+- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
 - [ ] Any jetpack compose components I added or changed are covered by compose previews
  
 #### I have tested any UI changes...


### PR DESCRIPTION
# Description

The main motivation for this PR was to add a section for testing instructions to the PR template. I think that this makes reviewing a PR much easier, particularly when it comes from an open source contributor where there may be less context around the change.

This is just a proposal. I'm definitely open to modifying this or not merging these changes.

--------------

# What this template looks like ⬇️ 

## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Fixes # <!-- issue number, if applicable -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
