### PR TITLE
End of Year: Listening time story design 

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/EndOfYearStoriesDataSource.kt
@@ -41,13 +41,13 @@ class EndOfYearStoriesDataSource @Inject constructor(
             endOfYearManager.getTotalListeningTimeInSecsForYear(YEAR),
             endOfYearManager.findListenedCategoriesForYear(YEAR),
             endOfYearManager.findListenedNumbersForYear(YEAR),
-            endOfYearManager.findTopPodcastsForYear(YEAR, limit = 5),
+            endOfYearManager.findTopPodcastsForYear(YEAR, limit = 10),
             endOfYearManager.findLongestPlayedEpisodeForYear(YEAR)
-        ) { listeningTime, listenedCategories, listenedNumbers, topFivePodcasts, longestEpisode ->
+        ) { listeningTime, listenedCategories, listenedNumbers, topPodcasts, longestEpisode ->
             val stories = mutableListOf<Story>()
 
             stories.add(StoryIntro())
-            listeningTime?.let { stories.add(StoryListeningTime(it)) }
+            listeningTime?.let { stories.add(StoryListeningTime(it, topPodcasts.takeLast(3))) }
             if (listenedCategories.isNotEmpty()) {
                 stories.add(StoryListenedCategories(listenedCategories))
                 stories.add(StoryTopListenedCategories(listenedCategories))
@@ -55,10 +55,10 @@ class EndOfYearStoriesDataSource @Inject constructor(
             if (listenedNumbers.numberOfEpisodes > 1 && listenedNumbers.numberOfPodcasts > 1) {
                 stories.add(StoryListenedNumbers(listenedNumbers))
             }
-            if (topFivePodcasts.isNotEmpty()) {
-                stories.add(StoryTopPodcast(topFivePodcasts.first()))
-                if (topFivePodcasts.size > 1) {
-                    stories.add(StoryTopFivePodcasts(topFivePodcasts))
+            if (topPodcasts.isNotEmpty()) {
+                stories.add(StoryTopPodcast(topPodcasts.first()))
+                if (topPodcasts.size > 1) {
+                    stories.add(StoryTopFivePodcasts(topPodcasts.take(5)))
                 }
             }
             longestEpisode?.let { stories.add(StoryLongestEpisode(it)) }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryListeningTime.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/stories/StoryListeningTime.kt
@@ -1,5 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.stories
 
+import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
+
 class StoryListeningTime(
     val listeningTimeInSecs: Long,
+    val podcasts: List<TopPodcast>,
 ) : Story()

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
@@ -1,20 +1,48 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Matrix
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.endofyear.R
 import au.com.shiftyjelly.pocketcasts.endofyear.stories.StoryListeningTime
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
 import au.com.shiftyjelly.pocketcasts.settings.util.FunnyTimeConverter
+import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+private const val PodcastCoverRotationAngle = -30f
+private const val PodcastCoverSkew = 0.45f
 
 @Composable
 fun StoryListeningTimeView(
@@ -32,22 +60,119 @@ fun StoryListeningTimeView(
             context.resources
         )
     }
-    Column(modifier.padding(16.dp)) {
-        TextH30(
-            text = stringResource(LR.string.end_of_year_listening_time, timeText),
-            textAlign = TextAlign.Center,
-            color = story.tintColor,
-            modifier = modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-        )
-        TextH30(
-            text = funnyText,
-            textAlign = TextAlign.Center,
-            color = story.tintColor,
-            modifier = modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-        )
+
+    val backgroundColor = if (story.podcasts.isEmpty()) {
+        Podcast().getTintColor(false)
+    } else {
+        // Get the middle podcast
+        story.podcasts.take(2).last().toPodcast()
+            .getTintColor(false)
     }
+    Column(
+        verticalArrangement = Arrangement.Top,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = Color(backgroundColor))
+            .verticalScroll(rememberScrollState())
+    ) {
+        Spacer(modifier = modifier.weight(1f))
+
+        Title(timeText, story, modifier)
+
+        FunnyText(funnyText, story, modifier)
+
+        Spacer(modifier = modifier.weight(1f))
+
+        PodcastCoverRow(story, modifier)
+
+        Spacer(modifier = modifier.weight(1f))
+
+        Logo(modifier)
+    }
+}
+
+@Composable
+private fun Title(
+    timeText: String,
+    story: StoryListeningTime,
+    modifier: Modifier,
+) {
+    TextH20(
+        text = stringResource(LR.string.end_of_year_listening_time, timeText),
+        textAlign = TextAlign.Center,
+        color = story.tintColor,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(start = 40.dp, end = 40.dp)
+    )
+}
+
+@Composable
+private fun FunnyText(
+    funnyText: String,
+    story: StoryListeningTime,
+    modifier: Modifier,
+) {
+    TextP40(
+        text = funnyText,
+        textAlign = TextAlign.Center,
+        color = story.tintColor,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = 24.dp, start = 40.dp, end = 40.dp)
+    )
+}
+
+@Composable
+private fun PodcastCoverRow(
+    story: StoryListeningTime,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val currentLocalView = LocalView.current
+    val coverWidth = remember { (currentLocalView.width.pxToDp(context).dp - 15.dp) / 3 }
+    val translateBy = remember { 20.dpToPx(context) }
+    val transformMatrix = remember { mutableStateOf(Matrix()) }
+    Row(
+        modifier
+            .graphicsLayer(
+                rotationZ = PodcastCoverRotationAngle
+            )
+            .drawWithContent {
+                withTransform(
+                    transformBlock = {
+                        transformMatrix.value.values[Matrix.SkewX] = PodcastCoverSkew
+                        transform(transformMatrix.value)
+                    }
+                ) {
+                    this@drawWithContent.drawContent()
+                }
+            }
+            .graphicsLayer(
+                translationX = -translateBy.toFloat()
+            )
+
+    ) {
+        story.podcasts.forEach { podcast ->
+            Row {
+                PodcastImage(
+                    uuid = podcast.uuid,
+                    dropShadow = false,
+                    modifier = modifier
+                        .size(coverWidth)
+                )
+                Spacer(modifier = modifier.width(5.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun Logo(modifier: Modifier) {
+    Image(
+        painter = painterResource(R.drawable.logo_white),
+        contentDescription = null,
+        modifier = modifier.padding(bottom = 40.dp)
+    )
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Matrix
@@ -27,6 +28,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
@@ -118,8 +120,10 @@ private fun FunnyText(
         text = funnyText,
         textAlign = TextAlign.Center,
         color = story.tintColor,
+        fontWeight = FontWeight.Bold,
         modifier = modifier
             .fillMaxWidth()
+            .alpha(0.8f)
             .padding(top = 24.dp, start = 40.dp, end = 40.dp)
     )
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopPodcastView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopPodcastView.kt
@@ -73,6 +73,7 @@ private fun StoryTopPodcastViewPreview(
                         uuid = "1",
                         title = "Title",
                         author = "Author",
+                        tintColorForLightBg = 0,
                         numberOfPlayedEpisodes = 1,
                         totalPlayedTime = 0.0,
                     )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
@@ -89,7 +89,8 @@ fun TextP40(
     modifier: Modifier = Modifier,
     textAlign: TextAlign? = null,
     color: Color = MaterialTheme.theme.colors.primaryText01,
-    maxLines: Int = Int.MAX_VALUE
+    maxLines: Int = Int.MAX_VALUE,
+    fontWeight: FontWeight? = null,
 ) {
     Text(
         text = text,
@@ -99,6 +100,7 @@ fun TextP40(
         textAlign = textAlign,
         maxLines = maxLines,
         overflow = TextOverflow.Ellipsis,
+        fontWeight = fontWeight,
         modifier = modifier
     )
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -348,7 +348,7 @@ abstract class PodcastDao {
 
     @Query(
         """
-        SELECT podcasts.uuid, podcasts.title, podcasts.author, SUM(episodes.played_up_to) as totalPlayedTime, COUNT(episodes.uuid) as numberOfPlayedEpisodes
+        SELECT podcasts.uuid, podcasts.title, podcasts.author, podcasts.primary_color as tintColorForLightBg, SUM(episodes.played_up_to) as totalPlayedTime, COUNT(episodes.uuid) as numberOfPlayedEpisodes
         FROM episodes
         JOIN podcasts ON episodes.podcast_id = podcasts.uuid
         WHERE episodes.last_playback_interaction_date IS NOT NULL AND episodes.last_playback_interaction_date > :fromEpochMs AND episodes.last_playback_interaction_date < :toEpochMs

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/TopPodcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/TopPodcast.kt
@@ -6,8 +6,9 @@ data class TopPodcast(
     val uuid: String,
     val title: String,
     val author: String,
+    val tintColorForLightBg: Int,
     val numberOfPlayedEpisodes: Int,
     val totalPlayedTime: Double,
 ) {
-    fun toPodcast() = Podcast(uuid = uuid, title = title, author = author)
+    fun toPodcast() = Podcast(uuid = uuid, title = title, author = author, tintColorForLightBg = tintColorForLightBg)
 }


### PR DESCRIPTION
| 📘 Project: #410 |
|:---:|

## Description
Add the design for the "listening time" story.

* In order to display some podcasts on this screen, top 10 podcasts are retrieved and then display the last 3.
* Displays dynamic background but does not add any gradient.

## Testing Instructions
1. Set `END_OF_YEAR_ENABLED` feature flag to `true` in base.gradle
2. Run the app and make sure you're logged in to an account with a few items on Listening History
3. When the prompt appears, tap "View My 2022"
4. Navigate to the second story
4. ✅ Check the design


## Screenshots or Screencast 

|Pixel 5| Pixel 2|
|----|-----|
| <img width = 320 src="https://user-images.githubusercontent.com/1405144/200987481-10e169d1-009c-4fe0-af7f-04740325f594.png"/> | <img width = 320 src="https://user-images.githubusercontent.com/1405144/200986203-083dbc41-c22e-47f7-96e6-bd33eb66a42c.png"/>



|Tablet (Nexus 5)|
|----------|
|<img width = 500 src="https://user-images.githubusercontent.com/1405144/200986132-6c4dae9c-64cf-4159-9b39-9590cb2a873d.png"/> |


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
