### PR TITLE
Temporary fix for unresponsive media notifications in Android 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
         ([#710](https://github.com/Automattic/pocket-casts-android/pull/710)).
     *   Make it easier to tap newsletter toggle
         ([#714](https://github.com/Automattic/pocket-casts-android/pull/714)).
+    *   Improved unresponsive media notifications
+        ([#709](https://github.com/Automattic/pocket-casts-android/pull/709)).
 
 7.30
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -285,12 +285,8 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
                             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "stopForeground state: $state removing notification: $removeNotification")
                         }
 
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                            stopForeground(if (removeNotification) STOP_FOREGROUND_REMOVE else STOP_FOREGROUND_DETACH)
-                        } else {
-                            @Suppress("DEPRECATION")
-                            stopForeground(removeNotification)
-                        }
+                        @Suppress("DEPRECATION")
+                        stopForeground(removeNotification)
                     }
 
                     if (state == PlaybackStateCompat.STATE_ERROR) {


### PR DESCRIPTION
## Description

Temporarily fixes unresponsive media notifications in Android 13 (#161).

According to [this](https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/app/Service.java#830), 

>  [...] If {@link #STOP_FOREGROUND_DETACH} is supplied, the service's association
with the notification will be severed. [...] 

For the steps outlined in https://github.com/Automattic/pocket-casts-android/issues/161#issuecomment-1191971420, where the service is stopped, I am unable to restart it from the notification media actions if  `STOP_FOREGROUND_DETACH` flag is passed to `stopForeground(...)`.

Until we figure out a proper fix, this PR reverts to using legacy flags with `stopForeground(...)`.

## Testing Instructions
1. Force close the app 
2. Start playback from within the app
3. Stop playback from within the app
4. Swipe app away from recent (don't force close the app because that removes the persistent media notification)
5. Click play on the persistent media notification 
6. ✅ Notice that playback is resumed


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- I have considered whether it makes sense to add tests for my changes
- All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...

- with different themes
- with a landscape orientation
- with the device set to have a large display and font size
- for accessibility with TalkBack
