### PR TITLE
EoY: Remove flaky tests

### DIFF
--- a/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
+++ b/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
@@ -1,14 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.endofyear
 
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
-import au.com.shiftyjelly.pocketcasts.utils.seconds
 import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -19,8 +16,6 @@ import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
-import kotlin.math.roundToInt
 
 private val story1 = mock<Story>()
 private val story2 = mock<Story>()
@@ -61,25 +56,6 @@ class StoriesViewModelTest {
         verify(dataSource).loadStories()
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @Test
-    fun `when stories are found, then progress increments`() = runTest {
-        val storyLengthInMs = 2.seconds()
-        whenever(story1.storyLength).thenReturn(storyLengthInMs)
-        whenever(story2.storyLength).thenReturn(storyLengthInMs)
-        val viewModel = StoriesViewModel(MockStoriesDataSource(listOf(story1, story2)))
-
-        val progress = mutableListOf<Float>()
-        val collectJob = launch(UnconfinedTestDispatcher()) {
-            viewModel.progress.collect {
-                progress.add(it)
-            }
-        }
-
-        assertTrue(progress.last() > 0f)
-        collectJob.cancel()
-    }
-
     @Test
     fun `given no stories found, when vm starts, then error is shown`() {
         val viewModel = StoriesViewModel(MockStoriesDataSource(emptyList()))
@@ -113,48 +89,6 @@ class StoriesViewModelTest {
 
         val state = viewModel.state.value as StoriesViewModel.State.Loaded
         assertEquals(state.currentStory, story1)
-    }
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @Test
-    fun `when next is invoked, then story skips to correct position`() = runTest {
-        whenever(story1.storyLength).thenReturn(5.seconds())
-        whenever(story2.storyLength).thenReturn(10.seconds())
-        val viewModel = StoriesViewModel(MockStoriesDataSource(listOf(story1, story2)))
-        val progress = mutableListOf<Float>()
-        val collectJob = launch(UnconfinedTestDispatcher()) {
-            viewModel.progress.collect {
-                progress.add(it)
-            }
-        }
-
-        viewModel.skipNext()
-
-        assertEquals(0.34f, (progress.last() * 100f).roundToInt() / 100f)
-        collectJob.cancel()
-    }
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @Test
-    fun `when prev is invoked, then story skips to correct position`() = runTest {
-        val story3 = mock<Story>()
-        whenever(story1.storyLength).thenReturn(5.seconds())
-        whenever(story2.storyLength).thenReturn(10.seconds())
-        whenever(story3.storyLength).thenReturn(5.seconds())
-        val viewModel = StoriesViewModel(MockStoriesDataSource(listOf(story1, story2, story3)))
-        viewModel.skipNext()
-        viewModel.skipNext() // At last story
-        val progress = mutableListOf<Float>()
-        val collectJob = launch(UnconfinedTestDispatcher()) {
-            viewModel.progress.collect {
-                progress.add(it)
-            }
-        }
-
-        viewModel.skipPrevious() // Skip to middle story
-
-        assertEquals(0.25f, (progress.last() * 100f).roundToInt() / 100f)
-        collectJob.cancel()
     }
 
     class MockStoriesDataSource(private val mockStories: List<Story>) : StoriesDataSource() {


### PR DESCRIPTION
This removes flaky tests inside `StoriesViewModelTest` that checks the progress indicator position. 
I'll consider re-adding them once I address their flakiness.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
