### PR TITLE
Prevent onboarding "shown" tracks from firing on configuration changes

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingCreateAccountPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingCreateAccountPage.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingCreateAccountViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.EmailAndPasswordFields
@@ -51,8 +52,11 @@ internal fun OnboardingCreateAccountPage(
     val systemUiController = rememberSystemUiController()
     val pocketCastsTheme = MaterialTheme.theme
 
-    LaunchedEffect(Unit) {
+    CallOnce {
         viewModel.onShown()
+    }
+
+    LaunchedEffect(Unit) {
         systemUiController.apply {
             // Use secondaryUI01 so the status bar matches the ThemedTopAppBar
             setStatusBarColor(pocketCastsTheme.colors.secondaryUi01, darkIcons = !theme.defaultLightIcons)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingForgotPasswordPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingForgotPasswordPage.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingForgotPasswordViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.EmailField
@@ -71,8 +72,11 @@ fun OnboardingForgotPasswordPage(
     val systemUiController = rememberSystemUiController()
     val pocketCastsTheme = MaterialTheme.theme
 
-    LaunchedEffect(Unit) {
+    CallOnce {
         viewModel.onShown()
+    }
+
+    LaunchedEffect(Unit) {
         emailFocusRequester.requestFocus()
         systemUiController.apply {
             setStatusBarColor(pocketCastsTheme.colors.secondaryUi01, darkIcons = !theme.defaultLightIcons)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
@@ -45,6 +45,7 @@ import au.com.shiftyjelly.pocketcasts.account.R
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.GoogleSignInState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingLoginOrSignUpViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
@@ -79,8 +80,11 @@ internal fun OnboardingLoginOrSignUpPage(
     val systemUiController = rememberSystemUiController()
     val pocketCastsTheme = MaterialTheme.theme
 
-    LaunchedEffect(Unit) {
+    CallOnce {
         viewModel.onShown(flow)
+    }
+
+    LaunchedEffect(Unit) {
         systemUiController.apply {
             setStatusBarColor(pocketCastsTheme.colors.primaryUi01.copy(alpha = 0.9f), darkIcons = !theme.darkTheme)
             setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingLogInViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.EmailAndPasswordFields
@@ -56,8 +57,11 @@ internal fun OnboardingLoginPage(
     val viewModel = hiltViewModel<OnboardingLogInViewModel>()
     val state by viewModel.state.collectAsState()
 
-    LaunchedEffect(Unit) {
+    CallOnce {
         viewModel.onShown()
+    }
+
+    LaunchedEffect(Unit) {
         systemUiController.apply {
             setStatusBarColor(pocketCastsTheme.colors.secondaryUi01, darkIcons = !theme.defaultLightIcons)
             setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingWelcomePage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingWelcomePage.kt
@@ -48,6 +48,7 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusH
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingWelcomeState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingWelcomeViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
@@ -82,8 +83,11 @@ fun OnboardingWelcomePage(
     val systemUiController = rememberSystemUiController()
     val pocketCastsTheme = MaterialTheme.theme
 
-    LaunchedEffect(Unit) {
+    CallOnce {
         viewModel.onShown(flow)
+    }
+
+    LaunchedEffect(Unit) {
         systemUiController.apply {
             setStatusBarColor(pocketCastsTheme.colors.primaryUi01.copy(alpha = 0.9f), darkIcons = !activeTheme.darkTheme)
             setNavigationBarColor(Color.Transparent, darkIcons = !activeTheme.darkTheme)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/import/OnboardingImportStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/import/OnboardingImportStartPage.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
@@ -50,8 +51,12 @@ fun OnboardingImportStartPage(
 ) {
     val systemUiController = rememberSystemUiController()
     val pocketCastsTheme = MaterialTheme.theme
-    LaunchedEffect(Unit) {
+
+    CallOnce {
         onShown()
+    }
+
+    LaunchedEffect(Unit) {
         systemUiController.apply {
             // Use secondaryUI01 so the status bar matches the ThemedTopAppBar
             setStatusBarColor(pocketCastsTheme.colors.secondaryUi01, darkIcons = !theme.defaultLightIcons)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
@@ -45,6 +45,7 @@ import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingRecommendation
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingRecommendationsStartPageViewModel.Section
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingRecommendationsStartPageViewModel.SectionId
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
 import au.com.shiftyjelly.pocketcasts.compose.components.SearchBarButton
@@ -77,8 +78,11 @@ fun OnboardingRecommendationsStartPage(
     val systemUiController = rememberSystemUiController()
     val pocketCastsTheme = MaterialTheme.theme
 
-    LaunchedEffect(Unit) {
+    CallOnce {
         viewModel.onShown()
+    }
+
+    LaunchedEffect(Unit) {
         systemUiController.apply {
             setStatusBarColor(pocketCastsTheme.colors.primaryUi01.copy(alpha = 0.9f), darkIcons = !theme.darkTheme)
             setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusFeaturesPage.kt
@@ -53,6 +53,7 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusH
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusHelper.PlusOutlinedRowButton
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusHelper.PlusRowButton
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusFeaturesViewModel
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
@@ -97,7 +98,7 @@ internal fun OnboardingPlusFeaturesPage(
         onBackPressed()
     }
 
-    LaunchedEffect(Unit) {
+    CallOnce {
         viewModel.onShown(flow, source)
     }
 


### PR DESCRIPTION
## Description
Updates the "shown" tracks events for the onboarding flow so that they do not get resent on configuration changes.

Fixes # <!-- issue number, if applicable -->

## Testing Instructions
Go through the onboarding flow for creating a new account. Make sure that rotating the device doesn't resend the "shown" event for the screen (if that screen has a shown event—there are a couple that don't have one). 

As you go through the flow, make sure you check the initial import screen as well (you have to select that option from the welcome page to see it, you won't automatically see it if you just click through everything).

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
