### PR TITLE
Add auto download settings tracks

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -1,7 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding
 
-import android.os.Build
-import android.os.Bundle
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -18,7 +16,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import java.io.Serializable
+import au.com.shiftyjelly.pocketcasts.utils.extensions.getSerializableCompat
 
 @Composable
 fun OnboardingFlowComposable(
@@ -218,21 +216,6 @@ fun OnboardingFlowComposable(
         }
     }
 }
-
-private fun <T : Serializable> Bundle.getSerializableCompat(key: String, clazz: Class<T>): T? =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        getSerializable(key, clazz)
-    } else {
-        @Suppress("DEPRECATION")
-        getSerializable(key)?.let { result ->
-            if (clazz.isInstance(result)) {
-                @Suppress("UNCHECKED_CAST")
-                result as T
-            } else {
-                null
-            }
-        }
-    }
 
 private object OnboardingNavRoute {
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
@@ -22,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.views.extensions.updateTint
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.PodcastSelectFragment
+import au.com.shiftyjelly.pocketcasts.views.fragments.PodcastSelectFragmentSource
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -87,7 +88,10 @@ class PodcastOptionsFragment : BaseFragment(), PodcastSelectFragment.Listener, C
             podcastSelectDisabled.isVisible = playlist.allPodcasts
             switchAllPodcasts.isChecked = playlist.allPodcasts
 
-            val fragment = PodcastSelectFragment.newInstance(color)
+            val fragment = PodcastSelectFragment.newInstance(
+                tintColor = color,
+                source = PodcastSelectFragmentSource.FILTERS
+            )
             childFragmentManager.commit {
                 add(R.id.podcastSelectFrame, fragment)
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
@@ -340,7 +340,10 @@ class PodcastSettingsFragment : BasePreferenceFragment(), CoroutineScope, Filter
 
     private fun setupFilters() {
         preferenceFilters?.setOnPreferenceClickListener {
-            val fragment = FilterSelectFragment.newInstance(shouldFilterPlaylistsWithAllPodcasts = true)
+            val fragment = FilterSelectFragment.newInstance(
+                source = FilterSelectFragment.Source.PODCAST_SETTINGS,
+                shouldFilterPlaylistsWithAllPodcasts = true
+            )
             childFragmentManager.beginTransaction()
                 .replace(UR.id.frameChildFragment, fragment)
                 .addToBackStack("filterSelect")

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoAddSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoAddSettingsFragment.kt
@@ -28,6 +28,7 @@ import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.PodcastSelectFragment
+import au.com.shiftyjelly.pocketcasts.views.fragments.PodcastSelectFragmentSource
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -134,7 +135,11 @@ class AutoAddSettingsFragment : BaseFragment(), PodcastSelectFragment.Listener {
     }
 
     private fun openPodcastsList() {
-        val fragment = PodcastSelectFragment.newInstance(ThemeColor.primaryInteractive01(theme.activeTheme), showToolbar = true)
+        val fragment = PodcastSelectFragment.newInstance(
+            tintColor = ThemeColor.primaryInteractive01(theme.activeTheme),
+            showToolbar = true,
+            source = PodcastSelectFragmentSource.AUTO_ADD
+        )
         fragment.listener = this
         (activity as? FragmentHostListener)?.addFragment(fragment)
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
@@ -24,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.extensions.findToolbar
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.fragments.PodcastSelectFragment
+import au.com.shiftyjelly.pocketcasts.views.fragments.PodcastSelectFragmentSource
 import au.com.shiftyjelly.pocketcasts.views.helper.HasBackstack
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
 import com.afollestad.materialdialogs.MaterialDialog
@@ -184,7 +185,7 @@ class NotificationsSettingsFragment :
     }
 
     private fun openSelectPodcasts() {
-        val fragment = PodcastSelectFragment()
+        val fragment = PodcastSelectFragment.newInstance(source = PodcastSelectFragmentSource.NOTIFICATIONS)
         childFragmentManager.beginTransaction()
             .replace(UR.id.frameChildFragment, fragment)
             .addToBackStack("podcastSelect")

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -1,0 +1,73 @@
+package au.com.shiftyjelly.pocketcasts.settings.viewmodel
+
+import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AutoDownloadSettingsViewModel @Inject constructor(
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val downloadManager: DownloadManager,
+    private val podcastManager: PodcastManager,
+) : ViewModel(), CoroutineScope {
+
+    override val coroutineContext = Dispatchers.Default
+    private var isFragmentChangingConfigurations: Boolean = false
+
+    fun onShown() {
+        if (!isFragmentChangingConfigurations) {
+            analyticsTracker.track(AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_SHOWN)
+        }
+    }
+
+    fun onFragmentPause(isChangingConfigurations: Boolean?) {
+        isFragmentChangingConfigurations = isChangingConfigurations ?: false
+    }
+
+    fun onUpNextChange(newValue: Boolean) {
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_UP_NEXT_TOGGLED,
+            mapOf("enabled" to newValue)
+        )
+    }
+
+    fun onNewEpisodesChange(newValue: Boolean) {
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_NEW_EPISODES_TOGGLED,
+            mapOf("enabled" to newValue)
+        )
+    }
+
+    fun stopAllDownloads() {
+        downloadManager.stopAllDownloads()
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_STOP_ALL_DOWNLOADS)
+    }
+
+    fun clearDownloadErrors() {
+        launch {
+            podcastManager.clearAllDownloadErrors()
+        }
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_CLEAR_DOWNLOAD_ERRORS)
+    }
+
+    fun onDownloadOnlyOnUnmeteredChange(enabled: Boolean) {
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_ONLY_ON_WIFI_TOGGLED,
+            mapOf("enabled" to enabled),
+        )
+    }
+
+    fun onDownloadOnlyWhenChargingChange(enabled: Boolean) {
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_ONLY_WHEN_CHARGING_TOGGLED,
+            mapOf("enabled" to enabled),
+        )
+    }
+}

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -419,6 +419,17 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_AUTO_ARCHIVE_INACTIVE_CHANGED("settings_auto_archive_inactive_changed"),
     SETTINGS_AUTO_ARCHIVE_INCLUDE_STARRED_TOGGLED("settings_auto_archive_include_starred_toggled"),
 
