### PR TITLE
Track search events

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
@@ -55,6 +56,7 @@ class OnboardingRecommendationsSearchViewModel @Inject constructor(
     )
 
     init {
+        searchHandler.setSource(AnalyticsSource.ONBOARDING_RECOMMENDATIONS_SEARCH)
         searchHandler.setOnlySearchRemote(true)
         viewModelScope.launch {
 
@@ -143,12 +145,11 @@ class OnboardingRecommendationsSearchViewModel @Inject constructor(
     }
 
     companion object {
-        private const val ONBOARDING_RECOMMENDATIONS_SEARCH = "onboarding_recommendations_search"
         private object AnalyticsProp {
             const val UUID = "uuid"
             const val SOURCE = "source"
             fun podcastSubscribeToggled(uuid: String) =
-                mapOf(UUID to uuid, SOURCE to ONBOARDING_RECOMMENDATIONS_SEARCH)
+                mapOf(UUID to uuid, SOURCE to AnalyticsSource.ONBOARDING_RECOMMENDATIONS_SEARCH)
         }
     }
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -105,7 +105,11 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
     }
 
     override fun onSearchClicked() {
-        val searchFragment = SearchFragment.newInstance(floating = true, onlySearchRemote = true)
+        val searchFragment = SearchFragment.newInstance(
+            floating = true,
+            onlySearchRemote = true,
+            source = AnalyticsSource.DISCOVER
+        )
         (activity as FragmentHostListener).addFragment(searchFragment, onTop = true)
         binding?.recyclerView?.smoothScrollToPosition(0)
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -16,6 +16,7 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
@@ -238,7 +239,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
     }
 
     private fun search() {
-        val searchFragment = SearchFragment()
+        val searchFragment = SearchFragment.newInstance(source = AnalyticsSource.PODCAST_LIST)
         (activity as FragmentHostListener).addFragment(searchFragment, onTop = true)
         realBinding?.recyclerView?.smoothScrollToPosition(0)
     }

--- a/modules/features/search/build.gradle
+++ b/modules/features/search/build.gradle
@@ -10,6 +10,7 @@ android {
 }
 
 dependencies {
+    implementation project(':modules:services:analytics')
     implementation project(':modules:services:localization')
     implementation project(':modules:services:preferences')
     implementation project(':modules:services:utils')

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -171,10 +171,22 @@ class SearchFragment : BaseFragment() {
         val searchAdapter = PodcastSearchAdapter(
             theme = theme,
             onPodcastClick = { podcast ->
+                viewModel.trackSearchResultTapped(
+                    source = source,
+                    uuid = podcast.uuid,
+                    onlySearchRemote = onlySearchRemote,
+                    isFolder = false
+                )
                 listener?.onSearchPodcastClick(podcast.uuid)
                 UiUtil.hideKeyboard(searchView)
             },
             onFolderClick = { folder ->
+                viewModel.trackSearchResultTapped(
+                    source = source,
+                    uuid = folder.uuid,
+                    onlySearchRemote = onlySearchRemote,
+                    isFolder = true
+                )
                 listener?.onSearchFolderClick(folder.uuid)
                 UiUtil.hideKeyboard(searchView)
             }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.search.SearchViewModel.SearchResultType
 import au.com.shiftyjelly.pocketcasts.search.adapter.PodcastSearchAdapter
 import au.com.shiftyjelly.pocketcasts.search.databinding.FragmentSearchBinding
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
@@ -174,8 +175,11 @@ class SearchFragment : BaseFragment() {
                 viewModel.trackSearchResultTapped(
                     source = source,
                     uuid = podcast.uuid,
-                    onlySearchRemote = onlySearchRemote,
-                    isFolder = false
+                    type = if (onlySearchRemote || !podcast.isSubscribed) {
+                        SearchResultType.PODCAST_REMOTE_RESULT
+                    } else {
+                        SearchResultType.PODCAST_LOCAL_RESULT
+                    }
                 )
                 listener?.onSearchPodcastClick(podcast.uuid)
                 UiUtil.hideKeyboard(searchView)
@@ -184,8 +188,7 @@ class SearchFragment : BaseFragment() {
                 viewModel.trackSearchResultTapped(
                     source = source,
                     uuid = folder.uuid,
-                    onlySearchRemote = onlySearchRemote,
-                    isFolder = true
+                    type = SearchResultType.FOLDER,
                 )
                 listener?.onSearchFolderClick(folder.uuid)
                 UiUtil.hideKeyboard(searchView)

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -13,6 +13,8 @@ import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.search.adapter.PodcastSearchAdapter
 import au.com.shiftyjelly.pocketcasts.search.databinding.FragmentSearchBinding
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
@@ -22,14 +24,17 @@ import au.com.shiftyjelly.pocketcasts.views.extensions.showKeyboard
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 private const val ARG_FLOATING = "arg_floating"
 private const val ARG_ONLY_SEARCH_REMOTE = "arg_only_search_remote"
+private const val ARG_SOURCE = "arg_source"
 
 @AndroidEntryPoint
 class SearchFragment : BaseFragment() {
+    @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     interface Listener {
         fun onSearchPodcastClick(podcastUuid: String)
@@ -37,11 +42,16 @@ class SearchFragment : BaseFragment() {
     }
 
     companion object {
-        fun newInstance(floating: Boolean, onlySearchRemote: Boolean): SearchFragment {
+        fun newInstance(
+            floating: Boolean = false,
+            onlySearchRemote: Boolean = false,
+            source: AnalyticsSource
+        ): SearchFragment {
             val fragment = SearchFragment()
             val arguments = Bundle().apply {
                 putBoolean(ARG_FLOATING, floating)
                 putBoolean(ARG_ONLY_SEARCH_REMOTE, onlySearchRemote)
+                putString(ARG_SOURCE, source.analyticsValue)
             }
             fragment.arguments = arguments
             return fragment
@@ -56,6 +66,8 @@ class SearchFragment : BaseFragment() {
         get() = arguments?.getBoolean(ARG_FLOATING) ?: false
     val onlySearchRemote: Boolean
         get() = arguments?.getBoolean(ARG_ONLY_SEARCH_REMOTE) ?: false
+    val source: AnalyticsSource
+        get() = AnalyticsSource.fromString(arguments?.getString(ARG_SOURCE))
 
     private val onScrollListener = object : RecyclerView.OnScrollListener() {
         override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {}
@@ -112,6 +124,7 @@ class SearchFragment : BaseFragment() {
             @Suppress("DEPRECATION")
             activity?.onBackPressed()
         }
+        viewModel.setSource(source)
 
         // hack as Search View ignores text size
         val searchView = binding.searchView

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.search
 
 import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -19,6 +20,10 @@ class SearchViewModel @Inject constructor(
 
     fun setOnlySearchRemote(remote: Boolean) {
         searchHandler.setOnlySearchRemote(remote)
+    }
+
+    fun setSource(source: AnalyticsSource) {
+        searchHandler.setSource(source)
     }
 }
 

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -1,14 +1,22 @@
 package au.com.shiftyjelly.pocketcasts.search
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SearchViewModel @Inject constructor(
-    private val searchHandler: SearchHandler
+    private val searchHandler: SearchHandler,
+    private val podcastManager: PodcastManager,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ViewModel() {
 
     val searchResults = searchHandler.searchResults
@@ -24,6 +32,43 @@ class SearchViewModel @Inject constructor(
 
     fun setSource(source: AnalyticsSource) {
         searchHandler.setSource(source)
+    }
+
+    fun trackSearchResultTapped(
+        source: AnalyticsSource,
+        uuid: String,
+        onlySearchRemote: Boolean,
+        isFolder: Boolean,
+    ) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val isLocalPodcast = !isFolder && podcastManager.findPodcastByUuid(uuid) != null
+            analyticsTracker.track(
+                AnalyticsEvent.SEARCH_RESULT_TAPPED,
+                AnalyticsProp.searchResultTapped(
+                    source = source,
+                    uuid = uuid,
+                    type = when {
+                        isFolder -> SearchResultType.FOLDER
+                        onlySearchRemote || !isLocalPodcast -> SearchResultType.PODCAST_REMOTE_RESULT
+                        else -> SearchResultType.PODCAST_LOCAL_RESULT
+                    }
+                )
+            )
+        }
+    }
+
+    enum class SearchResultType(val value: String) {
+        PODCAST_LOCAL_RESULT("podcast_local_result"),
+        PODCAST_REMOTE_RESULT("podcast_remote_result"),
+        FOLDER("folder"),
+    }
+
+    private object AnalyticsProp {
+        private const val SOURCE = "source"
+        private const val UUID = "uuid"
+        private const val RESULT_TYPE = "result_type"
+        fun searchResultTapped(source: AnalyticsSource, uuid: String, type: SearchResultType) =
+            mapOf(SOURCE to source.analyticsValue, UUID to uuid, RESULT_TYPE to type.value)
     }
 }
 

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -1,21 +1,16 @@
 package au.com.shiftyjelly.pocketcasts.search
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SearchViewModel @Inject constructor(
     private val searchHandler: SearchHandler,
-    private val podcastManager: PodcastManager,
     private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ViewModel() {
 
@@ -37,24 +32,12 @@ class SearchViewModel @Inject constructor(
     fun trackSearchResultTapped(
         source: AnalyticsSource,
         uuid: String,
-        onlySearchRemote: Boolean,
-        isFolder: Boolean,
+        type: SearchResultType
     ) {
-        viewModelScope.launch(Dispatchers.IO) {
-            val isLocalPodcast = !isFolder && podcastManager.findPodcastByUuid(uuid) != null
-            analyticsTracker.track(
-                AnalyticsEvent.SEARCH_RESULT_TAPPED,
-                AnalyticsProp.searchResultTapped(
-                    source = source,
-                    uuid = uuid,
-                    type = when {
-                        isFolder -> SearchResultType.FOLDER
-                        onlySearchRemote || !isLocalPodcast -> SearchResultType.PODCAST_REMOTE_RESULT
-                        else -> SearchResultType.PODCAST_LOCAL_RESULT
-                    }
-                )
-            )
-        }
+        analyticsTracker.track(
+            AnalyticsEvent.SEARCH_RESULT_TAPPED,
+            AnalyticsProp.searchResultTapped(source = source, uuid = uuid, type = type)
+        )
     }
 
     enum class SearchResultType(val value: String) {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -424,4 +424,8 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_PLUS_SHOWN("settings_plus_shown"),
     SETTINGS_PLUS_UPGRADE_BUTTON_TAPPED("settings_plus_upgrade_button_tapped"),
     SETTINGS_PLUS_LEARN_MORE_TAPPED("settings_plus_learn_more_tapped"),
+
+    /* Search */
+    SEARCH_PERFORMED("search_performed"),
+    SEARCH_FAILED("search_failed"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -428,4 +428,5 @@ enum class AnalyticsEvent(val key: String) {
     /* Search */
     SEARCH_PERFORMED("search_performed"),
     SEARCH_FAILED("search_failed"),
+    SEARCH_RESULT_TAPPED("search_result_tapped"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsSource.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsSource.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.analytics
 
 enum class AnalyticsSource(val analyticsValue: String) {
     PODCAST_SCREEN("podcast_screen"),
+    PODCAST_LIST("podcast_list"),
     FILTERS("filters"),
     DISCOVER("discover"),
     DISCOVER_PODCAST_LIST("discover_podcast_list"),
@@ -25,8 +26,14 @@ enum class AnalyticsSource(val analyticsValue: String) {
     AUTO_PAUSE("auto_pause"),
     PLAYER_PLAYBACK_EFFECTS("player_playback_effects"),
     PODCAST_SETTINGS("podcast_settings"),
+    ONBOARDING_RECOMMENDATIONS_SEARCH("onboarding_recommendations_search"),
     UNKNOWN("unknown"),
     TASKER("tasker");
 
     fun skipTracking() = this in listOf(AUTO_PLAY, AUTO_PAUSE)
+
+    companion object {
+        fun fromString(source: String?) =
+            AnalyticsSource.values().find { it.analyticsValue == source } ?: UNKNOWN
+    }
 }


### PR DESCRIPTION
## Description

- `search_performed`: When the user enters text and the search is performed
- `search_failed`: If the search results fail for any reason
- `search_result_tapped`: When the user taps one of the items in the search results list

## To test

1. Launch the app
2. Tap on the Podcasts tab
4. Search for a podcast that you are subscribed to
5. ✅ Verify the event isn't performed until you've finished typing
6. ✅ `🔵 Tracked: search_performed ["source": "podcast_list"]`
7. Tap on one of the podcast you search for
8. ✅ `🔵 Tracked: search_result_tapped ["result_type": "podcast_local_result", "uuid": "UUID", "source": "podcast_list"]` - Where the UUID is the uuid of the item that you tapped
9. Tap back, and search for a podcast that you are not subscribed to
10. ✅ `🔵 Tracked: search_result_tapped ["result_type": "podcast_remote_result", "uuid": "UUID", "source": "podcast_list"]`  - Where UUID is the uuid of the item that you tapped
11. Tap back, and search for a folder you have created
12. ✅ `🔵 Tracked: search_result_tapped ["source": "podcast_list", "uuid": "UUID", "result_type": "folder"]` - Where UUID is the uuid of the item
13. Tap on the Discover tab
14. Perform a search
15. ✅ `🔵 Tracked: search_performed ["source": "discover"]`
16. Tap on an item
17. ✅ `🔵 Tracked: search_result_tapped ["result_type": "podcast_remote_result", "source": "discover", "uuid": "UUID"]`
19. Disable your internet
20. Perform a search
21. ✅ `🔵 Tracked: search_failed ["source": "discover"]`
22. Start onboarding sign up flow 
23. Navigate to recommendations screen
24. Search podcast from recommendations screen
25. ✅ `🔵 Tracked: search_performed ["source": "onboarding_recommendations_search"]`
