### PR TITLE
End of Year: Hide share from first and last story

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
@@ -206,7 +207,8 @@ private fun StoriesView(
         }
         requireNotNull(onCaptureBitmap).let {
             ShareButton(
-                onClick = { onShareClicked.invoke(it) }
+                onClick = { onShareClicked.invoke(it) },
+                modifier = modifier.alpha(if (state.showShare) 1f else 0f)
             )
         }
     }
@@ -259,6 +261,7 @@ private fun StorySharableContent(
 @Composable
 private fun ShareButton(
     onClick: () -> Unit,
+    modifier: Modifier,
 ) {
     RowOutlinedButton(
         text = stringResource(id = LR.string.share),
@@ -271,7 +274,9 @@ private fun ShareButton(
         textIcon = rememberVectorPainter(Icons.Default.Share),
         onClick = {
             onClick.invoke()
-        }
+        },
+        modifier = modifier
+
     )
 }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
@@ -207,7 +207,7 @@ private fun StoriesView(
         }
         requireNotNull(onCaptureBitmap).let {
             ShareButton(
-                onClick = { onShareClicked.invoke(it) },
+                onClick = { if (state.showShare) { onShareClicked.invoke(it) } },
                 modifier = modifier.alpha(if (state.showShare) 1f else 0f)
             )
         }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -11,6 +11,8 @@ import au.com.shiftyjelly.pocketcasts.endofyear.ShareableTextProvider.ShareTextD
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State.Loaded.SegmentsData
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManager
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.Story
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryEpilogue
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryIntro
 import au.com.shiftyjelly.pocketcasts.utils.FileUtilWrapper
 import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -204,6 +206,8 @@ class StoriesViewModel @Inject constructor(
             val segmentsData: SegmentsData,
             val preparingShareText: Boolean = false,
         ) : State() {
+            val showShare: Boolean
+                get() = currentStory !is StoryIntro && currentStory !is StoryEpilogue
             data class SegmentsData(
                 val widths: List<Float> = emptyList(),
                 val xStartOffsets: List<Float> = emptyList(),

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -144,6 +144,7 @@ class StoriesViewModel @Inject constructor(
 
     fun onRetryClicked() {
         viewModelScope.launch {
+            analyticsTracker.track(AnalyticsEvent.END_OF_YEAR_STORY_RETRY_BUTTON_TAPPED)
             loadStories()
         }
     }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -316,4 +316,5 @@ enum class AnalyticsEvent(val key: String) {
     END_OF_YEAR_STORY_SHOWN("end_of_year_story_shown"),
     END_OF_YEAR_STORY_SHARE("end_of_year_story_share"),
     END_OF_YEAR_STORY_SHARED("end_of_year_story_shared"),
+    END_OF_YEAR_STORY_RETRY_BUTTON_TAPPED("end_of_year_story_retry_button_tapped"),
 }


### PR DESCRIPTION
| 📘 Project: #410  |
| --- |

## Description

This hides the share button from the first and last story.

## Testing Instructions
1. Run the app and make sure you're logged in to an account with a few items on Listening History
2. Go to Profile tab and tap "Your Year in Podcasts"
3. Notice that first and last stories do not show the share button.

P.S. I also added tracking (`🔵 Tracked: end_of_year_story_retry_button_tapped`) for retry button 
which was added in [this PR](https://github.com/Automattic/pocket-casts-android/pull/597). 


## Screenshots or Screencast 
https://user-images.githubusercontent.com/1405144/203697957-6ca5328d-0660-46e0-9b7b-f5d3336f9434.mp4

