### PR TITLE
Anonymous Bump Stats (part 1)

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
@@ -136,7 +136,8 @@ class AppDatabaseTest {
                 AppDatabase.MIGRATION_68_69,
                 AppDatabase.MIGRATION_69_70,
                 AppDatabase.MIGRATION_70_71,
-                AppDatabase.MIGRATION_71_72
+                AppDatabase.MIGRATION_71_72,
+                AppDatabase.MIGRATION_72_73
             )
             .build()
         // close the database and release any stream resources when the test finishes

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -8,6 +8,7 @@ import androidx.work.Configuration
 import au.com.shiftyjelly.pocketcasts.account.AccountAuth
 import au.com.shiftyjelly.pocketcasts.account.SignInSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.AnonymousBumpStatsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.TracksAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
@@ -70,7 +71,8 @@ class PocketCastsApplication : Application(), Configuration.Provider {
     @Inject lateinit var appIcon: AppIcon
     @Inject lateinit var coilImageLoader: ImageLoader
     @Inject lateinit var userManager: UserManager
-    @Inject lateinit var tracker: TracksAnalyticsTracker
+    @Inject lateinit var tracksTracker: TracksAnalyticsTracker
+    @Inject lateinit var bumpStatsTracker: AnonymousBumpStatsTracker
     @Inject lateinit var auth: AccountAuth
 
     private val applicationScope = MainScope()
@@ -102,7 +104,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
     }
 
     private fun setupAnalytics() {
-        AnalyticsTracker.registerTracker(tracker)
+        AnalyticsTracker.register(tracksTracker, bumpStatsTracker)
         AnalyticsTracker.init(settings)
         retrieveUserIdIfNeededAndRefreshMetadata()
     }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -60,6 +60,7 @@ import au.com.shiftyjelly.pocketcasts.profile.TrialFinishedFragment
 import au.com.shiftyjelly.pocketcasts.profile.cloud.CloudFileBottomSheetFragment
 import au.com.shiftyjelly.pocketcasts.profile.cloud.CloudFilesFragment
 import au.com.shiftyjelly.pocketcasts.profile.sonos.SonosAppLinkActivity
+import au.com.shiftyjelly.pocketcasts.repositories.bumpstats.BumpStatsTask
 import au.com.shiftyjelly.pocketcasts.repositories.opml.OpmlImportTask
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
@@ -285,8 +286,8 @@ class MainActivity :
         }
 
         refreshApp()
-
         addLineView()
