### PR TITLE
Make entire newsletter row tappable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
         ([#711](https://github.com/Automattic/pocket-casts-android/pull/711)).
     *   App does a better job respecting the device's dark/light mode settings
         ([#710](https://github.com/Automattic/pocket-casts-android/pull/710)).
+    *   Make it easier to tap newsletter toggle
+        ([#714](https://github.com/Automattic/pocket-casts-android/pull/714)).
 
 7.30
 -----

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingWelcomePage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingWelcomePage.kt
@@ -286,7 +286,7 @@ private fun NewsletterSwitch(
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
+        modifier = Modifier.clickable { onCheckedChange(!checked) }
     ) {
         Column(
             modifier = Modifier


### PR DESCRIPTION
| 📘 Project: #524  |
| --- |


## Description
On the onboarding welcome screen, this makes the entire row for the newsletter to be tappable as opposed to just having the toggle itself being tappable.

## Testing Instructions
1. Create a new account and advance through the onboarding flow until you get to the welcome screen
2. Confirm that tapping on the newsletter toggle still works
3. Confirm that tapping anywhere on the newsletter row flips the toggle

## Screenshots or Screencast 

https://user-images.githubusercontent.com/4656348/213260497-8ca69293-e31f-4100-817f-cf6642f517be.mov


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
