### PR TITLE
Media custom action: Allow odd speeds

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -631,10 +631,15 @@ class MediaSessionManager(
         launch {
             val speed = playbackManager.getPlaybackSpeed()
             val newSpeed = when {
+                speed < 1.1 -> 1.1
                 speed < 1.2 -> 1.2
+                speed < 1.3 -> 1.3
                 speed < 1.4 -> 1.4
+                speed < 1.5 -> 1.5
                 speed < 1.6 -> 1.6
+                speed < 1.7 -> 1.7
                 speed < 1.8 -> 1.8
+                speed < 1.9 -> 1.9
                 speed < 2 -> 2.0
                 else -> 1.0
             }


### PR DESCRIPTION
## Description
This allows odd playback speeds using media speed custom action available on android app media notification/ android auto/ android automotive.

(Internal discussion: https://a8c.slack.com/archives/C02A333D8LQ/p1674725427583819)

## Testing Instructions
1. Install automotive app.
2. Play an episode.
3. Tap on playback speed action on the player screen.
4. Notice that odd speeds 1.1x, 1.3x, 1.5x ... are now available.

## Screenshots or Screencast 
https://user-images.githubusercontent.com/1405144/214810449-0722383a-f3ed-4b74-91d3-446283dd64ce.mp4

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- I have considered whether it makes sense to add tests for my changes
- All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- with different themes
- with a landscape orientation
- with the device set to have a large display and font size
- for accessibility with TalkBack
