### PR TITLE
Fixed crashes with Tasker plugin actions when using minified code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 7.27
 -----
     *   Added ability to set playback effects in Tasker "Control Playback" action.
-        ([#415](https://github.com/Automattic/pocket-casts-android/pull/509)).
+        ([#509](https://github.com/Automattic/pocket-casts-android/pull/509)).
+    *   Fixed crashes with Tasker plugin actions when using minified code.
+        ([#543](https://github.com/Automattic/pocket-casts-android/pull/543)).
 
 7.26
 -----
 
 *   New Features:
     *   Added Tasker integration with "Play Filter" and "Control Playback" actions.
-        ([#415](https://github.com/Automattic/pocket-casts-android/pull/431)).
+        ([#431](https://github.com/Automattic/pocket-casts-android/pull/431)).
     *   Import OPML from a URL
         ([#482](https://github.com/Automattic/pocket-casts-android/pull/482)).
     *   Redesign of the fullscreen player share option

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/ViewModelBase.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/ViewModelBase.kt
@@ -14,8 +14,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 
 abstract class ViewModelBase<TInput : Any, THelper : TaskerPluginConfigHelperNoOutput<TInput, out TaskerPluginRunnerActionNoOutput<TInput>>>(application: Application) : AndroidViewModel(application), TaskerPluginConfig<TInput> {
     override val context get() = getApplication<Application>()
-    abstract val helperClass: Class<THelper>
-    private val taskerHelper by lazy { helperClass.getConstructor(TaskerPluginConfig::class.java).newInstance(this) }
+    abstract fun getNewHelper(pluginConfig: TaskerPluginConfig<TInput>): THelper
+    private val taskerHelper by lazy { getNewHelper(this) }
     protected var input: TInput? = null
 
     /**

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/config/ViewModelConfigControlPlayback.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/config/ViewModelConfigControlPlayback.kt
@@ -19,7 +19,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 class ViewModelConfigControlPlayback @Inject constructor(
     application: Application
 ) : ViewModelBase<InputControlPlayback, ActionHelperControlPlayback>(application), TaskerPluginConfig<InputControlPlayback> {
-    override val helperClass get() = ActionHelperControlPlayback::class.java
+    override fun getNewHelper(pluginConfig: TaskerPluginConfig<InputControlPlayback>) = ActionHelperControlPlayback(pluginConfig)
 
     /**
      * A field that only appears depending on the type of the playback command. For example, the field "Time to Skip To" will only appear if the command is "Skip To Time". A field can also always appear if it doesn't depend on a command type

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/playplaylist/config/ViewModelConfigPlayPlaylist.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/playplaylist/config/ViewModelConfigPlayPlaylist.kt
@@ -18,7 +18,7 @@ import javax.inject.Inject
 class ViewModelConfigPlayPlaylist @Inject constructor(
     application: Application
 ) : ViewModelBase<InputPlayPlaylist, ActionHelperPlayPlaylist>(application), TaskerPluginConfig<InputPlayPlaylist> {
-    override val helperClass get() = ActionHelperPlayPlaylist::class.java
+    override fun getNewHelper(pluginConfig: TaskerPluginConfig<InputPlayPlaylist>) = ActionHelperPlayPlaylist(pluginConfig)
 
     private inner class InputField constructor(@StringRes labelResId: Int, @DrawableRes iconResId: Int, valueGetter: InputPlayPlaylist.() -> String?, valueSetter: InputPlayPlaylist.(String?) -> Unit) : InputFieldBase<String>(labelResId, iconResId, valueGetter, valueSetter) {
         override val askFor get() = true


### PR DESCRIPTION
## Description
The Tasker plugin code has an issue that only occurs when code is minified (ie in release builds) that is fixed here. This bug is preventing the Tasker actions from being used at all.


## Testing Instructions
1. Build app with ```minifyEnabled true```
2. Try using any Pocket Casts Tasker action from Tasker
3. Check that it doesn't crash anymore
