### PR TITLE
End of Year: Generate stories with dummy data + support dynamic lengths

### DIFF
--- a/modules/features/endofyear/build.gradle
+++ b/modules/features/endofyear/build.gradle
@@ -13,6 +13,8 @@ dependencies {
     // services
     implementation project(':modules:services:compose')
     implementation project(':modules:services:localization')
+    implementation project(':modules:services:model')
+    implementation project(':modules:services:repositories')
     implementation project(':modules:services:ui')
     implementation project(':modules:services:utils')
     implementation project(':modules:services:views')

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/SegmentedProgressIndicator.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/SegmentedProgressIndicator.kt
@@ -12,11 +12,11 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State.Loaded.SegmentsData
 
 private val StrokeWidth = 2.dp
-private val GapWidth = 8.dp
 private val SegmentHeight = StrokeWidth
-private const val IndicatorBackgroundOpacity = 0.24f
+private const val IndicatorBackgroundOpacity = 0.5f
 
 @Composable
 fun SegmentedProgressIndicator(
@@ -24,7 +24,7 @@ fun SegmentedProgressIndicator(
     modifier: Modifier = Modifier,
     color: Color = Color.White,
     backgroundColor: Color = color.copy(alpha = IndicatorBackgroundOpacity),
-    numberOfSegments: Int,
+    segmentsData: SegmentsData,
 ) {
     Canvas(
         modifier
@@ -33,20 +33,20 @@ fun SegmentedProgressIndicator(
             .height(SegmentHeight)
             .focusable()
     ) {
-        drawSegmentsBackground(backgroundColor, numberOfSegments)
-        drawSegments(progress, color, numberOfSegments)
+        drawSegmentsBackground(backgroundColor, segmentsData)
+        drawSegments(progress, color, segmentsData)
     }
 }
 
 private fun DrawScope.drawSegmentsBackground(
     color: Color,
-    numberOfSegments: Int,
-) = drawSegments(1f, color, numberOfSegments)
+    segmentsData: SegmentsData,
+) = drawSegments(1f, color, segmentsData)
 
 private fun DrawScope.drawSegments(
     endFraction: Float,
     color: Color,
-    numberOfSegments: Int,
+    segmentsData: SegmentsData,
 ) {
     val width = size.width
     val height = size.height
@@ -55,11 +55,10 @@ private fun DrawScope.drawSegments(
 
     val barEnd = endFraction * width
 
-    val segmentWidth = calculateSegmentWidth(numberOfSegments)
-    val segmentAndGapWidth = segmentWidth + GapWidth.toPx()
+    repeat(segmentsData.widths.size) { index ->
+        val segmentWidth = segmentsData.widths[index] * width
+        val xOffsetStart = segmentsData.xStartOffsets[index] * width
 
-    repeat(numberOfSegments) { index ->
-        val xOffsetStart = index * segmentAndGapWidth
         val shouldDrawLine = xOffsetStart < barEnd
         if (shouldDrawLine) {
             val xOffsetEnd = (xOffsetStart + segmentWidth).coerceAtMost(barEnd)
@@ -67,12 +66,4 @@ private fun DrawScope.drawSegments(
             drawLine(color, Offset(xOffsetStart, yOffset), Offset(xOffsetEnd, yOffset), StrokeWidth.toPx())
         }
     }
-}
-
-private fun DrawScope.calculateSegmentWidth(
-    numberOfSegments: Int,
-): Float {
-    val width = size.width
-    val gapsWidth = (numberOfSegments - 1) * GapWidth.toPx()
-    return (width - gapsWidth) / numberOfSegments
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesDataSource.kt
@@ -9,8 +9,16 @@ abstract class StoriesDataSource {
     val numOfStories: Int
         get() = stories.size
     val totalLengthInMs
-        get() = stories.sumOf { it.storyLength }
+        get() = storyLengthsInMs.sum() + gapLengthsInMs
+    val storyLengthsInMs: List<Long>
+        get() = stories.map { it.storyLength }
+    private val gapLengthsInMs: Long
+        get() = STORY_GAP_LENGTH_MS * numOfStories.minus(1).coerceAtLeast(0)
 
     abstract suspend fun loadStories(): Flow<List<Story>>
     abstract fun storyAt(index: Int): Story?
+
+    companion object {
+        const val STORY_GAP_LENGTH_MS = 100L
+    }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
@@ -42,6 +42,9 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake1
+import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake2
+import au.com.shiftyjelly.pocketcasts.endofyear.storyviews.StoryFake1View
+import au.com.shiftyjelly.pocketcasts.endofyear.storyviews.StoryFake2View
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -141,8 +144,14 @@ private fun StoryView(
                 .fillMaxSize()
                 .weight(weight = 1f, fill = true)
                 .clip(RoundedCornerShape(StoryViewCornerSize))
-                .background(color = story.backgroundColor)
-        ) {}
+                .background(color = story.backgroundColor),
+            contentAlignment = Alignment.Center
+        ) {
+            when (story) {
+                is StoryFake1 -> StoryFake1View(story)
+                is StoryFake2 -> StoryFake2View(story)
+            }
+        }
         ShareButton()
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
@@ -42,6 +42,7 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake1
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -241,7 +242,7 @@ private fun StoriesScreenPreview(
 ) {
     AppTheme(themeType) {
         StoriesView(
-            state = State.Loaded(currentStory = StoryFake1(), numberOfStories = 2),
+            state = State.Loaded(currentStory = StoryFake1(listOf(Podcast())), numberOfStories = 2),
             progress = 0.5f,
             onSkipPrevious = {},
             onSkipNext = {},

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
@@ -124,7 +124,7 @@ private fun StoriesView(
         }
         SegmentedProgressIndicator(
             progress = progress,
-            numberOfSegments = state.numberOfStories,
+            segmentsData = state.segmentsData,
             modifier = modifier
                 .padding(8.dp)
                 .fillMaxWidth(),
@@ -251,8 +251,14 @@ private fun StoriesScreenPreview(
 ) {
     AppTheme(themeType) {
         StoriesView(
-            state = State.Loaded(currentStory = StoryFake1(listOf(Podcast())), numberOfStories = 2),
-            progress = 0.5f,
+            state = State.Loaded(
+                currentStory = StoryFake1(listOf(Podcast())),
+                segmentsData = State.Loaded.SegmentsData(
+                    xStartOffsets = listOf(0.0f, 0.28f),
+                    widths = listOf(0.25f, 0.75f)
+                )
+            ),
+            progress = 0.75f,
             onSkipPrevious = {},
             onSkipNext = {},
             onPause = {},

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -1,12 +1,15 @@
 package au.com.shiftyjelly.pocketcasts.endofyear
 
+import androidx.annotation.FloatRange
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State.Loaded.SegmentsData
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.util.Timer
 import javax.inject.Inject
 import kotlin.concurrent.fixedRateTimer
@@ -37,10 +40,15 @@ class StoriesViewModel @Inject constructor(
                 val state = if (stories.isEmpty()) {
                     State.Error
                 } else {
-                    State.Loaded(
-                        currentStory = storiesDataSource.storyAt(currentIndex),
-                        numberOfStories = numOfStories
-                    )
+                    with(storiesDataSource) {
+                        State.Loaded(
+                            currentStory = storyAt(currentIndex),
+                            segmentsData = SegmentsData(
+                                xStartOffsets = List(numOfStories) { getXStartOffsetAtIndex(it) },
+                                widths = storyLengthsInMs.map { it / totalLengthInMs.toFloat() },
+                            )
+                        )
+                    }
                 }
                 mutableState.value = state
                 if (state is State.Loaded) start()
@@ -85,6 +93,7 @@ class StoriesViewModel @Inject constructor(
     private fun skipToStoryAtIndex(index: Int) {
         if (timer == null) start()
         mutableProgress.value = getXStartOffsetAtIndex(index)
+        currentIndex = index
         mutableState.value =
             (state.value as State.Loaded).copy(currentStory = storiesDataSource.storyAt(index))
     }
@@ -101,16 +110,28 @@ class StoriesViewModel @Inject constructor(
 
     private fun Float.roundOff() = (this * 100.0).roundToInt()
 
-    private fun getXStartOffsetAtIndex(index: Int) =
-        (PROGRESS_END_VALUE / numOfStories.toFloat()).coerceAtMost(PROGRESS_END_VALUE) * index
+    @FloatRange(from = 0.0, to = 1.0)
+    fun getXStartOffsetAtIndex(index: Int): Float {
+        val sumOfStoryLengthsTillIndex = try {
+            storiesDataSource.storyLengthsInMs.subList(0, index).sum()
+        } catch (e: IndexOutOfBoundsException) {
+            Timber.e("Story offset checked at invalid index")
+            0L
+        }
+        return (sumOfStoryLengthsTillIndex + StoriesDataSource.STORY_GAP_LENGTH_MS * index) / storiesDataSource.totalLengthInMs.toFloat()
+    }
 
     sealed class State {
         object Loading : State()
         data class Loaded(
             val currentStory: Story?,
-            val numberOfStories: Int,
-        ) : State()
-
+            val segmentsData: SegmentsData,
+        ) : State() {
+            data class SegmentsData(
+                val widths: List<Float> = emptyList(),
+                val xStartOffsets: List<Float> = emptyList(),
+            )
+        }
         object Error : State()
     }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
@@ -1,20 +1,26 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.stories
 
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesDataSource
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EndOfYearManager
+import kotlinx.coroutines.flow.combine
 import timber.log.Timber
 import javax.inject.Inject
 
-class EndOfYearStoriesDataSource @Inject constructor() : StoriesDataSource() {
+class EndOfYearStoriesDataSource @Inject constructor(
+    private val endOfYearManager: EndOfYearManager,
+) : StoriesDataSource() {
     override val stories = mutableListOf<Story>()
 
-    override suspend fun loadStories(): Flow<List<Story>> {
-        delay(1000L) // TODO: Remove hardcoded delay added for testing
-        stories.addAll(listOf(StoryFake1(), StoryFake2()))
-        return flowOf(stories)
-    }
+    override suspend fun loadStories() =
+        combine(
+            endOfYearManager.findRandomPodcasts(),
+            endOfYearManager.findRandomEpisode()
+        ) { podcasts, episode ->
+            if (podcasts.isNotEmpty()) stories.add(StoryFake1(podcasts))
+            episode?.let { stories.add(StoryFake2(it)) }
+
+            stories
+        }
 
     override fun storyAt(index: Int) = try {
         stories[index]

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/Story.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/Story.kt
@@ -6,4 +6,5 @@ import au.com.shiftyjelly.pocketcasts.utils.seconds
 abstract class Story {
     open val storyLength: Long = 2.seconds()
     abstract val backgroundColor: Color
+    val tintColor: Color = Color.White
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/Story.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/Story.kt
@@ -4,6 +4,6 @@ import androidx.compose.ui.graphics.Color
 import au.com.shiftyjelly.pocketcasts.utils.seconds
 
 abstract class Story {
-    val storyLength: Long = 2.seconds()
+    open val storyLength: Long = 2.seconds()
     abstract val backgroundColor: Color
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryFake1.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryFake1.kt
@@ -1,7 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.stories
 
 import androidx.compose.ui.graphics.Color
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 
-class StoryFake1 : Story() {
+class StoryFake1(
+    val podcasts: List<Podcast>,
+) : Story() {
     override val backgroundColor: Color = Color.Magenta
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryFake2.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryFake2.kt
@@ -1,7 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.stories
 
 import androidx.compose.ui.graphics.Color
+import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 
-class StoryFake2 : Story() {
+class StoryFake2(
+    val episode: Episode,
+) : Story() {
     override val backgroundColor: Color = Color.Green
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryFake2.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryFake2.kt
@@ -2,9 +2,11 @@ package au.com.shiftyjelly.pocketcasts.endofyear.stories
 
 import androidx.compose.ui.graphics.Color
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
+import au.com.shiftyjelly.pocketcasts.utils.seconds
 
 class StoryFake2(
     val episode: Episode,
 ) : Story() {
+    override val storyLength: Long = 3.seconds()
     override val backgroundColor: Color = Color.Green
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/storyviews/StoryFake1View.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/storyviews/StoryFake1View.kt
@@ -1,0 +1,38 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.storyviews
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastItem
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake1
+
+@Composable
+fun StoryFake1View(
+    story: StoryFake1,
+    modifier: Modifier = Modifier,
+) {
+    Column {
+        TextH30(
+            text = "Your Top Podcasts",
+            textAlign = TextAlign.Center,
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp)
+        )
+        LazyColumn(modifier = modifier.fillMaxWidth()) {
+            items(story.podcasts.size) { index ->
+                PodcastItem(
+                    podcast = story.podcasts[index],
+                    onClick = {},
+                    showDivider = false
+                )
+            }
+        }
+    }
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/storyviews/StoryFake1View.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/storyviews/StoryFake1View.kt
@@ -21,6 +21,7 @@ fun StoryFake1View(
         TextH30(
             text = "Your Top Podcasts",
             textAlign = TextAlign.Center,
+            color = story.tintColor,
             modifier = modifier
                 .fillMaxWidth()
                 .padding(bottom = 16.dp)
@@ -30,6 +31,7 @@ fun StoryFake1View(
                 PodcastItem(
                     podcast = story.podcasts[index],
                     onClick = {},
+                    tintColor = story.tintColor,
                     showDivider = false
                 )
             }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/storyviews/StoryFake2View.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/storyviews/StoryFake2View.kt
@@ -19,6 +19,7 @@ fun StoryFake2View(
         TextH30(
             text = "The longest episode you listened to was ${story.episode.title}",
             textAlign = TextAlign.Center,
+            color = story.tintColor,
             modifier = modifier
                 .fillMaxWidth()
                 .padding(16.dp)

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/storyviews/StoryFake2View.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/storyviews/StoryFake2View.kt
@@ -1,0 +1,27 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.storyviews
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake2
+
+@Composable
+fun StoryFake2View(
+    story: StoryFake2,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier.padding(16.dp)) {
+        TextH30(
+            text = "The longest episode you listened to was ${story.episode.title}",
+            textAlign = TextAlign.Center,
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        )
+    }
+}

--- a/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
+++ b/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.endofyear
 
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
+import au.com.shiftyjelly.pocketcasts.utils.seconds
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.Dispatchers
@@ -18,6 +19,8 @@ import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.math.roundToInt
 
 private val story1 = mock<Story>()
 private val story2 = mock<Story>()
@@ -107,6 +110,48 @@ class StoriesViewModelTest {
 
         val state = viewModel.state.value as StoriesViewModel.State.Loaded
         assertEquals(state.currentStory, story1)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when next is invoked, then story skips to correct position`() = runTest {
+        whenever(story1.storyLength).thenReturn(5.seconds())
+        whenever(story2.storyLength).thenReturn(10.seconds())
+        val viewModel = StoriesViewModel(MockStoriesDataSource(listOf(story1, story2)))
+        val progress = mutableListOf<Float>()
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            viewModel.progress.collect {
+                progress.add(it)
+            }
+        }
+
+        viewModel.skipNext()
+
+        assertEquals(0.34f, (progress.last() * 100f).roundToInt() / 100f)
+        collectJob.cancel()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when prev is invoked, then story skips to correct position`() = runTest {
+        val story3 = mock<Story>()
+        whenever(story1.storyLength).thenReturn(5.seconds())
+        whenever(story2.storyLength).thenReturn(10.seconds())
+        whenever(story3.storyLength).thenReturn(5.seconds())
+        val viewModel = StoriesViewModel(MockStoriesDataSource(listOf(story1, story2, story3)))
+        viewModel.skipNext()
+        viewModel.skipNext() // At last story
+        val progress = mutableListOf<Float>()
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            viewModel.progress.collect {
+                progress.add(it)
+            }
+        }
+
+        viewModel.skipPrevious() // Skip to middle story
+
+        assertEquals(0.25f, (progress.last() * 100f).roundToInt() / 100f)
+        collectJob.cancel()
     }
 
     class MockStoriesDataSource(private val mockStories: List<Story>) : StoriesDataSource() {

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/adapter/SearchPodcastViewHolder.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/adapter/SearchPodcastViewHolder.kt
@@ -1,17 +1,21 @@
 package au.com.shiftyjelly.pocketcasts.search.adapter
 
+import androidx.compose.foundation.background
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastItem
+import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
-import au.com.shiftyjelly.pocketcasts.search.component.SearchPodcastRow
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 
 class SearchPodcastViewHolder(
     val composeView: ComposeView,
     val theme: Theme,
-    val onPodcastClick: (Podcast) -> Unit
+    val onPodcastClick: (Podcast) -> Unit,
 ) : RecyclerView.ViewHolder(composeView) {
 
     init {
@@ -23,7 +27,13 @@ class SearchPodcastViewHolder(
     fun bind(podcast: Podcast) {
         composeView.setContent {
             AppTheme(theme.activeTheme) {
-                SearchPodcastRow(podcast = podcast, subscribed = podcast.isSubscribed, onClick = { onPodcastClick(podcast) })
+                PodcastItem(
+                    podcast = podcast,
+                    subscribed = podcast.isSubscribed,
+                    onClick = { onPodcastClick(podcast) },
+                    modifier = Modifier
+                        .background(color = MaterialTheme.theme.colors.primaryUi01)
+                )
             }
         }
     }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
@@ -1,6 +1,5 @@
-package au.com.shiftyjelly.pocketcasts.search.component
+package au.com.shiftyjelly.pocketcasts.compose.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,23 +15,24 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
-import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
-import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
-fun SearchPodcastRow(podcast: Podcast, subscribed: Boolean, onClick: (() -> Unit)?, modifier: Modifier = Modifier) {
+fun PodcastItem(
+    podcast: Podcast,
+    onClick: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+    subscribed: Boolean = false,
+    showSubscribed: Boolean = false,
+) {
     Column {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = modifier
                 .fillMaxWidth()
-                .background(MaterialTheme.theme.colors.primaryUi01)
                 .padding(horizontal = 16.dp)
                 .then(if (onClick == null) Modifier else Modifier.clickable { onClick() })
         ) {
@@ -57,7 +57,7 @@ fun SearchPodcastRow(podcast: Podcast, subscribed: Boolean, onClick: (() -> Unit
                     color = MaterialTheme.theme.colors.primaryText02
                 )
             }
-            if (subscribed) {
+            if (subscribed && showSubscribed) {
                 Icon(
                     painter = painterResource(IR.drawable.ic_tick),
                     contentDescription = stringResource(LR.string.podcast_subscribed),

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
@@ -27,6 +27,7 @@ fun PodcastItem(
     modifier: Modifier = Modifier,
     subscribed: Boolean = false,
     showSubscribed: Boolean = false,
+    showDivider: Boolean = true,
 ) {
     Column {
         Row(
@@ -65,6 +66,8 @@ fun PodcastItem(
                 )
             }
         }
-        HorizontalDivider()
+        if (showDivider) {
+            HorizontalDivider()
+        }
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -25,6 +26,7 @@ fun PodcastItem(
     podcast: Podcast,
     onClick: (() -> Unit)?,
     modifier: Modifier = Modifier,
+    tintColor: Color? = null,
     subscribed: Boolean = false,
     showSubscribed: Boolean = false,
     showDivider: Boolean = true,
@@ -50,19 +52,20 @@ fun PodcastItem(
             ) {
                 TextP40(
                     text = podcast.title,
-                    maxLines = 1
+                    maxLines = 1,
+                    color = tintColor ?: MaterialTheme.theme.colors.primaryText01
                 )
                 TextP50(
                     text = podcast.author,
                     maxLines = 1,
-                    color = MaterialTheme.theme.colors.primaryText02
+                    color = tintColor ?: MaterialTheme.theme.colors.primaryText02
                 )
             }
             if (subscribed && showSubscribed) {
                 Icon(
                     painter = painterResource(IR.drawable.ic_tick),
                     contentDescription = stringResource(LR.string.podcast_subscribed),
-                    tint = MaterialTheme.theme.colors.support02
+                    tint = tintColor ?: MaterialTheme.theme.colors.support02
                 )
             }
         }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -20,6 +20,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import io.reactivex.Flowable
 import io.reactivex.Maybe
 import io.reactivex.Single
+import kotlinx.coroutines.flow.Flow
 import java.util.Date
 
 @Dao
@@ -307,4 +308,7 @@ abstract class EpisodeDao {
 
     @Query("UPDATE episodes SET playing_status = :playingStatus, playing_status_modified = :modified, played_up_to = 0, played_up_to_modified = :modified WHERE uuid IN (:episodesUUIDs)")
     abstract suspend fun markAllUnplayed(episodesUUIDs: List<String>, modified: Long, playingStatus: EpisodePlayingStatus = EpisodePlayingStatus.NOT_PLAYED)
+
+    @Query("SELECT * FROM episodes LIMIT 1")
+    abstract fun findRandomEpisode(): Flow<Episode?>
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -344,4 +344,7 @@ abstract class PodcastDao {
 
     @Query("UPDATE podcasts SET start_from = :startFromSecs, skip_last = :skipLastSecs, folder_uuid = :folderUuid, sort_order = :sortPosition, added_date = :addedDate WHERE uuid = :uuid")
     abstract suspend fun updateSyncData(uuid: String, startFromSecs: Int, skipLastSecs: Int, folderUuid: String?, sortPosition: Int, addedDate: Date)
+
+    @Query("SELECT * FROM podcasts LIMIT 5")
+    abstract fun findRandomPodcasts(): Flow<List<Podcast>>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
@@ -15,6 +15,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayerFactory
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayerFactoryImpl
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueueImpl
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EndOfYearManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EndOfYearManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
@@ -110,4 +112,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun provideUserEpisodeManager(userEpisodeManagerImpl: UserEpisodeManagerImpl): UserEpisodeManager
+
+    @Binds
+    @Singleton
+    abstract fun provideEndOfYearManager(endOfYearManagerImpl: EndOfYearManagerImpl): EndOfYearManager
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EndOfYearManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EndOfYearManager.kt
@@ -1,0 +1,11 @@
+package au.com.shiftyjelly.pocketcasts.repositories.podcast
+
+import au.com.shiftyjelly.pocketcasts.models.entity.Episode
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import kotlinx.coroutines.flow.Flow
+
+interface EndOfYearManager {
+    fun findRandomPodcasts(): Flow<List<Podcast>>
+
+    fun findRandomEpisode(): Flow<Episode?>
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EndOfYearManagerImpl.kt
@@ -1,0 +1,25 @@
+package au.com.shiftyjelly.pocketcasts.repositories.podcast
+
+import au.com.shiftyjelly.pocketcasts.models.entity.Episode
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
+
+class EndOfYearManagerImpl @Inject constructor(
+    private val podcastManager: PodcastManager,
+    private val episodeManager: EpisodeManager,
+) : EndOfYearManager, CoroutineScope {
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.Default
+
+    override fun findRandomPodcasts(): Flow<List<Podcast>> {
+        return podcastManager.findRandomPodcasts()
+    }
+
+    override fun findRandomEpisode(): Flow<Episode?> {
+        return episodeManager.findRandomEpisode()
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -12,6 +12,7 @@ import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Maybe
 import io.reactivex.Single
+import kotlinx.coroutines.flow.Flow
 import java.util.Date
 
 interface EpisodeManager {
@@ -134,4 +135,6 @@ interface EpisodeManager {
     suspend fun updatePlaybackInteractionDate(episode: Playable?)
     suspend fun deleteEpisodeFiles(episodes: List<Episode>, playbackManager: PlaybackManager)
     suspend fun findStaleDownloads(): List<Episode>
+
+    fun findRandomEpisode(): Flow<Episode?>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -1069,4 +1069,6 @@ class EpisodeManagerImpl @Inject constructor(
                 }
             }
     }
+
+    override fun findRandomEpisode() = episodeDao.findRandomEpisode()
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -136,4 +136,5 @@ interface PodcastManager {
     suspend fun findAutoAddToUpNextPodcasts(): List<Podcast>
 
     suspend fun refreshPodcastFeed(podcastUuid: String): Boolean
+    fun findRandomPodcasts(): Flow<List<Podcast>>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -749,4 +749,8 @@ class PodcastManagerImpl @Inject constructor(
     override suspend fun refreshPodcastFeed(podcastUuid: String): Boolean {
         return refreshServerManager.refreshPodcastFeed(podcastUuid).isSuccessful
     }
+
+    override fun findRandomPodcasts(): Flow<List<Podcast>> {
+        return podcastDao.findRandomPodcasts()
+    }
 }


### PR DESCRIPTION
| 📘 Project: #410 |
|:---:|

iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/397

Creates "dummy" stories based on randomly generated podcasts and episode. This PR also adds support for dynamic story lengths.

Same as the previous tasks, the designs here are not final and are mainly placeholders.

## Testing Instructions

1. Set `END_OF_YEAR_ENABLED` feature flag to `true` in `base.gradle`
2. Run the app
3. When the prompt appears tap "View my 2022"
4. ✅ A list of podcasts should appear ¶
5. Wait for 2 seconds
6. ✅ Notice that the next story starts displaying a random episode as the longest played episode
7. Wait for 3 seconds (dynamic time set for the second story)
8. ✅ Notice that stories progress ends
9. Play around with previous/ next taps
10. ✅ Notice that stories are skipped to correct positions

¶ If you don't see any podcasts, tap some podcasts on Discover or login.

## Screenshots or Screencast 

https://user-images.githubusercontent.com/1405144/197961191-f5a20174-3301-4a6a-b1d5-f92c6ecfae21.mp4


## Checklist
N/A as only fake story views are added

- If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews 
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- with different themes
- with a landscape orientation
- with the device set to have a large display and font size
- for accessibility with TalkBack
