### PR TITLE
Fix podcast filter title and hide filter option if no filters available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
         ([#482](https://github.com/Automattic/pocket-casts-android/pull/482)).
     *   Redesign of the fullscreen player share option
         ([#451](https://github.com/Automattic/pocket-casts-android/pull/451)).
+    *   Fix select filters title and hide filter option when applicable in the podcast settings
+        ([#494](https://github.com/Automattic/pocket-casts-android/pull/494)).
 *   Bug Fixes:
     *   Fixed Help & Feedback buttons being hidden when using text zoom.
         ([#446](https://github.com/Automattic/pocket-casts-android/pull/446)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
         ([#482](https://github.com/Automattic/pocket-casts-android/pull/482)).
     *   Redesign of the fullscreen player share option
         ([#451](https://github.com/Automattic/pocket-casts-android/pull/451)).
-    *   Fix select filters title and hide filter option when applicable in the podcast settings
+    *   Updated select filters title & hide podcast setting filter option when applicable
         ([#494](https://github.com/Automattic/pocket-casts-android/pull/494)).
 *   Bug Fixes:
     *   Fixed Help & Feedback buttons being hidden when using text zoom.

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
@@ -36,6 +36,7 @@ class PodcastSettingsViewModel @Inject constructor(
     var podcastUuid: String? = null
     lateinit var podcast: LiveData<Podcast>
     lateinit var includedFilters: LiveData<List<Playlist>>
+    lateinit var availableFilters: LiveData<List<Playlist>>
 
     val globalSettings = LiveDataReactiveStreams.fromPublisher(
         settings.autoAddUpNextLimit.toFlowable(BackpressureStrategy.LATEST)
@@ -50,6 +51,11 @@ class PodcastSettingsViewModel @Inject constructor(
             it.filter { filter -> filter.podcastUuidList.contains(uuid) }
         }
         includedFilters = LiveDataReactiveStreams.fromPublisher(filters)
+
+        val availablePodcastFilters = playlistManager.observeAll().map {
+            it.filter { filter -> !filter.allPodcasts }
+        }
+        availableFilters = LiveDataReactiveStreams.fromPublisher(availablePodcastFilters)
     }
 
     fun isAutoAddToUpNextOn(): Boolean {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -973,6 +973,7 @@
     <string name="settings_battery_update_message">Please tap the \"%s\" switch above to update your battery settings.</string>
     <string name="settings_battery_usage_message">Battery usage must be unrestricted to ensure uninterrupted playback when your screen is off.</string>
     <string name="settings_battery_learn_more_url" translatable="false">https://support.pocketcasts.com/article/playback-pausing-randomly-or-when-screen-is-locked/</string>
+    <string name="settings_select_filters">Select filters</string>
     <string name="settings_choose_podcasts">Choose podcasts</string>
     <string name="settings_close_upgrade_offer">close upgrade offer</string>
     <string name="settings_developer">Developer</string>

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/FilterSelectFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/FilterSelectFragment.kt
@@ -12,7 +12,7 @@ import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
 import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
-import au.com.shiftyjelly.pocketcasts.views.databinding.SettingsFragmentPodcastSelectBinding
+import au.com.shiftyjelly.pocketcasts.views.databinding.FragmentFilterSelectBinding
 import au.com.shiftyjelly.pocketcasts.views.databinding.SettingsRowFilterBinding
 import au.com.shiftyjelly.pocketcasts.views.helper.PlaylistHelper
 import dagger.hilt.android.AndroidEntryPoint
@@ -46,7 +46,7 @@ class FilterSelectFragment : BaseFragment() {
 
     private lateinit var listener: Listener
     private var adapter: FilterSelectAdapter? = null
-    private var binding: SettingsFragmentPodcastSelectBinding? = null
+    private var binding: FragmentFilterSelectBinding? = null
 
     @Inject lateinit var playlistManager: PlaylistManager
 
@@ -61,7 +61,7 @@ class FilterSelectFragment : BaseFragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        binding = SettingsFragmentPodcastSelectBinding.inflate(inflater, container, false)
+        binding = FragmentFilterSelectBinding.inflate(inflater, container, false)
         return binding?.root
     }
 
@@ -88,12 +88,12 @@ class FilterSelectFragment : BaseFragment() {
                 onSuccess = {
                     val adapter = FilterSelectAdapter(theme.isDarkTheme, it) {
                         val selectedList = it.map { it.uuid }
-                        binding?.lblPodcastsChosen?.text = resources.getStringPlural(count = selectedList.size, singular = LR.string.filters_chosen_singular, plural = LR.string.filters_chosen_plural)
+                        binding?.lblFiltersChosen?.text = resources.getStringPlural(count = selectedList.size, singular = LR.string.filters_chosen_singular, plural = LR.string.filters_chosen_plural)
                         listener.filterSelectFragmentSelectionChanged(selectedList)
                     }
 
                     val selected = it.filter { it.selected }
-                    binding?.lblPodcastsChosen?.text = resources.getStringPlural(count = selected.size, singular = LR.string.filters_chosen_singular, plural = LR.string.filters_chosen_plural)
+                    binding?.lblFiltersChosen?.text = resources.getStringPlural(count = selected.size, singular = LR.string.filters_chosen_singular, plural = LR.string.filters_chosen_plural)
                     binding?.recyclerView?.layoutManager = layoutManager
                     binding?.recyclerView?.adapter = adapter
 

--- a/modules/services/views/src/main/res/layout/fragment_filter_select.xml
+++ b/modules/services/views/src/main/res/layout/fragment_filter_select.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:background="?attr/primary_ui_01"
+    android:orientation="vertical">
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/toolbarLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/secondary_ui_01"
+            app:title="@string/settings_select_filters"/>
+    </com.google.android.material.appbar.AppBarLayout>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp">
+        <TextView
+            android:id="@+id/lblFiltersChosen"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            style="?attr/textBody2"
+            android:textColor="?attr/primary_text_02"
+            tools:text="21 filters chosen"/>
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnSelect"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAllCaps="false"
+            android:text="@string/select_all"
+            style="@style/Widget.MaterialComponents.Button.TextButton"/>
+    </LinearLayout>
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>


### PR DESCRIPTION
## Description
Fix for wrong title on the filter select screen "Choose podcasts" -> "Select filters" (match iOS design)
 - Added separate layout since the filter select screen was using the podcast select layout resulting in the incorrect title

Hide filters option in podcast settings if no filters available to assign the podcast to (match iOS behaviour)

Fixes #49 

## Screenshots or Screencast 
![Screenshot_20221026_023355](https://user-images.githubusercontent.com/22520267/197914173-64c53b47-cc3a-4794-899c-41ce972a788c.png)
![Screenshot_20221026_023329](https://user-images.githubusercontent.com/22520267/197914177-9c12981b-0d9b-49f8-9fec-91a272fa33a3.png)
![Screenshot_20221026_023258](https://user-images.githubusercontent.com/22520267/197914179-2d97ab53-b5c4-4636-b05e-9bb3b857fc78.png)

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
