### PR TITLE
End of Year: Listened categories design 

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -497,7 +497,6 @@ class MainActivity :
             var showDialog by rememberSaveable { mutableStateOf(false) }
             if (showDialog) {
                 StoriesPage(
-                    showDialog = true,
                     theme = theme,
                     onCloseClicked = { showDialog = false },
                 )

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -38,7 +38,6 @@ import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.databinding.ActivityMainBinding
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesPage
-import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel
 import au.com.shiftyjelly.pocketcasts.endofyear.views.EndOfYearLaunchBottomSheet
 import au.com.shiftyjelly.pocketcasts.filters.FiltersFragment
 import au.com.shiftyjelly.pocketcasts.localization.helper.LocaliseHelper
@@ -168,7 +167,6 @@ class MainActivity :
     private lateinit var observeUpNext: LiveData<UpNextQueue.State>
 
     private val viewModel: MainActivityViewModel by viewModels()
-    private val storiesViewModel: StoriesViewModel by viewModels()
     private val disposables = CompositeDisposable()
     private var videoPlayerShown: Boolean = false
     private var overrideNextRefreshTimer: Boolean = false
@@ -499,8 +497,7 @@ class MainActivity :
             var showDialog by rememberSaveable { mutableStateOf(false) }
             if (showDialog) {
                 StoriesPage(
-                    viewModel = storiesViewModel,
-                    showDialog = showDialog,
+                    showDialog = true,
                     theme = theme,
                     onCloseClicked = { showDialog = false },
                 )

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
@@ -9,7 +9,6 @@ import android.graphics.Bitmap
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.annotation.FloatRange
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -58,6 +57,7 @@ import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State
+import au.com.shiftyjelly.pocketcasts.endofyear.views.SegmentedProgressIndicator
 import au.com.shiftyjelly.pocketcasts.endofyear.views.convertibleToBitmap
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryEpilogueView
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryIntroView
@@ -84,6 +84,8 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import au.com.shiftyjelly.pocketcasts.utils.Util
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import timber.log.Timber
 import java.io.File
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -118,7 +120,6 @@ fun StoriesPage(
         UpdateSystemBarColors(theme)
 
         val state: State by viewModel.state.collectAsState()
-        val progress: Float by viewModel.progress.collectAsState()
         val dialogSize = remember { getDialogSize(context) }
         Dialog(
             onDismissRequest = { onCloseClicked.invoke() },
@@ -128,7 +129,7 @@ fun StoriesPage(
                 when (state) {
                     is State.Loaded -> StoriesView(
                         state = state as State.Loaded,
-                        progress = progress,
+                        progress = viewModel.progress,
                         onSkipPrevious = { viewModel.skipPrevious() },
                         onSkipNext = { viewModel.skipNext() },
                         onPause = { viewModel.pause() },
@@ -161,7 +162,7 @@ fun StoriesPage(
 @Composable
 private fun StoriesView(
     state: State.Loaded,
-    @FloatRange(from = 0.0, to = 1.0) progress: Float,
+    progress: StateFlow<Float>,
     onSkipPrevious: () -> Unit,
     onSkipNext: () -> Unit,
     onPause: () -> Unit,
@@ -188,7 +189,7 @@ private fun StoriesView(
                         )
                     })
                 SegmentedProgressIndicator(
-                    progress = progress,
+                    progressFlow = progress,
                     segmentsData = state.segmentsData,
                     modifier = modifier
                         .padding(8.dp)
@@ -474,7 +475,7 @@ private fun StoriesScreenPreview(
                     widths = listOf(0.25f, 0.75f)
                 )
             ),
-            progress = 0.75f,
+            progress = MutableStateFlow(0.75f),
             onSkipPrevious = {},
             onSkipNext = {},
             onPause = {},

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -155,9 +155,16 @@ class StoriesViewModel @Inject constructor(
         currentIndex = 0
     }
 
+    fun clear() {
+        if (mutableState.value is State.Loaded) {
+            skipToStoryAtIndex(0)
+        }
+        cancelTimer()
+    }
+
     override fun onCleared() {
         super.onCleared()
-        cancelTimer()
+        clear()
     }
 
     private fun Float.roundOff() = (this * 100.0).roundToInt()

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/util/StoryModifierExtensions.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/util/StoryModifierExtensions.kt
@@ -1,0 +1,23 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.util
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Matrix
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.graphics.graphicsLayer
+
+private const val PodcastCoverRotationAngle = -30f
+private const val PodcastCoverSkew = 0.45f
+
+fun Modifier.transformPodcastCover() =
+    graphicsLayer(rotationZ = PodcastCoverRotationAngle)
+        .drawWithContent {
+            withTransform({
+                val transformMatrix = Matrix()
+                transformMatrix.values[Matrix.SkewX] = PodcastCoverSkew
+                transform(transformMatrix)
+            }
+            ) {
+                this@drawWithContent.drawContent()
+            }
+        }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/SegmentedProgressIndicator.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/SegmentedProgressIndicator.kt
@@ -1,18 +1,20 @@
-package au.com.shiftyjelly.pocketcasts.endofyear
+package au.com.shiftyjelly.pocketcasts.endofyear.views
 
-import androidx.annotation.FloatRange
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.progressSemantics
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State.Loaded.SegmentsData
+import kotlinx.coroutines.flow.StateFlow
 
 private val StrokeWidth = 2.dp
 private val SegmentHeight = StrokeWidth
@@ -20,12 +22,13 @@ private const val IndicatorBackgroundOpacity = 0.5f
 
 @Composable
 fun SegmentedProgressIndicator(
-    @FloatRange(from = 0.0, to = 1.0) progress: Float,
+    progressFlow: StateFlow<Float>,
     modifier: Modifier = Modifier,
     color: Color = Color.White,
     backgroundColor: Color = color.copy(alpha = IndicatorBackgroundOpacity),
     segmentsData: SegmentsData,
 ) {
+    val progress by progressFlow.collectAsState()
     Canvas(
         modifier
             .progressSemantics(progress)

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedCategoriesView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedCategoriesView.kt
@@ -28,7 +28,6 @@ import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.endofyear.util.transformPodcastCover
-import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListenedCategories
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
@@ -39,13 +38,7 @@ fun StoryListenedCategoriesView(
     story: StoryListenedCategories,
     modifier: Modifier = Modifier,
 ) {
-    val backgroundColor = if (story.listenedCategories.isEmpty()) {
-        Podcast().getTintColor(false)
-    } else {
-        // Get the middle podcast
-        story.listenedCategories.take(2).last().toPodcast()
-            .getTintColor(false)
-    }
+    val backgroundColor = story.listenedCategories[0].toPodcast().getTintColor(false)
 
     Column(
         verticalArrangement = Arrangement.Top,
@@ -88,16 +81,18 @@ private fun PodcastCoverStack(
     val translateBy = (coverWidth.value * .2).toInt().dpToPx(context)
 
     Box {
-        for (index in (0..story.listenedCategories.lastIndex).reversed()) {
+        (0..2).reversed().forEach { index ->
             Box(
                 modifier = modifier
                     .padding(top = (index * (coverWidth.value * .25)).dp)
                     .transformPodcastCover()
                     .graphicsLayer(translationX = -translateBy.toFloat())
             ) {
+                val podcastIndex = index.coerceAtMost(story.listenedCategories.size - 1)
                 PodcastImage(
-                    uuid = story.listenedCategories[index].mostListenedPodcastId,
+                    uuid = story.listenedCategories[podcastIndex].mostListenedPodcastId,
                     dropShadow = false,
+                    cornerSize = 8.dp,
                     modifier = modifier.size(coverWidth)
                 )
             }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedCategoriesView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedCategoriesView.kt
@@ -1,36 +1,141 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.endofyear.util.transformPodcastCover
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListenedCategories
+import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun StoryListenedCategoriesView(
     story: StoryListenedCategories,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier.padding(16.dp)) {
-        TextH30(
-            text = "You listened to ${story.listenedCategories.count()} different categories this year",
-            textAlign = TextAlign.Center,
-            color = story.tintColor,
-            modifier = modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-        )
-        TextH30(
-            text = "Let's take a look at some of your favourites..",
-            textAlign = TextAlign.Center,
-            color = story.tintColor,
-            modifier = modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-        )
+    val backgroundColor = if (story.listenedCategories.isEmpty()) {
+        Podcast().getTintColor(false)
+    } else {
+        // Get the middle podcast
+        story.listenedCategories.take(2).last().toPodcast()
+            .getTintColor(false)
     }
+
+    Column(
+        verticalArrangement = Arrangement.Top,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = Color(backgroundColor))
+            .verticalScroll(rememberScrollState())
+    ) {
+        Spacer(modifier = modifier.height(40.dp))
+
+        Spacer(modifier = modifier.weight(0.7f))
+
+        PodcastCoverStack(story)
+
+        Spacer(modifier = modifier.weight(0.3f))
+
+        PrimaryText(story)
+
+        Spacer(modifier = modifier.weight(0.25f))
+
+        SecondaryText(story)
+
+        Spacer(modifier = modifier.weight(0.8f))
+
+        Logo()
+
+        Spacer(modifier = modifier.height(40.dp))
+    }
+}
+
+@Composable
+private fun PodcastCoverStack(
+    story: StoryListenedCategories,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val currentLocalView = LocalView.current
+    val coverWidth = (currentLocalView.width.pxToDp(context).dp) / 2.5f
+    val translateBy = (coverWidth.value * .2).toInt().dpToPx(context)
+
+    Box {
+        for (index in (0..story.listenedCategories.lastIndex).reversed()) {
+            Box(
+                modifier = modifier
+                    .padding(top = (index * (coverWidth.value * .25)).dp)
+                    .transformPodcastCover()
+                    .graphicsLayer(translationX = -translateBy.toFloat())
+            ) {
+                PodcastImage(
+                    uuid = story.listenedCategories[index].mostListenedPodcastId,
+                    dropShadow = false,
+                    modifier = modifier.size(coverWidth)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PrimaryText(
+    story: StoryListenedCategories,
+    modifier: Modifier = Modifier,
+) {
+    TextH20(
+        text = stringResource(
+            id = LR.string.end_of_year_story_listened_to_categories,
+            story.listenedCategories.count()
+        ),
+        textAlign = TextAlign.Center,
+        color = story.tintColor,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 40.dp)
+    )
+}
+
+@Composable
+private fun SecondaryText(
+    story: StoryListenedCategories,
+    modifier: Modifier = Modifier,
+) {
+    TextP40(
+        text = stringResource(id = LR.string.end_of_year_story_listened_to_categories_subtitle),
+        textAlign = TextAlign.Center,
+        color = story.tintColor,
+        fontWeight = FontWeight.Bold,
+        modifier = modifier
+            .fillMaxWidth()
+            .alpha(0.8f)
+            .padding(horizontal = 40.dp)
+    )
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
@@ -14,8 +14,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -53,15 +51,11 @@ fun StoryListeningTimeView(
 ) {
     val context = LocalContext.current
 
-    val timeText = remember {
-        StatsHelper.secondsToFriendlyString(story.listeningTimeInSecs, context.resources)
-    }
-    val funnyText = remember {
-        FunnyTimeConverter().timeSecsToFunnyText(
-            story.listeningTimeInSecs,
-            context.resources
-        )
-    }
+    val timeText = StatsHelper.secondsToFriendlyString(story.listeningTimeInSecs, context.resources)
+    val funnyText = FunnyTimeConverter().timeSecsToFunnyText(
+        story.listeningTimeInSecs,
+        context.resources
+    )
 
     val backgroundColor = if (story.podcasts.isEmpty()) {
         Podcast().getTintColor(false)
@@ -135,9 +129,8 @@ private fun PodcastCoverRow(
 ) {
     val context = LocalContext.current
     val currentLocalView = LocalView.current
-    val coverWidth = remember { (currentLocalView.width.pxToDp(context).dp - 15.dp) / 3 }
-    val translateBy = remember { 20.dpToPx(context) }
-    val transformMatrix = remember { mutableStateOf(Matrix()) }
+    val coverWidth = (currentLocalView.width.pxToDp(context).dp - 15.dp) / 3
+    val translateBy = 20.dpToPx(context)
     Row(
         modifier
             .graphicsLayer(
@@ -146,8 +139,9 @@ private fun PodcastCoverRow(
             .drawWithContent {
                 withTransform(
                     transformBlock = {
-                        transformMatrix.value.values[Matrix.SkewX] = PodcastCoverSkew
-                        transform(transformMatrix.value)
+                        val transformMatrix = Matrix()
+                        transformMatrix.values[Matrix.SkewX] = PodcastCoverSkew
+                        transform(transformMatrix)
                     }
                 ) {
                     this@drawWithContent.drawContent()

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
@@ -32,7 +32,6 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.endofyear.R
 import au.com.shiftyjelly.pocketcasts.endofyear.util.transformPodcastCover
-import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListeningTime
 import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
 import au.com.shiftyjelly.pocketcasts.settings.util.FunnyTimeConverter
@@ -53,13 +52,8 @@ fun StoryListeningTimeView(
         context.resources
     )
 
-    val backgroundColor = if (story.podcasts.isEmpty()) {
-        Podcast().getTintColor(false)
-    } else {
-        // Get the middle podcast
-        story.podcasts.take(2).last().toPodcast()
-            .getTintColor(false)
-    }
+    val backgroundColor = story.podcasts[0].toPodcast().getTintColor(false)
+
     Column(
         verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -136,10 +130,11 @@ private fun PodcastCoverRow(
             .transformPodcastCover()
             .graphicsLayer(translationX = -translateBy)
     ) {
-        story.podcasts.forEach { podcast ->
+        listOf(1, 0, 2).forEach { index ->
+            val podcastIndex = index.coerceAtMost(story.podcasts.size - 1)
             Row {
                 PodcastImage(
-                    uuid = podcast.uuid,
+                    uuid = story.podcasts[podcastIndex].uuid,
                     dropShadow = false,
                     modifier = modifier.size(coverWidth)
                 )

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -67,7 +68,9 @@ fun StoryListeningTimeView(
             .background(color = Color(backgroundColor))
             .verticalScroll(rememberScrollState())
     ) {
-        Spacer(modifier = modifier.weight(1f))
+        Spacer(modifier = modifier.height(40.dp))
+
+        Spacer(modifier = modifier.weight(.75f))
 
         Title(timeText, story, modifier)
 
@@ -79,7 +82,9 @@ fun StoryListeningTimeView(
 
         Spacer(modifier = modifier.weight(1f))
 
-        Logo(modifier)
+        Logo()
+
+        Spacer(modifier = modifier.height(40.dp))
     }
 }
 
@@ -145,10 +150,9 @@ private fun PodcastCoverRow(
 }
 
 @Composable
-private fun Logo(modifier: Modifier) {
+fun Logo() {
     Image(
         painter = painterResource(R.drawable.logo_white),
         contentDescription = null,
-        modifier = modifier.padding(bottom = 40.dp)
     )
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
@@ -17,10 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Matrix
-import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -33,6 +30,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.endofyear.R
+import au.com.shiftyjelly.pocketcasts.endofyear.util.transformPodcastCover
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListeningTime
 import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
@@ -40,9 +38,6 @@ import au.com.shiftyjelly.pocketcasts.settings.util.FunnyTimeConverter
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
-
-private const val PodcastCoverRotationAngle = -30f
-private const val PodcastCoverSkew = 0.45f
 
 @Composable
 fun StoryListeningTimeView(
@@ -130,35 +125,18 @@ private fun PodcastCoverRow(
     val context = LocalContext.current
     val currentLocalView = LocalView.current
     val coverWidth = (currentLocalView.width.pxToDp(context).dp - 15.dp) / 3
-    val translateBy = 20.dpToPx(context)
+    val translateBy = 20.dpToPx(context).toFloat()
     Row(
         modifier
-            .graphicsLayer(
-                rotationZ = PodcastCoverRotationAngle
-            )
-            .drawWithContent {
-                withTransform(
-                    transformBlock = {
-                        val transformMatrix = Matrix()
-                        transformMatrix.values[Matrix.SkewX] = PodcastCoverSkew
-                        transform(transformMatrix)
-                    }
-                ) {
-                    this@drawWithContent.drawContent()
-                }
-            }
-            .graphicsLayer(
-                translationX = -translateBy.toFloat()
-            )
-
+            .transformPodcastCover()
+            .graphicsLayer(translationX = -translateBy)
     ) {
         story.podcasts.forEach { podcast ->
             Row {
                 PodcastImage(
                     uuid = podcast.uuid,
                     dropShadow = false,
-                    modifier = modifier
-                        .size(coverWidth)
+                    modifier = modifier.size(coverWidth)
                 )
                 Spacer(modifier = modifier.width(5.dp))
             }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopListenedCategoriesView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopListenedCategoriesView.kt
@@ -118,7 +118,9 @@ private fun CategoryItemPreview(
                 listenedCategory = ListenedCategory(
                     numberOfPodcasts = 2,
                     totalPlayedTime = 1L,
-                    category = "News"
+                    category = "News",
+                    mostListenedPodcastId = "",
+                    mostListenedPodcastTintColor = 0
                 ),
                 position = 0,
                 tintColor = Color.White,

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -32,7 +32,6 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesPage
-import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel
 import au.com.shiftyjelly.pocketcasts.endofyear.views.EndOfYearPromptCard
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralSecondsMinutesHoursDaysOrYears
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
@@ -75,7 +74,6 @@ class ProfileFragment : BaseFragment() {
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     private val viewModel: ProfileViewModel by viewModels()
-    private val storiesViewModel: StoriesViewModel by viewModels()
 
     private var binding: FragmentProfileBinding? = null
     private val sections = listOf(
@@ -243,8 +241,7 @@ class ProfileFragment : BaseFragment() {
                 var showDialog by rememberSaveable { mutableStateOf(false) }
                 if (showDialog) {
                     StoriesPage(
-                        viewModel = storiesViewModel,
-                        showDialog = showDialog,
+                        showDialog = true,
                         theme = theme,
                         onCloseClicked = { showDialog = false },
                     )

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -241,7 +241,6 @@ class ProfileFragment : BaseFragment() {
                 var showDialog by rememberSaveable { mutableStateOf(false) }
                 if (showDialog) {
                     StoriesPage(
-                        showDialog = true,
                         theme = theme,
                         onCloseClicked = { showDialog = false },
                     )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastImage.kt
@@ -19,10 +19,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute.uuid
 import au.com.shiftyjelly.pocketcasts.ui.images.PodcastImageLoaderThemed
 import coil.compose.AsyncImagePainter
-import coil.compose.AsyncImagePainter.State.Empty.painter
 import coil.compose.rememberAsyncImagePainter
 
 fun podcastImageCornerSize(width: Dp): Dp {
@@ -40,10 +38,11 @@ fun PodcastImage(
     title: String = "", // also used as the image's content description
     showTitle: Boolean = false,
     roundCorners: Boolean = true,
-    dropShadow: Boolean = true
+    dropShadow: Boolean = true,
+    cornerSize: Dp? = null,
 ) {
     BoxWithConstraints(modifier = modifier) {
-        val corners = if (roundCorners) podcastImageCornerSize(maxWidth) else null
+        val corners = if (roundCorners) cornerSize ?: podcastImageCornerSize(maxWidth) else null
         if (dropShadow) {
             val elevation = when {
                 maxWidth <= 50.dp -> 1.dp

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -317,7 +317,7 @@ abstract class EpisodeDao {
 
     @Query(
         """
-        SELECT COUNT(DISTINCT podcast_id) as numberOfPodcasts, SUM(played_up_to) as totalPlayedTime, REPLACE(IFNULL(NULLIF(SUBSTR(podcasts.podcast_category, 0, INSTR(podcasts.podcast_category, char(10))), ''), podcasts.podcast_category), char(10), '') as category
+        SELECT COUNT(DISTINCT podcast_id) as numberOfPodcasts, SUM(played_up_to) as totalPlayedTime, REPLACE(IFNULL(NULLIF(SUBSTR(podcasts.podcast_category, 0, INSTR(podcasts.podcast_category, char(10))), ''), podcasts.podcast_category), char(10), '') as category, podcasts.uuid as mostListenedPodcastId, podcasts.primary_color as mostListenedPodcastTintColor
         FROM episodes
         JOIN podcasts ON episodes.podcast_id = podcasts.uuid
         WHERE episodes.last_playback_interaction_date IS NOT NULL AND episodes.last_playback_interaction_date > :fromEpochMs AND episodes.last_playback_interaction_date < :toEpochMs

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/ListenedCategory.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/ListenedCategory.kt
@@ -1,3 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.models.db.helper
 
-data class ListenedCategory(val numberOfPodcasts: Int, val totalPlayedTime: Long, val category: String)
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+
+data class ListenedCategory(
+    val numberOfPodcasts: Int,
+    val totalPlayedTime: Long,
+    val category: String,
+    val mostListenedPodcastId: String,
+    val mostListenedPodcastTintColor: Int,
+) {
+    fun toPodcast() = Podcast(uuid = mostListenedPodcastId, tintColorForLightBg = mostListenedPodcastTintColor)
+}


### PR DESCRIPTION
| 📘 Project: #410 |
|:---:|

iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/453

## Description
Adds the design for the "listened categories" story.

* The podcasts cover displayed are determined by getting the list of top categories and reversing it, picking the top 1 podcast for each of them
* Background is picked from the middle podcast in the stack (without any gradient)

## Testing Instructions
1. Set `END_OF_YEAR_ENABLED` feature flag to `true` in `base.gradle`
2. Run the app and make sure you're logged in to an account with a few items on Listening History
3. When the prompt appears, tap "View My 2022"
4. Navigate to the third story
4. ✅ Check the design

## Screenshots or Screencast 

| Phone (Pixel 5) |
| -------- | 
|  <img width = 320 src="https://user-images.githubusercontent.com/1405144/201099562-1486674c-935d-4471-9155-d7680e0eba87.png"/>|

| Tablet (Nexus 9) |
| -------- | 
|<img width = 500 src="https://user-images.githubusercontent.com/1405144/201099600-8a0cc476-6b36-418e-97df-5c2de4498c3c.png"/> |

P.S. -> Story speed issue has re-surfaced after `StoriesFragment` (bottom sheet fragment) was removed in favor of Compose dialog in [this commit](https://github.com/Automattic/pocket-casts-android/commit/07478904b503f0b7718ff120a72d920f28a6e4d4). I tried to fix in 67bf509e11297d02b28c549b851dc78f67a692d2 but I can still the issue. I'll try to fix it in the next PR.

## Checklist
- \If this is a user-facing change, I have added an entry in CHANGELOG.md
- I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
