### PR TITLE
Auto archive settings tracks

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoArchiveFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoArchiveFragment.kt
@@ -6,12 +6,15 @@ import android.view.View
 import androidx.appcompat.widget.Toolbar
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.helper.HasBackstack
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -19,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 class AutoArchiveFragment : PreferenceFragmentCompat(), HasBackstack, SharedPreferences.OnSharedPreferenceChangeListener {
     @Inject lateinit var settings: Settings
     @Inject lateinit var theme: Theme
+    @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     val toolbar: Toolbar?
         get() = view?.findViewById(R.id.toolbar)
@@ -30,8 +34,8 @@ class AutoArchiveFragment : PreferenceFragmentCompat(), HasBackstack, SharedPref
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
         toolbar?.setup(title = getString(LR.string.settings_title_auto_archive), navigationIcon = BackArrow, activity = activity, theme = theme)
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_AUTO_ARCHIVE_SHOWN)
     }
 
     override fun onResume() {
@@ -51,8 +55,45 @@ class AutoArchiveFragment : PreferenceFragmentCompat(), HasBackstack, SharedPref
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
-        if (key == Settings.AUTO_ARCHIVE_INCLUDE_STARRED) {
-            updateStarredSummary()
+        when (key) {
+            Settings.AUTO_ARCHIVE_INCLUDE_STARRED -> {
+                updateStarredSummary()
+                analyticsTracker.track(
+                    AnalyticsEvent.SETTINGS_AUTO_ARCHIVE_INCLUDE_STARRED_TOGGLED,
+                    mapOf("enabled" to settings.getAutoArchiveIncludeStarred())
+                )
+            }
+            Settings.AUTO_ARCHIVE_PLAYED_EPISODES_AFTER -> {
+                analyticsTracker.track(
+                    AnalyticsEvent.SETTINGS_AUTO_ARCHIVE_PLAYED_CHANGED,
+                    mapOf(
+                        "value" to when (settings.getAutoArchiveAfterPlaying()) {
+                            Settings.AutoArchiveAfterPlaying.Never -> "never"
+                            Settings.AutoArchiveAfterPlaying.AfterPlaying -> "after_playing"
+                            Settings.AutoArchiveAfterPlaying.Hours24 -> "after_24_hours"
+                            Settings.AutoArchiveAfterPlaying.Days2 -> "after_2_days"
+                            Settings.AutoArchiveAfterPlaying.Weeks1 -> "after_1_week"
+                        }
+                    )
+                )
+            }
+            Settings.AUTO_ARCHIVE_INACTIVE -> {
+                analyticsTracker.track(
+                    AnalyticsEvent.SETTINGS_AUTO_ARCHIVE_INACTIVE_CHANGED,
+                    mapOf(
+                        "value" to when (settings.getAutoArchiveInactive()) {
+                            Settings.AutoArchiveInactive.Never -> "never"
+                            Settings.AutoArchiveInactive.Hours24 -> "after_24_hours"
+                            Settings.AutoArchiveInactive.Days2 -> "after_2_days"
+                            Settings.AutoArchiveInactive.Weeks1 -> "after_1_week"
+                            Settings.AutoArchiveInactive.Weeks2 -> "after_2_weeks"
+                            Settings.AutoArchiveInactive.Days30 -> "after_30_days"
+                            Settings.AutoArchiveInactive.Days90 -> "after 3 months"
+                        }
+                    )
+                )
+            }
+            else -> Timber.d("Unknown preference changed: $key")
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoArchiveFragmentViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoArchiveFragmentViewModel.kt
@@ -1,0 +1,65 @@
+package au.com.shiftyjelly.pocketcasts.settings.viewmodel
+
+import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class AutoArchiveFragmentViewModel @Inject constructor(
+    private val settings: Settings,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+) : ViewModel() {
+    private var isFragmentChangingConfigurations: Boolean = false
+
+    fun onViewCreated() {
+        if (!isFragmentChangingConfigurations) {
+            analyticsTracker.track(AnalyticsEvent.SETTINGS_AUTO_ARCHIVE_SHOWN)
+        }
+    }
+
+    fun onStarredChanged() {
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_AUTO_ARCHIVE_INCLUDE_STARRED_TOGGLED,
+            mapOf("enabled" to settings.getAutoArchiveIncludeStarred())
+        )
+    }
+
+    fun onPlayedEpisodesAfterChanged() {
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_AUTO_ARCHIVE_PLAYED_CHANGED,
+            mapOf(
+                "value" to when (settings.getAutoArchiveAfterPlaying()) {
+                    Settings.AutoArchiveAfterPlaying.Never -> "never"
+                    Settings.AutoArchiveAfterPlaying.AfterPlaying -> "after_playing"
+                    Settings.AutoArchiveAfterPlaying.Hours24 -> "after_24_hours"
+                    Settings.AutoArchiveAfterPlaying.Days2 -> "after_2_days"
+                    Settings.AutoArchiveAfterPlaying.Weeks1 -> "after_1_week"
+                }
+            )
+        )
+    }
+
+    fun onInactiveChanged() {
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_AUTO_ARCHIVE_INACTIVE_CHANGED,
+            mapOf(
+                "value" to when (settings.getAutoArchiveInactive()) {
+                    Settings.AutoArchiveInactive.Never -> "never"
+                    Settings.AutoArchiveInactive.Hours24 -> "after_24_hours"
+                    Settings.AutoArchiveInactive.Days2 -> "after_2_days"
+                    Settings.AutoArchiveInactive.Weeks1 -> "after_1_week"
+                    Settings.AutoArchiveInactive.Weeks2 -> "after_2_weeks"
+                    Settings.AutoArchiveInactive.Days30 -> "after_30_days"
+                    Settings.AutoArchiveInactive.Days90 -> "after 3 months"
+                }
+            )
+        )
+    }
+
+    fun onFragmentPause(isChangingConfigurations: Boolean?) {
+        isFragmentChangingConfigurations = isChangingConfigurations ?: false
+    }
+}

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -413,6 +413,12 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_APPEARANCE_USE_EMBEDDED_ARTWORK_TOGGLED("settings_appearance_use_embedded_artwork_toggled"),
     SETTINGS_APPEARANCE_SHOW_ARTWORK_ON_LOCK_SCREEN_TOGGLED("settings_appearance_show_artwork_on_lock_screen_toggled"),
 
