### PR TITLE
Speed up the listening history sync

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.runtime.Composable
@@ -141,7 +142,10 @@ fun StoriesPage(
                     },
                 )
             }
-            State.Loading -> StoriesLoadingView(onCloseClicked)
+            is State.Loading -> StoriesLoadingView(
+                progress = (state as State.Loading).progress,
+                onCloseClicked = onCloseClicked
+            )
             State.Error -> {
                 viewModel.trackStoryFailedToLoad()
                 StoriesErrorView(onCloseClicked)
@@ -289,11 +293,20 @@ private fun CloseButtonView(
 
 @Composable
 private fun StoriesLoadingView(
+    progress: Float,
     onCloseClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     StoriesEmptyView(
-        content = { CircularProgressIndicator(color = Color.White) },
+        content = {
+            LinearProgressIndicator(
+                progress = progress,
+                color = Color.White,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp)
+            )
+        },
         onCloseClicked = onCloseClicked,
         modifier = modifier
     )
@@ -479,6 +492,7 @@ private fun StoriesLoadingViewPreview(
 ) {
     AppTheme(themeType) {
         StoriesLoadingView(
+            progress = 0.5f,
             onCloseClicked = {}
         )
     }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -81,9 +81,10 @@ class StoriesViewModel @Inject constructor(
             }
             mutableState.value = state
             if (state is State.Loaded) start()
-        } catch (e: Exception) {
-            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, e, "Failed to load end of year stories.")
-            SentryHelper.recordException(message = "Failed to load end of year stories.", throwable = e)
+        } catch (ex: Exception) {
+            val message = "Failed to load end of year stories."
+            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, ex, message)
+            SentryHelper.recordException(message, ex)
             mutableState.value = State.Error
         }
     }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -12,6 +12,8 @@ import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State.Loaded.Se
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManager
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.Story
 import au.com.shiftyjelly.pocketcasts.utils.FileUtilWrapper
