### PR TITLE
Podcast settings tracks

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastEffectsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastEffectsFragment.kt
@@ -10,6 +10,7 @@ import androidx.preference.ListPreference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.podcasts.R
 import au.com.shiftyjelly.pocketcasts.podcasts.view.components.PlaybackSpeedPreference
@@ -32,6 +33,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 class PodcastEffectsFragment : PreferenceFragmentCompat() {
 
     @Inject lateinit var theme: Theme
+    @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     private var preferenceCustomForPodcast: SwitchPreference? = null
     private var preferencePlaybackSpeed: PlaybackSpeedPreference? = null
@@ -113,7 +115,11 @@ class PodcastEffectsFragment : PreferenceFragmentCompat() {
         }
 
         preferenceCustomForPodcast?.setOnPreferenceChangeListener { _, newValue ->
-            viewModel.updateOverrideGlobalEffects(newValue as Boolean)
+            analyticsTracker.track(
+                AnalyticsEvent.PODCAST_SETTINGS_CUSTOM_PLAYBACK_EFFECTS_TOGGLED,
+                mapOf("enabled" to newValue as Boolean)
+            )
+            viewModel.updateOverrideGlobalEffects(newValue)
             true
         }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
@@ -285,7 +285,12 @@ class PodcastSettingsFragment : BasePreferenceFragment(), CoroutineScope, Filter
                 if (stringValue.isBlank()) {
                     stringValue = "0"
                 }
-                viewModel.updateStartFrom(stringValue.toInt())
+                val secs = stringValue.toInt()
+                analyticsTracker.track(
+                    AnalyticsEvent.PODCAST_SETTINGS_SKIP_FIRST_CHANGED,
+                    mapOf("value" to secs)
+                )
+                viewModel.updateStartFrom(secs)
             } catch (e: NumberFormatException) {
                 Timber.e(e)
             }
@@ -300,7 +305,12 @@ class PodcastSettingsFragment : BasePreferenceFragment(), CoroutineScope, Filter
                 if (stringValue.isBlank()) {
                     stringValue = "0"
                 }
-                viewModel.updateSkipLast(stringValue.toInt())
+                val secs = stringValue.toInt()
+                analyticsTracker.track(
+                    AnalyticsEvent.PODCAST_SETTINGS_SKIP_LAST_CHANGED,
+                    mapOf("value" to secs)
+                )
+                viewModel.updateSkipLast(secs)
             } catch (e: java.lang.NumberFormatException) {
                 Timber.e(e)
             }
@@ -310,7 +320,11 @@ class PodcastSettingsFragment : BasePreferenceFragment(), CoroutineScope, Filter
 
     private fun setupNotifications() {
         preferenceNotifications?.setOnPreferenceChangeListener { _, newValue ->
-            viewModel.showNotifications(newValue as Boolean)
+            analyticsTracker.track(
+                AnalyticsEvent.PODCAST_SETTINGS_NOTIFICATIONS_TOGGLED,
+                mapOf("enabled" to (newValue as Boolean))
+            )
+            viewModel.showNotifications(newValue)
             true
         }
     }
@@ -388,7 +402,11 @@ class PodcastSettingsFragment : BasePreferenceFragment(), CoroutineScope, Filter
         preferenceAddToUpNext?.run {
             isChecked = viewModel.isAutoAddToUpNextOn()
             setOnPreferenceChangeListener { _, isOn ->
-                viewModel.updateAutoAddToUpNext(isOn as Boolean)
+                analyticsTracker.track(
+                    AnalyticsEvent.PODCAST_SETTINGS_AUTO_ADD_UP_NEXT_TOGGLED,
+                    mapOf("enabled" to isOn as Boolean)
+                )
+                viewModel.updateAutoAddToUpNext(isOn)
                 true
             }
         }
