### PR TITLE
Replace "Not Now" button with X icon

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
@@ -7,7 +7,6 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -44,12 +43,13 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.R
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingLoginOrSignUpViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
+import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowTextButton
 import au.com.shiftyjelly.pocketcasts.compose.components.RectangleCover
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.images.HorizontalLogo
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
@@ -100,7 +100,16 @@ internal fun OnboardingLoginOrSignUpPage(
                 .padding(vertical = 12.dp, horizontal = 16.dp)
                 .fillMaxWidth()
         ) {
-            Spacer(Modifier.weight(1f))
+            Box(Modifier.weight(1f)) {
+                NavigationIconButton(
+                    iconColor = MaterialTheme.theme.colors.primaryText01,
+                    navigationButton = NavigationButton.Close,
+                    onNavigationClick = {
+                        viewModel.onDismiss(flow)
+                        onDismiss()
+                    }
+                )
+            }
 
             HorizontalLogo(
                 modifier = Modifier
@@ -108,19 +117,7 @@ internal fun OnboardingLoginOrSignUpPage(
                     .height(28.dp)
             )
 
-            Box(Modifier.weight(1f)) {
-                TextH30(
-                    text = stringResource(LR.string.not_now),
-                    textAlign = TextAlign.End,
-                    modifier = Modifier
-                        .clickable {
-                            viewModel.onDismiss(flow)
-                            onDismiss()
-                        }
-                        .padding(all = 4.dp)
-                        .align(Alignment.CenterEnd)
-                )
-            }
+            Spacer(Modifier.weight(1f))
         }
 
         Spacer(Modifier.height(32.dp))


### PR DESCRIPTION
| 📘 Project: #524  |
| --- |

## Description
Replacing the Not Now button with a close `X` icon like we use elsewhere in the app.

p1671147105113759/1671091615.388669-slack-C02A333D8LQ

> **Note**
> This PR is targeting the `release/7.29` branch.

## Testing Instructions
Verify that tapping the X button completes the onboarding flow and send off the event: `setup_account_dismissed, Properties: {"flow":"initial_onboarding"`

## Screenshots or Screencast 

| Light | Dark | Rose | Indigo |
| --- | --- | --- | --- |
| ![Screenshot 2022-12-16 at 9 07 33 AM](https://user-images.githubusercontent.com/4656348/208116158-969e02a7-e058-47a4-b6a1-ef372d1aa60c.png) | ![Screenshot 2022-12-16 at 9 09 18 AM](https://user-images.githubusercontent.com/4656348/208116324-62d1cf32-9213-4a52-b77b-2fe2dff4382b.png) | ![Screenshot 2022-12-16 at 9 07 52 AM](https://user-images.githubusercontent.com/4656348/208116185-e8884f67-bf7e-4d1c-8b42-788595799b34.png) | ![Screenshot 2022-12-16 at 9 08 14 AM](https://user-images.githubusercontent.com/4656348/208116192-b61e0721-0ecd-4528-9bb6-57ffbccee342.png) |


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack