### PR TITLE
Enable autolink for podcast descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,9 @@
 
 *   New Features:
     * Add End of Year stats
-      ([#410](https://github.com/Automattic/pocket-casts-android/issues/410)).
+        ([#410](https://github.com/Automattic/pocket-casts-android/issues/410)).  
     * Support Android 13 per-app language preferences
-      ([#519](https://github.com/Automattic/pocket-casts-android/pull/519)).
+        ([#519](https://github.com/Automattic/pocket-casts-android/pull/519)).
 *   Bug Fixes:
     *   Fixed some layout issues in the EpisodeFragment
         ([#459](https://github.com/Automattic/pocket-casts-android/pull/459)).
@@ -155,7 +155,7 @@
 7.21.0
 -----
 
-*   Bug Fixes:
+*   Bug Fixes:    
     *   Fix the mini player's play icon showing the wrong icon.
         ([#208](https://github.com/Automattic/pocket-casts-android/pull/208)).
     *   Fix dark theme background color.
@@ -187,7 +187,7 @@
 7.20.2
 -----
 
-*   Bug Fixes:
+*   Bug Fixes:    
     *   Fix OPML import.
     *   Fix podcasts and folders rearrange crash.
         ([#200](https://github.com/Automattic/pocket-casts-android/issues/200)).
@@ -216,7 +216,7 @@
         ([#3314](https://github.com/shiftyjelly/pocketcasts-android/issues/3314)).
     *   Improve speed of Automotive app
         ([#3330](https://github.com/shiftyjelly/pocketcasts-android/pull/3330)).
-*   Bug Fixes:
+*   Bug Fixes:    
     *   Import latest localizations.
     *   Up Next total time duration is no longer limited to 596h 31m.
     *   Fix video player out of memory issues
@@ -236,20 +236,20 @@
     *   Fix progress bar issue when playback is paused
         ([#3295](https://github.com/shiftyjelly/pocketcasts-android/issues/3295)).
     *   Fix discover single episode colors
-        ([#3288](https://github.com/shiftyjelly/pocketcasts-android/issues/3288)).
+        ([#3288](https://github.com/shiftyjelly/pocketcasts-android/issues/3288)).    
     *   Fix podcast website url
         ([#3290](https://github.com/shiftyjelly/pocketcasts-android/issues/3290)).
     *   Fix localizations
         ([#3277](https://github.com/shiftyjelly/pocketcasts-android/pull/3277)).
-    *   Improve warning when streaming will use metered data
+    *   Improve warning when streaming will use metered data 
         ([#3246](https://github.com/shiftyjelly/pocketcasts-android/pull/3426)).
-    *   Fix crash when switching to podcast without chapters
+    *   Fix crash when switching to podcast without chapters 
         ([#3450](https://github.com/shiftyjelly/pocketcasts-android/pull/3450)).
     *   Improve sharing a list of podcasts
         ([#97](https://github.com/shiftyjelly/pocketcasts-android/pull/97)).
     *   Fix displaying previous show notes briefly when switching episodes.
         ([#35](https://github.com/Automattic/pocket-casts-android/pull/35)).
-    *   Fix same chapter click behaviour
+    *   Fix same chapter click behaviour 
         ([#59](https://github.com/Automattic/pocket-casts-android/pull/59)).
     *   Replace duration with time left on episode screen from listening history  
         ([#83](https://github.com/Automattic/pocket-casts-android/pull/83)).
@@ -272,7 +272,7 @@
     *   Add two new localizations French (Canada) and Spanish (Mexico).
 *   Health:
     *   Migrate app to Android 12 by targeting the SDK version 31.
-*   Bug Fixes:
+*   Bug Fixes:    
     *   Import latest localizations.
     *   Fix localization layout
         ([#3173](https://github.com/shiftyjelly/pocketcasts-android/pull/3173)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.30
 -----
-
+* New Features:
+    *   Add tappable links to podcast description
+        ([#657](https://github.com/Automattic/pocket-casts-android/pull/657)).
 
 7.29
 -----
@@ -35,9 +37,9 @@
 
 *   New Features:
     * Add End of Year stats
-        ([#410](https://github.com/Automattic/pocket-casts-android/issues/410)).  
+      ([#410](https://github.com/Automattic/pocket-casts-android/issues/410)).
     * Support Android 13 per-app language preferences
-        ([#519](https://github.com/Automattic/pocket-casts-android/pull/519)).
+      ([#519](https://github.com/Automattic/pocket-casts-android/pull/519)).
 *   Bug Fixes:
     *   Fixed some layout issues in the EpisodeFragment
         ([#459](https://github.com/Automattic/pocket-casts-android/pull/459)).
@@ -153,7 +155,7 @@
 7.21.0
 -----
 
-*   Bug Fixes:    
+*   Bug Fixes:
     *   Fix the mini player's play icon showing the wrong icon.
         ([#208](https://github.com/Automattic/pocket-casts-android/pull/208)).
     *   Fix dark theme background color.
@@ -185,7 +187,7 @@
 7.20.2
 -----
 
-*   Bug Fixes:    
+*   Bug Fixes:
     *   Fix OPML import.
     *   Fix podcasts and folders rearrange crash.
         ([#200](https://github.com/Automattic/pocket-casts-android/issues/200)).
@@ -214,7 +216,7 @@
         ([#3314](https://github.com/shiftyjelly/pocketcasts-android/issues/3314)).
     *   Improve speed of Automotive app
         ([#3330](https://github.com/shiftyjelly/pocketcasts-android/pull/3330)).
-*   Bug Fixes:    
+*   Bug Fixes:
     *   Import latest localizations.
     *   Up Next total time duration is no longer limited to 596h 31m.
     *   Fix video player out of memory issues
@@ -234,20 +236,20 @@
     *   Fix progress bar issue when playback is paused
         ([#3295](https://github.com/shiftyjelly/pocketcasts-android/issues/3295)).
     *   Fix discover single episode colors
-        ([#3288](https://github.com/shiftyjelly/pocketcasts-android/issues/3288)).    
+        ([#3288](https://github.com/shiftyjelly/pocketcasts-android/issues/3288)).
     *   Fix podcast website url
         ([#3290](https://github.com/shiftyjelly/pocketcasts-android/issues/3290)).
     *   Fix localizations
         ([#3277](https://github.com/shiftyjelly/pocketcasts-android/pull/3277)).
-    *   Improve warning when streaming will use metered data 
+    *   Improve warning when streaming will use metered data
         ([#3246](https://github.com/shiftyjelly/pocketcasts-android/pull/3426)).
-    *   Fix crash when switching to podcast without chapters 
+    *   Fix crash when switching to podcast without chapters
         ([#3450](https://github.com/shiftyjelly/pocketcasts-android/pull/3450)).
     *   Improve sharing a list of podcasts
         ([#97](https://github.com/shiftyjelly/pocketcasts-android/pull/97)).
     *   Fix displaying previous show notes briefly when switching episodes.
         ([#35](https://github.com/Automattic/pocket-casts-android/pull/35)).
-    *   Fix same chapter click behaviour 
+    *   Fix same chapter click behaviour
         ([#59](https://github.com/Automattic/pocket-casts-android/pull/59)).
     *   Replace duration with time left on episode screen from listening history  
         ([#83](https://github.com/Automattic/pocket-casts-android/pull/83)).
@@ -270,7 +272,7 @@
     *   Add two new localizations French (Canada) and Spanish (Mexico).
 *   Health:
     *   Migrate app to Android 12 by targeting the SDK version 31.
-*   Bug Fixes:    
+*   Bug Fixes:
     *   Import latest localizations.
     *   Fix localization layout
         ([#3173](https://github.com/shiftyjelly/pocketcasts-android/pull/3173)).

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_bottom.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_bottom.xml
@@ -60,6 +60,7 @@
             android:layout_marginEnd="16dp"
             android:layout_marginStart="16dp"
             android:layout_marginTop="18dp"
+            android:autoLink="all"
             android:includeFontPadding="false"
             android:lineSpacingMultiplier="1.3"
             android:textAppearance="?attr/textBody1"

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_bottom.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_bottom.xml
@@ -66,6 +66,7 @@
             android:textAppearance="?attr/textBody1"
             android:text="@{podcast.podcastDescription}"
             android:textColor="?attr/primary_text_01"
+            android:textColorLink="@{tintColor}"
             app:readMore="@{3}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## Description
Enable autolink on podcast descriptions to allow you to click on urls. This should also support email addresses, but I haven't found any podcasts to test that on.

## Testing Instructions
1. Open a podcast with a link in their description. Up First and Waveform have them.
2. Ensure you can tap on them to open the browser
3. Ensure the color of these links matches the tintColor of the podcast

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md

## Before & After
<img width="300" alt="Before" src="https://user-images.githubusercontent.com/6628497/207758656-dd9911c7-a6a2-468f-a59b-b62d49d8d3e3.png">  <img width="300" alt="After" src="https://user-images.githubusercontent.com/6628497/207758673-6e63c843-f69a-4f0e-a551-c1f2754d594f.png">