@@ -403,13 +421,27 @@ class PodcastSettingsFragment : BasePreferenceFragment(), CoroutineScope, Filter
             entryValues = arrayOf("1", "2")
             setOnPreferenceChangeListener { _, newValue ->
                 val value = Integer.parseInt(newValue as String)
+                analyticsTracker.track(
+                    AnalyticsEvent.PODCAST_SETTINGS_AUTO_ADD_UP_NEXT_POSITION_OPTION_CHANGED,
+                    mapOf(
+                        "value" to when (value) {
+                            1 -> "play_last"
+                            2 -> "play_next"
+                            else -> "unknown"
+                        }
+                    )
+                )
                 viewModel.updateAutoAddToUpNextOrder(value)
                 true
             }
         }
 
         preferenceAutoDownload?.setOnPreferenceChangeListener { _, newValue ->
-            viewModel.setAutoDownloadEpisodes(newValue as Boolean)
+            analyticsTracker.track(
+                AnalyticsEvent.PODCAST_SETTINGS_AUTO_DOWNLOAD_TOGGLED,
+                mapOf("enabled" to newValue as Boolean)
+            )
+            viewModel.setAutoDownloadEpisodes(newValue)
             true
         }
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -201,6 +201,12 @@ enum class AnalyticsEvent(val key: String) {
     PODCAST_SCREEN_TOGGLE_SUMMARY("podcast_screen_toggle_summary"),
     PODCAST_SCREEN_SHARE_TAPPED("podcast_screen_share_tapped"),
 
+    /* Podcast Settings */
+    PODCAST_SETTINGS_FEED_ERROR_TAPPED("podcast_settings_feed_error_tapped"),
+    PODCAST_SETTINGS_FEED_ERROR_UPDATE_TAPPED("podcast_settings_feed_error_update_tapped"),
+    PODCAST_SETTINGS_FEED_ERROR_FIX_SUCCEEDED("podcast_settings_feed_error_fix_succeeded"),
+    PODCAST_SETTINGS_FEED_ERROR_FIX_FAILED("podcast_settings_feed_error_fix_failed"),
+
     /* Playback */
     PLAYBACK_PLAY("playback_play"),
     PLAYBACK_PAUSE("playback_pause"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -206,6 +206,17 @@ enum class AnalyticsEvent(val key: String) {
     PODCAST_SETTINGS_FEED_ERROR_UPDATE_TAPPED("podcast_settings_feed_error_update_tapped"),
     PODCAST_SETTINGS_FEED_ERROR_FIX_SUCCEEDED("podcast_settings_feed_error_fix_succeeded"),
     PODCAST_SETTINGS_FEED_ERROR_FIX_FAILED("podcast_settings_feed_error_fix_failed"),
+    PODCAST_SETTINGS_AUTO_DOWNLOAD_TOGGLED("podcast_settings_auto_download_toggled"),
+    PODCAST_SETTINGS_NOTIFICATIONS_TOGGLED("podcast_settings_notifications_toggled"),
+    PODCAST_SETTINGS_AUTO_ADD_UP_NEXT_TOGGLED("podcast_settings_auto_add_up_next_toggled"),
+    PODCAST_SETTINGS_AUTO_ADD_UP_NEXT_POSITION_OPTION_CHANGED("podcast_settings_auto_add_up_next_position_option_changed"),
+    PODCAST_SETTINGS_CUSTOM_PLAYBACK_EFFECTS_TOGGLED("podcast_settings_custom_playback_effects_toggled"),
+    PODCAST_SETTINGS_SKIP_FIRST_CHANGED("podcast_settings_skip_first_changed"),
+    PODCAST_SETTINGS_SKIP_LAST_CHANGED("podcast_settings_skip_last_changed"),
+    PODCAST_SETTINGS_AUTO_ARCHIVE_TOGGLED("podcast_settings_auto_archive_toggled"),
+    PODCAST_SETTINGS_AUTO_ARCHIVE_PLAYED_CHANGED("podcast_settings_auto_archive_played_changed"),
+    PODCAST_SETTINGS_AUTO_ARCHIVE_INACTIVE_CHANGED("podcast_settings_auto_archive_inactive_changed"),
+    PODCAST_SETTINGS_AUTO_ARCHIVE_EPISODE_LIMIT_CHANGED("podcast_settings_auto_archive_episode_limit_changed"),
 
     /* Playback */
     PLAYBACK_PLAY("playback_play"),


### PR DESCRIPTION
## Description
Adds tracks for the podcast settings screen:

- `podcast_settings_feed_error_tapped`: When the user taps the feed error item in the podcast settings
- `podcast_settings_feed_error_update_tapped`: When the user taps the update button on the feed error alert
- `podcast_settings_feed_error_fix_succeeded`: If the feed error issue was fixed
- `podcast_settings_feed_error_fix_failed`: If the feed error issue failed for any reason
- `podcast_settings_auto_download_toggled`: When the user toggles the Auto Download option
- `podcast_settings_notifications_toggled`: When the user toggles the Notifications option
- `podcast_settings_auto_add_up_next_toggled`: When the user toggles the Add to Up Next option
- `podcast_settings_auto_add_up_next_position_option_changed`: When the user changes the Position in Queue setting
- `podcast_settings_custom_playback_effects_toggled`: When the user toggles the custom playback effects
- `podcast_settings_skip_first_changed`: When the user changes the skip first option
- `podcast_settings_skip_last_changed`: When the user changes the skip last option
- `podcast_settings_auto_archive_toggled`: When the user toggles the custom Auto Archive option
- `podcast_settings_auto_archive_played_changed`: When the user changes the Archive Played Episodes option
- `podcast_settings_auto_archive_inactive_changed`: When the user changes the Archive Inactive Episodes option
- `podcast_settings_auto_archive_episode_limit_changed`: When the user changes the Archive episode limit option

## Testing Instructions
In order to test feed issues, make this change to force the feed issue option to appear:

``` diff
diff --git a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
index c5088f4b..3d370a59 100644
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
@@ -142,7 +142,7 @@ class PodcastSettingsFragment : BasePreferenceFragment(), CoroutineScope, Filter
             val colors = ToolbarColors.Podcast(podcast = podcast, theme = theme)
 
             preferenceFeedIssueDetected?.icon = context.getTintedDrawable(IR.drawable.ic_alert_small, colors.iconColor)
-            preferenceFeedIssueDetected?.isVisible = podcast.refreshAvailable
+            preferenceFeedIssueDetected?.isVisible = true
 
             val effectsDrawableId = if (podcast.overrideGlobalEffects) R.drawable.ic_effects_on else R.drawable.ic_effects_off
             preferencePlaybackEffects?.icon = context.getTintedDrawable(effectsDrawableId, colors.iconColor)

```

1. Subscribing to a podcast
2. Go to that podcast's page in the app and tap the ⚙️ to open the podcast's settings
3. Make changes to every option, confirming that an appropriate tracks event from above is sent off Note that for the playback effects, the only new event this PR adds is for toggling "Custom for this podcast" on and off.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
