### PR TITLE
Notification Settings Tracks

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
@@ -14,6 +14,8 @@ import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreference
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NewEpisodeNotificationAction
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
@@ -59,6 +61,7 @@ class NotificationsSettingsFragment :
     @Inject lateinit var settings: Settings
     @Inject lateinit var notificationHelper: NotificationHelper
     @Inject lateinit var theme: Theme
+    @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     private var screen: PreferenceScreen? = null
     private var notificationPodcasts: PreferenceScreen? = null
@@ -76,8 +79,8 @@ class NotificationsSettingsFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
         view.findToolbar().setup(title = getString(LR.string.settings_title_notifications), navigationIcon = BackArrow, activity = activity, theme = theme)
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_NOTIFICATIONS_SHOWN)
     }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -98,12 +101,44 @@ class NotificationsSettingsFragment :
         // add a listener for this preference if the SDK we're on supports it
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             systemSettingsPreference?.setOnPreferenceClickListener {
+                analyticsTracker.track(AnalyticsEvent.SETTINGS_NOTIFICATIONS_ADVANCED_SETTINGS_TAPPED)
                 notificationHelper.openEpisodeNotificationSettings(activity)
                 true
             }
         }
 
         updateNotificationsEnabled()
+
+        manager.run {
+            findPreference<SwitchPreference>(Settings.PREFERENCE_OVERRIDE_AUDIO)?.setOnPreferenceChangeListener { _, newValue ->
+                analyticsTracker.track(
+                    AnalyticsEvent.SETTINGS_NOTIFICATIONS_PLAY_OVER_NOTIFICATIONS_TOGGLED,
+                    mapOf("enabled" to newValue as Boolean)
+                )
+                true
+            }
+            findPreference<SwitchPreference>(Settings.PREFERENCE_HIDE_NOTIFICATION_ON_PAUSE)?.setOnPreferenceChangeListener { _, newValue ->
+                analyticsTracker.track(
+                    AnalyticsEvent.SETTINGS_NOTIFICATIONS_HIDE_PLAYBACK_NOTIFICATION_ON_PAUSE,
+                    mapOf("enabled" to newValue as Boolean)
+                )
+                true
+            }
+        }
+        vibratePreference?.setOnPreferenceChangeListener { _, newValue ->
+            analyticsTracker.track(
+                AnalyticsEvent.SETTINGS_NOTIFICATIONS_VIBRATION_CHANGED,
+                mapOf(
+                    "value" to when (newValue) {
+                        "0" -> "never"
+                        "1" -> "silent"
+                        "2" -> "new_episodes"
+                        else -> "unknown"
+                    }
+                )
+            )
+            true
+        }
     }
 
     private fun updateNotificationsEnabled() {
@@ -117,6 +152,11 @@ class NotificationsSettingsFragment :
 
                 enabledPreference?.setOnPreferenceChangeListener { _, newValue ->
                     val checked = newValue as Boolean
+
+                    analyticsTracker.track(
+                        AnalyticsEvent.SETTINGS_NOTIFICATIONS_NEW_EPISODES_TOGGLED,
+                        mapOf("enabled" to checked)
+                    )
 
                     podcastManager.updateAllShowNotificationsRx(checked)
                         .observeOn(AndroidSchedulers.mainThread())
@@ -208,6 +248,7 @@ class NotificationsSettingsFragment :
             val value = ringtone?.toString() ?: ""
             settings.setNotificationSoundPath(value)
             ringtonePreference?.summary = getRingtoneValue(value)
+            analyticsTracker.track(AnalyticsEvent.SETTINGS_NOTIFICATIONS_SOUND_CHANGED)
         } else {
             super.onActivityResult(requestCode, resultCode, data)
         }
@@ -216,7 +257,8 @@ class NotificationsSettingsFragment :
     private fun setupActions() {
         changeActionsSummary()
         notificationActions?.setOnPreferenceClickListener {
-            val selectedActions = NewEpisodeNotificationAction.loadFromSettings(settings).toMutableList()
+            val initialActions = NewEpisodeNotificationAction.loadFromSettings(settings)
+            val selectedActions = initialActions.toMutableList()
             val initialSelection = selectedActions.map { it.index() }.toIntArray()
             val onSelect: MultiChoiceListener = { dialog, _, items ->
                 selectedActions.clear()
@@ -231,6 +273,10 @@ class NotificationsSettingsFragment :
                     positiveButton(
                         res = LR.string.ok,
                         click = {
+                            val madeChange = initialActions != selectedActions
+                            if (madeChange) {
+                                trackActionsChange(selectedActions)
+                            }
                             NewEpisodeNotificationAction.saveToSettings(selectedActions, settings)
                             changeActionsSummary()
                         }
@@ -242,6 +288,19 @@ class NotificationsSettingsFragment :
 
             true
         }
+    }
+
+    private fun trackActionsChange(selectedActions: MutableList<NewEpisodeNotificationAction>) {
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_NOTIFICATIONS_ACTIONS_CHANGED,
+            mapOf(
+                "action_archive" to selectedActions.contains(NewEpisodeNotificationAction.ARCHIVE),
+                "action_download" to selectedActions.contains(NewEpisodeNotificationAction.DOWNLOAD),
+                "action_play" to selectedActions.contains(NewEpisodeNotificationAction.PLAY),
+                "action_play_next" to selectedActions.contains(NewEpisodeNotificationAction.PLAY_NEXT),
+                "action_play_last" to selectedActions.contains(NewEpisodeNotificationAction.PLAY_LAST),
+            )
+        )
     }
 
     private fun changeActionsSummary() {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -420,6 +420,17 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_SHOW_CUSTOM_TOGGLED("settings_general_media_notification_controls_show_custom_toggled"),
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_ORDER_CHANGED("settings_general_media_notification_controls_order_changed"),
 
+    /* Settings - Notifications */
+    SETTINGS_NOTIFICATIONS_SHOWN("settings_notifications_shown"),
+    SETTINGS_NOTIFICATIONS_NEW_EPISODES_TOGGLED("settings_notifications_new_episodes_toggled"),
+    SETTINGS_NOTIFICATIONS_PODCASTS_CHANGED("settings_notifications_podcasts_changed"),
+    SETTINGS_NOTIFICATIONS_ACTIONS_CHANGED("settings_notifications_actions_changed"),
+    SETTINGS_NOTIFICATIONS_ADVANCED_SETTINGS_TAPPED("settings_notifications_advanced_settings_tapped"),
+    SETTINGS_NOTIFICATIONS_PLAY_OVER_NOTIFICATIONS_TOGGLED("settings_notifications_play_over_notifications_toggled"),
+    SETTINGS_NOTIFICATIONS_HIDE_PLAYBACK_NOTIFICATION_ON_PAUSE("settings_notifications_hide_playback_notification_on_pause"),
+    SETTINGS_NOTIFICATIONS_SOUND_CHANGED("settings_notifications_sound_changed"),
+    SETTINGS_NOTIFICATIONS_VIBRATION_CHANGED("settings_notifications_vibration_changed"),
+
     /* Settings - Plus */
     SETTINGS_PLUS_SHOWN("settings_plus_shown"),
     SETTINGS_PLUS_UPGRADE_BUTTON_TAPPED("settings_plus_upgrade_button_tapped"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1050,7 +1050,7 @@
     <string name="settings_notification_vibrate">Vibrate when</string>
     <string name="settings_notification_vibrate_new_episodes">New episodes</string>
     <string name="settings_notification_vibrate_in_silent">Only in silent mode</string>
-    <string name="settings_notification_vibrate_never">New episodes</string>
+    <string name="settings_notification_vibrate_never">Never</string>
     <string name="settings_open_player_automatically">Open player automatically</string>
     <string name="settings_open_player_automatically_summary">If on, the full-screen player will open when you start playing a podcast episode.</string>
     <string name="settings_other_media_actions">Other media actions</string>

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/PodcastSelectFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/PodcastSelectFragment.kt
@@ -11,6 +11,8 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralPodcastsSelected
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
@@ -62,6 +64,7 @@ class PodcastSelectFragment : BaseFragment() {
     private var userChanged = false
 
     @Inject lateinit var podcastManager: PodcastManager
+    @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
     val disposables = CompositeDisposable()
 
     override fun onAttach(context: Context) {
@@ -148,6 +151,9 @@ class PodcastSelectFragment : BaseFragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         disposables.clear()
+        if (userChanged) {
+            analyticsTracker.track(AnalyticsEvent.SETTINGS_NOTIFICATIONS_PODCASTS_CHANGED)
+        }
         binding = null
     }
 


### PR DESCRIPTION
## Description
Adds tracks for notification settings.

In addition, 3705d8942d0be83a7c1e6f3de6d3d4922afd33f4 fixes an issue I noticed where the wrong string label was being used for the vibrate-never setting.

## Testing Instructions

#### On Any Device
1. Go to the Profile Tab → ⚙️ → Notifications
2. Tap on "Notify me"
3. ✅  Observe the event `settings_notifications_new_episodes_toggled, Properties: {"enabled":[true|false], ... }`
4. Leave "Notify me" toggled on
5. Tap on "Choose podcasts"
6. Change the podcast selection
7. Tap back
8. ✅  Observe the event `settings_notifications_podcasts_changed`
9. Tap on Actions, change the selected actions, and tap "Ok"
10. ✅ Observe the event `settings_notifications_actions_changed, Properties: {"action_archive":[true|false],"action_download":[true|false],"action_play":[true|false],"action_play_next":[true|false],"action_play_last":[true|false],`
11. Tap on Actions again, make some changes, and then press "Cancel"
12. ✅ Observe that a `settings_notifications_actions_changed` event is _not_ sent
13.  Tap on Actions again, do not make any changes, and tap "Ok"
14. ✅ Observe that a `settings_notifications_actions_changed` event is _not_ sent
15. Toggle "Play over notifications"
16. ✅ Observe the event `settings_notifications_play_over_notifications_toggled, Properties: {"enabled":[true|false],`
17. Toggle "Hide playback notification on pause"
18. ✅ Observe the event `settings_notifications_hide_playback_notification_on_pause, Properties: {"enabled":[true|false]`

#### On a device running Android N or older
1. Go to the Profile Tab → ⚙️ → Notifications
2. Toggle "Notify me" on
3. Tap on "Notification sound", select a sound, and tap "Ok"
4. ✅ Observe the event `settings_notifications_sound_changed`
5. Tap on "Notification sound" again, select a sound, but this time tap "Cancel"
6. ✅ Observe the event `settings_notifications_sound_changed` is _not_ sent
7. Tap on "Vibrate when", and change the selection
8. ✅ Observe the event `settings_notifications_vibration_changed, Properties: {"value":[new_episodes|silent|never|`
9. Tap on "Vibrate when" again, and then tap "Cancel"
10. ✅ Observe the event `settings_notifications_vibration_changed` is _not_ sent

#### On a device running Android O or newer
1. Go to the Profile Tab → ⚙️ → Notifications
2. Toggle "Notify me" on
3. Tap on "Advanced settings"
4. ✅ Observe the event `settings_notifications_advanced_settings_tapped`


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
