### PR TITLE
Tracks for notification settings

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
@@ -75,6 +75,7 @@ class AppearanceSettingsFragment : BaseFragment() {
                             (activity as? AppCompatActivity)?.let {
                                 theme.updateTheme(it, afterThemeType)
                                 binding.swtSystemTheme.isChecked = theme.getUseSystemTheme() // Update switch if changing the theme updated the setting
+                                viewModel.onThemeChanged(afterThemeType)
                             }
                         } else {
                             viewModel.updateChangeThemeType(Pair(beforeThemeType, afterThemeType))
@@ -155,7 +156,7 @@ class AppearanceSettingsFragment : BaseFragment() {
 
         binding.swtSystemTheme.isChecked = theme.getUseSystemTheme()
         binding.swtSystemTheme.setOnCheckedChangeListener { _, isChecked ->
-            theme.setUseSystemTheme(isChecked, activity as? AppCompatActivity)
+            viewModel.useAndroidLightDarkMode(isChecked, activity as? AppCompatActivity)
         }
 
         binding.swtShowArtwork.isChecked = viewModel.showArtworkOnLockScreen.value ?: false
@@ -186,6 +187,8 @@ class AppearanceSettingsFragment : BaseFragment() {
             settings.setUpgradeClosedAppearSettings(true)
             binding.upgradeGroup.isVisible = false
         }
+
+        viewModel.onShown()
     }
 
     private fun openOnboardingFlow() {
@@ -207,6 +210,7 @@ class AppearanceSettingsFragment : BaseFragment() {
     }
 
     private fun refreshArtwork() {
+        viewModel.onRefreshArtwork()
         val activity = activity ?: return
         AlertDialog.Builder(activity)
             .setTitle(LR.string.settings_refresh_artwork_title)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
@@ -1,9 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.settings.viewmodel
 
+import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
@@ -19,7 +22,8 @@ class SettingsAppearanceViewModel @Inject constructor(
     private val settings: Settings,
     val userEpisodeManager: UserEpisodeManager,
     val theme: Theme,
-    private val appIcon: AppIcon
+    private val appIcon: AppIcon,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ViewModel() {
 
     val signInState: LiveData<SignInState> = LiveDataReactiveStreams.fromPublisher(userManager.getSignInState())
@@ -29,6 +33,34 @@ class SettingsAppearanceViewModel @Inject constructor(
 
     var changeThemeType: Pair<Theme.ThemeType?, Theme.ThemeType?> = Pair(null, null)
     var changeAppIconType: Pair<AppIcon.AppIconType?, AppIcon.AppIconType?> = Pair(null, null)
+
+    fun onShown() {
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_APPEARANCE_SHOWN)
+    }
+
+    fun onRefreshArtwork() {
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_APPEARANCE_REFRESH_ALL_ARTWORK_TAPPED)
+    }
+
+    fun onThemeChanged(theme: Theme.ThemeType) {
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_APPEARANCE_THEME_CHANGED,
+            mapOf(
+                "value" to when (theme) {
+                    Theme.ThemeType.LIGHT -> "default_light"
+                    Theme.ThemeType.DARK -> "default_dark"
+                    Theme.ThemeType.ROSE -> "rose"
+                    Theme.ThemeType.INDIGO -> "indigo"
+                    Theme.ThemeType.EXTRA_DARK -> "extra_dark"
+                    Theme.ThemeType.DARK_CONTRAST -> "dark_contrast"
+                    Theme.ThemeType.LIGHT_CONTRAST -> "light_contrast"
+                    Theme.ThemeType.ELECTRIC -> "electric"
+                    Theme.ThemeType.CLASSIC_LIGHT -> "classic"
+                    Theme.ThemeType.RADIOACTIVE -> "radioactive"
+                }
+            )
+        )
+    }
 
     fun loadThemesAndIcons() {
         createAccountState.postValue(SettingsAppearanceState.ThemesAndIconsLoading)
@@ -44,16 +76,45 @@ class SettingsAppearanceViewModel @Inject constructor(
     fun updateGlobalIcon(appIconType: AppIcon.AppIconType) {
         appIcon.activeAppIcon = appIconType
         appIcon.enableSelectedAlias(appIconType)
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_APPEARANCE_APP_ICON_CHANGED,
+            mapOf(
+                "value" to when (appIconType) {
+                    AppIcon.AppIconType.DEFAULT -> "default"
+                    AppIcon.AppIconType.DARK -> "dark"
+                    AppIcon.AppIconType.ROUND_LIGHT -> "round_light"
+                    AppIcon.AppIconType.ROUND_DARK -> "round_dark"
+                    AppIcon.AppIconType.INDIGO -> "indigo"
+                    AppIcon.AppIconType.ROSE -> "rose"
+                    AppIcon.AppIconType.CAT -> "pocket_cats"
+                    AppIcon.AppIconType.REDVELVET -> "red_velvet"
+                    AppIcon.AppIconType.PLUS -> "plus"
+                    AppIcon.AppIconType.CLASSIC -> "classic"
+                    AppIcon.AppIconType.ELECTRIC_BLUE -> "electric_blue"
+                    AppIcon.AppIconType.ELECTRIC_PINK -> "electric_pink"
+                    AppIcon.AppIconType.RADIOACTIVE -> "radioactive"
+                    AppIcon.AppIconType.HALLOWEEN -> "halloween"
+                }
+            )
+        )
     }
 
     fun updateShowArtworkOnLockScreen(value: Boolean) {
         settings.setShowArtworkOnLockScreen(value)
         showArtworkOnLockScreen.value = value
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_APPEARANCE_SHOW_ARTWORK_ON_LOCK_SCREEN_TOGGLED,
+            mapOf("enabled" to value)
+        )
     }
 
     fun updateUseEmbeddedArtwork(value: Boolean) {
         settings.setUseEmbeddedArtwork(value)
         useEmbeddedArtwork.value = value
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_APPEARANCE_USE_EMBEDDED_ARTWORK_TOGGLED,
+            mapOf("enabled" to value)
+        )
     }
 
     fun updateChangeThemeType(value: Pair<Theme.ThemeType?, Theme.ThemeType?>) {
@@ -62,6 +123,14 @@ class SettingsAppearanceViewModel @Inject constructor(
 
     fun updateChangeAppIconType(value: Pair<AppIcon.AppIconType?, AppIcon.AppIconType?>) {
         changeAppIconType = value
+    }
+
+    fun useAndroidLightDarkMode(use: Boolean, activity: AppCompatActivity?) {
+        theme.setUseSystemTheme(use, activity)
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_APPEARANCE_FOLLOW_SYSTEM_THEME_TOGGLED,
+            mapOf("enabled" to use)
+        )
     }
 }
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -404,6 +404,15 @@ enum class AnalyticsEvent(val key: String) {
     CANCEL_CONFIRMATION_STAY_BUTTON_TAPPED("cancel_confirmation_stay_button_tapped"),
     CANCEL_CONFIRMATION_CANCEL_BUTTON_TAPPED("cancel_confirmation_cancel_button_tapped"),
 
+    /* Settings - Appearance */
+    SETTINGS_APPEARANCE_SHOWN("settings_appearance_shown"),
+    SETTINGS_APPEARANCE_FOLLOW_SYSTEM_THEME_TOGGLED("settings_appearance_follow_system_theme_toggled"),
+    SETTINGS_APPEARANCE_THEME_CHANGED("settings_appearance_theme_changed"),
+    SETTINGS_APPEARANCE_APP_ICON_CHANGED("settings_appearance_app_icon_changed"),
+    SETTINGS_APPEARANCE_REFRESH_ALL_ARTWORK_TAPPED("settings_appearance_refresh_all_artwork_tapped"),
+    SETTINGS_APPEARANCE_USE_EMBEDDED_ARTWORK_TOGGLED("settings_appearance_use_embedded_artwork_toggled"),
+    SETTINGS_APPEARANCE_SHOW_ARTWORK_ON_LOCK_SCREEN_TOGGLED("settings_appearance_show_artwork_on_lock_screen_toggled"),
+
     /* Settings - General */
     SETTINGS_GENERAL_SHOWN("settings_general_shown"),
     SETTINGS_GENERAL_ROW_ACTION_CHANGED("settings_general_row_action_changed"),


### PR DESCRIPTION
## Description
Adding tracks for the notification settings.

## Testing Instructions
1. Go to the Profile tab → ⚙️ → `Appearance` and check that the following events are being sent.
2. Change your theme to be light: `settings_appearance_theme_changed, Properties: {"value":"default_light", ...}`
3. Toggle "Use Android Light/Dark Mode": `settings_appearance_follow_system_theme_toggled, Properties: {"enabled":true|false, ... }`
4. Select the dark icon: `settings_appearance_app_icon_changed, Properties: {"value":"dark", ... }`
5. Toggle "Show artwork on lock screen" using either the toggle or by tapping on the row: `settings_appearance_show_artwork_on_lock_screen_toggled, Properties: {"enabled":true|false, ... }`
6. Toggle "Use embedded podcast artwork" using either the toggle or by tapping on the row: `settings_appearance_use_embedded_artwork_toggled, Properties: {"enabled":true|false, ... }`
7. Tap on "Refresh all podcast artwork": `settings_appearance_refresh_all_artwork_tapped`

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
