### PR TITLE
Disable 2022 EoY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
         ([#645](https://github.com/Automattic/pocket-casts-android/pull/645)).
     *   Display gravatar on profile screen
         ([#644](https://github.com/Automattic/pocket-casts-android/pull/644)).
+    *   Remove 2022 End of Year stats flow
+        ([#672](https://github.com/Automattic/pocket-casts-android/pull/672)).
 * Bug Fixes:
     *   Fixed podcast date format
         ([#477](https://github.com/Automattic/pocket-casts-android/pull/477)).

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -531,7 +531,7 @@ class MainActivity :
     }
 
     override fun showStoriesOrAccount(source: String) {
-        if (viewModel.isSignedIn || !settings.endOfYearRequireLogin()) {
+        if (viewModel.isSignedIn) {
             showStories(StoriesSource.fromString(source))
         } else {
             viewModel.waitingForSignInToShowStories = true

--- a/base.gradle
+++ b/base.gradle
@@ -30,7 +30,6 @@ android {
 
         // Feature Flags
         buildConfigField "boolean", "END_OF_YEAR_ENABLED", "false"
-        buildConfigField "boolean", "END_OF_YEAR_REQUIRE_LOGIN", "true"
         buildConfigField "boolean", "SINGLE_SIGN_ON_ENABLED", "false"
 
         testInstrumentationRunner project.testInstrumentationRunner

--- a/base.gradle
+++ b/base.gradle
@@ -29,6 +29,7 @@ android {
         buildConfigField "String", "GOOGLE_SIGN_IN_SERVER_CLIENT_ID", "\"${project.googleSignInServerClientId}\""
 
         // Feature Flags
+        buildConfigField "boolean", "END_OF_YEAR_ENABLED", "false"
         buildConfigField "boolean", "END_OF_YEAR_REQUIRE_LOGIN", "true"
         buildConfigField "boolean", "SINGLE_SIGN_ON_ENABLED", "false"
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -602,7 +602,6 @@ interface Settings {
 
     fun setEndOfYearModalHasBeenShown(value: Boolean)
     fun getEndOfYearModalHasBeenShown(): Boolean
-    fun endOfYearRequireLogin(): Boolean
 
     fun hasCompletedOnboarding(): Boolean
     fun setHasCompletedOnboarding()

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1488,10 +1488,6 @@ class SettingsImpl @Inject constructor(
     override fun getEndOfYearModalHasBeenShown(): Boolean =
         getBoolean(END_OF_YEAR_MODAL_HAS_BEEN_SHOWN_KEY, false)
 
-    override fun endOfYearRequireLogin(): Boolean {
-        return BuildConfig.END_OF_YEAR_REQUIRE_LOGIN
-    }
-
     override fun hasCompletedOnboarding() = getBoolean(COMPLETED_ONBOARDING_KEY, false)
 
     override fun setHasCompletedOnboarding() {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -5,6 +5,7 @@ import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.db.helper.LongestEpisode
 import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.BuildConfig
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.Story
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryEpilogue
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryIntro
@@ -50,7 +51,8 @@ class EndOfYearManagerImpl @Inject constructor(
         get() = Dispatchers.Default
 
     override suspend fun isEligibleForStories(): Boolean =
-        hasEpisodesPlayedUpto(YEAR, TimeUnit.MINUTES.toSeconds(EPISODE_MINIMUM_PLAYED_TIME_IN_MIN))
+        hasEpisodesPlayedUpto(YEAR, TimeUnit.MINUTES.toSeconds(EPISODE_MINIMUM_PLAYED_TIME_IN_MIN)) &&
+            BuildConfig.END_OF_YEAR_ENABLED
 
     /**
      * Download the year's listening history.


### PR DESCRIPTION
## Description

This PR disables 2022 EoY feature.

>**Warning**
> Targets 7.29

## Testing Instructions

1. Launch the app.
2. Login with an account with some listening history (>5mins).
3. Go to the `Profile` screen.
4. Notice that EoY profile screen card is not displayed.
5. Relaunch the app.
6. Notice that EoY launch modal is not shown.

