### PR TITLE
Onboarding: Recommendations Search

### DIFF
--- a/modules/features/account/build.gradle
+++ b/modules/features/account/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     // features
     implementation project(':modules:features:cartheme')
     implementation project(':modules:features:settings')
+    implementation project(':modules:features:search')
 
     // services
     implementation project(':modules:services:analytics')

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -7,6 +7,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations.OnboardingRecommendationsFlow
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -76,7 +77,7 @@ fun OnboardingFlowComposable(
                         navController.popBackStack()
                     },
                     onAccountCreated = {
-                        navController.navigate(OnboardingNavRoute.recommendations) {
+                        navController.navigate(OnboardingNavRoute.recommendationsFlow) {
                             // clear backstack after account is created
                             popUpTo(OnboardingNavRoute.logInOrSignUp) {
                                 inclusive = true
@@ -113,8 +114,8 @@ fun OnboardingFlowComposable(
                 )
             }
 
-            composable(OnboardingNavRoute.recommendations) {
-                OnboardingRecommendations(
+            composable(OnboardingNavRoute.recommendationsFlow) {
+                OnboardingRecommendationsFlow(
                     onShown = {
                         analyticsTracker.track(AnalyticsEvent.RECOMMENDATIONS_SHOWN)
                     },
@@ -176,7 +177,7 @@ private object OnboardingNavRoute {
     const val logIn = "log_in"
     const val logInGoogle = "log_in_google"
     const val forgotPassword = "forgot_password"
-    const val recommendations = "recommendations"
+    const val recommendationsFlow = "recommendationsFlow"
     const val plusUpgrade = "upgrade_upgrade"
     const val welcome = "welcome"
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
@@ -1,0 +1,42 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingRecommendationsStartPage
+
+@Composable
+fun OnboardingRecommendationsFlow(
+    onShown: () -> Unit,
+    onBackPressed: () -> Unit,
+    onComplete: () -> Unit,
+) {
+
+    LaunchedEffect(Unit) { onShown() }
+    BackHandler { onBackPressed() }
+
+    val navController = rememberNavController()
+    NavHost(
+        navController = navController,
+        startDestination = OnboardingRecommendationsNavRoute.start
+    ) {
+        composable(OnboardingRecommendationsNavRoute.start) {
+            OnboardingRecommendationsStartPage(
+                onSearch = { navController.navigate(OnboardingRecommendationsNavRoute.search) },
+                onComplete = onComplete,
+            )
+        }
+        composable(OnboardingRecommendationsNavRoute.search) {
+            OnboardingRecommendationsSearch(
+                onBackPressed = { navController.popBackStack() },
+            )
+        }
+    }
+}
+private object OnboardingRecommendationsNavRoute {
+    const val start = "start"
+    const val search = "search"
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
@@ -30,7 +30,7 @@ fun OnboardingRecommendationsFlow(
             )
         }
         composable(OnboardingRecommendationsNavRoute.search) {
-            OnboardingRecommendationsSearch(
+            OnboardingRecommendationsSearchPage(
                 onBackPressed = { navController.popBackStack() },
             )
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearch.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearch.kt
@@ -1,32 +1,99 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Divider
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastItem
+import au.com.shiftyjelly.pocketcasts.compose.components.SearchBar
+import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun OnboardingRecommendationsSearch(
     onBackPressed: () -> Unit,
 ) {
+    val viewModel = hiltViewModel<OnboardingRecommendationsSearchViewModel>()
+    val state by viewModel.state.collectAsState()
+
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
     BackHandler {
         onBackPressed()
     }
 
-    Column(
-        Modifier
-            .fillMaxHeight()
-            .verticalScroll(rememberScrollState())
-    ) {
+    Column(Modifier.fillMaxHeight()) {
         ThemedTopAppBar(
             title = stringResource(LR.string.onboarding_find_podcasts),
             onNavigationClick = onBackPressed
         )
+
+        SearchBar(
+            text = state.searchQuery,
+            placeholder = stringResource(LR.string.search),
+            onTextChanged = viewModel::updateSearchQuery,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .focusRequester(focusRequester)
+        )
+
+        Spacer(Modifier.height(16.dp))
+        Box(Modifier.height(2.dp)) {
+            Divider(color = MaterialTheme.theme.colors.secondaryUi02)
+            if (state.loading && state.results.isNotEmpty()) {
+                // Provide a subtle loading indicator when results are displayed, but being updated
+
+                LinearProgressIndicator(
+                    color = MaterialTheme.theme.colors.secondaryUi01,
+                    backgroundColor = MaterialTheme.theme.colors.secondaryUi02,
+                    modifier = Modifier.matchParentSize()
+                )
+            }
+        }
+
+        if (state.loading && state.results.isEmpty()) {
+            // Provide an obvious loading indicator when loading and there no results yet
+            Spacer(Modifier.weight(1f))
+            CircularProgressIndicator(Modifier.align(Alignment.CenterHorizontally))
+            Spacer(Modifier.weight(5f))
+        } else {
+            LazyColumn {
+                items(state.results) {
+                    PodcastItem(
+                        podcast = it.podcast,
+                        subscribed = it.isSubscribed,
+                        showSubscribed = true,
+                        onClick = { viewModel.toggleSubscribed(it) },
+                    )
+                }
+            }
+        }
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearch.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearch.kt
@@ -1,0 +1,32 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun OnboardingRecommendationsSearch(
+    onBackPressed: () -> Unit,
+) {
+    BackHandler {
+        onBackPressed()
+    }
+
+    Column(
+        Modifier
+            .fillMaxHeight()
+            .verticalScroll(rememberScrollState())
+    ) {
+        ThemedTopAppBar(
+            title = stringResource(LR.string.onboarding_find_podcasts),
+            onNavigationClick = onBackPressed
+        )
+    }
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearch.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearch.kt
@@ -58,6 +58,7 @@ fun OnboardingRecommendationsSearch(
             text = state.searchQuery,
             placeholder = stringResource(LR.string.search),
             onTextChanged = viewModel::updateSearchQuery,
+            onSearch = { viewModel.queryImmediately() },
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
@@ -69,7 +70,6 @@ fun OnboardingRecommendationsSearch(
             Divider(color = MaterialTheme.theme.colors.secondaryUi02)
             if (state.loading && state.results.isNotEmpty()) {
                 // Provide a subtle loading indicator when results are displayed, but being updated
-
                 LinearProgressIndicator(
                     color = MaterialTheme.theme.colors.secondaryUi01,
                     backgroundColor = MaterialTheme.theme.colors.secondaryUi02,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchPage.kt
@@ -33,7 +33,7 @@ import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
-fun OnboardingRecommendationsSearch(
+fun OnboardingRecommendationsSearchPage(
     onBackPressed: () -> Unit,
 ) {
     val viewModel = hiltViewModel<OnboardingRecommendationsSearchViewModel>()
@@ -90,6 +90,7 @@ fun OnboardingRecommendationsSearch(
                         podcast = it.podcast,
                         subscribed = it.isSubscribed,
                         showSubscribed = true,
+                        showPlusIfUnsubscribed = true,
                         onClick = { viewModel.toggleSubscribed(it) },
                     )
                 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
@@ -51,6 +51,10 @@ class OnboardingRecommendationsSearchViewModel @Inject constructor(
         searchHandler.updateSearchQuery(searchQuery)
     }
 
+    fun queryImmediately() {
+        searchHandler.updateSearchQuery(state.value.searchQuery, immediate = true)
+    }
+
     init {
         searchHandler.setOnlySearchRemote(true)
         viewModelScope.launch {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
@@ -1,0 +1,108 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asFlow
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.search.SearchHandler
+import au.com.shiftyjelly.pocketcasts.search.SearchState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.reactive.asFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class OnboardingRecommendationsSearchViewModel @Inject constructor(
+    private val podcastManager: PodcastManager,
+    private val playbackManager: PlaybackManager,
+    private val searchHandler: SearchHandler,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(
+        State(
+            searchQuery = "",
+            results = emptyList(),
+            loading = false,
+        )
+    )
+    val state: StateFlow<State> = _state
+
+    data class State(
+        val searchQuery: String,
+        val results: List<PodcastResult>,
+        val loading: Boolean,
+    )
+
+    data class PodcastResult(
+        val podcast: Podcast,
+        val isSubscribed: Boolean,
+    )
+
+    fun updateSearchQuery(searchQuery: String) {
+        _state.value = state.value.copy(searchQuery = searchQuery)
+        searchHandler.updateSearchQuery(searchQuery)
+    }
+
+    init {
+        searchHandler.setOnlySearchRemote(true)
+        viewModelScope.launch {
+
+            val subscribedUuidFlow = podcastManager
+                .observeSubscribed()
+                .asFlow()
+                .map { ls ->
+                    ls.map { it.uuid }
+                }
+
+            combine(
+                subscribedUuidFlow,
+                searchHandler.searchResults.asFlow()
+            ) { subscribedUuids, searchState ->
+
+                val podcasts = when (searchState) {
+                    SearchState.NoResults -> emptyList()
+                    is SearchState.Results -> {
+
+                        // TODO handle loading
+                        // TODO handle error
+
+                        searchState.list
+                            .filterIsInstance<FolderItem.Podcast>()
+                            .map {
+                                PodcastResult(
+                                    podcast = it.podcast,
+                                    isSubscribed = subscribedUuids.contains(it.podcast.uuid),
+                                )
+                            }
+                    }
+                }
+
+                val isLoading = (searchState as? SearchState.Results)?.loading == true
+
+                state.value.copy(
+                    results = podcasts,
+                    loading = isLoading,
+                )
+            }.stateIn(viewModelScope).collect {
+                _state.value = it
+            }
+        }
+    }
+
+    fun toggleSubscribed(podcastResult: PodcastResult) {
+        val uuid = podcastResult.podcast.uuid
+        if (podcastResult.isSubscribed) {
+            podcastManager.unsubscribeAsync(podcastUuid = uuid, playbackManager = playbackManager)
+        } else {
+            podcastManager.subscribeToPodcast(podcastUuid = uuid, sync = true)
+        }
+    }
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
@@ -46,15 +46,6 @@ class OnboardingRecommendationsSearchViewModel @Inject constructor(
         val isSubscribed: Boolean,
     )
 
-    fun updateSearchQuery(searchQuery: String) {
-        _state.value = state.value.copy(searchQuery = searchQuery)
-        searchHandler.updateSearchQuery(searchQuery)
-    }
-
-    fun queryImmediately() {
-        searchHandler.updateSearchQuery(state.value.searchQuery, immediate = true)
-    }
-
     init {
         searchHandler.setOnlySearchRemote(true)
         viewModelScope.launch {
@@ -99,6 +90,15 @@ class OnboardingRecommendationsSearchViewModel @Inject constructor(
                 _state.value = it
             }
         }
+    }
+
+    fun updateSearchQuery(searchQuery: String) {
+        _state.value = state.value.copy(searchQuery = searchQuery)
+        searchHandler.updateSearchQuery(searchQuery)
+    }
+
+    fun queryImmediately() {
+        searchHandler.updateSearchQuery(state.value.searchQuery, immediate = true)
     }
 
     fun toggleSubscribed(podcastResult: PodcastResult) {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,7 +13,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -24,6 +22,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+import au.com.shiftyjelly.pocketcasts.compose.components.SearchBarButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
@@ -32,15 +31,10 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
-fun OnboardingRecommendations(
-    onShown: () -> Unit,
-    onBackPressed: () -> Unit,
+fun OnboardingRecommendationsStartPage(
+    onSearch: () -> Unit,
     onComplete: () -> Unit,
 ) {
-
-    LaunchedEffect(Unit) { onShown() }
-    BackHandler { onBackPressed() }
-
     Column(
         Modifier
             .fillMaxHeight()
@@ -64,6 +58,12 @@ fun OnboardingRecommendations(
 
         TextP40(
             text = stringResource(LR.string.onboarding_recommendations_make_pocket_casts_yours),
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        SearchBarButton(
+            text = stringResource(LR.string.search),
+            onClick = onSearch,
             modifier = Modifier.padding(bottom = 16.dp)
         )
 
@@ -94,9 +94,8 @@ private fun Preview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppThemeWithBackground(themeType) {
-        OnboardingRecommendations(
-            onShown = {},
-            onBackPressed = {},
+        OnboardingRecommendationsStartPage(
+            onSearch = {},
             onComplete = {},
         )
     }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -1,0 +1,149 @@
+package au.com.shiftyjelly.pocketcasts.search
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.LiveDataReactiveStreams
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
+import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.servers.ServerManager
+import au.com.shiftyjelly.pocketcasts.servers.discover.PodcastSearch
+import com.jakewharton.rxrelay2.BehaviorRelay
+import io.reactivex.BackpressureStrategy
+import io.reactivex.Observable
+import io.reactivex.Single
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.rxkotlin.Observables
+import io.reactivex.schedulers.Schedulers
+import timber.log.Timber
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+class SearchHandler @Inject constructor(
+    val serverManager: ServerManager,
+    val podcastManager: PodcastManager,
+    val userManager: UserManager,
+    val settings: Settings,
+    folderManager: FolderManager
+) {
+    private val searchQuery = BehaviorRelay.create<String>().apply {
+        accept("")
+    }
+
+    private val loadingObservable = BehaviorRelay.create<Boolean>().apply {
+        accept(false)
+    }
+    private val onlySearchRemoteObservable = BehaviorRelay.create<Boolean>().apply {
+        accept(false)
+    }
+    private val signInStateObservable = userManager.getSignInState().startWith(SignInState.SignedOut()).toObservable()
+
+    private val localResults = Observable
+        .combineLatest(searchQuery, onlySearchRemoteObservable, signInStateObservable) { searchQuery, onlySearchRemoteObservable, signInState ->
+            Pair(if (onlySearchRemoteObservable) "" else searchQuery, signInState)
+        }
+        .subscribeOn(Schedulers.io())
+        .switchMap { (query, signInState) ->
+            if (query.isEmpty()) {
+                Observable.just(emptyList())
+            } else {
+                // search folders
+                val folderSearch =
+                    if (signInState.isSignedInAsPlus) {
+                        // only show folders if the user has Plus
+                        folderManager.findFoldersSingle()
+                            .subscribeOn(Schedulers.io())
+                            .flatMapObservable { Observable.fromIterable(it) }
+                            .filter { it.name.contains(query, ignoreCase = true) }
+                            .switchMapSingle { folder ->
+                                podcastManager
+                                    .findPodcastsInFolderSingle(folderUuid = folder.uuid)
+                                    .map { podcasts -> FolderItem.Folder(folder = folder, podcasts = podcasts) }
+                            }
+                            .toList()
+                    } else {
+                        Single.just(emptyList())
+                    }
+
+                // search podcasts
+                val podcastSearch = podcastManager.findSubscribedRx()
+                    .subscribeOn(Schedulers.io())
+                    .flatMapObservable { Observable.fromIterable(it) }
+                    .filter { it.title.contains(query, ignoreCase = true) || it.author.contains(query, ignoreCase = true) }
+                    .map { podcast ->
+                        podcast.isSubscribed = true
+                        FolderItem.Podcast(podcast)
+                    }
+                    .toList()
+
+                podcastSearch
+                    .zipWith(folderSearch) { podcasts, folders ->
+                        (podcasts + folders).sortedBy { PodcastsSortType.cleanStringForSort(it.title) }
+                    }
+                    .toObservable()
+            }
+        }
+
+    private val subscribedPodcastUuids = podcastManager
+        .findSubscribedRx()
+        .subscribeOn(Schedulers.io())
+        .toObservable()
+        .map { podcasts -> podcasts.map(Podcast::uuid).toHashSet() }
+
+    private val serverSearchResults = searchQuery
+        .subscribeOn(Schedulers.io())
+        .map { it.trim() }
+        .debounce { if (it.isEmpty()) Observable.empty() else Observable.timer(settings.getPodcastSearchDebounceMs(), TimeUnit.MILLISECONDS) }
+        .switchMap {
+            if (it.length <= 1) {
+                Observable.just(PodcastSearch())
+            } else {
+                loadingObservable.accept(true)
+                serverManager.searchForPodcastsRx(it).toObservable()
+                    .onErrorReturn { exception ->
+                        PodcastSearch(error = exception)
+                    }
+            }
+        }
+        .doOnNext { loadingObservable.accept(false) }
+
+    private val searchFlowable = Observables.combineLatest(searchQuery, subscribedPodcastUuids, localResults, serverSearchResults, loadingObservable) { searchTerm, subscribedPodcastUuids, localResults, serverSearchResults, loading ->
+        if (searchTerm.isBlank()) {
+            SearchState.Results(list = emptyList(), loading = loading, error = null)
+        } else {
+            // set if the podcast is subscribed so we can show a tick
+            val serverResults = serverSearchResults.searchResults.map { podcast -> FolderItem.Podcast(podcast) }
+            serverResults.forEach {
+                if (subscribedPodcastUuids.contains(it.podcast.uuid)) {
+                    it.podcast.isSubscribed = true
+                }
+            }
+            val searchResults = (localResults + serverResults).distinctBy { it.uuid }
+
+            if (serverSearchResults.searchTerm.isEmpty() || searchResults.isNotEmpty() || serverSearchResults.error != null) {
+                SearchState.Results(list = searchResults, loading = loading, error = serverSearchResults.error)
+            } else {
+                SearchState.NoResults
+            }
+        }
+    }
+        .doOnError { Timber.e(it) }
+        .onErrorReturn { exception -> SearchState.Results(list = emptyList(), loading = false, error = exception) }
+        .observeOn(AndroidSchedulers.mainThread())
+        .toFlowable(BackpressureStrategy.LATEST)
+
+    val searchResults: LiveData<SearchState> = LiveDataReactiveStreams.fromPublisher(searchFlowable)
+    val loading: LiveData<Boolean> = LiveDataReactiveStreams.fromPublisher(loadingObservable.toFlowable(BackpressureStrategy.LATEST))
+
+    fun updateSearchQuery(query: String) {
+        searchQuery.accept(query)
+    }
+
+    fun setOnlySearchRemote(remote: Boolean) {
+        onlySearchRemoteObservable.accept(remote)
+    }
+}

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -1,153 +1,24 @@
 package au.com.shiftyjelly.pocketcasts.search
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
-import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
-import au.com.shiftyjelly.pocketcasts.models.to.SignInState
-import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
-import au.com.shiftyjelly.pocketcasts.servers.ServerManager
-import au.com.shiftyjelly.pocketcasts.servers.discover.PodcastSearch
-import com.jakewharton.rxrelay2.BehaviorRelay
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.reactivex.BackpressureStrategy
-import io.reactivex.Observable
-import io.reactivex.Single
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.rxkotlin.Observables
-import io.reactivex.schedulers.Schedulers
-import timber.log.Timber
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 @HiltViewModel
 class SearchViewModel @Inject constructor(
-    val serverManager: ServerManager,
-    val podcastManager: PodcastManager,
-    val userManager: UserManager,
-    val settings: Settings,
-    folderManager: FolderManager
+    private val searchHandler: SearchHandler
 ) : ViewModel() {
 
-    private val searchQuery = BehaviorRelay.create<String>().apply {
-        accept("")
-    }
-    private val loadingObservable = BehaviorRelay.create<Boolean>().apply {
-        accept(false)
-    }
-    private val onlySearchRemoteObservable = BehaviorRelay.create<Boolean>().apply {
-        accept(false)
-    }
-    private val signInStateObservable = userManager.getSignInState().startWith(SignInState.SignedOut()).toObservable()
-
-    private val localResults = Observable
-        .combineLatest(searchQuery, onlySearchRemoteObservable, signInStateObservable) { searchQuery, onlySearchRemoteObservable, signInState ->
-            Pair(if (onlySearchRemoteObservable) "" else searchQuery, signInState)
-        }
-        .subscribeOn(Schedulers.io())
-        .switchMap { (query, signInState) ->
-            if (query.isEmpty()) {
-                Observable.just(emptyList())
-            } else {
-                // search folders
-                val folderSearch =
-                    if (signInState.isSignedInAsPlus) {
-                        // only show folders if the user has Plus
-                        folderManager.findFoldersSingle()
-                            .subscribeOn(Schedulers.io())
-                            .flatMapObservable { Observable.fromIterable(it) }
-                            .filter { it.name.contains(query, ignoreCase = true) }
-                            .switchMapSingle { folder ->
-                                podcastManager
-                                    .findPodcastsInFolderSingle(folderUuid = folder.uuid)
-                                    .map { podcasts -> FolderItem.Folder(folder = folder, podcasts = podcasts) }
-                            }
-                            .toList()
-                    } else {
-                        Single.just(emptyList())
-                    }
-
-                // search podcasts
-                val podcastSearch = podcastManager.findSubscribedRx()
-                    .subscribeOn(Schedulers.io())
-                    .flatMapObservable { Observable.fromIterable(it) }
-                    .filter { it.title.contains(query, ignoreCase = true) || it.author.contains(query, ignoreCase = true) }
-                    .map { podcast ->
-                        podcast.isSubscribed = true
-                        FolderItem.Podcast(podcast)
-                    }
-                    .toList()
-
-                podcastSearch
-                    .zipWith(folderSearch) { podcasts, folders ->
-                        (podcasts + folders).sortedBy { PodcastsSortType.cleanStringForSort(it.title) }
-                    }
-                    .toObservable()
-            }
-        }
-
-    private val subscribedPodcastUuids = podcastManager
-        .findSubscribedRx()
-        .subscribeOn(Schedulers.io())
-        .toObservable()
-        .map { podcasts -> podcasts.map(Podcast::uuid).toHashSet() }
-
-    private val serverSearchResults = searchQuery
-        .subscribeOn(Schedulers.io())
-        .map { it.trim() }
-        .debounce { if (it.isEmpty()) Observable.empty() else Observable.timer(settings.getPodcastSearchDebounceMs(), TimeUnit.MILLISECONDS) }
-        .switchMap {
-            if (it.length <= 1) {
-                Observable.just(PodcastSearch())
-            } else {
-                loadingObservable.accept(true)
-                serverManager.searchForPodcastsRx(it).toObservable()
-                    .onErrorReturn { exception ->
-                        PodcastSearch(error = exception)
-                    }
-            }
-        }
-        .doOnNext { loadingObservable.accept(false) }
-
-    private val searchFlowable = Observables.combineLatest(searchQuery, subscribedPodcastUuids, localResults, serverSearchResults, loadingObservable) { searchTerm, subscribedPodcastUuids, localResults, serverSearchResults, loading ->
-        if (searchTerm.isBlank()) {
-            SearchState.Results(list = emptyList(), loading = loading, error = null)
-        } else {
-            // set if the podcast is subscribed so we can show a tick
-            val serverResults = serverSearchResults.searchResults.map { podcast -> FolderItem.Podcast(podcast) }
-            serverResults.forEach {
-                if (subscribedPodcastUuids.contains(it.podcast.uuid)) {
-                    it.podcast.isSubscribed = true
-                }
-            }
-            val searchResults = (localResults + serverResults).distinctBy { it.uuid }
-
-            if (serverSearchResults.searchTerm.isEmpty() || searchResults.isNotEmpty() || serverSearchResults.error != null) {
-                SearchState.Results(list = searchResults, loading = loading, error = serverSearchResults.error)
-            } else {
-                SearchState.NoResults
-            }
-        }
-    }
-        .doOnError { Timber.e(it) }
-        .onErrorReturn { exception -> SearchState.Results(list = emptyList(), loading = false, error = exception) }
-        .observeOn(AndroidSchedulers.mainThread())
-        .toFlowable(BackpressureStrategy.LATEST)
-
-    val searchResults: LiveData<SearchState> = LiveDataReactiveStreams.fromPublisher(searchFlowable)
-    val loading: LiveData<Boolean> = LiveDataReactiveStreams.fromPublisher(loadingObservable.toFlowable(BackpressureStrategy.LATEST))
+    val searchResults = searchHandler.searchResults
+    val loading = searchHandler.loading
 
     fun updateSearchQuery(query: String) {
-        searchQuery.accept(query)
+        searchHandler.updateSearchQuery(query)
     }
 
     fun setOnlySearchRemote(remote: Boolean) {
-        onlySearchRemoteObservable.accept(remote)
+        searchHandler.setOnlySearchRemote(remote)
     }
 }
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
@@ -11,7 +11,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
@@ -28,10 +27,10 @@ fun PodcastItem(
     podcast: Podcast,
     onClick: (() -> Unit)?,
     modifier: Modifier = Modifier,
-    tintColor: Color? = null,
     iconSize: Dp = PodcastItemIconSize,
     subscribed: Boolean = false,
     showSubscribed: Boolean = false,
+    showPlusIfUnsubscribed: Boolean = false,
     showDivider: Boolean = true,
 ) {
     Column {
@@ -55,19 +54,25 @@ fun PodcastItem(
                 TextP40(
                     text = podcast.title,
                     maxLines = 1,
-                    color = tintColor ?: MaterialTheme.theme.colors.primaryText01
+                    color = MaterialTheme.theme.colors.primaryText01
                 )
                 TextP50(
                     text = podcast.author,
                     maxLines = 1,
-                    color = tintColor ?: MaterialTheme.theme.colors.primaryText02
+                    color = MaterialTheme.theme.colors.primaryText02
                 )
             }
             if (subscribed && showSubscribed) {
                 Icon(
                     painter = painterResource(IR.drawable.ic_tick),
                     contentDescription = stringResource(LR.string.podcast_subscribed),
-                    tint = tintColor ?: MaterialTheme.theme.colors.support02
+                    tint = MaterialTheme.theme.colors.support02
+                )
+            } else if (showPlusIfUnsubscribed) {
+                Icon(
+                    painter = painterResource(IR.drawable.plus_simple),
+                    contentDescription = stringResource(LR.string.subscribe),
+                    tint = MaterialTheme.theme.colors.primaryIcon02
                 )
             }
         }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
@@ -39,8 +39,8 @@ fun PodcastItem(
             verticalAlignment = Alignment.CenterVertically,
             modifier = modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
                 .then(if (onClick == null) Modifier else Modifier.clickable { onClick() })
+                .padding(horizontal = 16.dp)
         ) {
             PodcastImage(
                 uuid = podcast.uuid,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
@@ -1,7 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.compose.components
 
 import android.view.KeyEvent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
@@ -19,6 +22,11 @@ import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -30,14 +38,19 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
-fun SearchBar(text: String, onTextChanged: (String) -> Unit, modifier: Modifier = Modifier) {
+fun SearchBar(
+    text: String,
+    onTextChanged: (String) -> Unit,
+    placeholder: String = stringResource(LR.string.search_podcasts),
+    modifier: Modifier = Modifier
+) {
     val focusManager = LocalFocusManager.current
     OutlinedTextField(
         value = text,
         onValueChange = {
             onTextChanged(it.removeNewLines())
         },
-        placeholder = { Text(stringResource(LR.string.search_podcasts)) },
+        placeholder = { Text(placeholder) },
         colors = TextFieldDefaults.outlinedTextFieldColors(
             cursorColor = MaterialTheme.theme.colors.primaryText02,
             textColor = MaterialTheme.theme.colors.primaryText01,
@@ -83,6 +96,38 @@ fun SearchBar(text: String, onTextChanged: (String) -> Unit, modifier: Modifier 
             }
         }
     )
+}
+
+@Composable
+fun SearchBarButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .clearAndSetSemantics {
+                role = Role.Button
+                contentDescription = text
+                onClick {
+                    onClick()
+                    true
+                }
+            }
+    ) {
+        SearchBar(
+            text = "",
+            placeholder = text,
+            onTextChanged = {},
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Box(
+            Modifier
+                .matchParentSize() // cover SearchBar
+                .clickable { onClick() } // handle click events
+        )
+    }
 }
 
 @Preview(showBackground = true)

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
@@ -42,6 +42,7 @@ fun SearchBar(
     text: String,
     onTextChanged: (String) -> Unit,
     placeholder: String = stringResource(LR.string.search_podcasts),
+    onSearch: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val focusManager = LocalFocusManager.current
@@ -63,7 +64,12 @@ fun SearchBar(
         ),
         shape = RoundedCornerShape(10.dp),
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-        keyboardActions = KeyboardActions(onSearch = { focusManager.clearFocus() }),
+        keyboardActions = KeyboardActions(
+            onSearch = {
+                onSearch()
+                focusManager.clearFocus()
+            }
+        ),
         maxLines = 1,
         leadingIcon = {
             Icon(

--- a/modules/services/images/src/main/res/drawable/plus_simple.xml
+++ b/modules/services/images/src/main/res/drawable/plus_simple.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,4C12.552,4 13,4.448 13,5V11H19C19.552,11 20,11.448 20,12C20,12.552 19.552,13 19,13H13V19C13,19.552 12.552,20 12,20C11.448,20 11,19.552 11,19V13H5C4.448,13 4,12.552 4,12C4,11.448 4.448,11 5,11H11V5C11,4.448 11.448,4 12,4Z"
+      android:fillColor="#808080"/>
+</vector>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1493,6 +1493,7 @@
     <string name="onboarding_welcome_recommendations_title">Discover something new</string>
     <string name="onboarding_welcome_recommendations_text">Find under-the-radar and trending podcasts in our hand-curated Discover page.</string>
     <string name="onboarding_welcome_recommendations_button">Find My Next Podcast</string>
+    <string name="onboarding_find_podcasts">Find Podcasts</string>
 
     <!--    Tasker Plugin-->
 


### PR DESCRIPTION
| 📘 Project: #524  |
| --- |

## Description

Adding search button functionality to the onboarding recommendations screen


## Areas of Concern

### 1. Triggering search immediately

I've added the ability for the user to avoid the debounce on the search by tapping the search key on the soft keyboard in 02dd06635dfe33cb3b53ec2992b8a7a9a25900e8. This is a new behavior for the app, but I thought that if the user went to the trouble of tapping the search key, it would be a better user experience and not too much of a strain on our servers to kick off the search immediately.

### 2. Subscription state slow to update

When tapping on a podcast to subscribe, It can take a bit of time for the podcast manager to reflect that the podcast has been subscribed to, particularly on slow internet connections. Since the UI is listening for these updates from the podcast manager, the UI can be slow to update.

We could avoid this delay by just immediately updating the UI without waiting for the podcast manager to update, but I am hesitant to risk the UI getting out of sync with the podcast manager (i.e., if the subscription update failed for some reason such as a lack of an internet connection, the UI would indicate it had succeeded), so I didn't do this. Let me know if you have any thoughts here though.

## Testing Instructions

1. Turn on the onboarding flag in `base.gradle`
2. When not logged into the app, start the app and create a new account so the recommendations screen is loaded. (Please feel free to cheat here by making [these changes](https://gist.github.com/mchowning/4d9a754b93a7b57e1d7f98c0910bd191) so you can be logged in and go straight to the recommendations screen).
3. Tap on the search field
4. ✅  Observe that the full screen search view is opened, with the search bar focused and the keyboard open
5. Type one letter in the search field
6. ✅ Observe that the search does not start
7. Type a second letter into the search field
8. ✅ Observe that after a delay, the spinning loading indicator is shown until the search results are displayed (it's hard to see the loading indicator if your internet connection is fast)
9. Type a third letter in the search field
10. ✅ Observe that after a delay, a subtle linear loading indicator is shown at the top of the search results until the search results are updated. This is just something I added because I've been confused a few times thinking the app wasn't searching when it was--I thought this seemed like a good way to give some small visual indicator that something was happening without being distracting, but let me know what you think.
11. Type a fourth letter in the search field and immediately tap the search time action button on the soft keyboard
12. ✅ Observe that the search begins immediately (i.e., there is no debounce delay). **This immediate search is a new behavior for the app**, but I thought that if the user went to the trouble of tapping the search key, it would be a much better user experience and not too much of a strain on our servers to kick off the search immediately.
13. Tap on a few podcasts to subscribe and unsubscribe them.
14. ✅ Observe that the podcast row updates with a checkmark when it is subscribed and that the checkmark is removed when it is unsubscribed (note my concern about about this being slow when the internet connection is slow).
15. Swipe back twice to return to the main app.
16. ✅ Observe that the subscription changes you made in the search view are reflected in the podcasts tab of the main app.

## Screenshots or Screencast 

https://user-images.githubusercontent.com/4656348/203468654-fe2fea3f-2c1e-4c9b-9e18-8ad4fc665bf2.mp4

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack
