### PR TITLE
Add disable scale to replay button

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryEpilogueView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryEpilogueView.kt
@@ -36,6 +36,7 @@ import au.com.shiftyjelly.pocketcasts.endofyear.R
 import au.com.shiftyjelly.pocketcasts.endofyear.components.PodcastLogoWhite
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryPrimaryText
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StorySecondaryText
+import au.com.shiftyjelly.pocketcasts.endofyear.components.disableScale
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryEpilogue
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -145,6 +146,7 @@ private fun ReplayButton(
         TextP40(
             text = stringResource(id = LR.string.end_of_year_replay),
             color = Color.Black,
+            disableScale = disableScale(),
             modifier = modifier.padding(2.dp)
         )
     }


### PR DESCRIPTION
## Description
Disables scaling to large font sizes on the replay button so that it is consistent with the rest of the story view. Follow-up on changes in https://github.com/Automattic/pocket-casts-android/pull/619. If this was intended behavior, just close this PR. I just figured it would be quicker to put up a PR in case we do want that change. cc: @adamzelinski 

> **Note**
> This PR is targeting `release/7.21.1`, but I also think it would be fine to delay this to the next release since this is a minor issue.

## Testing Instructions
1. Set device font size to a large setting
2. View EOY epilogue Story
3. ✅  Observer that the replay button has a consistent size with the rest of the text

## Screenshots or Screencast 

| Before | After |
| --- | --- |
|  ![image](https://user-images.githubusercontent.com/4656348/205078459-385998ac-6725-4226-b08a-60fb091cdae0.png) | ![image](https://user-images.githubusercontent.com/4656348/205078538-71845111-46bd-4c94-b48a-95c9eebfa8be.png) |

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack
