### PR TITLE
Disable download for newly supported HLS streams

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -258,6 +258,8 @@ class EpisodeFragment : BaseDialogFragment() {
                         binding.podcastColor = ThemeColor.podcastIcon02(activeTheme, state.podcastColor)
 
                         binding.btnDownload.tintColor = iconColor
+                        binding.btnDownload.isEnabled = !state.episode.isHLS
+                        binding.btnDownload.alpha = if (state.episode.isHLS) 0.3f else 1.0f
                         binding.btnAddToUpNext.tintColor = iconColor
                         binding.btnArchive.tintColor = iconColor
                         binding.btnPlayed.tintColor = iconColor
@@ -295,8 +297,10 @@ class EpisodeFragment : BaseDialogFragment() {
                             else -> DownloadButton.State.Queued
                         }
 
-                        val playbackError = state.episode.playErrorDetails
-
+                        var playbackError = state.episode.playErrorDetails
+                        if (state.episode.isHLS) {
+                            playbackError = getString(LR.string.podcast_episode_downloaded_hls_playback_message)
+                        }
                         if (playbackError == null) {
                             binding.errorLayout.isVisible = episodeStatus == EpisodeStatusEnum.DOWNLOAD_FAILED || episodeStatus == EpisodeStatusEnum.WAITING_FOR_POWER || episodeStatus == EpisodeStatusEnum.WAITING_FOR_WIFI
                             binding.lblErrorDetail.isVisible = false
@@ -324,9 +328,14 @@ class EpisodeFragment : BaseDialogFragment() {
                             }
                         } else {
                             binding.errorLayout.isVisible = true
-                            binding.lblError.setText(LR.string.podcast_episode_playback_error)
                             binding.lblErrorDetail.text = playbackError
-                            binding.imgError.setImageResource(IR.drawable.ic_play_all)
+                            if (state.episode.isHLS) {
+                                binding.lblError.setText(LR.string.podcast_episode_download_not_supported)
+                                binding.imgError.setImageResource(IR.drawable.ic_info_outline)
+                            } else {
+                                binding.lblError.setText(LR.string.podcast_episode_playback_error)
+                                binding.imgError.setImageResource(IR.drawable.ic_play_all)
+                            }
                         }
 
                         // If we aren't showing another error we can show the episode limit warning

--- a/modules/services/images/src/main/res/drawable/ic_info_outline.xml
+++ b/modules/services/images/src/main/res/drawable/ic_info_outline.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M13,9h-2L11,7h2v2zM13,11h-2v6h2v-6zM12,4c-4.411,0 -8,3.589 -8,8s3.589,8 8,8 8,-3.589 8,-8 -3.589,-8 -8,-8m0,-2c5.523,0 10,4.477 10,10s-4.477,10 -10,10S2,17.523 2,12 6.477,2 12,2z"/>
+</vector>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -375,6 +375,8 @@
     <string name="podcast_archive_all_played">Archive all played</string>
     <string name="podcast_archive_played">You should only do this if you don\'t want to see them anymore.</string>
     <string name="podcast_download_all">Download all</string>
+    <string name="podcast_episode_download_not_supported">Download not supported</string>
+    <string name="podcast_episode_downloaded_hls_playback_message">Playing from downloaded HLS files is not supported.</string>
     <string name="podcast_episode_file_not_uploaded">File not uploaded</string>
     <string name="podcast_episode_manually_unarchived">Episode Manually Unarchived</string>
     <string name="podcast_episode_manually_unarchived_summary">It won\'t be auto archived by your new episode limit of %d</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -20,10 +20,9 @@ import com.google.android.exoplayer2.PlaybackParameters
 import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory
 import com.google.android.exoplayer2.extractor.mp3.Mp3Extractor
-import com.google.android.exoplayer2.source.hls.HlsMediaSource
-import com.google.android.exoplayer2.source.MediaSource
 import com.google.android.exoplayer2.source.ProgressiveMediaSource
 import com.google.android.exoplayer2.source.TrackGroupArray
+import com.google.android.exoplayer2.source.hls.HlsMediaSource
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray
 import com.google.android.exoplayer2.upstream.DefaultDataSource
@@ -260,7 +259,7 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
             HlsMediaSource.Factory(dataSourceFactory).createMediaSource(mediaItem)
         } else {
             ProgressiveMediaSource.Factory(dataSourceFactory, extractorsFactory)
-            .createMediaSource(mediaItem)
+                .createMediaSource(mediaItem)
         }
         player.setMediaSource(source)
         player.prepare()


### PR DESCRIPTION
## Description

This PR disables download for [newly supported HLS stream](https://github.com/Automattic/pocket-casts-android/pull/679) on the episode details screen.

Parent Issue #670

## Testing Instructions

1. Add an RSS link that produces HLS sources (e.g. https://ohdieux.ligature.ca/rss?programme_id=672).
2. Tap on one of the HLS source episodes to go to the episode details screen.
3. Notice that the download button is disabled and displays a message that playback from downloaded HLS files is not supported.

## Screenshots or Screencast 

<img src="https://user-images.githubusercontent.com/1405144/211480564-5569565b-dc8f-440d-b2fb-5f647d9a1184.png" width=320/>


## Checklist
- If this is a user-facing change, I have added an entry in CHANGELOG.md
- I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- with different themes
- with a landscape orientation
- with the device set to have a large display and font size
- for accessibility with TalkBack
