### PR TITLE
End of Year - Show different categories listened

### DIFF
--- a/modules/features/endofyear/build.gradle
+++ b/modules/features/endofyear/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation project(':modules:features:settings')
     // services
     implementation project(':modules:services:compose')
+    implementation project(':modules:services:images')
     implementation project(':modules:services:localization')
     implementation project(':modules:services:model')
     implementation project(':modules:services:repositories')

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -43,7 +43,7 @@ class StoriesFragment : BaseDialogFragment() {
             setContent {
                 AppTheme(theme.activeTheme) {
                     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                    StoriesScreen(
+                    StoriesPage(
                         viewModel = viewModel,
                         onCloseClicked = { dismiss() },
                         onShareClicked = { onCaptureBitmap ->

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
@@ -59,7 +59,7 @@ private val ShareButtonStrokeWidth = 2.dp
 private val StoryViewCornerSize = 10.dp
 
 @Composable
-fun StoriesScreen(
+fun StoriesPage(
     viewModel: StoriesViewModel,
     onCloseClicked: () -> Unit,
     onShareClicked: (() -> Bitmap) -> Unit,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesScreen.kt
@@ -43,10 +43,14 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake1
+import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryListenedCategories
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryListeningTime
+import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryTopListenedCategories
 import au.com.shiftyjelly.pocketcasts.endofyear.views.convertibleToBitmap
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryFake1View
+import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryListenedCategoriesView
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryListeningTimeView
+import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryTopListenedCategoriesView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -142,6 +146,8 @@ private fun StorySharableContent(
     ) {
         when (story) {
             is StoryListeningTime -> StoryListeningTimeView(story)
+            is StoryListenedCategories -> StoryListenedCategoriesView(story)
+            is StoryTopListenedCategories -> StoryTopListenedCategoriesView(story)
             is StoryFake1 -> StoryFake1View(story)
         }
     }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -51,6 +51,7 @@ class StoriesViewModel @Inject constructor(
         viewModelScope.launch {
             storiesDataSource.loadStories().stateIn(viewModelScope).collect { result ->
                 cancelTimer()
+                if (result.size != stories.value.size) resetProgressAndCurrentIndex()
                 stories.value = result
 
                 val state = if (result.isEmpty()) {
@@ -115,6 +116,11 @@ class StoriesViewModel @Inject constructor(
     private fun cancelTimer() {
         timer?.cancel()
         timer = null
+    }
+
+    private fun resetProgressAndCurrentIndex() {
+        mutableProgress.value = 0f
+        currentIndex = 0
     }
 
     override fun onCleared() {

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
@@ -12,7 +12,7 @@ class EndOfYearStoriesDataSource @Inject constructor(
     override suspend fun loadStories(): Flow<List<Story>> {
         return combine(
             endOfYearManager.getTotalListeningTimeInSecsForYear(YEAR),
-            endOfYearManager.findListeningCategoriesForYear(YEAR),
+            endOfYearManager.findListenedCategoriesForYear(YEAR),
             endOfYearManager.findRandomPodcasts(),
         ) { listeningTime, listenedCategories, podcasts ->
             val stories = mutableListOf<Story>()

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
@@ -12,11 +12,16 @@ class EndOfYearStoriesDataSource @Inject constructor(
     override suspend fun loadStories(): Flow<List<Story>> {
         return combine(
             endOfYearManager.getTotalListeningTimeInSecsForYear(YEAR),
+            endOfYearManager.findListeningCategoriesForYear(YEAR),
             endOfYearManager.findRandomPodcasts(),
-        ) { listeningTime, podcasts ->
+        ) { listeningTime, listenedCategories, podcasts ->
             val stories = mutableListOf<Story>()
 
             listeningTime?.let { stories.add(StoryListeningTime(it)) }
+            if (listenedCategories.isNotEmpty()) {
+                stories.add(StoryListenedCategories(listenedCategories))
+                stories.add(StoryTopListenedCategories(listenedCategories))
+            }
             if (podcasts.isNotEmpty()) stories.add(StoryFake1(podcasts))
 
             stories

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryListenedCategories.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryListenedCategories.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.stories
+
+import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
+
+class StoryListenedCategories(
+    val listenedCategories: List<ListenedCategory>
+) : Story()

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryTopListenedCategories.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryTopListenedCategories.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.stories
+
+import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
+
+class StoryTopListenedCategories(
+    val listenedCategories: List<ListenedCategory>
+) : Story()

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedCategoriesView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedCategoriesView.kt
@@ -1,0 +1,17 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryListenedCategories
+
+@Composable
+fun StoryListenedCategoriesView(
+    story: StoryListenedCategories,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier.padding(16.dp)) {
+    }
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedCategoriesView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedCategoriesView.kt
@@ -1,10 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryListenedCategories
 
 @Composable
@@ -13,5 +16,21 @@ fun StoryListenedCategoriesView(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier.padding(16.dp)) {
+        TextH30(
+            text = "You listened to ${story.listenedCategories.count()} different categories this year",
+            textAlign = TextAlign.Center,
+            color = story.tintColor,
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        )
+        TextH30(
+            text = "Let's take a look at some of your favourites..",
+            textAlign = TextAlign.Center,
+            color = story.tintColor,
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        )
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopListenedCategoriesView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopListenedCategoriesView.kt
@@ -1,0 +1,17 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryTopListenedCategories
+
+@Composable
+fun StoryTopListenedCategoriesView(
+    story: StoryTopListenedCategories,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier.padding(16.dp)) {
+    }
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopListenedCategoriesView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopListenedCategoriesView.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -100,25 +99,21 @@ fun CategoryItem(
                     .weight(1f),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Box(modifier = modifier.padding(top = 4.dp, end = 12.dp, bottom = 4.dp)) {
-                    Image(
-                        painter = painterResource(IR.drawable.defaultartwork),
-                        contentDescription = null,
-                        modifier = modifier.size(iconSize)
-                    )
-                }
-                Row(
+                Image(
+                    painter = painterResource(IR.drawable.defaultartwork),
+                    contentDescription = null,
+                    modifier = modifier
+                        .size(iconSize)
+                        .padding(top = 4.dp, end = 12.dp, bottom = 4.dp)
+                )
+                TextP40(
+                    text = listenedCategory.category,
+                    color = tintColor,
+                    textAlign = TextAlign.Start,
                     modifier = modifier
                         .padding(end = 16.dp)
                         .weight(1f),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    TextP40(
-                        text = listenedCategory.category,
-                        color = tintColor,
-                        textAlign = TextAlign.Center,
-                    )
-                }
+                )
                 Column {
                     TextP40(
                         text = "${listenedCategory.numberOfPodcasts}",
@@ -136,7 +131,7 @@ fun CategoryItem(
 
 @Preview(showBackground = true)
 @Composable
-private fun StoriesErrorViewPreview(
+private fun CategoryItemPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppTheme(themeType) {

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopListenedCategoriesView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopListenedCategoriesView.kt
@@ -1,17 +1,156 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryTopListenedCategories
+import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.images.R as IR
 
 @Composable
 fun StoryTopListenedCategoriesView(
     story: StoryTopListenedCategories,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier.padding(16.dp)) {
+    val context = LocalContext.current
+    var screenHeight by remember { mutableStateOf(1) }
+    var textFieldHeight by remember { mutableStateOf(1) }
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .onGloballyPositioned {
+                screenHeight = it.size.height
+            },
+        verticalArrangement = Arrangement.Center
+    ) {
+        TextH30(
+            text = "Your Top Categories",
+            textAlign = TextAlign.Center,
+            color = story.tintColor,
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp)
+                .onGloballyPositioned {
+                    textFieldHeight = it.size.height
+                }
+        )
+        story.listenedCategories.subList(0, minOf(story.listenedCategories.count(), 5))
+            .mapIndexed { index, listenedCategory ->
+                CategoryItem(
+                    listenedCategory = listenedCategory,
+                    position = index,
+                    tintColor = story.tintColor,
+                    iconSize = getIconSize(screenHeight, textFieldHeight, context)
+                )
+            }
+    }
+}
+
+@Composable
+fun CategoryItem(
+    listenedCategory: ListenedCategory,
+    position: Int,
+    tintColor: Color,
+    iconSize: Dp,
+    modifier: Modifier = Modifier,
+) {
+    Column {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+        ) {
+            TextP40(
+                text = "${position + 1}",
+                color = tintColor,
+                modifier = modifier.padding(end = 16.dp)
+            )
+            Row(
+                modifier = modifier
+                    .padding(end = 16.dp)
+                    .weight(1f),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(modifier = modifier.padding(top = 4.dp, end = 12.dp, bottom = 4.dp)) {
+                    Image(
+                        painter = painterResource(IR.drawable.defaultartwork),
+                        contentDescription = null,
+                        modifier = modifier.size(iconSize)
+                    )
+                }
+                Row(
+                    modifier = modifier
+                        .padding(end = 16.dp)
+                        .weight(1f),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TextP40(
+                        text = listenedCategory.category,
+                        color = tintColor,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+                Column {
+                    TextP40(
+                        text = "${listenedCategory.numberOfPodcasts}",
+                        color = tintColor
+                    )
+                    TextP40(
+                        text = "Podcasts",
+                        color = tintColor
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun StoriesErrorViewPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppTheme(themeType) {
+        Surface(color = Color.Black) {
+            CategoryItem(
+                listenedCategory = ListenedCategory(
+                    numberOfPodcasts = 2,
+                    totalPlayedTime = 1L,
+                    category = "News"
+                ),
+                position = 0,
+                tintColor = Color.White,
+                iconSize = 64.dp,
+            )
+        }
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.compose.components
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -43,14 +42,13 @@ fun PodcastItem(
                 .padding(horizontal = 16.dp)
                 .then(if (onClick == null) Modifier else Modifier.clickable { onClick() })
         ) {
-            Box(modifier = Modifier.padding(top = 4.dp, end = 12.dp, bottom = 4.dp)) {
-                PodcastImage(
-                    uuid = podcast.uuid,
-                    modifier = Modifier.size(iconSize)
-                )
-            }
+            PodcastImage(
+                uuid = podcast.uuid,
+                modifier = modifier.size(iconSize)
+                    .padding(top = 4.dp, end = 12.dp, bottom = 4.dp)
+            )
             Column(
-                modifier = Modifier
+                modifier = modifier
                     .padding(end = 16.dp)
                     .weight(1f)
             ) {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/ListenedCategory.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/ListenedCategory.kt
@@ -1,0 +1,3 @@
+package au.com.shiftyjelly.pocketcasts.models.db.helper
+
+data class ListenedCategory(val numberOfPodcasts: Int, val totalPlayedTime: Long, val category: String)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
@@ -7,5 +7,5 @@ import kotlinx.coroutines.flow.Flow
 interface EndOfYearManager {
     fun findRandomPodcasts(): Flow<List<Podcast>>
     fun getTotalListeningTimeInSecsForYear(year: Int): Flow<Long?>
-    fun findListeningCategoriesForYear(year: Int): Flow<List<ListenedCategory>>
+    fun findListenedCategoriesForYear(year: Int): Flow<List<ListenedCategory>>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
@@ -2,30 +2,10 @@ package au.com.shiftyjelly.pocketcasts.repositories.endofyear
 
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
-import au.com.shiftyjelly.pocketcasts.utils.DateUtil
 import kotlinx.coroutines.flow.Flow
-import timber.log.Timber
-import java.time.DateTimeException
-import java.time.LocalDate
 
 interface EndOfYearManager {
     fun findRandomPodcasts(): Flow<List<Podcast>>
     fun getTotalListeningTimeInSecsForYear(year: Int): Flow<Long?>
     fun findListeningCategoriesForYear(year: Int): Flow<List<ListenedCategory>>
-
-    fun getYearStartAndEndEpochMs(year: Int): YearStartAndEndEpochMs? {
-        var yearStartAndEndEpochMs: YearStartAndEndEpochMs? = null
-        try {
-            val date = LocalDate.of(year, 1, 1).atStartOfDay()
-            val fromEpochTimeInMs = DateUtil.toEpochMillis(date)
-            val toEpochTimeInMs = DateUtil.toEpochMillis(date.plusYears(1))
-            if (fromEpochTimeInMs != null && toEpochTimeInMs != null) {
-                yearStartAndEndEpochMs = YearStartAndEndEpochMs(fromEpochTimeInMs, toEpochTimeInMs)
-            }
-        } catch (e: DateTimeException) {
-            Timber.e(e)
-        }
-        return yearStartAndEndEpochMs
-    }
-    data class YearStartAndEndEpochMs(val start: Long, val end: Long)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
@@ -1,10 +1,29 @@
 package au.com.shiftyjelly.pocketcasts.repositories.endofyear
 
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.utils.DateUtil
 import kotlinx.coroutines.flow.Flow
+import timber.log.Timber
+import java.time.DateTimeException
+import java.time.LocalDate
 
 interface EndOfYearManager {
     fun findRandomPodcasts(): Flow<List<Podcast>>
-
     fun getTotalListeningTimeInSecsForYear(year: Int): Flow<Long?>
+
+    fun getYearStartAndEndEpochMs(year: Int): YearStartAndEndEpochMs? {
+        var yearStartAndEndEpochMs: YearStartAndEndEpochMs? = null
+        try {
+            val date = LocalDate.of(year, 1, 1).atStartOfDay()
+            val fromEpochTimeInMs = DateUtil.toEpochMillis(date)
+            val toEpochTimeInMs = DateUtil.toEpochMillis(date.plusYears(1))
+            if (fromEpochTimeInMs != null && toEpochTimeInMs != null) {
+                yearStartAndEndEpochMs = YearStartAndEndEpochMs(fromEpochTimeInMs, toEpochTimeInMs)
+            }
+        } catch (e: DateTimeException) {
+            Timber.e(e)
+        }
+        return yearStartAndEndEpochMs
+    }
+    data class YearStartAndEndEpochMs(val start: Long, val end: Long)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.endofyear
 
+import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.utils.DateUtil
 import kotlinx.coroutines.flow.Flow
@@ -10,6 +11,7 @@ import java.time.LocalDate
 interface EndOfYearManager {
     fun findRandomPodcasts(): Flow<List<Podcast>>
     fun getTotalListeningTimeInSecsForYear(year: Int): Flow<Long?>
+    fun findListeningCategoriesForYear(year: Int): Flow<List<ListenedCategory>>
 
     fun getYearStartAndEndEpochMs(year: Int): YearStartAndEndEpochMs? {
         var yearStartAndEndEpochMs: YearStartAndEndEpochMs? = null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -3,10 +3,14 @@ package au.com.shiftyjelly.pocketcasts.repositories.endofyear
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.utils.DateUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import timber.log.Timber
+import java.time.DateTimeException
+import java.time.LocalDate
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
@@ -30,4 +34,20 @@ class EndOfYearManagerImpl @Inject constructor(
         getYearStartAndEndEpochMs(year)?.let {
             episodeManager.findListenedCategories(it.start, it.end)
         } ?: flowOf(emptyList())
+
+    private fun getYearStartAndEndEpochMs(year: Int): YearStartAndEndEpochMs? {
+        var yearStartAndEndEpochMs: YearStartAndEndEpochMs? = null
+        try {
+            val date = LocalDate.of(year, 1, 1).atStartOfDay()
+            val fromEpochTimeInMs = DateUtil.toEpochMillis(date)
+            val toEpochTimeInMs = DateUtil.toEpochMillis(date.plusYears(1))
+            if (fromEpochTimeInMs != null && toEpochTimeInMs != null) {
+                yearStartAndEndEpochMs = YearStartAndEndEpochMs(fromEpochTimeInMs, toEpochTimeInMs)
+            }
+        } catch (e: DateTimeException) {
+            Timber.e(e)
+        }
+        return yearStartAndEndEpochMs
+    }
+    data class YearStartAndEndEpochMs(val start: Long, val end: Long)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -3,14 +3,10 @@ package au.com.shiftyjelly.pocketcasts.repositories.endofyear
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.utils.DateUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import timber.log.Timber
-import java.time.DateTimeException
-import java.time.LocalDate
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
@@ -25,20 +21,8 @@ class EndOfYearManagerImpl @Inject constructor(
         return podcastManager.findRandomPodcasts()
     }
 
-    override fun getTotalListeningTimeInSecsForYear(year: Int): Flow<Long?> {
-        return try {
-            val date = LocalDate.of(year, 1, 1).atStartOfDay()
-            val fromEpochTimeInMs = DateUtil.toEpochMillis(date)
-            val toEpochTimeInMs = DateUtil.toEpochMillis(date.plusYears(1))
-
-            if (fromEpochTimeInMs != null && toEpochTimeInMs != null) {
-                episodeManager.calculateListeningTime(fromEpochTimeInMs, toEpochTimeInMs)
-            } else {
-                flowOf(null)
-            }
-        } catch (e: DateTimeException) {
-            Timber.e(e)
-            flowOf(null)
-        }
-    }
+    override fun getTotalListeningTimeInSecsForYear(year: Int) =
+        getYearStartAndEndEpochMs(year)?.let {
+            episodeManager.calculateListeningTime(it.start, it.end)
+        } ?: flowOf(null)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -30,7 +30,7 @@ class EndOfYearManagerImpl @Inject constructor(
             episodeManager.calculateListeningTime(it.start, it.end)
         } ?: flowOf(null)
 
-    override fun findListeningCategoriesForYear(year: Int) =
+    override fun findListenedCategoriesForYear(year: Int) =
         getYearStartAndEndEpochMs(year)?.let {
             episodeManager.findListenedCategories(it.start, it.end)
         } ?: flowOf(emptyList())

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -25,4 +25,9 @@ class EndOfYearManagerImpl @Inject constructor(
         getYearStartAndEndEpochMs(year)?.let {
             episodeManager.calculateListeningTime(it.start, it.end)
         } ?: flowOf(null)
+
+    override fun findListeningCategoriesForYear(year: Int) =
+        getYearStartAndEndEpochMs(year)?.let {
+            episodeManager.findListenedCategories(it.start, it.end)
+        } ?: flowOf(emptyList())
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import androidx.lifecycle.LiveData
+import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -136,4 +137,5 @@ interface EpisodeManager {
     suspend fun deleteEpisodeFiles(episodes: List<Episode>, playbackManager: PlaybackManager)
     suspend fun findStaleDownloads(): List<Episode>
     fun calculateListeningTime(fromEpochMs: Long, toEpochMs: Long): Flow<Long?>
+    fun findListenedCategories(fromEpochMs: Long, toEpochMs: Long): Flow<List<ListenedCategory>>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -11,6 +11,7 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
+import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
 import au.com.shiftyjelly.pocketcasts.models.db.helper.QueryHelper
 import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
@@ -1073,4 +1074,7 @@ class EpisodeManagerImpl @Inject constructor(
 
     override fun calculateListeningTime(fromEpochMs: Long, toEpochMs: Long): Flow<Long?> =
         episodeDao.calculateListeningTime(fromEpochMs, toEpochMs)
+
+    override fun findListenedCategories(fromEpochMs: Long, toEpochMs: Long): Flow<List<ListenedCategory>> =
+        episodeDao.findListenedCategories(fromEpochMs, toEpochMs)
 }


### PR DESCRIPTION
| 📘 Project: #410 |
|:---:|

iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/413

## Description

This PR
- Adds two new stories:
    * Total categories listened
    * Top 5 categories listened

   PS: Design not covered, ignore hard-coded strings and design in `StoryView`s
- Attempts to fix story speed issue - ab33f966a4a03aaa6e8258539e2cfbd0f7f93ff6

## Testing Instructions

#### Test.1 - New Stories

1. Set `END_OF_YEAR_ENABLED` feature flag to `true` in `base.gradle`
2. Run the app and login with an account that has a Listening History with at least a few items
3. When the prompt appears, tap "View My 2022"
4. Skip the first story
5. ✅ Check that the second story shows the total number of categories you listened to
6. ✅ Check that the third story shows the top 5 categories you listened to with the number of different podcasts for each one

#### Test.2 - Story Speed

1. Set `END_OF_YEAR_ENABLED` feature flag to `true` in `base.gradle`
2. Fresh install the tap
3. Run the app, when the EoY prompt appears, tap "Not Now"
4. Go to Profile tab and login with an account that has a Listening History with at least a few items (<- this should initiate a sync)
5. While podcasts are loading, tap "Your Year in Podcasts" card so that stories page is opened
6. With the stories page open, wait for the sync to complete
7. ✅ Notice that story speed does not increase



## Screenshots or Screencast 
| Total categories | Top 5 categories |
| ---------------- | ---------------- |
<img width=320 src="https://user-images.githubusercontent.com/1405144/199488073-01acc307-5e5b-442d-bc3c-20133a97eaa1.png"/> | <img width=320 src="https://user-images.githubusercontent.com/1405144/199488082-a1dd72c7-cfe2-4a0e-b509-c82aa7b9d0a8.png"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
