### PR TITLE
Give substute fields more descriptive names

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -252,7 +252,7 @@ class PlayerViewModel @Inject constructor(
             if (it is Episode) {
                 podcastManager.observePodcastByUuid(it.podcastUuid)
             } else {
-                Flowable.just(Podcast(uuid = UserEpisodePodcastSubstitute.uuid, title = UserEpisodePodcastSubstitute.title, overrideGlobalEffects = false))
+                Flowable.just(Podcast(uuid = UserEpisodePodcastSubstitute.substituteUuid, title = UserEpisodePodcastSubstitute.substituteTitle, overrideGlobalEffects = false))
             }
         }
         .map { PodcastEffectsPair(it, if (it.overrideGlobalEffects) it.playbackEffects else settings.getGlobalPlaybackEffects()) }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/UserEpisodePodcastSubstitute.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/UserEpisodePodcastSubstitute.kt
@@ -4,6 +4,6 @@ package au.com.shiftyjelly.pocketcasts.models.db.helper
 // I thought about making this an actual Podcast but then there
 // is nothing stopping it getting passed in to a podcast manager function.
 object UserEpisodePodcastSubstitute {
-    const val uuid = "da7aba5e-f11e-f11e-f11e-da7aba5ef11e"
-    const val title = "Custom Episode"
+    const val substituteUuid = "da7aba5e-f11e-f11e-f11e-da7aba5ef11e"
+    const val substituteTitle = "Custom Episode"
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/UserEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/UserEpisode.kt
@@ -53,7 +53,7 @@ data class UserEpisode(
     override var playing: Boolean = false
 
     override fun displaySubtitle(podcast: Podcast?): String {
-        return UserEpisodePodcastSubstitute.title
+        return UserEpisodePodcastSubstitute.substituteTitle
     }
 
     val isUploading: Boolean

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/extensions/Podcast.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/extensions/Podcast.kt
@@ -8,9 +8,9 @@ val Podcast.largeArtworkUrl: String
     get() = getArtworkUrl(960)
 
 fun Podcast.getArtworkUrl(size: Int): String {
-    return if (uuid == UserEpisodePodcastSubstitute.uuid) thumbnailUrl ?: "" else PodcastImage.getArtworkUrl(size, uuid)
+    return if (uuid == UserEpisodePodcastSubstitute.substituteUuid) thumbnailUrl ?: "" else PodcastImage.getArtworkUrl(size, uuid)
 }
 
 fun Podcast.getArtworkJpgUrl(size: Int): String {
-    return if (uuid == UserEpisodePodcastSubstitute.uuid) thumbnailUrl ?: "" else PodcastImage.getArtworkJpgUrl(size, uuid)
+    return if (uuid == UserEpisodePodcastSubstitute.substituteUuid) thumbnailUrl ?: "" else PodcastImage.getArtworkJpgUrl(size, uuid)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
@@ -103,7 +103,7 @@ class NotificationDrawerImpl @Inject constructor(
         }
 
         val bitmap = if (podcast != null) loadArtwork(podcast) else if (episode is UserEpisode) loadUserEpisodeArtwork(episode) else null
-        val podcastTitle = (if (episode is Episode) podcast?.title else UserEpisodePodcastSubstitute.title) ?: ""
+        val podcastTitle = (if (episode is Episode) podcast?.title else UserEpisodePodcastSubstitute.substituteTitle) ?: ""
 
         val data = NotificationData(
             episodeUuid = episodeUuid,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -404,7 +404,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
         Timber.d("Loading sugggested children")
         val upNext = listOfNotNull(playbackManager.getCurrentEpisode()) + playbackManager.upNextQueue.queueEpisodes
         val mediaUpNext = upNext.take(NUM_SUGGESTED_ITEMS).mapNotNull { playable ->
-            val filesPodcast = Podcast(uuid = UserEpisodePodcastSubstitute.uuid, title = UserEpisodePodcastSubstitute.title)
+            val filesPodcast = Podcast(uuid = UserEpisodePodcastSubstitute.substituteUuid, title = UserEpisodePodcastSubstitute.substituteTitle)
             val parentPodcast = (if (playable is Episode) podcastManager.findPodcastByUuid(playable.podcastUuid) else filesPodcast) ?: return@mapNotNull null
             AutoConverter.convertEpisodeToMediaItem(this, playable, parentPodcast)
         }
@@ -433,7 +433,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
     private fun loadRecentChildren(): ArrayList<MediaBrowserCompat.MediaItem> {
         Timber.d("Loading recent children")
         val upNext = playbackManager.getCurrentEpisode() ?: return arrayListOf()
-        val filesPodcast = Podcast(uuid = UserEpisodePodcastSubstitute.uuid, title = UserEpisodePodcastSubstitute.title)
+        val filesPodcast = Podcast(uuid = UserEpisodePodcastSubstitute.substituteUuid, title = UserEpisodePodcastSubstitute.substituteTitle)
         val parentPodcast = (if (upNext is Episode) podcastManager.findPodcastByUuid(upNext.podcastUuid) else filesPodcast) ?: return arrayListOf()
 
         Timber.d("Recent item ${upNext.title}")
@@ -545,7 +545,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
 
     protected suspend fun loadFilesChildren(): List<MediaBrowserCompat.MediaItem> {
         return userEpisodeManager.findUserEpisodes().map {
-            val podcast = Podcast(uuid = UserEpisodePodcastSubstitute.uuid, title = UserEpisodePodcastSubstitute.title, thumbnailUrl = it.artworkUrl)
+            val podcast = Podcast(uuid = UserEpisodePodcastSubstitute.substituteUuid, title = UserEpisodePodcastSubstitute.substituteTitle, thumbnailUrl = it.artworkUrl)
             AutoConverter.convertEpisodeToMediaItem(this, it, podcast)
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -1062,7 +1062,7 @@ class EpisodeManagerImpl @Inject constructor(
     override fun downloadMissingEpisode(episodeUuid: String, podcastUuid: String, skeletonEpisode: Episode, podcastManager: PodcastManager, downloadMetaData: Boolean): Maybe<Playable> {
         return episodeDao.existsRx(episodeUuid)
             .flatMapMaybe { episodeExists ->
-                if (episodeExists || podcastUuid == UserEpisodePodcastSubstitute.uuid) {
+                if (episodeExists || podcastUuid == UserEpisodePodcastSubstitute.substituteUuid) {
                     observePlayableByUuid(episodeUuid).firstElement()
                 } else {
                     podcastCacheServerManager.getPodcastAndEpisode(podcastUuid, episodeUuid).flatMapMaybe { response ->

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
 import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
-import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute.uuid
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -742,8 +741,8 @@ class PodcastManagerImpl @Inject constructor(
 
     override fun buildUserEpisodePodcast(episode: UserEpisode): Podcast {
         return Podcast(
-            uuid = UserEpisodePodcastSubstitute.uuid,
-            title = UserEpisodePodcastSubstitute.title,
+            uuid = UserEpisodePodcastSubstitute.substituteUuid,
+            title = UserEpisodePodcastSubstitute.substituteTitle,
             thumbnailUrl = episode.getUrlForArtwork()
         )
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
@@ -144,7 +144,7 @@ class WidgetManagerImpl @Inject constructor(
             return
         }
 
-        val podcastTitle = podcast?.title ?: UserEpisodePodcastSubstitute.title
+        val podcastTitle = podcast?.title ?: UserEpisodePodcastSubstitute.substituteTitle
         views.setContentDescription(R.id.widget_artwork, "$podcastTitle. Open Pocket Casts")
         views.setImageViewResource(R.id.widget_artwork, IR.drawable.defaultartwork_small_dark)
 


### PR DESCRIPTION
## Description

This avoids an issue I've noticed where if Android Studio is set to automatically add unambiguous imports it will immediately import one of these fields if it sees, for exampple, a uuid field used that hasn't been initialized.

This might avoid a bug where we accidentally have this substitute uuid imported and used somewhere we don't intend to use the substitute.

## Testing Instructions
As long as the app compiles, this should be good since this was a pretty straightforward automated refactoring. Going above and beyond would be to make sure you can play a user-added file.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
