### PR TITLE
Fix skip forward/ backward buttons not showing in media notification while casting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
         ([#527](https://github.com/Automattic/pocket-casts-android/pull/527)).
     *   Fixed talkback issues
         ([#630](https://github.com/Automattic/pocket-casts-android/pull/630)).
+    *   Fixed skip forward/ backward buttons not showing in media notification while casting
+        ([#630](https://github.com/Automattic/pocket-casts-android/pull/630)).
 
 7.27
 -----

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -111,7 +111,7 @@ project.ext {
             browser: "androidx.browser:browser:1.4.0",
             percent: "androidx.percentlayout:percentlayout:1.0.0-rc02",
             preference: "androidx.preference:preference:1.2.0",
-            cast: "com.google.android.gms:play-services-cast-framework:21.1.0",
+            cast: "com.google.android.gms:play-services-cast-framework:21.2.0",
             desugarJdk: "com.android.tools:desugar_jdk_libs:1.1.5",
             // Firebase BoM (Bill of Materials enables you to manage all your Firebase library versions by specifying only one version)
             firebaseBom: "com.google.firebase:firebase-bom:30.5.0",


### PR DESCRIPTION
## Description
This updates Cast SDK to the latest version which supports new media controls style.

[Cast Release Notes october-10,-2022](https://developers.google.com/cast/docs/release-notes#october-10,-2022)
> Updated [MediaNotificationService](https://developers.google.com/android/reference/com/google/android/gms/cast/framework/media/MediaNotificationService) with [Media controls in System UI](https://source.android.com/docs/core/display/media-control).

Fixes #578

> **Warning**
Targets release/7.28

## Testing Instructions

1. Open the app and play an episode.
2. Open "Now Playing" screen.
3. Select Chromecast from the options at the bottom.
4. Check that on the lock screen or notification player, skip forward/skip back buttons are shown while casting.

## Screenshots or Screencast 
<img width=320 src="https://user-images.githubusercontent.com/1405144/206173208-9eb4a0de-9198-4850-866c-4b2c2f01643d.png"/>


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- I have considered whether it makes sense to add tests for my changes
- All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- with different themes
- with a landscape orientation
- with the device set to have a large display and font size
- for accessibility with TalkBack
