### PR TITLE
Switched to using the new user login and register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.31
 -----
-
+*   Health:
+    *   Switched to using the new user login and register endpoints.
+        ([#685](https://github.com/Automattic/pocket-casts-android/pull/685)).
 
 7.30
 -----

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountAuth.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountAuth.kt
@@ -14,20 +14,22 @@ import au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsThread
 import au.com.shiftyjelly.pocketcasts.servers.ServerCallback
 import au.com.shiftyjelly.pocketcasts.servers.ServerManager
 import au.com.shiftyjelly.pocketcasts.servers.model.AuthResultModel
+import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServerManager
+import au.com.shiftyjelly.pocketcasts.servers.sync.parseErrorResponse
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import retrofit2.HttpException
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Singleton
 class AccountAuth @Inject constructor(
     private val settings: Settings,
     private val serverManager: ServerManager,
+    private val syncServerManager: SyncServerManager,
     private val podcastManager: PodcastManager,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     @ApplicationContext private val context: Context
@@ -44,7 +46,7 @@ class AccountAuth @Inject constructor(
         signInSource: SignInSource
     ): AuthResult {
         return withContext(Dispatchers.IO) {
-            val authResult = loginToSyncServer(email, password)
+            val authResult = login(email, password)
             if (authResult is AuthResult.Success) {
                 signInSuccessful(email, password, authResult.result)
             }
@@ -60,7 +62,7 @@ class AccountAuth @Inject constructor(
                 analyticsTracker.track(AnalyticsEvent.USER_SIGNED_IN, properties)
             }
             is AuthResult.Failed -> {
-                val errorCodeValue = authResult.serverMessageId ?: TracksAnalyticsTracker.INVALID_OR_NULL_VALUE
+                val errorCodeValue = authResult.messageId ?: TracksAnalyticsTracker.INVALID_OR_NULL_VALUE
                 val errorProperties = properties.plus(KEY_ERROR_CODE to errorCodeValue)
                 analyticsTracker.track(AnalyticsEvent.USER_SIGNIN_FAILED, errorProperties)
             }
@@ -69,77 +71,52 @@ class AccountAuth @Inject constructor(
 
     suspend fun createUserWithEmailAndPassword(email: String, password: String): AuthResult {
         return withContext(Dispatchers.IO) {
-            val authResult = registerWithSyncServer(email, password)
+            val authResult = register(email, password)
             if (authResult is AuthResult.Success) {
                 signInSuccessful(email, password, authResult.result)
             }
+            trackRegister(authResult)
             authResult
         }
     }
 
-    private suspend fun registerWithSyncServer(email: String, password: String): AuthResult {
-        return suspendCoroutine { continuation ->
-            serverManager.registerWithSyncServer(
-                email, password,
-                object : ServerCallback<AuthResultModel> {
-                    override fun dataReturned(result: AuthResultModel?) {
-                        continuation.resume(AuthResult.Success(result))
-                        analyticsTracker.track(AnalyticsEvent.USER_ACCOUNT_CREATED)
-                    }
-
-                    override fun onFailed(
-                        errorCode: Int,
-                        userMessage: String?,
-                        serverMessageId: String?,
-                        serverMessage: String?,
-                        throwable: Throwable?
-                    ) {
-                        val message = LocaliseHelper.serverMessageIdToMessage(serverMessageId, ::getResourceString)
-                            ?: userMessage
-                            ?: getResourceString(LR.string.error_login_failed)
-                        continuation.resume(
-                            AuthResult.Failed(
-                                message = message,
-                                serverMessageId = serverMessageId
-                            )
-                        )
-                        val errorCodeValue = serverMessageId ?: TracksAnalyticsTracker.INVALID_OR_NULL_VALUE
-                        analyticsTracker.track(AnalyticsEvent.USER_ACCOUNT_CREATION_FAILED, mapOf(KEY_ERROR_CODE to errorCodeValue))
-                    }
-                }
-            )
+    private fun trackRegister(authResult: AuthResult) {
+        when (authResult) {
+            is AuthResult.Success -> {
+                analyticsTracker.track(AnalyticsEvent.USER_ACCOUNT_CREATED)
+            }
+            is AuthResult.Failed -> {
+                val errorCodeValue = authResult.messageId ?: TracksAnalyticsTracker.INVALID_OR_NULL_VALUE
+                analyticsTracker.track(AnalyticsEvent.USER_ACCOUNT_CREATION_FAILED, mapOf(KEY_ERROR_CODE to errorCodeValue))
+            }
         }
     }
 
-    private suspend fun loginToSyncServer(email: String, password: String): AuthResult {
-        return suspendCoroutine { continuation ->
-            serverManager.loginToSyncServer(
-                email, password,
-                object : ServerCallback<AuthResultModel> {
-                    override fun dataReturned(result: AuthResultModel?) {
-                        continuation.resume(AuthResult.Success(result))
-                    }
-
-                    override fun onFailed(
-                        errorCode: Int,
-                        userMessage: String?,
-                        serverMessageId: String?,
-                        serverMessage: String?,
-                        throwable: Throwable?
-                    ) {
-                        val message = LocaliseHelper.serverMessageIdToMessage(serverMessageId, ::getResourceString)
-                            ?: userMessage
-                            ?: getResourceString(LR.string.error_login_failed)
-                        continuation.resume(
-                            AuthResult.Failed(
-                                message = message,
-                                serverMessageId = serverMessageId
-                            )
-                        )
-                    }
-                }
-            )
+    private suspend fun register(email: String, password: String): AuthResult {
+        return try {
+            val response = syncServerManager.register(email = email, password = password)
+            AuthResult.Success(AuthResultModel(token = response.token, uuid = response.uuid))
+        } catch (ex: Exception) {
+            exceptionToAuthResult(exception = ex, fallbackMessage = LR.string.error_login_failed)
         }
+    }
+
+    private suspend fun login(email: String, password: String): AuthResult {
+        return try {
+            val response = syncServerManager.login(email = email, password = password)
+            val result = AuthResultModel(token = response.token, uuid = response.uuid)
+            AuthResult.Success(result)
+        } catch (ex: Exception) {
+            exceptionToAuthResult(exception = ex, fallbackMessage = LR.string.error_login_failed)
+        }
+    }
+
+    private fun exceptionToAuthResult(exception: Exception, fallbackMessage: Int): AuthResult.Failed {
+        val errorResponse = (exception as HttpException).parseErrorResponse()
+        val resources = context.resources
+        val message = errorResponse?.messageLocalized(resources) ?: resources.getString(fallbackMessage)
+        val messageId = errorResponse?.messageId
+        return AuthResult.Failed(message = message, messageId = messageId)
     }
 
     fun resetPasswordWithEmail(email: String, complete: (AuthResult) -> Unit) {
@@ -162,10 +139,7 @@ class AccountAuth @Inject constructor(
                         ?: userMessage
                         ?: getResourceString(LR.string.profile_reset_password_failed)
                     complete(
-                        AuthResult.Failed(
-                            message = message,
-                            serverMessageId = serverMessageId
-                        )
+                        AuthResult.Failed(message = message, messageId = serverMessageId)
                     )
                 }
             }
@@ -175,7 +149,7 @@ class AccountAuth @Inject constructor(
     private suspend fun signInSuccessful(email: String, password: String, authResult: AuthResultModel?) {
         LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Signed in successfully to $email")
         // Store details in android account manager
-        if (authResult?.token != null && authResult.token?.isNotEmpty() == true) {
+        if (authResult != null && authResult.token.isNotEmpty()) {
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Saving $email to account manager")
             val account = Account(email, AccountConstants.ACCOUNT_TYPE)
             val accountManager = AccountManager.get(context)
@@ -200,7 +174,7 @@ class AccountAuth @Inject constructor(
 
     sealed class AuthResult {
         data class Success(val result: AuthResultModel?) : AuthResult()
-        data class Failed(val message: String, val serverMessageId: String?) : AuthResult()
+        data class Failed(val message: String, val messageId: String?) : AuthResult()
     }
 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/PromoCodeFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/PromoCodeFragment.kt
@@ -36,7 +36,7 @@ class PromoCodeFragment : BaseFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        viewModel.setup(promoCode)
+        viewModel.setup(promoCode, requireContext())
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UploadEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UploadEpisodeTask.kt
@@ -7,7 +7,7 @@ import androidx.work.RxWorker
 import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
-import au.com.shiftyjelly.pocketcasts.servers.sync.parseErrorMessage
+import au.com.shiftyjelly.pocketcasts.servers.sync.parseErrorResponse
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -48,7 +48,8 @@ class UploadEpisodeTask @AssistedInject constructor(
                 val retry: Boolean
 
                 if (it is HttpException) {
-                    errorMessage = it.parseErrorMessage()
+                    val errorResponse = it.parseErrorResponse()
+                    errorMessage = errorResponse?.messageLocalized(context.resources)
 
                     if (errorMessage == null) {
                         errorMessage = when (it.code()) {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerManager.kt
@@ -12,7 +12,6 @@ import au.com.shiftyjelly.pocketcasts.models.to.Share
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.servers.di.NoCacheTokenedOkHttpClient
 import au.com.shiftyjelly.pocketcasts.servers.discover.PodcastSearch
-import au.com.shiftyjelly.pocketcasts.servers.model.AuthResultModel
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import io.reactivex.Single
 import io.reactivex.SingleEmitter
@@ -23,8 +22,6 @@ import okhttp3.FormBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
-import org.json.JSONException
-import org.json.JSONObject
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import timber.log.Timber
@@ -43,33 +40,6 @@ open class ServerManager @Inject constructor(
     companion object {
         private const val LIST_SEPERATOR = ","
         private const val NO_INTERNET_CONNECTION_MSG = "Check your connection and try again."
-    }
-
-    fun registerWithSyncServer(email: String, password: String, callback: ServerCallback<AuthResultModel>): Call? {
-        return postToSyncServer("/security/register", email, password, null, true, authResultExtractionCallback(callback))
-    }
-
-    fun loginToSyncServer(email: String, password: String, callback: ServerCallback<AuthResultModel>): Call? {
-        return postToSyncServer("/security/login", email, password, null, true, authResultExtractionCallback(callback))
-    }
-
-    private fun authResultExtractionCallback(callback: ServerCallback<AuthResultModel>): PostCallback {
-        return object : PostCallback, ServerFailure by callback {
-            override fun onSuccess(data: String?, response: ServerResponse) {
-                try {
-                    if (data == null) {
-                        throw Exception("Response empty")
-                    }
-                    val jsonData = JSONObject(data)
-                    val token = jsonData.getString("token")
-                    val uuid = jsonData.getString("uuid")
-                    callback.dataReturned(AuthResultModel(token = token, uuid = uuid))
-                } catch (e: JSONException) {
-                    Timber.e(e)
-                    callback.dataReturned(null)
-                }
-            }
-        }
     }
 
     fun obtainThirdPartyToken(email: String, password: String, scope: String, callback: ServerCallback<String>) {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/AuthResultModel.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/AuthResultModel.kt
@@ -1,6 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.servers.model
 
 data class AuthResultModel(
-    val token: String?,
-    val uuid: String?,
+    val token: String,
+    val uuid: String
 )

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/HttpExceptionMessage.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/HttpExceptionMessage.kt
@@ -1,27 +1,31 @@
 package au.com.shiftyjelly.pocketcasts.servers.sync
 
+import android.content.res.Resources
+import au.com.shiftyjelly.pocketcasts.localization.helper.LocaliseHelper
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import retrofit2.HttpException
+import timber.log.Timber
 
-fun HttpException.parseErrorMessage(): String? {
-    val errorBody = this.response()?.errorBody()
-    if (errorBody != null) {
+fun HttpException.parseErrorResponse(): ErrorResponse? {
+    val errorBody = this.response()?.errorBody() ?: return null
+    return try {
         val errorMoshi = Moshi.Builder().build()
-
-        try {
-            val response = errorMoshi.adapter(PCErrorBody::class.java).fromJson(errorBody.source())
-            if (response != null) {
-                return response.message
-            }
-        } catch (e: Exception) {
-            return null
-        }
+        errorMoshi.adapter(ErrorResponse::class.java).fromJson(errorBody.source())
+    } catch (e: Exception) {
+        Timber.e(e)
+        null
     }
-
-    return null
 }
 
 @JsonClass(generateAdapter = true)
-data class PCErrorBody(@field:Json(name = "errorMessage") val message: String)
+data class ErrorResponse(
+    @field:Json(name = "errorMessage") val message: String,
+    @field:Json(name = "errorMessageId") val messageId: String
+) {
+
+    fun messageLocalized(resources: Resources): String {
+        return LocaliseHelper.serverMessageIdToMessage(messageId, resources::getString) ?: message
+    }
+}

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/LoginResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/LoginResponse.kt
@@ -1,9 +1,0 @@
-package au.com.shiftyjelly.pocketcasts.servers.sync
-
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
-
-@JsonClass(generateAdapter = true)
-data class LoginResponse(
-    @field:Json(name = "token") val token: String? = null
-)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServer.kt
@@ -4,6 +4,10 @@ import au.com.shiftyjelly.pocketcasts.models.to.HistorySyncRequest
 import au.com.shiftyjelly.pocketcasts.models.to.HistorySyncResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.history.HistoryYearResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.history.HistoryYearSyncRequest
+import au.com.shiftyjelly.pocketcasts.servers.sync.login.LoginRequest
+import au.com.shiftyjelly.pocketcasts.servers.sync.login.LoginResponse
+import au.com.shiftyjelly.pocketcasts.servers.sync.register.RegisterRequest
+import au.com.shiftyjelly.pocketcasts.servers.sync.register.RegisterResponse
 import io.reactivex.Single
 import okhttp3.RequestBody
 import retrofit2.Call
@@ -19,7 +23,10 @@ import retrofit2.http.Url
 
 interface SyncServer {
     @POST("/user/login")
-    fun login(@Body request: LoginRequest): Single<LoginResponse>
+    suspend fun login(@Body request: LoginRequest): LoginResponse
+
+    @POST("/user/register")
+    suspend fun register(@Body request: RegisterRequest): RegisterResponse
 
     @POST("/user/change_email")
     fun emailChange(@Header("Authorization") authorization: String, @Body request: EmailChangeRequest): Single<UserChangeResponse>

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/login/LoginRequest.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/login/LoginRequest.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.servers.sync
+package au.com.shiftyjelly.pocketcasts.servers.sync.login
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/login/LoginResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/login/LoginResponse.kt
@@ -1,0 +1,11 @@
+package au.com.shiftyjelly.pocketcasts.servers.sync.login
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class LoginResponse(
+    @field:Json(name = "token") val token: String,
+    @field:Json(name = "uuid") val uuid: String,
+    @field:Json(name = "email") val email: String?
+)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/register/RegisterRequest.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/register/RegisterRequest.kt
@@ -1,0 +1,11 @@
+package au.com.shiftyjelly.pocketcasts.servers.sync.register
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class RegisterRequest(
+    @field:Json(name = "email") val email: String,
+    @field:Json(name = "password") val password: String,
+    @field:Json(name = "scope") val scope: String
+)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/register/RegisterResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/register/RegisterResponse.kt
@@ -1,0 +1,10 @@
+package au.com.shiftyjelly.pocketcasts.servers.sync.register
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class RegisterResponse(
+    @field:Json(name = "token") val token: String,
+    @field:Json(name = "uuid") val uuid: String
+)


### PR DESCRIPTION
## Description
As part of the Single Sign-On change, this upgrades from the legacy user login and register endpoints. The iOS app has been using these new endpoints for a long time, so I don't see any danger in switching to them.

This change also switches over to using Retrofit and Coroutines. Hopefully, we can get rid of the [ServerManager](https://github.com/Automattic/pocket-casts-android/blob/main/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerManager.kt) class as it feels very dated when compared with Retrofit.

## Testing Instructions
1. Clean install the app
2. Tap 'Sign up' on the welcome screen
3. Enter an existing Pocket Casts account email and any password
4. Tap 'Create Account'
5. ✅  Verify an error message is displayed
6. Enter a new email which doesn't exist
7. Tap 'Create Account'
8. ✅  Verify you are taken to the "Find your favorite podcasts" screen.
9. Go to the Profile tab and sign out of the account
10. Tap the 'Set Up Account' and 'Sign in'
11. Enter an existing email and password
12. ✅  Verify you are signed in
