### PR TITLE
Fix for auto subscribe enabled in main app

### DIFF
--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -494,7 +494,7 @@ class SettingsImpl @Inject constructor(
     }
 
     override fun getAutoSubscribeToPlayed(): Boolean {
-        return getBoolean(Settings.PREFERENCE_AUTO_SUBSCRIBE_ON_PLAY, true)
+        return getBoolean(Settings.PREFERENCE_AUTO_SUBSCRIBE_ON_PLAY, false)
     }
 
     override fun getAutoShowPlayed(): Boolean {


### PR DESCRIPTION
## Description
Auto subscribe is enabled in the main app since the default return value from the settings preferences is set to true instead of false. From some comments I've seen, auto subscribe is only meant to be enabled in the automotive app.

Fixes #544 

## Testing Instructions
1. Open the discover tab and click on any random podcast you aren't subscribed to
2. Play an episode
3. Go back to the podcasts list, and you will notice you are now subscribed to the podcast

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
