### PR TITLE
Accessibility: Fix talkback after EoY modal bottom sheet is hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
         ([#575](https://github.com/Automattic/pocket-casts-android/pull/575)).
     *   Fixed miniplayer play icon animation on theme change
         ([#527](https://github.com/Automattic/pocket-casts-android/pull/527)).
+    *   Fixed talkback issues
+        ([#630](https://github.com/Automattic/pocket-casts-android/pull/630)).
 
 7.27
 -----

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -62,7 +62,7 @@
             android:clickable="true"
             android:translationZ="200dp"/>
 
-        <androidx.compose.ui.platform.ComposeView
+        <FrameLayout
             android:id="@+id/modalBottomSheet"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/EndOfYearLaunchBottomSheet.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/EndOfYearLaunchBottomSheet.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.views
 
+import android.view.ViewGroup
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -39,12 +40,14 @@ private val ImageContentCoverBottomPadding = 8.dp
 
 @Composable
 fun EndOfYearLaunchBottomSheet(
+    parent: ViewGroup,
     modifier: Modifier = Modifier,
     shouldShow: Boolean = true,
     onClick: () -> Unit,
     onExpanded: () -> Unit,
 ) {
     ModalBottomSheet(
+        parent = parent,
         shouldShow = shouldShow,
         onExpanded = onExpanded,
         content = BottomSheetContentState.Content(


### PR DESCRIPTION
## Description

This PR attempts to fix talkback issues after End of Year launch modal bottom sheet is shown.

From the issue description: 
> The only way to navigate is to use the swipe left/right on the edge of the screen gestures.

It felt strange that we could navigate through talkback by swiping on the x-axis, which means after the modal was dismissed, talkback focus was moved from the bottom sheet to the screen elements. I wonder if this behavior was due to one of the compose modal bottom sheet issues ([1](https://issuetracker.google.com/issues/180101663), [2](https://issuetracker.google.com/issues/230039401)).

As a workaround, I remove EoY compose modal bottom sheet once it is hidden. And re-add it when it is needed again with minimum changes to the existing logic.

>**Warning**
PR targets release/7.28

Fixes #621

## Testing Instructions

- Fresh install the app
- Build a listening history of at least 5 mins
- Restart the app
- When EoY launch modal is shown, dismiss it
- Turn on talkback
- Tap on screen elements
- Notice that talkback works properly


## Screenshots or Screencast 

https://user-images.githubusercontent.com/1405144/205607941-7560c75f-9619-437e-bd1b-76026f7d7723.mp4
