### PR TITLE
Task/onboarding flow 17 design feedback updates

### DIFF
--- a/base.gradle
+++ b/base.gradle
@@ -239,6 +239,7 @@ dependencies {
     implementation libs.hiltWorkManager
     implementation libs.hiltNavigationCompose
     implementation libs.accompanistFlowLayout
+    implementation libs.accompanistSystemUiController
     implementation platform(libs.sentryBom)
     implementation libs.sentry
     implementation libs.sentryFragment

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -237,6 +237,7 @@ project.ext {
             barista: "com.adevinta.android:barista:4.2.0",
             // Accompanist - https://google.github.io/accompanist/
             accompanistFlowLayout: "com.google.accompanist:accompanist-flowlayout:0.25.1",
+            accompanistSystemUiController: "com.google.accompanist:accompanist-systemuicontroller:0.28.0",
             // Automattic Tracks
             automatticTracks: "com.automattic:Automattic-Tracks-Android:$versionTracks",
             // Sentry

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.core.view.WindowCompat
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContract.OnboardingFinish
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -22,11 +23,15 @@ class OnboardingActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Make content edge-to-edge
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
         setContent {
             val signInState by userManager.getSignInState().asFlow().collectAsState(null)
 
             OnboardingFlowComposable(
-                activeTheme = theme.activeTheme,
+                theme = theme.activeTheme,
                 completeOnboarding = { finishWithResult(OnboardingFinish.Completed) },
                 completeOnboardingToDiscover = { finishWithResult(OnboardingFinish.CompletedGoToDiscover) },
                 abortOnboarding = { finishWithResult(OnboardingFinish.AbortedOnboarding) },

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingCreateAccountPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingCreateAccountPage.kt
@@ -3,8 +3,13 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
@@ -13,6 +18,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -29,10 +35,12 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun OnboardingCreateAccountPage(
+    theme: Theme.ThemeType,
     onBackPressed: () -> Unit,
     onAccountCreated: () -> Unit,
 ) {
@@ -40,7 +48,18 @@ internal fun OnboardingCreateAccountPage(
     val viewModel = hiltViewModel<OnboardingCreateAccountViewModel>()
     val state by viewModel.stateFlow.collectAsState()
 
-    LaunchedEffect(Unit) { viewModel.onShown() }
+    val systemUiController = rememberSystemUiController()
+    val pocketCastsTheme = MaterialTheme.theme
+
+    LaunchedEffect(Unit) {
+        viewModel.onShown()
+        systemUiController.apply {
+            // Use secondaryUI01 so the status bar matches the ThemedTopAppBar
+            setStatusBarColor(pocketCastsTheme.colors.secondaryUi01, darkIcons = !theme.defaultLightIcons)
+            setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
+        }
+    }
+
     BackHandler {
         viewModel.onBackPressed()
         onBackPressed()
@@ -53,7 +72,12 @@ internal fun OnboardingCreateAccountPage(
         onAccountCreated()
     }
 
-    Column {
+    Column(
+        Modifier
+            .windowInsetsPadding(WindowInsets.statusBars)
+            .windowInsetsPadding(WindowInsets.navigationBars)
+            .windowInsetsPadding(WindowInsets.ime)
+    ) {
         ThemedTopAppBar(
             title = stringResource(LR.string.create_account),
             onNavigationClick = {
@@ -122,6 +146,7 @@ private fun OnboardingCreateAccountPagePreview(
 ) {
     AppThemeWithBackground(themeType) {
         OnboardingCreateAccountPage(
+            theme = themeType,
             onBackPressed = {},
             onAccountCreated = {},
         )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -20,13 +20,13 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 
 @Composable
 fun OnboardingFlowComposable(
-    activeTheme: Theme.ThemeType,
+    theme: Theme.ThemeType,
     completeOnboarding: () -> Unit,
     completeOnboardingToDiscover: () -> Unit,
     abortOnboarding: () -> Unit,
     signInState: SignInState?
 ) {
-    AppThemeWithBackground(activeTheme) {
+    AppThemeWithBackground(theme) {
         val navController = rememberNavController()
 
         val backStackEntry by navController.currentBackStackEntryAsState()
@@ -51,9 +51,10 @@ fun OnboardingFlowComposable(
             startDestination = OnboardingNavRoute.logInOrSignUp
         ) {
 
-            importFlowGraph(navController, flow)
+            importFlowGraph(theme, navController, flow)
 
             onboardingRecommendationsFlowGraph(
+                theme = theme,
                 flow = flow,
                 onBackPressed = completeOnboarding,
                 onComplete = {
@@ -64,6 +65,7 @@ fun OnboardingFlowComposable(
 
             composable(OnboardingNavRoute.logInOrSignUp) {
                 OnboardingLoginOrSignUpPage(
+                    theme = theme,
                     flow = flow,
                     onDismiss = { completeOnboarding() },
                     onSignUpClicked = { navController.navigate(OnboardingNavRoute.createFreeAccount) },
@@ -74,6 +76,7 @@ fun OnboardingFlowComposable(
 
             composable(OnboardingNavRoute.createFreeAccount) {
                 OnboardingCreateAccountPage(
+                    theme = theme,
                     onBackPressed = { navController.popBackStack() },
                     onAccountCreated = {
                         navController.navigate(OnboardingRecommendationsFlow.route) {
@@ -88,6 +91,7 @@ fun OnboardingFlowComposable(
 
             composable(OnboardingNavRoute.logIn) {
                 OnboardingLoginPage(
+                    theme = theme,
                     onBackPressed = { navController.popBackStack() },
                     onLoginComplete = completeOnboarding,
                     onForgotPasswordTapped = { navController.navigate(OnboardingNavRoute.forgotPassword) },
@@ -100,6 +104,7 @@ fun OnboardingFlowComposable(
 
             composable(OnboardingNavRoute.forgotPassword) {
                 OnboardingForgotPasswordPage(
+                    theme = theme,
                     onBackPressed = { navController.popBackStack() },
                     onCompleted = completeOnboarding,
                 )
@@ -124,6 +129,7 @@ fun OnboardingFlowComposable(
 
             composable(OnboardingNavRoute.welcome) {
                 OnboardingWelcomePage(
+                    activeTheme = theme,
                     flow = flow,
                     isSignedInAsPlus = signInState?.isSignedInAsPlus ?: false,
                     onDone = completeOnboarding,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingForgotPasswordPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingForgotPasswordPage.kt
@@ -3,8 +3,13 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
@@ -16,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
@@ -34,10 +40,13 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.google.androidbrowserhelper.trusted.Utils.setStatusBarColor
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun OnboardingForgotPasswordPage(
+    theme: Theme.ThemeType,
     onBackPressed: () -> Unit,
     onCompleted: () -> Unit,
 ) {
@@ -59,16 +68,28 @@ fun OnboardingForgotPasswordPage(
         )
     }
 
+    val systemUiController = rememberSystemUiController()
+    val pocketCastsTheme = MaterialTheme.theme
+
     LaunchedEffect(Unit) {
         viewModel.onShown()
         emailFocusRequester.requestFocus()
+        systemUiController.apply {
+            setStatusBarColor(pocketCastsTheme.colors.secondaryUi01, darkIcons = !theme.defaultLightIcons)
+            setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
+        }
     }
     BackHandler {
         viewModel.onBackPressed()
         onBackPressed()
     }
 
-    Column {
+    Column(
+        Modifier
+            .windowInsetsPadding(WindowInsets.statusBars)
+            .windowInsetsPadding(WindowInsets.navigationBars)
+            .windowInsetsPadding(WindowInsets.ime)
+    ) {
         ThemedTopAppBar(
             title = stringResource(LR.string.profile_reset_password),
             onNavigationClick = {
@@ -124,6 +145,7 @@ fun OnboardingForgotPasswordPreview(
 ) {
     AppThemeWithBackground(themeType) {
         OnboardingForgotPasswordPage(
+            theme = themeType,
             onBackPressed = {},
             onCompleted = {},
         )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
@@ -107,7 +107,7 @@ internal fun OnboardingLoginOrSignUpPage(
                 .verticalScroll(rememberScrollState())
                 .weight(1f)
         ) {
-            Spacer(Modifier.weight(1f))
+            Spacer(Modifier.height(32.dp))
 
             Artwork(viewModel.showContinueWithGoogleButton)
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
@@ -12,10 +12,15 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ButtonDefaults
@@ -24,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -50,11 +56,13 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun OnboardingLoginOrSignUpPage(
+    theme: Theme.ThemeType,
     flow: String,
     onDismiss: () -> Unit,
     onSignUpClicked: () -> Unit,
@@ -63,8 +71,15 @@ internal fun OnboardingLoginOrSignUpPage(
     viewModel: OnboardingLoginOrSignUpViewModel = hiltViewModel()
 ) {
 
+    val systemUiController = rememberSystemUiController()
+    val pocketCastsTheme = MaterialTheme.theme
+
     LaunchedEffect(Unit) {
         viewModel.onShown(flow)
+        systemUiController.apply {
+            setStatusBarColor(pocketCastsTheme.colors.primaryUi01.copy(alpha = 0.9f), darkIcons = !theme.darkTheme)
+            setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
+        }
     }
 
     BackHandler {
@@ -72,7 +87,13 @@ internal fun OnboardingLoginOrSignUpPage(
         onDismiss()
     }
 
-    Column {
+    Column(
+        Modifier
+            .fillMaxHeight()
+            .verticalScroll(rememberScrollState())
+    ) {
+
+        Spacer(Modifier.windowInsetsPadding(WindowInsets.statusBars))
 
         Row(
             Modifier
@@ -102,57 +123,54 @@ internal fun OnboardingLoginOrSignUpPage(
             }
         }
 
-        Column(
+        Spacer(Modifier.height(32.dp))
+
+        Artwork(viewModel.showContinueWithGoogleButton)
+
+        Spacer(Modifier.weight(1f))
+
+        TextH10(
+            text = stringResource(LR.string.onboarding_discover_your_next_favorite_podcast),
             modifier = Modifier
-                .verticalScroll(rememberScrollState())
-                .weight(1f)
-        ) {
-            Spacer(Modifier.height(32.dp))
+                .padding(horizontal = 24.dp)
+                .fillMaxWidth(),
+            textAlign = TextAlign.Center,
+        )
 
-            Artwork(viewModel.showContinueWithGoogleButton)
+        Spacer(Modifier.height(8.dp))
 
-            Spacer(Modifier.weight(1f))
+        TextH40(
+            text = stringResource(LR.string.onboarding_create_an_account_to),
+            modifier = Modifier
+                .padding(horizontal = 24.dp)
+                .fillMaxWidth(),
+            textAlign = TextAlign.Center
+        )
 
-            TextH10(
-                text = stringResource(LR.string.onboarding_discover_your_next_favorite_podcast),
-                modifier = Modifier
-                    .padding(horizontal = 24.dp)
-                    .fillMaxWidth(),
-                textAlign = TextAlign.Center,
-                maxLines = 2
-            )
+        Spacer(Modifier.weight(1f))
 
+        if (viewModel.showContinueWithGoogleButton) {
             Spacer(Modifier.height(8.dp))
-
-            TextH40(
-                text = stringResource(LR.string.onboarding_create_an_account_to),
-                modifier = Modifier
-                    .padding(horizontal = 24.dp)
-                    .fillMaxWidth(),
-                textAlign = TextAlign.Center
+            ContinueWithGoogleButton(
+                flow = flow,
+                viewModel = viewModel,
+                onClick = onContinueWithGoogleClicked
             )
-
-            Spacer(Modifier.weight(1f))
-
-            if (viewModel.showContinueWithGoogleButton) {
-                Spacer(Modifier.height(8.dp))
-                ContinueWithGoogleButton(
-                    flow = flow,
-                    viewModel = viewModel,
-                    onClick = onContinueWithGoogleClicked
-                )
-            } else {
-                Spacer(Modifier.height(32.dp))
-            }
-            SignUpButton(onClick = {
-                viewModel.onSignUpClicked(flow)
-                onSignUpClicked()
-            })
-            LogInButton(onClick = {
-                viewModel.onLoginClicked(flow)
-                onLoginClicked()
-            })
+        } else {
+            Spacer(Modifier.height(32.dp))
         }
+
+        SignUpButton(onClick = {
+            viewModel.onSignUpClicked(flow)
+            onSignUpClicked()
+        })
+
+        LogInButton(onClick = {
+            viewModel.onLoginClicked(flow)
+            onLoginClicked()
+        })
+
+        Spacer(Modifier.windowInsetsPadding(WindowInsets.navigationBars))
     }
 }
 @Composable
@@ -314,6 +332,7 @@ private object Artwork {
 private fun RowOutlinedButtonPreview(@PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType) {
     AppThemeWithBackground(themeType) {
         OnboardingLoginOrSignUpPage(
+            theme = themeType,
             flow = "initial_onboarding",
             onDismiss = {},
             onSignUpClicked = {},

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
@@ -4,10 +4,15 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
@@ -17,6 +22,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -34,19 +40,29 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun OnboardingLoginPage(
+    theme: Theme.ThemeType,
     onBackPressed: () -> Unit,
     onLoginComplete: () -> Unit,
     onForgotPasswordTapped: () -> Unit,
 ) {
+    val systemUiController = rememberSystemUiController()
+    val pocketCastsTheme = MaterialTheme.theme
 
     val viewModel = hiltViewModel<OnboardingLogInViewModel>()
     val state by viewModel.state.collectAsState()
 
-    LaunchedEffect(Unit) { viewModel.onShown() }
+    LaunchedEffect(Unit) {
+        viewModel.onShown()
+        systemUiController.apply {
+            setStatusBarColor(pocketCastsTheme.colors.secondaryUi01, darkIcons = !theme.defaultLightIcons)
+            setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
+        }
+    }
     BackHandler {
         viewModel.onBackPressed()
         onBackPressed()
@@ -59,7 +75,12 @@ internal fun OnboardingLoginPage(
         onLoginComplete()
     }
 
-    Column {
+    Column(
+        Modifier
+            .windowInsetsPadding(WindowInsets.statusBars)
+            .windowInsetsPadding(WindowInsets.navigationBars)
+            .windowInsetsPadding(WindowInsets.ime)
+    ) {
 
         ThemedTopAppBar(
             title = stringResource(LR.string.onboarding_welcome_back),
@@ -123,11 +144,12 @@ internal fun OnboardingLoginPage(
 
 @Preview(showBackground = true)
 @Composable
-fun OnBoardingLoginPage_Preview(
+fun OnboardingLoginPage_Preview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppThemeWithBackground(themeType) {
         OnboardingLoginPage(
+            theme = themeType,
             onBackPressed = {},
             onLoginComplete = {},
             onForgotPasswordTapped = {},

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingWelcomePage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingWelcomePage.kt
@@ -9,12 +9,16 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -56,11 +60,13 @@ import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun OnboardingWelcomePage(
+    activeTheme: Theme.ThemeType,
     flow: String,
     isSignedInAsPlus: Boolean,
     onDone: () -> Unit,
@@ -68,12 +74,18 @@ fun OnboardingWelcomePage(
     onImportTapped: () -> Unit,
     onBackPressed: () -> Unit,
 ) {
-
     val viewModel = hiltViewModel<OnboardingWelcomeViewModel>()
     val state by viewModel.stateFlow.collectAsState()
 
+    val systemUiController = rememberSystemUiController()
+    val pocketCastsTheme = MaterialTheme.theme
+
     LaunchedEffect(Unit) {
         viewModel.onShown(flow)
+        systemUiController.apply {
+            setStatusBarColor(pocketCastsTheme.colors.primaryUi01.copy(alpha = 0.9f), darkIcons = !activeTheme.darkTheme)
+            setNavigationBarColor(Color.Transparent, darkIcons = !activeTheme.darkTheme)
+        }
     }
 
     BackHandler {
@@ -117,11 +129,13 @@ private fun Content(
 ) {
     Column(
         Modifier
+//            .windowInsetsPadding(WindowInsets.statusBars)
             .padding(horizontal = 24.dp)
             .fillMaxHeight()
             .verticalScroll(rememberScrollState())
     ) {
-        Spacer(modifier = Modifier.weight(1f))
+        Spacer(Modifier.windowInsetsPadding(WindowInsets.statusBars))
+        Spacer(Modifier.weight(1f))
 
         if (isSignedInAsPlus) {
             PlusPersonCheckmark()
@@ -160,6 +174,7 @@ private fun Content(
         )
 
         Spacer(modifier = Modifier.weight(1f))
+        Spacer(Modifier.height(16.dp))
 
         NewsletterSwitch(
             checked = state.newsletter,
@@ -171,8 +186,14 @@ private fun Content(
             text = stringResource(LR.string.done),
             includePadding = false,
             onClick = onDone,
+
         )
-        Spacer(Modifier.height(24.dp))
+
+        Spacer(
+            Modifier
+                .windowInsetsPadding(WindowInsets.navigationBars)
+                .height(16.dp)
+        )
     }
 }
 
@@ -325,13 +346,13 @@ private fun PersonCheckmark(
 @Composable
 private fun OnboardingWelcomePagePreview(@PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType) {
     AppThemeWithBackground(themeType) {
-        OnboardingWelcomePage(
-            flow = "flow",
-            onDone = {},
+        Content(
+            isSignedInAsPlus = false,
             onContinueToDiscover = {},
             onImportTapped = {},
-            onBackPressed = {},
-            isSignedInAsPlus = false
+            state = OnboardingWelcomeState(newsletter = false),
+            onDone = {},
+            onNewsletterCheckedChanged = {},
         )
     }
 }
@@ -344,9 +365,7 @@ private fun OnboardingWelcomePagePlusPreview(@PreviewParameter(ThemePreviewParam
             isSignedInAsPlus = true,
             onContinueToDiscover = {},
             onImportTapped = {},
-            state = OnboardingWelcomeState(
-                newsletter = false
-            ),
+            state = OnboardingWelcomeState(newsletter = false),
             onDone = {},
             onNewsletterCheckedChanged = {},
         )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/import/OnboardingImportFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/import/OnboardingImportFlow.kt
@@ -10,6 +10,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingImportViewModel
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -17,7 +18,11 @@ object OnboardingImportFlow {
 
     const val route = "onboardingImportFlow"
 
-    fun NavGraphBuilder.importFlowGraph(navController: NavController, flow: String) {
+    fun NavGraphBuilder.importFlowGraph(
+        theme: Theme.ThemeType,
+        navController: NavController,
+        flow: String
+    ) {
         navigation(
             route = this@OnboardingImportFlow.route,
             startDestination = NavigationRoutes.start,
@@ -25,6 +30,7 @@ object OnboardingImportFlow {
             composable(NavigationRoutes.start) {
                 val viewModel = hiltViewModel<OnboardingImportViewModel>()
                 OnboardingImportStartPage(
+                    theme = theme,
                     onShown = { viewModel.onImportStartPageShown(flow) },
                     onCastboxClicked = {
                         viewModel.onAppSelected(flow, AnalyticsProps.castbox)
@@ -44,6 +50,7 @@ object OnboardingImportFlow {
             composable(NavigationRoutes.castbox) {
                 val viewModel = hiltViewModel<OnboardingImportViewModel>()
                 OnboardingImportFrom(
+                    theme = theme,
                     drawableRes = IR.drawable.castbox,
                     title = (stringResource(LR.string.onboarding_import_from_castbox)),
                     steps = listOf(
@@ -66,6 +73,7 @@ object OnboardingImportFlow {
 
             composable(NavigationRoutes.otherApps) {
                 OnboardingImportFrom(
+                    theme = theme,
                     drawableRes = IR.drawable.other_apps,
                     title = stringResource(LR.string.onboarding_import_from_other_apps),
                     text = stringResource(LR.string.onboarding_can_import_from_opml),

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/import/OnboardingImportFrom.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/import/OnboardingImportFrom.kt
@@ -4,14 +4,20 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextAlign
@@ -26,11 +32,15 @@ import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.google.androidbrowserhelper.trusted.Utils.setStatusBarColor
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 
 @Composable
 fun OnboardingImportFrom(
+    theme: Theme.ThemeType,
     @DrawableRes drawableRes: Int,
     title: String,
     text: String? = null,
@@ -39,17 +49,27 @@ fun OnboardingImportFrom(
     buttonClick: (() -> Unit)? = null,
     onBackPressed: () -> Unit,
 ) {
+    rememberSystemUiController().apply {
+        // Use the secondaryUI01 so the status bar matches the ThemedTopAppBar
+        setStatusBarColor(MaterialTheme.theme.colors.secondaryUi01, darkIcons = !theme.defaultLightIcons)
+        setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
+    }
+
     Column(
         Modifier
             .fillMaxHeight()
-            .verticalScroll(rememberScrollState())
     ) {
 
         ThemedTopAppBar(
             onNavigationClick = onBackPressed,
+            modifier = Modifier.windowInsetsPadding(WindowInsets.statusBars)
         )
 
-        Column(Modifier.padding(horizontal = 24.dp)) {
+        Column(
+            Modifier
+                .padding(horizontal = 24.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
 
             Image(
                 painter = painterResource(drawableRes),
@@ -75,6 +95,7 @@ fun OnboardingImportFrom(
                 onClick = buttonClick,
             )
         }
+        Spacer(Modifier.windowInsetsPadding(WindowInsets.navigationBars))
     }
 }
 
@@ -129,6 +150,7 @@ private fun OnboardingImportFromPreview(
 ) {
     AppThemeWithBackground(themeType = themeType) {
         OnboardingImportFrom(
+            theme = themeType,
             drawableRes = IR.drawable.castbox,
             title = "Import from something",
             text = "Some text to go with the title.",

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/import/OnboardingImportStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/import/OnboardingImportStartPage.kt
@@ -6,17 +6,23 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -28,57 +34,72 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun OnboardingImportStartPage(
+    theme: Theme.ThemeType,
     onShown: () -> Unit,
     onCastboxClicked: () -> Unit,
     onOtherAppsClicked: () -> Unit,
     onBackPressed: () -> Unit,
 ) {
-
+    val systemUiController = rememberSystemUiController()
+    val pocketCastsTheme = MaterialTheme.theme
     LaunchedEffect(Unit) {
         onShown()
+        systemUiController.apply {
+            // Use secondaryUI01 so the status bar matches the ThemedTopAppBar
+            setStatusBarColor(pocketCastsTheme.colors.secondaryUi01, darkIcons = !theme.defaultLightIcons)
+            setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
+        }
     }
 
-    Column(
-        Modifier
-            .fillMaxHeight()
-            .verticalScroll(rememberScrollState())
-    ) {
+    Column {
 
-        ThemedTopAppBar(
-            onNavigationClick = onBackPressed
-        )
+        Column(
+            Modifier
+                .fillMaxHeight()
+                .verticalScroll(rememberScrollState())
+        ) {
 
-        TextH10(
-            text = stringResource(LR.string.onboarding_bring_your_podcasts),
-            modifier = Modifier.padding(horizontal = 24.dp)
-        )
+            Spacer(Modifier.windowInsetsPadding(WindowInsets.statusBars))
 
-        Spacer(Modifier.height(8.dp))
-        TextP40(
-            text = stringResource(LR.string.onboarding_coming_from_another_app),
-            modifier = Modifier.padding(horizontal = 24.dp)
-        )
+            ThemedTopAppBar(
+                onNavigationClick = onBackPressed,
+            )
 
-        Spacer(Modifier.height(24.dp))
-        ImportRow(
-            text = stringResource(LR.string.onboarding_import_from_castbox),
-            iconRes = IR.drawable.castbox,
-            onClick = onCastboxClicked,
-        )
+            TextH10(
+                text = stringResource(LR.string.onboarding_bring_your_podcasts),
+                modifier = Modifier.padding(horizontal = 24.dp)
+            )
 
-        ImportRow(
-            text = stringResource(LR.string.onboarding_import_from_other_apps),
-            iconRes = IR.drawable.other_apps,
-            onClick = onOtherAppsClicked,
-        )
+            Spacer(Modifier.height(8.dp))
+            TextP40(
+                text = stringResource(LR.string.onboarding_coming_from_another_app),
+                modifier = Modifier.padding(horizontal = 24.dp)
+            )
 
-        Spacer(Modifier.weight(1f))
+            Spacer(Modifier.height(24.dp))
+            ImportRow(
+                text = stringResource(LR.string.onboarding_import_from_castbox),
+                iconRes = IR.drawable.castbox,
+                onClick = onCastboxClicked,
+            )
+
+            ImportRow(
+                text = stringResource(LR.string.onboarding_import_from_other_apps),
+                iconRes = IR.drawable.other_apps,
+                onClick = onOtherAppsClicked,
+            )
+
+            Spacer(Modifier.weight(1f))
+            Spacer(Modifier.windowInsetsPadding(WindowInsets.navigationBars))
+        }
     }
 }
 
@@ -111,6 +132,7 @@ private fun OnboardingImportStartPagePreview(
 ) {
     AppThemeWithBackground(themeType) {
         OnboardingImportStartPage(
+            theme = themeType,
             onShown = {},
             onCastboxClicked = {},
             onOtherAppsClicked = {},

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/import/OnboardingImportStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/import/OnboardingImportStartPage.kt
@@ -73,6 +73,7 @@ fun OnboardingImportStartPage(
                 onNavigationClick = onBackPressed,
             )
 
+            Spacer(Modifier.height(12.dp))
             TextH10(
                 text = stringResource(LR.string.onboarding_bring_your_podcasts),
                 modifier = Modifier.padding(horizontal = 24.dp)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import au.com.shiftyjelly.pocketcasts.account.onboarding.import.OnboardingImportFlow
 import au.com.shiftyjelly.pocketcasts.account.onboarding.import.OnboardingImportFlow.importFlowGraph
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -19,6 +20,7 @@ object OnboardingRecommendationsFlow {
     private const val search = "search"
 
     fun NavGraphBuilder.onboardingRecommendationsFlowGraph(
+        theme: Theme.ThemeType,
         flow: String,
         onBackPressed: () -> Unit,
         onComplete: () -> Unit,
@@ -29,10 +31,11 @@ object OnboardingRecommendationsFlow {
             startDestination = start
         ) {
 
-            importFlowGraph(navController, flow)
+            importFlowGraph(theme, navController, flow)
 
             composable(start) {
                 OnboardingRecommendationsStartPage(
+                    theme = theme,
                     onImportClicked = { navController.navigate(OnboardingImportFlow.route) },
                     onSearch = with(LocalContext.current) {
                         {
@@ -53,6 +56,7 @@ object OnboardingRecommendationsFlow {
             }
             composable(search) {
                 OnboardingRecommendationsSearchPage(
+                    theme = theme,
                     onBackPressed = { navController.popBackStack() },
                 )
             }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchPage.kt
@@ -4,10 +4,14 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.CircularProgressIndicator
@@ -23,33 +27,52 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastItem
 import au.com.shiftyjelly.pocketcasts.compose.components.SearchBar
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun OnboardingRecommendationsSearchPage(
+    theme: Theme.ThemeType,
     onBackPressed: () -> Unit,
 ) {
+
     val viewModel = hiltViewModel<OnboardingRecommendationsSearchViewModel>()
     val state by viewModel.state.collectAsState()
 
     val focusRequester = remember { FocusRequester() }
+    val systemUiController = rememberSystemUiController()
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
+        systemUiController.apply {
+            setStatusBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
+            setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
+        }
     }
 
     BackHandler {
         onBackPressed()
     }
 
-    Column(Modifier.fillMaxHeight()) {
+    Column(
+        Modifier
+            .windowInsetsPadding(WindowInsets.statusBars)
+            .windowInsetsPadding(WindowInsets.ime)
+            .fillMaxHeight()
+    ) {
         ThemedTopAppBar(
             title = stringResource(LR.string.onboarding_find_podcasts),
             onNavigationClick = onBackPressed
@@ -98,5 +121,18 @@ fun OnboardingRecommendationsSearchPage(
                 }
             }
         }
+    }
+}
+
+@Preview
+@Composable
+fun OnboardingRecommendationSearchPage_Preview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppThemeWithBackground(themeType) {
+        OnboardingRecommendationsSearchPage(
+            theme = themeType,
+            onBackPressed = {},
+        )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchPage.kt
@@ -55,10 +55,12 @@ fun OnboardingRecommendationsSearchPage(
 
     val focusRequester = remember { FocusRequester() }
     val systemUiController = rememberSystemUiController()
+    val pocketCastsTheme = MaterialTheme.theme
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
         systemUiController.apply {
-            setStatusBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
+            // Use secondaryUI01 so the status bar matches the ThemedTopAppBar
+            setStatusBarColor(pocketCastsTheme.colors.secondaryUi01, darkIcons = !theme.defaultLightIcons)
             setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
         }
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
@@ -8,18 +8,24 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
@@ -42,20 +48,33 @@ import au.com.shiftyjelly.pocketcasts.compose.components.textH60FontSize
 import au.com.shiftyjelly.pocketcasts.compose.extensions.header
 import au.com.shiftyjelly.pocketcasts.compose.podcast.PodcastSubscribeImage
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun OnboardingRecommendationsStartPage(
+    theme: Theme.ThemeType,
     onImportClicked: () -> Unit,
     onSearch: () -> Unit,
     onBackPressed: () -> Unit,
     onComplete: () -> Unit,
 ) {
+
     val viewModel = hiltViewModel<OnboardingRecommendationsStartPageViewModel>()
     val state by viewModel.state.collectAsState()
 
-    LaunchedEffect(Unit) { viewModel.onShown() }
+    val systemUiController = rememberSystemUiController()
+    val pocketCastsTheme = MaterialTheme.theme
+
+    LaunchedEffect(Unit) {
+        viewModel.onShown()
+        systemUiController.apply {
+            setStatusBarColor(pocketCastsTheme.colors.primaryUi01.copy(alpha = 0.9f), darkIcons = !theme.darkTheme)
+            setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
+        }
+    }
     BackHandler {
         viewModel.onBackPressed()
         onBackPressed()
@@ -90,25 +109,12 @@ private fun Content(
     onComplete: () -> Unit,
 ) {
     Column {
-        Row(
-            horizontalArrangement = Arrangement.End,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 18.dp)
-
-        ) {
-            TextH30(
-                text = stringResource(LR.string.onboarding_recommendations_import),
-                modifier = Modifier
-                    .clickable { onImportClicked() }
-                    .padding(horizontal = 16.dp, vertical = 9.dp)
-            )
-        }
 
         val numColumns = when (LocalConfiguration.current.orientation) {
             Configuration.ORIENTATION_LANDSCAPE -> 7
             else -> 3
         }
+
         LazyVerticalGrid(
             columns = GridCells.Fixed(numColumns),
             contentPadding = PaddingValues(horizontal = 24.dp),
@@ -119,6 +125,21 @@ private fun Content(
 
             header {
                 Column {
+                    Spacer(Modifier.windowInsetsPadding(WindowInsets.statusBars))
+                    Row(
+                        horizontalArrangement = Arrangement.End,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 18.dp)
+
+                    ) {
+                        TextH30(
+                            text = stringResource(LR.string.onboarding_recommendations_import),
+                            modifier = Modifier
+                                .clickable { onImportClicked() }
+                                .padding(horizontal = 16.dp, vertical = 9.dp)
+                        )
+                    }
 
                     TextH10(
                         text = stringResource(LR.string.onboarding_recommendations_find_favorite_podcasts),
@@ -182,6 +203,7 @@ private fun Content(
             text = stringResource(buttonRes),
             onClick = onComplete,
         )
+        Spacer(Modifier.windowInsetsPadding(WindowInsets.navigationBars))
     }
 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusBottomSheet.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusBottomSheet.kt
@@ -13,8 +13,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -75,9 +78,10 @@ fun OnboardingPlusBottomSheet(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .background(Color(0xFF282829))
+            .verticalScroll(rememberScrollState())
+            .windowInsetsPadding(WindowInsets.statusBars)
             .padding(horizontal = 20.dp)
             .padding(top = 20.dp, bottom = 40.dp)
-            .verticalScroll(rememberScrollState())
     ) {
 
         Pill()

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/ThemedTopAppBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/ThemedTopAppBar.kt
@@ -33,6 +33,7 @@ sealed class NavigationButton(val image: ImageVector, val contentDescription: In
 
 @Composable
 fun ThemedTopAppBar(
+    modifier: Modifier = Modifier,
     title: String? = null,
     navigationButton: NavigationButton = NavigationButton.Back,
     iconColor: Color = MaterialTheme.theme.colors.secondaryIcon01,
@@ -40,7 +41,7 @@ fun ThemedTopAppBar(
     backgroundColor: Color = MaterialTheme.theme.colors.secondaryUi01,
     bottomShadow: Boolean = false,
     actions: @Composable RowScope.() -> Unit = {},
-    onNavigationClick: () -> Unit
+    onNavigationClick: () -> Unit,
 ) {
     TopAppBar(
         navigationIcon = {
@@ -61,9 +62,9 @@ fun ThemedTopAppBar(
         actions = actions,
         backgroundColor = backgroundColor,
         elevation = 0.dp,
-        modifier = if (bottomShadow) Modifier
+        modifier = if (bottomShadow) modifier
             .zIndex(1f)
-            .shadow(4.dp) else Modifier
+            .shadow(4.dp) else modifier
     )
 }
 


### PR DESCRIPTION
| 📘 Project: #524  |
| --- |

## Description
This PR does two things:
1. Improve spacing around the text on the initial onboarding screen so that the text is centered between the artwork and the buttons
2. Makes the onboarding screens edge-to-edge

## Testing Instructions

### 1. Initial Onboarding Screen Text
Check that the text is centered between the artwork and the buttons with different font sizes

### 2. Edge-to-Edge
Check each of the onboarding screens to ensure that the screen is edge to edge and that the status bar and navigation bars look ok:
1. Log in or Signup
2. Create account
3. Log in
4. Forgot password
5. Recommendations
6. Recommendations search
7. Plus features
8. Welcome (now with an awesome confetti animation 🎉 )
9. Import
10. Import from X 

When testing these screens, it would be a good idea to test with three different themes:
1. A light theme
2. A dark theme
3. In addition, I found that there was some trickiness around the themes that are light with a dark app bar (Indigo and Classic), so it would be good to check one of those as well.

I was torn about how to handle the Plus upgrade screen because it looked much better without a status bar scrim with a normal font size, but if a bigger font was used where it was possible to scroll, then the status bar icons and the screen text would overlap and not look great. The best solution I came up with was to animate a scrim into/out-of place depending on the scroll position. Let me know if you see any issues with that.

## Screenshots or Screencast 

<details>
<summary>Initial onboarding</summary>

![Screenshot 2022-12-14 at 5 23 28 PM](https://user-images.githubusercontent.com/4656348/207728110-94875f1d-2911-4276-9d49-8d5dc8543708.png)

</details>


<details>


<summary>Create account</summary>

![Screenshot 2022-12-14 at 5 23 38 PM](https://user-images.githubusercontent.com/4656348/207728127-a054fb97-1128-4001-a058-11801374ee2b.png)

</details>

<details>
<summary>Log in</summary>

![Screenshot 2022-12-14 at 5 23 43 PM](https://user-images.githubusercontent.com/4656348/207728145-156d34d8-6f47-4626-a1c6-6da23e7624a2.png)

</details>

<details>
<summary>Forgot password</summary>

![Screenshot 2022-12-14 at 5 23 48 PM](https://user-images.githubusercontent.com/4656348/207728153-e75bf2ea-0f5f-4cf1-bb95-4ded34a6d07c.png)

</details>


<details>
<summary>Recommendations</summary>

![Screenshot 2022-12-14 at 5 22 18 PM](https://user-images.githubusercontent.com/4656348/207728175-9ef8461e-a410-4e61-aa55-5c01e870947a.png)

</details>


<details>
<summary>Plus upgrade</summary>

![Screenshot 2022-12-14 at 5 22 25 PM](https://user-images.githubusercontent.com/4656348/207728190-568c698e-5a17-4271-86e8-b9d5e2dbd08c.png)

</details>


<details>
<summary>Welcome</summary>

![Screenshot 2022-12-14 at 5 22 41 PM](https://user-images.githubusercontent.com/4656348/207728204-361b249f-c3e2-4b82-8d6c-351013b50f3d.png)

</details>

<details>
<summary>Import</summary>

![Screenshot 2022-12-14 at 5 22 49 PM](https://user-images.githubusercontent.com/4656348/207728214-40a3ea77-92d9-4532-802a-80a1159e9c77.png)

</details>


<details>
<summary>Import from...</summary>

![Screenshot 2022-12-14 at 5 22 59 PM](https://user-images.githubusercontent.com/4656348/207728234-9c821cb3-b529-4091-8940-9705c60db856.png)

</details>


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack
