### PR TITLE
Add onboarding flow release note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 7.29
 -----
 
+* New Features:
+    *   Onboarding flow for new users
+        ([#645](https://github.com/Automattic/pocket-casts-android/pull/645)).
 * Bug Fixes:
     *   Fixed podcast date format
         ([#477](https://github.com/Automattic/pocket-casts-android/pull/477)).


### PR DESCRIPTION
## Description
I forgot to add a release note for the new onboarding flow when I finally turned it on. Note that this PR is targeting the release/7.29 branch.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
