### PR TITLE
Task/onboarding flow 20 update sub selection design

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusBottomSheet.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusBottomSheet.kt
@@ -91,7 +91,7 @@ fun OnboardingPlusBottomSheet(
             // Using LazyColumn instead of Column to avoid issue where unselected button that was not
             // being tapped would sometimes display the on-touch ripple effect
             Column(
-                verticalArrangement = Arrangement.spacedBy(16.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
                 subscriptions.forEach { subscription ->
 
@@ -106,21 +106,28 @@ fun OnboardingPlusBottomSheet(
                         ?.numPeriodFreeTrial(resources)
                         ?.uppercase(Locale.getDefault())
 
-                    if (subscription == state.selectedSubscription) {
-                        PlusOutlinedRowButton(
-                            text = text,
-                            topText = topText,
-                            onClick = { viewModel.updateSelectedSubscription(subscription) },
-                            interactionSource = interactionSource,
-                            selectedCheckMark = true,
-                        )
-                    } else {
-                        UnselectedPlusOutlinedRowButton(
-                            text = text,
-                            topText = topText,
-                            onClick = { viewModel.updateSelectedSubscription(subscription) },
-                            interactionSource = interactionSource,
-                        )
+                    Column {
+
+                        if (topText == null) {
+                            Spacer(Modifier.height(8.dp))
+                        }
+
+                        if (subscription == state.selectedSubscription) {
+                            PlusOutlinedRowButton(
+                                text = text,
+                                topText = topText,
+                                onClick = { viewModel.updateSelectedSubscription(subscription) },
+                                interactionSource = interactionSource,
+                                selectedCheckMark = true,
+                            )
+                        } else {
+                            UnselectedPlusOutlinedRowButton(
+                                text = text,
+                                topText = topText,
+                                onClick = { viewModel.updateSelectedSubscription(subscription) },
+                                interactionSource = interactionSource,
+                            )
+                        }
                     }
                 }
             }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusBottomSheet.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusBottomSheet.kt
@@ -12,11 +12,8 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBars
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
@@ -75,9 +72,8 @@ fun OnboardingPlusBottomSheet(
         modifier = Modifier
             .background(Color(0xFF282829))
             .verticalScroll(rememberScrollState())
-            .windowInsetsPadding(WindowInsets.statusBars)
             .padding(horizontal = 20.dp)
-            .padding(top = 20.dp, bottom = 40.dp)
+            .padding(top = 16.dp, bottom = 40.dp)
     ) {
 
         Pill()

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusBottomSheet.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusBottomSheet.kt
@@ -10,7 +10,6 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -19,7 +18,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
@@ -34,7 +32,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -44,7 +41,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusFeatures.PlusOutlinedRowButton
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusFeatures.PlusRowButton
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusFeatures.UnselectedPlusOutlinedRowButton
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusFeatures.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusBottomSheetState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusBottomSheetViewModel
 import au.com.shiftyjelly.pocketcasts.compose.bottomsheet.Pill
@@ -95,48 +91,11 @@ fun OnboardingPlusBottomSheet(
 
         if (state is OnboardingPlusBottomSheetState.Loaded) {
             Spacer(Modifier.height(16.dp))
-            AnimatedVisibility(
-                visible = state.showTrialInfo,
-                enter = expandVertically(
-                    expandFrom = Alignment.Top,
-                    animationSpec = animationSpec,
-                ),
-                exit = shrinkVertically(
-                    shrinkTowards = Alignment.Top,
-                    animationSpec = animationSpec,
-                ),
-            ) {
-                Box(
-                    Modifier
-                        .padding(bottom = 16.dp)
-                        .background(
-                            brush = plusGradientBrush,
-                            shape = RoundedCornerShape(4.dp)
-                        )
-                ) {
-                    state
-                        .mostRecentlySelectedTrialPhase
-                        ?.numPeriodFreeTrial(resources)
-                        ?.uppercase(Locale.getDefault())
-                        ?.let { text ->
-                            TextP60(
-                                text = text,
-                                color = Color.Black,
-                                textAlign = TextAlign.Center,
-                                fontWeight = FontWeight.SemiBold,
-                                modifier = Modifier.padding(
-                                    horizontal = 12.dp,
-                                    vertical = 4.dp
-                                ),
-                            )
-                        }
-                }
-            }
 
             // Using LazyColumn instead of Column to avoid issue where unselected button that was not
             // being tapped would sometimes display the on-touch ripple effect
             Column(
-                verticalArrangement = Arrangement.spacedBy(16.dp)
+                verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 subscriptions.forEach { subscription ->
 
@@ -145,42 +104,50 @@ fun OnboardingPlusBottomSheet(
                     // as the user changes selections.
                     val interactionSource = remember(subscription) { MutableInteractionSource() }
 
+                    val text = subscription.recurringPricingPhase.pricePerPeriod(resources)
+                    val topText = subscription
+                        .trialPricingPhase
+                        ?.numPeriodFreeTrial(resources)
+                        ?.uppercase(Locale.getDefault())
+
                     if (subscription == state.selectedSubscription) {
                         PlusOutlinedRowButton(
-                            text = subscription.recurringPricingPhase.pricePerPeriod(resources),
-                            selectedCheckMark = true,
+                            text = text,
+                            topText = topText,
+                            onClick = { viewModel.updateSelectedSubscription(subscription) },
                             interactionSource = interactionSource,
-                            onClick = { viewModel.updateSelectedSubscription(subscription) }
+                            selectedCheckMark = true,
                         )
                     } else {
                         UnselectedPlusOutlinedRowButton(
-                            text = subscription.recurringPricingPhase.pricePerPeriod(resources),
+                            text = text,
+                            topText = topText,
                             onClick = { viewModel.updateSelectedSubscription(subscription) },
-                            interactionSource = interactionSource
-
+                            interactionSource = interactionSource,
                         )
                     }
                 }
             }
 
-            AnimatedVisibility(
-                visible = state.showTrialInfo,
-                enter = expandVertically(animationSpec),
-                exit = shrinkVertically(animationSpec),
-            ) {
-                state.mostRecentlySelectedTrialPhase?.let { trialPhase ->
-                    val text = stringResource(
+            val descriptionText = state.selectedSubscription.trialPricingPhase.let { trialPhase ->
+                if (trialPhase != null) {
+                    stringResource(
                         LR.string.onboarding_plus_recurring_after_free_trial,
                         recurringAfterString(trialPhase, resources)
                     )
-                    TextP60(
-                        text = text,
-                        color = Color.White,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(top = 16.dp)
-                    )
+                } else {
+                    val firstLine = stringResource(state.selectedSubscription.recurringPricingPhase.renews)
+                    val secondLine = stringResource(LR.string.onboarding_plus_can_be_canceled_at_any_time)
+                    "$firstLine.\n$secondLine"
                 }
             }
+
+            TextP60(
+                text = descriptionText,
+                color = Color.White,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 16.dp)
+            )
 
             AnimatedVisibility(
                 visible = state.purchaseFailed,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusUpgradeFlow.kt
@@ -4,7 +4,9 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -29,17 +31,26 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.constraintlayout.compose.ConstrainedLayoutReference
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.ConstraintLayoutScope
 import androidx.hilt.navigation.compose.hiltViewModel
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusFeatures.PlusOutlinedRowButton
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusFeatures.UnselectedPlusOutlinedRowButton
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusBottomSheetState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusBottomSheetViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusFeaturesViewModel
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.extensions.brush
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import kotlinx.coroutines.NonDisposableHandle.parent
 import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 
@@ -130,6 +141,7 @@ object OnboardingPlusFeatures {
         0f to Color(0xFFFED745),
         1f to Color(0xFFFEB525),
     )
+    val unselectedColor = Color(0xFF666666)
 
     @Composable
     fun PlusRowButton(
@@ -167,72 +179,165 @@ object OnboardingPlusFeatures {
     @Composable
     fun PlusOutlinedRowButton(
         text: String,
+        topText: String? = null,
         onClick: () -> Unit,
         selectedCheckMark: Boolean = false,
         interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
         modifier: Modifier = Modifier,
     ) {
-        Button(
-            onClick = onClick,
-            shape = RoundedCornerShape(12.dp),
-            border = BorderStroke(2.dp, plusGradientBrush),
-            elevation = null,
-            interactionSource = interactionSource,
-            colors = ButtonDefaults.outlinedButtonColors(backgroundColor = Color.Transparent),
-            modifier = modifier,
-        ) {
 
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
+        ConstraintLayout(modifier) {
+
+            val buttonRef = createRef()
+            Button(
+                onClick = onClick,
+                shape = RoundedCornerShape(12.dp),
+                border = BorderStroke(2.dp, plusGradientBrush),
+                elevation = null,
+                interactionSource = interactionSource,
+                colors = ButtonDefaults.outlinedButtonColors(backgroundColor = Color.Transparent),
+                modifier = Modifier.constrainAs(buttonRef) {
+                    bottom.linkTo(parent.bottom)
+                },
+            ) {
+
+                Box(Modifier.fillMaxWidth()) {
+                    TextH30(
+                        text = text,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .padding(vertical = 6.dp, horizontal = 24.dp)
+                            .align(Alignment.Center)
+                            .brush(plusGradientBrush)
+                    )
+                    if (selectedCheckMark) {
+                        Icon(
+                            painter = painterResource(IR.drawable.plus_check),
+                            contentDescription = null,
+                            modifier = Modifier
+                                .brush(plusGradientBrush)
+                                .align(Alignment.CenterEnd)
+                                .width(24.dp)
+                        )
+                    }
+                }
+            }
+
+            if (topText != null) {
+                TopText(
+                    buttonRef = buttonRef,
+                    topText = topText,
+                    selected = true
+                )
+            }
+        }
+    }
+    @Composable
+    fun UnselectedPlusOutlinedRowButton(
+        text: String,
+        topText: String? = null,
+        onClick: () -> Unit,
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+        modifier: Modifier = Modifier,
+    ) {
+        ConstraintLayout(modifier) {
+
+            val buttonRef = createRef()
+            Button(
+                onClick = onClick,
+                shape = RoundedCornerShape(12.dp),
+                border = BorderStroke(2.dp, unselectedColor),
+                elevation = null,
+                interactionSource = interactionSource,
+                colors = ButtonDefaults.outlinedButtonColors(backgroundColor = Color.Transparent),
+                modifier = Modifier.constrainAs(buttonRef) {
+                    bottom.linkTo(parent.bottom)
+                },
             ) {
                 TextH30(
                     text = text,
                     textAlign = TextAlign.Center,
+                    color = unselectedColor,
                     modifier = Modifier
-                        .padding(top = 6.dp, bottom = 6.dp, start = 6.dp, end = 24.dp)
-                        .align(Alignment.Center)
-                        .brush(plusGradientBrush)
+                        .fillMaxWidth()
+                        .padding(vertical = 6.dp, horizontal = 24.dp)
                 )
-                if (selectedCheckMark) {
-                    Icon(
-                        painter = painterResource(IR.drawable.plus_check),
-                        contentDescription = null,
-                        modifier = Modifier
-                            .brush(plusGradientBrush)
-                            .align(Alignment.CenterEnd)
-                            .width(24.dp)
-                    )
-                }
+            }
+
+            if (topText != null) {
+                TopText(
+                    buttonRef = buttonRef,
+                    topText = topText,
+                    selected = false
+                )
             }
         }
     }
 
     @Composable
-    fun UnselectedPlusOutlinedRowButton(
-        text: String,
-        onClick: () -> Unit,
-        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-        modifier: Modifier = Modifier,
+    private fun ConstraintLayoutScope.TopText(
+        buttonRef: ConstrainedLayoutReference,
+        topText: String,
+        selected: Boolean,
     ) {
-        val unselectedColor = Color.White.copy(alpha = 0.4f)
-        Button(
-            onClick = onClick,
-            shape = RoundedCornerShape(12.dp),
-            border = BorderStroke(2.dp, unselectedColor),
-            elevation = null,
-            interactionSource = interactionSource,
-            colors = ButtonDefaults.outlinedButtonColors(backgroundColor = Color.Transparent),
-            modifier = modifier
-        ) {
-            TextH30(
-                text = text,
-                textAlign = TextAlign.Center,
+        val modifier = if (selected) {
+            Modifier.background(
+                brush = plusGradientBrush,
+                shape = RoundedCornerShape(4.dp)
+            )
+        } else {
+            Modifier.background(
                 color = unselectedColor,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(6.dp)
+                shape = RoundedCornerShape(4.dp)
             )
         }
+
+        val topTextRef = createRef()
+        Box(
+            modifier.constrainAs(topTextRef) {
+                top.linkTo(buttonRef.top)
+                bottom.linkTo(buttonRef.top)
+                start.linkTo(parent.start)
+                end.linkTo(parent.end)
+            }
+        ) {
+            TextP60(
+                text = topText,
+                color = Color.Black,
+                textAlign = TextAlign.Center,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.padding(
+                    horizontal = 12.dp,
+                    vertical = 2.dp
+                ),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun OutlinedButtonPreview() {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        PlusOutlinedRowButton(
+            text = "one this is way too long | | | | | | | | | | |",
+            selectedCheckMark = true,
+            onClick = {},
+        )
+        PlusOutlinedRowButton(
+            text = "two",
+            topText = "woohoo!",
+            selectedCheckMark = true,
+            onClick = {},
+        )
+        UnselectedPlusOutlinedRowButton(
+            text = "three",
+            onClick = {},
+        )
+        UnselectedPlusOutlinedRowButton(
+            text = "four this is also way too long | | | | | | |",
+            topText = "woohoo!",
+            onClick = {},
+        )
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1504,6 +1504,7 @@
     <string name="onboarding_plus_terms_and_conditions">Terms and Conditions</string>
     <string name="onboarding_plus_start_free_trial_and_subscribe">Start Free Trial &amp; Subscribe</string>
     <string name="onboarding_plus_recurring_after_free_trial">Recurring payments will begin after your %s</string>
+    <string name="onboarding_plus_can_be_canceled_at_any_time">Can be canceled at any time.</string>
     <string name="onboarding_welcome_get_you_listening">Welcome, now let\'s get you listening!</string>
     <string name="onboarding_welcome_get_you_listening_plus">Thank you, now let\'s get you listening!</string>
     <string name="onboarding_welcome_recommendations_title">Discover something new</string>


### PR DESCRIPTION
| 📘 Project: #524  |
| --- |

## Description
Updates the subscription selection bottom modal with new designs (p1669080905462829/1668645351.529999-slack-C04AV00GV39).

In addition, this PR removes some extra padding I accidentally added to the top of that modal in [an earlier PR](https://github.com/Automattic/pocket-casts-android/pull/656).

## Testing Instructions
1. Using a build that can access our subscriptions from the google play store and that has the test subscription with the 4-day trial active, proceed through the onboarding flow until you get to the feature upgrade screen.
2. Tap "Unlock All Features"
3. Observe that the UI matches the updated designs linked-to above.

## Screenshots or Screencast 

https://user-images.githubusercontent.com/4656348/207967412-0da6b569-bc8c-4925-900f-4b90985e5595.mov


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack