### PR TITLE
Fix small "Go to Podcast" icon in Landscape

### DIFF
--- a/modules/features/player/src/main/res/drawable/ic_gotoarrow.xml
+++ b/modules/features/player/src/main/res/drawable/ic_gotoarrow.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-  <path
-      android:fillColor="#FF000000"
-      android:pathData="M15.5858,13L10.5,13C8.0147,13 6,10.9853 6,8.5C6,7.9477 6.4477,7.5 7,7.5C7.5523,7.5 8,7.9477 8,8.5C8,9.8807 9.1193,11 10.5,11L15.5858,11L13.7929,9.2071C13.4024,8.8166 13.4024,8.1834 13.7929,7.7929C14.1834,7.4024 14.8166,7.4024 15.2071,7.7929L19.4142,12L15.1716,16.2426C14.781,16.6332 14.1479,16.6332 13.7574,16.2426C13.3668,15.8521 13.3668,15.219 13.7574,14.8284L15.5858,13Z"/>
-</vector>

--- a/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
@@ -349,7 +349,7 @@
             <ImageButton
                 android:id="@+id/podcast"
                 android:contentDescription="@string/go_to_podcast"
-                app:srcCompat="@drawable/ic_arrow_goto"
+                app:srcCompat="@drawable/ic_goto_32"
                 app:tint="?attr/player_contrast_03"
                 style="@style/shelf_item" />
 


### PR DESCRIPTION
This PR fixes the "Go to Podcast" Icon in Landscape. 

The reason the "Go to Podcast" arrow looks small in landscape is that it's using a 24dp version rather than the 32dp version that's used in Portrait. 

I noticed there seem to be some design inconsistencies between the drawable arrow used when editing your custom shelf and the one that's actually displayed on the shelf. The 32dp seems to have a thinner tail compared to a shorter, more bold tail of the 24dp version. It would probably be worth aligning these assets and using only one.  

I also removed the `ic_gotoarrow` drawable as it's unused in the project.

Fixes #55

## Testing Instructions

1. Add the "Go to Podcast" arrow to the shelf in the Player
2. Rotate to landscape if necessary
3. Ensure the "Go to Podcast" arrow matches that of the Portrait version 

## Screenshots or Screencast 

![Screenshot_20221105_144232](https://user-images.githubusercontent.com/8364032/200125365-bd308409-855b-43fc-8112-ebffcccfa4ca.png)

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