+    /* Settings - Auto download */
+    SETTINGS_AUTO_DOWNLOAD_SHOWN("settings_auto_download_shown"),
+    SETTINGS_AUTO_DOWNLOAD_UP_NEXT_TOGGLED("settings_auto_download_up_next_toggled"),
+    SETTINGS_AUTO_DOWNLOAD_NEW_EPISODES_TOGGLED("settings_auto_download_new_episodes_toggled"),
+    SETTINGS_AUTO_DOWNLOAD_PODCASTS_CHANGED("settings_auto_download_podcasts_changed"),
+    SETTINGS_AUTO_DOWNLOAD_FILTERS_CHANGED("settings_auto_download_filters_changed"),
+    SETTINGS_AUTO_DOWNLOAD_ONLY_ON_WIFI_TOGGLED("settings_auto_download_only_on_wifi_toggled"),
+    SETTINGS_AUTO_DOWNLOAD_ONLY_WHEN_CHARGING_TOGGLED("settings_auto_download_only_when_charging_toggled"),
+    SETTINGS_AUTO_DOWNLOAD_STOP_ALL_DOWNLOADS("settings_auto_download_stop_all_downloads"),
+    SETTINGS_AUTO_DOWNLOAD_CLEAR_DOWNLOAD_ERRORS("settings_auto_download_clear_download_errors"),
+
     /* Settings - General */
     SETTINGS_GENERAL_SHOWN("settings_general_shown"),
     SETTINGS_GENERAL_ROW_ACTION_CHANGED("settings_general_row_action_changed"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistUpdateAnalytics.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistUpdateAnalytics.kt
@@ -18,7 +18,6 @@ class PlaylistUpdateAnalytics @Inject constructor(
         userPlaylistUpdate: UserPlaylistUpdate?,
         isCreatingFilter: Boolean
     ) {
-
         when {
             isCreatingFilter -> sendPlaylistCreatedEvent(playlist)
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/Bundle.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/Bundle.kt
@@ -1,0 +1,20 @@
+package au.com.shiftyjelly.pocketcasts.utils.extensions
+
+import android.os.Build
+import android.os.Bundle
+import java.io.Serializable
+
+fun <T : Serializable> Bundle.getSerializableCompat(key: String, clazz: Class<T>): T? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getSerializable(key, clazz)
+    } else {
+        @Suppress("DEPRECATION")
+        getSerializable(key)?.let { result ->
+            if (clazz.isInstance(result)) {
+                @Suppress("UNCHECKED_CAST")
+                result as T
+            } else {
+                null
+            }
+        }
+    }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/viewmodels/FilterSelectViewModel.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/viewmodels/FilterSelectViewModel.kt
@@ -1,0 +1,33 @@
+package au.com.shiftyjelly.pocketcasts.views.viewmodels
+
+import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.views.fragments.FilterSelectFragment
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class FilterSelectViewModel @Inject constructor(
+    private val analyticsTracker: AnalyticsTrackerWrapper
+) : ViewModel() {
+
+    private var isFragmentChangingConfigurations: Boolean = false
+
+    fun trackFilterChange(source: FilterSelectFragment.Source) {
+        if (!isFragmentChangingConfigurations) {
+            when (source) {
+                FilterSelectFragment.Source.AUTO_DOWNLOAD -> {
+                    analyticsTracker.track(AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_FILTERS_CHANGED)
+                }
+                FilterSelectFragment.Source.PODCAST_SETTINGS -> {
+                    // Do not track because the filter_updated event was tracked when the change was persisted
+                }
+            }
+        }
+    }
+
+    fun onFragmentPause(isChangingConfigurations: Boolean?) {
+        isFragmentChangingConfigurations = isChangingConfigurations ?: false
+    }
+}


### PR DESCRIPTION
## Description
Adding tracks for the auto download settings.

## Testing Instructions
1. Within the app, go to the Profile tab → ⚙️ → `Auto download`
2. Observe the `settings_auto_download_shown` is sent when you open the screen
3. Observe that a configuration change (i.e., rotating the phone to landscape) does _not_ resend the event.
4. Toggle "Episodes added to Up Next" and observe the event `settings_auto_download_up_next_toggled, Properties: {"enabled":true|false, ... }`
5. Toggle "New episodes" and observe the event `settings_auto_download_new_episodes_toggled, Properties: {"enabled":true|false, ... }`
6. With "New episodes" toggled on, tap on "Choose podcasts"
7. Change the podcasts that are set to auto download new episodes
8. Exit the podcast selection screen to return to the Auto downloads settings
9. Observe that when you exit the screen the event `settings_auto_download_podcasts_changed, Properties: {"number_selected":[number], ... }` is sent.
10. Tap on choose podcasts again, but this time do not change the selection
11. Observe that the `settings_auto_download_podcasts_changed` event is not sent when leaving the screen this time
12. Tap on "All filter episodes"
13. Change the filter selections, and observe the event `filter_auto_download_updated, Properties: {"source":"auto_download_settings","enabled":true|false, ... }` is sent for each change
14. Exit the filter selection screen and return to the auto download settings screen, observing that the `settings_auto_download_filters_changed` event is sent.
15. Tap on "All filter episodes" again, but this time exit the filter selection screen without making any changes
16. Observe that the `settings_auto_download_filters_changed` event is _not_ sent.
17. Tap "Only on unmetered wifi" and observe the event `settings_auto_download_only_on_wifi_toggled, Properties: {"enabled":true|false, ... }`
18. Tap "Only when charging" and observe the event `settings_auto_download_only_when_charging_toggled, Properties: {"enabled":true, ... }`
19. Tap "Stop all downloads" and observe the event `settings_auto_download_stop_all_downloads`
20. Tap "Clear all download errors" and observe the event `settings_auto_download_clear_download_errors`

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
