### PR TITLE
Fix recommendations placeholder color and have Activities respect dark/light mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 7.31
 -----
-*   Health:
-    *   Switched to using the new user login and register endpoints.
-        ([#685](https://github.com/Automattic/pocket-casts-android/pull/685)).
 *   New Features:
     *   Add support for HLS streams
         ([#679](https://github.com/Automattic/pocket-casts-android/pull/679)).
@@ -11,6 +8,12 @@
 *   Updates
     *   Update styling of upgrade prompt on account details screen
         ([#706](https://github.com/Automattic/pocket-casts-android/pull/706)).
+*   Health:
+    *   Switched to using the new user login and register endpoints.
+        ([#685](https://github.com/Automattic/pocket-casts-android/pull/685)).
+*   Bug Fixes:
+    *   App does a better job respecting the device's dark/light mode settings
+        ([#710](https://github.com/Automattic/pocket-casts-android/pull/710)).
 
 7.30
 -----

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountActivity.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountActivity.kt
@@ -37,7 +37,7 @@ class AccountActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setTheme(theme.activeTheme.resourceId)
+        theme.setupThemeForConfig(this, resources.configuration)
 
         binding = AccountActivityBinding.inflate(layoutInflater)
         val view = binding.root

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
@@ -26,6 +26,7 @@ class OnboardingActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        theme.setupThemeForConfig(this, resources.configuration)
 
         // Make content edge-to-edge
         WindowCompat.setDecorFitsSystemWindows(window, false)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateActivity.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateActivity.kt
@@ -16,7 +16,7 @@ class ShareListCreateActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setTheme(theme.activeTheme.resourceId)
+        theme.setupThemeForConfig(this, resources.configuration)
 
         setContentView(R.layout.activity_blank_fragment)
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -165,7 +165,7 @@ class AddFileActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setTheme(theme.activeTheme.resourceId)
+        theme.setupThemeForConfig(this, resources.configuration)
 
         binding = ActivityAddFileBinding.inflate(layoutInflater)
         val view = binding.root


### PR DESCRIPTION
## Description
This PR fixes the placeholders in the onboarding recommendations always reflecting a dark theme even when the theme was light.

This issue was caused by the fact that the theme was not being set on the `OnboardingActivity`, which meant that the app would not be able to get the theme information from the activity context [here](https://github.com/Automattic/pocket-casts-android/blob/d1502d9bf89fec3e19098f3ec78bc41e1473b447/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt#L41-L57).

In fixing this, I noticed that `MainActivity` was calling `theme.setupThemeForConfig(this, resources.configuration)`, but our other Activities were calling `setTheme(theme.activeTheme.resourceId)`. As a result, when the app was set up to respect the system dark/light mode, changing the system dark/light mode within one of the app's other activities would not update the app's theme within that activity. By making this change, you can now change between dark/light mode from within these other Activities as well and immediately see the app's theme updated.

## Testing Instructions
Within each activity, check that if Pocket Casts is set to the system UI theme (Profile tab → ⚙️ → Appearance → "Use Android Light/Dark Mode"), then changing the device from dark to light mode (or vice versa also immediately updates the app theme appearance (I used an Android quick settings shortcut to easily switch between dark/light mode from the notification drawer when I was testing this). If the app's toggle for respecting the system's dark/light mode is off, then changing the device's light/dark should not change the app theme appearance.

#### 1. OnboardingActivity
1. Sign out of the app
2. From the Profile tab tap on the prompt to sign in so that the sign in screen appears
3. Sign up for a new account
4. When the recommendations screen loads, verify that the placeholder images that are shown are theme appropriate (previously, they were always dark).

In order to make it easier to see the placeholder images, you may want to prevent the loading of the podcast artwork with this change:

<details>
<summary>diff</summary>

``` diff
diff --git a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
index 3df7b2b6..494dae06 100644
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
@@ -83,29 +83,7 @@ open class PodcastImageLoader(
     }
 
     fun loadCoil(podcastUuid: String?, size: Int? = null, placeholder: Boolean = true, onComplete: () -> Unit = {}): ImageRequest.Builder {
-        if (podcastUuid == null) return loadNoPodcastCoil()
-        val url = if (size != null) PodcastImage.getArtworkUrl(size = size, uuid = podcastUuid) else PodcastImage.getLargeArtworkUrl(uuid = podcastUuid)
-
-        val placeholderDrawable = if (placeholder) placeholderResId() else 0
-        var builder = ImageRequest.Builder(context)
-            .data(url)
-            .placeholder(placeholderDrawable)
-            .error(placeholderDrawable)
-            .transformations()
-            .listener(onSuccess = { _, _ -> onComplete() })
-
-        if (!shouldScale) {
-            builder = builder.size(Size.ORIGINAL)
-        }
-
-        val imageTransformation = buildList {
-            add(RoundedCornersTransformation(radiusPx.toFloat()))
-            addAll(transformations)
-        }
-
-        builder = builder.transformations(imageTransformation)
-
-        return builder
+        return loadNoPodcastCoil()
     }
 
     @JvmOverloads
```


</details>


#### 2. AddFileActivity
1. From the Profile tab, tap on "Files"
2. Tap on the `+` button to add a file
6. Select a file, so that the add file screen is shown

#### 3. ShareListCreateActivity
1. From the Podcasts tab, tap on the overflow menu
2. Tap "Share podcasts" in the bottom modal

#### 4. AccountActivity
I've removed most of the places this is used, so it's actually not very easy to open this activity now. The easiest way is probably to just add `startActivity(AccountActivity.newUpgradeInstance(this))` to the end of `MainActivity::onCreate`.

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack
