### PR TITLE
EoY: Update initial value for the launch modal to check listening history

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -30,8 +30,12 @@ class MainActivityViewModel
 
     var isPlayerOpen: Boolean = false
     var lastPlaybackState: PlaybackState? = null
-    val shouldShowStoriesModal = MutableStateFlow(!settings.getEndOfYearModalHasBeenShown())
+    val shouldShowStoriesModal = MutableStateFlow(false)
     var waitingForSignInToShowStories = false
+
+    init {
+        updateStoriesModalShowState(!settings.getEndOfYearModalHasBeenShown())
+    }
 
     private val playbackStateRx = playbackManager.playbackStateRelay
         .doOnNext {


### PR DESCRIPTION
## Description

Adds a safety check so that EoY modal is not shown to newly signed-up users (who do not have a listening history) after the onboarding flow is complete.

While this check is added in MainActivity [here](https://github.com/Automattic/pocket-casts-android/blob/main/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt#L202), I noticed that EoY modal was shown after creating a new account through the onboarding flow. I updated the initial value for showing the launch modal to consider the listening history eligibility.

## Testing Instructions
1. Create a new account using the onboarding flow.
2. Proceed to the welcome screen and click `Done` button.
3. Notice that EoY modal is not shown. 

## Checklist
- If this is a user-facing change, I have added an entry in CHANGELOG.md
- I have considered whether it makes sense to add tests for my changes
- All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- with different themes
- with a landscape orientation
- with the device set to have a large display and font size
- for accessibility with TalkBack
