### PR TITLE
Add categories to recommendations screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
         ([#657](https://github.com/Automattic/pocket-casts-android/pull/657)).
     *   Added new Tasker "Query Podcasts", "Query Podcast Episodes", "Query Filter", "Query Filter Episodes" and "Add To Up Next" actions.
         ([#583](https://github.com/Automattic/pocket-casts-android/pull/583)).
+    *   Add categories to recommendations screen
+        ([#675](https://github.com/Automattic/pocket-casts-android/pull/675)).
 
 7.29
 -----

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
@@ -14,12 +14,15 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.progressSemantics
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -83,7 +86,7 @@ fun OnboardingRecommendationsStartPage(
     }
 
     Content(
-        sections = state.sections,
+        state = state,
         buttonRes = state.buttonRes,
         onImportClicked = {
             viewModel.onImportClick()
@@ -104,7 +107,7 @@ fun OnboardingRecommendationsStartPage(
 
 @Composable
 private fun Content(
-    sections: List<OnboardingRecommendationsStartPageViewModel.RecommendationSection>,
+    state: OnboardingRecommendationsStartPageViewModel.State,
     buttonRes: Int,
     onImportClicked: () -> Unit,
     onSubscribeTap: (OnboardingRecommendationsStartPageViewModel.RecommendationPodcast) -> Unit,
@@ -164,12 +167,20 @@ private fun Content(
                 }
             }
 
-            sections.forEach { section ->
+            state.sections.forEach { section ->
                 section(
                     section = section,
                     onShowMore = { showMore(section.title) },
                     onSubscribeTap = onSubscribeTap
                 )
+            }
+
+            if (state.showLoadingSpinner) {
+                header {
+                    Row(horizontalArrangement = Arrangement.Center) {
+                        CircularProgressIndicator(Modifier.progressSemantics().size(48.dp))
+                    }
+                }
             }
         }
 
@@ -244,8 +255,11 @@ private fun Preview(
 ) {
     AppThemeWithBackground(themeType) {
         Content(
-            emptyList(),
-            LR.string.not_now,
+            state = OnboardingRecommendationsStartPageViewModel.State(
+                sections = emptyList(),
+                showLoadingSpinner = true,
+            ),
+            buttonRes = LR.string.not_now,
             onImportClicked = {},
             onSubscribeTap = {},
             onSearch = {},

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
@@ -40,6 +40,9 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingRecommendationsStartPageViewModel
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingRecommendationsStartPageViewModel.Podcast
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingRecommendationsStartPageViewModel.Section
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingRecommendationsStartPageViewModel.SectionId
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
@@ -97,7 +100,6 @@ fun OnboardingRecommendationsStartPage(
             viewModel.onSearch()
             onSearch()
         },
-        showMore = viewModel::showMore,
         onComplete = {
             viewModel.onComplete()
             onComplete()
@@ -110,9 +112,8 @@ private fun Content(
     state: OnboardingRecommendationsStartPageViewModel.State,
     buttonRes: Int,
     onImportClicked: () -> Unit,
-    onSubscribeTap: (OnboardingRecommendationsStartPageViewModel.RecommendationPodcast) -> Unit,
+    onSubscribeTap: (Podcast) -> Unit,
     onSearch: () -> Unit,
-    showMore: (String) -> Unit,
     onComplete: () -> Unit,
 ) {
     Column {
@@ -170,7 +171,6 @@ private fun Content(
             state.sections.forEach { section ->
                 section(
                     section = section,
-                    onShowMore = { showMore(section.title) },
                     onSubscribeTap = onSubscribeTap
                 )
             }
@@ -193,9 +193,8 @@ private fun Content(
 }
 
 private fun LazyGridScope.section(
-    section: OnboardingRecommendationsStartPageViewModel.RecommendationSection,
-    onShowMore: () -> Unit,
-    onSubscribeTap: (OnboardingRecommendationsStartPageViewModel.RecommendationPodcast) -> Unit
+    section: Section,
+    onSubscribeTap: (Podcast) -> Unit
 ) {
     if (section.visiblePodcasts.isEmpty()) return
 
@@ -242,7 +241,7 @@ private fun LazyGridScope.section(
         RowOutlinedButton(
             text = stringResource(LR.string.onboarding_recommendations_more, section.title),
             includePadding = false,
-            onClick = onShowMore,
+            onClick = section::onShowMore,
             modifier = Modifier.padding(bottom = 16.dp)
         )
     }
@@ -253,17 +252,39 @@ private fun LazyGridScope.section(
 private fun Preview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
+
+    fun podcast(isSubscribed: Boolean = false) = Podcast(
+        uuid = "5168e260-372e-013b-efad-0acc26574db2",
+        title = "Why Do We Do That?",
+        isSubscribed = isSubscribed
+    )
+
     AppThemeWithBackground(themeType) {
         Content(
             state = OnboardingRecommendationsStartPageViewModel.State(
-                sections = emptyList(),
+                sections = listOf(
+                    Section(
+                        title = "A Very Special Section",
+                        sectionId = SectionId(""),
+                        numToShow = 6,
+                        podcasts = listOf(
+                            podcast(),
+                            podcast(isSubscribed = true),
+                            podcast(),
+                            podcast(),
+                            podcast(),
+                            podcast(),
+                            podcast(),
+                        ),
+                        onShowMoreFun = {},
+                    )
+                ),
                 showLoadingSpinner = true,
             ),
             buttonRes = LR.string.not_now,
             onImportClicked = {},
             onSubscribeTap = {},
             onSearch = {},
-            showMore = {},
             onComplete = {}
         )
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.localization.helper.tryToLocalise
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -250,7 +251,7 @@ class OnboardingRecommendationsStartPageViewModel @Inject constructor(
                 .podcasts?.let { podcasts ->
                     sectionsFlow.emit(
                         sectionsFlow.value + SectionInternal(
-                            title = category.title,
+                            title = category.title.tryToLocalise(getApplication<Application>().resources),
                             podcasts = podcasts
                         )
                     )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
@@ -79,7 +79,7 @@ class OnboardingRecommendationsStartPageViewModel @Inject constructor(
     data class Section(
         val title: String,
         val sectionId: SectionId,
-        val numToShow: Int = NUM_TO_SHOW_DEFAULT,
+        val numToShow: Int,
         private val podcasts: List<Podcast>,
         private val onShowMoreFun: (Section) -> Unit,
     ) {
@@ -111,10 +111,18 @@ class OnboardingRecommendationsStartPageViewModel @Inject constructor(
                                 isSubscribed = podcast.uuid in subscriptions,
                             )
                         }
+
+                        // use the previous value if it exists
+                        val numToShow = state.value.sections
+                            .find { it.sectionId == section.sectionId }
+                            ?.numToShow
+                            ?: NUM_TO_SHOW_DEFAULT
+
                         Section(
                             title = section.title,
                             sectionId = section.sectionId,
                             podcasts = podcasts,
+                            numToShow = numToShow,
                             onShowMoreFun = ::onShowMore,
                         )
                     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
@@ -104,6 +104,7 @@ class OnboardingRecommendationsStartPageViewModel @Inject constructor(
                     }
                 combine(sectionsFlow, subscriptionsFlow) { sections, subscriptions ->
                     sections.map { section ->
+
                         val podcasts = section.podcasts.map { podcast ->
                             Podcast(
                                 uuid = podcast.uuid,
@@ -112,19 +113,16 @@ class OnboardingRecommendationsStartPageViewModel @Inject constructor(
                             )
                         }
 
-                        // use the previous value if it exists
-                        val numToShow = state.value.sections
+                        _state.value.sections
                             .find { it.sectionId == section.sectionId }
-                            ?.numToShow
-                            ?: NUM_TO_SHOW_DEFAULT
-
-                        Section(
-                            title = section.title,
-                            sectionId = section.sectionId,
-                            podcasts = podcasts,
-                            numToShow = numToShow,
-                            onShowMoreFun = ::onShowMore,
-                        )
+                            ?.copy(podcasts = podcasts) // update previous section if it exists
+                            ?: Section( // otherwise create a new section
+                                title = section.title,
+                                sectionId = section.sectionId,
+                                podcasts = podcasts,
+                                numToShow = NUM_TO_SHOW_DEFAULT,
+                                onShowMoreFun = ::onShowMore,
+                            )
                     }
                 }.collect { sections ->
                     _state.update { it.copy(sections = sections) }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -303,6 +303,7 @@ enum class AnalyticsEvent(val key: String) {
     RECOMMENDATIONS_DISMISSED("recommendations_dismissed"),
     RECOMMENDATIONS_SEARCH_TAPPED("recommendations_search_tapped"),
     RECOMMENDATIONS_IMPORT_TAPPED("recommendations_import_tapped"),
+    RECOMMENDATIONS_MORE_TAPPED("recommendations_more_tapped"),
     RECOMMENDATIONS_CONTINUE_TAPPED("recommendations_continue_tapped"),
 
     /* End of Year */

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1485,6 +1485,7 @@
     <string name="onboarding_recommendations_find_favorite_podcasts">Find your favorite podcasts</string>
     <string name="onboarding_recommendations_make_pocket_casts_yours">Make Pocket Casts yours by selecting your favorite podcasts or import them from another podcast player. You can always do this later.</string>
     <string name="onboarding_recommendations_import">Import</string>
+    <string name="onboarding_recommendations_more">More %s</string>
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">Everything you love about Pocket Casts, plus more</string>
     <string name="onboarding_upgrade_exclusive_features_and_options">Get access to exclusive features and customization options</string>
     <string name="onboarding_upgrade_unlock_all_features">Unlock All Features</string>

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModel.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModel.kt
@@ -31,7 +31,7 @@ interface NetworkLoadableList {
     }
 
     companion object {
-        private const val TRENDING = "trending"
+        const val TRENDING = "trending"
         private const val POPULAR = "popular"
         const val NONE = "none"
     }


### PR DESCRIPTION
| 📘 Project: #524  |
| --- |

## Description
Adds rows for our categories to the onboarding recommendations screen based on @adamzelinski 's [feedback](https://github.com/Automattic/pocket-casts-android/issues/524#issuecomment-1347960181).

I implemented this so that the sections are loaded one at a time. I thought this would be good for users with slow connections so that they didn't have to either wait for all the sections to load or have the sections moving around on them as the network responses came back. Let me know if you think there's a better way to handle this.

## Testing Instructions
1. Open a fresh install of the app so that the onboarding flow is triggered. You may want to also [make this change](https://gist.github.com/mchowning/f60082a45df993dd7c0fffbecb60585b) so that the onboarding flow just goes straight to the recommendations screen. Otherwise, navigate through the flow to the recommendations screen.
2. From the recommendations screen, verify that 6 podcasts are shown for each section, first "Trending" and then one section for each "category" from our Discover feed.
3. Verify that tapping the "More ____" button adds an additional 6 podcasts to that section and that the following event is sent: `recommendations_more_tapped, Properties: {"section":"trending","number_visible":6, ...`.
4. Verfiy that landscape mode also looks good and the "More ___" button works as expected.
5. Change your device's language
6. Observe that the titles of the sections change to the new language
7. Observe that the `section` part of the analytics event that gets sent when you tap one of the "More ____" buttons does _**not**_ get translated (so they remain consistent regardless of the device's language).

## Screenshots or Screencast 

https://user-images.githubusercontent.com/4656348/210627440-ff23f1e3-f1ea-43d6-bd88-db4385f81685.mov

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack
