### PR TITLE
Fix norwegian translations

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,7 +33,7 @@ SUPPORTED_LOCALES = [
   { glotpress: "it", android: "it", google_play: "it-IT",  promo_config: {} },
   { glotpress: "ja", android: "ja", google_play: "ja-JP",  promo_config: {} },
   { glotpress: "nl", android: "nl", google_play: "nl-NL",  promo_config: {} },
-  { glotpress: "nl", android: "nb", google_play: "nb-NB",  promo_config: {} },
+  { glotpress: "nb", android: "nb", google_play: "nb-NB",  promo_config: {} },
   { glotpress: "pt-br", android: "pt-rBR", google_play: "pt-BR",  promo_config: {} },
   { glotpress: "ru", android: "ru", google_play: "ru-RU",  promo_config: {} },
   { glotpress: "sv", android: "sv", google_play: "sv-SE",  promo_config: {} },


### PR DESCRIPTION
## Description

This fixes Norwegian translations by changing GlotPress language code to `nb` in Fastlane for the language. 

> **Warning**
> Targets release/7.29.1

Fixes #687

## Testing Instructions
1. (Copied from [original PR](https://github.com/Automattic/pocket-casts-android/pull/631)) Add a temporary lane in the Fastfile, containing:

```
  lane :test do 
    # Download Localizations
    android_download_translations(
      res_dir: File.join('modules', 'services', 'localization', 'src', 'main', 'res'),
      glotpress_url: GLOTPRESS_APP_STRINGS_PROJECT_URL,
      locales: SUPPORTED_LOCALES,
      lint_task: 'lintRelease'
    )
  end
```

2. Run `bundle install && bundle exec fastlane test`, which will download the translations using the release toolkit – you'll see significant diffs on the translation files.
3. Open `values-nb/strings.xml`
4. Search for a translated string like "auto_download". 
5. :white_check_mark: The translation should be for the [Norwegian language from GlotPress](https://translate.wordpress.com/projects/pocket-casts/android/nb/default/?page=94):

    `<string name="auto_download">Last ned automatisk</string>`

    instead of for [Dutch language in GlotPress](https://translate.wordpress.com/projects/pocket-casts/android/nl/default/?page=94):

    `<string name="auto_download">Automatisch downloaden</string>`
6. Delete temporary lane in the Fastfile added for local testing in step 1 and undo any translations committed due to local testing. These will get auto-downloaded during the next beta release.