### PR TITLE
Onboarding: Support login dynamic artwork

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
@@ -1,4 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding
+
 import android.content.res.Configuration
 import android.content.res.Configuration.ORIENTATION_LANDSCAPE
 import android.widget.Toast
@@ -47,6 +48,7 @@ import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowTextButton
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastCover
 import au.com.shiftyjelly.pocketcasts.compose.components.RectangleCover
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
@@ -54,6 +56,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.images.HorizontalLogo
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
@@ -125,7 +128,7 @@ internal fun OnboardingLoginOrSignUpPage(
 
         Spacer(Modifier.height(32.dp))
 
-        Artwork(viewModel.showContinueWithGoogleButton)
+        Artwork(viewModel.showContinueWithGoogleButton, viewModel.randomPodcasts)
 
         Spacer(Modifier.weight(1f))
 
@@ -173,8 +176,12 @@ internal fun OnboardingLoginOrSignUpPage(
         Spacer(Modifier.windowInsetsPadding(WindowInsets.navigationBars))
     }
 }
+
 @Composable
-private fun Artwork(googleSignInShown: Boolean) {
+private fun Artwork(
+    googleSignInShown: Boolean,
+    podcasts: List<Podcast>,
+) {
     val context = LocalContext.current
     val localView = LocalView.current
     val configuration = LocalConfiguration.current
@@ -194,17 +201,26 @@ private fun Artwork(googleSignInShown: Boolean) {
             .fillMaxWidth()
             .offset(x = artworkWidth * Artwork.getOffsetFactor(googleSignInShown))
     ) {
-        Artwork.coverModels.map { model ->
-            RectangleCover(
+        Artwork.coverModels.mapIndexed { index, model ->
+            val coverWidth = (artworkWidth * model.size).coerceAtMost(artworkHeight / 2f)
+            val modifier = Modifier
+                .offset(
+                    x = artworkWidth * model.x,
+                    y = artworkHeight * model.y * Artwork.getCoverYOffsetFactor(configuration)
+                )
+            val podcast = if (index < podcasts.size) podcasts[index] else null
+            podcast?.let {
+                PodcastCover(
+                    uuid = it.uuid,
+                    coverWidth = coverWidth,
+                    cornerRadius = 4.dp,
+                    modifier = modifier
+                )
+            } ?: RectangleCover(
                 imageResId = model.imageResId,
-                coverWidth = (artworkWidth * model.size)
-                    .coerceAtMost(artworkHeight / 2f),
+                coverWidth = coverWidth,
                 cornerRadius = 4.dp,
-                modifier = Modifier
-                    .offset(
-                        x = artworkWidth * model.x,
-                        y = artworkHeight * model.y * Artwork.getCoverYOffsetFactor(configuration)
-                    )
+                modifier = modifier
             )
         }
     }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastCover.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastCover.kt
@@ -21,11 +21,13 @@ fun PodcastCover(
     coverWidth: Dp,
     modifier: Modifier = Modifier,
     coverSize: CoverSize = CoverSize.SMALL,
+    cornerRadius: Dp? = null,
 ) {
+    val cornerRadiusSize = cornerRadius ?: if (coverSize == CoverSize.SMALL) 4.dp else 8.dp
     PodcastImage(
         uuid = uuid,
         elevation = if (coverSize == CoverSize.SMALL) 4.dp else 8.dp,
-        cornerSize = if (coverSize == CoverSize.SMALL) 4.dp else 8.dp,
+        cornerSize = cornerRadiusSize,
         modifier = modifier.size(coverWidth)
     )
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -361,4 +361,7 @@ abstract class PodcastDao {
         """
     )
     abstract suspend fun findTopPodcasts(fromEpochMs: Long, toEpochMs: Long, limit: Int): List<TopPodcast>
+
+    @Query("SELECT * FROM podcasts ORDER BY random() LIMIT :limit")
+    abstract fun findRandomPodcasts(limit: Int): List<Podcast>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -141,4 +141,6 @@ interface PodcastManager {
     suspend fun refreshPodcastFeed(podcastUuid: String): Boolean
 
     suspend fun findTopPodcasts(fromEpochMs: Long, toEpochMs: Long, limit: Int): List<TopPodcast>
+
+    fun findRandomPodcasts(limit: Int): List<Podcast>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -761,4 +761,8 @@ class PodcastManagerImpl @Inject constructor(
 
     override suspend fun findTopPodcasts(fromEpochMs: Long, toEpochMs: Long, limit: Int): List<TopPodcast> =
         podcastDao.findTopPodcasts(fromEpochMs, toEpochMs, limit)
+
+    override fun findRandomPodcasts(limit: Int): List<Podcast> {
+        return podcastDao.findRandomPodcasts(limit)
+    }
 }


### PR DESCRIPTION
| 📘 Project: #524  |
| --- |

## Description

This populates login artwork icons from local DB podcasts if they're available. 

## Testing Instructions

1. Comment out `lines 191, 193, and 195` in `MainActivity` so that onboarding flow is launched every time when app restarts
2. Login with an account with some podcasts
3. Restart the app
4. Notice that 
    - Artwork is populated with icons from random podcasts available in local DB
    - If local DB podcasts count is less than the max count (6), then default icons are shown

## Screenshots or Screencast 
<img width=320 src="https://user-images.githubusercontent.com/1405144/208103259-06d0d3a3-1e27-4f5e-a575-e42e71cb132d.png"/>


## Checklist
- If this is a user-facing change, I have added an entry in CHANGELOG.md
- I have considered whether it makes sense to add tests for my changes
- All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- with different themes
- with a landscape orientation
- with the device set to have a large display and font size
- for accessibility with TalkBack
