### PR TITLE
Onboarding: recommendations trending section

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
@@ -36,10 +36,10 @@ object OnboardingRecommendationsFlow {
                     onShown = onShown,
                     onImportClicked = { navController.navigate(OnboardingImportFlow.route) },
                     onSearch = with(LocalContext.current) {
-                        if (Network.isConnected(this)) {
-                            { navController.navigate(search) }
-                        } else {
-                            {
+                        {
+                            if (Network.isConnected(this)) {
+                                navController.navigate(search)
+                            } else {
                                 Toast.makeText(
                                     this,
                                     this.getString(LR.string.error_check_your_internet_connection),

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
@@ -1,11 +1,15 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
 
+import android.widget.Toast
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import au.com.shiftyjelly.pocketcasts.account.onboarding.import.OnboardingImportFlow
 import au.com.shiftyjelly.pocketcasts.account.onboarding.import.OnboardingImportFlow.importFlowGraph
+import au.com.shiftyjelly.pocketcasts.utils.Network
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 object OnboardingRecommendationsFlow {
 
@@ -31,7 +35,19 @@ object OnboardingRecommendationsFlow {
                 OnboardingRecommendationsStartPage(
                     onShown = onShown,
                     onImportClicked = { navController.navigate(OnboardingImportFlow.route) },
-                    onSearch = { navController.navigate(search) },
+                    onSearch = with(LocalContext.current) {
+                        if (Network.isConnected(this)) {
+                            { navController.navigate(search) }
+                        } else {
+                            {
+                                Toast.makeText(
+                                    this,
+                                    this.getString(LR.string.error_check_your_internet_connection),
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            }
+                        }
+                    },
                     onBackPressed = onBackPressed,
                     onComplete = onComplete,
                 )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchPage.kt
@@ -61,11 +61,10 @@ fun OnboardingRecommendationsSearchPage(
             onSearch = { viewModel.queryImmediately() },
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
+                .padding(horizontal = 16.dp, vertical = 8.dp)
                 .focusRequester(focusRequester)
         )
 
-        Spacer(Modifier.height(16.dp))
         Box(Modifier.height(2.dp)) {
             Divider(color = MaterialTheme.theme.colors.secondaryUi02)
             if (state.loading && state.results.isNotEmpty()) {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchPage.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -58,7 +59,9 @@ fun OnboardingRecommendationsSearchPage(
             text = state.searchQuery,
             placeholder = stringResource(LR.string.search),
             onTextChanged = viewModel::updateSearchQuery,
-            onSearch = { viewModel.queryImmediately() },
+            onSearch = with(LocalContext.current) {
+                { viewModel.queryImmediately(this) }
+            },
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 8.dp)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
@@ -1,5 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
 
+import android.content.Context
+import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.viewModelScope
@@ -9,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.search.SearchHandler
 import au.com.shiftyjelly.pocketcasts.search.SearchState
+import au.com.shiftyjelly.pocketcasts.utils.Network
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,6 +21,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
 import javax.inject.Inject
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
 class OnboardingRecommendationsSearchViewModel @Inject constructor(
@@ -97,8 +101,16 @@ class OnboardingRecommendationsSearchViewModel @Inject constructor(
         searchHandler.updateSearchQuery(searchQuery)
     }
 
-    fun queryImmediately() {
-        searchHandler.updateSearchQuery(state.value.searchQuery, immediate = true)
+    fun queryImmediately(context: Context) {
+        if (Network.isConnected(context)) {
+            searchHandler.updateSearchQuery(state.value.searchQuery, immediate = true)
+        } else {
+            Toast.makeText(
+                context,
+                context.getString(LR.string.error_check_your_internet_connection),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
     }
 
     fun toggleSubscribed(podcastResult: PodcastResult) {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
@@ -1,34 +1,44 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingRecommendationsStartPageViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.SearchBarButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH60
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.components.textH60FontSize
+import au.com.shiftyjelly.pocketcasts.compose.extensions.header
+import au.com.shiftyjelly.pocketcasts.compose.podcast.PodcastSubscribeImage
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -45,12 +55,10 @@ fun OnboardingRecommendationsStartPage(
     LaunchedEffect(Unit) { onShown() }
     BackHandler { onBackPressed() }
 
-    Column(
-        Modifier
-            .fillMaxHeight()
-            .verticalScroll(rememberScrollState())
-            .padding(all = 16.dp)
-    ) {
+    val viewModel = hiltViewModel<OnboardingRecommendationsStartPageViewModel>()
+    val state by viewModel.state.collectAsState()
+
+    Column {
         Row(
             horizontalArrangement = Arrangement.End,
             modifier = Modifier
@@ -66,38 +74,75 @@ fun OnboardingRecommendationsStartPage(
             )
         }
 
-        TextH10(
-            text = stringResource(LR.string.onboarding_recommendations_find_favorite_podcasts),
-            modifier = Modifier.padding(bottom = 16.dp)
-        )
-
-        TextP40(
-            text = stringResource(LR.string.onboarding_recommendations_make_pocket_casts_yours),
-            modifier = Modifier.padding(bottom = 16.dp)
-        )
-
-        SearchBarButton(
-            text = stringResource(LR.string.search),
-            onClick = onSearch,
-            modifier = Modifier.padding(bottom = 16.dp)
-        )
-
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .aspectRatio(1.2f)
-                .fillMaxWidth()
-                .padding(bottom = 16.dp)
-                .background(Color.Gray),
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(3),
+            contentPadding = PaddingValues(horizontal = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(9.dp),
+            modifier = Modifier.weight(1f)
         ) {
-            TextP40("PLACEHOLDER")
-        }
 
-        Spacer(Modifier.weight(1f))
+            header {
+                Column {
+
+                    TextH10(
+                        text = stringResource(LR.string.onboarding_recommendations_find_favorite_podcasts),
+                        modifier = Modifier.padding(bottom = 16.dp)
+                    )
+
+                    TextP40(
+                        text = stringResource(LR.string.onboarding_recommendations_make_pocket_casts_yours),
+                        modifier = Modifier.padding(bottom = 16.dp)
+                    )
+
+                    SearchBarButton(
+                        text = stringResource(LR.string.search),
+                        onClick = onSearch,
+                        modifier = Modifier.padding(bottom = 25.dp)
+                    )
+
+                    TextH20(
+                        text = stringResource(LR.string.discover_trending),
+                        modifier = Modifier.padding(bottom = 16.dp)
+                    )
+                }
+            }
+
+            items(items = state) {
+
+                // Simulate minLines = 2
+                // This is a bit of a hack based on https://stackoverflow.com/a/66401128/1910286
+                // Google is working on adding a minLines capability though: https://issuetracker.google.com/issues/122476634
+                val twoLines = with(LocalDensity.current) {
+                    val pixelsInAPoint = 4 / 3
+                    val lineHeight = textH60FontSize * pixelsInAPoint
+                    val twoLines = lineHeight * 2
+                    twoLines.toDp()
+                }
+
+                Column(Modifier.semantics(mergeDescendants = true) {}) {
+                    PodcastSubscribeImage(
+                        podcastUuid = it.uuid,
+                        podcastTitle = it.title,
+                        podcastSubscribed = it.isSubscribed,
+                        onSubscribeClick = { viewModel.updateSubscribed(it) },
+                    )
+
+                    Spacer(Modifier.height(8.dp))
+
+                    TextH60(
+                        text = it.title,
+                        maxLines = 2,
+                        modifier = Modifier
+                            .heightIn(min = twoLines)
+                            .clearAndSetSemantics {}
+                    )
+                }
+            }
+        }
 
         RowButton(
             text = stringResource(LR.string.not_now),
-            includePadding = false,
             onClick = onComplete,
         )
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
 
+import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -19,6 +20,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -92,8 +94,12 @@ private fun Content(
             )
         }
 
+        val numColumns = when (LocalConfiguration.current.orientation) {
+            Configuration.ORIENTATION_LANDSCAPE -> 7
+            else -> 3
+        }
         LazyVerticalGrid(
-            columns = GridCells.Fixed(3),
+            columns = GridCells.Fixed(numColumns),
             contentPadding = PaddingValues(horizontal = 24.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
             horizontalArrangement = Arrangement.spacedBy(9.dp),

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingRecommendationsStartPageViewModel
-import au.com.shiftyjelly.pocketcasts.account.viewmodel.RecommendationPodcast
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.SearchBarButton
@@ -59,10 +58,11 @@ fun OnboardingRecommendationsStartPage(
     BackHandler { onBackPressed() }
 
     val viewModel = hiltViewModel<OnboardingRecommendationsStartPageViewModel>()
-    val trendingPodcasts by viewModel.trendingPodcasts.collectAsState()
+    val state by viewModel.state.collectAsState()
 
     Content(
-        trendingPodcasts = trendingPodcasts,
+        trendingPodcasts = state.trendingPodcasts,
+        buttonRes = state.buttonRes,
         onImportClicked = onImportClicked,
         onSubscribeTap = viewModel::updateSubscribed,
         onSearch = onSearch,
@@ -72,9 +72,10 @@ fun OnboardingRecommendationsStartPage(
 
 @Composable
 private fun Content(
-    trendingPodcasts: List<RecommendationPodcast>,
+    trendingPodcasts: List<OnboardingRecommendationsStartPageViewModel.RecommendationPodcast>,
+    buttonRes: Int,
     onImportClicked: () -> Unit,
-    onSubscribeTap: (RecommendationPodcast) -> Unit,
+    onSubscribeTap: (OnboardingRecommendationsStartPageViewModel.RecommendationPodcast) -> Unit,
     onSearch: () -> Unit,
     onComplete: () -> Unit,
 ) {
@@ -168,7 +169,7 @@ private fun Content(
         }
 
         RowButton(
-            text = stringResource(LR.string.not_now),
+            text = stringResource(buttonRes),
             onClick = onComplete,
         )
     }
@@ -182,17 +183,18 @@ private fun Preview(
     AppThemeWithBackground(themeType) {
         Content(
             trendingPodcasts = listOf(
-                RecommendationPodcast(
+                OnboardingRecommendationsStartPageViewModel.RecommendationPodcast(
                     uuid = "e7a6f7d0-02f2-0133-1c51-059c869cc4eb",
                     title = "Short title",
                     isSubscribed = false,
                 ),
-                RecommendationPodcast(
+                OnboardingRecommendationsStartPageViewModel.RecommendationPodcast(
                     uuid = "e7a6f7d0-02f2-0133-1c51-059c869cc4eb",
                     title = "A very very long title that is longer than will fit on two lines",
                     isSubscribed = true,
                 )
             ),
+            LR.string.not_now,
             onImportClicked = {},
             onSubscribeTap = {},
             onSearch = {},

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
@@ -125,10 +125,12 @@ private fun Content(
                         modifier = Modifier.padding(bottom = 25.dp)
                     )
 
-                    TextH20(
-                        text = stringResource(LR.string.discover_trending),
-                        modifier = Modifier.padding(bottom = 16.dp)
-                    )
+                    if (trendingPodcasts.isNotEmpty()) {
+                        TextH20(
+                            text = stringResource(LR.string.discover_trending),
+                            modifier = Modifier.padding(bottom = 16.dp)
+                        )
+                    }
                 }
             }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingRecommendationsStartPageViewModel
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.RecommendationPodcast
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.SearchBarButton
@@ -56,8 +57,25 @@ fun OnboardingRecommendationsStartPage(
     BackHandler { onBackPressed() }
 
     val viewModel = hiltViewModel<OnboardingRecommendationsStartPageViewModel>()
-    val state by viewModel.state.collectAsState()
+    val trendingPodcasts by viewModel.trendingPodcasts.collectAsState()
 
+    Content(
+        trendingPodcasts = trendingPodcasts,
+        onImportClicked = onImportClicked,
+        onSubscribeTap = viewModel::updateSubscribed,
+        onSearch = onSearch,
+        onComplete = onComplete
+    )
+}
+
+@Composable
+private fun Content(
+    trendingPodcasts: List<RecommendationPodcast>,
+    onImportClicked: () -> Unit,
+    onSubscribeTap: (RecommendationPodcast) -> Unit,
+    onSearch: () -> Unit,
+    onComplete: () -> Unit,
+) {
     Column {
         Row(
             horizontalArrangement = Arrangement.End,
@@ -108,7 +126,7 @@ fun OnboardingRecommendationsStartPage(
                 }
             }
 
-            items(items = state) {
+            items(items = trendingPodcasts) {
 
                 // Simulate minLines = 2
                 // This is a bit of a hack based on https://stackoverflow.com/a/66401128/1910286
@@ -125,7 +143,7 @@ fun OnboardingRecommendationsStartPage(
                         podcastUuid = it.uuid,
                         podcastTitle = it.title,
                         podcastSubscribed = it.isSubscribed,
-                        onSubscribeClick = { viewModel.updateSubscribed(it) },
+                        onSubscribeClick = { onSubscribeTap(it) },
                     )
 
                     Spacer(Modifier.height(8.dp))
@@ -154,12 +172,22 @@ private fun Preview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppThemeWithBackground(themeType) {
-        OnboardingRecommendationsStartPage(
-            onShown = {},
+        Content(
+            trendingPodcasts = listOf(
+                RecommendationPodcast(
+                    uuid = "e7a6f7d0-02f2-0133-1c51-059c869cc4eb",
+                    title = "Short title",
+                    isSubscribed = false,
+                ),
+                RecommendationPodcast(
+                    uuid = "e7a6f7d0-02f2-0133-1c51-059c869cc4eb",
+                    title = "A very very long title that is longer than will fit on two lines",
+                    isSubscribed = true,
+                )
+            ),
             onImportClicked = {},
+            onSubscribeTap = {},
             onSearch = {},
-            onBackPressed = {},
-            onComplete = {},
-        )
+        ) {}
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
@@ -1,0 +1,106 @@
+package au.com.shiftyjelly.pocketcasts.account.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.servers.model.transformWithRegion
+import au.com.shiftyjelly.pocketcasts.servers.server.ListRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.rx2.await
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class OnboardingRecommendationsStartPageViewModel @Inject constructor(
+    val podcastManager: PodcastManager,
+    val playbackManager: PlaybackManager,
+    repository: ListRepository,
+    settings: Settings,
+    app: Application,
+) : AndroidViewModel(app) {
+
+    private val _state: MutableStateFlow<List<RecommendationPodcast>> = MutableStateFlow(emptyList())
+    val state: StateFlow<List<RecommendationPodcast>> = _state
+
+    init {
+        viewModelScope.launch {
+
+            val feed = repository.getDiscoverFeed().await()
+            val regionCode = settings.getDiscoveryCountryCode()
+            val region = feed.regions[regionCode]
+                ?: feed.regions[feed.defaultRegionCode]
+
+            if (region == null) {
+                val message = "Could not get region $regionCode"
+                Timber.e(message)
+                return@launch
+            }
+
+            val replacements = mapOf(
+                feed.regionCodeToken to region.code,
+                feed.regionNameToken to region.name
+            )
+
+            val updatedList = feed.layout.transformWithRegion(
+                region,
+                replacements,
+                getApplication<Application>().resources
+            ) // Update the list with the correct region substituted in where needed
+
+            val discoverPodcastList = updatedList
+                .find { it.id == "trending" } // only care about the trending list
+                ?.let { trendingRow ->
+                    repository
+                        .getListFeed(trendingRow.source).await()
+                        .podcasts
+                }
+
+            if (discoverPodcastList == null) {
+                Timber.e("Could not get trending podcast list")
+                return@launch
+            }
+
+            podcastManager
+                .observeSubscribed()
+                .asFlow()
+                .map { subscribed ->
+                    val subscribedUuids = subscribed.map { it.uuid }
+                    discoverPodcastList.map { discoverPodcast ->
+                        RecommendationPodcast(
+                            uuid = discoverPodcast.uuid,
+                            title = discoverPodcast.title ?: "",
+                            isSubscribed = discoverPodcast.uuid in subscribedUuids
+                        )
+                    }
+                }
+                .stateIn(viewModelScope)
+                .collectLatest {
+                    _state.value = it
+                }
+        }
+    }
+
+    fun updateSubscribed(podcast: RecommendationPodcast) {
+        if (podcast.isSubscribed) {
+            podcastManager.unsubscribeAsync(podcastUuid = podcast.uuid, playbackManager = playbackManager)
+        } else {
+            podcastManager.subscribeToPodcast(podcastUuid = podcast.uuid, sync = true)
+        }
+    }
+}
+
+data class RecommendationPodcast(
+    val uuid: String,
+    val title: String,
+    val isSubscribed: Boolean,
+)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
@@ -35,7 +35,13 @@ class OnboardingRecommendationsStartPageViewModel @Inject constructor(
     init {
         viewModelScope.launch {
 
-            val feed = repository.getDiscoverFeed().await()
+            val feed = try {
+                repository.getDiscoverFeed().await()
+            } catch (e: Exception) {
+                Timber.e(e)
+                return@launch
+            }
+
             val regionCode = settings.getDiscoveryCountryCode()
             val region = feed.regions[regionCode]
                 ?: feed.regions[feed.defaultRegionCode]
@@ -60,9 +66,14 @@ class OnboardingRecommendationsStartPageViewModel @Inject constructor(
             val discoverPodcastList = updatedList
                 .find { it.id == "trending" } // only care about the trending list
                 ?.let { trendingRow ->
-                    repository
-                        .getListFeed(trendingRow.source).await()
-                        .podcasts
+                    try {
+                        repository
+                            .getListFeed(trendingRow.source).await()
+                            .podcasts
+                    } catch (e: Exception) {
+                        Timber.e(e)
+                        null
+                    }
                 }
 
             if (discoverPodcastList == null) {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
@@ -30,7 +30,7 @@ class OnboardingRecommendationsStartPageViewModel @Inject constructor(
 ) : AndroidViewModel(app) {
 
     private val _state: MutableStateFlow<List<RecommendationPodcast>> = MutableStateFlow(emptyList())
-    val state: StateFlow<List<RecommendationPodcast>> = _state
+    val trendingPodcasts: StateFlow<List<RecommendationPodcast>> = _state
 
     init {
         viewModelScope.launch {

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
@@ -43,7 +43,7 @@ fun TextH10(
         color = color,
         fontSize = 31.sp,
         lineHeight = 37.sp,
-        fontWeight = FontWeight.Bold,
+        fontWeight = FontWeight.W700,
         maxLines = maxLines,
         overflow = TextOverflow.Ellipsis,
         textAlign = textAlign,
@@ -67,7 +67,7 @@ fun TextH20(
         color = color,
         fontSize = if (disableScale) fontSize.value.nonScaledSp else fontSize,
         lineHeight = if (disableScale) lineHeight.value.nonScaledSp else lineHeight.value.sp,
-        fontWeight = FontWeight.Bold,
+        fontWeight = FontWeight.W700,
         maxLines = maxLines,
         overflow = TextOverflow.Ellipsis,
         textAlign = textAlign,
@@ -93,7 +93,7 @@ fun TextH30(
         fontSize = if (disableScale) fontSize.value.nonScaledSp else fontSize,
         lineHeight = if (disableScale) lineHeight.value.nonScaledSp else lineHeight.value.sp,
         textAlign = textAlign,
-        fontWeight = fontWeight ?: FontWeight.SemiBold,
+        fontWeight = fontWeight ?: FontWeight.W600,
         maxLines = maxLines,
         overflow = TextOverflow.Ellipsis,
         modifier = modifier
@@ -107,7 +107,7 @@ fun TextP30(
     textAlign: TextAlign? = null,
     color: Color = MaterialTheme.theme.colors.primaryText01,
     maxLines: Int = Int.MAX_VALUE,
-    fontWeight: FontWeight? = FontWeight.Medium,
+    fontWeight: FontWeight? = FontWeight.W500,
 ) {
     Text(
         text = text,
@@ -129,7 +129,7 @@ fun TextH40(
     textAlign: TextAlign? = null,
     color: Color = MaterialTheme.theme.colors.primaryText01,
     maxLines: Int = Int.MAX_VALUE,
-    fontWeight: FontWeight = FontWeight.Medium,
+    fontWeight: FontWeight = FontWeight.W500,
     disableScale: Boolean = false
 ) {
     Text(
@@ -182,7 +182,7 @@ fun TextH50(
         text = text,
         color = color,
         fontSize = 14.sp,
-        fontWeight = FontWeight.Medium,
+        fontWeight = FontWeight.W500,
         lineHeight = 20.sp,
         textAlign = textAlign,
         maxLines = maxLines,
@@ -236,6 +236,28 @@ fun TextP50(
     )
 }
 
+val textH60FontSize = 12.sp
+@Composable
+fun TextH60(
+    text: String,
+    modifier: Modifier = Modifier,
+    textAlign: TextAlign? = null,
+    color: Color = MaterialTheme.theme.colors.primaryText01,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        color = color,
+        fontSize = textH60FontSize,
+        fontWeight = FontWeight.W600,
+        lineHeight = 14.sp,
+        maxLines = maxLines,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier,
+        textAlign = textAlign,
+    )
+}
+
 @Composable
 fun TextP60(
     text: String,
@@ -265,7 +287,7 @@ fun TextH70(
     modifier: Modifier = Modifier,
     textAlign: TextAlign? = null,
     color: Color = MaterialTheme.theme.colors.primaryText01,
-    fontWeight: FontWeight = FontWeight(500),
+    fontWeight: FontWeight = FontWeight.W500,
     maxLines: Int = Int.MAX_VALUE,
     disableScale: Boolean = false
 ) {
@@ -294,7 +316,7 @@ fun TextC70(
         color = MaterialTheme.theme.colors.primaryText02,
         fontFamily = FontFamily.SansSerif,
         fontSize = 12.sp,
-        fontWeight = FontWeight.Medium,
+        fontWeight = FontWeight.W500,
         lineHeight = 14.sp,
         letterSpacing = 0.6.sp,
         maxLines = maxLines,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/PodcastSubscribeImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/PodcastSubscribeImage.kt
@@ -1,0 +1,117 @@
+package au.com.shiftyjelly.pocketcasts.compose.podcast
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun PodcastSubscribeImage(
+    podcastUuid: String,
+    podcastTitle: String,
+    podcastSubscribed: Boolean,
+    onSubscribeClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    BoxWithConstraints(
+        modifier = modifier
+            .aspectRatio(1f)
+            .clickable(
+                onClickLabel = if (podcastSubscribed) {
+                    stringResource(LR.string.unsubscribe)
+                } else {
+                    stringResource(LR.string.subscribe)
+                },
+                onClick = onSubscribeClick
+            )
+            .semantics(mergeDescendants = true) {},
+        contentAlignment = Alignment.Center
+    ) {
+        PodcastImage(
+            uuid = podcastUuid,
+            title = podcastTitle,
+            showTitle = true,
+            modifier = Modifier.fillMaxSize()
+        )
+
+        val buttonBackgroundColor = Color.Black.copy(alpha = 0.4f)
+        Box(
+            contentAlignment = Alignment.BottomEnd,
+            modifier = Modifier.fillMaxSize().padding(8.dp)
+        ) {
+            if (podcastSubscribed) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .shadow(2.dp, shape = CircleShape)
+                        .size(20.dp)
+                        .clip(CircleShape)
+                        .background(buttonBackgroundColor)
+                ) {
+                    Icon(
+                        painter = painterResource(IR.drawable.ic_tick),
+                        contentDescription = stringResource(LR.string.podcast_subscribed),
+                        tint = Color.White,
+                        modifier = Modifier.size(16.dp)
+                    )
+                }
+            } else {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .shadow(1.dp, shape = CircleShape)
+                        .size(20.dp)
+                        .clip(CircleShape)
+                        .background(buttonBackgroundColor)
+                ) {
+                    Icon(
+                        painter = painterResource(IR.drawable.ic_add_black_24dp),
+                        contentDescription = stringResource(LR.string.podcast_not_subscribed),
+                        tint = Color.White,
+                        modifier = Modifier.size(16.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PodcastSelectImagePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppThemeWithBackground(themeType) {
+        PodcastSubscribeImage(
+            podcastUuid = "e7a6f7d0-02f2-0133-1c51-059c869cc4eb",
+            podcastTitle = "A Great Podcast Title",
+            podcastSubscribed = false,
+            onSubscribeClick = {},
+            modifier = Modifier
+        )
+    }
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -450,6 +450,7 @@
     <string name="podcast_show_archived" translatable="false">@string/show_archived</string>
     <string name="podcast_sort_episodes">Sort episodes</string>
     <string name="podcast_subscribed">Subscribed</string>
+    <string name="podcast_not_subscribed">Not Subscribed</string>
     <string name="podcast_support_this_podcast">Support This Show</string>
     <string name="podcast_supporter">SUPPORTER</string>
     <string name="podcast_supporter_cancelled">Support cancelled</string>


### PR DESCRIPTION
| 📘 Project: #524  |
| --- |

## Description
Add the trending section to the recommendation screen

## Testing Instructions
1. Enable onboarding in `base.gradle` file. You may want to consider updating the startDestination [here](https://github.com/Automattic/pocket-casts-android/blob/2c6b39dccba6eb67aa643e17e59fdc3df59db437/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt#L49) to be `OnboardingRecommendationsFlow.route`.
2. Open the onboarding recommendations screen
3. Observe that you can scroll through the trending podcasts for your region
4. Observe that tapping on any of the podcast subscribes/unsubscribes to that podcast

## Screenshots or Screencast 

https://user-images.githubusercontent.com/4656348/206279048-5405ab23-c988-4639-b519-8c4109f2d8de.mov

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack
