### PR TITLE
End of Year: Top categories story design 

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/CategoryPillar.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/CategoryPillar.kt
@@ -1,0 +1,167 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Matrix
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
+import au.com.shiftyjelly.pocketcasts.endofyear.R
+import au.com.shiftyjelly.pocketcasts.endofyear.utils.FadeDirection
+import au.com.shiftyjelly.pocketcasts.endofyear.utils.dynamicBackground
+import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
+
+private const val PillarRotationAngle = -30f
+private const val PillarTextSkew = 0.5f
+private const val PillarTopAspectRatio = .58f
+private val PillarColor = Color(0xFFFE7E61)
+
+@Composable
+fun CategoryPillar(
+    title: String,
+    duration: String,
+    text: String,
+    height: Dp,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val currentLocalView = LocalView.current
+    val width = currentLocalView.width.pxToDp(context).dp * .2f
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Bottom,
+        modifier = modifier
+    ) {
+        Title(
+            text = title,
+            modifier = Modifier
+                .padding(bottom = 0.dp)
+                .width(width)
+        )
+        Duration(
+            text = duration,
+            modifier = Modifier
+                .width(width)
+                .alpha(0.8f)
+                .padding(bottom = 30.dp)
+        )
+        Pillar(
+            text = text,
+            width = width,
+            height = height,
+        )
+    }
+}
+
+@Composable
+private fun Title(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    TextH40(
+        text = text,
+        textAlign = TextAlign.Center,
+        color = Color.White,
+        fontWeight = FontWeight.Bold,
+        disableScale = true,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun Duration(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    TextH70(
+        text = text,
+        textAlign = TextAlign.Center,
+        color = Color.White,
+        disableScale = true,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun Pillar(
+    text: String,
+    width: Dp,
+    height: Dp,
+    modifier: Modifier = Modifier,
+) {
+    val pillarTopAspectRatio = PillarTopAspectRatio
+    val pillarTopHeight = width * pillarTopAspectRatio
+    Box {
+        Box(
+            modifier = modifier
+                .width(width)
+                .height(height)
+                .padding(top = pillarTopHeight / 2)
+                .dynamicBackground(
+                    baseColor = PillarColor,
+                    colorStops = listOf(Color.Black, Color.Transparent),
+                    direction = FadeDirection.TopToBottom
+                )
+        )
+        Box {
+            Image(
+                painter = painterResource(R.drawable.rectangle),
+                modifier = modifier.width(width),
+                contentDescription = null,
+                contentScale = ContentScale.FillWidth
+            )
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = modifier
+                    .width(width)
+                    .height(pillarTopHeight)
+                    .graphicsLayer {
+                        rotationZ = PillarRotationAngle
+                    }
+                    .drawWithContent {
+                        withTransform(
+                            {
+                                val transformMatrix = Matrix()
+                                transformMatrix.values[Matrix.SkewX] = PillarTextSkew
+                                transform(transformMatrix)
+                            }
+                        ) {
+                            this@drawWithContent.drawContent()
+                        }
+                    }
+                    .offset(x = -width * 0.15f)
+            ) {
+                TextH30(
+                    text = text,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    disableScale = true,
+                    color = Color.White,
+                )
+            }
+        }
+    }
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/CategoryPillar.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/CategoryPillar.kt
@@ -58,13 +58,12 @@ fun CategoryPillar(
         Title(
             text = title,
             modifier = Modifier
-                .padding(bottom = 0.dp)
-                .width(width)
+                .width(width * 1.2f)
         )
         Duration(
             text = duration,
             modifier = Modifier
-                .width(width)
+                .width(width * 1.2f)
                 .alpha(0.8f)
                 .padding(bottom = 30.dp)
         )

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/utils/StoryModifierExtensions.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/utils/StoryModifierExtensions.kt
@@ -8,10 +8,16 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 
+private const val Black50 = 0x80000000
+
 fun Modifier.podcastDynamicBackground(podcast: Podcast) =
     dynamicBackground(Color(podcast.getTintColor(false)))
 
-fun Modifier.dynamicBackground(color: Color) =
+fun Modifier.dynamicBackground(
+    baseColor: Color,
+    colorStops: List<Color> = listOf(Color.Black, Color(Black50)),
+    direction: FadeDirection = FadeDirection.BottomToTop,
+) =
     graphicsLayer {
         /*
         https://rb.gy/iju6fn
@@ -19,18 +25,19 @@ fun Modifier.dynamicBackground(color: Color) =
         The Clear blend mode will not work without it */
         alpha = 0.99f
     }.drawWithContent {
-        val colors = listOf(
-            Color.Black,
-            Color(0x80000000), // 50% Black
-        )
-        drawRect(color = color)
+        drawRect(color = baseColor)
         drawRect(
             brush = Brush.verticalGradient(
-                colors,
-                startY = Float.POSITIVE_INFINITY,
-                endY = 0f,
+                colorStops,
+                startY = if (direction == FadeDirection.BottomToTop) Float.POSITIVE_INFINITY else 0f,
+                endY = if (direction == FadeDirection.BottomToTop) 0f else Float.POSITIVE_INFINITY,
             ),
             blendMode = BlendMode.DstIn
         )
         drawContent()
     }
+
+enum class FadeDirection {
+    TopToBottom,
+    BottomToTop
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopListenedCategoriesView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopListenedCategoriesView.kt
@@ -1,130 +1,126 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
 
-import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
-import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
-import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.endofyear.components.CategoryPillar
+import au.com.shiftyjelly.pocketcasts.endofyear.components.PodcastLogoWhite
+import au.com.shiftyjelly.pocketcasts.endofyear.utils.dynamicBackground
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopListenedCategories
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+private const val BackgroundColor = 0xFF744F9D
 
 @Composable
 fun StoryTopListenedCategoriesView(
     story: StoryTopListenedCategories,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.verticalScroll(rememberScrollState())) {
-        TextH30(
-            text = "Your Top Categories",
-            textAlign = TextAlign.Center,
-            color = story.tintColor,
-            modifier = modifier
-                .fillMaxWidth()
-                .padding(vertical = 16.dp)
-        )
-        story.listenedCategories.subList(0, minOf(story.listenedCategories.count(), 5))
-            .mapIndexed { index, listenedCategory ->
-                CategoryItem(
-                    listenedCategory = listenedCategory,
-                    position = index,
-                    tintColor = story.tintColor,
-                )
-            }
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .fillMaxSize()
+            .dynamicBackground(Color(BackgroundColor))
+            .verticalScroll(rememberScrollState())
+    ) {
+        Spacer(modifier = modifier.height(40.dp))
+
+        Spacer(modifier = modifier.weight(1f))
+
+        Title(story)
+
+        Spacer(modifier = modifier.weight(0.5f))
+
+        CategoryPillars(story, modifier)
+
+        Spacer(modifier = modifier.weight(1f))
+
+        PodcastLogoWhite()
+
+        Spacer(modifier = modifier.height(40.dp))
     }
 }
 
 @Composable
-fun CategoryItem(
-    listenedCategory: ListenedCategory,
-    position: Int,
-    tintColor: Color,
+private fun Title(
+    story: StoryTopListenedCategories,
     modifier: Modifier = Modifier,
 ) {
-    Column {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-        ) {
-            TextP40(
-                text = "${position + 1}",
-                color = tintColor,
-                modifier = modifier.padding(end = 16.dp)
+    val text = stringResource(LR.string.end_of_year_story_top_categories)
+    TextH30(
+        text = text,
+        textAlign = TextAlign.Center,
+        color = story.tintColor,
+        modifier = modifier
+            .padding(horizontal = 40.dp)
+            .fillMaxWidth()
+    )
+}
+
+@Composable
+private fun CategoryPillars(
+    story: StoryTopListenedCategories,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    Row(
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.Bottom,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 40.dp)
+    ) {
+        listOf(1, 0, 2).forEach { index ->
+            Spacer(modifier.weight(1f))
+
+            val listenedCategory = story.listenedCategories.atIndex(index)
+            listenedCategory?.let {
+                val timeText =
+                    StatsHelper.secondsToFriendlyString(
+                        listenedCategory.totalPlayedTime,
+                        context.resources
+                    )
+                CategoryPillar(
+                    title = listenedCategory.category,
+                    duration = timeText,
+                    text = (index + 1).toString(),
+                    height = (200 - index * 55).dp,
+                    modifier = modifier
+                        .padding(
+                            bottom = if (index == 0) 70.dp else 0.dp,
+                        )
+                )
+            } ?: CategoryPillar(
+                title = "",
+                duration = "",
+                text = "",
+                height = 200.dp,
+                modifier = modifier.alpha(0f)
             )
-            Row(
-                modifier = modifier
-                    .padding(end = 16.dp)
-                    .weight(1f),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Image(
-                    painter = painterResource(IR.drawable.defaultartwork),
-                    contentDescription = null,
-                    modifier = modifier
-                        .size(64.dp)
-                        .padding(top = 4.dp, end = 12.dp, bottom = 4.dp)
-                )
-                TextP40(
-                    text = listenedCategory.category,
-                    color = tintColor,
-                    textAlign = TextAlign.Start,
-                    modifier = modifier
-                        .padding(end = 16.dp)
-                        .weight(1f),
-                )
-                Column {
-                    TextP40(
-                        text = "${listenedCategory.numberOfPodcasts}",
-                        color = tintColor
-                    )
-                    TextP40(
-                        text = "Podcasts",
-                        color = tintColor
-                    )
-                }
-            }
+
+            Spacer(modifier.weight(1f))
         }
     }
 }
 
-@Preview(showBackground = true)
-@Composable
-private fun CategoryItemPreview(
-    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
-) {
-    AppTheme(themeType) {
-        Surface(color = Color.Black) {
-            CategoryItem(
-                listenedCategory = ListenedCategory(
-                    numberOfPodcasts = 2,
-                    totalPlayedTime = 1L,
-                    category = "News",
-                    mostListenedPodcastId = "",
-                    mostListenedPodcastTintColor = 0
-                ),
-                position = 0,
-                tintColor = Color.White,
-            )
-        }
-    }
-}
+private fun List<ListenedCategory>.atIndex(index: Int) =
+    if (index < size) this[index] else null

--- a/modules/features/endofyear/src/main/res/drawable/rectangle.xml
+++ b/modules/features/endofyear/src/main/res/drawable/rectangle.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="83dp"
+    android:height="48dp"
+    android:viewportWidth="83"
+    android:viewportHeight="48">
+  <path
+      android:pathData="M0.671,23.785L41.662,0.234L82.645,23.785L41.662,47.563L0.671,23.785Z"
+      android:fillColor="#FE7E61"/>
+</vector>

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
@@ -237,7 +237,7 @@ fun TextH70(
     Text(
         text = text,
         color = color,
-        fontSize = 12.sp,
+        fontSize = if (disableScale) 12.nonScaledSp else 12.sp,
         fontWeight = fontWeight,
         lineHeight = if (disableScale) 14.nonScaledSp else 14.sp,
         letterSpacing = if (disableScale) .25f.nonScaledSp else .25.sp,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -14,11 +15,20 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import java.util.Locale
+
+private val Float.nonScaledSp
+    @Composable
+    get() = (this / LocalDensity.current.fontScale).sp
+
+private val Int.nonScaledSp
+    @Composable
+    get() = (this / LocalDensity.current.fontScale).sp
 
 @Composable
 fun TextH10(
@@ -69,13 +79,15 @@ fun TextH30(
     textAlign: TextAlign? = null,
     color: Color = MaterialTheme.theme.colors.primaryText01,
     fontWeight: FontWeight? = null,
-    maxLines: Int = Int.MAX_VALUE
+    maxLines: Int = Int.MAX_VALUE,
+    disableScale: Boolean = false,
+    fontSize: TextUnit = 18.sp
 ) {
     Text(
         text = text,
         color = color,
-        fontSize = 18.sp,
-        lineHeight = 21.sp,
+        fontSize = if (disableScale) fontSize.value.nonScaledSp else fontSize,
+        lineHeight = if (disableScale) 21.nonScaledSp else 21.sp,
         textAlign = textAlign,
         fontWeight = fontWeight ?: FontWeight.SemiBold,
         maxLines = maxLines,
@@ -90,14 +102,16 @@ fun TextH40(
     modifier: Modifier = Modifier,
     textAlign: TextAlign? = null,
     color: Color = MaterialTheme.theme.colors.primaryText01,
-    maxLines: Int = Int.MAX_VALUE
+    maxLines: Int = Int.MAX_VALUE,
+    fontWeight: FontWeight = FontWeight.Medium,
+    disableScale: Boolean = false
 ) {
     Text(
         text = text,
         color = color,
-        fontSize = 15.sp,
-        fontWeight = FontWeight.Medium,
-        lineHeight = 21.sp,
+        fontSize = if (disableScale) 15.nonScaledSp else 15.sp,
+        fontWeight = fontWeight,
+        lineHeight = if (disableScale) 21.nonScaledSp else 21.sp,
         textAlign = textAlign,
         maxLines = maxLines,
         overflow = TextOverflow.Ellipsis,
@@ -217,15 +231,16 @@ fun TextH70(
     textAlign: TextAlign? = null,
     color: Color = MaterialTheme.theme.colors.primaryText01,
     fontWeight: FontWeight = FontWeight(500),
-    maxLines: Int = Int.MAX_VALUE
+    maxLines: Int = Int.MAX_VALUE,
+    disableScale: Boolean = false
 ) {
     Text(
         text = text,
         color = color,
         fontSize = 12.sp,
         fontWeight = fontWeight,
-        lineHeight = 14.sp,
-        letterSpacing = 0.25.sp,
+        lineHeight = if (disableScale) 14.nonScaledSp else 14.sp,
+        letterSpacing = if (disableScale) .25f.nonScaledSp else .25.sp,
         maxLines = maxLines,
         overflow = TextOverflow.Ellipsis,
         modifier = modifier,


### PR DESCRIPTION
| 📘 Project: #410 |
|:---:|

iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/468

## Description
Adds the design for the top categories story.

## Testing Instructions
1. Set `END_OF_YEAR_ENABLED` feature flag to `true` in base.gradle
2. Run the app and make sure you're logged in to an account with a few items on Listening History
3. When the prompt appears, tap "View My 2022"
4. Navigate to the 4th story
4. ✅ Check the design

## Screenshots or Screencast 

| Pixel 5 | Nexus 7 (2012)|
|----|---|
<img width=320 src="https://user-images.githubusercontent.com/1405144/201849260-bd1542b5-6ee2-443e-af4d-cbf6696da0f8.png"/> | <img width=500 src="https://user-images.githubusercontent.com/1405144/201849336-f93fcc2e-fe0a-4746-8bda-0c765d07ec95.png"/>


## Checklist
- If this is a user-facing change, I have added an entry in CHANGELOG.md
- I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
