### PR TITLE
Reduce size of "Not Now" button

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
@@ -43,7 +43,6 @@ import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowTextButton
 import au.com.shiftyjelly.pocketcasts.compose.components.RectangleCover
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.images.HorizontalLogo
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
@@ -88,7 +87,7 @@ internal fun OnboardingLoginOrSignUpPage(
             )
 
             Box(Modifier.weight(1f)) {
-                TextH30(
+                TextH40(
                     text = stringResource(LR.string.not_now),
                     textAlign = TextAlign.End,
                     modifier = Modifier


### PR DESCRIPTION
| 📘 Project: #524  |
| --- |

## Description
I noticed that the designs call for the "Not Now" button to be H40 instead of H30. This makes that update, but take a look and let me know what you think because although the designs specify H30, the button in the designs uses a slightly larger font (16) than we have for H30 [in the app](https://github.com/Automattic/pocket-casts-android/blob/0db6f36f113d771ece6b5f5a62139cf4d27f0afe/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt#L138) (15).

Related discussion: p1671091615388669-slack-C02A333D8LQ

## Testing Instructions
Just see how the button looks. Let's hold off on merging this until @adamzelinski chimes in with his thoughts.

## Screenshots or Screencast 
| Before (H30) | After (H30) |
| --- | --- |
| ![Screenshot 2022-12-15 at 8 00 39 AM](https://user-images.githubusercontent.com/4656348/207868521-02e3b21c-31ba-4602-92e8-05685b910b3a.png) | ![Screenshot 2022-12-15 at 7 59 33 AM](https://user-images.githubusercontent.com/4656348/207868536-d35a9f2e-2d9c-4f66-8d8e-2c21f0c53d8e.png) |


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack