### PR TITLE
Storage settings tracks

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/StorageSettingsPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/StorageSettingsPage.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.DialogButtonState
 import au.com.shiftyjelly.pocketcasts.compose.components.DialogFrame
@@ -78,6 +79,11 @@ fun StorageSettingsPage(
             onDismiss = { showProgressDialog = false }
         )
     }
+
+    CallOnce {
+        viewModel.onShown()
+    }
+
     LaunchedEffect(Unit) {
         viewModel.progressDialog
             .collect { showDialog ->

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/StorageSettingsPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/StorageSettingsPage.kt
@@ -50,6 +50,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.StorageSettingsViewModel
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Util
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import kotlinx.coroutines.delay
 import java.util.*
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -182,27 +183,35 @@ private fun StorageChoiceRow(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
-    val (storageLabels, storagePaths) = storageChoiceState.choices
     val defaultStorageFolderLabel = stringResource(LR.string.settings_storage_phone)
+    val choices = storageChoiceState.choices
     SettingRadioDialogRow(
         primaryText = stringResource(LR.string.settings_storage_store_on),
         modifier = modifier,
         secondaryText = storageChoiceState.summary,
-        options = storageLabels.asList(),
+        options = choices.map { it.label },
         savedOption = storageChoiceState.summary,
         optionToLocalisedString = {
             val label = it ?: defaultStorageFolderLabel
-            val path = storagePaths[storageLabels.indexOf(it)]
+            val folderLocation = choices
+                .find { folderLocation ->
+                    it == folderLocation.label
+                }
+            val path = folderLocation?.filePath
             if (path == Settings.STORAGE_ON_CUSTOM_FOLDER) {
                 "$label…"
             } else {
                 mapToStringWithStorageSpace(label, path, context)
             }
         },
-        onSave = {
-            storageChoiceState.onStateChange(
-                storagePaths[storageLabels.indexOf(it)]
-            )
+        onSave = { label ->
+            val folderLocation = choices
+                .find { it.label == label }
+            if (folderLocation == null) {
+                LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Could not find folder location for label $label")
+            } else {
+                storageChoiceState.onStateChange(folderLocation)
+            }
         }
     )
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
@@ -101,7 +101,6 @@ class StorageSettingsViewModel
                     )
                 }
         }
-        analyticsTracker.track(AnalyticsEvent.SETTINGS_STORAGE_SHOWN)
     }
 
     private fun initState() = State(
@@ -411,6 +410,10 @@ class StorageSettingsViewModel
             )
         )
     )
+
+    fun onShown() {
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_STORAGE_SHOWN)
+    }
 
     data class State(
         val downloadedFilesState: DownloadedFilesState,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
@@ -6,6 +6,8 @@ import android.os.Build
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.components.DialogButtonState
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
@@ -37,6 +39,7 @@ class StorageSettingsViewModel
     private val fileStorage: FileStorage,
     private val fileUtil: FileUtilWrapper,
     private val settings: Settings,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
     @ApplicationContext private val context: Context,
 ) : ViewModel() {
     private val mutableState = MutableStateFlow(initState())
@@ -98,6 +101,7 @@ class StorageSettingsViewModel
                     )
                 }
         }
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_STORAGE_SHOWN)
     }
 
     private fun initState() = State(
@@ -105,21 +109,42 @@ class StorageSettingsViewModel
         storageChoiceState = State.StorageChoiceState(
             title = settings.getStorageChoice(),
             summary = storageChoiceSummary,
-            onStateChange = { onStorageChoiceChange(it) }
+            onStateChange = { folderLocation ->
+                onStorageChoiceChange(folderLocation.filePath)
+                analyticsTracker.track(
+                    AnalyticsEvent.SETTINGS_STORAGE_LOCATION,
+                    mapOf("location" to folderLocation.analyticsLabel),
+                )
+            }
         ),
         storageFolderState = State.StorageFolderState(
             isVisible = settings.usingCustomFolderStorage(),
             summary = storageFolderSummary,
-            onStateChange = { onStorageFolderChange(it) }
+            onStateChange = {
+                onStorageFolderChange(it)
+                analyticsTracker.track(AnalyticsEvent.SETTINGS_STORAGE_SET_FOLDER_LOCATION)
+            }
         ),
         backgroundRefreshState = State.BackgroundRefreshState(
             summary = backgroundRefreshSummary,
             isChecked = settings.refreshPodcastsAutomatically(),
-            onCheckedChange = { onBackgroundRefreshCheckedChange(it) }
+            onCheckedChange = {
+                onBackgroundRefreshCheckedChange(it)
+                analyticsTracker.track(
+                    AnalyticsEvent.SETTINGS_STORAGE_BACKGROUND_REFRESH_TOGGLED,
+                    mapOf("enabled" to it)
+                )
+            }
         ),
         storageDataWarningState = State.StorageDataWarningState(
             isChecked = settings.warnOnMeteredNetwork(),
-            onCheckedChange = { onStorageDataWarningCheckedChange(it) }
+            onCheckedChange = {
+                onStorageDataWarningCheckedChange(it)
+                analyticsTracker.track(
+                    AnalyticsEvent.SETTINGS_STORAGE_WARN_BEFORE_USING_DATA_TOGGLED,
+                    mapOf("enabled" to it)
+                )
+            }
         ),
     )
 