+    /* Settings - Auto archive */
+    SETTINGS_AUTO_ARCHIVE_SHOWN("settings_auto_archive_shown"),
+    SETTINGS_AUTO_ARCHIVE_PLAYED_CHANGED("settings_auto_archive_played_changed"),
+    SETTINGS_AUTO_ARCHIVE_INACTIVE_CHANGED("settings_auto_archive_inactive_changed"),
+    SETTINGS_AUTO_ARCHIVE_INCLUDE_STARRED_TOGGLED("settings_auto_archive_include_starred_toggled"),
+
     /* Settings - General */
     SETTINGS_GENERAL_SHOWN("settings_general_shown"),
     SETTINGS_GENERAL_ROW_ACTION_CHANGED("settings_general_row_action_changed"),


### PR DESCRIPTION
## Description
Adding tracks for the auto archive settings

## Testing Instructions
1. Open the app and to to the Profile tab → ⚙️ → `Auto archive`
2. ✅  Observe the event `settings_auto_archive_shown`
3. Change the setting for "Archive played episodes"
4. ✅ Observe the event `settings_auto_archive_played_changed` with an appropriate `value` property reflecting your selected setting
5. Change the setting for "Archive inactive episodes"
6.  ✅ Observe the event `settings_auto_archive_inactive_changed` with an appropriate `value` property reflecting your selected setting
7. Toggle "Include starred episodes"
8. ✅ Observe the event `settings_auto_archive_include_starred_toggled, Properties: {"enabled":true|false, ... }`

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
