### PR TITLE
Lower version of accompanist

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -79,7 +79,8 @@ project.ext {
 
     // Library versions
     versionBillingClient = '5.0.0'
-    versionCompose = '1.2.1'
+    versionCompose = '1.2.1' // When updating this, also check if versionComposeAccompanist should be updated as well: https://github.com/google/accompanist#compose-versions
+    versionComposeAccompanist = '0.25.1'
     versionComposeCompiler = '1.3.0'
     versionDagger = '2.41'
     versionEspresso = '3.4.0'
@@ -236,8 +237,8 @@ project.ext {
             mockWebServer: "com.squareup.okhttp3:mockwebserver:4.9.3",
             barista: "com.adevinta.android:barista:4.2.0",
             // Accompanist - https://google.github.io/accompanist/
-            accompanistFlowLayout: "com.google.accompanist:accompanist-flowlayout:0.25.1",
-            accompanistSystemUiController: "com.google.accompanist:accompanist-systemuicontroller:0.28.0",
+            accompanistFlowLayout: "com.google.accompanist:accompanist-flowlayout:$versionComposeAccompanist",
+            accompanistSystemUiController: "com.google.accompanist:accompanist-systemuicontroller:$versionComposeAccompanist",
             // Automattic Tracks
             automatticTracks: "com.automattic:Automattic-Tracks-Android:$versionTracks",
             // Sentry


### PR DESCRIPTION
## Description
Using the `0.28.0` version of Accompanist's SystemUiController was increasing our compose version transitively from `1.2.1` to `1.3` (see note [here](https://github.com/google/accompanist#compose-versions)). I didn't intend to make that change in a beta release, so bumping that version down to `0.25.1` to get us back to `1.2.1`.

## Testing Instructions
Just do a quick smoke test of the onboarding flow to verify that it still works as expected.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