+import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -77,6 +79,8 @@ class StoriesViewModel @Inject constructor(
             mutableState.value = state
             if (state is State.Loaded) start()
         } catch (e: Exception) {
+            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, e, "Failed to load end of year stories.")
+            SentryHelper.recordException(message = "Failed to load end of year stories.", throwable = e)
             mutableState.value = State.Error
         }
     }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -33,7 +33,7 @@ class StoriesViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) : ViewModel() {
 
-    private val mutableState = MutableStateFlow<State>(State.Loading)
+    private val mutableState = MutableStateFlow<State>(State.Loading())
     val state: StateFlow<State> = mutableState
 
     private val mutableProgress = MutableStateFlow(0f)
@@ -63,7 +63,10 @@ class StoriesViewModel @Inject constructor(
 
     private suspend fun loadStories() {
         try {
-            endOfYearManager.downloadListeningHistory()
+            val onProgressChanged: (Float) -> Unit = { progress ->
+                mutableState.value = State.Loading(progress)
+            }
+            endOfYearManager.downloadListeningHistory(onProgressChanged = onProgressChanged)
             stories.addAll(endOfYearManager.loadStories())
             val state = if (stories.isEmpty()) {
                 State.Error
@@ -181,7 +184,9 @@ class StoriesViewModel @Inject constructor(
     }
 
     sealed class State {
-        object Loading : State()
+        data class Loading(
+            val progress: Float = 0f
+        ) : State()
         data class Loaded(
             val currentStory: Story?,
             val segmentsData: SegmentsData,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -22,6 +22,9 @@ import java.util.Date
 @Dao
 abstract class PodcastDao {
 
+    @Query("SELECT uuid FROM podcasts")
+    abstract suspend fun findAllUuids(): List<String>
+
     @Query("SELECT * FROM podcasts WHERE subscribed = 1 ORDER BY LOWER(title) ASC")
     abstract fun findSubscribed(): List<Podcast>
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -22,9 +22,6 @@ import java.util.Date
 @Dao
 abstract class PodcastDao {
 
-    @Query("SELECT uuid FROM podcasts")
-    abstract suspend fun findAllUuids(): List<String>
-
     @Query("SELECT * FROM podcasts WHERE subscribed = 1 ORDER BY LOWER(title) ASC")
     abstract fun findSubscribed(): List<Podcast>
 
@@ -36,6 +33,9 @@ abstract class PodcastDao {
 
     @Query("SELECT * FROM podcasts WHERE subscribed = 1")
     abstract suspend fun findSubscribedNoOrder(): List<Podcast>
+
+    @Query("SELECT uuid FROM podcasts WHERE subscribed = 1")
+    abstract suspend fun findSubscribedUuids(): List<String>
 
     @Query("SELECT * FROM podcasts WHERE subscribed = 0")
     abstract fun findUnsubscribed(): List<Podcast>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
@@ -8,7 +8,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.Story
 
 interface EndOfYearManager {
     suspend fun isEligibleForStories(): Boolean
-    suspend fun downloadListeningHistory()
+    suspend fun downloadListeningHistory(onProgressChanged: (Float) -> Unit)
     suspend fun loadStories(): List<Story>
     suspend fun hasEpisodesPlayedUpto(year: Int, playedUpToInSecs: Long): Boolean
     suspend fun getTotalListeningTimeInSecsForYear(year: Int): Long?

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -61,6 +61,7 @@ interface EpisodeManager {
     /** Add methods  */
     fun add(episode: Episode, downloadMetaData: Boolean): Boolean
     fun add(episodes: List<Episode>, podcastUuid: String, downloadMetaData: Boolean): List<Episode>
+    fun insert(episodes: List<Episode>)
 
     /** Update methods  */
     fun update(episode: Episode?)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -916,6 +916,12 @@ class EpisodeManagerImpl @Inject constructor(
         return addedEpisodes
     }
 
+    override fun insert(episodes: List<Episode>) {
+        if (episodes.isNotEmpty()) {
+            episodeDao.insertAll(episodes)
+        }
+    }
+
     override fun findEpisodesToSync(): List<Episode> {
         return episodeDao.findEpisodesToSync()
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -1066,6 +1066,7 @@ class EpisodeManagerImpl @Inject constructor(
                     observePlayableByUuid(episodeUuid).firstElement()
                 } else {
                     podcastCacheServerManager.getPodcastAndEpisode(podcastUuid, episodeUuid).flatMapMaybe { response ->
+                        Timber.i("HistoryManager downloadMissingEpisode episode found? ${response.episodes.firstOrNull() != null}")
                         val episode = response.episodes.firstOrNull() ?: skeletonEpisode
                         add(episode, downloadMetaData = downloadMetaData)
                         podcastManager.findPodcastByUuidRx(podcastUuid).zipWith(findByUuidRx(episodeUuid))

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -1066,7 +1066,6 @@ class EpisodeManagerImpl @Inject constructor(
                     observePlayableByUuid(episodeUuid).firstElement()
                 } else {
                     podcastCacheServerManager.getPodcastAndEpisode(podcastUuid, episodeUuid).flatMapMaybe { response ->
-                        Timber.i("HistoryManager downloadMissingEpisode episode found? ${response.episodes.firstOrNull() != null}")
                         val episode = response.episodes.firstOrNull() ?: skeletonEpisode
                         add(episode, downloadMetaData = downloadMetaData)
                         podcastManager.findPodcastByUuidRx(podcastUuid).zipWith(findByUuidRx(episodeUuid))

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/HistoryManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/HistoryManager.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.rx2.await
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 import java.util.Date
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -47,8 +46,8 @@ class HistoryManager @Inject constructor(
         val podcastUuids = changes
             .mapNotNull { change -> change.podcast }
             .toSet()
-        val databasePodcastUuids = podcastManager.findPodcastUuids().toHashSet()
-        val missingPodcastUuids = podcastUuids.minus(databasePodcastUuids)
+        val databaseSubscribedPodcastUuids = podcastManager.findSubscribedUuids().toHashSet()
+        val missingPodcastUuids = podcastUuids.minus(databaseSubscribedPodcastUuids)
         Observable.fromIterable(missingPodcastUuids)
             .observeOn(Schedulers.io())
             .flatMap({ podcastUuid -> podcastManager.addPodcast(podcastUuid = podcastUuid, sync = false, subscribed = false).toObservable() }, true, 5)
@@ -80,7 +79,6 @@ class HistoryManager @Inject constructor(
                         downloadUrl = change.url,
                         lastPlaybackInteraction = interactionDate
                     )
-                    Timber.i("HistoryManager adding episode: ${skeleton.uuid} podcast: ${skeleton.podcastUuid} title: ${skeleton.title}")
                     skeletonEpisodes.add(skeleton)
                 }
             } else if (change.action == ACTION_DELETE) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -50,6 +50,7 @@ interface PodcastManager {
     fun findPodcastsAutodownload(): List<Podcast>
 
     fun exists(podcastUuid: String): Boolean
+    suspend fun findPodcastUuids(): List<String>
 
     /** Add methods  */
     fun subscribeToPodcast(podcastUuid: String, sync: Boolean)
@@ -59,6 +60,7 @@ interface PodcastManager {
     fun isSubscribingToPodcasts(): Boolean
     fun getSubscribedPodcastUuids(): Single<List<String>>
     fun isSubscribingToPodcast(podcastUuid: String): Boolean
+    fun addPodcast(podcastUuid: String, sync: Boolean, subscribed: Boolean): Single<Podcast>
 
     fun addFolderPodcast(podcast: Podcast)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -39,6 +39,7 @@ interface PodcastManager {
     fun findPodcastsInFolderSingle(folderUuid: String): Single<List<Podcast>>
     suspend fun findPodcastsNotInFolder(): List<Podcast>
     fun observePodcastsInFolderOrderByUserChoice(folder: Folder): Flowable<List<Podcast>>
+    suspend fun findSubscribedUuids(): List<String>
 
     fun observePodcastsOrderByLatestEpisode(): Flowable<List<Podcast>>
     fun observeSubscribed(): Flowable<List<Podcast>>
@@ -50,7 +51,6 @@ interface PodcastManager {
     fun findPodcastsAutodownload(): List<Podcast>
 
     fun exists(podcastUuid: String): Boolean
-    suspend fun findPodcastUuids(): List<String>
 
     /** Add methods  */
     fun subscribeToPodcast(podcastUuid: String, sync: Boolean)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
 import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
+import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute.uuid
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -117,7 +118,7 @@ class PodcastManagerImpl @Inject constructor(
      * Do this now rather than adding it to a queue.
      */
     override fun subscribeToPodcastRx(podcastUuid: String, sync: Boolean): Single<Podcast> {
-        return subscribeManager.addPodcast(podcastUuid, sync, subscribed = true)
+        return addPodcast(podcastUuid = podcastUuid, sync = sync, subscribed = true)
     }
 
     /**
@@ -127,6 +128,10 @@ class PodcastManagerImpl @Inject constructor(
         return findPodcastByUuidRx(podcastUuid)
             .switchIfEmpty(subscribeManager.addPodcast(podcastUuid, sync = false, subscribed = false).toMaybe())
             .toSingle()
+    }
+
+    override fun addPodcast(podcastUuid: String, sync: Boolean, subscribed: Boolean): Single<Podcast> {
+        return subscribeManager.addPodcast(podcastUuid = podcastUuid, sync = sync, subscribed = subscribed)
     }
 
     override fun isSubscribingToPodcast(podcastUuid: String): Boolean {
@@ -332,6 +337,10 @@ class PodcastManagerImpl @Inject constructor(
         }
 
         return false
+    }
+
+    override suspend fun findPodcastUuids(): List<String> {
+        return podcastDao.findAllUuids()
     }
 
     override fun findPodcastByUuid(uuid: String): Podcast? {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -339,8 +339,8 @@ class PodcastManagerImpl @Inject constructor(
         return false
     }
 
-    override suspend fun findPodcastUuids(): List<String> {
-        return podcastDao.findAllUuids()
+    override suspend fun findSubscribedUuids(): List<String> {
+        return podcastDao.findSubscribedUuids()
     }
 
     override fun findPodcastByUuid(uuid: String): Podcast? {


### PR DESCRIPTION
## Description

My listening history sync for the end of year stats was taking 94 seconds, this change speeds it up to 14 seconds. I did this by adding podcasts in parallel and instead using the full podcast JSON to load the episodes rather than calling the server for each individual episode.
Also I have changed the loading page from a circle progress spinner to a linear progress bar. This makes it feel like there is an end rather than with the circular spinner it feels like it's never going to end. 

## Testing Instructions
1. Set `END_OF_YEAR_ENABLED` feature flag to `true` in base.gradle
2. Fresh install the app
3. Login to your sync account
4. Re-run the app
5. Tap "View my 2022"
6. ✅ The linear progress bar should appear, followed by the end of year story

## Screenshots or Screencast 

https://user-images.githubusercontent.com/308331/202955649-914ac5fa-5976-4032-af4e-9656650d8bdc.mp4
