### PR TITLE
End of Year: Add stories datasource + gestures

### DIFF
--- a/modules/features/endofyear/build.gradle
+++ b/modules/features/endofyear/build.gradle
@@ -14,5 +14,6 @@ dependencies {
     implementation project(':modules:services:compose')
     implementation project(':modules:services:localization')
     implementation project(':modules:services:ui')
+    implementation project(':modules:services:utils')
     implementation project(':modules:services:views')
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesDataSource.kt
@@ -4,6 +4,8 @@ import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
 
 interface StoriesDataSource {
     var stories: List<Story>
+    val totalLengthInMs
+        get() = stories.sumOf { it.storyLength }
 
     fun loadStories(): List<Story>
     fun storyAt(index: Int): Story?

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesDataSource.kt
@@ -1,12 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.endofyear
 
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
+import kotlinx.coroutines.flow.Flow
 
 interface StoriesDataSource {
     var stories: List<Story>
     val totalLengthInMs
         get() = stories.sumOf { it.storyLength }
 
-    fun loadStories(): List<Story>
+    suspend fun loadStories(): Flow<List<Story>>
     fun storyAt(index: Int): Story?
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesDataSource.kt
@@ -3,11 +3,14 @@ package au.com.shiftyjelly.pocketcasts.endofyear
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
 import kotlinx.coroutines.flow.Flow
 
-interface StoriesDataSource {
-    var stories: List<Story>
+abstract class StoriesDataSource {
+    protected abstract val stories: List<Story>
+
+    val numOfStories: Int
+        get() = stories.size
     val totalLengthInMs
         get() = stories.sumOf { it.storyLength }
 
-    suspend fun loadStories(): Flow<List<Story>>
-    fun storyAt(index: Int): Story?
+    abstract suspend fun loadStories(): Flow<List<Story>>
+    abstract fun storyAt(index: Int): Story?
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesDataSource.kt
@@ -1,0 +1,10 @@
+package au.com.shiftyjelly.pocketcasts.endofyear
+
+import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
+
+interface StoriesDataSource {
+    var stories: List<Story>
+
+    fun loadStories(): List<Story>
+    fun storyAt(index: Int): Story?
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -7,12 +7,14 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.ui.R
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 
 class StoriesFragment : BaseDialogFragment() {
+    private val viewModel: StoriesViewModel by viewModels()
     override val statusBarColor: StatusBarColor
         get() = StatusBarColor.Custom(Color.BLACK, true)
 
@@ -31,6 +33,7 @@ class StoriesFragment : BaseDialogFragment() {
                 AppTheme(theme.activeTheme) {
                     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
                     StoriesScreen(
+                        viewModel = viewModel,
                         onCloseClicked = { dismiss() },
                     )
                 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -45,9 +46,10 @@ private const val NumberOfSegments = 2
 
 @Composable
 fun StoriesScreen(
+    viewModel: StoriesViewModel,
     onCloseClicked: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
+    val state: StoriesViewModel.State by viewModel.state.collectAsState()
     var running by remember { mutableStateOf(false) }
     val progress: Float by animateFloatAsState(
         if (running) 1f else 0f,
@@ -56,6 +58,25 @@ fun StoriesScreen(
             easing = LinearEasing
         )
     )
+    StoriesView(
+        state = state,
+        progress = progress,
+        onCloseClicked = onCloseClicked,
+    )
+
+    LaunchedEffect(Unit) {
+        running = true
+    }
+}
+
+@Suppress("UNUSED_PARAMETER")
+@Composable
+private fun StoriesView(
+    state: StoriesViewModel.State,
+    progress: Float,
+    onCloseClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Box(modifier = modifier.background(color = Color.Black)) {
         StoryView(color = Color.Gray)
         SegmentedProgressIndicator(
@@ -66,10 +87,6 @@ fun StoriesScreen(
                 .fillMaxWidth(),
         )
         CloseButtonView(onCloseClicked)
-    }
-
-    LaunchedEffect(Unit) {
-        running = true
     }
 }
 
@@ -134,7 +151,9 @@ private fun StoriesScreenPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppTheme(themeType) {
-        StoriesScreen(
+        StoriesView(
+            state = StoriesViewModel.State.Loaded,
+            progress = 1f,
             onCloseClicked = {}
         )
     }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
@@ -40,6 +40,8 @@ import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State
+import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
+import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake1
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -63,7 +65,7 @@ fun StoriesScreen(
         )
     )
     when (state) {
-        State.Loaded -> StoriesView(
+        is State.Loaded -> StoriesView(
             state = state as State.Loaded,
             progress = progress,
             onCloseClicked = onCloseClicked
@@ -77,16 +79,17 @@ fun StoriesScreen(
     }
 }
 
-@Suppress("UNUSED_PARAMETER")
 @Composable
 private fun StoriesView(
-    state: State,
+    state: State.Loaded,
     progress: Float,
     onCloseClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier.background(color = Color.Black)) {
-        StoryView(color = Color.Gray)
+        state.currentStory?.let {
+            StoryView(it)
+        }
         SegmentedProgressIndicator(
             progress = progress,
             numberOfSegments = NumberOfSegments,
@@ -100,7 +103,7 @@ private fun StoriesView(
 
 @Composable
 private fun StoryView(
-    color: Color,
+    story: Story,
     modifier: Modifier = Modifier,
 ) {
     Column {
@@ -109,7 +112,7 @@ private fun StoryView(
                 .fillMaxSize()
                 .weight(weight = 1f, fill = true)
                 .clip(RoundedCornerShape(StoryViewCornerSize))
-                .background(color = color)
+                .background(color = story.backgroundColor)
         ) {}
         ShareButton()
     }
@@ -210,7 +213,7 @@ private fun StoriesScreenPreview(
 ) {
     AppTheme(themeType) {
         StoriesView(
-            state = State.Loaded,
+            state = State.Loaded(currentStory = StoryFake1()),
             progress = 1f,
             onCloseClicked = {}
         )

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
@@ -1,8 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.endofyear
 
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -20,12 +17,8 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -45,10 +38,8 @@ import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake1
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-private const val ProgressDurationMs = 5_000
 private val ShareButtonStrokeWidth = 2.dp
 private val StoryViewCornerSize = 10.dp
-private const val NumberOfSegments = 2
 
 @Composable
 fun StoriesScreen(
@@ -56,14 +47,7 @@ fun StoriesScreen(
     onCloseClicked: () -> Unit,
 ) {
     val state: State by viewModel.state.collectAsState()
-    var running by remember { mutableStateOf(false) }
-    val progress: Float by animateFloatAsState(
-        if (running) 1f else 0f,
-        animationSpec = tween(
-            durationMillis = ProgressDurationMs,
-            easing = LinearEasing
-        )
-    )
+    val progress: Float by viewModel.progress.collectAsState()
     when (state) {
         is State.Loaded -> StoriesView(
             state = state as State.Loaded,
@@ -72,10 +56,6 @@ fun StoriesScreen(
         )
         State.Loading -> StoriesLoadingView(onCloseClicked)
         State.Error -> StoriesErrorView(onCloseClicked)
-    }
-
-    LaunchedEffect(Unit) {
-        running = true
     }
 }
 
@@ -86,13 +66,17 @@ private fun StoriesView(
     onCloseClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Box(modifier = modifier.background(color = Color.Black)) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(color = Color.Black)
+    ) {
         state.currentStory?.let {
             StoryView(it)
         }
         SegmentedProgressIndicator(
             progress = progress,
-            numberOfSegments = NumberOfSegments,
+            numberOfSegments = state.numberOfStories,
             modifier = modifier
                 .padding(8.dp)
                 .fillMaxWidth(),
@@ -213,7 +197,7 @@ private fun StoriesScreenPreview(
 ) {
     AppTheme(themeType) {
         StoriesView(
-            state = State.Loaded(currentStory = StoryFake1()),
+            state = State.Loaded(currentStory = StoryFake1(), numberOfStories = 1),
             progress = 1f,
             onCloseClicked = {}
         )

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -5,33 +5,92 @@ import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import java.util.Timer
 import javax.inject.Inject
+import kotlin.concurrent.fixedRateTimer
+import kotlin.math.roundToInt
 
 @HiltViewModel
 class StoriesViewModel @Inject constructor(
-    storiesDataSource: StoriesDataSource,
+    private val storiesDataSource: StoriesDataSource,
 ) : ViewModel() {
     private val mutableState = MutableStateFlow<State>(State.Loading)
     val state: StateFlow<State> = mutableState
 
+    private val mutableProgress = MutableStateFlow(0f)
+    val progress: StateFlow<Float> = mutableProgress
+
+    private val numOfStories: Int
+        get() = storiesDataSource.stories.size
+
     private var currentIndex: Int = 0
+    private val nextIndex
+        get() = (currentIndex.plus(1)).coerceAtMost(numOfStories.minus(1))
+
+    private var timer: Timer? = null
+    private var timerCancelled = false
 
     init {
         val stories = storiesDataSource.loadStories()
         val state = if (stories.isEmpty()) {
             State.Error
         } else {
-            State.Loaded(currentStory = storiesDataSource.storyAt(currentIndex))
+            State.Loaded(
+                currentStory = storiesDataSource.storyAt(currentIndex),
+                numberOfStories = numOfStories
+            )
         }
         mutableState.value = state
+        if (state is State.Loaded) start()
     }
+
+    private fun start() {
+        val currentState = state.value as State.Loaded
+        val progressFraction =
+            (PROGRESS_UPDATE_INTERVAL_MS / storiesDataSource.totalLengthInMs.toFloat()).coerceAtMost(PROGRESS_END_VALUE)
+
+        timer = fixedRateTimer(period = PROGRESS_UPDATE_INTERVAL_MS) {
+            timerCancelled = false
+            val newProgress = (progress.value + progressFraction)
+                .coerceIn(PROGRESS_START_VALUE, PROGRESS_END_VALUE)
+
+            val nextIndexXStartOffset = (PROGRESS_END_VALUE / numOfStories.toFloat()).coerceAtMost(PROGRESS_END_VALUE) * nextIndex
+            if (newProgress.roundOff() == nextIndexXStartOffset.roundOff()) {
+                currentIndex = nextIndex
+                mutableState.value =
+                    currentState.copy(currentStory = storiesDataSource.storyAt(currentIndex))
+            }
+
+            mutableProgress.value = newProgress
+            if (newProgress == PROGRESS_END_VALUE) cancelTimer()
+        }
+    }
+
+    private fun cancelTimer() {
+        timer?.cancel()
+        timerCancelled = true
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        cancelTimer()
+    }
+
+    private fun Float.roundOff() = (this * 100.0).roundToInt()
 
     sealed class State {
         object Loading : State()
         data class Loaded(
             val currentStory: Story?,
+            val numberOfStories: Int
         ) : State()
 
         object Error : State()
+    }
+
+    companion object {
+        private const val PROGRESS_START_VALUE = 0f
+        private const val PROGRESS_END_VALUE = 1f
+        private const val PROGRESS_UPDATE_INTERVAL_MS = 10L
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -1,10 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.endofyear
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import java.util.Timer
 import javax.inject.Inject
 import kotlin.concurrent.fixedRateTimer
@@ -31,17 +33,19 @@ class StoriesViewModel @Inject constructor(
     private var timerCancelled = false
 
     init {
-        val stories = storiesDataSource.loadStories()
-        val state = if (stories.isEmpty()) {
-            State.Error
-        } else {
-            State.Loaded(
-                currentStory = storiesDataSource.storyAt(currentIndex),
-                numberOfStories = numOfStories
-            )
+        viewModelScope.launch {
+            val stories = storiesDataSource.loadStories()
+            val state = if (stories.isEmpty()) {
+                State.Error
+            } else {
+                State.Loaded(
+                    currentStory = storiesDataSource.storyAt(currentIndex),
+                    numberOfStories = numOfStories
+                )
+            }
+            mutableState.value = state
+            if (state is State.Loaded) start()
         }
-        mutableState.value = state
-        if (state is State.Loaded) start()
     }
 
     fun start() {

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -1,20 +1,37 @@
 package au.com.shiftyjelly.pocketcasts.endofyear
 
 import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
 @HiltViewModel
-class StoriesViewModel
-@Inject constructor() : ViewModel() {
+class StoriesViewModel @Inject constructor(
+    storiesDataSource: StoriesDataSource,
+) : ViewModel() {
     private val mutableState = MutableStateFlow<State>(State.Loading)
     val state: StateFlow<State> = mutableState
 
+    private var currentIndex: Int = 0
+
+    init {
+        val stories = storiesDataSource.loadStories()
+        val state = if (stories.isEmpty()) {
+            State.Error
+        } else {
+            State.Loaded(currentStory = storiesDataSource.storyAt(currentIndex))
+        }
+        mutableState.value = state
+    }
+
     sealed class State {
         object Loading : State()
-        object Loaded : State()
+        data class Loaded(
+            val currentStory: Story?,
+        ) : State()
+
         object Error : State()
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -30,7 +30,6 @@ class StoriesViewModel @Inject constructor(
         get() = (currentIndex.plus(1)).coerceAtMost(numOfStories.minus(1))
 
     private var timer: Timer? = null
-    private var timerCancelled = false
 
     init {
         viewModelScope.launch {
@@ -56,7 +55,6 @@ class StoriesViewModel @Inject constructor(
                 .coerceAtMost(PROGRESS_END_VALUE)
 
         timer = fixedRateTimer(period = PROGRESS_UPDATE_INTERVAL_MS) {
-            timerCancelled = false
             val newProgress = (progress.value + progressFraction)
                 .coerceIn(PROGRESS_START_VALUE, PROGRESS_END_VALUE)
 
@@ -85,7 +83,7 @@ class StoriesViewModel @Inject constructor(
     }
 
     private fun skipToStoryAtIndex(index: Int) {
-        if (timerCancelled) start()
+        if (timer == null) start()
         mutableProgress.value = getXStartOffsetAtIndex(index)
         mutableState.value =
             (state.value as State.Loaded).copy(currentStory = storiesDataSource.storyAt(index))
@@ -93,7 +91,7 @@ class StoriesViewModel @Inject constructor(
 
     private fun cancelTimer() {
         timer?.cancel()
-        timerCancelled = true
+        timer = null
     }
 
     override fun onCleared() {

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -34,17 +34,18 @@ class StoriesViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            val stories = storiesDataSource.loadStories()
-            val state = if (stories.isEmpty()) {
-                State.Error
-            } else {
-                State.Loaded(
-                    currentStory = storiesDataSource.storyAt(currentIndex),
-                    numberOfStories = numOfStories
-                )
+            storiesDataSource.loadStories().collect { stories ->
+                val state = if (stories.isEmpty()) {
+                    State.Error
+                } else {
+                    State.Loaded(
+                        currentStory = storiesDataSource.storyAt(currentIndex),
+                        numberOfStories = numOfStories
+                    )
+                }
+                mutableState.value = state
+                if (state is State.Loaded) start()
             }
-            mutableState.value = state
-            if (state is State.Loaded) start()
         }
     }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -23,7 +23,7 @@ class StoriesViewModel @Inject constructor(
     val progress: StateFlow<Float> = mutableProgress
 
     private val numOfStories: Int
-        get() = storiesDataSource.stories.size
+        get() = storiesDataSource.numOfStories
 
     private var currentIndex: Int = 0
     private val nextIndex

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -1,0 +1,20 @@
+package au.com.shiftyjelly.pocketcasts.endofyear
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class StoriesViewModel
+@Inject constructor() : ViewModel() {
+    private val mutableState = MutableStateFlow<State>(State.Loading)
+    val state: StateFlow<State> = mutableState
+
+    sealed class State {
+        object Loading : State()
+        object Loaded : State()
+        object Error : State()
+    }
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -44,18 +44,18 @@ class StoriesViewModel @Inject constructor(
         if (state is State.Loaded) start()
     }
 
-    private fun start() {
+    fun start() {
         val currentState = state.value as State.Loaded
         val progressFraction =
-            (PROGRESS_UPDATE_INTERVAL_MS / storiesDataSource.totalLengthInMs.toFloat()).coerceAtMost(PROGRESS_END_VALUE)
+            (PROGRESS_UPDATE_INTERVAL_MS / storiesDataSource.totalLengthInMs.toFloat())
+                .coerceAtMost(PROGRESS_END_VALUE)
 
         timer = fixedRateTimer(period = PROGRESS_UPDATE_INTERVAL_MS) {
             timerCancelled = false
             val newProgress = (progress.value + progressFraction)
                 .coerceIn(PROGRESS_START_VALUE, PROGRESS_END_VALUE)
 
-            val nextIndexXStartOffset = (PROGRESS_END_VALUE / numOfStories.toFloat()).coerceAtMost(PROGRESS_END_VALUE) * nextIndex
-            if (newProgress.roundOff() == nextIndexXStartOffset.roundOff()) {
+            if (newProgress.roundOff() == getXStartOffsetAtIndex(nextIndex).roundOff()) {
                 currentIndex = nextIndex
                 mutableState.value =
                     currentState.copy(currentStory = storiesDataSource.storyAt(currentIndex))
@@ -64,6 +64,26 @@ class StoriesViewModel @Inject constructor(
             mutableProgress.value = newProgress
             if (newProgress == PROGRESS_END_VALUE) cancelTimer()
         }
+    }
+
+    fun skipPrevious() {
+        val prevIndex = (currentIndex.minus(1)).coerceAtLeast(0)
+        skipToStoryAtIndex(prevIndex)
+    }
+
+    fun skipNext() {
+        skipToStoryAtIndex(nextIndex)
+    }
+
+    fun pause() {
+        cancelTimer()
+    }
+
+    private fun skipToStoryAtIndex(index: Int) {
+        if (timerCancelled) start()
+        mutableProgress.value = getXStartOffsetAtIndex(index)
+        mutableState.value =
+            (state.value as State.Loaded).copy(currentStory = storiesDataSource.storyAt(index))
     }
 
     private fun cancelTimer() {
@@ -78,11 +98,14 @@ class StoriesViewModel @Inject constructor(
 
     private fun Float.roundOff() = (this * 100.0).roundToInt()
 
+    private fun getXStartOffsetAtIndex(index: Int) =
+        (PROGRESS_END_VALUE / numOfStories.toFloat()).coerceAtMost(PROGRESS_END_VALUE) * index
+
     sealed class State {
         object Loading : State()
         data class Loaded(
             val currentStory: Story?,
-            val numberOfStories: Int
+            val numberOfStories: Int,
         ) : State()
 
         object Error : State()

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/di/EndOfYearModule.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/di/EndOfYearModule.kt
@@ -1,0 +1,15 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.di
+
+import au.com.shiftyjelly.pocketcasts.endofyear.StoriesDataSource
+import au.com.shiftyjelly.pocketcasts.endofyear.stories.EndOfYearStoriesDataSource
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class EndOfYearModule {
+    @Binds
+    abstract fun providesEndOfYearStoriesDataSource(dataSource: EndOfYearStoriesDataSource): StoriesDataSource
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
@@ -1,0 +1,21 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.stories
+
+import au.com.shiftyjelly.pocketcasts.endofyear.StoriesDataSource
+import timber.log.Timber
+import javax.inject.Inject
+
+class EndOfYearStoriesDataSource @Inject constructor() : StoriesDataSource {
+    override var stories: List<Story> = emptyList()
+
+    override fun loadStories(): List<Story> {
+        stories = listOf(StoryFake1(), StoryFake2())
+        return stories
+    }
+
+    override fun storyAt(index: Int) = try {
+        stories[index]
+    } catch (e: IndexOutOfBoundsException) {
+        Timber.e("Story index is out of bounds")
+        null
+    }
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
@@ -1,15 +1,17 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.stories
 
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesDataSource
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import timber.log.Timber
 import javax.inject.Inject
 
 class EndOfYearStoriesDataSource @Inject constructor() : StoriesDataSource {
     override var stories: List<Story> = emptyList()
 
-    override fun loadStories(): List<Story> {
+    override suspend fun loadStories(): Flow<List<Story>> {
         stories = listOf(StoryFake1(), StoryFake2())
-        return stories
+        return flowOf(stories)
     }
 
     override fun storyAt(index: Int) = try {

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
@@ -7,12 +7,12 @@ import kotlinx.coroutines.flow.flowOf
 import timber.log.Timber
 import javax.inject.Inject
 
-class EndOfYearStoriesDataSource @Inject constructor() : StoriesDataSource {
-    override var stories: List<Story> = emptyList()
+class EndOfYearStoriesDataSource @Inject constructor() : StoriesDataSource() {
+    override val stories = mutableListOf<Story>()
 
     override suspend fun loadStories(): Flow<List<Story>> {
         delay(1000L) // TODO: Remove hardcoded delay added for testing
-        stories = listOf(StoryFake1(), StoryFake2())
+        stories.addAll(listOf(StoryFake1(), StoryFake2()))
         return flowOf(stories)
     }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.stories
 
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesDataSource
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import timber.log.Timber
@@ -10,6 +11,7 @@ class EndOfYearStoriesDataSource @Inject constructor() : StoriesDataSource {
     override var stories: List<Story> = emptyList()
 
     override suspend fun loadStories(): Flow<List<Story>> {
+        delay(1000L) // TODO: Remove hardcoded delay added for testing
         stories = listOf(StoryFake1(), StoryFake2())
         return flowOf(stories)
     }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/Story.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/Story.kt
@@ -1,7 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.stories
 
 import androidx.compose.ui.graphics.Color
+import au.com.shiftyjelly.pocketcasts.utils.seconds
 
-interface Story {
-    val backgroundColor: Color
+abstract class Story {
+    val storyLength: Long = 2.seconds()
+    abstract val backgroundColor: Color
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/Story.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/Story.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.stories
+
+import androidx.compose.ui.graphics.Color
+
+interface Story {
+    val backgroundColor: Color
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryFake1.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryFake1.kt
@@ -2,6 +2,6 @@ package au.com.shiftyjelly.pocketcasts.endofyear.stories
 
 import androidx.compose.ui.graphics.Color
 
-class StoryFake1 : Story {
+class StoryFake1 : Story() {
     override val backgroundColor: Color = Color.Magenta
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryFake1.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryFake1.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.stories
+
+import androidx.compose.ui.graphics.Color
+
+class StoryFake1 : Story {
+    override val backgroundColor: Color = Color.Magenta
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryFake2.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryFake2.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.stories
+
+import androidx.compose.ui.graphics.Color
+
+class StoryFake2 : Story {
+    override val backgroundColor: Color = Color.Green
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryFake2.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryFake2.kt
@@ -2,6 +2,6 @@ package au.com.shiftyjelly.pocketcasts.endofyear.stories
 
 import androidx.compose.ui.graphics.Color
 
-class StoryFake2 : Story {
+class StoryFake2 : Story() {
     override val backgroundColor: Color = Color.Green
 }

--- a/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
+++ b/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
@@ -1,0 +1,128 @@
+package au.com.shiftyjelly.pocketcasts.endofyear
+
+import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
+import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake1
+import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake2
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+private val story1 = StoryFake1()
+private val story2 = StoryFake2()
+
+@RunWith(MockitoJUnitRunner::class)
+class StoriesViewModelTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when vm starts, then loading is shown`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher())
+        val viewModel = StoriesViewModel(MockStoriesDataSource(listOf(story1, story2)))
+
+        assertEquals(viewModel.state.value is StoriesViewModel.State.Loading, true)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when vm starts, then progress is zero`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher())
+        val viewModel = StoriesViewModel(MockStoriesDataSource(listOf(story1, story2)))
+
+        assertEquals(viewModel.progress.value, 0f)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when vm starts, then stories are loaded`() = runTest {
+        val dataSource = mock<StoriesDataSource>()
+        StoriesViewModel(dataSource)
+
+        verify(dataSource).loadStories()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when stories are found, then progress increments`() = runTest {
+        val viewModel = StoriesViewModel(MockStoriesDataSource(listOf(story1, story2)))
+
+        val progress = mutableListOf<Float>()
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            viewModel.progress.collect {
+                progress.add(it)
+            }
+        }
+
+        assertTrue(progress.last() > 0f)
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `given no stories found, when vm starts, then error is shown`() {
+        val viewModel = StoriesViewModel(MockStoriesDataSource(emptyList()))
+
+        assertEquals(viewModel.state.value is StoriesViewModel.State.Error, true)
+    }
+
+    @Test
+    fun `given stories found, when vm starts, then screen is loaded`() {
+        val viewModel = StoriesViewModel(MockStoriesDataSource(listOf(story1, story2)))
+
+        assertEquals(viewModel.state.value is StoriesViewModel.State.Loaded, true)
+    }
+
+    @Test
+    fun `when next is invoked, then next story is shown`() {
+        val viewModel = StoriesViewModel(MockStoriesDataSource(listOf(story1, story2)))
+
+        viewModel.skipNext()
+
+        val state = viewModel.state.value as StoriesViewModel.State.Loaded
+        assertEquals(state.currentStory, story2)
+    }
+
+    @Test
+    fun `when previous is invoked, then previous story is shown`() {
+        val viewModel = StoriesViewModel(MockStoriesDataSource(listOf(story1, story2)))
+        viewModel.skipNext()
+
+        viewModel.skipPrevious()
+
+        val state = viewModel.state.value as StoriesViewModel.State.Loaded
+        assertEquals(state.currentStory, story1)
+    }
+
+    class MockStoriesDataSource(private val mockStories: List<Story>) : StoriesDataSource {
+        override var stories: List<Story> = emptyList()
+
+        override fun loadStories(): List<Story> {
+            stories = mockStories
+            return stories
+        }
+
+        override fun storyAt(index: Int): Story? {
+            return try {
+                stories[index]
+            } catch (e: IndexOutOfBoundsException) {
+                null
+            }
+        }
+    }
+}

--- a/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
+++ b/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
@@ -7,6 +7,8 @@ import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -112,9 +114,9 @@ class StoriesViewModelTest {
     class MockStoriesDataSource(private val mockStories: List<Story>) : StoriesDataSource {
         override var stories: List<Story> = emptyList()
 
-        override fun loadStories(): List<Story> {
+        override suspend fun loadStories(): Flow<List<Story>> {
             stories = mockStories
-            return stories
+            return flowOf(mockStories)
         }
 
         override fun storyAt(index: Int): Story? {

--- a/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
+++ b/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
@@ -1,8 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.endofyear
 
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
-import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake1
-import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake2
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.Dispatchers
@@ -21,8 +19,8 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
-private val story1 = StoryFake1()
-private val story2 = StoryFake2()
+private val story1 = mock<Story>()
+private val story2 = mock<Story>()
 
 @RunWith(MockitoJUnitRunner::class)
 class StoriesViewModelTest {
@@ -111,12 +109,12 @@ class StoriesViewModelTest {
         assertEquals(state.currentStory, story1)
     }
 
-    class MockStoriesDataSource(private val mockStories: List<Story>) : StoriesDataSource {
-        override var stories: List<Story> = emptyList()
+    class MockStoriesDataSource(private val mockStories: List<Story>) : StoriesDataSource() {
+        override val stories = mutableListOf<Story>()
 
         override suspend fun loadStories(): Flow<List<Story>> {
-            stories = mockStories
-            return flowOf(mockStories)
+            stories.addAll(mockStories)
+            return flowOf(stories)
         }
 
         override fun storyAt(index: Int): Story? {


### PR DESCRIPTION
| 📘 Project: #410 |
|:---:|

iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/389

# Description

This PR adds a data source to populate the Stories view with stories and also adds a few gestures.
Currently, it just updates the background color of the StoryView. Different story views will be added in future PRs.

https://user-images.githubusercontent.com/1405144/197767780-76d7537a-fac9-40a6-a361-f2222a04e237.mp4

## To test

1. Set `END_OF_YEAR_ENABLED` feature flag to `true` in `base.gradle`
2. Run the app
3. When the prompt appears, tap "View My 2022"
4. ✅ Check that each story is shown for 2s and that the story indicator (the rectangles at the top) are reflecting the state
5. ✅ Tap and hold, check that the current story is "paused". The rectangle stop progressing and the story doesn't change
6. ✅ While seeing the green story, tap the left portion of the screen, you should go back to the magenta one
7. ✅ While seeing the magenta story, tap the right portion of the screen, you should go to the next story (green)


**Loading and error**

2. Return an empty list from `EndOfYearStoriesDataSource.loadStories`
3. Run the app
4. When the prompt appears, tap "View My 2022"
5. ✅ Check that loading indicator appears while stories are loading (I added a delay to test this)
6. Wait for a sec
7. ✅ Notice that error message is displayed when no stories are found.


https://user-images.githubusercontent.com/1405144/197771060-b651452f-38ac-4c04-b42d-aab17980e6a9.mp4



# Checklist

- Should this change be included in the release notes? If yes, please add a line in CHANGELOG.md
- [ ] Have you tested in landscape?
- Have you tested accessibility with TalkBack?
- [x] Have you tested in different themes?
- Does the change work with a large display font?
- Are all the strings localized?
- [x] Could you have written any new tests?
- [x] Did you include Compose previews with any components?