### PR TITLE
End of Year: Require login

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.ui
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -12,6 +13,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.BackpressureStrategy
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.Date
 import javax.inject.Inject
@@ -27,6 +30,7 @@ class MainActivityViewModel
 
     var isPlayerOpen: Boolean = false
     var lastPlaybackState: PlaybackState? = null
+    val shouldShowStoriesModal = MutableStateFlow(true)
 
     private val playbackStateRx = playbackManager.playbackStateRelay
         .doOnNext {
@@ -52,4 +56,9 @@ class MainActivityViewModel
     }
 
     suspend fun isEndOfYearStoriesEligible() = endOfYearManager.isEligibleForStories()
+    fun updateStoriesModalShowState(show: Boolean) {
+        viewModelScope.launch {
+            shouldShowStoriesModal.value = show && isEndOfYearStoriesEligible()
+        }
+    }
 }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -31,6 +31,7 @@ class MainActivityViewModel
     var isPlayerOpen: Boolean = false
     var lastPlaybackState: PlaybackState? = null
     val shouldShowStoriesModal = MutableStateFlow(true)
+    var waitingForSignInToShowStories = false
 
     private val playbackStateRx = playbackManager.playbackStateRelay
         .doOnNext {
@@ -40,6 +41,8 @@ class MainActivityViewModel
     val playbackState = LiveDataReactiveStreams.fromPublisher(playbackStateRx)
 
     val signInState: LiveData<SignInState> = LiveDataReactiveStreams.fromPublisher(userManager.getSignInState())
+    val isSignedIn: Boolean
+        get() = signInState.value?.isSignedIn ?: false
 
     fun shouldShowCancelled(subscriptionStatus: SubscriptionStatus): Boolean {
         val plusStatus = (subscriptionStatus as? SubscriptionStatus.Plus) ?: return false

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
@@ -140,4 +140,7 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
     override fun isUpNextShowing(): Boolean {
         return false
     }
+
+    override fun showStoriesOrAccount() {
+    }
 }

--- a/base.gradle
+++ b/base.gradle
@@ -29,6 +29,7 @@ android {
 
         // Feature Flags
         buildConfigField "boolean", "END_OF_YEAR_ENABLED", "false"
+        buildConfigField "boolean", "END_OF_YEAR_REQUIRE_LOGIN", "true"
         buildConfigField "boolean", "ONBOARDING_ENABLED", "false"
 
         testInstrumentationRunner project.testInstrumentationRunner

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/EndOfYearLaunchBottomSheet.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/EndOfYearLaunchBottomSheet.kt
@@ -40,10 +40,13 @@ private val ImageContentCoverBottomPadding = 8.dp
 @Composable
 fun EndOfYearLaunchBottomSheet(
     modifier: Modifier = Modifier,
+    shouldShow: Boolean = true,
     onClick: () -> Unit,
+    onExpanded: () -> Unit,
 ) {
     ModalBottomSheet(
-        showOnLoad = true,
+        shouldShow = shouldShow,
+        onExpanded = onExpanded,
         content = BottomSheetContentState.Content(
             titleText = stringResource(LR.string.end_of_year_launch_modal_title),
             imageContent = { ImageContent(modifier) },

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -25,7 +25,6 @@ import au.com.shiftyjelly.pocketcasts.account.AccountActivity
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.endofyear.StoriesFragment
 import au.com.shiftyjelly.pocketcasts.endofyear.views.EndOfYearPromptCard
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralSecondsMinutesHoursDaysOrYears
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
@@ -232,8 +231,7 @@ class ProfileFragment : BaseFragment() {
                 AppTheme(theme.activeTheme) {
                     EndOfYearPromptCard(
                         onClick = {
-                            StoriesFragment.newInstance()
-                                .show(childFragmentManager, "stories_dialog")
+                            (activity as? FragmentHostListener)?.showStoriesOrAccount()
                         }
                     )
                 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bottomsheet/ModalBottomSheet.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bottomsheet/ModalBottomSheet.kt
@@ -8,7 +8,9 @@ import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineScope
@@ -17,11 +19,13 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun ModalBottomSheet(
-    showOnLoad: Boolean = false,
+    onExpanded: () -> Unit,
+    shouldShow: Boolean,
     content: BottomSheetContentState.Content,
 ) {
     val sheetState = rememberModalBottomSheetState(
-        initialValue = if (showOnLoad) ModalBottomSheetValue.Expanded else ModalBottomSheetValue.Hidden,
+        initialValue = ModalBottomSheetValue.Hidden,
+        skipHalfExpanded = true,
     )
     val coroutineScope = rememberCoroutineScope()
 
@@ -43,11 +47,30 @@ fun ModalBottomSheet(
         scrimColor = Color.Black.copy(alpha = .25f),
         content = {}
     )
+
+    if (!sheetState.isVisible && shouldShow) {
+        displayBottomSheet(coroutineScope, sheetState)
+    }
+    LaunchedEffect(Unit) {
+        snapshotFlow { sheetState.currentValue }
+            .collect {
+                if (sheetState.currentValue == ModalBottomSheetValue.Expanded) {
+                    onExpanded.invoke()
+                }
+            }
+    }
 }
 
 @OptIn(ExperimentalMaterialApi::class)
 fun hideBottomSheet(coroutineScope: CoroutineScope, sheetState: ModalBottomSheetState) {
     coroutineScope.launch {
         sheetState.hide()
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+fun displayBottomSheet(coroutineScope: CoroutineScope, sheetState: ModalBottomSheetState) {
+    coroutineScope.launch {
+        sheetState.show()
     }
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -590,4 +590,8 @@ interface Settings {
 
     fun setEndOfYearShowBadge2022(value: Boolean)
     fun getEndOfYearShowBadge2022(): Boolean
+
+    fun setEndOfYearModalHasBeenShown(value: Boolean)
+    fun getEndOfYearModalHasBeenShown(): Boolean
+    fun endOfYearRequireLogin(): Boolean
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -70,6 +70,7 @@ class SettingsImpl @Inject constructor(
         private const val SEND_CRASH_REPORTS_KEY = "SendCrashReportsKey"
         private const val LINK_CRASH_REPORTS_TO_USER_KEY = "LinkCrashReportsToUserKey"
         private const val END_OF_YEAR_SHOW_BADGE_2022_KEY = "EndOfYearShowBadge2022Key"
+        private const val END_OF_YEAR_MODAL_HAS_BEEN_SHOWN_KEY = "EndOfYearModalHasBeenShownKey"
     }
 
     private var languageCode: String? = null
@@ -1484,4 +1485,15 @@ class SettingsImpl @Inject constructor(
 
     override fun getEndOfYearShowBadge2022(): Boolean =
         getBoolean(END_OF_YEAR_SHOW_BADGE_2022_KEY, true)
+
+    override fun setEndOfYearModalHasBeenShown(value: Boolean) {
+        setBoolean(END_OF_YEAR_MODAL_HAS_BEEN_SHOWN_KEY, value)
+    }
+
+    override fun getEndOfYearModalHasBeenShown(): Boolean =
+        getBoolean(END_OF_YEAR_MODAL_HAS_BEEN_SHOWN_KEY, true)
+
+    override fun endOfYearRequireLogin(): Boolean {
+        return BuildConfig.END_OF_YEAR_REQUIRE_LOGIN
+    }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -39,7 +39,7 @@ class EndOfYearManagerImpl @Inject constructor(
 
     companion object {
         private const val YEAR = 2022
-        private const val EPISODE_MINIMUM_PLAYED_TIME_IN_MIN = 30L
+        private const val EPISODE_MINIMUM_PLAYED_TIME_IN_MIN = 5L
     }
 
     private val yearStart = epochAtStartOfYear(YEAR)

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
@@ -28,4 +28,5 @@ interface FragmentHostListener {
     fun updateSystemColors()
     fun overrideNextRefreshTimer()
     fun isUpNextShowing(): Boolean
+    fun showStoriesOrAccount()
 }


### PR DESCRIPTION
| 📘 Project: #410 |
|:---:|

iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/474
## Description

In order to provide better End of Year stats next year, it's required to create an account to see 2022 End of Year stats.

## To test

1. Set `END_OF_YEAR_ENABLED` feature flag to `true` in base.gradle
2. Run the app and make sure you're logged in to an account with a few items on Listening History
3. Logout
4. Re-run the app
5. ✅ The 2022 prompt should appear, even though you're logged out
6. Tap "View my 2022"
7. You should be prompted to login or create an account
8. Login (or create an account)
11. ✅ The stories should appear

You should see the same behavior when tapping the card under Profile. If you're logged in, the stories should appear. If not, the login/sign up screen should appear.

I also updated min played time eligibility from 30min to 5min based on this comment https://github.com/Automattic/pocket-casts-android/pull/551#issuecomment-1305493401.

P.S. 
1. Remote feature flag is not added in this PR due to issues in retrieving it from Firebase.
2. Apologies for using quite a few booleans in this PR, I'll create a tech-debt task to clean those up.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
