### PR TITLE
End of Year - Show number of listened podcasts and episodes 

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
@@ -44,11 +44,13 @@ import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.Story
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryFake1
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryListenedCategories
+import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryListenedNumbers
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryListeningTime
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryTopListenedCategories
 import au.com.shiftyjelly.pocketcasts.endofyear.views.convertibleToBitmap
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryFake1View
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryListenedCategoriesView
+import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryListenedNumbersView
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryListeningTimeView
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryTopListenedCategoriesView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -148,6 +150,7 @@ private fun StorySharableContent(
             is StoryListeningTime -> StoryListeningTimeView(story)
             is StoryListenedCategories -> StoryListenedCategoriesView(story)
             is StoryTopListenedCategories -> StoryTopListenedCategoriesView(story)
+            is StoryListenedNumbers -> StoryListenedNumbersView(story)
             is StoryFake1 -> StoryFake1View(story)
         }
     }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
@@ -13,8 +13,9 @@ class EndOfYearStoriesDataSource @Inject constructor(
         return combine(
             endOfYearManager.getTotalListeningTimeInSecsForYear(YEAR),
             endOfYearManager.findListenedCategoriesForYear(YEAR),
+            endOfYearManager.findListenedNumbersForYear(YEAR),
             endOfYearManager.findRandomPodcasts(),
-        ) { listeningTime, listenedCategories, podcasts ->
+        ) { listeningTime, listenedCategories, listenedNumbers, podcasts ->
             val stories = mutableListOf<Story>()
 
             listeningTime?.let { stories.add(StoryListeningTime(it)) }
@@ -22,6 +23,7 @@ class EndOfYearStoriesDataSource @Inject constructor(
                 stories.add(StoryListenedCategories(listenedCategories))
                 stories.add(StoryTopListenedCategories(listenedCategories))
             }
+            stories.add(StoryListenedNumbers(listenedNumbers))
             if (podcasts.isNotEmpty()) stories.add(StoryFake1(podcasts))
 
             stories

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
@@ -23,7 +23,7 @@ class EndOfYearStoriesDataSource @Inject constructor(
                 stories.add(StoryListenedCategories(listenedCategories))
                 stories.add(StoryTopListenedCategories(listenedCategories))
             }
-            if (listenedNumbers.numberOfEpisodes > 0 && listenedNumbers.numberOfPodcasts > 0) {
+            if (listenedNumbers.numberOfEpisodes > 1 && listenedNumbers.numberOfPodcasts > 1) {
                 stories.add(StoryListenedNumbers(listenedNumbers))
             }
             if (podcasts.isNotEmpty()) stories.add(StoryFake1(podcasts))

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
@@ -23,7 +23,9 @@ class EndOfYearStoriesDataSource @Inject constructor(
                 stories.add(StoryListenedCategories(listenedCategories))
                 stories.add(StoryTopListenedCategories(listenedCategories))
             }
-            stories.add(StoryListenedNumbers(listenedNumbers))
+            if (listenedNumbers.numberOfEpisodes > 0 && listenedNumbers.numberOfPodcasts > 0) {
+                stories.add(StoryListenedNumbers(listenedNumbers))
+            }
             if (podcasts.isNotEmpty()) stories.add(StoryFake1(podcasts))
 
             stories

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryListenedNumbers.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryListenedNumbers.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.stories
+
+import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
+
+class StoryListenedNumbers(
+    val listenedNumbers: ListenedNumbers,
+) : Story()

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedNumbersView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedNumbersView.kt
@@ -1,12 +1,52 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
 
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryListenedNumbers
+import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 
 @Composable
 fun StoryListenedNumbersView(
     story: StoryListenedNumbers,
     modifier: Modifier = Modifier,
 ) {
+    TextH30(
+        text = "You listened to ${story.listenedNumbers.numberOfPodcasts} different podcasts and ${story.listenedNumbers.numberOfEpisodes} episodes, but there was one that you kept coming back to...",
+        textAlign = TextAlign.Center,
+        color = story.tintColor,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun StoryListenedNumbersPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppTheme(themeType) {
+        Surface(color = Color.Black) {
+            StoryListenedNumbersView(
+                story = StoryListenedNumbers(
+                    ListenedNumbers(
+                        numberOfPodcasts = 2,
+                        numberOfEpisodes = 3,
+                    )
+                ),
+            )
+        }
+    }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedNumbersView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedNumbersView.kt
@@ -1,0 +1,12 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryListenedNumbers
+
+@Composable
+fun StoryListenedNumbersView(
+    story: StoryListenedNumbers,
+    modifier: Modifier = Modifier,
+) {
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -12,6 +12,7 @@ import androidx.room.Update
 import androidx.sqlite.db.SupportSQLiteQuery
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
+import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.db.helper.QueryHelper
 import au.com.shiftyjelly.pocketcasts.models.db.helper.UuidCount
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
@@ -324,4 +325,14 @@ abstract class EpisodeDao {
         """
     )
     abstract fun findListenedCategories(fromEpochMs: Long, toEpochMs: Long): Flow<List<ListenedCategory>>
+
+    @Query(
+        """
+        SELECT COUNT(episodes.uuid) as numberOfEpisodes, COUNT(DISTINCT podcasts.uuid) as numberOfPodcasts
+        FROM episodes
+        JOIN podcasts ON episodes.podcast_id = podcasts.uuid
+        WHERE episodes.last_playback_interaction_date IS NOT NULL AND episodes.last_playback_interaction_date > :fromEpochMs AND episodes.last_playback_interaction_date < :toEpochMs
+        """
+    )
+    abstract fun findListenedNumbers(fromEpochMs: Long, toEpochMs: Long): Flow<ListenedNumbers>
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/ListenedNumbers.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/ListenedNumbers.kt
@@ -1,0 +1,3 @@
+package au.com.shiftyjelly.pocketcasts.models.db.helper
+
+data class ListenedNumbers(val numberOfPodcasts: Int = 0, val numberOfEpisodes: Int = 0)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.endofyear
 
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
+import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import kotlinx.coroutines.flow.Flow
 
@@ -8,4 +9,5 @@ interface EndOfYearManager {
     fun findRandomPodcasts(): Flow<List<Podcast>>
     fun getTotalListeningTimeInSecsForYear(year: Int): Flow<Long?>
     fun findListenedCategoriesForYear(year: Int): Flow<List<ListenedCategory>>
+    fun findListenedNumbersForYear(year: Int): Flow<ListenedNumbers>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.endofyear
 
+import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -35,6 +36,11 @@ class EndOfYearManagerImpl @Inject constructor(
             episodeManager.findListenedCategories(it.start, it.end)
         } ?: flowOf(emptyList())
 
+    override fun findListenedNumbersForYear(year: Int) =
+        getYearStartAndEndEpochMs(year)?.let {
+            episodeManager.findListenedNumbers(it.start, it.end)
+        } ?: flowOf(ListenedNumbers())
+
     private fun getYearStartAndEndEpochMs(year: Int): YearStartAndEndEpochMs? {
         var yearStartAndEndEpochMs: YearStartAndEndEpochMs? = null
         try {
@@ -49,5 +55,6 @@ class EndOfYearManagerImpl @Inject constructor(
         }
         return yearStartAndEndEpochMs
     }
+
     data class YearStartAndEndEpochMs(val start: Long, val end: Long)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import androidx.lifecycle.LiveData
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
+import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -138,4 +139,5 @@ interface EpisodeManager {
     suspend fun findStaleDownloads(): List<Episode>
     fun calculateListeningTime(fromEpochMs: Long, toEpochMs: Long): Flow<Long?>
     fun findListenedCategories(fromEpochMs: Long, toEpochMs: Long): Flow<List<ListenedCategory>>
+    fun findListenedNumbers(fromEpochMs: Long, toEpochMs: Long): Flow<ListenedNumbers>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -12,6 +12,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
+import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.db.helper.QueryHelper
 import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
@@ -1077,4 +1078,7 @@ class EpisodeManagerImpl @Inject constructor(
 
     override fun findListenedCategories(fromEpochMs: Long, toEpochMs: Long): Flow<List<ListenedCategory>> =
         episodeDao.findListenedCategories(fromEpochMs, toEpochMs)
+
+    override fun findListenedNumbers(fromEpochMs: Long, toEpochMs: Long): Flow<ListenedNumbers> =
+        episodeDao.findListenedNumbers(fromEpochMs, toEpochMs)
 }


### PR DESCRIPTION
| 📘 Project: #410 |
|:---:|

iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/414

## Description
Adds a story that shows the number of listened podcasts and episodes. (Designs not covered)

## Testing Instructions
1.  Set `END_OF_YEAR_ENABLED` feature flag to `true` in `base.gradle`
2. Run the app and make sure you're logged in to an account with a few items on Listening History
3. When the prompt appears, tap "View My 2022"
4. Skip to the fourth story
5. ✅ Check that the number of played podcasts and episodes is shown

## Screenshots or Screencast 
<img width=320 src="https://user-images.githubusercontent.com/1405144/199658113-3052e277-5245-4a8b-935d-fbc9807b887d.png"/>

## Checklist
N/A (Added placeholder layouts and strings)

- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
