### PR TITLE
End of Year: Fix modal keeps popping up when opening the app (logged out state)

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -594,8 +594,6 @@ class MainActivity :
                 } else if (!settings.getEndOfYearModalHasBeenShown()) {
                     viewModel.updateStoriesModalShowState(true)
                 }
-            } else {
-                settings.setEndOfYearModalHasBeenShown(false)
             }
 
             if (signinState.isSignedInAsPlus) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -108,6 +108,7 @@ class UserManagerImpl @Inject constructor(
 
         settings.setMarketingOptIn(false)
         settings.setMarketingOptInNeedsSync(false)
+        settings.setEndOfYearModalHasBeenShown(false)
         analyticsTracker.track(AnalyticsEvent.USER_SIGNED_OUT, mapOf(KEY_USER_INITIATED to wasInitiatedByUser))
         analyticsTracker.flush()
         analyticsTracker.clearAllData()


### PR DESCRIPTION
## Description
This fixes EoY modal that keeps popping up when opening the app when the user is not logged into the app.

Fixes #622

## Testing Instructions

1. Sign out of your Pocket Casts account
2. Close the app
3. Re-open it and notice the pop-up
4. Dismiss the popup
5. Close the app
6. Re-open the app, close it again
7. Notice on the second time you re-open the app, the Pop-up is not reshown

## Screenshots or Screencast 

https://user-images.githubusercontent.com/1405144/205042056-b57bc883-a258-4bb3-b2f3-e9e5848854d5.mp4
