### PR TITLE
Playback - Add seek to accuracy setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.32
 -----
-
+*   Bug Fixes:
+    *   Added a new setting to enable more accurate seeking
+        ([#733](https://github.com/Automattic/pocket-casts-android/pull/733)). 
 
 7.31
 -----

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -699,7 +699,13 @@ class AddFileActivity :
             .setUserAgent("Pocket Casts")
             .setAllowCrossProtocolRedirects(true)
         val dataSourceFactory = DefaultDataSource.Factory(this, httpDataSourceFactory)
-        val extractorsFactory = DefaultExtractorsFactory().setMp3ExtractorFlags(Mp3Extractor.FLAG_ENABLE_CONSTANT_BITRATE_SEEKING)
+        val extractorsFactory = DefaultExtractorsFactory().setMp3ExtractorFlags(
+            if (settings.seekToAccuracy()) {
+                Mp3Extractor.FLAG_ENABLE_INDEX_SEEKING
+            } else {
+                Mp3Extractor.FLAG_ENABLE_CONSTANT_BITRATE_SEEKING
+            }
+        )
         val source = ProgressiveMediaSource.Factory(dataSourceFactory, extractorsFactory).createMediaSource(MediaItem.fromUri(uri))
         player.setMediaSource(source)
         player.prepare()

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -170,6 +170,11 @@ class PlaybackSettingsFragment : BaseFragment() {
                         }
                     )
 
+                    SeekToAccuracy(
+                        saved = settings.seekToAccuracyFlow.collectAsState().value,
+                        onSave = settings::setSeekToAccuracy
+                    )
+
                     KeepScreenAwake(
                         saved = settings.keepScreenAwakeFlow.collectAsState().value,
                         onSave = settings::setKeepScreenAwake
@@ -386,6 +391,15 @@ class PlaybackSettingsFragment : BaseFragment() {
             if (int.isPositive()) int else null
         }
     }
+
+    @Composable
+    private fun SeekToAccuracy(saved: Boolean, onSave: (Boolean) -> Unit) =
+        SettingRow(
+            primaryText = stringResource(LR.string.settings_seek_to_accuracy),
+            secondaryText = stringResource(LR.string.settings_seek_to_accuracy_summary),
+            toggle = SettingRowToggle.Switch(checked = saved),
+            modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) }
+        )
 
     @Composable
     private fun KeepScreenAwake(saved: Boolean, onSave: (Boolean) -> Unit) =

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1078,6 +1078,8 @@
     <string name="settings_row_action_download" translatable="false">@string/download</string>
     <string name="settings_row_action_play" translatable="false">@string/play</string>
     <string name="settings_row_action_summary">For episodes that aren\'t downloaded yet, lists will show %s buttons.</string>
