### PR TITLE
Added basic support for Android 13 per-app language preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
         ([#483](https://github.com/Automattic/pocket-casts-android/pull/483)).
     *   Updated select filters title & hide podcast setting filter option when applicable
         ([#494](https://github.com/Automattic/pocket-casts-android/pull/494)).
+    *   Support Android 13 per-app language preferences
+        ([#519](https://github.com/Automattic/pocket-casts-android/pull/519)).
 *   Bug Fixes:
     *   Fixed Help & Feedback buttons being hidden when using text zoom.
         ([#446](https://github.com/Automattic/pocket-casts-android/pull/446)).

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,7 @@
             tools:replace="android:supportsRtl"
             android:theme="@style/ThemeDark"
             android:networkSecurityConfig="@xml/network_security_config"
+            android:localeConfig="@xml/locales_config"
             tools:ignore="UnusedAttribute">
 
         <meta-data android:name="com.google.android.gms.car.application"

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en"/>
+    <locale android:name="en-rGB"/>
+    <locale android:name="ar"/>
+    <locale android:name="de"/>
+    <locale android:name="es"/>
+    <locale android:name="es-rMX"/>
+    <locale android:name="fr"/>
+    <locale android:name="fr-rCA"/>
+    <locale android:name="it"/>
+    <locale android:name="ja"/>
+    <locale android:name="nb"/>
+    <locale android:name="nl"/>
+    <locale android:name="pt-rBR"/>
+    <locale android:name="ru"/>
+    <locale android:name="sv"/>
+    <locale android:name="zh"/>
+    <locale android:name="zh-rTW"/>
+</locale-config>


### PR DESCRIPTION
## Description
Added basic support for Android 13 per-app language preferences
https://developer.android.com/guide/topics/resources/app-languages#app-language-settings

## Testing Instructions
Users can select their preferred language for each app through the system settings. They can access these settings in two different ways:

Access through the System settings:
Settings > System > Languages & Input > App Languages > (select an app)

Access through Apps settings:
Settings > Apps > (select an app) > Language

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
