### PR TITLE
Improve episode sync error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 *   Updates
     *   Update styling of upgrade prompt on account details screen
         ([#706](https://github.com/Automattic/pocket-casts-android/pull/706)).
+*   Bug Fixes:
+    *   Improved handling of sync errors
+        ([#711](https://github.com/Automattic/pocket-casts-android/pull/711)).
 
 7.30
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -245,7 +245,9 @@ open class PlaybackManager @Inject constructor(
         syncTimerDisposable = playbackStateRelay.sample(settings.getPeriodicSaveTimeMs(), TimeUnit.MILLISECONDS)
             .concatMap {
                 if (it.isPlaying && settings.isLoggedIn()) {
-                    syncEpisodeProgress(it).toObservable()
+                    syncEpisodeProgress(it)
+                        .toObservable<EpisodeSyncResponse>()
+                        .onErrorResumeNext(Observable.empty())
                 } else {
                     Observable.empty<EpisodeSyncResponse>()
                 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServer.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.login.LoginTokenRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.LoginTokenResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.register.RegisterRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.register.RegisterResponse
+import io.reactivex.Completable
 import io.reactivex.Single
 import okhttp3.RequestBody
 import retrofit2.Call
@@ -76,7 +77,7 @@ interface SyncServer {
     suspend fun historyYear(@Header("Authorization") authorization: String, @Body request: HistoryYearSyncRequest): HistoryYearResponse
 
     @POST("/sync/update_episode")
-    fun episodeProgressSync(@Header("Authorization") authorization: String, @Body request: EpisodeSyncRequest): Single<Void>
+    fun episodeProgressSync(@Header("Authorization") authorization: String, @Body request: EpisodeSyncRequest): Completable
 
     @GET("/subscription/status")
     fun subscriptionStatus(@Header("Authorization") authorization: String): Single<SubscriptionStatusResponse>

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
@@ -195,9 +195,9 @@ open class SyncServerManager @Inject constructor(
     }
 
     fun episodeSync(request: EpisodeSyncRequest): Completable {
-        return getCacheTokenOrLogin { token ->
+        return getCacheTokenOrLoginCompletable { token ->
             server.episodeProgressSync(addBearer(token), request)
-        }.ignoreElement()
+        }
     }
 
     fun subscriptionStatus(): Single<SubscriptionStatusResponse> {
@@ -349,6 +349,12 @@ open class SyncServerManager @Inject constructor(
             val token = refreshTokenSuspend()
             return serverCall(token)
         }
+    }
+
+    private fun getCacheTokenOrLoginCompletable(serverCall: (token: String) -> Completable): Completable {
+        return getCacheTokenOrLogin { token ->
+            serverCall(token).toSingleDefault(Unit)
+        }.ignoreElement()
     }
 
     private fun <T : Any> getCacheTokenOrLogin(serverCall: (token: String) -> Single<T>): Single<T> {


### PR DESCRIPTION
## Description
This PR should improve the reliability of our episode sync.

In my testing, all the calls to sync episode data were failing and a NoSuchElementException was getting logged. I think there are two separate causes of this, and fixing either of them solves the issue. This PR includes both fixes.

The [first fix](https://github.com/Automattic/pocket-casts-android/commit/0b84d1502f3e372c2d10f2768fc981ea77eb2863) is that although we were calling `onErrorReturnItem` with our sync poller (which syncs the episode status every 60 seconds), that handler would complete the polling, causing sync to stop. The better approach is to handle the error inside the `concatMap` call because that way the polling doesn't stop if there is an error.

The [second fix](https://github.com/Automattic/pocket-casts-android/commit/727f27e04f5ebffe089a9bfd8835e3be0120ac00) is that, in my testing, every time I call the `sync/update_episode` endpoint, I would get the `NoSuchElementException`. It [sounds like](https://stackoverflow.com/questions/56761945/getting-java-util-nosuchelementexception-when-trying-to-do-post-to-server-the-a) this can be an issue with using a `Single` without a response body. Changing this to be a `Completable` resolved the problem.

The problem is that I feel pretty confident that I'm missing something there because as far as I can tell, this code hasn't changed recently, and I find it unlikely that sync has been as broken as I'm experiencing that entire time, so maybe there is something I'm doing that is uniquely making this problem appear. 

Basically, please look at these changes with a skeptical eye, particularly the changes to the `sync/update_episode` endpoint, since the additional error handling on its own is sufficient to fix the bug. I just made the second change to avoid throwing and catching an error on every API call to that endpoint, but we can easily and safely remove that change (I put it in [a separate commit](https://github.com/Automattic/pocket-casts-android/commit/727f27e04f5ebffe089a9bfd8835e3be0120ac00) for exactly that reason).

## Testing Instructions

### Verify the problem
1. Using a build that does _not_ have the changes from this PR
2. (recommended, but optional) update the code [here](https://github.com/Automattic/pocket-casts-android/blob/0b84d1502f3e372c2d10f2768fc981ea77eb2863/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt#L245) to force the sync to happen every 10 seconds (default is 60 seconds, but who has that kind of patience 😄 )
3. Log into the app and begin playing a podcast
4. Observe that after 10 seconds a call is made to the sync API endpoint, and it returns an empty response
5. Wait at least 10 seconds and observe that no other calls are made to the sync API endpoint. (This is what I was observing at least, but I would like to confirm that it's not only me who is seeing this).
6. If the response doesn't error on it's own, it may be interesting to see if changing the response code to 404 causes the sync polling to stop (it does for me without the changes in this PR).

### Verify the fix
1. Using a build that includes the changes from this PR
2. Again, update the frequency of the sync polling
3. Log into the app and begin playing a podcast
4. Observe that after 10 seconds a call is made to the sync API endpoint, and it returns an empty response
5. Observe that polling continues every 10 seconds
7. Intercept one of the responses and change the status code to be an error (I used 404)
8. Observe that the polling continues every 10 seconds

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack

Related issue: https://github.com/Automattic/pocket-casts-android/issues/616
