### PR TITLE
Onboarding: remove feature flag

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -189,7 +189,8 @@ class MainActivity :
         theme.setupThemeForConfig(this, resources.configuration)
 
         val showOnboarding = !settings.hasCompletedOnboarding() && !settings.isLoggedIn()
-        if (showOnboarding) {
+        // Only show if savedInstanceState is null in order to avoid creating onboarding activity twice.
+        if (showOnboarding && savedInstanceState == null) {
             openOnboardingFlow()
         }
 

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -188,9 +188,7 @@ class MainActivity :
         super.onCreate(savedInstanceState)
         theme.setupThemeForConfig(this, resources.configuration)
 
-        val showOnboarding = BuildConfig.ONBOARDING_ENABLED &&
-            !settings.getHasCompletedOnboarding() &&
-            !settings.isLoggedIn()
+        val showOnboarding = !settings.hasCompletedOnboarding() && !settings.isLoggedIn()
         if (showOnboarding) {
             openOnboardingFlow()
         }

--- a/base.gradle
+++ b/base.gradle
@@ -30,7 +30,6 @@ android {
 
         // Feature Flags
         buildConfigField "boolean", "END_OF_YEAR_REQUIRE_LOGIN", "true"
-        buildConfigField "boolean", "ONBOARDING_ENABLED", "false"
         buildConfigField "boolean", "SINGLE_SIGN_ON_ENABLED", "false"
 
         testInstrumentationRunner project.testInstrumentationRunner

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -604,6 +604,6 @@ interface Settings {
     fun getEndOfYearModalHasBeenShown(): Boolean
     fun endOfYearRequireLogin(): Boolean
 
-    fun getHasCompletedOnboarding(): Boolean
+    fun hasCompletedOnboarding(): Boolean
     fun setHasCompletedOnboarding()
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1492,7 +1492,7 @@ class SettingsImpl @Inject constructor(
         return BuildConfig.END_OF_YEAR_REQUIRE_LOGIN
     }
 
-    override fun getHasCompletedOnboarding() = getBoolean(COMPLETED_ONBOARDING_KEY, false)
+    override fun hasCompletedOnboarding() = getBoolean(COMPLETED_ONBOARDING_KEY, false)
 
     override fun setHasCompletedOnboarding() {
         setBoolean(COMPLETED_ONBOARDING_KEY, true)


### PR DESCRIPTION
| 📘 Project: #524  |
| --- |

## Description
This turns on the onboarding feature so it can go out to our open beta testers in 7.29.

I considered leaving this turned off for debug builds by default and having a feature flag that could be used to turn it on for debug builds in order to not make development more difficult, but since this only gets presented a single time after a fresh install (and can be dismissed with a single button tap), I decided that probably wasn't necessary. Happy to add a flag if you disagree though.

## Testing Instructions
Just make sure the feature loads up on a fresh install. Everything else has already been tested, so no other specific testing is needed for this change. Don't hesitate to give the feature a bit of smoke-testing if you're up for it though.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
