### PR TITLE
End of Year: Fix to match iOS podcasts ordering

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -232,6 +232,7 @@ class ProfileFragment : BaseFragment() {
                 AppTheme(theme.activeTheme) {
                     EndOfYearPromptCard(
                         onClick = {
+                            analyticsTracker.track(AnalyticsEvent.END_OF_YEAR_PROFILE_CARD_TAPPED)
                             (activity as? FragmentHostListener)?.showStoriesOrAccount(StoriesSource.PROFILE.value)
                         }
                     )

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -317,4 +317,5 @@ enum class AnalyticsEvent(val key: String) {
     END_OF_YEAR_STORY_SHARE("end_of_year_story_share"),
     END_OF_YEAR_STORY_SHARED("end_of_year_story_shared"),
     END_OF_YEAR_STORY_RETRY_BUTTON_TAPPED("end_of_year_story_retry_button_tapped"),
+    END_OF_YEAR_PROFILE_CARD_TAPPED("end_of_year_profile_card_tapped")
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -356,7 +356,7 @@ abstract class PodcastDao {
         JOIN podcasts ON episodes.podcast_id = podcasts.uuid
         WHERE episodes.last_playback_interaction_date IS NOT NULL AND episodes.last_playback_interaction_date > :fromEpochMs AND episodes.last_playback_interaction_date < :toEpochMs
         GROUP BY podcast_id
-        ORDER BY numberOfPlayedEpisodes DESC, totalPlayedTime DESC
+        ORDER BY totalPlayedTime DESC, numberOfPlayedEpisodes DESC
         LIMIT :limit
         """
     )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -140,8 +140,7 @@ class EndOfYearManagerImpl @Inject constructor(
         return episodeManager.findListenedNumbers(yearStart, yearEnd)
     }
 
-    /* Returns top podcasts ordered by number of played episodes. If there's a tie on number of played episodes,
-    played time is checked. */
+    /* Returns top podcasts ordered by total played time. If there's a tie on total played time, check number of played episodes. */
     override suspend fun findTopPodcastsForYear(year: Int, limit: Int): List<TopPodcast> {
         return podcastManager.findTopPodcasts(yearStart, yearEnd, limit)
     }


### PR DESCRIPTION
| 📘 Project: #410 |
|:---:|

iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/533

This PR fixes 2 issues to match iOS behavior:

* Order top podcasts by total time played instead of number of episodes.
* Track when the user tap the Profile's EOY card

## To test

1. Run the app
2. Check your stories
3. ✅ Check your top podcasts
4. Dismiss stories
5. Go to profile
6. Tap the card
7. ✅ `end_of_year_profile_card_tapped` should be tracked
