### PR TITLE
End of Year: Fix pause and vm issues

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -12,10 +12,6 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
@@ -39,7 +35,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.databinding.ActivityMainBinding
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment
-import au.com.shiftyjelly.pocketcasts.endofyear.StoriesPage
+import au.com.shiftyjelly.pocketcasts.endofyear.StoriesFragment
 import au.com.shiftyjelly.pocketcasts.endofyear.views.EndOfYearLaunchBottomSheet
 import au.com.shiftyjelly.pocketcasts.filters.FiltersFragment
 import au.com.shiftyjelly.pocketcasts.localization.helper.LocaliseHelper
@@ -505,17 +501,11 @@ class MainActivity :
 
     private fun setupEndOfYearLaunchBottomSheet() {
         binding.modalBottomSheet.setContent {
-            var showDialog by rememberSaveable { mutableStateOf(false) }
-            if (showDialog) {
-                StoriesPage(
-                    theme = theme,
-                    onCloseClicked = { showDialog = false },
-                )
-            }
             AppTheme(theme.activeTheme) {
                 EndOfYearLaunchBottomSheet(
                     onClick = {
-                        showDialog = true
+                        StoriesFragment.newInstance()
+                            .show(supportFragmentManager, "stories_dialog")
                     }
                 )
             }

--- a/base.gradle
+++ b/base.gradle
@@ -200,6 +200,7 @@ dependencies {
     implementation androidLibs.composeUi
     implementation androidLibs.composeUiToolingPreview
     implementation androidLibs.composeViewModel
+    implementation androidLibs.composeUiUtil
 
     implementation libs.kotlinCoroutines
     implementation libs.kotlinCoroutinesAndroid

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -166,6 +166,7 @@ project.ext {
             composeUiToolingPreview: "androidx.compose.ui:ui-tooling-preview:$versionCompose",
             composeRx: "androidx.compose.runtime:runtime-rxjava2:$versionCompose",
             composeViewModel: "androidx.lifecycle:lifecycle-viewmodel-compose:$versionLifecycle",
+            composeUiUtil: "androidx.compose.ui:ui-util:$versionCompose",
             guava: 'com.google.guava:guava:27.1-android' // Required to fix conflict between versions in exoplayer and workmanager
     ]
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -1,0 +1,54 @@
+package au.com.shiftyjelly.pocketcasts.endofyear
+
+import android.annotation.SuppressLint
+import android.content.pm.ActivityInfo
+import android.graphics.Color
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.utils.Util
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseAppCompatDialogFragment
+
+class StoriesFragment : BaseAppCompatDialogFragment() {
+    private val viewModel: StoriesViewModel by viewModels()
+    override val statusBarColor: StatusBarColor
+        get() = StatusBarColor.Custom(Color.BLACK, true)
+
+    @SuppressLint("SourceLockedOrientationActivity")
+    override fun onCreate(savedInstance: Bundle?) {
+        super.onCreate(savedInstance)
+        val isTablet = Util.isTablet(requireContext())
+        if (!isTablet) {
+            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+            setStyle(STYLE_NORMAL, android.R.style.Theme_Material_NoActionBar)
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                AppTheme(theme.activeTheme) {
+                    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+                    StoriesPage(
+                        viewModel = viewModel,
+                        onCloseClicked = { dismiss() },
+                    )
+                }
+            }
+        }
+    }
+
+    companion object {
+        fun newInstance() = StoriesFragment()
+    }
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
@@ -1,10 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.endofyear
 
-import android.app.Activity
 import android.content.Context
-import android.content.ContextWrapper
 import android.content.Intent
-import android.content.pm.ActivityInfo
 import android.graphics.Bitmap
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResultLauncher
@@ -28,14 +25,12 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -47,8 +42,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.core.app.ShareCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
@@ -81,8 +74,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryLonges
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopFivePodcasts
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopListenedCategories
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopPodcast
-import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import au.com.shiftyjelly.pocketcasts.utils.Util
@@ -99,13 +90,11 @@ private const val MaxHeightPercentFactor = 0.9f
 private const val LongPressThresholdTimeInMs = 150
 const val StoriesViewAspectRatioForTablet = 2f
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun StoriesPage(
     modifier: Modifier = Modifier,
-    viewModel: StoriesViewModel = viewModel(),
+    viewModel: StoriesViewModel,
     onCloseClicked: () -> Unit,
-    theme: Theme,
 ) {
     val shareLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult()
@@ -116,53 +105,34 @@ fun StoriesPage(
 
     val context = LocalContext.current
 
-    val isTablet = Util.isTablet(context)
-    if (!isTablet) LockScreenOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
-    UpdateSystemBarColors(theme)
-
     val state: State by viewModel.state.collectAsState()
     val dialogSize = remember { getDialogSize(context) }
-    Dialog(
-        onDismissRequest = { onCloseClicked.invoke() },
-        properties = DialogProperties(usePlatformDefaultWidth = isTablet),
-    ) {
-        Box(modifier = modifier.size(dialogSize)) {
-            when (state) {
-                is State.Loaded -> {
-                    StoriesView(
-                        state = state as State.Loaded,
-                        progress = viewModel.progress,
-                        onSkipPrevious = { viewModel.skipPrevious() },
-                        onSkipNext = { viewModel.skipNext() },
-                        onPause = { viewModel.pause() },
-                        onStart = { viewModel.start() },
-                        onCloseClicked = onCloseClicked,
-                        onReplayClicked = { viewModel.replay() },
-                        onShareClicked = {
-                            val currentStory = requireNotNull((state as State.Loaded).currentStory)
-                            viewModel.onShareClicked(it, currentStory, context) { file, shareTextData ->
-                                showShareForFile(
-                                    context,
-                                    file,
-                                    shareLauncher,
-                                    shareTextData
-                                )
-                            }
-                        },
-                    )
-                }
-                State.Loading -> StoriesLoadingView(onCloseClicked)
-                State.Error -> StoriesErrorView(onCloseClicked)
+    Box(modifier = modifier.size(dialogSize)) {
+        when (state) {
+            is State.Loaded -> {
+                StoriesView(
+                    state = state as State.Loaded,
+                    progress = viewModel.progress,
+                    onSkipPrevious = { viewModel.skipPrevious() },
+                    onSkipNext = { viewModel.skipNext() },
+                    onPause = { viewModel.pause() },
+                    onStart = { viewModel.start() },
+                    onCloseClicked = onCloseClicked,
+                    onReplayClicked = { viewModel.replay() },
+                    onShareClicked = {
+                        viewModel.onShareClicked(it, context) { file, shareTextData ->
+                            showShareForFile(
+                                context,
+                                file,
+                                shareLauncher,
+                                shareTextData
+                            )
+                        }
+                    },
+                )
             }
-        }
-    }
-
-    DisposableEffect(Unit) {
-        if (state is State.Loaded) {
-            viewModel.start()
-        }
-        onDispose {
-            viewModel.clear()
+            State.Loading -> StoriesLoadingView(onCloseClicked)
+            State.Error -> StoriesErrorView(onCloseClicked)
         }
     }
 }
@@ -439,44 +409,6 @@ private fun getDialogSize(context: Context): DpSize {
     }
 
     return DpSize(dialogWidth.dp, dialogHeight.dp)
-}
-
-@Composable
-fun LockScreenOrientation(orientation: Int) {
-    val context = LocalContext.current
-    DisposableEffect(Unit) {
-        val activity = context.findActivity() ?: return@DisposableEffect onDispose {}
-        val originalOrientation = activity.requestedOrientation
-        activity.requestedOrientation = orientation
-        onDispose {
-            // restore original orientation when view disappears
-            activity.requestedOrientation = originalOrientation
-        }
-    }
-}
-
-@Composable
-fun UpdateSystemBarColors(theme: Theme) {
-    val context = LocalContext.current
-    DisposableEffect(Unit) {
-        val activity = context.findActivity() ?: return@DisposableEffect onDispose {}
-        theme.updateWindowStatusBar(
-            activity.window,
-            StatusBarColor.Custom(android.graphics.Color.BLACK, true),
-            activity
-        )
-        theme.setNavigationBarColor(activity.window, true, android.graphics.Color.BLACK)
-        onDispose {
-            // restore original system colors
-            (activity as FragmentHostListener).updateSystemColors()
-        }
-    }
-}
-
-fun Context.findActivity(): Activity? = when (this) {
-    is Activity -> this
-    is ContextWrapper -> baseContext.findActivity()
-    else -> null
 }
 
 @Preview(showBackground = true)

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.core.app.ShareCompat
-import androidx.lifecycle.viewmodel.compose.viewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
@@ -51,6 +50,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.endofyear.ShareableTextProvider.ShareTextData
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State
+import au.com.shiftyjelly.pocketcasts.endofyear.utils.waitForUpInitial
 import au.com.shiftyjelly.pocketcasts.endofyear.views.SegmentedProgressIndicator
 import au.com.shiftyjelly.pocketcasts.endofyear.views.convertibleToBitmap
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryEpilogueView
@@ -343,10 +343,10 @@ private fun StorySwitcher(
             .pointerInput(Unit) {
                 detectTapGestures(
                     onPress = {
-                        val pressStartTime = System.currentTimeMillis()
-                        onPause()
-                        val isReleased = tryAwaitRelease()
-                        if (isReleased) {
+                        awaitPointerEventScope {
+                            val pressStartTime = System.currentTimeMillis()
+                            onPause()
+                            waitForUpInitial()
                             val pressEndTime = System.currentTimeMillis()
                             val diffPressTime = pressEndTime - pressStartTime
                             if (diffPressTime < LongPressThresholdTimeInMs) {
@@ -358,8 +358,6 @@ private fun StorySwitcher(
                             } else {
                                 onStart()
                             }
-                        } else {
-                            onStart()
                         }
                     }
                 )

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -81,8 +81,6 @@ class StoriesViewModel @Inject constructor(
     }
 
     fun start() {
-        if (timer != null) clear()
-
         val currentState = state.value as State.Loaded
         val progressFraction =
             (PROGRESS_UPDATE_INTERVAL_MS / totalLengthInMs.toFloat())
@@ -130,11 +128,12 @@ class StoriesViewModel @Inject constructor(
 
     fun onShareClicked(
         onCaptureBitmap: () -> Bitmap,
-        story: Story,
         context: Context,
         showShareForFile: (File, ShareTextData) -> Unit,
     ) {
         pause()
+        val currentState = (state.value as State.Loaded)
+        val story = requireNotNull(currentState.currentStory)
         viewModelScope.launch {
             val savedFile = fileUtilWrapper.saveBitmapToFile(
                 onCaptureBitmap.invoke(),
@@ -143,7 +142,6 @@ class StoriesViewModel @Inject constructor(
                 EOY_STORY_SAVE_FILE_NAME
             )
 
-            val currentState = (state.value as State.Loaded)
             mutableState.value = currentState.copy(preparingShareText = true)
 
             val shareTextData = shareableTextProvider.getShareableDataForStory(story)
@@ -163,7 +161,7 @@ class StoriesViewModel @Inject constructor(
         currentIndex = 0
     }
 
-    fun clear() {
+    private fun clear() {
         if (mutableState.value is State.Loaded) {
             skipToStoryAtIndex(0)
         }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/utils/PointerEventUtil.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/utils/PointerEventUtil.kt
@@ -1,0 +1,17 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.utils
+
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.changedToUp
+import androidx.compose.ui.util.fastAll
+
+suspend fun AwaitPointerEventScope.waitForUpInitial(): PointerInputChange {
+    while (true) {
+        /* PointerEventPass.Initial: Allows parent to consume aspects of PointerInputChange before children. */
+        val event = awaitPointerEvent(PointerEventPass.Initial)
+        if (event.changes.fastAll { it.changedToUp() }) {
+            return event.changes[0]
+        }
+    }
+}

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -11,8 +11,6 @@ import android.widget.TextView
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
@@ -31,7 +29,7 @@ import au.com.shiftyjelly.pocketcasts.account.AccountActivity
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.endofyear.StoriesPage
+import au.com.shiftyjelly.pocketcasts.endofyear.StoriesFragment
 import au.com.shiftyjelly.pocketcasts.endofyear.views.EndOfYearPromptCard
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralSecondsMinutesHoursDaysOrYears
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
@@ -238,17 +236,11 @@ class ProfileFragment : BaseFragment() {
     private fun FragmentProfileBinding.setupEndOfYearPromptCard(isEligible: Boolean) {
         endOfYearPromptCard.setContent {
             if (isEligible) {
-                var showDialog by rememberSaveable { mutableStateOf(false) }
-                if (showDialog) {
-                    StoriesPage(
-                        theme = theme,
-                        onCloseClicked = { showDialog = false },
-                    )
-                }
                 AppTheme(theme.activeTheme) {
                     EndOfYearPromptCard(
                         onClick = {
-                            showDialog = true
+                            StoriesFragment.newInstance()
+                                .show(childFragmentManager, "stories_dialog")
                         }
                     )
                 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseAppCompatDialogFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseAppCompatDialogFragment.kt
@@ -1,0 +1,51 @@
+package au.com.shiftyjelly.pocketcasts.views.fragments
+
+import android.content.DialogInterface
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatDialogFragment
+import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
+import au.com.shiftyjelly.pocketcasts.ui.R as UR
+
+@AndroidEntryPoint
+open class BaseAppCompatDialogFragment : AppCompatDialogFragment(), CoroutineScope {
+
+    open val statusBarColor: StatusBarColor? = StatusBarColor.Light
+
+    @Inject
+    lateinit var theme: Theme
+
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.Main
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        if (view.background == null) {
+            view.setBackgroundColor(view.context.getThemeColor(UR.attr.primary_ui_01))
+        }
+        view.isClickable = true
+
+        val activity = activity
+        val statusBarColor = statusBarColor
+        if (activity != null && statusBarColor != null) {
+            theme.updateWindowStatusBar(
+                window = activity.window,
+                statusBarColor = statusBarColor,
+                context = activity
+            )
+        }
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        (activity as? FragmentHostListener)?.updateStatusBar()
+    }
+}


### PR DESCRIPTION
## Description

This PR attempts to fix following two issues

#### Pause behavior: https://github.com/Automattic/pocket-casts-android/pull/567#pullrequestreview-1179288351

For this, I added an `AwaitPointerEventScope` extension inspired from [this post](https://stackoverflow.com/a/68878910/193545). - 68e8851f333da7fc5564923c2b13f739430c2a75

#### `StoriesViewModel` Scope: https://github.com/Automattic/pocket-casts-android/pull/570#discussion_r1021785677

Due to [viewmodels not being scoped to a composable](https://issuetracker.google.com/issues/165642391), I changed the way the dialog is shown. - 9c140aa3e47936301290a31d4d3a889381c02425


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
