### PR TITLE
Improving Automotive search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
         ([#583](https://github.com/Automattic/pocket-casts-android/pull/583)).
     *   Add categories to recommendations screen
         ([#675](https://github.com/Automattic/pocket-casts-android/pull/675)).
+    *   Improved the Android Automotive search
+        ([#681](https://github.com/Automattic/pocket-casts-android/pull/681)).
 
 7.29
 -----

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -133,9 +133,6 @@ abstract class EpisodeDao {
     @Query("SELECT * FROM episodes WHERE podcast_id = :podcastUuid ORDER BY published_date DESC, added_date DESC LIMIT 1")
     abstract fun findLatestRx(podcastUuid: String): Maybe<Episode>
 
-    @Query("SELECT * FROM episodes WHERE podcast_id = :podcastUuid AND playing_status != 2 ORDER BY published_date DESC LIMIT 10")
-    abstract fun findPodcastEpisodesForMediaBrowserSearch(podcastUuid: String): List<Episode>
-
     @Query("SELECT * FROM episodes WHERE (download_task_id IS NOT NULL OR episode_status == :downloadEpisodeStatusEnum OR (episode_status == :failedEpisodeStatusEnum AND last_download_attempt_date > :failedDownloadCutoff AND archived == 0)) ORDER BY last_download_attempt_date DESC")
     abstract fun observeDownloadingEpisodesIncludingFailed(failedDownloadCutoff: Long, failedEpisodeStatusEnum: EpisodeStatusEnum = EpisodeStatusEnum.DOWNLOAD_FAILED, downloadEpisodeStatusEnum: EpisodeStatusEnum = EpisodeStatusEnum.DOWNLOADED): Flowable<List<Episode>>
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -661,7 +661,7 @@ class MediaSessionManager(
      * ‘Listen to [filter name] in Pocket Casts’
      * ‘Listen to Up Next in Pocket Casts’
      * ‘Play Up Next in Pocket Casts’
-     * ‘Play New Releasees Next in Pocket Casts’
+     * ‘Play New Releases Next in Pocket Casts’
      */
     private fun performPlayFromSearch(searchTerm: String?) {
         Timber.d("performSearch $searchTerm")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -40,7 +40,6 @@ interface EpisodeManager {
     fun findLatestUnfinishedEpisodeByPodcast(podcast: Podcast): Episode?
     fun findLatestEpisodeToPlay(): Episode?
     fun observeEpisodesByPodcastOrderedRx(podcast: Podcast): Flowable<List<Episode>>
-    fun findPodcastEpisodesForMediaBrowserSearch(podcastUuid: String): List<Episode>
     fun observeEpisodesWhere(queryAfterWhere: String): Flowable<List<Episode>>
     fun observeDownloadingEpisodes(): LiveData<List<Episode>>
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -173,10 +173,6 @@ class EpisodeManagerImpl @Inject constructor(
         }
     }
 
-    override fun findPodcastEpisodesForMediaBrowserSearch(podcastUuid: String): List<Episode> {
-        return episodeDao.findPodcastEpisodesForMediaBrowserSearch(podcastUuid)
-    }
-
     override fun findEpisodesWhere(queryAfterWhere: String): List<Episode> {
         return episodeDao.findEpisodes(SimpleSQLiteQuery("SELECT episodes.* FROM episodes JOIN podcasts ON episodes.podcast_id = podcasts.uuid WHERE podcasts.subscribed = 1 AND $queryAfterWhere"))
     }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerManager.kt
@@ -1,9 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.servers
 
+import android.content.res.Resources
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.text.TextUtils
+import au.com.shiftyjelly.pocketcasts.localization.R
+import au.com.shiftyjelly.pocketcasts.localization.helper.LocaliseHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.Share
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -13,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.servers.model.AuthResultModel
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import io.reactivex.Single
 import io.reactivex.SingleEmitter
+import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.FormBody
@@ -28,6 +32,8 @@ import java.io.IOException
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 @Singleton
 open class ServerManager @Inject constructor(
@@ -117,6 +123,39 @@ open class ServerManager @Inject constructor(
                 }
             }
         )
+    }
+
+    suspend fun searchForPodcastsSuspend(searchTerm: String, resources: Resources): PodcastSearch {
+        if (searchTerm.isEmpty()) {
+            return PodcastSearch()
+        }
+        return suspendCancellableCoroutine { continuation ->
+            searchForPodcasts(
+                searchTerm = searchTerm,
+                callback = object : ServerCallback<PodcastSearch> {
+                    override fun dataReturned(result: PodcastSearch?) {
+                        if (result == null) {
+                            continuation.resumeWithException(Exception(resources.getString(R.string.error_search_failed)))
+                        } else {
+                            continuation.resume(result)
+                        }
+                    }
+
+                    override fun onFailed(
+                        errorCode: Int,
+                        userMessage: String?,
+                        serverMessageId: String?,
+                        serverMessage: String?,
+                        throwable: Throwable?,
+                    ) {
+                        val message = LocaliseHelper.serverMessageIdToMessage(serverMessageId, resources::getString)
+                            ?: userMessage
+                            ?: resources.getString(R.string.error_search_failed)
+                        continuation.resumeWithException(throwable ?: Exception(message))
+                    }
+                }
+            )
+        }
     }
 
     open fun searchForPodcastsRx(searchTerm: String): Single<PodcastSearch> {


### PR DESCRIPTION
## Description
This change improves the Automotive search. One of our partners has reported search issues. The previous search was based on our voice search which I don't believe works well in this use case. 

Fixes #663
Fixes #664

## Testing Instructions
1. Deploy the Automotive module to an Automotive emulator
2. Tap the search icon (next to the settings cog)
3. Search for 'Tech News'
4. Scroll down to 'Daily Tech News Show'
5. Tap the row
6. Tap the first episode
7. Pause the episode, close the player, tap the back button twice
8. ✅ Verify on the 'Podcasts' tab that the podcast 'Daily Tech News Show' is listed (on Automotive by default, you are subscribed to podcasts)
9. Tap the search icon again
10. Clear the search text
11. Search for 'Tech News'
12. ✅ Verify the top result is now 'Daily Tech News Show' (your subscribed to podcasts should appear first)
13. Clear the search
14. Tap on the wifi icon in the status bar
15. Turn off mobile and wifi data
16. Search for 'Material'
17. ✅ Verify the error message 'Something went wrong' is displayed. (Unfortunately I couldn't find a way to add a custom error message)

## Screenshot

![Screenshot_20230109_200641](https://user-images.githubusercontent.com/308331/211278423-e68dc773-8d5e-4255-9ddc-9ca851d9161b.png)

![Screenshot_20230109_200155](https://user-images.githubusercontent.com/308331/211277540-bb65a5b5-86cd-437d-9c88-f70cec78d81e.png)
