### PR TITLE
Onboarding analytics: sign in, create account, forgot password, and recommendations

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
@@ -8,7 +8,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContract.OnboardingFinish
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import dagger.hilt.android.AndroidEntryPoint
@@ -19,7 +18,6 @@ import javax.inject.Inject
 class OnboardingActivity : AppCompatActivity() {
 
     @Inject lateinit var theme: Theme
-    @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
     @Inject lateinit var userManager: UserManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -32,7 +30,6 @@ class OnboardingActivity : AppCompatActivity() {
                 completeOnboarding = { finishWithResult(OnboardingFinish.Completed) },
                 completeOnboardingToDiscover = { finishWithResult(OnboardingFinish.CompletedGoToDiscover) },
                 abortOnboarding = { finishWithResult(OnboardingFinish.AbortedOnboarding) },
-                analyticsTracker = analyticsTracker,
                 signInState = signInState,
             )
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingCreateAccountPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingCreateAccountPage.kt
@@ -33,16 +33,18 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun OnboardingCreateAccountPage(
-    onShown: () -> Unit,
     onBackPressed: () -> Unit,
     onAccountCreated: () -> Unit,
 ) {
 
-    LaunchedEffect(Unit) { onShown() }
-    BackHandler { onBackPressed() }
-
     val viewModel = hiltViewModel<OnboardingCreateAccountViewModel>()
     val state by viewModel.stateFlow.collectAsState()
+
+    LaunchedEffect(Unit) { viewModel.onShown() }
+    BackHandler {
+        viewModel.onBackPressed()
+        onBackPressed()
+    }
 
     val view = LocalView.current
     @Suppress("NAME_SHADOWING")
@@ -54,7 +56,10 @@ internal fun OnboardingCreateAccountPage(
     Column {
         ThemedTopAppBar(
             title = stringResource(LR.string.create_account),
-            onNavigationClick = onBackPressed
+            onNavigationClick = {
+                viewModel.onBackPressed()
+                onBackPressed()
+            }
         )
 
         Column(
@@ -117,7 +122,6 @@ private fun OnboardingCreateAccountPagePreview(
 ) {
     AppThemeWithBackground(themeType) {
         OnboardingCreateAccountPage(
-            onShown = {},
             onBackPressed = {},
             onAccountCreated = {},
         )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -12,8 +12,6 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.import.OnboardingImport
 import au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations.OnboardingRecommendationsFlow
 import au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations.OnboardingRecommendationsFlow.onboardingRecommendationsFlowGraph
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusUpgradeFlow
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -24,7 +22,6 @@ fun OnboardingFlowComposable(
     completeOnboarding: () -> Unit,
     completeOnboardingToDiscover: () -> Unit,
     abortOnboarding: () -> Unit,
-    analyticsTracker: AnalyticsTrackerWrapper,
     signInState: SignInState?
 ) {
     AppThemeWithBackground(activeTheme) {
@@ -55,11 +52,7 @@ fun OnboardingFlowComposable(
             importFlowGraph(navController)
 
             onboardingRecommendationsFlowGraph(
-                onShown = { analyticsTracker.track(AnalyticsEvent.RECOMMENDATIONS_SHOWN) },
-                onBackPressed = {
-                    analyticsTracker.track(AnalyticsEvent.RECOMMENDATIONS_DISMISSED)
-                    completeOnboarding()
-                },
+                onBackPressed = completeOnboarding,
                 onComplete = {
                     navController.navigate(OnboardingNavRoute.plusUpgrade)
                 },

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -78,11 +78,7 @@ fun OnboardingFlowComposable(
 
             composable(OnboardingNavRoute.createFreeAccount) {
                 OnboardingCreateAccountPage(
-                    onShown = { analyticsTracker.track(AnalyticsEvent.CREATE_ACCOUNT_SHOWN) },
-                    onBackPressed = {
-                        analyticsTracker.track(AnalyticsEvent.CREATE_ACCOUNT_DISMISSED)
-                        navController.popBackStack()
-                    },
+                    onBackPressed = { navController.popBackStack() },
                     onAccountCreated = {
                         navController.navigate(OnboardingRecommendationsFlow.route) {
                             // clear backstack after account is created

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -96,11 +96,7 @@ fun OnboardingFlowComposable(
 
             composable(OnboardingNavRoute.logIn) {
                 OnboardingLoginPage(
-                    onShown = { analyticsTracker.track(AnalyticsEvent.SIGNIN_SHOWN) },
-                    onBackPressed = {
-                        analyticsTracker.track(AnalyticsEvent.SIGNIN_DISMISSED)
-                        navController.popBackStack()
-                    },
+                    onBackPressed = { navController.popBackStack() },
                     onLoginComplete = completeOnboarding,
                     onForgotPasswordTapped = { navController.navigate(OnboardingNavRoute.forgotPassword) },
                 )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -108,11 +108,7 @@ fun OnboardingFlowComposable(
 
             composable(OnboardingNavRoute.forgotPassword) {
                 OnboardingForgotPasswordPage(
-                    onShown = { analyticsTracker.track(AnalyticsEvent.FORGOT_PASSWORD_SHOWN) },
-                    onBackPressed = {
-                        analyticsTracker.track(AnalyticsEvent.FORGOT_PASSWORD_DISMISSED)
-                        navController.popBackStack()
-                    },
+                    onBackPressed = { navController.popBackStack() },
                     onCompleted = completeOnboarding,
                 )
             }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingForgotPasswordPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingForgotPasswordPage.kt
@@ -38,10 +38,13 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun OnboardingForgotPasswordPage(
-    onShown: () -> Unit,
     onBackPressed: () -> Unit,
     onCompleted: () -> Unit,
 ) {
+
+    val viewModel = hiltViewModel<OnboardingForgotPasswordViewModel>()
+    val state by viewModel.stateFlow.collectAsState()
+
     val emailFocusRequester = remember { FocusRequester() }
 
     val context = LocalContext.current
@@ -57,18 +60,21 @@ fun OnboardingForgotPasswordPage(
     }
 
     LaunchedEffect(Unit) {
-        onShown()
+        viewModel.onShown()
         emailFocusRequester.requestFocus()
     }
-    BackHandler { onBackPressed() }
-
-    val viewModel = hiltViewModel<OnboardingForgotPasswordViewModel>()
-    val state by viewModel.stateFlow.collectAsState()
+    BackHandler {
+        viewModel.onBackPressed()
+        onBackPressed()
+    }
 
     Column {
         ThemedTopAppBar(
             title = stringResource(LR.string.profile_reset_password),
-            onNavigationClick = onBackPressed
+            onNavigationClick = {
+                viewModel.onBackPressed()
+                onBackPressed()
+            }
         )
 
         Column(
@@ -118,7 +124,6 @@ fun OnboardingForgotPasswordPreview(
 ) {
     AppThemeWithBackground(themeType) {
         OnboardingForgotPasswordPage(
-            onShown = {},
             onBackPressed = {},
             onCompleted = {},
         )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
@@ -38,16 +38,19 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun OnboardingLoginPage(
-    onShown: () -> Unit,
     onBackPressed: () -> Unit,
     onLoginComplete: () -> Unit,
     onForgotPasswordTapped: () -> Unit,
 ) {
-    LaunchedEffect(Unit) { onShown() }
-    BackHandler { onBackPressed() }
 
     val viewModel = hiltViewModel<OnboardingLogInViewModel>()
     val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(Unit) { viewModel.onShown() }
+    BackHandler {
+        viewModel.onBackPressed()
+        onBackPressed()
+    }
 
     val view = LocalView.current
     @Suppress("NAME_SHADOWING")
@@ -60,7 +63,10 @@ internal fun OnboardingLoginPage(
 
         ThemedTopAppBar(
             title = stringResource(LR.string.onboarding_welcome_back),
-            onNavigationClick = onBackPressed
+            onNavigationClick = {
+                viewModel.onBackPressed()
+                onBackPressed()
+            }
         )
 
         Column(
@@ -122,7 +128,6 @@ fun OnBoardingLoginPage_Preview(
 ) {
     AppThemeWithBackground(themeType) {
         OnboardingLoginPage(
-            onShown = {},
             onBackPressed = {},
             onLoginComplete = {},
             onForgotPasswordTapped = {},

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
@@ -19,7 +19,6 @@ object OnboardingRecommendationsFlow {
     private const val search = "search"
 
     fun NavGraphBuilder.onboardingRecommendationsFlowGraph(
-        onShown: () -> Unit,
         onBackPressed: () -> Unit,
         onComplete: () -> Unit,
         navController: NavController,
@@ -33,7 +32,6 @@ object OnboardingRecommendationsFlow {
 
             composable(start) {
                 OnboardingRecommendationsStartPage(
-                    onShown = onShown,
                     onImportClicked = { navController.navigate(OnboardingImportFlow.route) },
                     onSearch = with(LocalContext.current) {
                         {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
@@ -47,26 +47,36 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun OnboardingRecommendationsStartPage(
-    onShown: () -> Unit,
     onImportClicked: () -> Unit,
     onSearch: () -> Unit,
     onBackPressed: () -> Unit,
     onComplete: () -> Unit,
 ) {
-
-    LaunchedEffect(Unit) { onShown() }
-    BackHandler { onBackPressed() }
-
     val viewModel = hiltViewModel<OnboardingRecommendationsStartPageViewModel>()
     val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(Unit) { viewModel.onShown() }
+    BackHandler {
+        viewModel.onBackPressed()
+        onBackPressed()
+    }
 
     Content(
         trendingPodcasts = state.trendingPodcasts,
         buttonRes = state.buttonRes,
-        onImportClicked = onImportClicked,
+        onImportClicked = {
+            viewModel.onImportClick()
+            onImportClicked()
+        },
         onSubscribeTap = viewModel::updateSubscribed,
-        onSearch = onSearch,
-        onComplete = onComplete
+        onSearch = {
+            viewModel.onSearch()
+            onSearch()
+        },
+        onComplete = {
+            viewModel.onComplete()
+            onComplete()
+        }
     )
 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingCreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingCreateAccountViewModel.kt
@@ -3,8 +3,8 @@ package au.com.shiftyjelly.pocketcasts.account.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.account.AccountAuth
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
@@ -21,7 +21,6 @@ class OnboardingCreateAccountViewModel @Inject constructor(
     private val auth: AccountAuth,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val subscriptionManager: SubscriptionManager,
-    private val settings: Settings,
 ) : ViewModel(), CoroutineScope {
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
@@ -30,6 +29,14 @@ class OnboardingCreateAccountViewModel @Inject constructor(
         OnboardingCreateAccountState()
     )
     val stateFlow: StateFlow<OnboardingCreateAccountState> = _stateFlow
+
+    fun onShown() {
+        analyticsTracker.track(AnalyticsEvent.CREATE_ACCOUNT_SHOWN)
+    }
+
+    fun onBackPressed() {
+        analyticsTracker.track(AnalyticsEvent.CREATE_ACCOUNT_DISMISSED)
+    }
 
     fun updateEmail(email: String) {
         _stateFlow.update { it.copy(email = email.trim()) }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingForgotPasswordViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingForgotPasswordViewModel.kt
@@ -2,6 +2,8 @@ package au.com.shiftyjelly.pocketcasts.account.viewmodel
 
 import androidx.lifecycle.ViewModel
 import au.com.shiftyjelly.pocketcasts.account.AccountAuth
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -10,6 +12,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class OnboardingForgotPasswordViewModel @Inject constructor(
+    private val analyticsTracker: AnalyticsTrackerWrapper,
     private val auth: AccountAuth
 ) : ViewModel() {
 
@@ -17,6 +20,14 @@ class OnboardingForgotPasswordViewModel @Inject constructor(
         OnboardingForgotPasswordState()
     )
     val stateFlow: StateFlow<OnboardingForgotPasswordState> = _stateFlow
+
+    fun onShown() {
+        analyticsTracker.track(AnalyticsEvent.FORGOT_PASSWORD_SHOWN)
+    }
+
+    fun onBackPressed() {
+        analyticsTracker.track(AnalyticsEvent.FORGOT_PASSWORD_DISMISSED)
+    }
 
     fun updateEmail(email: String) {
         _stateFlow.update { it.copy(email = email.trim()) }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.account.AccountAuth
 import au.com.shiftyjelly.pocketcasts.account.SignInSource
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
@@ -18,6 +20,7 @@ import kotlin.coroutines.CoroutineContext
 @HiltViewModel
 class OnboardingLogInViewModel @Inject constructor(
     private val auth: AccountAuth,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
     private val subscriptionManager: SubscriptionManager,
 ) : ViewModel(), CoroutineScope {
 
@@ -69,6 +72,14 @@ class OnboardingLogInViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    fun onShown() {
+        analyticsTracker.track(AnalyticsEvent.SIGNIN_SHOWN)
+    }
+
+    fun onBackPressed() {
+        analyticsTracker.track(AnalyticsEvent.SIGNIN_DISMISSED)
     }
 }
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -300,6 +300,9 @@ enum class AnalyticsEvent(val key: String) {
     /* Recommendations */
     RECOMMENDATIONS_SHOWN("recommendations_shown"),
     RECOMMENDATIONS_DISMISSED("recommendations_dismissed"),
+    RECOMMENDATIONS_SEARCH_TAPPED("recommendations_search_tapped"),
+    RECOMMENDATIONS_IMPORT_TAPPED("recommendations_import_tapped"),
+    RECOMMENDATIONS_CONTINUE_TAPPED("recommendations_continue_tapped"),
 
     /* Onboarding upgrade */
     ONBOARDING_UPGRADE_SHOWN("onboarding_upgrade_shown"),


### PR DESCRIPTION
| 📘 Project: #524  |
| --- |


## Description
This is moving the analytics logic out of the navigation composable and into the view models for the specific pages. I'm making that change because I don't think it makes sense for the navigation composable to be responsible for analytics like I had it before. Not only does it make the navigation composable more complex, but it also makes it more difficult to reuse the composable views, which we'll be doing once we replace the main app account-creation and plus-upgrade screens with the new screens from the onboarding flow.

## Testing Instructions

### Sign up (Create Account) Screen
1. On load, the `create_account_shown` event is sent
2. Either (a) swiping back or (b) tapping the back arrow sends `create_account_dismissed`

### Log in Screen
1. On load, the `signin_shown` event is sent
2. Either (a) swiping back or (b) tapping the back arrow sends `sigin_dismissed`

### Forgot Password Screen (accessible from Log in screen)
1. On loead, the `forgot_password_shown` event is sent
2. Either (a) swiping back or (b) tapping the back arrow sends `forgot_password_dismissed`

### Recommendation Screen (accessible after creating a new account)
1. On load, the `recommendations_shown` event is sent
4. Swiping back sends `recommendations_dismissed, Properties: {"subscriptions":###`
5. Tapping the search field sends `recommendations_search_tapped`
6. Tapping the import button sends `recommendations_import_tapped`
7. Tapping the not-now/continue button sends `recommendations_continue_tapped, Properties: {"subscriptions":###`

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
