### PR TITLE
Add contentDescription string label to episode up next icon

### DIFF
--- a/modules/features/podcasts/src/main/res/layout/adapter_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_episode.xml
@@ -33,7 +33,6 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:visibility="gone"
-            android:importantForAccessibility="noHideDescendants">
             <FrameLayout
                 android:id="@id/leftRightItem2"
                 android:layout_width="match_parent"
@@ -168,7 +167,7 @@
                     android:layout_width="16dp"
                     android:layout_height="16dp"
                     android:src="@drawable/ic_upnext"
-                    android:contentLabel="@string/episode_status_up_next"
+                    android:contentDescription="@string/episode_status_up_next"
                     android:layout_gravity="center"
                     android:layout_marginEnd="4dp"
                     android:visibility="@{inUpNext}"

--- a/modules/features/podcasts/src/main/res/layout/adapter_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_episode.xml
@@ -33,6 +33,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:visibility="gone"
+            android:importantForAccessibility="noHideDescendants">
             <FrameLayout
                 android:id="@id/leftRightItem2"
                 android:layout_width="match_parent"
@@ -167,11 +168,12 @@
                     android:layout_width="16dp"
                     android:layout_height="16dp"
                     android:src="@drawable/ic_upnext"
-                    android:contentDescription="@string/episode_status_up_next"
                     android:layout_gravity="center"
                     android:layout_marginEnd="4dp"
                     android:visibility="@{inUpNext}"
-                    app:tint="?attr/support_01" />
+                    app:tint="?attr/support_01"
+                    android:contentDescription="@string/episode_status_up_next"
+                    android:importantForAccessibility="yes" />
                 <ImageView
                     android:id="@+id/imgIcon"
                     android:layout_width="16dp"

--- a/modules/features/podcasts/src/main/res/layout/adapter_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_episode.xml
@@ -46,7 +46,6 @@
                         android:padding="23dp"
                         android:layout_gravity="center_vertical|right"
                         android:src="@drawable/ic_upnext_playlast"
-                        android:contentLabel="@string/episode_status_up_next"
                         app:tint="@android:color/white"/>
             </FrameLayout>
             <FrameLayout
@@ -169,6 +168,7 @@
                     android:layout_width="16dp"
                     android:layout_height="16dp"
                     android:src="@drawable/ic_upnext"
+                    android:contentLabel="@string/episode_status_up_next"
                     android:layout_gravity="center"
                     android:layout_marginEnd="4dp"
                     android:visibility="@{inUpNext}"

--- a/modules/features/podcasts/src/main/res/layout/adapter_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_episode.xml
@@ -46,6 +46,7 @@
                         android:padding="23dp"
                         android:layout_gravity="center_vertical|right"
                         android:src="@drawable/ic_upnext_playlast"
+                        android:contentLabel="@string/episode_status_up_next"
                         app:tint="@android:color/white"/>
             </FrameLayout>
             <FrameLayout

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -500,7 +500,7 @@
     <string name="episode_short_episode">E%d</string>
     <string name="episode_added_to_up_next">Added to up next</string>
     <string name="episode_removed_from_up_next">Removed from up next</string>
-    <string name="episode_status_up_next">Episode queued for up next</string>
+    <string name="episode_status_up_next">Episode in up next queue</string>
 
     <!-- Supporter -->
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -500,6 +500,7 @@
     <string name="episode_short_episode">E%d</string>
     <string name="episode_added_to_up_next">Added to up next</string>
     <string name="episode_removed_from_up_next">Removed from up next</string>
+    <string name="episode_status_up_next">Episode queued for up next</string>
 
     <!-- Supporter -->
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -500,7 +500,7 @@
     <string name="episode_short_episode">E%d</string>
     <string name="episode_added_to_up_next">Added to up next</string>
     <string name="episode_removed_from_up_next">Removed from up next</string>
-    <string name="episode_status_up_next">Episode in up next queue</string>
+    <string name="episode_status_up_next">In up next queue</string>
 
     <!-- Supporter -->
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Fixes #750 

Adds a contentDescription to the up next icon in the podcast episode list. This is needed so screen readers will read if the episode is queued for up next.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

Still not real sure how to test this. My first Android app contribution.
1. Open a podcast.
2. Add an episode to your up next queue.
3. Verify the up next queued icon now contains a contentDescription.

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
