### PR TITLE
Update subscribe button text depending on trial availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 -----
 
 
+7.29.2
+-----
+* Bug Fixes:
+    *    Fix text on purchase button in new onboarding flow
+         ([#698](https://github.com/Automattic/pocket-casts-android/pull/698)).
+
 7.29
 -----
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusBottomSheet.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusBottomSheet.kt
@@ -170,20 +170,26 @@ fun OnboardingPlusBottomSheet(
                     modifier = Modifier.padding(top = 16.dp)
                 )
             }
+
+            Divider(
+                thickness = 1.dp,
+                color = Color(0xFFE4E4E4),
+                modifier = Modifier
+                    .padding(vertical = 16.dp)
+                    .alpha(0.24f)
+            )
+
+            PlusRowButton(
+                text = stringResource(
+                    if (state.selectedSubscription.trialPricingPhase != null) {
+                        LR.string.onboarding_plus_start_free_trial_and_subscribe
+                    } else {
+                        LR.string.subscribe
+                    }
+                ),
+                onClick = onClickSubscribe,
+            )
         }
-
-        Divider(
-            thickness = 1.dp,
-            color = Color(0xFFE4E4E4),
-            modifier = Modifier
-                .padding(vertical = 16.dp)
-                .alpha(0.24f)
-        )
-
-        PlusRowButton(
-            text = stringResource(LR.string.onboarding_plus_start_free_trial_and_subscribe),
-            onClick = onClickSubscribe,
-        )
 
         Spacer(Modifier.height(16.dp))
 


### PR DESCRIPTION
## Description
Fixes the purchase/subscribe button in the [new onboarding flow](https://github.com/Automattic/pocket-casts-android/issues/524) so that its text only indicates there is a free trial if the selected plan has a free trial (issue originally observed [here](https://github.com/Automattic/pocket-casts-android/pull/694#issuecomment-1379932790)).

> **Warning**
> I believe this fix needs to be a hotfix or a betafix. I'm leaning toward making it a hotfix since it is addressing misleading text on probably the most important button in the app for converting users to be subscribers, but let me know if you think a betafix makes more sense.

## Testing Instructions
1. Set the app up to have a free trial available
2. Go through the onboarding flow to the plus upgrade screen
3. Tap "Unlock All Features"
4. Observe that the button text says "Subscribe" if the currently selected plan does not have a free trial and "Start Free Trial & Subscribe" _only_ if the selected plan has a free trial.

## Screenshots or Screencast 
Here's a screenshot showing our fake free trial subscription:


https://user-images.githubusercontent.com/4656348/212133684-a8d100d9-3845-48b6-9c2b-d4e8ef52d833.mov




## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack
