### PR TITLE
Fix Spotless error

### DIFF
--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/ComposableBase.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/ComposableBase.kt
@@ -164,9 +164,11 @@ fun ComposableTaskerInputFieldList(
     fieldContents: List<TaskerInputFieldState.Content<*>>,
     onFinish: () -> Unit
 ) {
-    Box(modifier = Modifier
+    Box(
+        modifier = Modifier
             .padding(8.dp)
-            .fillMaxHeight()) {
+            .fillMaxHeight()
+    ) {
         LazyColumn {
             fieldContents.forEach { content ->
                 item {


### PR DESCRIPTION
The Spotless check is failing. This change fixes that.

```
[2022-10-25T21:04:36Z] FAILURE: Build failed with an exception.
--
  | [2022-10-25T21:04:36Z]
  | [2022-10-25T21:04:36Z] * What went wrong:
  | [2022-10-25T21:04:36Z] Execution failed for task ':spotlessKotlinCheck'.
  | [2022-10-25T21:04:36Z] > The following files had format violations:
  | [2022-10-25T21:04:36Z]       modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/ComposableBase.kt
  | [2022-10-25T21:04:36Z]           @@ -164,9 +164,11 @@
  | [2022-10-25T21:04:36Z]            ····fieldContents:·List<TaskerInputFieldState.Content<*>>,
  | [2022-10-25T21:04:36Z]            ····onFinish:·()·->·Unit
  | [2022-10-25T21:04:36Z]            )·{
  | [2022-10-25T21:04:36Z]           -····Box(modifier·=·Modifier
  | [2022-10-25T21:04:36Z]           +····Box(
  | [2022-10-25T21:04:36Z]           +········modifier·=·Modifier
  | [2022-10-25T21:04:36Z]            ············.padding(8.dp)
  | [2022-10-25T21:04:36Z]           -············.fillMaxHeight())·{
  | [2022-10-25T21:04:36Z]           +············.fillMaxHeight()
  | [2022-10-25T21:04:36Z]           +····)·{
  | [2022-10-25T21:04:36Z]            ········LazyColumn·{
  | [2022-10-25T21:04:36Z]            ············fieldContents.forEach·{·content·->
  | [2022-10-25T21:04:36Z]            ················item·{
  | [2022-10-25T21:04:36Z]   Run './gradlew :spotlessApply' to fix these violations.
```