### PR TITLE
End of Year: Story snapshot and share

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesDataSource.kt
@@ -3,22 +3,6 @@ package au.com.shiftyjelly.pocketcasts.endofyear
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
 import kotlinx.coroutines.flow.Flow
 
-abstract class StoriesDataSource {
-    protected abstract val stories: List<Story>
-
-    val numOfStories: Int
-        get() = stories.size
-    val totalLengthInMs
-        get() = storyLengthsInMs.sum() + gapLengthsInMs
-    val storyLengthsInMs: List<Long>
-        get() = stories.map { it.storyLength }
-    private val gapLengthsInMs: Long
-        get() = STORY_GAP_LENGTH_MS * numOfStories.minus(1).coerceAtLeast(0)
-
-    abstract suspend fun loadStories(): Flow<List<Story>>
-    abstract fun storyAt(index: Int): Story?
-
-    companion object {
-        const val STORY_GAP_LENGTH_MS = 100L
-    }
+interface StoriesDataSource {
+    suspend fun loadStories(): Flow<List<Story>>
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
@@ -22,6 +23,11 @@ class StoriesFragment : BaseDialogFragment() {
     private val viewModel: StoriesViewModel by viewModels()
     override val statusBarColor: StatusBarColor
         get() = StatusBarColor.Custom(Color.BLACK, true)
+
+    private val shareLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        /* Share activity dismissed, start paused story */
+        viewModel.start()
+    }
 
     override fun onCreate(savedInstance: Bundle?) {
         super.onCreate(savedInstance)
@@ -60,12 +66,7 @@ class StoriesFragment : BaseDialogFragment() {
             intent.type = "image/png"
             val uri = FileUtil.createUriWithReadPermissions(file, intent, requireContext())
             intent.putExtra(Intent.EXTRA_STREAM, uri)
-            context.startActivity(
-                Intent.createChooser(
-                    intent,
-                    context.getString(LR.string.end_of_year_share_via)
-                )
-            )
+            shareLauncher.launch(Intent.createChooser(intent, context.getString(LR.string.end_of_year_share_via)))
         } catch (e: Exception) {
             Timber.e(e)
         }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.endofyear
 
+import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -11,7 +12,11 @@ import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.ui.R
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import timber.log.Timber
+import java.io.File
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 class StoriesFragment : BaseDialogFragment() {
     private val viewModel: StoriesViewModel by viewModels()
@@ -35,9 +40,34 @@ class StoriesFragment : BaseDialogFragment() {
                     StoriesScreen(
                         viewModel = viewModel,
                         onCloseClicked = { dismiss() },
+                        onShareClicked = { onCaptureBitmap ->
+                            viewModel.onShareClicked(
+                                onCaptureBitmap,
+                                requireContext(),
+                                ::showShareForFile
+                            )
+                        }
                     )
                 }
             }
+        }
+    }
+
+    private fun showShareForFile(file: File) {
+        val context = requireContext()
+        try {
+            val intent = Intent(Intent.ACTION_SEND)
+            intent.type = "image/png"
+            val uri = FileUtil.createUriWithReadPermissions(file, intent, requireContext())
+            intent.putExtra(Intent.EXTRA_STREAM, uri)
+            context.startActivity(
+                Intent.createChooser(
+                    intent,
+                    context.getString(LR.string.end_of_year_share_via)
+                )
+            )
+        } catch (e: Exception) {
+            Timber.e(e)
         }
     }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
@@ -44,7 +44,7 @@ import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake1
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake2
-import au.com.shiftyjelly.pocketcasts.endofyear.views.snapShot
+import au.com.shiftyjelly.pocketcasts.endofyear.views.convertibleToBitmap
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryFake1View
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryFake2View
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -96,7 +96,8 @@ private fun StoriesView(
         state.currentStory?.let { story ->
             Box(modifier = modifier.weight(weight = 1f, fill = true)) {
                 if (!story.isInteractive) {
-                    onCaptureBitmap = snapShot(content = { StorySharableContent(story, modifier) })
+                    onCaptureBitmap =
+                        convertibleToBitmap(content = { StorySharableContent(story, modifier) })
                 }
                 StorySwitcher(
                     onSkipPrevious = onSkipPrevious,
@@ -106,7 +107,7 @@ private fun StoriesView(
                 ) {
                     if (story.isInteractive) {
                         onCaptureBitmap =
-                            snapShot(content = { StorySharableContent(story, modifier) })
+                            convertibleToBitmap(content = { StorySharableContent(story, modifier) })
                     }
                 }
                 SegmentedProgressIndicator(

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
@@ -54,7 +54,6 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 private val ShareButtonStrokeWidth = 2.dp
 private val StoryViewCornerSize = 10.dp
 
-private var onCaptureBitmap: (() -> Bitmap)? = null
 @Composable
 fun StoriesScreen(
     viewModel: StoriesViewModel,
@@ -93,25 +92,32 @@ private fun StoriesView(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.background(color = Color.Black)) {
-        Box(modifier = modifier.weight(weight = 1f, fill = true)) {
-            state.currentStory?.let {
-                if (!it.isInteractive) StoryView(story = it)
+        var onCaptureBitmap: (() -> Bitmap)? = null
+        state.currentStory?.let { story ->
+            Box(modifier = modifier.weight(weight = 1f, fill = true)) {
+                if (!story.isInteractive) {
+                    onCaptureBitmap = snapShot(content = { StorySharableContent(story, modifier) })
+                }
                 StorySwitcher(
                     onSkipPrevious = onSkipPrevious,
                     onSkipNext = onSkipNext,
                     onPause = onPause,
                     onStart = onStart,
-                    content = { if (it.isInteractive) StoryView(story = it) }
+                ) {
+                    if (story.isInteractive) {
+                        onCaptureBitmap =
+                            snapShot(content = { StorySharableContent(story, modifier) })
+                    }
+                }
+                SegmentedProgressIndicator(
+                    progress = progress,
+                    segmentsData = state.segmentsData,
+                    modifier = modifier
+                        .padding(8.dp)
+                        .fillMaxWidth(),
                 )
+                CloseButtonView(onCloseClicked)
             }
-            SegmentedProgressIndicator(
-                progress = progress,
-                segmentsData = state.segmentsData,
-                modifier = modifier
-                    .padding(8.dp)
-                    .fillMaxWidth(),
-            )
-            CloseButtonView(onCloseClicked)
         }
         ShareButton(
             onClick = {
@@ -119,16 +125,6 @@ private fun StoriesView(
             }
         )
     }
-}
-
-@Composable
-private fun StoryView(
-    story: Story,
-    modifier: Modifier = Modifier,
-) {
-    onCaptureBitmap = snapShot(
-        content = { StorySharableContent(story, modifier) }
-    )
 }
 
 @Composable

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
@@ -119,11 +119,11 @@ private fun StoriesView(
                 CloseButtonView(onCloseClicked)
             }
         }
-        ShareButton(
-            onClick = {
-                onShareClicked.invoke(requireNotNull(onCaptureBitmap))
-            }
-        )
+        requireNotNull(onCaptureBitmap).let {
+            ShareButton(
+                onClick = { onShareClicked.invoke(it) }
+            )
+        }
     }
 }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
@@ -43,8 +43,8 @@ import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake1
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake2
-import au.com.shiftyjelly.pocketcasts.endofyear.views.StoryFake1View
-import au.com.shiftyjelly.pocketcasts.endofyear.views.StoryFake2View
+import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryFake1View
+import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryFake2View
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -130,14 +130,17 @@ class StoriesViewModel @Inject constructor(
         onCaptureBitmap: () -> Bitmap,
         context: Context,
         showShareForFile: (File) -> Unit
-    ) = viewModelScope.launch {
-        val savedFile = fileUtilWrapper.saveBitmapToFile(
-            onCaptureBitmap.invoke(),
-            context,
-            EOY_STORY_SAVE_FOLDER_NAME,
-            EOY_STORY_SAVE_FILE_NAME
-        )
-        savedFile?.let { showShareForFile.invoke(it) }
+    ) {
+        pause()
+        viewModelScope.launch {
+            val savedFile = fileUtilWrapper.saveBitmapToFile(
+                onCaptureBitmap.invoke(),
+                context,
+                EOY_STORY_SAVE_FOLDER_NAME,
+                EOY_STORY_SAVE_FILE_NAME
+            )
+            savedFile?.let { showShareForFile.invoke(it) }
+        }
     }
 
     sealed class State {

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
@@ -2,30 +2,24 @@ package au.com.shiftyjelly.pocketcasts.endofyear.stories
 
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesDataSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EndOfYearManager
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import timber.log.Timber
 import javax.inject.Inject
 
 class EndOfYearStoriesDataSource @Inject constructor(
     private val endOfYearManager: EndOfYearManager,
-) : StoriesDataSource() {
-    override val stories = mutableListOf<Story>()
-
-    override suspend fun loadStories() =
-        combine(
+) : StoriesDataSource {
+    override suspend fun loadStories(): Flow<List<Story>> {
+        return combine(
             endOfYearManager.findRandomPodcasts(),
             endOfYearManager.findRandomEpisode()
         ) { podcasts, episode ->
+            val stories = mutableListOf<Story>()
+
             if (podcasts.isNotEmpty()) stories.add(StoryFake1(podcasts))
             episode?.let { stories.add(StoryFake2(it)) }
 
             stories
         }
-
-    override fun storyAt(index: Int) = try {
-        stories[index]
-    } catch (e: IndexOutOfBoundsException) {
-        Timber.e("Story index is out of bounds")
-        null
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/Story.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/Story.kt
@@ -7,4 +7,5 @@ abstract class Story {
     open val storyLength: Long = 2.seconds()
     abstract val backgroundColor: Color
     val tintColor: Color = Color.White
+    val isInteractive: Boolean = false
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/SnapShot.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/SnapShot.kt
@@ -8,18 +8,16 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.drawToBitmap
 
-/* Returns a callback to get latest composable bitmap.
+/* Returns a callback to get bitmap for the passed composable.
+The composable is converted to ComposeView and laid out into AndroidView otherwise an illegal state exception is thrown:
+View needs to be laid out before calling drawToBitmap()
 Credits: https://rb.gy/g5vuez */
 @Composable
-fun snapShot(
+fun convertibleToBitmap(
     content: @Composable () -> Unit,
 ): () -> Bitmap {
     val context = LocalContext.current
     val composeView = remember { ComposeView(context) }
-
-    fun onCaptureBitmap(): Bitmap {
-        return composeView.drawToBitmap()
-    }
 
     AndroidView(
         factory = {
@@ -31,5 +29,5 @@ fun snapShot(
         }
     )
 
-    return ::onCaptureBitmap
+    return { composeView.drawToBitmap() }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/SnapShot.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/SnapShot.kt
@@ -1,0 +1,35 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.views
+
+import android.graphics.Bitmap
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.view.drawToBitmap
+
+/* Returns a callback to get latest composable bitmap.
+Credits: https://rb.gy/g5vuez */
+@Composable
+fun snapShot(
+    content: @Composable () -> Unit,
+): () -> Bitmap {
+    val context = LocalContext.current
+    val composeView = remember { ComposeView(context) }
+
+    fun onCaptureBitmap(): Bitmap {
+        return composeView.drawToBitmap()
+    }
+
+    AndroidView(
+        factory = {
+            composeView.apply {
+                setContent {
+                    content.invoke()
+                }
+            }
+        }
+    )
+
+    return ::onCaptureBitmap
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryFake1View.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryFake1View.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.endofyear.views
+package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryFake1View.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryFake1View.kt
@@ -1,35 +1,64 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
 
+import android.content.Context
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.coerceAtMost
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastItem
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake1
+import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 
 @Composable
 fun StoryFake1View(
     story: StoryFake1,
     modifier: Modifier = Modifier,
 ) {
-    Column {
+    val context = LocalContext.current
+    var screenHeight by remember { mutableStateOf(1) }
+    var textFieldHeight by remember { mutableStateOf(1) }
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .onGloballyPositioned {
+                screenHeight = it.size.height
+            },
+        verticalArrangement = Arrangement.Center
+    ) {
         TextH30(
             text = "Your Top Podcasts",
             textAlign = TextAlign.Center,
             color = story.tintColor,
             modifier = modifier
                 .fillMaxWidth()
-                .padding(bottom = 16.dp)
+                .padding(vertical = 16.dp)
+                .onGloballyPositioned {
+                    textFieldHeight = it.size.height
+                }
         )
-        LazyColumn(modifier = modifier.fillMaxWidth()) {
+        LazyColumn(
+            modifier = modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.Center
+        ) {
             items(story.podcasts.size) { index ->
                 PodcastItem(
                     podcast = story.podcasts[index],
+                    iconSize = getIconSize(screenHeight, textFieldHeight, context),
                     onClick = {},
                     tintColor = story.tintColor,
                     showDivider = false
@@ -37,4 +66,15 @@ fun StoryFake1View(
             }
         }
     }
+}
+
+fun getIconSize(
+    screenHeight: Int,
+    textFieldHeight: Int,
+    context: Context
+): Dp {
+    return screenHeight.pxToDp(context).dp
+        .minus(32.dp + textFieldHeight.dp)
+        .div(5)
+        .coerceAtMost(64.dp)
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryFake2View.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryFake2View.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.endofyear.views
+package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
@@ -15,11 +15,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+private val PodcastItemIconSize = 64.dp
 
 @Composable
 fun PodcastItem(
@@ -27,6 +30,7 @@ fun PodcastItem(
     onClick: (() -> Unit)?,
     modifier: Modifier = Modifier,
     tintColor: Color? = null,
+    iconSize: Dp = PodcastItemIconSize,
     subscribed: Boolean = false,
     showSubscribed: Boolean = false,
     showDivider: Boolean = true,
@@ -42,7 +46,7 @@ fun PodcastItem(
             Box(modifier = Modifier.padding(top = 4.dp, end = 12.dp, bottom = 4.dp)) {
                 PodcastImage(
                     uuid = podcast.uuid,
-                    modifier = Modifier.size(64.dp)
+                    modifier = Modifier.size(iconSize)
                 )
             }
             Column(

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1388,6 +1388,7 @@
     <string name="end_of_year_launch_modal_secondary_button_title">Not Now</string>
     <string name="end_of_year_prompt_card_title" translatable="false">@string/end_of_year_launch_modal_title</string>
     <string name="end_of_year_prompt_card_summary">See your top podcasts, categories, listening stats and more.</string>
+    <string name="end_of_year_share_via">@string/podcasts_share_via</string>
 
     <!--    Tasker Plugin-->
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1388,7 +1388,7 @@
     <string name="end_of_year_launch_modal_secondary_button_title">Not Now</string>
     <string name="end_of_year_prompt_card_title" translatable="false">@string/end_of_year_launch_modal_title</string>
     <string name="end_of_year_prompt_card_summary">See your top podcasts, categories, listening stats and more.</string>
-    <string name="end_of_year_share_via">@string/podcasts_share_via</string>
+    <string name="end_of_year_share_via" translatable="false">@string/podcasts_share_via</string>
 
     <!--    Tasker Plugin-->
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilWrapper.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilWrapper.kt
@@ -16,7 +16,7 @@ class FileUtilWrapper @Inject constructor() {
     }
 
     suspend fun saveBitmapToFile(
-        image: Bitmap,
+        bitmap: Bitmap,
         context: Context,
         saveFolderName: String,
         saveFileName: String,
@@ -27,7 +27,7 @@ class FileUtilWrapper @Inject constructor() {
             imagesFolder.mkdirs()
             file = File(imagesFolder, saveFileName)
             val stream = FileOutputStream(file)
-            image.compress(Bitmap.CompressFormat.PNG, 90, stream)
+            bitmap.compress(Bitmap.CompressFormat.PNG, 90, stream)
             stream.flush()
             stream.close()
         } catch (e: IOException) {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilWrapper.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilWrapper.kt
@@ -26,10 +26,10 @@ class FileUtilWrapper @Inject constructor() {
         try {
             imagesFolder.mkdirs()
             file = File(imagesFolder, saveFileName)
-            val stream = FileOutputStream(file)
-            bitmap.compress(Bitmap.CompressFormat.PNG, 90, stream)
-            stream.flush()
-            stream.close()
+            FileOutputStream(file).use { stream ->
+                bitmap.compress(Bitmap.CompressFormat.PNG, 90, stream)
+                stream.flush()
+            }
         } catch (e: IOException) {
             Timber.e("Error while saving image to file " + e.message)
         }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilWrapper.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilWrapper.kt
@@ -1,9 +1,38 @@
 package au.com.shiftyjelly.pocketcasts.utils
 
+import android.content.Context
+import android.graphics.Bitmap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
 import javax.inject.Inject
 
 class FileUtilWrapper @Inject constructor() {
     fun deleteDirectoryContents(path: String) {
         FileUtil.deleteDirectoryContents(path)
+    }
+
+    suspend fun saveBitmapToFile(
+        image: Bitmap,
+        context: Context,
+        saveFolderName: String,
+        saveFileName: String,
+    ): File? = withContext(Dispatchers.IO) {
+        val imagesFolder = File(context.cacheDir, saveFolderName)
+        var file: File? = null
+        try {
+            imagesFolder.mkdirs()
+            file = File(imagesFolder, saveFileName)
+            val stream = FileOutputStream(file)
+            image.compress(Bitmap.CompressFormat.PNG, 90, stream)
+            stream.flush()
+            stream.close()
+        } catch (e: IOException) {
+            Timber.e("Error while saving image to file " + e.message)
+        }
+        file
     }
 }


### PR DESCRIPTION
| 📘 Project: #410 |
|:---:|

iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/404

## Description


This PR
- Generates an image for the latest story and passes it to the share intent.
    
    The image generation uses Android's `view.drawToBitmap()` function. Selected story's sharable composable is converted to `ComposeView` and laid out into `AndroidView` otherwise an exception is thrown: `java.lang.IllegalStateException: View needs to be laid out before calling drawToBitmap()`
 
    It only captures the visible screen.

    The share button click action invokes a callback that generates the bitmap, saves it, and opens it in `share` view. 

- Two other changes includes in this PR:
    - Fix weird state noticed in https://github.com/Automattic/pocket-casts-android/pull/495#issuecomment-1292676258 [94276c7](https://github.com/Automattic/pocket-casts-android/pull/505/commits/94276c73ccee938847ae3533ffe7693c595cade2) - Converts combined flow to state flow on view model scope
    - Introduce `isInteractive` story [052069b](https://github.com/Automattic/pocket-casts-android/pull/505/commits/052069b0e5708c33a2616677304b3b3ce79567f0)

## Testing Instructions

1. Set `END_OF_YEAR_ENABLED` feature flag to `true` in `base.gradle`
2. Run the app
3. When the prompt appears, tap "View My 2022"
4. Tap "Share"
5. Tap "Edit"
6. ✅ Make sure the generated image is correct
8. Go back to the app, and share the story again
9. Select Instagram or Facebook (story)
10. ✅ Check that the image appears correctly in those apps

## Screenshots or Screencast 

Share View| Screenshot
---|----
<img width=320 src="https://user-images.githubusercontent.com/1405144/198588986-1587325e-fc68-45d1-aec0-0011d9972a89.png"/> | <img width=320 src="https://user-images.githubusercontent.com/1405144/198598538-5ca9dee5-bc5f-4265-bc65-d4caf9dbf73c.png"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
