### PR TITLE
Onboarding: Convert recommendations flow to a nested navigation graph

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -60,13 +60,7 @@ fun OnboardingFlowComposable(
                     completeOnboarding()
                 },
                 onComplete = {
-                    navController.navigate(
-                        if (signInState?.isSignedInAsPlus == false) {
-                            OnboardingNavRoute.plusUpgrade
-                        } else {
-                            OnboardingNavRoute.welcome
-                        }
-                    )
+                    navController.navigate(OnboardingNavRoute.plusUpgrade)
                 },
                 navController = navController,
             )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -10,6 +10,7 @@ import androidx.navigation.compose.rememberNavController
 import au.com.shiftyjelly.pocketcasts.account.onboarding.import.OnboardingImportFlow
 import au.com.shiftyjelly.pocketcasts.account.onboarding.import.OnboardingImportFlow.importFlowGraph
 import au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations.OnboardingRecommendationsFlow
+import au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations.OnboardingRecommendationsFlow.onboardingRecommendationsFlowGraph
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -52,6 +53,24 @@ fun OnboardingFlowComposable(
 
             importFlowGraph(navController)
 
+            onboardingRecommendationsFlowGraph(
+                onShown = { analyticsTracker.track(AnalyticsEvent.RECOMMENDATIONS_SHOWN) },
+                onBackPressed = {
+                    analyticsTracker.track(AnalyticsEvent.RECOMMENDATIONS_DISMISSED)
+                    completeOnboarding()
+                },
+                onComplete = {
+                    navController.navigate(
+                        if (signInState?.isSignedInAsPlus == false) {
+                            OnboardingNavRoute.plusUpgrade
+                        } else {
+                            OnboardingNavRoute.welcome
+                        }
+                    )
+                },
+                navController = navController,
+            )
+
             composable(OnboardingNavRoute.logInOrSignUp) {
                 OnboardingLoginOrSignUpPage(
                     onNotNowClicked = {
@@ -82,7 +101,7 @@ fun OnboardingFlowComposable(
                         navController.popBackStack()
                     },
                     onAccountCreated = {
-                        navController.navigate(OnboardingNavRoute.recommendationsFlow) {
+                        navController.navigate(OnboardingRecommendationsFlow.route) {
                             // clear backstack after account is created
                             popUpTo(OnboardingNavRoute.logInOrSignUp) {
                                 inclusive = true
@@ -116,27 +135,6 @@ fun OnboardingFlowComposable(
                         navController.popBackStack()
                     },
                     onCompleted = completeOnboarding,
-                )
-            }
-
-            composable(OnboardingNavRoute.recommendationsFlow) {
-                OnboardingRecommendationsFlow(
-                    onShown = {
-                        analyticsTracker.track(AnalyticsEvent.RECOMMENDATIONS_SHOWN)
-                    },
-                    onBackPressed = {
-                        analyticsTracker.track(AnalyticsEvent.RECOMMENDATIONS_DISMISSED)
-                        completeOnboarding()
-                    },
-                    onComplete = {
-                        navController.navigate(
-                            if (signInState?.isSignedInAsPlus == false) {
-                                OnboardingNavRoute.plusUpgrade
-                            } else {
-                                OnboardingNavRoute.welcome
-                            }
-                        )
-                    }
                 )
             }
 
@@ -185,6 +183,5 @@ private object OnboardingNavRoute {
     const val logInGoogle = "log_in_google"
     const val logInOrSignUp = "log_in_or_sign_up"
     const val plusUpgrade = "upgrade_upgrade"
-    const val recommendationsFlow = "recommendationsFlow"
     const val welcome = "welcome"
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
@@ -1,42 +1,41 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
 
-import androidx.activity.compose.BackHandler
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.navigation.compose.NavHost
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navigation
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingRecommendationsStartPage
 
-@Composable
-fun OnboardingRecommendationsFlow(
-    onShown: () -> Unit,
-    onBackPressed: () -> Unit,
-    onComplete: () -> Unit,
-) {
+object OnboardingRecommendationsFlow {
 
-    LaunchedEffect(Unit) { onShown() }
-    BackHandler { onBackPressed() }
+    const val route = "onboardingRecommendationsFlow"
 
-    val navController = rememberNavController()
-    NavHost(
-        navController = navController,
-        startDestination = OnboardingRecommendationsNavRoute.start
+    private const val start = "start"
+    private const val search = "search"
+
+    fun NavGraphBuilder.onboardingRecommendationsFlowGraph(
+        onShown: () -> Unit,
+        onBackPressed: () -> Unit,
+        onComplete: () -> Unit,
+        navController: NavController,
     ) {
-        composable(OnboardingRecommendationsNavRoute.start) {
-            OnboardingRecommendationsStartPage(
-                onSearch = { navController.navigate(OnboardingRecommendationsNavRoute.search) },
-                onComplete = onComplete,
-            )
-        }
-        composable(OnboardingRecommendationsNavRoute.search) {
-            OnboardingRecommendationsSearchPage(
-                onBackPressed = { navController.popBackStack() },
-            )
+        navigation(
+            route = this@OnboardingRecommendationsFlow.route,
+            startDestination = start
+        ) {
+            composable(start) {
+                OnboardingRecommendationsStartPage(
+                    onShown = onShown,
+                    onSearch = { navController.navigate(search) },
+                    onBackPressed = onBackPressed,
+                    onComplete = onComplete,
+                )
+            }
+            composable(search) {
+                OnboardingRecommendationsSearchPage(
+                    onBackPressed = { navController.popBackStack() },
+                )
+            }
         }
     }
-}
-private object OnboardingRecommendationsNavRoute {
-    const val start = "start"
-    const val search = "search"
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
@@ -4,7 +4,8 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
-import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingRecommendationsStartPage
+import au.com.shiftyjelly.pocketcasts.account.onboarding.import.OnboardingImportFlow
+import au.com.shiftyjelly.pocketcasts.account.onboarding.import.OnboardingImportFlow.importFlowGraph
 
 object OnboardingRecommendationsFlow {
 
@@ -23,9 +24,13 @@ object OnboardingRecommendationsFlow {
             route = this@OnboardingRecommendationsFlow.route,
             startDestination = start
         ) {
+
+            importFlowGraph(navController)
+
             composable(start) {
                 OnboardingRecommendationsStartPage(
                     onShown = onShown,
+                    onImportClicked = { navController.navigate(OnboardingImportFlow.route) },
                     onSearch = { navController.navigate(search) },
                     onBackPressed = onBackPressed,
                     onComplete = onComplete,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
@@ -1,7 +1,8 @@
-package au.com.shiftyjelly.pocketcasts.account.onboarding
+package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -35,6 +36,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 fun OnboardingRecommendationsStartPage(
     onShown: () -> Unit,
+    onImportClicked: () -> Unit,
     onSearch: () -> Unit,
     onBackPressed: () -> Unit,
     onComplete: () -> Unit,
@@ -53,10 +55,15 @@ fun OnboardingRecommendationsStartPage(
             horizontalArrangement = Arrangement.End,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = 16.dp)
+                .padding(bottom = 18.dp)
 
         ) {
-            TextH30(stringResource(LR.string.onboarding_recommendations_import))
+            TextH30(
+                text = stringResource(LR.string.onboarding_recommendations_import),
+                modifier = Modifier
+                    .clickable { onImportClicked() }
+                    .padding(horizontal = 16.dp, vertical = 9.dp)
+            )
         }
 
         TextH10(
@@ -103,8 +110,9 @@ private fun Preview(
 ) {
     AppThemeWithBackground(themeType) {
         OnboardingRecommendationsStartPage(
-            onSearch = {},
             onShown = {},
+            onImportClicked = {},
+            onSearch = {},
             onBackPressed = {},
             onComplete = {},
         )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -32,9 +34,15 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun OnboardingRecommendationsStartPage(
+    onShown: () -> Unit,
     onSearch: () -> Unit,
+    onBackPressed: () -> Unit,
     onComplete: () -> Unit,
 ) {
+
+    LaunchedEffect(Unit) { onShown() }
+    BackHandler { onBackPressed() }
+
     Column(
         Modifier
             .fillMaxHeight()
@@ -96,6 +104,8 @@ private fun Preview(
     AppThemeWithBackground(themeType) {
         OnboardingRecommendationsStartPage(
             onSearch = {},
+            onShown = {},
+            onBackPressed = {},
             onComplete = {},
         )
     }


### PR DESCRIPTION
| 📘 Project: #524  |
| --- |

This PR includes the changes in https://github.com/Automattic/pocket-casts-android/pull/634.

## Description

Updating the recommendation flow to use a proper nested graph. This also hooks up the import button, and removes some logic for possibly skipping the upgrade screen after recommendations (no longer needed because of a previous change whereby the recommendations screen will always be followed by the upgrade screen because you now only get to the recommendations screen after creating a new account).

Note that the UI for th initial recommendations screen is not yet completed.

Also, feel free to ignore any code for Tracks. I will be making changes to that in a follow-up PR that focuses on Tracks.

## Testing Instructions

1. Turn on the onboarding feature in `base.gradle`
2. Ensure that navigation with the recommendation screen  works as expected
    1. Going back should return you to the main app's dashboard (not back to the sign-up screen)
    2. Tapping Import should take you to the import screens
    3. Tapping the Search field should take you to a full screen search view
    4. Tapping "Not Now" Should take you to the upgrade screens

## Checklist
- [X If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack
