### PR TITLE
Tracks for Plus and General settings

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlusSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlusSettingsFragment.kt
@@ -73,8 +73,31 @@ class PlusSettingsFragment : BaseFragment() {
             val feature2 = PlusSection.Feature(R.drawable.ic_cloud_storage, LR.string.plus_cloud_storage, LR.string.plus_cloud_storage_body)
             val feature3 = PlusSection.Feature(R.drawable.ic_themes_icons, LR.string.plus_themes_icons, LR.string.plus_themes_icons_body)
             val feature4 = PlusSection.Feature(R.drawable.plus_folder, LR.string.plus_folder, LR.string.plus_folder_body)
-            val upgrade = PlusSection.UpgradeButton(subscriptions)
-            val link = PlusSection.LinkBlock(theme.verticalPlusLogoRes(), LR.string.plus_description_body, LR.string.plus_learn_more_about_plus, Settings.INFO_LEARN_MORE_URL)
+            val upgrade = PlusSection.UpgradeButton(
+                subscriptions = subscriptions,
+                onClick = {
+                    analyticsTracker.track(AnalyticsEvent.SETTINGS_PLUS_UPGRADE_BUTTON_TAPPED)
+                    val flow = if (settings.isLoggedIn()) {
+                        OnboardingFlow.PlusAccountUpgrade(OnboardingUpgradeSource.PLUS_DETAILS)
+                    } else {
+                        OnboardingFlow.PlusAccountUpgradeNeedsLogin
+                    }
+                    OnboardingLauncher.openOnboardingFlow(activity, flow)
+                }
+            )
+            val link = PlusSection.LinkBlock(
+                icon = theme.verticalPlusLogoRes(),
+                body = LR.string.plus_description_body,
+                linkText = LR.string.plus_learn_more_about_plus,
+                onClick = {
+                    analyticsTracker.track(AnalyticsEvent.SETTINGS_PLUS_LEARN_MORE_TAPPED)
+                    context?.let { context ->
+                        val intent =
+                            WebViewActivity.newInstance(context, "Learn More", Settings.INFO_LEARN_MORE_URL)
+                        context.startActivity(intent)
+                    }
+                }
+            )
 
             val sections = listOf(
                 PlusSection.Header,
@@ -90,25 +113,7 @@ class PlusSettingsFragment : BaseFragment() {
                 upgrade
             )
 
-            val adapter = PlusAdapter(
-                onAccountUpgradeClick = {
-                    analyticsTracker.track(AnalyticsEvent.SETTINGS_PLUS_UPGRADE_BUTTON_TAPPED)
-                    val flow = if (settings.isLoggedIn()) {
-                        OnboardingFlow.PlusAccountUpgrade(OnboardingUpgradeSource.PLUS_DETAILS)
-                    } else {
-                        OnboardingFlow.PlusAccountUpgradeNeedsLogin
-                    }
-                    OnboardingLauncher.openOnboardingFlow(activity, flow)
-                },
-                onLearnMoreClick = { targetLink ->
-                    analyticsTracker.track(AnalyticsEvent.SETTINGS_PLUS_LEARN_MORE_TAPPED)
-                    context?.let { context ->
-                        val intent =
-                            WebViewActivity.newInstance(context, "Learn More", targetLink)
-                        context.startActivity(intent)
-                    }
-                }
-            )
+            val adapter = PlusAdapter()
             recyclerView.adapter = adapter
             recyclerView.layoutManager = LinearLayoutManager(rootView.context, LinearLayoutManager.VERTICAL, false)
 
@@ -137,11 +142,16 @@ class PlusSettingsFragment : BaseFragment() {
 }
 
 private sealed class PlusSection {
-    data class UpgradeButton(val subscriptions: List<Subscription>?) : PlusSection()
+    data class UpgradeButton(val subscriptions: List<Subscription>?, val onClick: () -> Unit) : PlusSection()
     data class Feature(@DrawableRes val icon: Int, @StringRes val title: Int, @StringRes val body: Int) : PlusSection()
     object Header : PlusSection()
     data class TextBlock(@StringRes val title: Int, @StringRes val body: Int) : PlusSection()
-    data class LinkBlock(@DrawableRes val icon: Int, @StringRes val body: Int, @StringRes val linkText: Int, val link: String) : PlusSection()
+    data class LinkBlock(
+        @DrawableRes val icon: Int,
+        @StringRes val body: Int,
+        @StringRes val linkText: Int,
+        val onClick: () -> Unit
+    ) : PlusSection()
     object Divider : PlusSection()
 }
 
@@ -155,10 +165,7 @@ private val SECTION_DIFF = object : DiffUtil.ItemCallback<PlusSection>() {
     }
 }
 
-private class PlusAdapter(
-    val onAccountUpgradeClick: () -> Unit,
-    private val onLearnMoreClick: (String) -> Unit
-) : ListAdapter<PlusSection, RecyclerView.ViewHolder>(SECTION_DIFF) {
+private class PlusAdapter : ListAdapter<PlusSection, RecyclerView.ViewHolder>(SECTION_DIFF) {
     class FeatureViewHolder(val root: View) : RecyclerView.ViewHolder(root) {
         private val imgIcon = root.findViewById<GradientIcon>(R.id.imgIcon)
         private val lblTitle = root.findViewById<TextView>(R.id.lblTitle)
@@ -171,14 +178,12 @@ private class PlusAdapter(
         }
     }
 
-    class UpgradeViewHolder(val root: View, val onAccountUpgradeClick: () -> Unit) : RecyclerView.ViewHolder(root) {
+    class UpgradeViewHolder(val root: View) : RecyclerView.ViewHolder(root) {
         private val lblSubtitle = root.findViewById<TextView>(R.id.lblSubtitle)
         private val btnUpgrade = root.findViewById<TextView>(R.id.btnUpgrade)
 
         fun bind(upgrade: PlusSection.UpgradeButton) {
-            btnUpgrade.setOnClickListener {
-                onAccountUpgradeClick()
-            }
+            btnUpgrade.setOnClickListener { upgrade.onClick() }
 
             upgrade.subscriptions?.let { subscriptions ->
                 val trials = subscriptions.filterIsInstance<Subscription.WithTrial>()
@@ -239,10 +244,7 @@ private class PlusAdapter(
         }
     }
 
-    class LinkBlockHolder(
-        root: View,
-        private val onLinkClick: (String) -> Unit
-    ) : RecyclerView.ViewHolder(root) {
+    class LinkBlockHolder(root: View) : RecyclerView.ViewHolder(root) {
         private val imgLogo = root.findViewById<ImageView>(R.id.imgLogo)
         private val lblBody = root.findViewById<TextView>(R.id.lblBody)
         private val lblLink = root.findViewById<TextView>(R.id.lblLink)
@@ -250,7 +252,7 @@ private class PlusAdapter(
         fun bind(linkBlock: PlusSection.LinkBlock) {
             lblBody.setText(linkBlock.body)
             lblLink.setText(linkBlock.linkText)
-            lblLink.setOnClickListener { onLinkClick(linkBlock.link) }
+            lblLink.setOnClickListener { linkBlock.onClick() }
             imgLogo.setImageResource(linkBlock.icon)
         }
     }
@@ -272,10 +274,10 @@ private class PlusAdapter(
         val itemView = LayoutInflater.from(parent.context).inflate(viewType, parent, false)
         return when (viewType) {
             R.layout.adapter_plus_feature_row -> FeatureViewHolder(itemView)
-            R.layout.adapter_plus_upgrade_button -> UpgradeViewHolder(itemView, onAccountUpgradeClick)
+            R.layout.adapter_plus_upgrade_button -> UpgradeViewHolder(itemView)
             R.layout.adapter_plus_header -> HeaderViewHolder(itemView)
             R.layout.adapter_plus_text_block -> TextBlockHolder(itemView)
-            R.layout.adapter_plus_link_block -> LinkBlockHolder(itemView, onLearnMoreClick)
+            R.layout.adapter_plus_link_block -> LinkBlockHolder(itemView)
             R.layout.adapter_plus_divider -> DividerHolder(itemView)
             else -> throw IllegalStateException("Unknown view type in plus settings")
         }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -394,6 +394,9 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_GENERAL_OPEN_PLAYER_AUTOMATICALLY_TOGGLED("settings_general_open_player_automatically_toggled"),
     SETTINGS_GENERAL_INTELLIGENT_PLAYBACK_TOGGLED("settings_general_intelligent_playback_toggled"),
     SETTINGS_GENERAL_PLAY_UP_NEXT_ON_TAP_TOGGLED("settings_general_play_up_next_on_tap_toggled"),
+    SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_SHOWN("settings_general_media_notification_controls_shown"),
+    SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_SHOW_CUSTOM_TOGGLED("settings_general_media_notification_controls_show_custom_toggled"),
+    SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_ORDER_CHANGED("settings_general_media_notification_controls_order_changed"),
 
     /* Settings - Plus */
     SETTINGS_PLUS_SHOWN("settings_plus_shown"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -380,5 +380,10 @@ enum class AnalyticsEvent(val key: String) {
     CANCEL_CONFIRMATION_VIEW_SHOWN("cancel_confirmation_view_shown"),
     CANCEL_CONFIRMATION_VIEW_DISMISSED("cancel_confirmation_view_dismissed"),
     CANCEL_CONFIRMATION_STAY_BUTTON_TAPPED("cancel_confirmation_stay_button_tapped"),
-    CANCEL_CONFIRMATION_CANCEL_BUTTON_TAPPED("cancel_confirmation_cancel_button_tapped")
+    CANCEL_CONFIRMATION_CANCEL_BUTTON_TAPPED("cancel_confirmation_cancel_button_tapped"),
+
+    /* Settings - Plus */
+    SETTINGS_PLUS_SHOWN("settings_plus_shown"),
+    SETTINGS_PLUS_UPGRADE_BUTTON_TAPPED("settings_plus_upgrade_button_tapped"),
+    SETTINGS_PLUS_LEARN_MORE_TAPPED("settings_plus_learn_more_tapped"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -382,6 +382,19 @@ enum class AnalyticsEvent(val key: String) {
     CANCEL_CONFIRMATION_STAY_BUTTON_TAPPED("cancel_confirmation_stay_button_tapped"),
     CANCEL_CONFIRMATION_CANCEL_BUTTON_TAPPED("cancel_confirmation_cancel_button_tapped"),
 
+    /* Settings - General */
+    SETTINGS_GENERAL_SHOWN("settings_general_shown"),
+    SETTINGS_GENERAL_ROW_ACTION_CHANGED("settings_general_row_action_changed"),
+    SETTINGS_GENERAL_EPISODE_GROUPING_CHANGED("settings_general_episode_grouping_changed"),
+    SETTINGS_GENERAL_ARCHIVED_EPISODES_CHANGED("settings_general_archived_episodes_changed"),
+    SETTINGS_GENERAL_UP_NEXT_SWIPE_CHANGED("settings_general_up_next_swipe_changed"),
+    SETTINGS_GENERAL_SKIP_FORWARD_CHANGED("settings_general_skip_forward_changed"),
+    SETTINGS_GENERAL_SKIP_BACK_CHANGED("settings_general_skip_back_changed"),
+    SETTINGS_GENERAL_KEEP_SCREEN_AWAKE_TOGGLED("settings_general_keep_screen_awake_toggled"),
+    SETTINGS_GENERAL_OPEN_PLAYER_AUTOMATICALLY_TOGGLED("settings_general_open_player_automatically_toggled"),
+    SETTINGS_GENERAL_INTELLIGENT_PLAYBACK_TOGGLED("settings_general_intelligent_playback_toggled"),
+    SETTINGS_GENERAL_PLAY_UP_NEXT_ON_TAP_TOGGLED("settings_general_play_up_next_on_tap_toggled"),
+
     /* Settings - Plus */
     SETTINGS_PLUS_SHOWN("settings_plus_shown"),
     SETTINGS_PLUS_UPGRADE_BUTTON_TAPPED("settings_plus_upgrade_button_tapped"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1051,7 +1051,7 @@
     <string name="settings_notification_vibrate_new_episodes">New episodes</string>
     <string name="settings_notification_vibrate_in_silent">Only in silent mode</string>
     <string name="settings_notification_vibrate_never">New episodes</string>
-    <string name="settings_open_player_automatically">Open Player Automatically</string>
+    <string name="settings_open_player_automatically">Open player automatically</string>
     <string name="settings_open_player_automatically_summary">If on, the full-screen player will open when you start playing a podcast episode.</string>
     <string name="settings_other_media_actions">Other media actions</string>
     <string name="settings_playback_resumption">Intelligent playback resumption</string>


### PR DESCRIPTION
## Description
Adds tracks for the plus and general section of the settings.

In addition, I updated the "Open Player Automatically" setting to use sentence case like the rest of our settings in 5b9186b8fdb8183b16c8548d4d2b2ba8979c7449.

#### Plus Settings
- `settings_plus_shown` - When the settings plus view is displayed
- `settings_plus_upgrade_button_tapped` - When the user taps any upgrade button on the view
- `settings_plus_learn_more_tapped` - When the user taps the learn more button

#### General Settings
- `settings_general_shown` - When the general settings section is displayed
- `settings_general_row_action_changed` - When the user changes the row action option
- `settings_general_episode_grouping_changed` - When the user changes the Podcast Episode Grouping option
- `settings_general_archived_episodes_changed` - When the user changes the Archived Episodes option
- `settings_general_up_next_swipe_changed` - When the user changes the Up Next Swipe option
- `settings_general_skip_forward_changed` - When the user changes the Skip Forward option
- `settings_general_skip_back_changed` - When the user changes the Skip Back option
- `settings_general_keep_screen_awake_toggled` - When the user toggles the Keep Screen Aware option
- `settings_general_open_player_automatically_toggled` - When the user toggles the Open Player Automatically option
- `settings_general_intelligent_playback_toggled` - When the user toggles the Intelligent Playback Resumption option
- `settings_general_play_up_next_on_tap_toggled` - When the user toggles the Play Up Next on Tap option
- `settings_general_media_notification_controls_shown` - When the user opens the media notification controls settings
- `settings_general_media_notification_controls_show_custom_toggled` - When the user toggles showing custom media actions
- `settings_general_media_notification_controls_order_changed` - The user has changed the order priority of the custom media actions

## Testing Instructions

### Plus Settings
1. Open the app without signing in
2. Go to `Profile Tab` → ⚙️ → `Pocket Casts Plus`
3. Tap on the first `Upgrade to Plus` button and observe the event: `settings_plus_upgrade_button_tapped`
4. Go back to the Pocket Casts Plus screen and scroll to the bottom
5. Tap on the first `Upgrade to Plus` button and again observe the event: `settings_plus_upgrade_button_tapped`
6. Go back to the Pocket Casts Plus screen and scroll to the bottom
7. Tap on "Learn more about Pocket Casts Plus" and observe the event: `settings_plus_learn_more_tapped`

### General Settings
1. Go to `Profile Tab` → ⚙️ → `General`
2. Observe that changing the row action sends the event: `settings_general_row_action_changed, Properties: {"value":"[play|download]", ...}`
3. Observe that changing the up next swipe sends the event: `settings_general_up_next_swipe_changed, Properties: {"value":"[play_next|play_last]", ... }`
4. Observe that changing the podcast episode grouping sends the event: `settings_general_episode_grouping_changed, Properties: {"value":"[none|downloaded|unplayed|season|starred]", ... }`
5. Observe that changing the show archived setting sends the event: `settings_general_archived_episodes_changed, Properties: {"value":"hide|show", ... }`
6. Tap on "Media Notification Controls"
7. Observe the event `settings_general_media_notification_controls_shown`
8. Observe that toggling "show custom media actions" sends the event: `settings_general_media_notification_controls_show_custom_toggled, Properties: {"enabled":true|false, ... }`
9. Observe that reordering the first custom media action to down to the second position sends the following kind of event: `settings_general_media_notification_controls_order_changed, Properties: {"item":"playback_speed","previous_position":0,"updated_position":1, ... }`
10. Return to the general settings screen.
11. Observe that updating the "Skip forward time" sends the event: `settings_general_skip_forward_changed, Properties: {"value":30, ... }`
12. Observe that updating the "Skip back time" sends the event: `settings_general_skip_back_changed, Properties: {"value":10, ... }` 
13. Observe that toggling "Keep screen awake" sends the event: `settings_general_keep_screen_awake_toggled, Properties: {"enabled":true|false, ... }`
14. Observe that toggling "Open Player Automatically" sends the event: `settings_general_open_player_automatically_toggled, Properties: {"enabled":true|false, ... }`
15. Observe that toggling "Intelligent playback resumption" sends the event: `settings_general_intelligent_playback_toggled, Properties: {"enabled":true|false, ... }`
16. Observe that toggling "Play Up Next episode on tap" sends the event: `settings_general_play_up_next_on_tap_toggled, Properties: {"enabled":true|false, ... }`

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
