### PR TITLE
Remove bump stats

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/FirebaseAnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/FirebaseAnalyticsTracker.kt
@@ -29,7 +29,7 @@ object FirebaseAnalyticsTracker {
         params.putString("list_id", listId)
         params.putString("podcast_uuid", podcastUuid)
 
-        bumpStat("discover_list_episode_play", params)
+        logEvent("discover_list_episode_play", params)
     }
 
     fun podcastEpisodeTappedFromList(listId: String, podcastUuid: String, episodeUuid: String) {
@@ -38,7 +38,7 @@ object FirebaseAnalyticsTracker {
             putString("podcast_uuid", podcastUuid)
             putString("episode_uuid", episodeUuid)
         }
-        bumpStat("discover_list_podcast_episode_tap", params)
+        logEvent("discover_list_podcast_episode_tap", params)
     }
 
     fun podcastSubscribedFromList(listId: String, podcastUuid: String) {
@@ -46,7 +46,7 @@ object FirebaseAnalyticsTracker {
         params.putString("list_id", listId)
         params.putString("podcast_uuid", podcastUuid)
 
-        bumpStat("discover_list_podcast_subscribe", params)
+        logEvent("discover_list_podcast_subscribe", params)
     }
 
     fun podcastTappedFromList(listId: String, podcastUuid: String) {
@@ -54,21 +54,21 @@ object FirebaseAnalyticsTracker {
         params.putString("list_id", listId)
         params.putString("podcast_uuid", podcastUuid)
 
-        bumpStat("discover_list_podcast_tap", params)
+        logEvent("discover_list_podcast_tap", params)
     }
 
     fun listShowAllTapped(listId: String) {
         val params = Bundle()
         params.putString("list_id", listId)
 
-        bumpStat("discover_list_show_all", params)
+        logEvent("discover_list_show_all", params)
     }
 
     fun listImpression(listId: String) {
         val params = Bundle()
         params.putString("list_id", listId)
 
-        bumpStat("discover_list_impression", params)
+        logEvent("discover_list_impression", params)
     }
 
     fun listShared(listId: String) {
@@ -258,10 +258,6 @@ object FirebaseAnalyticsTracker {
 
     fun folderCreated() {
         logEvent("folder_created")
-    }
-
-    private fun bumpStat(name: String, bundle: Bundle? = Bundle()) {
-        firebaseAnalytics.logEvent(name, bundle)
     }
 
     private fun logEvent(name: String, bundle: Bundle? = Bundle()) {


### PR DESCRIPTION
## Description

This removes the bump stats usage of firebase.

> **Note**
> I have this PR is targeting the `release/7.26` branch.

## Testing Instructions

Make sure that we're handling the analytics opt-out appropriately:
1. Turn ON sharing of analytics in `Profile` -> ⚙️ -> `Privacy` -> `Analytics`
2. Go to the discover page and scroll around, click around a bit
3. ✅ Observe that the app logs show various "Analytic event" logs from [here](https://github.com/Automattic/pocket-casts-android/blob/4f154218212ef2f0a34e5ff17b1588ea4f375e83/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/FirebaseAnalyticsTracker.kt#L267).
4. Turn OFF sharing of analytics in `Profile` -> ⚙️ -> `Privacy` -> `Analytics` 
5. Go to the discover page and scroll around, click around a bit
6. ✅ Observe that there are no "Analytics event" logs being added anymore.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack

internal ref: p1667239823282319/1667179471.022889-slack-C02ATC80MUM