+        BumpStatsTask.scheduleToRun(this)
     }
 
     override fun onPause() {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTracker.kt
@@ -11,8 +11,8 @@ object AnalyticsTracker {
         trackers.forEach { it.clearAllData() }
     }
 
-    fun registerTracker(tracker: Tracker?) {
-        tracker?.let { trackers.add(tracker) }
+    fun register(vararg trackers: Tracker) {
+        this.trackers.addAll(trackers)
     }
 
     fun track(event: AnalyticsEvent, properties: Map<String, Any> = emptyMap()) {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnonymousBumpStatsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnonymousBumpStatsTracker.kt
@@ -32,11 +32,10 @@ class AnonymousBumpStatsTracker @Inject constructor(
     override fun track(event: AnalyticsEvent, properties: Map<String, Any>) {
         if (shouldTrack(event)) {
             launch {
-                val name = "pcandroid_" + event.name.lowercase(Locale.ENGLISH) + "_bump"
                 val bumpStat = AnonymousBumpStat(
-                    name = name,
+                    name = event.name.lowercase(Locale.getDefault()),
                     customEventProps = properties
-                )
+                ).withBumpName()
                 bumpStatsDao.insert(bumpStat)
             }
         }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnonymousBumpStatsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnonymousBumpStatsTracker.kt
@@ -1,0 +1,48 @@
+package au.com.shiftyjelly.pocketcasts.analytics
+
+import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
+import au.com.shiftyjelly.pocketcasts.models.entity.AnonymousBumpStat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.util.Locale
+import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
+
+class AnonymousBumpStatsTracker @Inject constructor(
+    appDatabase: AppDatabase
+) : Tracker, CoroutineScope {
+    companion object {
+        private val PAID_SPONSOR_RELATED_EVENTS = listOf(
+            AnalyticsEvent.DISCOVER_LIST_IMPRESSION,
+            AnalyticsEvent.DISCOVER_LIST_SHOW_ALL_TAPPED,
+            AnalyticsEvent.DISCOVER_LIST_EPISODE_PLAY,
+            AnalyticsEvent.DISCOVER_LIST_EPISODE_TAPPED,
+            AnalyticsEvent.DISCOVER_LIST_PODCAST_SUBSCRIBED,
+            AnalyticsEvent.DISCOVER_LIST_PODCAST_TAPPED
+        )
+
+        private fun shouldTrack(event: AnalyticsEvent) =
+            PAID_SPONSOR_RELATED_EVENTS.contains(event)
+    }
+
+    override val coroutineContext: CoroutineContext = Dispatchers.IO
+    private val bumpStatsDao = appDatabase.bumpStatsDao()
+
+    override fun track(event: AnalyticsEvent, properties: Map<String, Any>) {
+        if (shouldTrack(event)) {
+            launch {
+                val name = "pcandroid_" + event.name.lowercase(Locale.ENGLISH) + "_bump"
+                val bumpStat = AnonymousBumpStat(
+                    name = name,
+                    customEventProps = properties
+                )
+                bumpStatsDao.insert(bumpStat)
+            }
+        }
+    }
+
+    override fun refreshMetadata() {}
+    override fun flush() {}
+    override fun clearAllData() {}
+}

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/IdentifyingTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/IdentifyingTracker.kt
@@ -1,0 +1,49 @@
+package au.com.shiftyjelly.pocketcasts.analytics
+
+import android.content.SharedPreferences
+import timber.log.Timber
+import java.util.UUID
+
+abstract class IdentifyingTracker(
+    private val preferences: SharedPreferences
+) : Tracker {
+    private var anonymousID: String? = null // do not access this variable directly. Use methods.
+    protected abstract val anonIdPrefKey: String?
+    var userId: String? = null
+
+    abstract override fun track(event: AnalyticsEvent, properties: Map<String, Any>)
+    abstract override fun refreshMetadata()
+
+    abstract override fun flush()
+    override fun clearAllData() {
+        clearAnonID()
+        userId = null
+    }
+
+    protected fun clearAnonID() {
+        anonymousID = null
+        if (preferences.contains(anonIdPrefKey)) {
+            val editor = preferences.edit()
+            editor.remove(anonIdPrefKey)
+            editor.apply()
+        }
+    }
+
+    protected val anonID: String?
+        get() {
+            if (anonymousID == null) {
+                anonymousID = preferences.getString(anonIdPrefKey, null)
+            }
+            return anonymousID
+        }
+
+    protected fun generateNewAnonID(): String {
+        val uuid = UUID.randomUUID().toString().replace("-", "")
+        Timber.d("\uD83D\uDD35 New anonID generated in " + this.javaClass.simpleName + ": " + uuid)
+        val editor = preferences.edit()
+        editor.putString(anonIdPrefKey, uuid)
+        editor.apply()
+        anonymousID = uuid
+        return uuid
+    }
+}

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/Tracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/Tracker.kt
@@ -1,49 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.analytics
 
-import android.content.SharedPreferences
-import timber.log.Timber
-import java.util.UUID
-
-abstract class Tracker(
-    private val preferences: SharedPreferences
-) {
-    private var anonymousID: String? = null // do not access this variable directly. Use methods.
-    abstract val anonIdPrefKey: String?
-    var userId: String? = null
-
-    abstract fun track(event: AnalyticsEvent, properties: Map<String, Any> = emptyMap())
-    abstract fun refreshMetadata()
-
-    abstract fun flush()
-    open fun clearAllData() {
-        clearAnonID()
-        userId = null
-    }
-
-    fun clearAnonID() {
-        anonymousID = null
-        if (preferences.contains(anonIdPrefKey)) {
-            val editor = preferences.edit()
-            editor.remove(anonIdPrefKey)
-            editor.apply()
-        }
-    }
-
-    val anonID: String?
-        get() {
-            if (anonymousID == null) {
-                anonymousID = preferences.getString(anonIdPrefKey, null)
-            }
-            return anonymousID
-        }
-
-    fun generateNewAnonID(): String {
-        val uuid = UUID.randomUUID().toString().replace("-", "")
-        Timber.d("\uD83D\uDD35 New anonID generated in " + this.javaClass.simpleName + ": " + uuid)
-        val editor = preferences.edit()
-        editor.putString(anonIdPrefKey, uuid)
-        editor.apply()
-        anonymousID = uuid
-        return uuid
-    }
+interface Tracker {
+    fun track(event: AnalyticsEvent, properties: Map<String, Any> = emptyMap())
+    fun refreshMetadata()
+    fun flush()
+    fun clearAllData()
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/TracksAnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/TracksAnalyticsTracker.kt
@@ -17,7 +17,7 @@ class TracksAnalyticsTracker @Inject constructor(
     @PublicSharedPreferences preferences: SharedPreferences,
     private val displayUtil: DisplayUtil,
     private val settings: Settings,
-) : Tracker(preferences) {
+) : IdentifyingTracker(preferences) {
     private val tracksClient: TracksClient? = TracksClient.getClient(appContext)
     override val anonIdPrefKey: String = TRACKS_ANON_ID
     private val plusSubscription: SubscriptionStatus.Plus?

--- a/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/73.json
+++ b/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/73.json
@@ -1,0 +1,1258 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 73,
+    "identityHash": "514e25c0954e7886b6a00c8c07bae784",
+    "entities": [
+      {
+        "tableName": "bump_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `event_time` INTEGER NOT NULL, `custom_event_props` TEXT NOT NULL, PRIMARY KEY(`name`, `event_time`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventTime",
+            "columnName": "event_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customEventProps",
+            "columnName": "custom_event_props",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "name",
+            "event_time"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `episode_description` TEXT NOT NULL, `published_date` INTEGER NOT NULL, `title` TEXT NOT NULL, `size_in_bytes` INTEGER NOT NULL, `episode_status` INTEGER NOT NULL, `file_type` TEXT, `duration` REAL NOT NULL, `download_url` TEXT, `downloaded_file_path` TEXT, `downloaded_error_details` TEXT, `play_error_details` TEXT, `played_up_to` REAL NOT NULL, `playing_status` INTEGER NOT NULL, `podcast_id` TEXT NOT NULL, `added_date` INTEGER NOT NULL, `auto_download_status` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `thumbnail_status` INTEGER NOT NULL, `last_download_attempt_date` INTEGER, `playing_status_modified` INTEGER, `played_up_to_modified` INTEGER, `duration_modified` INTEGER, `starred_modified` INTEGER, `archived` INTEGER NOT NULL, `archived_modified` INTEGER, `season` INTEGER, `number` INTEGER, `type` TEXT, `cleanTitle` TEXT, `last_playback_interaction_date` INTEGER, `last_playback_interaction_sync_status` INTEGER NOT NULL, `exclude_from_episode_limit` INTEGER NOT NULL, `download_task_id` TEXT, `last_archive_interaction_date` INTEGER, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeDescription",
+            "columnName": "episode_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "published_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeInBytes",
+            "columnName": "size_in_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeStatus",
+            "columnName": "episode_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "file_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadedFilePath",
+            "columnName": "downloaded_file_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadErrorDetails",
+            "columnName": "downloaded_error_details",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playErrorDetails",
+            "columnName": "play_error_details",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playedUpTo",
+            "columnName": "played_up_to",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playingStatus",
+            "columnName": "playing_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isStarred",
+            "columnName": "starred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailStatus",
+            "columnName": "thumbnail_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptDate",
+            "columnName": "last_download_attempt_date",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playingStatusModified",
+            "columnName": "playing_status_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playedUpToModified",
+            "columnName": "played_up_to_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "durationModified",
+            "columnName": "duration_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "starredModified",
+            "columnName": "starred_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archivedModified",
+            "columnName": "archived_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "season",
+            "columnName": "season",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "cleanTitle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastPlaybackInteraction",
+            "columnName": "last_playback_interaction_date",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastPlaybackInteractionSyncStatus",
+            "columnName": "last_playback_interaction_sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeFromEpisodeLimit",
+            "columnName": "exclude_from_episode_limit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTaskId",
+            "columnName": "download_task_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastArchiveInteraction",
+            "columnName": "last_archive_interaction_date",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "episode_last_download_attempt_date",
+            "unique": false,
+            "columnNames": [
+              "last_download_attempt_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_last_download_attempt_date` ON `${TABLE_NAME}` (`last_download_attempt_date`)"
+          },
+          {
+            "name": "episode_podcast_id",
+            "unique": false,
+            "columnNames": [
+              "podcast_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_podcast_id` ON `${TABLE_NAME}` (`podcast_id`)"
+          },
+          {
+            "name": "episode_published_date",
+            "unique": false,
+            "columnNames": [
+              "published_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_published_date` ON `${TABLE_NAME}` (`published_date`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `name` TEXT NOT NULL, `color` INTEGER NOT NULL, `added_date` INTEGER NOT NULL, `sort_position` INTEGER NOT NULL, `podcasts_sort_type` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `sync_modified` INTEGER NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastsSortType",
+            "columnName": "podcasts_sort_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncModified",
+            "columnName": "sync_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "filters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER, `uuid` TEXT NOT NULL, `title` TEXT NOT NULL, `sortPosition` INTEGER, `manual` INTEGER NOT NULL, `unplayed` INTEGER NOT NULL, `partiallyPlayed` INTEGER NOT NULL, `finished` INTEGER NOT NULL, `audioVideo` INTEGER NOT NULL, `allPodcasts` INTEGER NOT NULL, `podcastUuids` TEXT, `downloaded` INTEGER NOT NULL, `downloading` INTEGER NOT NULL, `notDownloaded` INTEGER NOT NULL, `autoDownload` INTEGER NOT NULL, `autoDownloadWifiOnly` INTEGER NOT NULL, `autoDownloadPowerOnly` INTEGER NOT NULL, `sortId` INTEGER NOT NULL, `iconId` INTEGER NOT NULL, `filterHours` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `syncStatus` INTEGER NOT NULL, `autoDownloadLimit` INTEGER NOT NULL, `filterDuration` INTEGER NOT NULL, `longerThan` INTEGER NOT NULL, `shorterThan` INTEGER NOT NULL, `draft` INTEGER NOT NULL, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sortPosition",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "manual",
+            "columnName": "manual",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unplayed",
+            "columnName": "unplayed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partiallyPlayed",
+            "columnName": "partiallyPlayed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finished",
+            "columnName": "finished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioVideo",
+            "columnName": "audioVideo",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allPodcasts",
+            "columnName": "allPodcasts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuids",
+            "columnName": "podcastUuids",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloaded",
+            "columnName": "downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloading",
+            "columnName": "downloading",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notDownloaded",
+            "columnName": "notDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownload",
+            "columnName": "autoDownload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadUnmeteredOnly",
+            "columnName": "autoDownloadWifiOnly",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadPowerOnly",
+            "columnName": "autoDownloadPowerOnly",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortId",
+            "columnName": "sortId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconId",
+            "columnName": "iconId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filterHours",
+            "columnName": "filterHours",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "starred",
+            "columnName": "starred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autodownloadLimit",
+            "columnName": "autoDownloadLimit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filterDuration",
+            "columnName": "filterDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longerThan",
+            "columnName": "longerThan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shorterThan",
+            "columnName": "shorterThan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "draft",
+            "columnName": "draft",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "filters_uuid",
+            "unique": false,
+            "columnNames": [
+              "uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `filters_uuid` ON `${TABLE_NAME}` (`uuid`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "filter_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `playlistId` INTEGER NOT NULL, `episodeUuid` TEXT NOT NULL, `position` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episodeUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "filter_episodes_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `filter_episodes_playlist_id` ON `${TABLE_NAME}` (`playlistId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "podcasts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `added_date` INTEGER, `thumbnail_url` TEXT, `title` TEXT NOT NULL, `podcast_url` TEXT, `podcast_description` TEXT NOT NULL, `podcast_category` TEXT NOT NULL, `podcast_language` TEXT NOT NULL, `media_type` TEXT, `latest_episode_uuid` TEXT, `author` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `episodes_sort_order` INTEGER NOT NULL, `latest_episode_date` INTEGER, `episodes_to_keep` INTEGER NOT NULL, `override_global_settings` INTEGER NOT NULL, `override_global_effects` INTEGER NOT NULL, `start_from` INTEGER NOT NULL, `playback_speed` REAL NOT NULL, `silence_removed` INTEGER NOT NULL, `volume_boosted` INTEGER NOT NULL, `is_folder` INTEGER NOT NULL, `subscribed` INTEGER NOT NULL, `show_notifications` INTEGER NOT NULL, `auto_download_status` INTEGER NOT NULL, `auto_add_to_up_next` INTEGER NOT NULL, `most_popular_color` INTEGER NOT NULL, `primary_color` INTEGER NOT NULL, `secondary_color` INTEGER NOT NULL, `light_overlay_color` INTEGER NOT NULL, `fab_for_light_bg` INTEGER NOT NULL, `link_for_dark_bg` INTEGER NOT NULL, `link_for_light_bg` INTEGER NOT NULL, `color_version` INTEGER NOT NULL, `color_last_downloaded` INTEGER NOT NULL, `sync_status` INTEGER NOT NULL, `exclude_from_auto_archive` INTEGER NOT NULL, `override_global_archive` INTEGER NOT NULL, `auto_archive_played_after` INTEGER NOT NULL, `auto_archive_inactive_after` INTEGER NOT NULL, `auto_archive_episode_limit` INTEGER, `estimated_next_episode` INTEGER, `episode_frequency` TEXT, `grouping` INTEGER NOT NULL, `skip_last` INTEGER NOT NULL, `show_archived` INTEGER NOT NULL, `trim_silence_level` INTEGER NOT NULL, `refresh_available` INTEGER NOT NULL, `folder_uuid` TEXT, `licensing` INTEGER NOT NULL, `isPaid` INTEGER NOT NULL, `bundleuuid` TEXT, `bundlebundleUrl` TEXT, `bundlepaymentUrl` TEXT, `bundledescription` TEXT, `bundlepodcastUuid` TEXT, `bundlepaidType` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnail_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUrl",
+            "columnName": "podcast_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "podcastDescription",
+            "columnName": "podcast_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastCategory",
+            "columnName": "podcast_category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastLanguage",
+            "columnName": "podcast_language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latestEpisodeUuid",
+            "columnName": "latest_episode_uuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodesSortType",
+            "columnName": "episodes_sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latestEpisodeDate",
+            "columnName": "latest_episode_date",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "episodesToKeep",
+            "columnName": "episodes_to_keep",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalSettings",
+            "columnName": "override_global_settings",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalEffects",
+            "columnName": "override_global_effects",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startFromSecs",
+            "columnName": "start_from",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playback_speed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSilenceRemoved",
+            "columnName": "silence_removed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isVolumeBoosted",
+            "columnName": "volume_boosted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFolder",
+            "columnName": "is_folder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSubscribed",
+            "columnName": "subscribed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isShowNotifications",
+            "columnName": "show_notifications",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoAddToUpNext",
+            "columnName": "auto_add_to_up_next",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundColor",
+            "columnName": "most_popular_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tintColorForLightBg",
+            "columnName": "primary_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tintColorForDarkBg",
+            "columnName": "secondary_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fabColorForDarkBg",
+            "columnName": "light_overlay_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fabColorForLightBg",
+            "columnName": "fab_for_light_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkColorForLightBg",
+            "columnName": "link_for_dark_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkColorForDarkBg",
+            "columnName": "link_for_light_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorVersion",
+            "columnName": "color_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorLastDownloaded",
+            "columnName": "color_last_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeFromAutoArchive",
+            "columnName": "exclude_from_auto_archive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalArchive",
+            "columnName": "override_global_archive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveAfterPlaying",
+            "columnName": "auto_archive_played_after",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveInactive",
+            "columnName": "auto_archive_inactive_after",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveEpisodeLimit",
+            "columnName": "auto_archive_episode_limit",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "estimatedNextEpisode",
+            "columnName": "estimated_next_episode",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "episodeFrequency",
+            "columnName": "episode_frequency",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "grouping",
+            "columnName": "grouping",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skipLastSecs",
+            "columnName": "skip_last",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showArchived",
+            "columnName": "show_archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trimMode",
+            "columnName": "trim_silence_level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "refreshAvailable",
+            "columnName": "refresh_available",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderUuid",
+            "columnName": "folder_uuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "licensing",
+            "columnName": "licensing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "singleBundle.uuid",
+            "columnName": "bundleuuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singleBundle.bundleUrl",
+            "columnName": "bundlebundleUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singleBundle.paymentUrl",
+            "columnName": "bundlepaymentUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singleBundle.description",
+            "columnName": "bundledescription",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singleBundle.podcastUuid",
+            "columnName": "bundlepodcastUuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singleBundle.paidType",
+            "columnName": "bundlepaidType",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "up_next_changes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `type` INTEGER NOT NULL, `uuid` TEXT, `uuids` TEXT, `modified` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "uuids",
+            "columnName": "uuids",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "modified",
+            "columnName": "modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "up_next_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `episodeUuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `playlistId` INTEGER, `title` TEXT NOT NULL, `publishedDate` INTEGER, `downloadUrl` TEXT, `podcastUuid` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episodeUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "publishedDate",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcastUuid",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "user_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `published_date` INTEGER NOT NULL, `episode_description` TEXT NOT NULL, `title` TEXT NOT NULL, `size_in_bytes` INTEGER NOT NULL, `episode_status` INTEGER NOT NULL, `file_type` TEXT, `duration` REAL NOT NULL, `download_url` TEXT, `played_up_to` REAL NOT NULL, `playing_status` INTEGER NOT NULL, `added_date` INTEGER NOT NULL, `auto_download_status` INTEGER NOT NULL, `last_download_attempt_date` INTEGER, `archived` INTEGER NOT NULL, `download_task_id` TEXT, `downloaded_file_path` TEXT, `playing_status_modified` INTEGER, `played_up_to_modified` INTEGER, `artwork_url` TEXT, `play_error_details` TEXT, `server_status` INTEGER NOT NULL, `upload_error_details` TEXT, `downloaded_error_details` TEXT, `tint_color_index` INTEGER NOT NULL, `has_custom_image` INTEGER NOT NULL, `upload_task_id` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "published_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeDescription",
+            "columnName": "episode_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeInBytes",
+            "columnName": "size_in_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeStatus",
+            "columnName": "episode_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "file_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playedUpTo",
+            "columnName": "played_up_to",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playingStatus",
+            "columnName": "playing_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptDate",
+            "columnName": "last_download_attempt_date",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTaskId",
+            "columnName": "download_task_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadedFilePath",
+            "columnName": "downloaded_file_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playingStatusModified",
+            "columnName": "playing_status_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playedUpToModified",
+            "columnName": "played_up_to_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "artworkUrl",
+            "columnName": "artwork_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playErrorDetails",
+            "columnName": "play_error_details",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "serverStatus",
+            "columnName": "server_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadErrorDetails",
+            "columnName": "upload_error_details",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadErrorDetails",
+            "columnName": "downloaded_error_details",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tintColorIndex",
+            "columnName": "tint_color_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomImage",
+            "columnName": "has_custom_image",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadTaskId",
+            "columnName": "upload_task_id",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "user_episode_last_download_attempt_date",
+            "unique": false,
+            "columnNames": [
+              "last_download_attempt_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `user_episode_last_download_attempt_date` ON `${TABLE_NAME}` (`last_download_attempt_date`)"
+          },
+          {
+            "name": "user_episode_published_date",
+            "unique": false,
+            "columnNames": [
+              "published_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `user_episode_published_date` ON `${TABLE_NAME}` (`published_date`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '514e25c0954e7886b6a00c8c07bae784')"
+    ]
+  }
+}

--- a/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/73.json
+++ b/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/73.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 73,
-    "identityHash": "514e25c0954e7886b6a00c8c07bae784",
+    "identityHash": "d858de797cee44020ce6b3c728e81aff",
     "entities": [
       {
         "tableName": "bump_stats",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `event_time` INTEGER NOT NULL, `custom_event_props` TEXT NOT NULL, PRIMARY KEY(`name`, `event_time`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `event_time` INTEGER NOT NULL, `custom_event_props` TEXT NOT NULL, PRIMARY KEY(`name`, `event_time`, `custom_event_props`))",
         "fields": [
           {
             "fieldPath": "name",
@@ -30,7 +30,8 @@
         "primaryKey": {
           "columnNames": [
             "name",
-            "event_time"
+            "event_time",
+            "custom_event_props"
           ],
           "autoGenerate": false
         },
@@ -1252,7 +1253,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '514e25c0954e7886b6a00c8c07bae784')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd858de797cee44020ce6b3c728e81aff')"
     ]
   }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -19,7 +19,7 @@ import au.com.shiftyjelly.pocketcasts.models.converter.PodcastLicensingEnumConve
 import au.com.shiftyjelly.pocketcasts.models.converter.PodcastsSortTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.TrimModeTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.UserEpisodeServerStatusConverter
-import au.com.shiftyjelly.pocketcasts.models.db.dao.BumpStatDao
+import au.com.shiftyjelly.pocketcasts.models.db.dao.BumpStatsDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.FolderDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PlaylistDao
@@ -74,7 +74,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun upNextChangeDao(): UpNextChangeDao
     abstract fun userEpisodeDao(): UserEpisodeDao
     abstract fun folderDao(): FolderDao
-    abstract fun bumpStatDao(): BumpStatDao
+    abstract fun bumpStatsDao(): BumpStatsDao
 
     companion object {
         // This seems dodgy but I got it from Google, https://github.com/googlesamples/android-sunflower/blob/master/app/src/main/java/com/google/samples/apps/sunflower/data/AppDatabase.kt

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -368,7 +368,7 @@ abstract class AppDatabase : RoomDatabase() {
                       name TEXT NOT NULL,
                       event_time INTEGER NOT NULL,
                       custom_event_props TEXT NOT NULL,
-                      PRIMARY KEY(name, event_time)
+                      PRIMARY KEY(name, event_time, custom_event_props)
                     );
                 """.trimIndent()
             )

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BumpStatDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BumpStatDao.kt
@@ -1,0 +1,21 @@
+package au.com.shiftyjelly.pocketcasts.models.db.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import au.com.shiftyjelly.pocketcasts.models.entity.AnonymousBumpStat
+
+@Dao
+abstract class BumpStatDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun insert(bumpStat: AnonymousBumpStat)
+
+    @Query("SELECT * FROM bump_stats")
+    abstract suspend fun get(): List<AnonymousBumpStat>
+
+    @Delete
+    abstract suspend fun deleteAll(bumpStats: List<AnonymousBumpStat>)
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BumpStatsDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BumpStatsDao.kt
@@ -8,7 +8,7 @@ import androidx.room.Query
 import au.com.shiftyjelly.pocketcasts.models.entity.AnonymousBumpStat
 
 @Dao
-abstract class BumpStatDao {
+abstract class BumpStatsDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract suspend fun insert(bumpStat: AnonymousBumpStat)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AnonymousBumpStat.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AnonymousBumpStat.kt
@@ -1,0 +1,114 @@
+package au.com.shiftyjelly.pocketcasts.models.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.TypeConverter
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.ToJson
+import com.squareup.moshi.Types
+import timber.log.Timber
+
+@Entity(tableName = "bump_stats", primaryKeys = ["name", "event_time"])
+data class AnonymousBumpStat(
+    @ColumnInfo(name = "name") var name: String,
+    @ColumnInfo(name = "event_time") var eventTime: Long = System.currentTimeMillis(),
+    @ColumnInfo(name = "custom_event_props") var customEventProps: Map<String, Any> = emptyMap()
+) {
+    companion object {
+        object JsonKey {
+            const val NAME = "_en"
+            const val EVENT_TIME = "_ts"
+            const val UUID = "_ui"
+            const val USER_TYPE = "_ut"
+        }
+
+        const val userType = "anon"
+        const val uuid = "ANONYMOUS"
+    }
+
+    class CustomEventPropsTypeConverter {
+
+        private val moshi = Moshi.Builder()
+            .build()
+            .adapter<Map<String, Any>>(
+                Types.newParameterizedType(
+                    Map::class.java,
+                    String::class.java,
+                    Any::class.java
+                )
+            )
+
+        @TypeConverter
+        fun toCustomEventProps(value: String?): Map<String, Any>? =
+            value?.let {
+                moshi.fromJson(it)
+            }
+
+        @TypeConverter
+        fun toJsonString(value: Map<String, Any>?): String? = moshi.toJson(value)
+    }
+
+    object Adapter {
+
+        // Prefix that is applied to custom event prop keys in order to avoid possible clashes with
+        // the other json keys like name, event_time, uuid, user_type.
+        private const val CUSTOM_EVENT_PROP_PREFIX = "customEventProp_"
+
+        @ToJson
+        fun toJson(bumpStat: AnonymousBumpStat): Map<String, Any> =
+            buildMap {
+                put(JsonKey.NAME, bumpStat.name)
+                put(JsonKey.EVENT_TIME, bumpStat.eventTime)
+                put(JsonKey.UUID, uuid)
+                put(JsonKey.USER_TYPE, userType)
+
+                // include custom event props in root object
+                bumpStat.customEventProps.forEach { (k, v) ->
+                    put(CUSTOM_EVENT_PROP_PREFIX + k, v)
+                }
+            }
+
+        @FromJson
+        fun fromJson(bumpStatMap: Map<String, Any>): AnonymousBumpStat? {
+            val eventProps = buildMap {
+                bumpStatMap.keys.forEach { key ->
+                    when (key) {
+                        JsonKey.NAME,
+                        JsonKey.EVENT_TIME,
+                        JsonKey.USER_TYPE,
+                        JsonKey.UUID -> { /* ignore fields that are not dynamic */ }
+
+                        else -> {
+                            // include dynamic values in eventProps
+                            bumpStatMap[CUSTOM_EVENT_PROP_PREFIX + key]?.let { value ->
+                                put(key, value)
+                            }
+                            Unit
+                        }
+                    }
+                }
+            }
+
+            val name = bumpStatMap[JsonKey.NAME]
+                as? String
+                ?: run {
+                    Timber.e("Failed to parse ${JsonKey.NAME} for ${AnonymousBumpStat::class.qualifiedName}")
+                    return null
+                }
+
+            val eventTime = bumpStatMap[JsonKey.EVENT_TIME]
+                as? Long
+                ?: run {
+                    Timber.e("Failed to parse ${JsonKey.EVENT_TIME} for ${AnonymousBumpStat::class.qualifiedName}")
+                    return null
+                }
+
+            return AnonymousBumpStat(
+                name = name,
+                eventTime = eventTime,
+                customEventProps = eventProps
+            )
+        }
+    }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AnonymousBumpStat.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AnonymousBumpStat.kt
@@ -9,7 +9,7 @@ import com.squareup.moshi.ToJson
 import com.squareup.moshi.Types
 import timber.log.Timber
 
-@Entity(tableName = "bump_stats", primaryKeys = ["name", "event_time"])
+@Entity(tableName = "bump_stats", primaryKeys = ["name", "event_time", "custom_event_props"])
 data class AnonymousBumpStat(
     @ColumnInfo(name = "name") var name: String,
     @ColumnInfo(name = "event_time") var eventTime: Long = System.currentTimeMillis(),

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AnonymousBumpStat.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AnonymousBumpStat.kt
@@ -15,16 +15,35 @@ data class AnonymousBumpStat(
     @ColumnInfo(name = "event_time") var eventTime: Long = System.currentTimeMillis(),
     @ColumnInfo(name = "custom_event_props") var customEventProps: Map<String, Any> = emptyMap()
 ) {
+
+    init {
+        val conflictingKeys = customEventProps.keys.filter { rootJsonKeys.contains(it) }
+        if (conflictingKeys.isNotEmpty()) {
+            // There should never be conflicting keys because when we convert this object to json, the
+            // rootJsonKeys and the customEventProp keys are all included at the root level. Fail
+            // quickly if we have created conflicting keys since this is a developer error.
+            throw IllegalStateException("customEventProps contained a key that conflicted with a root key: $conflictingKeys")
+        }
+    }
+
+    fun withBumpName(): AnonymousBumpStat {
+        val bumpName = "pcandroid_${name}_bump"
+        return copy(name = bumpName)
+    }
+
     companion object {
-        object JsonKey {
-            const val NAME = "_en"
-            const val EVENT_TIME = "_ts"
-            const val UUID = "_ui"
-            const val USER_TYPE = "_ut"
+
+        private enum class JsonKey(val value: String) {
+            NAME("_en"),
+            EVENT_TIME("_ts"),
+            UUID("_ui"),
+            USER_TYPE("_ut")
         }
 
-        const val userType = "anon"
-        const val uuid = "ANONYMOUS"
+        private val rootJsonKeys = JsonKey.values().map { it.value }
+
+        const val userTypeValue = "anon"
+        const val uuidValue = "ANONYMOUS"
     }
 
     class CustomEventPropsTypeConverter {
@@ -50,59 +69,40 @@ data class AnonymousBumpStat(
     }
 
     object Adapter {
-
-        // Prefix that is applied to custom event prop keys in order to avoid possible clashes with
-        // the other json keys like name, event_time, uuid, user_type.
-        private const val CUSTOM_EVENT_PROP_PREFIX = "customEventProp_"
-
         @ToJson
         fun toJson(bumpStat: AnonymousBumpStat): Map<String, Any> =
             buildMap {
-                put(JsonKey.NAME, bumpStat.name)
-                put(JsonKey.EVENT_TIME, bumpStat.eventTime)
-                put(JsonKey.UUID, uuid)
-                put(JsonKey.USER_TYPE, userType)
+                put(JsonKey.NAME.value, bumpStat.name)
+                put(JsonKey.EVENT_TIME.value, bumpStat.eventTime)
+                put(JsonKey.UUID.value, uuidValue)
+                put(JsonKey.USER_TYPE.value, userTypeValue)
 
                 // include custom event props in root object
                 bumpStat.customEventProps.forEach { (k, v) ->
-                    put(CUSTOM_EVENT_PROP_PREFIX + k, v)
+                    put(k, v)
                 }
             }
 
         @FromJson
         fun fromJson(bumpStatMap: Map<String, Any>): AnonymousBumpStat? {
-            val eventProps = buildMap {
-                bumpStatMap.keys.forEach { key ->
-                    when (key) {
-                        JsonKey.NAME,
-                        JsonKey.EVENT_TIME,
-                        JsonKey.USER_TYPE,
-                        JsonKey.UUID -> { /* ignore fields that are not dynamic */ }
 
-                        else -> {
-                            // include dynamic values in eventProps
-                            bumpStatMap[CUSTOM_EVENT_PROP_PREFIX + key]?.let { value ->
-                                put(key, value)
-                            }
-                            Unit
-                        }
-                    }
-                }
-            }
+            val eventProps = bumpStatMap.filterKeys { !rootJsonKeys.contains(it) }
 
-            val name = bumpStatMap[JsonKey.NAME]
+            val name = bumpStatMap[JsonKey.NAME.value]
                 as? String
                 ?: run {
-                    Timber.e("Failed to parse ${JsonKey.NAME} for ${AnonymousBumpStat::class.qualifiedName}")
+                    Timber.e("Failed to parse ${JsonKey.NAME.value} for ${AnonymousBumpStat::class.qualifiedName}")
                     return null
                 }
 
-            val eventTime = bumpStatMap[JsonKey.EVENT_TIME]
+            val eventTime = bumpStatMap[JsonKey.EVENT_TIME.value]
                 as? Long
                 ?: run {
-                    Timber.e("Failed to parse ${JsonKey.EVENT_TIME} for ${AnonymousBumpStat::class.qualifiedName}")
+                    Timber.e("Failed to parse ${JsonKey.EVENT_TIME.value} for ${AnonymousBumpStat::class.qualifiedName}")
                     return null
                 }
+
+            // Ignoring JsonKey.UUID and JsonKey.USER_TYPE because those are hardcoded values
 
             return AnonymousBumpStat(
                 name = name,

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -25,6 +25,7 @@ interface Settings {
         const val SERVER_SHORT_URL = BuildConfig.SERVER_SHORT_URL
         const val SERVER_LIST_URL = BuildConfig.SERVER_LIST_URL
         const val SERVER_LIST_HOST = BuildConfig.SERVER_LIST_HOST
+        const val WP_COM_API_URL = "https://public-api.wordpress.com"
 
         const val SHARING_SERVER_SECRET = BuildConfig.SHARING_SERVER_SECRET
         val SETTINGS_ENCRYPT_SECRET = BuildConfig.SETTINGS_ENCRYPT_SECRET.toCharArray()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bumpstats/BumpStatsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bumpstats/BumpStatsTask.kt
@@ -1,0 +1,69 @@
+package au.com.shiftyjelly.pocketcasts.repositories.bumpstats
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
+import au.com.shiftyjelly.pocketcasts.servers.bumpstats.WpComServerManager
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import timber.log.Timber
+
+@HiltWorker
+class BumpStatsTask @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters,
+    private val appDatabase: AppDatabase,
+    private val wpComServerManager: WpComServerManager
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+
+        val bumpStatsDao = appDatabase.bumpStatDao()
+        val bumpStats = bumpStatsDao.get()
+
+        return if (bumpStats.isNotEmpty()) {
+            val response = wpComServerManager.bumpStatAnonymously(bumpStats)
+            if (response.isSuccessful && response.body() == "Accepted") {
+                Timber.i("$TAG, successfully sent bump stats")
+
+                // Remove the bump stat events that were successfully sent from the db
+                bumpStatsDao.deleteAll(bumpStats)
+
+                Result.success()
+            } else {
+                LogBuffer.i(TAG, "Failed to send bump stats")
+                Result.failure()
+            }
+        } else {
+            Timber.i("$TAG, no bump stat events to send")
+            Result.success()
+        }
+    }
+
+    companion object {
+        private const val TAG = "BumpStatsTask"
+
+        fun scheduleToRun(context: Context) {
+
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+
+            val workRequest = OneTimeWorkRequestBuilder<BumpStatsTask>()
+                .setConstraints(constraints)
+                .build()
+
+            WorkManager
+                .getInstance(context)
+                .enqueueUniqueWork(TAG, ExistingWorkPolicy.REPLACE, workRequest)
+        }
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bumpstats/BumpStatsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bumpstats/BumpStatsTask.kt
@@ -26,7 +26,7 @@ class BumpStatsTask @AssistedInject constructor(
 
     override suspend fun doWork(): Result {
 
-        val bumpStatsDao = appDatabase.bumpStatDao()
+        val bumpStatsDao = appDatabase.bumpStatsDao()
         val bumpStats = bumpStatsDao.get()
 
         return if (bumpStats.isNotEmpty()) {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/AnonymousBumpStatsRequest.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/AnonymousBumpStatsRequest.kt
@@ -1,96 +1,15 @@
 package au.com.shiftyjelly.pocketcasts.servers.bumpstats
 
-import com.squareup.moshi.FromJson
+import au.com.shiftyjelly.pocketcasts.models.entity.AnonymousBumpStat
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import com.squareup.moshi.ToJson
-import timber.log.Timber
 import java.util.Locale
 
 @JsonClass(generateAdapter = true)
 data class AnonymousBumpStatsRequest(
-    @field:Json(name = "events") val events: List<Event> = emptyList(),
+    @field:Json(name = "events") val events: List<AnonymousBumpStat> = emptyList(),
     @field:Json(name = "commonProps") val commonProps: CommonProps = CommonProps.get()
 ) {
-
-    data class Event(
-        val name: String,
-        val eventTime: Long,
-        val customEventProps: Map<String, Any> = emptyMap()
-    ) {
-
-        val uuid = "ANONYMOUS"
-        val userType = "anon"
-
-        companion object {
-            object JsonKey {
-                const val NAME = "_en"
-                const val EVENT_TIME = "_ts"
-                const val UUID = "_ui"
-                const val USER_TYPE = "_ut"
-            }
-        }
-
-        object Adapter {
-            @ToJson
-            fun toJson(event: Event): Map<String, Any> =
-                buildMap {
-                    put(JsonKey.NAME, event.name)
-                    put(JsonKey.EVENT_TIME, event.eventTime)
-                    put(JsonKey.UUID, event.uuid)
-                    put(JsonKey.USER_TYPE, event.userType)
-
-                    // include custom event props in root object
-                    event.customEventProps.forEach { (k, v) ->
-                        put(k, v)
-                    }
-                }
-
-            @FromJson
-            fun fromJson(event: Map<String, Any>): Event? {
-                val eventProps = buildMap {
-                    event.keys.forEach { key ->
-                        when (key) {
-                            JsonKey.NAME,
-                            JsonKey.EVENT_TIME,
-                            JsonKey.USER_TYPE,
-                            JsonKey.UUID -> { /* ignore fields that are not dynamic */
-                            }
-
-                            else -> {
-                                // include dynamic values in eventProps
-                                event[key]?.let { value ->
-                                    put(key, value)
-                                }
-                                Unit
-                            }
-                        }
-                    }
-                }
-
-                val name = event[JsonKey.NAME]
-                    as? String
-                    ?: run {
-                        Timber.e("Failed to parse ${JsonKey.NAME} for ${Event::class.qualifiedName}")
-                        return null
-                    }
-
-                val eventTime = event[JsonKey.EVENT_TIME]
-                    as? Long
-                    ?: run {
-                        Timber.e("Failed to parse ${JsonKey.EVENT_TIME} for ${Event::class.qualifiedName}")
-                        return null
-                    }
-
-                return Event(
-                    name = name,
-                    eventTime = eventTime,
-                    customEventProps = eventProps
-                )
-            }
-        }
-    }
-
     @JsonClass(generateAdapter = true)
     data class CommonProps(
         @field:Json(name = "_lg") val language: String,

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/AnonymousBumpStatsRequest.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/AnonymousBumpStatsRequest.kt
@@ -1,0 +1,109 @@
+package au.com.shiftyjelly.pocketcasts.servers.bumpstats
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.ToJson
+import timber.log.Timber
+import java.util.Locale
+
+@JsonClass(generateAdapter = true)
+data class AnonymousBumpStatsRequest(
+    @field:Json(name = "events") val events: List<Event> = emptyList(),
+    @field:Json(name = "commonProps") val commonProps: CommonProps = CommonProps.get()
+) {
+
+    data class Event(
+        val name: String,
+        val eventTime: Long,
+        val customEventProps: Map<String, Any> = emptyMap()
+    ) {
+
+        val uuid = "ANONYMOUS"
+        val userType = "anon"
+
+        companion object {
+            object JsonKey {
+                const val NAME = "_en"
+                const val EVENT_TIME = "_ts"
+                const val UUID = "_ui"
+                const val USER_TYPE = "_ut"
+            }
+        }
+
+        object Adapter {
+            @ToJson
+            fun toJson(event: Event): Map<String, Any> =
+                buildMap {
+                    put(JsonKey.NAME, event.name)
+                    put(JsonKey.EVENT_TIME, event.eventTime)
+                    put(JsonKey.UUID, event.uuid)
+                    put(JsonKey.USER_TYPE, event.userType)
+
+                    // include custom event props in root object
+                    event.customEventProps.forEach { (k, v) ->
+                        put(k, v)
+                    }
+                }
+
+            @FromJson
+            fun fromJson(event: Map<String, Any>): Event? {
+                val eventProps = buildMap {
+                    event.keys.forEach { key ->
+                        when (key) {
+                            JsonKey.NAME,
+                            JsonKey.EVENT_TIME,
+                            JsonKey.USER_TYPE,
+                            JsonKey.UUID -> { /* ignore fields that are not dynamic */
+                            }
+
+                            else -> {
+                                // include dynamic values in eventProps
+                                event[key]?.let { value ->
+                                    put(key, value)
+                                }
+                                Unit
+                            }
+                        }
+                    }
+                }
+
+                val name = event[JsonKey.NAME]
+                    as? String
+                    ?: run {
+                        Timber.e("Failed to parse ${JsonKey.NAME} for ${Event::class.qualifiedName}")
+                        return null
+                    }
+
+                val eventTime = event[JsonKey.EVENT_TIME]
+                    as? Long
+                    ?: run {
+                        Timber.e("Failed to parse ${JsonKey.EVENT_TIME} for ${Event::class.qualifiedName}")
+                        return null
+                    }
+
+                return Event(
+                    name = name,
+                    eventTime = eventTime,
+                    customEventProps = eventProps
+                )
+            }
+        }
+    }
+
+    @JsonClass(generateAdapter = true)
+    data class CommonProps(
+        @field:Json(name = "_lg") val language: String,
+        @field:Json(name = "_rt") val requestTime: Long,
+        @field:Json(name = "_via_ua") val source: String
+    ) {
+        companion object {
+            fun get() =
+                CommonProps(
+                    language = Locale.getDefault().toString(),
+                    requestTime = System.currentTimeMillis(),
+                    source = "Pocket Casts Android"
+                )
+        }
+    }
+}

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/WpComServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/WpComServer.kt
@@ -1,0 +1,12 @@
+package au.com.shiftyjelly.pocketcasts.servers.bumpstats
+
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface WpComServer {
+    /**
+     * Notify the that an event X occurred at Y time.
+     */
+    @POST("/rest/v1.1/tracks/record")
+    suspend fun bumpStatAnonymously(@Body request: AnonymousBumpStatsRequest)
+}

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/WpComServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/WpComServer.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.servers.bumpstats
 
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
 
@@ -8,5 +9,5 @@ interface WpComServer {
      * Notify the that an event X occurred at Y time.
      */
     @POST("/rest/v1.1/tracks/record")
-    suspend fun bumpStatAnonymously(@Body request: AnonymousBumpStatsRequest)
+    suspend fun bumpStatAnonymously(@Body request: AnonymousBumpStatsRequest): Response<String>
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/WpComServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/WpComServer.kt
@@ -5,9 +5,7 @@ import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface WpComServer {
-    /**
-     * Notify the that an event X occurred at Y time.
-     */
+
     @POST("/rest/v1.1/tracks/record")
     suspend fun bumpStatAnonymously(@Body request: AnonymousBumpStatsRequest): Response<String>
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/WpComServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/WpComServerManager.kt
@@ -1,25 +1,18 @@
 package au.com.shiftyjelly.pocketcasts.servers.bumpstats
 
+import au.com.shiftyjelly.pocketcasts.models.entity.AnonymousBumpStat
 import au.com.shiftyjelly.pocketcasts.servers.di.WpComServerRetrofit
+import retrofit2.Response
 import retrofit2.Retrofit
 import javax.inject.Inject
 
 class WpComServerManager @Inject constructor(
     @WpComServerRetrofit retrofit: Retrofit
 ) {
-
     private val server: WpComServer = retrofit.create(WpComServer::class.java)
 
-    suspend fun bumpStatAnonymously(key: String, properties: Map<String, String>) {
-        val request = AnonymousBumpStatsRequest(
-            events = listOf(
-                AnonymousBumpStatsRequest.Event(
-                    name = key,
-                    eventTime = System.currentTimeMillis(), // FIXME make sure this stays the time of the event
-                    customEventProps = properties
-                )
-            )
-        )
+    suspend fun bumpStatAnonymously(bumpStats: List<AnonymousBumpStat>): Response<String> {
+        val request = AnonymousBumpStatsRequest(bumpStats)
         return server.bumpStatAnonymously(request)
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/WpComServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/WpComServerManager.kt
@@ -1,0 +1,25 @@
+package au.com.shiftyjelly.pocketcasts.servers.bumpstats
+
+import au.com.shiftyjelly.pocketcasts.servers.di.WpComServerRetrofit
+import retrofit2.Retrofit
+import javax.inject.Inject
+
+class WpComServerManager @Inject constructor(
+    @WpComServerRetrofit retrofit: Retrofit
+) {
+
+    private val server: WpComServer = retrofit.create(WpComServer::class.java)
+
+    suspend fun bumpStatAnonymously(key: String, properties: Map<String, String>) {
+        val request = AnonymousBumpStatsRequest(
+            events = listOf(
+                AnonymousBumpStatsRequest.Event(
+                    name = key,
+                    eventTime = System.currentTimeMillis(), // FIXME make sure this stays the time of the event
+                    customEventProps = properties
+                )
+            )
+        )
+        return server.bumpStatAnonymously(request)
+    }
+}

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
@@ -2,12 +2,12 @@ package au.com.shiftyjelly.pocketcasts.servers.di
 
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.localization.BuildConfig
+import au.com.shiftyjelly.pocketcasts.models.entity.AnonymousBumpStat
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatusMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortTypeMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.servers.bumpstats.AnonymousBumpStatsRequest
 import au.com.shiftyjelly.pocketcasts.servers.model.DisplayStyleMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyleMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.servers.model.ListTypeMoshiAdapter
@@ -251,7 +251,7 @@ class ServersModule {
     @Singleton
     internal fun provideWpComApiRetrofit(@CachedOkHttpClient okHttpClient: OkHttpClient): Retrofit {
         val moshi = Moshi.Builder()
-            .add(AnonymousBumpStatsRequest.Event.Adapter)
+            .add(AnonymousBumpStat.Adapter)
             .build()
 
         return Retrofit.Builder()

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
@@ -7,6 +7,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatusMoshiAdapt
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortTypeMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.servers.bumpstats.AnonymousBumpStatsRequest
 import au.com.shiftyjelly.pocketcasts.servers.model.DisplayStyleMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyleMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.servers.model.ListTypeMoshiAdapter
@@ -246,6 +247,21 @@ class ServersModule {
     }
 
     @Provides
+    @WpComServerRetrofit
+    @Singleton
+    internal fun provideWpComApiRetrofit(@CachedOkHttpClient okHttpClient: OkHttpClient): Retrofit {
+        val moshi = Moshi.Builder()
+            .add(AnonymousBumpStatsRequest.Event.Adapter)
+            .build()
+
+        return Retrofit.Builder()
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .baseUrl(Settings.WP_COM_API_URL)
+            .client(okHttpClient)
+            .build()
+    }
+
+    @Provides
     @RefreshServerRetrofit
     @Singleton
     internal fun provideRefreshRetrofit(@NoCacheTokenedOkHttpClient okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
@@ -402,6 +418,10 @@ annotation class SyncServerRetrofit
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class OldSyncServerRetrofit
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class WpComServerRetrofit
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)


### PR DESCRIPTION
## Description

This adds the ability to anonymously bump a stat. We need this for purposes of allowing users to opt-out of analytics while still allowing us to get the data we need to be able to provide to paid sponsors. 

The only data that is provided with these events are:
1. An event name
2. The time of the event
3. Any specific properties about the event (i.e., the id of the list that the user interacted with in the discover feed)

The second part of this work will involve providing anonymous daily unique stats, which I will address in a follow-up PR. This sets us up to drop Firebase as an analytics provider, and allows us to do a better job of restricting the data we collect.

## Testing Instructions
1. Load the app
2. Go to the discover screen and perform the the following actions:
    1. Subscribe to a podcast
    2. Tap on "Show All" to see all of a list
    6. Play a featured episode from the Discover Screen
    7. Tap on a podcast on the Discover screen
    8. Tap. on an episode on the Discover screen
3. Put the app in the background and reload it
4. Observe that the relevant events are sent to Tracks

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
