### PR TITLE
Immediately update subscribed UI when user taps

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
@@ -216,6 +216,23 @@ class OnboardingRecommendationsStartPageViewModel @Inject constructor(
         } else {
             podcastManager.subscribeToPodcast(podcastUuid = podcast.uuid, sync = true)
         }
+
+        // Immediately update subscribed state in the UI
+        _state.update {
+            it.copy(
+                sections = it.sections.map { section ->
+                    section.copy(
+                        podcasts = section.visiblePodcasts.map { podcastInList ->
+                            if (podcastInList.uuid == podcast.uuid) {
+                                podcastInList.copy(isSubscribed = !podcastInList.isSubscribed)
+                            } else {
+                                podcastInList
+                            }
+                        }
+                    )
+                }
+            )
+        }
     }
 
     private suspend fun updateFlowWith(


### PR DESCRIPTION
| 📘 Project: #524  |
| --- |

## Description
This PR updates the recommendation screen so that when the user taps to subscribe to a podcast, the UI doesn't wait for the db to reflect the subscription and instead immediately updates to reflect the new subscription state.

## Testing Instructions
1. Create a new account so you are taken to the recommendation screen
2. Tap on a podcast to change it's subscribe status
3. Observe that the UI updates to reflect the new subscription status without any delay

## Screenshots or Screencast 

https://user-images.githubusercontent.com/4656348/213270868-f17e2436-a4f6-483b-8e83-7b29af20a11b.mov

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md (I don't think this change needs a changelog entry, but let me know if you disagree)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
