### PR TITLE
Update UI immediately when tapping on search result

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
 import javax.inject.Inject
@@ -119,6 +120,18 @@ class OnboardingRecommendationsSearchViewModel @Inject constructor(
             podcastManager.unsubscribeAsync(podcastUuid = uuid, playbackManager = playbackManager)
         } else {
             podcastManager.subscribeToPodcast(podcastUuid = uuid, sync = true)
+        }
+
+        _state.update {
+            it.copy(
+                results = it.results.map { podcast ->
+                    if (podcast.podcast.uuid == uuid) {
+                        podcast.copy(isSubscribed = !podcastResult.isSubscribed)
+                    } else {
+                        podcast
+                    }
+                }
+            )
         }
     }
 }


### PR DESCRIPTION
| 📘 Project: #524  |
| --- |

## Description
This is a follow-up to https://github.com/Automattic/pocket-casts-android/pull/717. It adds the same immediately-update-the-UI logic to the recommendations search screen, as suggested [here](https://github.com/Automattic/pocket-casts-android/pull/717#issuecomment-1396468512).

## Testing Instructions
1. Create a new account so you are taken to the recommendation screen
2. Perform a search from the recommendations screen
3. Tap to subscribe-to or unsubscribe-from one of the search results
4. Observe that the UI updates to reflect the new subscription status without any delay

## Screenshots or Screencast 

https://user-images.githubusercontent.com/4656348/213539741-91dfc7e1-0085-4160-9bd8-2303c02c446b.mov

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md (I don't think this needs a changelog entry)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews

