### PR TITLE
Add drop shadow for recommendations button

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.progressSemantics
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -184,10 +185,12 @@ private fun Content(
             }
         }
 
-        RowButton(
-            text = stringResource(buttonRes),
-            onClick = onComplete,
-        )
+        Surface(elevation = 8.dp) {
+            RowButton(
+                text = stringResource(buttonRes),
+                onClick = onComplete,
+            )
+        }
         Spacer(Modifier.windowInsetsPadding(WindowInsets.navigationBars))
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
@@ -189,9 +189,9 @@ private fun Content(
             RowButton(
                 text = stringResource(buttonRes),
                 onClick = onComplete,
+                modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars),
             )
         }
-        Spacer(Modifier.windowInsetsPadding(WindowInsets.navigationBars))
     }
 }
 


### PR DESCRIPTION
| 📘 Project: #524  |
| --- |

## Description
Adds a drop shadow to the part of the recommendations screen with the button so it is visually cleaner as content scrolls under the button.

I picked the `8.dp` drop shadow because it looked about right to me, but let me know if you think another value would be better.

## Testing Instructions
1. Create a new account so you are taken to the recommendations screen
2. Confirm that the bottom part of the screen with the `Not Now`/`Continue` button has a slight drop shadow now.

## Screenshots or Screencast 

| Before | After |
| --- | --- |
| ![Screenshot 2023-01-18 at 1 26 04 PM](https://user-images.githubusercontent.com/4656348/213263805-c574ac42-3605-4a0b-a40f-c79a4f0c0913.png) | ![Screenshot 2023-01-18 at 1 25 00 PM](https://user-images.githubusercontent.com/4656348/213263597-653cd95e-e117-4158-98ab-c0a7628d61a4.png) |

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md (I don't think this needs a changelog entry. Let me know if you disagree).
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack
