### PR TITLE
Update analytics for account setup screens

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -68,23 +68,11 @@ fun OnboardingFlowComposable(
 
             composable(OnboardingNavRoute.logInOrSignUp) {
                 OnboardingLoginOrSignUpPage(
-                    onNotNowClicked = {
-                        analyticsTracker.track(AnalyticsEvent.SETUP_ACCOUNT_DISMISSED, AnalyticsProp.source)
-                        completeOnboarding()
-                    },
-                    onSignUpClicked = {
-                        analyticsTracker.track(AnalyticsEvent.SETUP_ACCOUNT_BUTTON_TAPPED, AnalyticsProp.ButtonTapped.createAccount)
-                        navController.navigate(OnboardingNavRoute.createFreeAccount)
-                    },
-                    onLoginClicked = {
-                        analyticsTracker.track(AnalyticsEvent.SETUP_ACCOUNT_BUTTON_TAPPED, AnalyticsProp.ButtonTapped.signIn)
-                        navController.navigate(OnboardingNavRoute.logIn)
-                    },
-                    onContinueWithGoogleClicked = {
-                        analyticsTracker.track(AnalyticsEvent.SETUP_ACCOUNT_BUTTON_TAPPED, AnalyticsProp.ButtonTapped.continueWithGoogle)
-                        navController.navigate(OnboardingNavRoute.logInGoogle)
-                    },
-                    onShown = { analyticsTracker.track(AnalyticsEvent.SETUP_ACCOUNT_SHOWN, AnalyticsProp.source) }
+                    flow = "initial_onboarding",
+                    onDismiss = { completeOnboarding() },
+                    onSignUpClicked = { navController.navigate(OnboardingNavRoute.createFreeAccount) },
+                    onLoginClicked = { navController.navigate(OnboardingNavRoute.logIn) },
+                    onContinueWithGoogleClicked = { navController.navigate(OnboardingNavRoute.logInGoogle) },
                 )
             }
 


### PR DESCRIPTION
## Description
Adding setup account screen analytics to the initial screen in the onboarding flow.


## Testing Instructions

### New Onboarding Page
1. Turn on the onboarding flag in `base.gradle`.
2. Hardcode the `Continue With Google` button to show by commenting out [this if-check](https://github.com/Automattic/pocket-casts-android/blob/dae23f0da1e2dfb2a8be6057faff148ce875417a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt#L137).
3. Open the app and load the Initial onboarding screen.
4. Verfiy that the following event is immediately sent: `setup_account_shown, Properties: {"flow":"initial_onboarding"`
5. Verify that tapping on "Continue With Google" fires `setup_account_button_tapped, Properties: {"flow":"initial_onboarding","button":"continue_with_google"`
6. Verify that tapping on "Sign up" fires `setup_account_button_tapped, Properties: {"flow":"initial_onboarding","button":"create_account"`
7. Verify that tapping on "Log in" fires `setup_account_button_tapped, Properties: {"flow":"initial_onboarding","button":"sign_in"`
8. Verify that either swiping back or tapping the "Not Now" button sends `setup_account_dismissed, Properties: {"flow":"initial_onboarding"`

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
