### PR TITLE
End of Year: Share text

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ShareableAssetProvider.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ShareableAssetProvider.kt
@@ -1,0 +1,111 @@
+package au.com.shiftyjelly.pocketcasts.endofyear
+
+import android.content.Context
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.Story
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListenedCategories
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListenedNumbers
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListeningTime
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryLongestEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopFivePodcasts
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopPodcast
+import au.com.shiftyjelly.pocketcasts.servers.list.ListServerManager
+import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+class ShareableAssetProvider @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val listServerManager: ListServerManager,
+) {
+    private var shortURL: String = Settings.SERVER_SHORT_URL
+    private val hashtags = listOf("pocketcasts", "endofyear2022").joinToString(" ") { "#$it" }
+
+    suspend fun getShareableDataForStory(
+        story: Story,
+    ): ShareTextData {
+        val text = getText(story)
+        val shareableLink: String = when (story) {
+            is StoryTopFivePodcasts -> {
+                listServerManager.createPodcastList(
+                    title = getText(story),
+                    description = "",
+                    podcasts = story.topPodcasts.map { it.toPodcast() }
+                ) ?: shortURL
+            }
+            is StoryTopPodcast -> {
+                "$shortURL/podcast/${story.topPodcast.uuid}"
+            }
+            is StoryLongestEpisode -> {
+                "$shortURL/episode/${story.longestEpisode.uuid}"
+            }
+            else -> shortURL
+        }
+        return ShareTextData(
+            text = text,
+            link = shareableLink,
+            hashTags = hashtags
+        )
+    }
+
+    private fun getText(
+        story: Story,
+    ): String {
+        val resources = context.resources
+        return when (story) {
+            is StoryListeningTime -> {
+                val timeText =
+                    StatsHelper.secondsToFriendlyString(story.listeningTimeInSecs, resources)
+                resources.getString(
+                    LR.string.end_of_year_story_listened_to_share_text,
+                    timeText
+                )
+            }
+
+            is StoryListenedCategories -> {
+                resources.getString(
+                    LR.string.end_of_year_story_listened_to_categories_share_text,
+                    story.listenedCategories.size
+                )
+            }
+
+            is StoryListenedNumbers -> {
+                resources.getString(
+                    LR.string.end_of_year_story_listened_to_numbers_share_text,
+                    story.listenedNumbers.numberOfPodcasts,
+                    story.listenedNumbers.numberOfEpisodes
+                )
+            }
+
+            is StoryTopPodcast -> {
+                resources.getString(
+                    LR.string.end_of_year_story_top_podcast_share_text,
+                    story.topPodcast.title
+                )
+            }
+
+            is StoryTopFivePodcasts -> {
+                resources.getString(
+                    LR.string.end_of_year_story_top_podcasts_share_text,
+                    story.topPodcasts[0].title
+                )
+            }
+
+            is StoryLongestEpisode -> {
+                resources.getString(
+                    LR.string.end_of_year_story_longest_episode_share_text,
+                    story.longestEpisode.title
+                )
+            }
+
+            else -> ""
+        }
+    }
+
+    data class ShareTextData(
+        val text: String,
+        val hashTags: String,
+        val link: String,
+    )
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ShareableTextProvider.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ShareableTextProvider.kt
@@ -15,7 +15,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-class ShareableAssetProvider @Inject constructor(
+class ShareableTextProvider @Inject constructor(
     @ApplicationContext private val context: Context,
     private val listServerManager: ListServerManager,
 ) {

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ShareableTextProvider.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ShareableTextProvider.kt
@@ -12,6 +12,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopPod
 import au.com.shiftyjelly.pocketcasts.servers.list.ListServerManager
 import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
 import dagger.hilt.android.qualifiers.ApplicationContext
+import timber.log.Timber
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -28,11 +29,16 @@ class ShareableTextProvider @Inject constructor(
         val text = getText(story)
         val shareableLink: String = when (story) {
             is StoryTopFivePodcasts -> {
-                listServerManager.createPodcastList(
-                    title = getText(story),
-                    description = "",
-                    podcasts = story.topPodcasts.map { it.toPodcast() }
-                ) ?: shortURL
+                try {
+                    listServerManager.createPodcastList(
+                        title = getText(story),
+                        description = "",
+                        podcasts = story.topPodcasts.map { it.toPodcast() }
+                    ) ?: shortURL
+                } catch (ex: Exception) {
+                    Timber.e(ex)
+                    shortURL
+                }
             }
             is StoryTopPodcast -> {
                 "$shortURL/podcast/${story.topPodcast.uuid}"

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ShareableTextProvider.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ShareableTextProvider.kt
@@ -26,12 +26,15 @@ class ShareableTextProvider @Inject constructor(
     suspend fun getShareableDataForStory(
         story: Story,
     ): ShareTextData {
-        val text = getText(story)
+        var showShortURLAtEnd = false
         val shareableLink: String = when (story) {
             is StoryTopFivePodcasts -> {
                 try {
                     listServerManager.createPodcastList(
-                        title = getText(story),
+                        title = context.resources.getString(
+                            LR.string.end_of_year_story_top_podcasts_share_text,
+                            ""
+                        ),
                         description = "",
                         podcasts = story.topPodcasts.map { it.toPodcast() }
                     ) ?: shortURL
@@ -46,17 +49,22 @@ class ShareableTextProvider @Inject constructor(
             is StoryLongestEpisode -> {
                 "$shortURL/episode/${story.longestEpisode.uuid}"
             }
-            else -> shortURL
+            else -> {
+                showShortURLAtEnd = true
+                shortURL
+            }
         }
+        val textWithLink = getTextWithLink(story, shareableLink)
         return ShareTextData(
-            text = text,
-            link = shareableLink,
-            hashTags = hashtags
+            textWithLink = textWithLink,
+            hashTags = hashtags,
+            showShortURLAtEnd = showShortURLAtEnd
         )
     }
 
-    private fun getText(
+    private fun getTextWithLink(
         story: Story,
+        shareableLink: String
     ): String {
         val resources = context.resources
         return when (story) {
@@ -87,21 +95,21 @@ class ShareableTextProvider @Inject constructor(
             is StoryTopPodcast -> {
                 resources.getString(
                     LR.string.end_of_year_story_top_podcast_share_text,
-                    story.topPodcast.title
+                    shareableLink
                 )
             }
 
             is StoryTopFivePodcasts -> {
                 resources.getString(
                     LR.string.end_of_year_story_top_podcasts_share_text,
-                    story.topPodcasts[0].title
+                    shareableLink
                 )
             }
 
             is StoryLongestEpisode -> {
                 resources.getString(
                     LR.string.end_of_year_story_longest_episode_share_text,
-                    story.longestEpisode.title
+                    shareableLink
                 )
             }
 
@@ -110,8 +118,8 @@ class ShareableTextProvider @Inject constructor(
     }
 
     data class ShareTextData(
-        val text: String,
+        val textWithLink: String,
         val hashTags: String,
-        val link: String,
+        val showShortURLAtEnd: Boolean
     )
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
@@ -70,6 +70,7 @@ import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryTopFivePodcas
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryTopListenedCategoriesView
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryTopPodcastView
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.Story
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryEpilogue
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryIntro
@@ -406,7 +407,10 @@ private fun showShareForFile(
 ) {
     try {
         val uri = FileUtil.getUriForFile(context, file)
-        val shareText = "${shareTextData.text} ${shareTextData.hashTags} ${shareTextData.link}"
+        var shareText = "${shareTextData.textWithLink} ${shareTextData.hashTags}"
+        if (shareTextData.showShortURLAtEnd) {
+            shareText += " ${Settings.SERVER_SHORT_URL}"
+        }
 
         val chooserIntent = ShareCompat.IntentBuilder(context)
             .setType("image/png")

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
@@ -56,6 +56,7 @@ import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.endofyear.ShareableTextProvider.ShareTextData
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State
 import au.com.shiftyjelly.pocketcasts.endofyear.views.SegmentedProgressIndicator
 import au.com.shiftyjelly.pocketcasts.endofyear.views.convertibleToBitmap
@@ -401,7 +402,7 @@ private fun showShareForFile(
     context: Context,
     file: File,
     shareLauncher: ActivityResultLauncher<Intent>,
-    shareTextData: ShareableAssetProvider.ShareTextData,
+    shareTextData: ShareTextData,
 ) {
     try {
         val uri = FileUtil.getUriForFile(context, file)

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -5,7 +5,7 @@ import android.graphics.Bitmap
 import androidx.annotation.FloatRange
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import au.com.shiftyjelly.pocketcasts.endofyear.ShareableAssetProvider.ShareTextData
+import au.com.shiftyjelly.pocketcasts.endofyear.ShareableTextProvider.ShareTextData
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State.Loaded.SegmentsData
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManager
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.Story
@@ -26,7 +26,7 @@ import kotlin.math.roundToInt
 class StoriesViewModel @Inject constructor(
     private val endOfYearManager: EndOfYearManager,
     private val fileUtilWrapper: FileUtilWrapper,
-    private val shareableAssetProvider: ShareableAssetProvider,
+    private val shareableTextProvider: ShareableTextProvider,
 ) : ViewModel() {
 
     private val mutableState = MutableStateFlow<State>(State.Loading)
@@ -146,7 +146,7 @@ class StoriesViewModel @Inject constructor(
             val currentState = (state.value as State.Loaded)
             mutableState.value = currentState.copy(preparingShareText = true)
 
-            val shareTextData = shareableAssetProvider.getShareableDataForStory(story)
+            val shareTextData = shareableTextProvider.getShareableDataForStory(story)
             mutableState.value = currentState.copy(preparingShareText = false)
 
             savedFile?.let { showShareForFile.invoke(it, shareTextData) }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/SnapShot.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/SnapShot.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewAspectRatioForTablet
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.deviceAspectRatio
+import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 
 /* Returns a callback to get bitmap for the passed composable.
 The composable is converted to ComposeView and laid out into AndroidView otherwise an illegal state exception is thrown:
@@ -37,10 +38,12 @@ fun convertibleToBitmap(
     )
 
     return {
+        val height = composeView.width * getAspectRatioForBitmap(context)
+        val availableHeight = height - 50.dpToPx(context) // Reduce approx share button height
         createBitmapFromView(
             view = composeView,
             width = composeView.width,
-            height = (composeView.width * getAspectRatioForBitmap(context)).toInt()
+            height = availableHeight.toInt()
         )
     }
 }

--- a/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
+++ b/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
@@ -113,7 +113,7 @@ class StoriesViewModelTest {
         return StoriesViewModel(
             endOfYearManager = endOfYearManager,
             fileUtilWrapper = fileUtilWrapper,
-            shareableAssetProvider = mock()
+            shareableTextProvider = mock()
         )
     }
 }

--- a/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
+++ b/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
@@ -112,7 +112,8 @@ class StoriesViewModelTest {
         whenever(endOfYearManager.loadStories()).thenReturn(flowOf(mockStories))
         return StoriesViewModel(
             endOfYearManager = endOfYearManager,
-            fileUtilWrapper = fileUtilWrapper
+            fileUtilWrapper = fileUtilWrapper,
+            shareableAssetProvider = mock()
         )
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -339,7 +339,7 @@ abstract class EpisodeDao {
 
     @Query(
         """
-        SELECT episodes.title, episodes.duration, podcasts.uuid as podcastUuid, podcasts.title as podcastTitle, podcasts.primary_color as tintColorForLightBg, podcasts.secondary_color as tintColorForDarkBg
+        SELECT episodes.uuid, episodes.title, episodes.duration, podcasts.uuid as podcastUuid, podcasts.title as podcastTitle, podcasts.primary_color as tintColorForLightBg, podcasts.secondary_color as tintColorForDarkBg
         FROM episodes
         JOIN podcasts ON episodes.podcast_id = podcasts.uuid
         WHERE episodes.last_playback_interaction_date IS NOT NULL AND episodes.last_playback_interaction_date > :fromEpochMs AND episodes.last_playback_interaction_date < :toEpochMs

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/LongestEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/LongestEpisode.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.models.db.helper
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 
 data class LongestEpisode(
+    val uuid: String,
     val title: String,
     val duration: Double,
     val podcastUuid: String,


### PR DESCRIPTION
| 📘 Project: #410  |
|:---:|

iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/478

## Description
Adds text content for each story shared and for the top podcast(s) and longest episode add a link to them.

How the shared content is handled is up to the app. Some apps work fine with images + text, and some do not. E.g. Facebook app only allows sharing an image. 

## Testing Instructions
1. Set `END_OF_YEAR_ENABLED` feature flag to `true` in base.gradle
2. Run the app and make sure you're logged in to an account with a few items on Listening History
3. Check your 2022 EoY stats (either by tapping "View My 2022" on the modal or going to Profile and tapping the card there)
4. When the first story appears, tap "Share"
5. Share to Notes or Twitter
6. ✅ Check the content and the image for the shared story
7. Repeat these steps for each story, always checking the output (image + text)

## Additional Tests
1. ✅ For the top 1 podcast, check that the URL contained in the text redirects to the podcast
2. ✅ For the longest episode, check that the URL contained in the text redirects to the episode
3. ✅ For the top 5 podcasts, check that the URL opens a list containing exactly the 5 top podcasts

**Share Text**

<img width="320" src="https://user-images.githubusercontent.com/1405144/201685435-8e5663c2-2fef-4935-971f-ba370028f819.png">

## Checklist
- If this is a user-facing change, I have added an entry in CHANGELOG.md
- I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- with different themes
- with a landscape orientation
- with the device set to have a large display and font size
- for accessibility with TalkBack
