### PR TITLE
Fix Plus features not working after cancelled but not expired.

### DIFF
--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/SignInStateTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/SignInStateTest.kt
@@ -1,0 +1,46 @@
+package au.com.shiftyjelly.pocketcasts.models.to
+
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
+import org.junit.Test
+import java.util.Date
+
+class SignInStateTest {
+
+    @Test
+    fun isSignedInAsPlusPaid() {
+        val email = "support@pocketcasts.com"
+        val statusAndroidPlusPaid = SubscriptionStatus.Plus(
+            expiry = Date(),
+            autoRenew = true,
+            giftDays = 0,
+            frequency = SubscriptionFrequency.MONTHLY,
+            platform = SubscriptionPlatform.ANDROID,
+            subscriptionList = emptyList(),
+            type = SubscriptionType.PLUS,
+            index = 0
+        )
+        // test an Android paying Plus subscriber
+        val stateAndroid = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid)
+        assert(stateAndroid.isSignedInAsPlusPaid)
+        // test an iOS paying Plus subscriber
+        val stateiOS = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid.copy(platform = SubscriptionPlatform.IOS))
+        assert(stateiOS.isSignedInAsPlusPaid)
+        // test a Web Player paying Plus subscriber
+        val stateWebPlayer = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid.copy(platform = SubscriptionPlatform.WEB))
+        assert(stateWebPlayer.isSignedInAsPlusPaid)
+        // test a gift Plus user
+        val statePayingGift = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid.copy(platform = SubscriptionPlatform.GIFT))
+        assert(!statePayingGift.isSignedInAsPlusPaid)
+        // test a paying Plus subscriber
+        val statePaying = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid)
+        assert(statePaying.isSignedInAsPlusPaid)
+        // a cancelled Plus subscriber should still have access to the paid Plus features, we don't need to check the expiry as loading the state will covert it to a free account
+        val stateCancelled = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid.copy(autoRenew = false))
+        assert(stateCancelled.isSignedInAsPlusPaid)
+        // free users should not have access to paid Plus features
+        val stateFree = SignInState.SignedIn(email = email, subscriptionStatus = SubscriptionStatus.Free())
+        assert(!stateFree.isSignedInAsPlusPaid)
+    }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
@@ -4,6 +4,8 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.utils.DateUtil
 import java.util.Date
 
+private val paidSubscriptionPlatforms = listOf(SubscriptionPlatform.ANDROID, SubscriptionPlatform.IOS, SubscriptionPlatform.WEB)
+
 sealed class SignInState {
     data class SignedIn(val email: String, val subscriptionStatus: SubscriptionStatus) : SignInState()
     class SignedOut : SignInState()
@@ -18,7 +20,7 @@ sealed class SignInState {
         get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus
 
     val isSignedInAsPlusPaid: Boolean
-        get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && this.subscriptionStatus.autoRenew
+        get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && paidSubscriptionPlatforms.contains(this.subscriptionStatus.platform)
 
     val isSignedInAsPlusGifted: Boolean
         get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && this.subscriptionStatus.platform == SubscriptionPlatform.GIFT && this.subscriptionStatus.giftDays != 0


### PR DESCRIPTION
When a user has paid for Plus the sponsors are removed from the discover section. There was an issue that these sponsors were shown after a user had cancelled their paid Plus subscription but it hadn't expired. The change fixes this issue.

We could start checking the expiry date but then we would need to rely on the device time. A safe way seems to be to let the Plus expire the next time the server is called. 

I had trouble testing this as I could buy Plus from my development builds, so instead I wrote some tests.

## Test steps
1. Subscribed to monthly Plus 
1. Confirmed paid placements were removed in Discover
1. Cancelled Plus subscription
1. The Paid Placements had reappeared in Discover