### PR TITLE
End of Year: Fix occasional crash on returning from share

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -90,6 +90,8 @@ class StoriesViewModel @Inject constructor(
     }
 
     fun start() {
+        if (state.value !is State.Loaded) return
+
         val currentState = state.value as State.Loaded
         val progressFraction =
             (PROGRESS_UPDATE_INTERVAL_MS / totalLengthInMs.toFloat())


### PR DESCRIPTION
| 📘 Project: #410  |
| --- |

## Description

This fixes an occasional crash when at the time of sharing, the activity from where stories are launched, is moved to the background and killed due to low memory. On returning from share, the activity is recreated and stories are reloaded, but restarting the paused timer, and trying to update the current story when stories are still loading, crashes the app.

The fix ensures that the timer to switch to the next story doesn't start when stories are still loading. Once stories are loaded, the timer starts again.

## Testing Instructions

1. Enable "Don't keep activities" in device developer options
2. Run the app and make sure you're logged in to an account with a few items on Listening History
3. Go to Profile tab and tap "Your Year in Podcasts"
6. When the stories appear, tap "Share"
7. Choose WhatsApp which opens a full screen "Send to..." screen and moves the current activity to the background, killing it due to developer settings done in step 1
8. Go back to the app using back button or gesture
9. Notice that stories are reloaded and the app doesn't crash

