### PR TITLE
Redesign the long press option in the fullscreen player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
         ([#482](https://github.com/Automattic/pocket-casts-android/pull/482)).
     *   Redesign of the fullscreen player share option
         ([#451](https://github.com/Automattic/pocket-casts-android/pull/451)).
+    *   Redesign of the fullscreen player long press option
+        ([#483](https://github.com/Automattic/pocket-casts-android/pull/483)).
 *   Bug Fixes:
     *   Fixed Help & Feedback buttons being hidden when using text zoom.
         ([#446](https://github.com/Automattic/pocket-casts-android/pull/446)).

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/LongPressOptionsFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/LongPressOptionsFragment.kt
@@ -1,0 +1,54 @@
+package au.com.shiftyjelly.pocketcasts.player.view
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.fragment.app.activityViewModels
+import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentLongPressOptionsBinding
+import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.views.extensions.applyColor
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class LongPressOptionsFragment : BaseDialogFragment() {
+
+    override val statusBarColor: StatusBarColor? = null
+
+    private val viewModel: PlayerViewModel by activityViewModels()
+    private var binding: FragmentLongPressOptionsBinding? = null
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        val binding = FragmentLongPressOptionsBinding.inflate(inflater, container, false)
+        this.binding = binding
+
+        binding.buttonMarkPlayed.setOnClickListener {
+            viewModel.onMarkAsPlayedClick()
+            dismiss()
+        }
+        binding.buttonNextEpisode.setOnClickListener {
+            viewModel.onNextEpisodeClick()
+            dismiss()
+        }
+
+        binding.nextEpisode.isVisible = viewModel.hasNextEpisode()
+
+        return binding.root
+    }
+
+    @Suppress("DEPRECATION")
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
+        viewModel.playingEpisodeLive.observe(viewLifecycleOwner) { (_, backgroundColor) ->
+            applyColor(theme, backgroundColor)
+        }
+
+        (dialog as? BottomSheetDialog)?.behavior?.state = BottomSheetBehavior.STATE_EXPANDED
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -436,7 +436,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
     }
 
     override fun onSkipForwardLongPress() {
-        viewModel.longSkipForwardOptionsDialog().show(parentFragmentManager, "longpressoptions")
+        LongPressOptionsFragment().show(parentFragmentManager, "longpressoptions")
     }
 
     override fun onEffectsClick() {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -39,7 +39,6 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
-import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.helper.CloudDeleteHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.DeleteState
 import com.jakewharton.rxrelay2.BehaviorRelay
@@ -387,20 +386,18 @@ class PlayerViewModel @Inject constructor(
         playbackManager.skipForward(playbackSource = playbackSource)
     }
 
-    fun longSkipForwardOptionsDialog(): OptionsDialog {
-        var optionsDialogBuilder = OptionsDialog().setForceDarkTheme(true)
-        optionsDialogBuilder = optionsDialogBuilder.addTextOption(titleId = LR.string.mark_played) {
-            playbackManager.upNextQueue.currentEpisode?.let {
-                markAsPlayedConfirmed(it)
-            }
+    fun onMarkAsPlayedClick() {
+        playbackManager.upNextQueue.currentEpisode?.let {
+            markAsPlayedConfirmed(it)
         }
-        if (playbackManager.upNextQueue.queueEpisodes.isNotEmpty()) {
-            optionsDialogBuilder = optionsDialogBuilder.addTextOption(titleId = LR.string.next_episode) {
-                playbackManager.playNextInQueue(playbackSource = playbackSource)
-            }
-        }
+    }
 
-        return optionsDialogBuilder
+    fun hasNextEpisode(): Boolean {
+        return playbackManager.upNextQueue.queueEpisodes.isNotEmpty()
+    }
+
+    fun onNextEpisodeClick() {
+        playbackManager.playNextInQueue(playbackSource = playbackSource)
     }
 
     private fun markAsPlayedConfirmed(episode: Playable) {

--- a/modules/features/player/src/main/res/layout/fragment_long_press_options.xml
+++ b/modules/features/player/src/main/res/layout/fragment_long_press_options.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/primary_ui_01"
+    android:theme="@style/PlayerTheme">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="24dp">
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/markPlayed"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="labelMarkPlayed,buttonMarkPlayed"
+            tools:ignore="MissingConstraints" />
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/nextEpisode"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="separator1,labelNextEpisode,buttonNextEpisode"
+            tools:ignore="MissingConstraints" />
+
+        <View
+            android:layout_width="48dp"
+            android:layout_height="4dp"
+            android:layout_marginTop="4dp"
+            android:background="@drawable/background_dragger_player"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/labelMarkPlayed"
+            style="@style/DarkSubtitle1"
+            android:layout_width="wrap_content"
+            android:layout_height="64dp"
+            android:layout_marginStart="32dp"
+            android:layout_marginTop="24dp"
+            android:gravity="center_vertical"
+            android:importantForAccessibility="no"
+            android:text="@string/mark_played"
+            android:textColor="?attr/player_contrast_01"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <View
+            android:id="@+id/buttonMarkPlayed"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:contentDescription="@string/mark_played"
+            android:focusable="true"
+            app:layout_constraintBottom_toBottomOf="@+id/labelMarkPlayed"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/labelMarkPlayed" />
+
+        <View
+            android:id="@+id/separator1"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/divider_height"
+            android:background="?attr/player_contrast_05"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/labelMarkPlayed" />
+
+        <TextView
+            android:id="@+id/labelNextEpisode"
+            style="@style/DarkSubtitle1"
+            android:layout_width="wrap_content"
+            android:layout_height="64dp"
+            android:layout_marginStart="32dp"
+            android:gravity="center_vertical"
+            android:importantForAccessibility="no"
+            android:text="@string/next_episode"
+            android:textColor="?attr/player_contrast_01"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/separator1" />
+
+        <View
+            android:id="@+id/buttonNextEpisode"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:contentDescription="@string/next_episode"
+            android:focusable="true"
+            app:layout_constraintBottom_toBottomOf="@+id/labelNextEpisode"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/labelNextEpisode" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
Redesign the long press option in the fullscreen player to match the rest of the bottom sheet design

Continuation of this work https://github.com/Automattic/pocket-casts-android/pull/451, think all the bottom sheets in the player have the same design now 😄 

Fixes #31 

# Checklist

- [x] Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [x] Have you tested in landscape?
- [ ] Have you tested accessibility with TalkBack?
- [x] Have you tested in different themes?
- [x] Does the change work with a large display font?
- [x] Are all the strings localized?
- [ ] Could you have written any new tests?
- [ ] Did you include Compose previews with any components?


https://user-images.githubusercontent.com/22520267/197683072-ce296e1f-1d3e-469c-b7e2-608834450ff6.mp4

