### PR TITLE
PC-I25: Prevent Mini Player From Animating When Changing Theme

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerBottomSheet.kt
@@ -134,14 +134,14 @@ class PlayerBottomSheet @JvmOverloads constructor(context: Context, attrs: Attri
         binding.miniPlayer.setPlaybackState(playbackState)
     }
 
-    fun setUpNext(upNext: UpNextQueue.State, theme: Theme) {
+    fun setUpNext(upNext: UpNextQueue.State, theme: Theme, shouldAnimateOnAttach: Boolean) {
         binding.miniPlayer.setUpNext(upNext, theme)
 
         // only show the mini player when an episode is loaded
         if (upNext is UpNextQueue.State.Loaded) {
             if ((isHidden() || !hasLoadedFirstTime)) {
                 show()
-                if (!shouldPlayerOpenOnAttach) {
+                if (!shouldPlayerOpenOnAttach && shouldAnimateOnAttach) {
                     translationY = 68.dpToPx(context).toFloat()
                     animate().translationY(0f).setListener(object : AnimatorListenerAdapter() {
                         override fun onAnimationEnd(animation: Animator) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerBottomSheet.kt
@@ -151,6 +151,10 @@ class PlayerBottomSheet @JvmOverloads constructor(context: Context, attrs: Attri
                     })
                 } else {
                     translationY = 0f
+                    if (!shouldAnimateOnAttach) {
+                        listener?.onMiniPlayerVisible()
+                        hasLoadedFirstTime = true
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
## Description
Store the state of the mini player when recreating the MainActivity so that the mini player animation can be disabled when changing the theme.

Fixes #25 

## Testing Instructions
1. Navigate to Appearance settings
2. Select a theme different from the currently applied theme
3. Mini player should not animate

## Screenshots or Screencast 
https://user-images.githubusercontent.com/20568035/198835613-b27c9045-0dd0-426f-bc44-8c3008ef6778.mp4

