### PR TITLE
Track global episode events - Part 1

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -31,6 +31,7 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivity
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContract
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContract.OnboardingFinish
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.databinding.ActivityMainBinding
@@ -67,7 +68,6 @@ import au.com.shiftyjelly.pocketcasts.profile.sonos.SonosAppLinkActivity
 import au.com.shiftyjelly.pocketcasts.repositories.bumpstats.BumpStatsTask
 import au.com.shiftyjelly.pocketcasts.repositories.opml.OpmlImportTask
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
@@ -820,31 +820,31 @@ class MainActivity :
                 playbackManager.getCurrentEpisode()?.let { episode ->
                     launch(Dispatchers.Main) {
                         if (episode.isDownloaded) {
-                            playbackManager.playQueue(PlaybackSource.MINIPLAYER)
+                            playbackManager.playQueue(AnalyticsSource.MINIPLAYER)
                             warningsHelper.showBatteryWarningSnackbarIfAppropriate()
                         } else {
-                            warningsHelper.streamingWarningDialog(episode = episode, playbackSource = PlaybackSource.MINIPLAYER)
+                            warningsHelper.streamingWarningDialog(episode = episode, playbackSource = AnalyticsSource.MINIPLAYER)
                                 .show(supportFragmentManager, "streaming dialog")
                         }
                     }
                 }
             }
         } else {
-            playbackManager.playQueue(PlaybackSource.MINIPLAYER)
+            playbackManager.playQueue(AnalyticsSource.MINIPLAYER)
             warningsHelper.showBatteryWarningSnackbarIfAppropriate()
         }
     }
 
     override fun onPauseClicked() {
-        playbackManager.pause(playbackSource = PlaybackSource.MINIPLAYER)
+        playbackManager.pause(playbackSource = AnalyticsSource.MINIPLAYER)
     }
 
     override fun onSkipBackwardClicked() {
-        playbackManager.skipBackward(playbackSource = PlaybackSource.MINIPLAYER)
+        playbackManager.skipBackward(playbackSource = AnalyticsSource.MINIPLAYER)
     }
 
     override fun onSkipForwardClicked() {
-        playbackManager.skipForward(playbackSource = PlaybackSource.MINIPLAYER)
+        playbackManager.skipForward(playbackSource = AnalyticsSource.MINIPLAYER)
     }
 
     override fun addFragment(fragment: Fragment, onTop: Boolean) {

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
@@ -11,6 +11,7 @@ import androidx.annotation.StringRes
 import androidx.core.os.bundleOf
 import androidx.media.utils.MediaConstants.DESCRIPTION_EXTRAS_KEY_CONTENT_STYLE_BROWSABLE
 import androidx.media.utils.MediaConstants.DESCRIPTION_EXTRAS_VALUE_CONTENT_STYLE_LIST_ITEM
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.localization.helper.tryToLocalise
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -19,7 +20,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.EXTRA_CONTENT_STYLE_
 import au.com.shiftyjelly.pocketcasts.repositories.playback.FOLDER_ROOT_PREFIX
 import au.com.shiftyjelly.pocketcasts.repositories.playback.MEDIA_ID_ROOT
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PODCASTS_ROOT
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackService
 import au.com.shiftyjelly.pocketcasts.repositories.playback.auto.AutoConverter
 import au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsTask
@@ -59,7 +59,7 @@ class AutoPlaybackService : PlaybackService() {
         super.onDestroy()
         Log.d(Settings.LOG_TAG_AUTO, "Auto playback service destroyed")
 
-        playbackManager.pause(transientLoss = false, playbackSource = PlaybackSource.AUTO_PAUSE)
+        playbackManager.pause(transientLoss = false, playbackSource = AnalyticsSource.AUTO_PAUSE)
     }
 
     override fun onLoadChildren(parentId: String, result: Result<List<MediaBrowserCompat.MediaItem>>) {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -3,10 +3,10 @@ package au.com.shiftyjelly.pocketcasts.discover.viewmodel
 import android.content.res.Resources
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
@@ -41,7 +41,7 @@ class DiscoverViewModel @Inject constructor(
     val userManager: UserManager
 ) : ViewModel() {
     private val disposables = CompositeDisposable()
-    private val playbackSource = PlaybackSource.DISCOVER
+    private val playbackSource = AnalyticsSource.DISCOVER
     val state = MutableLiveData<DiscoverState>().apply { value = DiscoverState.Loading }
     var currentRegionCode: String? = settings.getDiscoveryCountryCode()
     var replacements = emptyMap<String, String>()

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/PodcastListViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/PodcastListViewModel.kt
@@ -2,10 +2,10 @@ package au.com.shiftyjelly.pocketcasts.discover.viewmodel
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.repositories.colors.ColorManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
@@ -151,11 +151,11 @@ class PodcastListViewModel @Inject constructor(
     }
 
     fun playEpisode(episode: Episode) {
-        playbackManager.playNow(episode, forceStream = true, playbackSource = PlaybackSource.DISCOVER_PODCAST_LIST)
+        playbackManager.playNow(episode, forceStream = true, playbackSource = AnalyticsSource.DISCOVER_PODCAST_LIST)
     }
 
     fun stopPlayback() {
-        playbackManager.stopAsync(playbackSource = PlaybackSource.DISCOVER_PODCAST_LIST)
+        playbackManager.stopAsync(playbackSource = AnalyticsSource.DISCOVER_PODCAST_LIST)
     }
 }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -388,6 +388,7 @@ class FilterEpisodeListFragment : BaseFragment() {
         itemTouchHelper.attachToRecyclerView(recyclerView)
 
         val multiSelectToolbar = binding.multiSelectToolbar
+        multiSelectHelper.source = AnalyticsSource.FILTERS
         multiSelectHelper.isMultiSelectingLive.observe(
             viewLifecycleOwner,
             Observer {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -17,6 +17,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.filters.databinding.FragmentFilterBinding
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralPodcasts
@@ -32,7 +33,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImageLoader
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getStringForDuration
@@ -115,7 +115,7 @@ class FilterEpisodeListFragment : BaseFragment() {
             radiusPx = 4.dpToPx(context)
         }.smallPlaceholder()
 
-        playButtonListener.playbackSource = PlaybackSource.FILTERS
+        playButtonListener.source = AnalyticsSource.FILTERS
         adapter = EpisodeListAdapter(downloadManager, playbackManager, upNextQueue, settings, this::onRowClick, playButtonListener, imageLoader, multiSelectHelper, childFragmentManager)
     }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
@@ -13,7 +14,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistProperty
@@ -122,7 +122,7 @@ class FilterEpisodeListViewModel @Inject constructor(
             if (startIndex > -1) {
                 playbackManager.upNextQueue.removeAll()
                 val count = min(episodes.size - startIndex, settings.getMaxUpNextEpisodes())
-                playbackManager.playEpisodes(episodes = episodes.subList(startIndex, startIndex + count), playbackSource = PlaybackSource.FILTERS)
+                playbackManager.playEpisodes(episodes = episodes.subList(startIndex, startIndex + count), playbackSource = AnalyticsSource.FILTERS)
             }
         }
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
@@ -11,6 +11,7 @@ import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.fragment.app.activityViewModels
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
@@ -252,6 +253,6 @@ class EffectsFragment : BaseDialogFragment(), CompoundButton.OnCheckedChangeList
     }
 
     private fun trackPlaybackEffectsEvent(event: AnalyticsEvent, props: Map<String, Any> = emptyMap()) {
-        playbackManager.trackPlaybackEffectsEvent(event, props, PlaybackManager.PlaybackSource.PLAYER_PLAYBACK_EFFECTS)
+        playbackManager.trackPlaybackEffectsEvent(event, props, AnalyticsSource.PLAYER_PLAYBACK_EFFECTS)
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -18,6 +18,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
@@ -30,7 +31,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.images.into
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.images.PodcastImageLoaderThemed
 import au.com.shiftyjelly.pocketcasts.ui.images.ThemedImageTintTransformation
@@ -79,7 +79,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
     private var binding: AdapterPlayerHeaderBinding? = null
     private var skippedFirstTouch: Boolean = false
     private var hasReceivedOnTouchDown = false
-    private val playbackSource = PlaybackSource.PLAYER
+    private val playbackSource = AnalyticsSource.PLAYER
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = AdapterPlayerHeaderBinding.inflate(inflater, container, false)
@@ -121,7 +121,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         binding.seekBar.changeListener = object : PlayerSeekBar.OnUserSeekListener {
             override fun onSeekPositionChangeStop(progress: Int, seekComplete: () -> Unit) {
                 viewModel.seekToMs(progress, seekComplete)
-                playbackManager.trackPlaybackSeek(progress, PlaybackSource.PLAYER)
+                playbackManager.trackPlaybackSeek(progress, AnalyticsSource.PLAYER)
             }
 
             override fun onSeekPositionChanging(progress: Int) {}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -16,6 +16,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
@@ -25,7 +26,6 @@ import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentUpnextBinding
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
@@ -81,7 +81,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     lateinit var adapter: UpNextAdapter
-    private val playbackSource = PlaybackSource.UP_NEXT
+    private val playbackSource = AnalyticsSource.UP_NEXT
     private val playerViewModel: PlayerViewModel by activityViewModels()
     private var userRearrangingFrom: Int? = null
     private var userDraggingStart: Int? = null

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -127,6 +127,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
     override fun onAttach(context: Context) {
         super.onAttach(context)
         val imageLoader = PodcastImageLoaderThemed(context)
+        multiSelectHelper.source = AnalyticsSource.UP_NEXT
         adapter = UpNextAdapter(
             context = context,
             imageLoader = imageLoader,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
@@ -11,12 +11,12 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentVideoBinding
 import au.com.shiftyjelly.pocketcasts.player.view.PlayerSeekBar
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.VideoViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.SimplePlayer
 import au.com.shiftyjelly.pocketcasts.views.extensions.hide
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
@@ -159,7 +159,7 @@ class VideoFragment : Fragment(), PlayerSeekBar.OnUserSeekListener {
 
     override fun onSeekPositionChangeStop(progress: Int, seekComplete: () -> Unit) {
         viewModel.seekToMs(progress)
-        playbackManager.trackPlaybackSeek(progress, PlaybackSource.FULL_SCREEN_VIDEO)
+        playbackManager.trackPlaybackSeek(progress, AnalyticsSource.FULL_SCREEN_VIDEO)
         seekComplete()
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -6,8 +6,10 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
@@ -74,6 +76,7 @@ class PlayerViewModel @Inject constructor(
     private val settings: Settings,
     private val theme: Theme,
     private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val episodeAnalytics: EpisodeAnalytics,
     @ApplicationContext private val context: Context,
 ) : ViewModel(), CoroutineScope {
 
@@ -445,6 +448,11 @@ class PlayerViewModel @Inject constructor(
         if (episode.episodeStatus != EpisodeStatusEnum.NOT_DOWNLOADED) {
             launch {
                 episodeManager.deleteEpisodeFile(episode, playbackManager, disableAutoDownload = false, removeFromUpNext = episode.episodeStatus == EpisodeStatusEnum.DOWNLOADED)
+                episodeAnalytics.trackEvent(
+                    event = AnalyticsEvent.EPISODE_DOWNLOAD_DELETED,
+                    source = source,
+                    uuid = episode.uuid,
+                )
             }
         } else {
             launch {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
@@ -27,7 +28,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getUrlForArtwork
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.saveToGlobalSettings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.SleepTimer
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
@@ -149,7 +149,7 @@ class PlayerViewModel @Inject constructor(
     ) {
         fun isSameChapter(chapter: Chapter) = currentChapter?.let { it.index == chapter.index } ?: false
     }
-    private val playbackSource = PlaybackSource.PLAYER
+    private val source = AnalyticsSource.PLAYER
     private val _showPlayerFlow = MutableSharedFlow<Unit>()
     val showPlayerFlow: SharedFlow<Unit> = _showPlayerFlow
 
@@ -368,10 +368,10 @@ class PlayerViewModel @Inject constructor(
 
     fun play() {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Play clicked in player")
-        playbackManager.playQueue(playbackSource = playbackSource)
+        playbackManager.playQueue(playbackSource = source)
     }
 
-    fun playEpisode(uuid: String, playbackSource: PlaybackSource = PlaybackSource.UNKNOWN) {
+    fun playEpisode(uuid: String, playbackSource: AnalyticsSource = AnalyticsSource.UNKNOWN) {
         launch {
             val episode = episodeManager.findPlayableByUuid(uuid) ?: return@launch
             playbackManager.playNow(episode = episode, playbackSource = playbackSource)
@@ -379,11 +379,11 @@ class PlayerViewModel @Inject constructor(
     }
 
     fun skipBackward() {
-        playbackManager.skipBackward(playbackSource = playbackSource)
+        playbackManager.skipBackward(playbackSource = source)
     }
 
     fun skipForward() {
-        playbackManager.skipForward(playbackSource = playbackSource)
+        playbackManager.skipForward(playbackSource = source)
     }
 
     fun onMarkAsPlayedClick() {
@@ -397,7 +397,7 @@ class PlayerViewModel @Inject constructor(
     }
 
     fun onNextEpisodeClick() {
-        playbackManager.playNextInQueue(playbackSource = playbackSource)
+        playbackManager.playNextInQueue(playbackSource = source)
     }
 
     private fun markAsPlayedConfirmed(episode: Playable) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/VideoViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/VideoViewModel.kt
@@ -5,8 +5,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.BackpressureStrategy
@@ -27,7 +27,7 @@ class VideoViewModel @Inject constructor(
     private var lastTimeHidingControls = 0L
 
     private var controlsVisibleMutable = MutableLiveData(true)
-    private val playbackSource = PlaybackSource.FULL_SCREEN_VIDEO
+    private val playbackSource = AnalyticsSource.FULL_SCREEN_VIDEO
     val controlsVisible: LiveData<Boolean> get() = controlsVisibleMutable
 
     fun play() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
@@ -2,7 +2,9 @@ package au.com.shiftyjelly.pocketcasts.podcasts.helper
 
 import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.podcasts.view.components.PlayButton
@@ -27,6 +29,7 @@ class PlayButtonListener @Inject constructor(
     val settings: Settings,
     private val warningsHelper: WarningsHelper,
     @ActivityContext private val activity: Context,
+    private val episodeAnalytics: EpisodeAnalytics
 ) : PlayButton.OnClickListener, CoroutineScope {
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
@@ -108,6 +111,11 @@ class PlayButtonListener @Inject constructor(
                         it.autoDownloadStatus = Episode.AUTO_DOWNLOAD_STATUS_MANUALLY_DOWNLOADED
                     }
                     downloadManager.addEpisodeToQueue(it, "play button", true)
+                    episodeAnalytics.trackEvent(
+                        AnalyticsEvent.EPISODE_DOWNLOAD_QUEUED,
+                        source = source,
+                        uuid = episodeUuid
+                    )
                     launch {
                         episodeManager.unarchive(it)
                     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
@@ -2,13 +2,13 @@ package au.com.shiftyjelly.pocketcasts.podcasts.helper
 
 import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.podcasts.view.components.PlayButton
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -31,7 +31,7 @@ class PlayButtonListener @Inject constructor(
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
 
-    override var playbackSource = PlaybackSource.UNKNOWN
+    override var source = AnalyticsSource.UNKNOWN
 
     override fun onPlayClicked(episodeUuid: String) {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "In app play button pushed for $episodeUuid")
@@ -43,7 +43,7 @@ class PlayButtonListener @Inject constructor(
                         if (episode.isDownloaded) {
                             play(episode)
                         } else if (activity is AppCompatActivity) {
-                            warningsHelper.streamingWarningDialog(episode = episode, playbackSource = playbackSource)
+                            warningsHelper.streamingWarningDialog(episode = episode, playbackSource = source)
                                 .show(activity.supportFragmentManager, "streaming dialog")
                         }
                     }
@@ -55,12 +55,12 @@ class PlayButtonListener @Inject constructor(
     }
 
     private fun play(episode: Playable, force: Boolean = true) {
-        playbackManager.playNow(episode = episode, forceStream = force, playbackSource = playbackSource)
+        playbackManager.playNow(episode = episode, forceStream = force, playbackSource = source)
         warningsHelper.showBatteryWarningSnackbarIfAppropriate()
     }
 
     override fun onPauseClicked() {
-        playbackManager.pause(playbackSource = playbackSource)
+        playbackManager.pause(playbackSource = source)
     }
 
     override fun onPlayedClicked(episodeUuid: String) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
@@ -28,7 +29,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImageLoader
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.settings.AutoDownloadSettingsFragment
@@ -124,10 +124,10 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             radiusPx = 4.dpToPx(context)
         }.smallPlaceholder()
 
-        playButtonListener.playbackSource = when (mode) {
-            Mode.Downloaded -> PlaybackSource.DOWNLOADS
-            Mode.Starred -> PlaybackSource.STARRED
-            Mode.History -> PlaybackSource.LISTENING_HISTORY
+        playButtonListener.source = when (mode) {
+            Mode.Downloaded -> AnalyticsSource.DOWNLOADS
+            Mode.Starred -> AnalyticsSource.STARRED
+            Mode.History -> AnalyticsSource.LISTENING_HISTORY
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -124,11 +124,8 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             radiusPx = 4.dpToPx(context)
         }.smallPlaceholder()
 
-        playButtonListener.source = when (mode) {
-            Mode.Downloaded -> AnalyticsSource.DOWNLOADS
-            Mode.Starred -> AnalyticsSource.STARRED
-            Mode.History -> AnalyticsSource.LISTENING_HISTORY
-        }
+        playButtonListener.source = getAnalyticsEventSource()
+        multiSelectHelper.source = getAnalyticsEventSource()
     }
 
     override fun onPause() {
@@ -395,5 +392,11 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             Mode.Starred -> AnalyticsEvent.STARRED_MULTI_SELECT_EXITED
         }
         analyticsTracker.track(analyticsEvent)
+    }
+
+    private fun getAnalyticsEventSource() = when (mode) {
+        Mode.Downloaded -> AnalyticsSource.DOWNLOADS
+        Mode.Starred -> AnalyticsSource.STARRED
+        Mode.History -> AnalyticsSource.LISTENING_HISTORY
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/PlayButton.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/PlayButton.kt
@@ -8,13 +8,13 @@ import android.widget.ImageView
 import android.widget.PopupMenu
 import androidx.annotation.ColorInt
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.podcasts.R
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.views.component.ProgressCircleView
 import au.com.shiftyjelly.pocketcasts.views.extensions.inflate
@@ -69,7 +69,7 @@ class PlayButton @JvmOverloads constructor(
     }
 
     interface OnClickListener {
-        var playbackSource: PlaybackManager.PlaybackSource
+        var source: AnalyticsSource
         fun onPlayClicked(episodeUuid: String)
         fun onPauseClicked()
         fun onPlayNext(episodeUuid: String)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -50,12 +51,13 @@ class EpisodeFragmentViewModel @Inject constructor(
     val serverManager: ServerManager,
     val playbackManager: PlaybackManager,
     val settings: Settings,
-    private val analyticsTracker: AnalyticsTrackerWrapper
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val episodeAnalytics: EpisodeAnalytics
 ) : ViewModel(), CoroutineScope {
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
 
-    private val playbackSource = AnalyticsSource.EPISODE_DETAILS
+    private val source = AnalyticsSource.EPISODE_DETAILS
     lateinit var state: LiveData<EpisodeFragmentState>
     val showNotes: MutableLiveData<String> = MutableLiveData()
     lateinit var inUpNext: LiveData<Boolean>
@@ -166,13 +168,19 @@ class EpisodeFragmentViewModel @Inject constructor(
     fun downloadEpisode() {
         launch {
             episode?.let {
+                var analyticsEvent: AnalyticsEvent? = null
                 if (it.downloadTaskId != null) {
                     episodeManager.stopDownloadAndCleanUp(it, "episode card")
+                    analyticsEvent = AnalyticsEvent.EPISODE_DOWNLOAD_CANCELLED
                 } else if (!it.isDownloaded) {
                     it.autoDownloadStatus = Episode.AUTO_DOWNLOAD_STATUS_MANUAL_OVERRIDE_WIFI
                     downloadManager.addEpisodeToQueue(it, "episode card", true)
+                    analyticsEvent = AnalyticsEvent.EPISODE_DOWNLOAD_QUEUED
                 }
                 episodeManager.clearPlaybackError(episode)
+                analyticsEvent?.let { event ->
+                    episodeAnalytics.trackEvent(event, source = source, uuid = it.uuid)
+                }
             }
         }
     }
@@ -246,14 +254,14 @@ class EpisodeFragmentViewModel @Inject constructor(
     ): Boolean {
         episode?.let { episode ->
             if (isPlaying.value == true) {
-                playbackManager.pause(playbackSource = playbackSource)
+                playbackManager.pause(playbackSource = source)
                 return false
             } else {
                 fromListUuid?.let {
                     FirebaseAnalyticsTracker.podcastEpisodePlayedFromList(it, episode.podcastUuid)
                     analyticsTracker.track(AnalyticsEvent.DISCOVER_LIST_EPISODE_PLAY, mapOf(LIST_ID_KEY to it, PODCAST_ID_KEY to episode.podcastUuid))
                 }
-                playbackManager.playNow(episode, forceStream = force, playbackSource = playbackSource)
+                playbackManager.playNow(episode, forceStream = force, playbackSource = source)
                 warningsHelper.showBatteryWarningSnackbarIfAppropriate()
                 return true
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -155,6 +155,11 @@ class EpisodeFragmentViewModel @Inject constructor(
         episode?.let {
             launch {
                 episodeManager.deleteEpisodeFile(it, playbackManager, disableAutoDownload = true, removeFromUpNext = true)
+                episodeAnalytics.trackEvent(
+                    event = AnalyticsEvent.EPISODE_DOWNLOAD_DELETED,
+                    source = source,
+                    uuid = it.uuid,
+                )
             }
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
@@ -15,7 +16,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -55,7 +55,7 @@ class EpisodeFragmentViewModel @Inject constructor(
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
 
-    private val playbackSource = PlaybackSource.EPISODE_DETAILS
+    private val playbackSource = AnalyticsSource.EPISODE_DETAILS
     lateinit var state: LiveData<EpisodeFragmentState>
     val showNotes: MutableLiveData<String> = MutableLiveData()
     lateinit var inUpNext: LiveData<Boolean>

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
@@ -40,7 +41,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -514,7 +514,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
             }
         }
 
-        playButtonListener.playbackSource = PlaybackSource.PODCAST_SCREEN
+        playButtonListener.source = AnalyticsSource.PODCAST_SCREEN
         if (adapter == null) {
             adapter = PodcastAdapter(downloadManager, playbackManager, upNextQueue, settings, theme, fromListUuid, onHeaderSummaryToggled, onSubscribeClicked, onUnsubscribeClicked, onEpisodesOptionsClicked, onRowLongPress, onFoldersClicked, onNotificationsClicked, onSettingsClicked, playButtonListener, onRowClicked, onSearchQueryChanged, onSearchFocus, onShowArchivedClicked, multiSelectHelper, onArtworkLongClicked)
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -588,7 +588,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                 }
             }
         }
-
+        multiSelectHelper.source = AnalyticsSource.PODCAST_SCREEN
         binding.multiSelectToolbar.setup(viewLifecycleOwner, multiSelectHelper, menuRes = null, fragmentManager = parentFragmentManager)
 
         return binding.root

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
@@ -107,6 +108,6 @@ class PodcastEffectsViewModel
     }
 
     fun trackPlaybackEffectsEvent(event: AnalyticsEvent, props: Map<String, Any> = emptyMap()) {
-        playbackManager.trackPlaybackEffectsEvent(event, props, PlaybackManager.PlaybackSource.PODCAST_SETTINGS)
+        playbackManager.trackPlaybackEffectsEvent(event, props, AnalyticsSource.PODCAST_SETTINGS)
     }
 }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
@@ -61,6 +61,11 @@ class CloudBottomSheetViewModel @Inject constructor(
     fun deleteEpisode(episode: UserEpisode, deleteState: DeleteState) {
         CloudDeleteHelper.deleteEpisode(episode, deleteState, playbackManager, episodeManager, userEpisodeManager)
         analyticsTracker.track(AnalyticsEvent.USER_FILE_DELETED)
+        episodeAnalytics.trackEvent(
+            event = if (deleteState == DeleteState.Cloud && !episode.isDownloaded) AnalyticsEvent.EPISODE_DELETED_FROM_CLOUD else AnalyticsEvent.EPISODE_DOWNLOAD_DELETED,
+            source = source,
+            uuid = episode.uuid,
+        )
     }
 
     fun uploadEpisode(episode: UserEpisode) {
@@ -71,6 +76,7 @@ class CloudBottomSheetViewModel @Inject constructor(
     fun removeEpisode(episode: UserEpisode) {
         userEpisodeManager.removeFromCloud(episode)
         trackOptionTapped(DELETE_FROM_CLOUD)
+        episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_DELETED_FROM_CLOUD, source = source, uuid = episode.uuid)
     }
 
     fun cancelUpload(episode: UserEpisode) {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
@@ -5,12 +5,12 @@ import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.containsUuid
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -121,12 +121,12 @@ class CloudBottomSheetViewModel @Inject constructor(
     }
 
     fun playNow(episode: UserEpisode, forceStream: Boolean) {
-        playbackManager.playNow(episode = episode, forceStream = forceStream, playbackSource = PlaybackSource.FILES)
+        playbackManager.playNow(episode = episode, forceStream = forceStream, playbackSource = AnalyticsSource.FILES)
         analyticsTracker.track(AnalyticsEvent.USER_FILE_PLAY_PAUSE_BUTTON_TAPPED, mapOf(OPTION_KEY to PLAY))
     }
 
     fun pause() {
-        playbackManager.pause(playbackSource = PlaybackSource.FILES)
+        playbackManager.pause(playbackSource = AnalyticsSource.FILES)
         analyticsTracker.track(AnalyticsEvent.USER_FILE_PLAY_PAUSE_BUTTON_TAPPED, mapOf(OPTION_KEY to PAUSE))
     }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheet.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheet.kt
@@ -15,6 +15,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
@@ -325,7 +326,7 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
     private fun upload(episode: UserEpisode, isOnWifi: Boolean) {
         viewModel.trackOptionTapped(UPLOAD)
         if (settings.warnOnMeteredNetwork() && !isOnWifi) {
-            warningsHelper.uploadWarning(episodeUUID)
+            warningsHelper.uploadWarning(episodeUUID, source = AnalyticsSource.FILES)
                 .show(parentFragmentManager, "upload_warning")
         } else {
             viewModel.uploadEpisode(episode)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -28,7 +29,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImageLoader
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.images.PodcastImageLoaderThemed
@@ -96,7 +96,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             radiusPx = 4.dpToPx(context)
         }.smallPlaceholder()
 
-        playButtonListener.playbackSource = PlaybackSource.FILES
+        playButtonListener.source = AnalyticsSource.FILES
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -242,6 +242,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             }
         }
         multiSelectHelper.coordinatorLayout = (activity as FragmentHostListener).snackBarView()
+        multiSelectHelper.source = AnalyticsSource.FILES
         binding?.multiSelectToolbar?.setup(viewLifecycleOwner, multiSelectHelper, menuRes = null, fragmentManager = parentFragmentManager)
     }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
@@ -3,7 +3,9 @@ package au.com.shiftyjelly.pocketcasts.profile.cloud
 import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -32,6 +34,7 @@ class CloudFilesViewModel @Inject constructor(
     private val settings: Settings,
     userManager: UserManager,
     private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val episodeAnalytics: EpisodeAnalytics
 ) : ViewModel() {
 
     val sortOrderRelay = BehaviorRelay.create<Settings.CloudSortOrder>().apply { accept(settings.getCloudSortOrder()) }
@@ -77,6 +80,11 @@ class CloudFilesViewModel @Inject constructor(
 
     fun deleteEpisode(episode: UserEpisode, deleteState: DeleteState) {
         CloudDeleteHelper.deleteEpisode(episode, deleteState, playbackManager, episodeManager, userEpisodeManager)
+        episodeAnalytics.trackEvent(
+            event = if (deleteState == DeleteState.Cloud && !episode.isDownloaded) AnalyticsEvent.EPISODE_DELETED_FROM_CLOUD else AnalyticsEvent.EPISODE_DOWNLOAD_DELETED,
+            source = AnalyticsSource.FILES,
+            uuid = episode.uuid,
+        )
     }
 
     fun changeSort(sortOrder: Settings.CloudSortOrder) {

--- a/modules/features/taskerplugin/build.gradle
+++ b/modules/features/taskerplugin/build.gradle
@@ -10,6 +10,7 @@ android {
 }
 
 dependencies {
+    implementation project(':modules:services:analytics')
     implementation project(':modules:services:localization')
     implementation project(':modules:services:ui')
     implementation project(':modules:services:compose')

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/addtoupnext/ActionRunnerAddToUpNext.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/addtoupnext/ActionRunnerAddToUpNext.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.taskerplugin.addtoupnext
 
 import android.content.Context
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.localization.R
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.episodeManager
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.playbackManager
 import com.joaomgcd.taskerpluginlibrary.action.TaskerPluginRunnerActionNoOutput
@@ -40,7 +40,7 @@ class ActionRunnerAddToUpNext : TaskerPluginRunnerActionNoOutput<InputAddToUpNex
         }
 
         if (regularInput.startPlaying?.toBooleanStrictOrNull() == true) {
-            playbackManager.playEpisodes(episodesToPlay, PlaybackManager.PlaybackSource.TASKER)
+            playbackManager.playEpisodes(episodesToPlay, AnalyticsSource.TASKER)
         } else {
             upNextQueue.changeList(episodesToPlay)
         }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
@@ -1,10 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.taskerplugin.controlplayback
 
 import android.content.Context
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.saveToGlobalSettings
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.playbackManager
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.podcastManager
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.settings
@@ -46,12 +46,14 @@ class ActionRunnerControlPlayback : TaskerPluginRunnerActionNoOutput<InputContro
                 val jumpAmountSeconds = input.regular.skipSeconds?.toIntOrNull() ?: return TaskerPluginResultError(ERROR_INVALID_TIME_TO_SKIP_PROVIDED, context.getString(R.string.time_to_skip_not_valid, input.regular.skipSeconds))
 
                 if (commandEnum == InputControlPlayback.PlaybackCommand.SkipBack) {
-                    playbackManager.skipBackward(jumpAmountSeconds = jumpAmountSeconds, playbackSource = PlaybackManager.PlaybackSource.TASKER)
+                    playbackManager.skipBackward(jumpAmountSeconds = jumpAmountSeconds, playbackSource = AnalyticsSource.TASKER)
                 } else {
-                    playbackManager.skipForward(jumpAmountSeconds = jumpAmountSeconds, playbackSource = PlaybackManager.PlaybackSource.TASKER)
+                    playbackManager.skipForward(jumpAmountSeconds = jumpAmountSeconds, playbackSource = AnalyticsSource.TASKER)
                 }
             }
-            InputControlPlayback.PlaybackCommand.PlayNextInQueue -> playbackManager.playNextInQueue(PlaybackManager.PlaybackSource.TASKER)
+            InputControlPlayback.PlaybackCommand.PlayNextInQueue -> playbackManager.playNextInQueue(
+                AnalyticsSource.TASKER
+            )
             InputControlPlayback.PlaybackCommand.SetPlaybackSpeed -> {
                 val speed = input.regular.playbackSpeed?.toDoubleOrNull() ?: return TaskerPluginResultError(ERROR_INVALID_PLAYBACK_SPEED_PROVIDED, context.getString(R.string.playback_speed_not_valid, input.regular.playbackSpeed))
 

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/playplaylist/ActionRunnerPlayPlaylist.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/playplaylist/ActionRunnerPlayPlaylist.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.taskerplugin.playplaylist
 
 import android.content.Context
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.localization.R
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.episodeManager
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.playbackManager
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.playlistManager
@@ -31,7 +31,7 @@ class ActionRunnerPlayPlaylist : TaskerPluginRunnerActionNoOutput<InputPlayPlayl
         val episodes = playlistManager.findEpisodes(playlist, episodeManager, playbackManager)
         if (episodes.isEmpty()) return TaskerPluginResultError(ERROR_PLAYLIST_NO_EPISODES, context.getString(R.string.no_episodes_in_filter_x, title))
 
-        playbackManager.playEpisodes(episodes, PlaybackManager.PlaybackSource.TASKER)
+        playbackManager.playEpisodes(episodes, AnalyticsSource.TASKER)
         return TaskerPluginResultSucess()
     }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -293,6 +293,9 @@ enum class AnalyticsEvent(val key: String) {
     PLAYER_SHELF_OVERFLOW_MENU_REARRANGE_FINISHED("player_shelf_overflow_menu_rearrange_finished"),
 
     /* Episode */
+    EPISODE_DOWNLOAD_DELETED("episode_download_deleted"),
+    EPISODE_BULK_DOWNLOAD_DELETED("episode_bulk_download_deleted"),
+    EPISODE_DELETED_FROM_CLOUD("episode_deleted_from_cloud"),
     EPISODE_DOWNLOAD_QUEUED("episode_download_queued"),
     EPISODE_BULK_DOWNLOAD_QUEUED("episode_bulk_download_queued"),
     EPISODE_DOWNLOAD_FINISHED("episode_download_finished"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -293,6 +293,10 @@ enum class AnalyticsEvent(val key: String) {
     PLAYER_SHELF_OVERFLOW_MENU_REARRANGE_FINISHED("player_shelf_overflow_menu_rearrange_finished"),
 
     /* Episode */
+    EPISODE_DOWNLOAD_QUEUED("episode_download_queued"),
+    EPISODE_BULK_DOWNLOAD_QUEUED("episode_bulk_download_queued"),
+    EPISODE_DOWNLOAD_FINISHED("episode_download_finished"),
+    EPISODE_DOWNLOAD_CANCELLED("episode_download_cancelled"),
     EPISODE_UPLOAD_QUEUED("episode_upload_queued"),
     EPISODE_UPLOAD_CANCELLED("episode_upload_cancelled"),
     EPISODE_UPLOAD_FINISHED("episode_upload_finished"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -292,6 +292,11 @@ enum class AnalyticsEvent(val key: String) {
     PLAYER_SHELF_OVERFLOW_MENU_REARRANGE_ACTION_MOVED("player_shelf_overflow_menu_rearrange_action_moved"),
     PLAYER_SHELF_OVERFLOW_MENU_REARRANGE_FINISHED("player_shelf_overflow_menu_rearrange_finished"),
 
+    /* Episode */
+    EPISODE_UPLOAD_QUEUED("episode_upload_queued"),
+    EPISODE_UPLOAD_CANCELLED("episode_upload_cancelled"),
+    EPISODE_UPLOAD_FINISHED("episode_upload_finished"),
+
     /* Episode Details */
     EPISODE_DETAIL_SHOWN("episode_detail_shown"),
     EPISODE_DETAIL_DISMISSED("episode_detail_dismissed"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsSource.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsSource.kt
@@ -1,0 +1,30 @@
+package au.com.shiftyjelly.pocketcasts.analytics
+
+enum class AnalyticsSource(val analyticsValue: String) {
+    PODCAST_SCREEN("podcast_screen"),
+    FILTERS("filters"),
+    DISCOVER("discover"),
+    DISCOVER_PODCAST_LIST("discover_podcast_list"),
+    DOWNLOADS("downloads"),
+    FILES("files"),
+    STARRED("starred"),
+    LISTENING_HISTORY("listening_history"),
+    EPISODE_DETAILS("episode_details"),
+    MINIPLAYER("miniplayer"),
+    PLAYER("player"),
+    NOTIFICATION("notification"),
+    FULL_SCREEN_VIDEO("full_screen_video"),
+    UP_NEXT("up_next"),
+    MEDIA_BUTTON_BROADCAST_ACTION("media_button_broadcast_action"),
+    MEDIA_BUTTON_BROADCAST_SEARCH_ACTION("media_button_broadcast_search_action"),
+    PLAYER_BROADCAST_ACTION("player_broadcast_action"),
+    CHROMECAST("chromecast"),
+    AUTO_PLAY("auto_play"),
+    AUTO_PAUSE("auto_pause"),
+    PLAYER_PLAYBACK_EFFECTS("player_playback_effects"),
+    PODCAST_SETTINGS("podcast_settings"),
+    UNKNOWN("unknown"),
+    TASKER("tasker");
+
+    fun skipTracking() = this in listOf(AUTO_PLAY, AUTO_PAUSE)
+}

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
@@ -1,0 +1,37 @@
+package au.com.shiftyjelly.pocketcasts.analytics
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class EpisodeAnalytics @Inject constructor(
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+) {
+    private val uploadEpisodeUuidQueue = mutableListOf<String>()
+
+    fun trackEvent(event: AnalyticsEvent, source: AnalyticsSource, uuid: String) {
+        if (event == AnalyticsEvent.EPISODE_UPLOAD_QUEUED) {
+            uploadEpisodeUuidQueue.add(uuid)
+        }
+        analyticsTracker.track(event, AnalyticsProp.sourceAndUuidMap(source, uuid))
+    }
+
+    fun trackEvent(event: AnalyticsEvent, uuid: String) {
+        if (event == AnalyticsEvent.EPISODE_UPLOAD_FINISHED) {
+            if (uploadEpisodeUuidQueue.contains(uuid)) {
+                uploadEpisodeUuidQueue.remove(uuid)
+            } else {
+                return
+            }
+        }
+
+        analyticsTracker.track(event, AnalyticsProp.uuidMap(uuid))
+    }
+
+    private object AnalyticsProp {
+        private const val source = "source"
+        private const val episode_uuid = "episode_uuid"
+        fun sourceAndUuidMap(eventSource: AnalyticsSource, uuid: String) = mapOf(source to eventSource.analyticsValue, episode_uuid to uuid)
+        fun uuidMap(uuid: String) = mapOf(episode_uuid to uuid)
+    }
+}

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
@@ -38,6 +38,10 @@ class EpisodeAnalytics @Inject constructor(
         analyticsTracker.track(event, AnalyticsProp.uuidMap(uuid))
     }
 
+    fun trackBulkEvent(event: AnalyticsEvent, source: AnalyticsSource, count: Int) {
+        analyticsTracker.track(event, AnalyticsProp.bulkMap(source, count))
+    }
+
     fun trackBulkEvent(event: AnalyticsEvent, source: AnalyticsSource, episodes: List<Playable>) {
         if (event == AnalyticsEvent.EPISODE_BULK_DOWNLOAD_QUEUED) {
             downloadEpisodeUuidQueue.clear()

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.analytics
 
+import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -7,17 +8,26 @@ import javax.inject.Singleton
 class EpisodeAnalytics @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
 ) {
+    private val downloadEpisodeUuidQueue = mutableListOf<String>()
     private val uploadEpisodeUuidQueue = mutableListOf<String>()
 
     fun trackEvent(event: AnalyticsEvent, source: AnalyticsSource, uuid: String) {
-        if (event == AnalyticsEvent.EPISODE_UPLOAD_QUEUED) {
+        if (event == AnalyticsEvent.EPISODE_DOWNLOAD_QUEUED) {
+            downloadEpisodeUuidQueue.add(uuid)
+        } else if (event == AnalyticsEvent.EPISODE_UPLOAD_QUEUED) {
             uploadEpisodeUuidQueue.add(uuid)
         }
         analyticsTracker.track(event, AnalyticsProp.sourceAndUuidMap(source, uuid))
     }
 
     fun trackEvent(event: AnalyticsEvent, uuid: String) {
-        if (event == AnalyticsEvent.EPISODE_UPLOAD_FINISHED) {
+        if (event == AnalyticsEvent.EPISODE_DOWNLOAD_FINISHED) {
+            if (downloadEpisodeUuidQueue.contains(uuid)) {
+                downloadEpisodeUuidQueue.remove(uuid)
+            } else {
+                return
+            }
+        } else if (event == AnalyticsEvent.EPISODE_UPLOAD_FINISHED) {
             if (uploadEpisodeUuidQueue.contains(uuid)) {
                 uploadEpisodeUuidQueue.remove(uuid)
             } else {
@@ -28,10 +38,20 @@ class EpisodeAnalytics @Inject constructor(
         analyticsTracker.track(event, AnalyticsProp.uuidMap(uuid))
     }
 
+    fun trackBulkEvent(event: AnalyticsEvent, source: AnalyticsSource, episodes: List<Playable>) {
+        if (event == AnalyticsEvent.EPISODE_BULK_DOWNLOAD_QUEUED) {
+            downloadEpisodeUuidQueue.clear()
+            downloadEpisodeUuidQueue.addAll(downloadEpisodeUuidQueue.union(episodes.map { it.uuid }))
+        }
+        analyticsTracker.track(event, AnalyticsProp.bulkMap(source, episodes.size))
+    }
+
     private object AnalyticsProp {
         private const val source = "source"
         private const val episode_uuid = "episode_uuid"
+        private const val count = "count"
         fun sourceAndUuidMap(eventSource: AnalyticsSource, uuid: String) = mapOf(source to eventSource.analyticsValue, episode_uuid to uuid)
         fun uuidMap(uuid: String) = mapOf(episode_uuid to uuid)
+        fun bulkMap(eventSource: AnalyticsSource, count: Int) = mapOf(source to eventSource.analyticsValue, this.count to count)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
@@ -12,6 +12,8 @@ import androidx.work.Data
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -57,7 +59,8 @@ class DownloadManagerImpl @Inject constructor(
     private val fileStorage: FileStorage,
     private val settings: Settings,
     private val notificationHelper: NotificationHelper,
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
+    private val episodeAnalytics: EpisodeAnalytics
 ) : DownloadManager, CoroutineScope {
 
     companion object {
@@ -387,6 +390,7 @@ class DownloadManagerImpl @Inject constructor(
 
             if (result.success) {
                 episodeManager.updateEpisodeStatus(episode, EpisodeStatusEnum.DOWNLOADED)
+                episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_DOWNLOAD_FINISHED, uuid = episode.uuid)
 
                 RefreshPodcastsThread.updateNotifications(settings.getNotificationLastSeen(), settings, podcastManager, episodeManager, notificationHelper, context)
             } else {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -16,13 +16,13 @@ import android.support.v4.media.session.PlaybackStateCompat
 import android.view.KeyEvent
 import androidx.annotation.DrawableRes
 import androidx.core.os.bundleOf
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationControls
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.saveToGlobalSettings
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.auto.AutoConverter
 import au.com.shiftyjelly.pocketcasts.repositories.playback.auto.AutoMediaId
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -81,7 +81,7 @@ class MediaSessionManager(
     val mediaSession = MediaSessionCompat(context, "PocketCastsMediaSession")
     val disposables = CompositeDisposable()
     var seeking = false
-    private val playbackSource = PlaybackSource.MEDIA_BUTTON_BROADCAST_ACTION
+    private val source = AnalyticsSource.MEDIA_BUTTON_BROADCAST_ACTION
 
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
@@ -451,7 +451,7 @@ class MediaSessionManager(
                         object : TimerTask() {
                             override fun run() {
                                 logEvent("play from headset hook", inSessionCallback = false)
-                                playbackManager.playPause(playbackSource = playbackSource)
+                                playbackManager.playPause(playbackSource = source)
                                 playPauseTimer = null
                             }
                         },
@@ -464,7 +464,7 @@ class MediaSessionManager(
                 playPauseTimer = null
 
                 logEvent("skip forwards from headset hook")
-                playbackManager.skipForward(playbackSource = playbackSource)
+                playbackManager.skipForward(playbackSource = source)
             }
         }
 
@@ -482,12 +482,12 @@ class MediaSessionManager(
 
         override fun onPlay() {
             logEvent("play")
-            playbackManager.playQueue(playbackSource = playbackSource)
+            playbackManager.playQueue(playbackSource = source)
         }
 
         override fun onPause() {
             logEvent("pause")
-            playbackManager.pause(playbackSource = playbackSource)
+            playbackManager.pause(playbackSource = source)
         }
 
         override fun onPlayFromSearch(query: String?, extras: Bundle?) {
@@ -502,18 +502,18 @@ class MediaSessionManager(
             logEvent("stop")
             launch {
                 // note: the stop event is called from cars when they only want to pause, this is less destructive and doesn't cause issues if they try to play again
-                playbackManager.pause(playbackSource = playbackSource)
+                playbackManager.pause(playbackSource = source)
             }
         }
 
         override fun onSkipToPrevious() {
             logEvent("skip backwards")
-            playbackManager.skipBackward(playbackSource = playbackSource)
+            playbackManager.skipBackward(playbackSource = source)
         }
 
         override fun onSkipToNext() {
             logEvent("skip forwards")
-            playbackManager.skipForward(playbackSource = playbackSource)
+            playbackManager.skipForward(playbackSource = source)
         }
 
         override fun onSetRating(rating: RatingCompat?) {
@@ -534,7 +534,7 @@ class MediaSessionManager(
                 val autoMediaId = AutoMediaId.fromMediaId(mediaId)
                 val playableId = autoMediaId.playableId
                 episodeManager.findPlayableByUuid(playableId)?.let { episode ->
-                    playbackManager.playNow(episode, playbackSource = playbackSource)
+                    playbackManager.playNow(episode, playbackSource = source)
 
                     playbackManager.lastLoadedFromPodcastOrPlaylistUuid = autoMediaId.sourceId
                 }
@@ -561,7 +561,7 @@ class MediaSessionManager(
             if (state is UpNextQueue.State.Loaded) {
                 state.queue.find { it.adapterId == id }?.let { episode ->
                     logEvent("play from skip to queue item")
-                    playbackManager.playNow(episode = episode, playbackSource = playbackSource)
+                    playbackManager.playNow(episode = episode, playbackSource = source)
                 }
             }
         }
@@ -571,7 +571,7 @@ class MediaSessionManager(
             seeking = true
             launch {
                 playbackManager.seekToTimeMs(pos.toInt())
-                playbackManager.trackPlaybackSeek(pos.toInt(), PlaybackSource.MEDIA_BUTTON_BROADCAST_ACTION)
+                playbackManager.trackPlaybackSeek(pos.toInt(), AnalyticsSource.MEDIA_BUTTON_BROADCAST_ACTION)
             }
         }
     }
@@ -669,7 +669,7 @@ class MediaSessionManager(
 
         Timber.i("performPlayFromSearch query: $query")
 
-        val playbackSource = PlaybackSource.MEDIA_BUTTON_BROADCAST_SEARCH_ACTION
+        val playbackSource = AnalyticsSource.MEDIA_BUTTON_BROADCAST_SEARCH_ACTION
         launch {
             if (query.startsWith("up next")) {
                 playbackManager.playQueue(playbackSource = playbackSource)
@@ -739,7 +739,7 @@ class MediaSessionManager(
         return Completable.fromAction { performPlayFromSearch(searchTerm) }
     }
 
-    private fun playEpisodes(episodes: List<Episode>, playbackSource: PlaybackSource) {
+    private fun playEpisodes(episodes: List<Episode>, playbackSource: AnalyticsSource) {
         if (episodes.isEmpty()) {
             return
         }
@@ -747,7 +747,7 @@ class MediaSessionManager(
         playbackManager.playEpisodes(episodes = episodes, playbackSource = playbackSource)
     }
 
-    private suspend fun playPodcast(podcast: Podcast, playbackSource: PlaybackSource = PlaybackSource.UNKNOWN) {
+    private suspend fun playPodcast(podcast: Podcast, playbackSource: AnalyticsSource = AnalyticsSource.UNKNOWN) {
         val latestEpisode = withContext(Dispatchers.Default) { episodeManager.findLatestUnfinishedEpisodeByPodcast(podcast) } ?: return
         playbackManager.playNow(episode = latestEpisode, playbackSource = playbackSource)
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -12,6 +12,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LiveDataReactiveStreams
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.localization.BuildConfig
@@ -216,7 +217,7 @@ open class PlaybackManager @Inject constructor(
         withContext(Dispatchers.Default) {
             upNextQueue.playNext(autoPlayEpisode, downloadManager) {
                 launch {
-                    loadCurrentEpisode(play = autoPlay, playbackSource = PlaybackSource.AUTO_PLAY)
+                    loadCurrentEpisode(play = autoPlay, playbackSource = AnalyticsSource.AUTO_PLAY)
                 }
             }
         }
@@ -329,7 +330,7 @@ open class PlaybackManager @Inject constructor(
         return playbackStateRelay.blockingFirst().playbackSpeed
     }
 
-    fun playPause(playbackSource: PlaybackSource = PlaybackSource.UNKNOWN) {
+    fun playPause(playbackSource: AnalyticsSource = AnalyticsSource.UNKNOWN) {
         if (isPlaying()) {
             pause(playbackSource = playbackSource)
         } else {
@@ -337,7 +338,7 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    fun playQueue(playbackSource: PlaybackSource = PlaybackSource.UNKNOWN) {
+    fun playQueue(playbackSource: AnalyticsSource = AnalyticsSource.UNKNOWN) {
         launch {
             if (upNextQueue.currentEpisode != null) {
                 loadEpisodeWhenRequired(playbackSource)
@@ -345,14 +346,14 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    fun playNow(episode: Playable, forceStream: Boolean = false, playbackSource: PlaybackSource = PlaybackSource.UNKNOWN) {
+    fun playNow(episode: Playable, forceStream: Boolean = false, playbackSource: AnalyticsSource = AnalyticsSource.UNKNOWN) {
         launch {
             forcePlayerSwitch = true
             playNowSync(episode = episode, forceStream = forceStream, playbackSource = playbackSource)
         }
     }
 
-    private suspend fun playNowSync(episode: Playable, forceStream: Boolean = false, playbackSource: PlaybackSource = PlaybackSource.UNKNOWN) {
+    private suspend fun playNowSync(episode: Playable, forceStream: Boolean = false, playbackSource: AnalyticsSource = AnalyticsSource.UNKNOWN) {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Play now: ${episode.uuid} ${episode.title}")
 
         if (episode.isArchived) {
@@ -401,7 +402,7 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    private suspend fun loadEpisodeWhenRequired(playbackSource: PlaybackSource = PlaybackSource.UNKNOWN) {
+    private suspend fun loadEpisodeWhenRequired(playbackSource: AnalyticsSource = AnalyticsSource.UNKNOWN) {
         if (isPlayerSwitchRequired()) {
             loadCurrentEpisode(play = true, playbackSource = playbackSource)
         } else {
@@ -409,7 +410,7 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    fun playEpisodes(episodes: List<Playable>, playbackSource: PlaybackSource = PlaybackSource.UNKNOWN) {
+    fun playEpisodes(episodes: List<Playable>, playbackSource: AnalyticsSource = AnalyticsSource.UNKNOWN) {
         if (episodes.isEmpty()) {
             return
         }
@@ -466,7 +467,7 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    fun pause(transientLoss: Boolean = false, playbackSource: PlaybackSource = PlaybackSource.UNKNOWN) {
+    fun pause(transientLoss: Boolean = false, playbackSource: AnalyticsSource = AnalyticsSource.UNKNOWN) {
         if (!transientLoss) {
             focusManager.giveUpAudioFocus()
             playbackStateRelay.blockingFirst().let { playbackState ->
@@ -488,7 +489,7 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    fun stopAsync(isAudioFocusFailed: Boolean = false, playbackSource: PlaybackSource = PlaybackSource.UNKNOWN) {
+    fun stopAsync(isAudioFocusFailed: Boolean = false, playbackSource: AnalyticsSource = AnalyticsSource.UNKNOWN) {
         launch {
             if (!isAudioFocusFailed) {
                 trackPlayback(AnalyticsEvent.PLAYBACK_STOP, playbackSource)
@@ -588,7 +589,7 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    fun playNextInQueue(playbackSource: PlaybackSource = PlaybackSource.UNKNOWN) {
+    fun playNextInQueue(playbackSource: AnalyticsSource = AnalyticsSource.UNKNOWN) {
         launch {
             upNextQueue.queueEpisodes.getOrNull(0)?.let {
                 playNowSync(episode = it, playbackSource = playbackSource)
@@ -596,7 +597,7 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    fun skipForward(playbackSource: PlaybackSource = PlaybackSource.UNKNOWN, jumpAmountSeconds: Int = settings.getSkipForwardInSecs()) {
+    fun skipForward(playbackSource: AnalyticsSource = AnalyticsSource.UNKNOWN, jumpAmountSeconds: Int = settings.getSkipForwardInSecs()) {
         launch {
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Skip forward tapped")
 
@@ -620,7 +621,7 @@ open class PlaybackManager @Inject constructor(
         trackPlayback(AnalyticsEvent.PLAYBACK_SKIP_FORWARD, playbackSource)
     }
 
-    fun skipBackward(playbackSource: PlaybackSource = PlaybackSource.UNKNOWN, jumpAmountSeconds: Int = settings.getSkipBackwardInSecs()) {
+    fun skipBackward(playbackSource: AnalyticsSource = AnalyticsSource.UNKNOWN, jumpAmountSeconds: Int = settings.getSkipBackwardInSecs()) {
         launch {
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Skip backward tapped")
 
@@ -728,7 +729,7 @@ open class PlaybackManager @Inject constructor(
                 upNextQueue.removeEpisode(episodeToRemove)
 
                 if (isCurrentEpisode) {
-                    loadCurrentEpisode(play = isPlaying, playbackSource = PlaybackSource.AUTO_PLAY)
+                    loadCurrentEpisode(play = isPlaying, playbackSource = AnalyticsSource.AUTO_PLAY)
                 }
             }
         }
@@ -770,7 +771,7 @@ open class PlaybackManager @Inject constructor(
         upNextQueue.currentEpisode ?: return
         launch {
             if (isPlayerSwitchRequired()) {
-                loadCurrentEpisode(true, playbackSource = PlaybackSource.CHROMECAST)
+                loadCurrentEpisode(true, playbackSource = AnalyticsSource.CHROMECAST)
             }
         }
     }
@@ -783,7 +784,7 @@ open class PlaybackManager @Inject constructor(
             stop()
 
             if (isPlayerSwitchRequired()) {
-                loadCurrentEpisode(false, playbackSource = PlaybackSource.CHROMECAST)
+                loadCurrentEpisode(false, playbackSource = AnalyticsSource.CHROMECAST)
             }
         }
     }
@@ -1016,7 +1017,7 @@ open class PlaybackManager @Inject constructor(
                 shutdown()
             }
         } else {
-            loadCurrentEpisode(play = autoPlay, playbackSource = PlaybackSource.AUTO_PLAY)
+            loadCurrentEpisode(play = autoPlay, playbackSource = AnalyticsSource.AUTO_PLAY)
         }
     }
 
@@ -1070,7 +1071,7 @@ open class PlaybackManager @Inject constructor(
 
         val podcast = playbackStateRelay.blockingFirst().podcast
         if (podcast != null && podcast.skipLastSecs > 0) {
-            pause(playbackSource = PlaybackSource.AUTO_PAUSE)
+            pause(playbackSource = AnalyticsSource.AUTO_PAUSE)
         }
         onPlayerPaused()
 
@@ -1180,7 +1181,7 @@ open class PlaybackManager @Inject constructor(
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Focus lost while playing")
             focusWasPlaying = Date()
 
-            pause(transientLoss = transientLoss, playbackSource = PlaybackSource.AUTO_PAUSE)
+            pause(transientLoss = transientLoss, playbackSource = AnalyticsSource.AUTO_PAUSE)
         } else {
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Focus lost not playing")
             focusWasPlaying = null
@@ -1203,7 +1204,7 @@ open class PlaybackManager @Inject constructor(
             return
         }
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "System fired 'Audio Becoming Noisy' event, pausing playback.")
-        pause(playbackSource = PlaybackSource.AUTO_PAUSE)
+        pause(playbackSource = AnalyticsSource.AUTO_PAUSE)
         focusWasPlaying = null
     }
 
@@ -1249,7 +1250,7 @@ open class PlaybackManager @Inject constructor(
     /**
      * Load the episode
      */
-    private suspend fun loadCurrentEpisode(play: Boolean, forceStream: Boolean = false, playbackSource: PlaybackSource = PlaybackSource.UNKNOWN) {
+    private suspend fun loadCurrentEpisode(play: Boolean, forceStream: Boolean = false, playbackSource: AnalyticsSource = AnalyticsSource.UNKNOWN) {
         // make sure we have the most recent copy from the database
         val currentUpNextEpisode = upNextQueue.currentEpisode
         val episode: Playable? = if (currentUpNextEpisode is Episode) {
@@ -1536,7 +1537,7 @@ open class PlaybackManager @Inject constructor(
         return PendingIntent.getBroadcast(context, intentId, intent, PendingIntent.FLAG_UPDATE_CURRENT.or(PendingIntent.FLAG_IMMUTABLE))
     }
 
-    private suspend fun play(playbackSource: PlaybackSource = PlaybackSource.UNKNOWN) {
+    private suspend fun play(playbackSource: AnalyticsSource = AnalyticsSource.UNKNOWN) {
         val episode = getCurrentEpisode()
         if (episode == null || player == null) {
             return
@@ -1858,8 +1859,8 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    private fun trackPlayback(event: AnalyticsEvent, playbackSource: PlaybackSource) {
-        if (playbackSource == PlaybackSource.UNKNOWN) {
+    private fun trackPlayback(event: AnalyticsEvent, playbackSource: AnalyticsSource) {
+        if (playbackSource == AnalyticsSource.UNKNOWN) {
             Timber.w("Found unknown playback source.")
         }
         if (!playbackSource.skipTracking()) {
@@ -1869,7 +1870,7 @@ open class PlaybackManager @Inject constructor(
 
     fun trackPlaybackSeek(
         positionMs: Int,
-        playbackSource: PlaybackSource
+        playbackSource: AnalyticsSource
     ) {
         val episode = getCurrentEpisode()
         episode?.let {
@@ -1892,40 +1893,11 @@ open class PlaybackManager @Inject constructor(
     fun trackPlaybackEffectsEvent(
         event: AnalyticsEvent,
         props: Map<String, Any> = emptyMap(),
-        playbackSource: PlaybackSource
+        playbackSource: AnalyticsSource
     ) {
         val properties = HashMap<String, Any>()
         properties[SOURCE_KEY] = playbackSource.analyticsValue
         properties.putAll(props)
         analyticsTracker.track(event, properties)
-    }
-
-    enum class PlaybackSource(val analyticsValue: String) {
-        PODCAST_SCREEN("podcast_screen"),
-        FILTERS("filters"),
-        DISCOVER("discover"),
-        DISCOVER_PODCAST_LIST("discover_podcast_list"),
-        DOWNLOADS("downloads"),
-        FILES("files"),
-        STARRED("starred"),
-        LISTENING_HISTORY("listening_history"),
-        EPISODE_DETAILS("episode_details"),
-        MINIPLAYER("miniplayer"),
-        PLAYER("player"),
-        NOTIFICATION("notification"),
-        FULL_SCREEN_VIDEO("full_screen_video"),
-        UP_NEXT("up_next"),
-        MEDIA_BUTTON_BROADCAST_ACTION("media_button_broadcast_action"),
-        MEDIA_BUTTON_BROADCAST_SEARCH_ACTION("media_button_broadcast_search_action"),
-        PLAYER_BROADCAST_ACTION("player_broadcast_action"),
-        CHROMECAST("chromecast"),
-        AUTO_PLAY("auto_play"),
-        AUTO_PAUSE("auto_pause"),
-        PLAYER_PLAYBACK_EFFECTS("player_playback_effects"),
-        PODCAST_SETTINGS("podcast_settings"),
-        UNKNOWN("unknown"),
-        TASKER("tasker");
-
-        fun skipTracking() = this in listOf(AUTO_PLAY, AUTO_PAUSE)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiver.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.AndroidEntryPoint
@@ -28,7 +28,7 @@ class PlayerBroadcastReceiver : BroadcastReceiver() {
 
     @Inject lateinit var podcastManager: PodcastManager
     @Inject lateinit var playbackManager: PlaybackManager
-    private val playbackSource = PlaybackSource.PLAYER_BROADCAST_ACTION
+    private val playbackSource = AnalyticsSource.PLAYER_BROADCAST_ACTION
 
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action == INTENT_ACTION_REFRESH_PODCASTS) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerReceiver.kt
@@ -4,7 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -17,7 +17,7 @@ class SleepTimerReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Paused from sleep timer.")
         Toast.makeText(context, "Sleep timer stopped your podcast.\nNight night!", Toast.LENGTH_LONG).show()
-        playbackManager.pause(playbackSource = PlaybackSource.AUTO_PAUSE)
+        playbackManager.pause(playbackSource = AnalyticsSource.AUTO_PAUSE)
         playbackManager.updateSleepTimerStatus(running = false)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -7,6 +7,9 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -121,7 +124,9 @@ class UserEpisodeManagerImpl @Inject constructor(
     val settings: Settings,
     val subscriptionManager: SubscriptionManager,
     val downloadManager: DownloadManager,
-    @ApplicationContext val context: Context
+    @ApplicationContext val context: Context,
+    val analyticsTracker: AnalyticsTrackerWrapper,
+    val episodeAnalytics: EpisodeAnalytics
 ) : UserEpisodeManager, CoroutineScope {
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.IO
@@ -464,6 +469,7 @@ class UserEpisodeManagerImpl @Inject constructor(
                     }
                     .flatMapCompletable { success ->
                         if (success) {
+                            episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_UPLOAD_FINISHED, uuid = userEpisode.uuid)
                             userEpisodeDao.updateServerStatusRx(userEpisode.uuid, serverStatus = UserEpisodeServerStatus.UPLOADED)
                         } else {
                             userEpisodeDao.updateUploadErrorRx(userEpisode.uuid, "Upload failed")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -8,7 +8,6 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
@@ -125,7 +124,6 @@ class UserEpisodeManagerImpl @Inject constructor(
     val subscriptionManager: SubscriptionManager,
     val downloadManager: DownloadManager,
     @ApplicationContext val context: Context,
-    val analyticsTracker: AnalyticsTrackerWrapper,
     val episodeAnalytics: EpisodeAnalytics
 ) : UserEpisodeManager, CoroutineScope {
     override val coroutineContext: CoroutineContext

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/NotificationBroadcastReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/NotificationBroadcastReceiver.kt
@@ -4,11 +4,11 @@ import android.app.NotificationManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.PlaybackSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import dagger.hilt.android.AndroidEntryPoint
@@ -27,7 +27,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver(), CoroutineScope {
     @Inject lateinit var downloadManager: DownloadManager
     @Inject lateinit var playbackManager: PlaybackManager
 
-    private val playbackSource = PlaybackSource.NOTIFICATION
+    private val source = AnalyticsSource.NOTIFICATION
 
     companion object {
 
@@ -92,7 +92,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver(), CoroutineScope {
     private fun playNow(episodeUuid: String, forceStream: Boolean) {
         launch {
             episodeManager.findPlayableByUuid(episodeUuid)?.let { episode ->
-                playbackManager.playNow(episode, forceStream = forceStream, playbackSource = playbackSource)
+                playbackManager.playNow(episode, forceStream = forceStream, playbackSource = source)
             }
         }
     }
@@ -134,7 +134,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver(), CoroutineScope {
             episodeManager.findPlayableByUuid(episodeUuid)?.let { episode ->
                 playbackManager.playLast(episode)
                 if (playNext) {
-                    playbackManager.playNextInQueue(playbackSource = playbackSource)
+                    playbackManager.playNextInQueue(playbackSource = source)
                 }
             }
         }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.view.View
 import androidx.fragment.app.Fragment
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -41,7 +42,7 @@ class WarningsHelper @Inject constructor(
     fun streamingWarningDialog(
         episode: Playable,
         snackbarParentView: View? = null,
-        playbackSource: PlaybackManager.PlaybackSource
+        playbackSource: AnalyticsSource
     ): ConfirmationDialog {
         return streamingWarningDialog(onConfirm = {
             GlobalScope.launch {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
@@ -4,7 +4,9 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.view.View
 import androidx.fragment.app.Fragment
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -35,7 +37,8 @@ class WarningsHelper @Inject constructor(
     private val playbackManager: PlaybackManager,
     private val settings: Settings,
     private val systemBatteryRestrictions: SystemBatteryRestrictions,
-    private val userEpisodeManager: UserEpisodeManager
+    private val userEpisodeManager: UserEpisodeManager,
+    private val episodeAnalytics: EpisodeAnalytics,
 ) {
 
     @OptIn(DelicateCoroutinesApi::class)
@@ -76,7 +79,7 @@ class WarningsHelper @Inject constructor(
             .setOnSecondary { download(episodeUuid, waitForWifi = true, from = from) }
     }
 
-    fun uploadWarning(episodeUuid: String): ConfirmationDialog {
+    fun uploadWarning(episodeUuid: String, source: AnalyticsSource): ConfirmationDialog {
         val titleRes =
             if (Network.isWifiConnection(activity)) LR.string.profile_cloud_upload_warning_title_metered_wifi else LR.string.profile_cloud_upload_warning_title_on_wifi
         return ConfirmationDialog()
@@ -84,19 +87,20 @@ class WarningsHelper @Inject constructor(
             .setTitle(activity.getString(titleRes))
             .setSummary(activity.getString(LR.string.profile_cloud_upload_warning_summary))
             .setButtonType(ConfirmationDialog.ButtonType.Normal(activity.getString(LR.string.profile_cloud_upload_warning_button)))
-            .setOnConfirm { upload(episodeUuid, waitForWifi = false) }
+            .setOnConfirm { upload(episodeUuid, waitForWifi = false, source = source) }
             .setSecondaryButtonType(ConfirmationDialog.ButtonType.Normal(activity.getString(LR.string.profile_cloud_upload_warning_later)))
-            .setOnSecondary { upload(episodeUuid, waitForWifi = true) }
+            .setOnSecondary { upload(episodeUuid, waitForWifi = true, source = source) }
     }
 
     @OptIn(DelicateCoroutinesApi::class)
-    private fun upload(episodeUuid: String, waitForWifi: Boolean) {
+    private fun upload(episodeUuid: String, waitForWifi: Boolean, source: AnalyticsSource) {
         GlobalScope.launch {
             episodeManager.findPlayableByUuid(episodeUuid)?.let {
                 if (it !is UserEpisode) return@let
 
                 if (!it.isUploaded && !it.isQueuedForUpload && !it.isUploading) {
                     userEpisodeManager.uploadToServer(it, waitForWifi)
+                    episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_UPLOAD_QUEUED, source = source, uuid = it.uuid)
                 }
             }
         }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectHelper.kt
@@ -403,6 +403,14 @@ class MultiSelectHelper @Inject constructor(
             val userEpisodes = list.filterIsInstance<UserEpisode>()
             userEpisodeManager.deleteAll(userEpisodes, playbackManager)
 
+            if (episodes.isNotEmpty()) {
+                episodeAnalytics.trackBulkEvent(
+                    AnalyticsEvent.EPISODE_BULK_DOWNLOAD_DELETED,
+                    source = source,
+                    count = if (episodes.isNotEmpty()) episodes.size else userEpisodes.size
+                )
+            }
+
             withContext(Dispatchers.Main) {
                 closeMultiSelect()
             }
@@ -469,6 +477,7 @@ class MultiSelectHelper @Inject constructor(
                 Timber.d("Deleting $it")
                 CloudDeleteHelper.deleteEpisode(it, state, playbackManager, episodeManager, userEpisodeManager)
             }
+            episodeAnalytics.trackBulkEvent(AnalyticsEvent.EPISODE_BULK_DOWNLOAD_DELETED, source, episodesToDelete.size)
 
             val snackText = resources.getStringPlural(episodesToDelete.size, LR.string.episodes_deleted_singular, LR.string.episodes_deleted_plural)
             showSnackBar(snackText)

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectHelper.kt
@@ -8,6 +8,8 @@ import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
@@ -48,7 +50,8 @@ class MultiSelectHelper @Inject constructor(
     val podcastManager: PodcastManager,
     val playbackManager: PlaybackManager,
     val downloadManager: DownloadManager,
-    val settings: Settings
+    val settings: Settings,
+    private val episodeAnalytics: EpisodeAnalytics
 ) :
     CoroutineScope {
     interface Listener {
@@ -85,6 +88,7 @@ class MultiSelectHelper @Inject constructor(
 
     var coordinatorLayout: View? = null
     var context: Context? = null
+    var source = AnalyticsSource.UNKNOWN
 
     lateinit var listener: Listener
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectHelper.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
@@ -381,6 +382,7 @@ class MultiSelectHelper @Inject constructor(
             trimmedList.forEach {
                 downloadManager.addEpisodeToQueue(it, "podcast download all", false)
             }
+            episodeAnalytics.trackBulkEvent(AnalyticsEvent.EPISODE_BULK_DOWNLOAD_QUEUED, source, trimmedList)
             val snackText = resources.getStringPlural(trimmedList.size, LR.string.download_queued_singular, LR.string.download_queued_plural)
             showSnackBar(snackText)
             closeMultiSelect()


### PR DESCRIPTION
## Description

- This tracks below episode events:
    - `episode_download_queued`: When the user triggers episode for downloading
    - `episode_download_finished`: When episode download is finished
    - `episode_bulk_download_queued`: When the user triggers multiple episodes download while in multi select mode
    - `episode_download_cancelled`: When the user cancels an active download
    - `episode_upload_queued`: When the user uploads a custom file to the cloud
    - `episode_upload_cancelled`: When the user cancels an active cloud upload
    - `episode_upload_finished`: When episode upload is finished
    - `episode_deleted_from_cloud`: When the user deletes a file from the cloud
    - `episode_download_deleted`: When the user deletes a downloaded episode
    - `episode_bulk_download_deleted`: When the user deletes multiple downloaded episodes while in multi select mode
- Since episode sources are spread across multiple screens and are mostly common to playback sources, `PlaybackSource` is extracted to a common `AnalyticsSource` and reused as episode source as well - 73af404133a8e136f6c8548041f62baa1d23d080.
- Other events covered in corresponding [iOS PR](https://github.com/Automattic/pocket-casts-ios/pull/298) will be added as part of another PR.

------




## Testing Instructions
<details><summary>Download / Bulk Download / Download Cancel</summary>

1. Tap on the Podcasts tab
2. Tap on a podcast
3. Tap on an episode
4. Tap the download button
5. ✅ `🔵 Tracked: episode_download_queued ["source": "episode_detail", "episode_uuid": "UUID"]`
7. Wait for it to finish downloading, 
8. ✅ `🔵 Tracked: episode_download_finished ["source": "episode_detail", "episode_uuid": "UUID"]`
9. Tap the download button again to delete it
10. ✅ `🔵 Tracked: episode_download_deleted ["episode_uuid": "UUID", "source": "episode_detail"]`
11. Tap the download button again, and then tap it again to cancel the download before it finishes
12. ✅ `🔵 Tracked: episode_download_cancelled ["episode_uuid": "UUID", "source": "episode_detail"]`
13. Dismiss the episode details
14. Tap and hold on the podcast list to enter multi select mode
15. Select multiple episodes
16. Tap the ... if the Download action is not in your shelf
17. Tap the Download action
18. ✅ `🔵 Tracked: episode_bulk_downloaded ["episode_count": COUNT, "source": "podcast_screen"]` - Verify the count is the number of episodes you selected
19. Enter multi select mode again
20. Select the same episodes
21. Tap the Remove Download action
22. ✅ `🔵 Tracked: episode_bulk_download_deleted ["episode_count": COUNT, "source": "podcast_screen"]`

**Repeat the steps on the following views:**
1. Filter Details
2. Downloads
3. Starred
4. Listening History
5. Files
</details>

<details><summary>Episode Upload / Cancelled / Deleted</summary>

1. Tap on the Profile icon
2. Tap on Files
3. If you don't have any custom files, add a couple by dragging and dropping an audio file from your Mac to the simulator
4. Tap on a file in the list
5. Tap Upload to Cloud
6. ✅ `🔵 Tracked: episode_upload_queued ["episode_uuid": "UUID", "source": "files"]`
7. Wait for it to finish uploading, 
8. ✅ `🔵 Tracked: episode_upload_finished ["episode_uuid": "UUID", "source": "files"]`
8. Tap the same file again
9. Tap the Remove from Cloud action
10. ✅ `🔵 Tracked: episode_deleted_from_cloud ["episode_uuid": "UUID", "source": "files"]`
11. Tap the file again, and select upload to cloud
12. While the file is uploading, tap it again and select the Cancel Download action
13. ✅ `🔵 Tracked: episode_upload_cancelled ["episode_uuid": "UUID", "source": "files"]`
</details>

