### PR TITLE
Onboarding: FIx plus upgrade page to alwasy be full screen

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations.OnboardingRecommendationsFlow
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusUpgradeFlow
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingWelcomePage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingWelcomePage.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusFeatures
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingWelcomeState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingWelcomeViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusBottomSheet.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusBottomSheet.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.account.onboarding
+package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
 import android.content.res.Resources
 import android.view.ViewTreeObserver
@@ -38,10 +38,10 @@ import androidx.compose.ui.unit.dp
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.hilt.navigation.compose.hiltViewModel
-import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingPlusFeatures.PlusOutlinedRowButton
-import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingPlusFeatures.PlusRowButton
-import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingPlusFeatures.UnselectedPlusOutlinedRowButton
-import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingPlusFeatures.plusGradientBrush
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusFeatures.PlusOutlinedRowButton
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusFeatures.PlusRowButton
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusFeatures.UnselectedPlusOutlinedRowButton
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusFeatures.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusBottomSheetState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusBottomSheetViewModel
 import au.com.shiftyjelly.pocketcasts.compose.bottomsheet.Pill

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusFeaturesPage.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
@@ -18,6 +19,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -92,27 +94,31 @@ internal fun OnboardingPlusFeaturesPage(
 
     LaunchedEffect(Unit) { viewModel.onShown() }
 
-    Box(
-        Modifier
-            .verticalScroll(rememberScrollState())
-            .background(background)
-    ) {
-        Background()
+    // Need this BoxWithConstraints so we can force the inner column to fill the screen
+    BoxWithConstraints(Modifier.fillMaxHeight()) {
 
-        Column {
+        Box(
+            Modifier
+                .verticalScroll(rememberScrollState())
+                .background(background)
+        ) {
 
-            Spacer(Modifier.height(8.dp))
-            NavigationIconButton(
-                onNavigationClick = onBackPressed,
-                iconColor = Color.White,
-                modifier = Modifier
-                    .height(48.dp)
-                    .width(48.dp)
-            )
+            Background()
 
-            Spacer(Modifier.height(12.dp))
+            Column(
+                Modifier.heightIn(min = this@BoxWithConstraints.maxHeight)
+            ) {
 
-            Column {
+                Spacer(Modifier.height(8.dp))
+                NavigationIconButton(
+                    onNavigationClick = onBackPressed,
+                    iconColor = Color.White,
+                    modifier = Modifier
+                        .height(48.dp)
+                        .width(48.dp)
+                )
+
+                Spacer(Modifier.height(12.dp))
 
                 IconRow(Modifier.padding(horizontal = 24.dp))
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusFeaturesPage.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.account.onboarding
+package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
 import android.os.Build
 import androidx.annotation.DrawableRes
@@ -47,8 +47,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.R
-import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingPlusFeatures.PlusOutlinedRowButton
-import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingPlusFeatures.PlusRowButton
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusFeatures.PlusOutlinedRowButton
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusFeatures.PlusRowButton
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusFeaturesViewModel
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusUpgradeFlow.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.account.onboarding
+package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke


### PR DESCRIPTION
| 📘 Project: #524  |
| --- |

## Description
This fixes a bug where the Plus upgrade screen's content would not always expand to the full-height of the screen. Apparently this is due to a bit of weirdness in how heights are calculated inside a scrollable composable (see this [Stackoverflow discussion](https://stackoverflow.com/questions/69394543/fillmaxsize-modifier-not-working-when-combined-with-verticalscroll-in-jetpack-co)).


## Testing Instructions
1. Turn on the onboarding flow in `base.gradle` and if you want to save yourself some time, update the startDestination [here](https://github.com/Automattic/pocket-casts-android/blob/2c6b39dccba6eb67aa643e17e59fdc3df59db437/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt#L49) to be `OnboardingNavRoute.plusUpgrade`. 
2. Update your phone to have the smallest possible font size
3. ✅  Verify that the plus screen button(s) are at the bottom of the screen
4. Update your phone to have the largest possible font size
5. ✅ Verify that the plus screen can be scrolled

## Screenshots or Screencast 

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/4656348/206030133-6d275f70-8846-4e45-8a33-898fa09c1045.png) | ![image](https://user-images.githubusercontent.com/4656348/206029985-2580b1c9-807a-45ba-a95b-baa3da2e5ba1.png) |
* Note that only the "Not Now" button is showing in these screen shots because this was a debug build that could not retrieve any subscriptions from the Google Play store.


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack
