### PR TITLE
Allow cleartext traffic

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,9 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-<debug-overrides>
-    <trust-anchors>
-        <!-- Trust user added CAs while debuggable only -->
-        <certificates src="user" />
-    </trust-anchors>
-</debug-overrides>
+    <!-- Clear text traffic is required for communication with feeds that don't have SSL -->
+    <!-- The default configuration for apps targeting Android 7.0 (API level 24) to Android 8.1 (API level 27) is as follows:  -->
+    <!-- https://developer.android.com/training/articles/security-config#CleartextTrafficPermitted -->
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+
+    <debug-overrides>
+        <trust-anchors>
+            <!-- Trust user added CAs while debuggable only -->
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
 </network-security-config>


### PR DESCRIPTION
## Description
When adding the network-security-config for debug builds, Android apparently also applied a new default to disable clear text traffic for all builds. 😞 You [warned me](https://github.com/Automattic/pocket-casts-android/pull/472#pullrequestreview-1155477910) about something like this @geekygecko ! 🙂 😭 

I think adding this should cover us (FWIW: it's also what [the WordPress Android does](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/res/xml/network_security_config.xml)).

Alternatively, we could just remove the network security config entirely. I kind of like keeping it myself to make intercepting traffic during development with a proxy easier, but obviously it's caused us problems once already, so I don't feel strongly, and I'm fine just removing it if you prefer.

> **Note**
> This PR is targeting the `release/7.26` branch so we can cut a new release candidate.

Fixes #533 

## Testing Instructions
1. Go to the `BBC Newscast` podcast
2. Try to stream or download an episode
3. ✅  Observe that the stream/download succeeds


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