+    <string name="settings_seek_to_accuracy">Seek to accuracy</string>
+    <string name="settings_seek_to_accuracy_summary">If on, seeking will be more accurate but it can make seeking slower.</string>
     <string name="settings_show_archived" translatable="false">@string/show_archived</string>
     <string name="settings_show_archived_action_hide">Hide</string>
     <string name="settings_show_archived_action_show">Show</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -96,6 +96,7 @@ interface Settings {
         const val PREFERENCE_CHAPTERS_EXPANDED = "chaptersExpanded"
         const val PREFERENCE_UPNEXT_EXPANDED = "upnextExpanded"
         const val INTELLIGENT_PLAYBACK_RESUMPTION = "intelligentPlaybackResumption"
+        const val PREFERENCE_SEEK_TO_ACCURACY = "seekToAccuracy"
 
         const val PREFERENCE_AUTO_PLAY_ON_EMPTY = "autoUpNextEmpty"
         const val PREFERENCE_AUTO_SUBSCRIBE_ON_PLAY = "autoSubscribeToPlayed"
@@ -302,6 +303,7 @@ interface Settings {
     val openPlayerAutomaticallyFlow: StateFlow<Boolean>
     val tapOnUpNextShouldPlayFlow: StateFlow<Boolean>
     val customMediaActionsVisibilityFlow: StateFlow<Boolean>
+    val seekToAccuracyFlow: StateFlow<Boolean>
 
     fun getVersion(): String
     fun getVersionCode(): Int
@@ -412,6 +414,9 @@ interface Settings {
 
     fun keepScreenAwake(): Boolean
     fun setKeepScreenAwake(newValue: Boolean)
+
+    fun seekToAccuracy(): Boolean
+    fun setSeekToAccuracy(newValue: Boolean)
 
     fun openPlayerAutomatically(): Boolean
     fun setOpenPlayerAutomatically(newValue: Boolean)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -104,6 +104,7 @@ class SettingsImpl @Inject constructor(
     override val intelligentPlaybackResumptionFlow = MutableStateFlow(getIntelligentPlaybackResumption())
     override val tapOnUpNextShouldPlayFlow = MutableStateFlow(getTapOnUpNextShouldPlay())
     override val customMediaActionsVisibilityFlow = MutableStateFlow(areCustomMediaActionsVisible())
+    override val seekToAccuracyFlow = MutableStateFlow(seekToAccuracy())
 
     override val refreshStateObservable = BehaviorRelay.create<RefreshState>().apply {
         val lastError = getLastRefreshError()
@@ -783,6 +784,15 @@ class SettingsImpl @Inject constructor(
     override fun setStreamingMode(newValue: Boolean) {
         setBoolean(Settings.PREFERENCE_GLOBAL_STREAMING_MODE, newValue)
         rowActionObservable.accept(newValue)
+    }
+
+    override fun seekToAccuracy(): Boolean {
+        return sharedPreferences.getBoolean(Settings.PREFERENCE_SEEK_TO_ACCURACY, false)
+    }
+
+    override fun setSeekToAccuracy(newValue: Boolean) {
+        setBoolean(Settings.PREFERENCE_SEEK_TO_ACCURACY, newValue)
+        seekToAccuracyFlow.update { newValue }
     }
 
     override fun keepScreenAwake(): Boolean {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -230,7 +230,13 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
             .setUserAgent("Pocket Casts")
             .setAllowCrossProtocolRedirects(true)
         val dataSourceFactory = DefaultDataSource.Factory(context, httpDataSourceFactory)
-        val extractorsFactory = DefaultExtractorsFactory().setMp3ExtractorFlags(Mp3Extractor.FLAG_ENABLE_CONSTANT_BITRATE_SEEKING)
+        val extractorsFactory = DefaultExtractorsFactory().setMp3ExtractorFlags(
+            if (settings.seekToAccuracy()) {
+                Mp3Extractor.FLAG_ENABLE_INDEX_SEEKING
+            } else {
+                Mp3Extractor.FLAG_ENABLE_CONSTANT_BITRATE_SEEKING
+            }
+        )
         val location = episodeLocation
         if (location == null) {
             onError(PlayerEvent.PlayerError("Episode has no source"))


### PR DESCRIPTION
## Description

This adds a setting enabling more accurate playback seeking to overcome an [ExoPlayer seekTo limitation](https://rb.gy/rojbz2) for large MP3 files. 

ℹ️ Note that enabling more accuracy can make seeking slower so it is not enabled by default and it is mentioned in the setting summary.

Internal discussion: p1674202802570419-slack-C02A333D8LQ

## Testing Instructions

Steps to reproduce
1. Play a long episode in MP3 format, e.g. https://pca.st/xrfsu987 (I tested in `debugProd` env.)
2. Do forward/ backward seeking a few times. (I was able to reproduce the issue more reliably by doing this.)
3. Seek to almost the end of the episode until a few secs left for it to complete.
4. Listen till the end of the episode.
5. ✅ Notice that the episode keeps playing for a few more seconds than the original duration (see in screenshots).

Test new behavior

7. Go to Profile -> Settings -> General
8. Enable "Seek to accuracy" (feel free to improve wording).
9. Reopen the same episode. 
10. Repeat steps 1-4.
11. ✅ Notice that episode ends almost at the original duration.

## Screenshots or Screencast 

Original duration | Episode plays beyond duration | New Setting
--|--|--
![duration](https://user-images.githubusercontent.com/1405144/215027258-dae31149-6ca2-4c6c-982a-9d06301e5299.png) | ![issue](https://user-images.githubusercontent.com/1405144/215027300-2f5e08bf-5032-41e3-bff1-f5ca11907bd3.png) | ![new setting](https://user-images.githubusercontent.com/1405144/215027341-191d6343-f19f-4eab-9f3a-0d352c3bcf05.png)

P.S. This new setting is not available in the automotive app. I can add it separately once this PR is approved.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- I have considered whether it makes sense to add tests for my changes
- All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- with different themes
- with a landscape orientation
- with the device set to have a large display and font size
- for accessibility with TalkBack