### PR TITLE
Display gravatar on profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
         ([#477](https://github.com/Automattic/pocket-casts-android/pull/477)).
     *   Fix unable to permanently change "Skip back time" setting
         ([#632](https://github.com/Automattic/pocket-casts-android/pull/632)).
+    *   Display gravatar on profile screen
+        ([#644](https://github.com/Automattic/pocket-casts-android/pull/644)).
 
 7.28
 -----

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/UserView.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/UserView.kt
@@ -16,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.TimeConstants
 import au.com.shiftyjelly.pocketcasts.utils.days
+import au.com.shiftyjelly.pocketcasts.utils.extensions.md5Hex
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatLongStyle
 import java.util.Date
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -53,6 +54,9 @@ open class UserView @JvmOverloads constructor(
             is SignInState.SignedIn -> {
                 val strPocketCastsPlus = context.getString(LR.string.pocket_casts_plus).uppercase()
                 val strSignedInAs = context.getString(LR.string.profile_signed_in_as).uppercase()
+                /* https://en.gravatar.com/site/implement/images/
+                   d=404: display no image if there is not one associated with the requested email hash */
+                val gravatarUrl = "https://www.gravatar.com/avatar/${signInState.email.md5Hex()}?d=404"
 
                 lblUsername.text = signInState.email
                 lblSignInStatus.text = if (signInState.isSignedInAsPlus) strPocketCastsPlus else strSignedInAs
@@ -65,7 +69,7 @@ open class UserView @JvmOverloads constructor(
                 if (daysLeft != null && daysLeft > 0 && daysLeft <= 30) {
                     percent = daysLeft / 30f
                 }
-                imgProfilePicture.setup(percent, signInState.isSignedInAsPlus)
+                imgProfilePicture.setup(percent, signInState.isSignedInAsPlus, gravatarUrl)
             }
             is SignInState.SignedOut -> {
                 lblUsername.text = context.getString(LR.string.profile_set_up_account)

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/String.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/String.kt
@@ -1,7 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.utils.extensions
 
 import timber.log.Timber
+import java.io.UnsupportedEncodingException
 import java.security.MessageDigest
+import java.security.NoSuchAlgorithmException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -73,4 +75,25 @@ fun String.sha1(): String? {
     } catch (e: Exception) {
         null
     }
+}
+
+/* https://en.gravatar.com/site/implement/images/java/ */
+fun String.md5Hex(): String? {
+    try {
+        val md = MessageDigest.getInstance("MD5")
+        return hex(md.digest(this.toByteArray(charset("CP1252"))))
+    } catch (e: NoSuchAlgorithmException) {
+        Timber.e(e.message)
+    } catch (e: UnsupportedEncodingException) {
+        Timber.e(e.message)
+    }
+    return null
+}
+
+private fun hex(array: ByteArray): String {
+    val sb = StringBuffer()
+    for (i in array.indices) {
+        sb.append(Integer.toHexString((array[i].toInt() and 0xFF) or 0x100).substring(1, 3))
+    }
+    return sb.toString()
 }


### PR DESCRIPTION
## Description

Displays gravatar on the profile screen.

## Testing Instructions

1. Create an account in gravatar.com and set your avatar (if you don't have one)
2. Run the app
3. Login with your email
4. Check the Profile tab
5. ✅ It should show your Gravatar
6. Tap on the gravatar + email view
7. ✅ It should show your Gravatar in a slightly bigger size
8. Logout
9. Login with an account without gravatar
10. ✅ The app won't show any gravatar avatar and it will fallback to the way it was before

## Screenshots or Screencast 
not_signed_in | without_plus | plus_small
---|--|--
![not_signed_in](https://user-images.githubusercontent.com/1405144/206715970-e7cb3dae-199c-4434-988a-685f8def2814.png)| ![without_plus](https://user-images.githubusercontent.com/1405144/206715985-975a489a-9028-4c8d-9d99-e2832972aba6.png)| ![plus_small](https://user-images.githubusercontent.com/1405144/206716020-8aa396a2-973a-4430-a1bf-cb2ab043f2e8.png)

without_plus_big | plus_big
--|--
![without_plus_big](https://user-images.githubusercontent.com/1405144/206716046-6813bc8f-6fac-4808-9ac6-a312831a1edb.png)|![plus_big](https://user-images.githubusercontent.com/1405144/206716081-0d44df7a-1234-4003-9590-3a5176f39437.png)

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- I have considered whether it makes sense to add tests for my changes
- All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