@@ -133,6 +158,7 @@ class StorageSettingsViewModel
             fileUtil.deleteDirectoryContents(tempPath.absolutePath)
             mutableSnackbarMessage.emit(LR.string.settings_storage_clear_cache)
         }
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_STORAGE_CLEAR_DOWNLOAD_CACHE)
     }
 
     private fun onStorageDataWarningCheckedChange(isChecked: Boolean) {
@@ -165,26 +191,24 @@ class StorageSettingsViewModel
     private fun setupStorage() {
         /* Find all the places the user might want to store their podcasts, but still give them a custom folder option on sdk version < 29 */
         foldersAvailable = folderLocations()
-        var optionsCount = foldersAvailable.size
-        if (sdkVersion < 29) {
-            optionsCount++
-        }
 
-        val entries = arrayOfNulls<String>(optionsCount)
-        val entryValues = arrayOfNulls<String>(optionsCount)
-        foldersAvailable.mapIndexed { index, folderLocation ->
-            entries[index] = folderLocation.label
-            entryValues[index] = folderLocation.filePath
-        }
+        val choices = buildList {
+            addAll(foldersAvailable)
 
-        if (sdkVersion < 29) {
-            entries[foldersAvailable.size] = context.getString(LR.string.settings_storage_custom_folder)
-            entryValues[foldersAvailable.size] = Settings.STORAGE_ON_CUSTOM_FOLDER
+            if (sdkVersion < 29) {
+                add(
+                    FolderLocation(
+                        label = context.getString(LR.string.settings_storage_custom_folder),
+                        filePath = Settings.STORAGE_ON_CUSTOM_FOLDER,
+                        analyticsLabel = "custom"
+                    )
+                )
+            }
         }
 
         mutableState.value = mutableState.value.copy(
             storageChoiceState = mutableState.value.storageChoiceState.copy(
-                choices = Pair(entries, entryValues)
+                choices = choices,
             )
         )
 
@@ -229,7 +253,7 @@ class StorageSettingsViewModel
         }
 
         if (sdkVersion >= 29 && settings.usingCustomFolderStorage()) {
-            val (_, folderPaths) = mutableState.value.storageChoiceState.choices
+            val folderPaths = mutableState.value.storageChoiceState.choices.map { it.filePath }
             mutableState.value = mutableState.value.copy(
                 storageChoiceState = mutableState.value.storageChoiceState.copy(
                     summary = folderPaths.firstOrNull() ?: ""
@@ -402,8 +426,8 @@ class StorageSettingsViewModel
         data class StorageChoiceState(
             val title: String? = null,
             val summary: String? = null,
-            val choices: Pair<Array<String?>, Array<String?>> = Pair(emptyArray(), emptyArray()),
-            val onStateChange: (String?) -> Unit
+            val choices: List<FolderLocation> = emptyList(),
+            val onStateChange: (FolderLocation) -> Unit
         )
 
         data class StorageFolderState(

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -444,4 +444,12 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_PLUS_SHOWN("settings_plus_shown"),
     SETTINGS_PLUS_UPGRADE_BUTTON_TAPPED("settings_plus_upgrade_button_tapped"),
     SETTINGS_PLUS_LEARN_MORE_TAPPED("settings_plus_learn_more_tapped"),
+
+    /* Settings - Storage & Data Use */
+    SETTINGS_STORAGE_SHOWN("settings_storage_shown"),
+    SETTINGS_STORAGE_CLEAR_DOWNLOAD_CACHE("settings_storage_clear_download_cache"),
+    SETTINGS_STORAGE_LOCATION("settings_storage_location"),
+    SETTINGS_STORAGE_SET_FOLDER_LOCATION("settings_storage_set_folder_location"),
+    SETTINGS_STORAGE_BACKGROUND_REFRESH_TOGGLED("settings_storage_background_refresh_toggled"),
+    SETTINGS_STORAGE_WARN_BEFORE_USING_DATA_TOGGLED("settings_storage_warn_before_using_data_toggled"),
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/ComposeUtils.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/ComposeUtils.kt
@@ -1,0 +1,22 @@
+package au.com.shiftyjelly.pocketcasts.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+
+/**
+ * Calls a function a single time. This can be useful for calling a
+ * function when a composable is first shown even if there are
+ * configuration changes. Compare to LaunchedEffect(Unit), which will
+ * call the function again after configuration changes.
+ *
+ * @param onShown The function to call when the composable is first shown.
+ */
+@Composable
+fun CallOnce(onShown: () -> Unit) {
+    val shown = rememberSaveable { mutableStateOf(false) }
+    if (!shown.value) {
+        onShown()
+    }
+    shown.value = true
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FolderLocation.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FolderLocation.kt
@@ -3,4 +3,5 @@ package au.com.shiftyjelly.pocketcasts.repositories.file
 data class FolderLocation(
     val filePath: String,
     val label: String,
+    val analyticsLabel: String,
 )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/StorageOptions.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/StorageOptions.kt
@@ -65,8 +65,9 @@ class StorageOptions {
                 "folderLocations can not be null"
             }.add(
                 FolderLocation(
-                    firstMountPoint,
-                    resources.getString(R.string.settings_storage_phone)
+                    filePath = firstMountPoint,
+                    label = resources.getString(R.string.settings_storage_phone),
+                    analyticsLabel = "phone",
                 )
             )
         } else {
@@ -74,8 +75,9 @@ class StorageOptions {
                 "folderLocations can not be null"
             }.add(
                 FolderLocation(
-                    firstMountPoint,
-                    resources.getString(R.string.settings_storage_sd_card)
+                    filePath = firstMountPoint,
+                    label = resources.getString(R.string.settings_storage_sd_card),
+                    analyticsLabel = "sd_card"
                 )
             )
             externalSDCardCount++
@@ -93,7 +95,13 @@ class StorageOptions {
             }
             requireNotNull(folderLocations) {
                 "folderLocations can not be null"
-            }.add(FolderLocation(mountPoint, label))
+            }.add(
+                FolderLocation(
+                    filePath = mountPoint,
+                    label = label,
+                    analyticsLabel = "sd_card"
+                )
+            )
             externalSDCardCount++
         }
     }


### PR DESCRIPTION
## Description
Adding tracks for the storage settings.

I also did a minor refactor here so that instead of passing around a `Pair<String, String>` (which would have become a `Triple<String, String, String>` in order to include the analytics info), we're now passing around the `FolderLocation` object, which contains those three strings. I think this is much clearer and makes it more difficult to mix the strings up.

## Testing Instructions
1. Open the app, go to Profile tab → ⚙️ → `Storage & data use`
2. ✅ Observe the event `settings_storage_shown`
3. Tap on "Clear download cache"
4. ✅ Observe the event: `settings_storage_clear_download_cache`
5. Tap on "Store podcasts on"
6. Select a storage option and tap "Ok". 
7. ✅ Observe the event `settings_storage_location, Properties: {"location":"sd_card|phone|custom", ... }`
8. On a device with API <29, you will have the `Custom Folder...` option when you tap on "Store podcasts on"—select that option and tap ok
9. ✅ Observe that this time the `settings_storage_location` event has a "location" property of "custom"
10. Tap on the new option for "Custom folder location" and then tap ok
11. ✅ Observe the event `settings_storage_set_folder_location`
12. Toggle background refresh
13. ✅ Observe the event `settings_storage_background_refresh_toggled, Properties: {"enabled":true|false, ... }`
14. Toggle "Warn before using data
15. ✅ Observe the event `settings_storage_warn_before_using_data_toggled, Properties: {"enabled":true|false, ... }`


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews

