### PR TITLE
Use `ShareCompat.IntentBuilder` to create share intent

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.endofyear
 
-import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -9,6 +8,7 @@ import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.app.ShareCompat
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.ui.R
@@ -62,11 +62,15 @@ class StoriesFragment : BaseDialogFragment() {
     private fun showShareForFile(file: File) {
         val context = requireContext()
         try {
-            val intent = Intent(Intent.ACTION_SEND)
-            intent.type = "image/png"
-            val uri = FileUtil.createUriWithReadPermissions(file, intent, requireContext())
-            intent.putExtra(Intent.EXTRA_STREAM, uri)
-            shareLauncher.launch(Intent.createChooser(intent, context.getString(LR.string.end_of_year_share_via)))
+            val uri = FileUtil.getUriForFile(context, file)
+
+            val chooserIntent = ShareCompat.IntentBuilder(context)
+                .setType("image/png")
+                .addStream(uri)
+                .setChooserTitle(LR.string.end_of_year_share_via)
+                .createChooserIntent()
+
+            shareLauncher.launch(chooserIntent)
         } catch (e: Exception) {
             Timber.e(e)
         }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/FileUtil.java
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/FileUtil.java
@@ -192,6 +192,10 @@ public class FileUtil {
         return uri;
     }
 
+    public static Uri getUriForFile(@NonNull Context context, @NonNull File file) {
+        return FileProvider.getUriForFile(context, context.getPackageName() + ".fileprovider", file);
+    }
+
     public static long folderSize(File directory) {
         if (!directory.isDirectory()) {
             return 0;


### PR DESCRIPTION
## Description
`ShareCompat` takes care of granting URI permissions so the share sheet can display preview images.
Without this, the share sheet can't (reliably) show preview images.

See https://issuetracker.google.com/issues/173137936

## Testing Instructions
1. Set `END_OF_YEAR_ENABLED` feature flag to `true` in `base.gradle`
1. Run the app
1. When the prompt appears, tap "View My 2022"
1. Tap "Share"

## Screenshots or Screencast 
|Before|After|
|-|-|
|![pocket_casts__share_story__before](https://user-images.githubusercontent.com/218061/200147535-95763d93-7748-4610-94ae-b031aa75ced4.png)|![pocket_casts__share_story__after](https://user-images.githubusercontent.com/218061/200147539-a85f65b5-1ef3-43b0-b2f6-54c53f2a3cee.png)|

Side note: As can be seen in the screenshot, the transparent background is not working that well for the share sheet. You could extend `FileProvider` to return an image with a non-transparent background if a specific size is requested. See [ContentResolver.loadThumbnail()](https://developer.android.com/reference/kotlin/android/content/ContentResolver#loadthumbnail).

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
