### PR TITLE
Add the Korean language

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -32,6 +32,7 @@ SUPPORTED_LOCALES = [
   { glotpress: "fr", android: "fr-rCA", google_play: "fr-CA",  promo_config: {} },
   { glotpress: "it", android: "it", google_play: "it-IT",  promo_config: {} },
   { glotpress: "ja", android: "ja", google_play: "ja-JP",  promo_config: {} },
+  { glotpress: "ko", android: "ko", google_play: "ko-KR",  promo_config: {} },
   { glotpress: "nl", android: "nl", google_play: "nl-NL",  promo_config: {} },
   { glotpress: "nb", android: "nb", google_play: "nb-NB",  promo_config: {} },
   { glotpress: "pt-br", android: "pt-rBR", google_play: "pt-BR",  promo_config: {} },

--- a/modules/services/localization/src/main/res/values-ko/strings.xml
+++ b/modules/services/localization/src/main/res/values-ko/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+</resources>


### PR DESCRIPTION
This pull request adds the Korean language to the import from GlotPress. This happens as part of the `finalize_release` deployment step.

The translations aren't available yet, but here is the empty GlotPress ready to be added.
https://translate.wordpress.com/projects/pocket-casts/android/ko/default/
