### PR TITLE
Tracks for auto add to Up Next settings

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
@@ -6,6 +6,7 @@ import androidx.room.testing.MigrationTestHelper
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -91,7 +92,7 @@ class AppDatabaseTest {
         assertEquals(true, podcast?.isSubscribed)
         assertEquals(true, podcast?.isShowNotifications)
         assertEquals(2, podcast?.autoDownloadStatus)
-        assertEquals(1, podcast?.autoAddToUpNext)
+        assertEquals(Podcast.AutoAddUpNext.PLAY_LAST, podcast?.autoAddToUpNext)
         assertEquals(0xF00000, podcast?.backgroundColor)
         assertEquals(0xFF0000, podcast?.tintColorForLightBg)
         assertEquals(0xFFF000, podcast?.tintColorForDarkBg)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
@@ -164,8 +164,8 @@ class PodcastSettingsFragment : BasePreferenceFragment(), CoroutineScope, Filter
 
             preferenceAddToUpNext?.isChecked = !podcast.isAutoAddToUpNextOff
             preferenceAddToUpNextOrder?.isVisible = !podcast.isAutoAddToUpNextOff
-            preferenceAddToUpNextOrder?.summary = if (podcast.autoAddToUpNext == Podcast.AutoAddUpNext.PLAY_NEXT.databaseInt) getString(LR.string.play_next) else getString(LR.string.play_last)
-            preferenceAddToUpNextOrder?.setValueIndex(if (podcast.isAutoAddToUpNextOff) 0 else podcast.autoAddToUpNext - 1)
+            preferenceAddToUpNextOrder?.summary = if (podcast.autoAddToUpNext == Podcast.AutoAddUpNext.PLAY_NEXT) getString(LR.string.play_next) else getString(LR.string.play_last)
+            preferenceAddToUpNextOrder?.setValueIndex(if (podcast.isAutoAddToUpNextOff) 0 else podcast.autoAddToUpNext.databaseInt - 1)
             preferenceAddToUpNextGlobal?.isVisible = preferenceAddToUpNextOrder?.isVisible ?: false
 
             preferenceSkipFirst?.text = podcast.startFromSecs.toString()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
@@ -68,13 +68,13 @@ class PodcastSettingsViewModel @Inject constructor(
 
     fun updateAutoAddToUpNext(isOn: Boolean) {
         val podcast = this.podcast.value ?: return
-        val value = if (isOn) Podcast.AUTO_ADD_TO_UP_NEXT_PLAY_LAST else Podcast.AUTO_ADD_TO_UP_NEXT_OFF
+        val value = if (isOn) Podcast.AutoAddUpNext.PLAY_LAST else Podcast.AutoAddUpNext.OFF
         launch {
             podcastManager.updateAutoAddToUpNext(podcast, value)
         }
     }
 
-    fun updateAutoAddToUpNextOrder(value: Int) {
+    fun updateAutoAddToUpNextOrder(value: Podcast.AutoAddUpNext) {
         val podcast = this.podcast.value ?: return
         launch {
             podcastManager.updateAutoAddToUpNext(podcast, value)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoAddSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoAddSettingsFragment.kt
@@ -66,12 +66,12 @@ class AutoAddSettingsFragment : BaseFragment(), PodcastSelectFragment.Listener {
                 .setTitle(getString(LR.string.settings_auto_up_next_add_to))
                 .addCheckedOption(
                     titleString = getString(LR.string.settings_auto_up_next_top),
-                    checked = it.autoAddToUpNext == Podcast.AutoAddUpNext.PLAY_NEXT.databaseInt,
+                    checked = it.autoAddToUpNext == Podcast.AutoAddUpNext.PLAY_NEXT,
                     click = { viewModel.updatePodcast(it, Podcast.AutoAddUpNext.PLAY_NEXT) }
                 )
                 .addCheckedOption(
                     titleString = getString(LR.string.settings_auto_up_next_bottom),
-                    checked = it.autoAddToUpNext == Podcast.AutoAddUpNext.PLAY_LAST.databaseInt,
+                    checked = it.autoAddToUpNext == Podcast.AutoAddUpNext.PLAY_LAST,
                     click = { viewModel.updatePodcast(it, Podcast.AutoAddUpNext.PLAY_LAST) }
                 )
                 .show(childFragmentManager, "autoadd_options")
@@ -278,10 +278,10 @@ class AutoAddPodcastAdapter(val imageLoader: PodcastImageLoader, val onClick: (P
             imageLoader.load(podcast).into(imageView)
             lblTitle.text = podcast.title
             val resources = holder.itemView.resources
-            lblSubtitle.text = when (Podcast.AutoAddUpNext.fromInt(podcast.autoAddToUpNext)) {
+            lblSubtitle.text = when (podcast.autoAddToUpNext) {
                 Podcast.AutoAddUpNext.PLAY_NEXT -> resources.getString(LR.string.settings_auto_up_next_to_top)
                 Podcast.AutoAddUpNext.PLAY_LAST -> resources.getString(LR.string.settings_auto_up_next_to_bottom)
-                Podcast.AutoAddUpNext.OFF, null -> null
+                Podcast.AutoAddUpNext.OFF -> null
             }
             root.setOnClickListener { onClick(podcast) }
         }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoAddSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoAddSettingsFragment.kt
@@ -43,6 +43,11 @@ class AutoAddSettingsFragment : BaseFragment(), PodcastSelectFragment.Listener {
     private val binding get() = _binding!!
     val viewModel by activityViewModels<AutoAddSettingsViewModel>()
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        viewModel.onShown()
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentAutoAddSettingsBinding.inflate(inflater, container, false)
         return binding.root
@@ -136,8 +141,6 @@ class AutoAddSettingsFragment : BaseFragment(), PodcastSelectFragment.Listener {
 
             autoAddAdapter.submitList(podcasts)
         }
-
-        viewModel.onShown()
     }
 
     override fun onPause() {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -413,6 +413,13 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_APPEARANCE_USE_EMBEDDED_ARTWORK_TOGGLED("settings_appearance_use_embedded_artwork_toggled"),
     SETTINGS_APPEARANCE_SHOW_ARTWORK_ON_LOCK_SCREEN_TOGGLED("settings_appearance_show_artwork_on_lock_screen_toggled"),
 
+    /* Settings - Auto add */
+    SETTINGS_AUTO_ADD_UP_NEXT_SHOWN("settings_auto_add_up_next_shown"),
+    SETTINGS_AUTO_ADD_UP_NEXT_AUTO_ADD_LIMIT_CHANGED("settings_auto_add_up_next_auto_add_limit_changed"),
+    SETTINGS_AUTO_ADD_UP_NEXT_LIMIT_REACHED_CHANGED("settings_auto_add_up_next_limit_reached_changed"),
+    SETTINGS_AUTO_ADD_UP_NEXT_PODCASTS_CHANGED("settings_auto_add_up_next_podcasts_changed"),
+    SETTINGS_AUTO_ADD_UP_NEXT_PODCAST_POSITION_OPTION_CHANGED("settings_auto_add_up_next_podcast_position_option_changed"),
+
     /* Settings - Auto archive */
     SETTINGS_AUTO_ARCHIVE_SHOWN("settings_auto_archive_shown"),
     SETTINGS_AUTO_ARCHIVE_PLAYED_CHANGED("settings_auto_archive_played_changed"),

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/PodcastAutoUpNextConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/PodcastAutoUpNextConverter.kt
@@ -1,0 +1,15 @@
+package au.com.shiftyjelly.pocketcasts.models.converter
+
+import androidx.room.TypeConverter
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+
+class PodcastAutoUpNextConverter {
+
+    @TypeConverter
+    fun toPodcastAutoUpNext(value: Int?) =
+        Podcast.AutoAddUpNext.fromDatabaseInt(value)
+
+    @TypeConverter
+    fun toInt(value: Podcast.AutoAddUpNext?) =
+        value?.databaseInt
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -15,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.models.converter.DateTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.EpisodePlayingStatusConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.EpisodeStatusEnumConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.EpisodesSortTypeConverter
+import au.com.shiftyjelly.pocketcasts.models.converter.PodcastAutoUpNextConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.PodcastLicensingEnumConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.PodcastsSortTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.TrimModeTypeConverter
@@ -55,16 +56,17 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
     exportSchema = true
 )
 @TypeConverters(
+    AnonymousBumpStat.CustomEventPropsTypeConverter::class,
+    BundlePaidTypeConverter::class,
     DateTypeConverter::class,
     EpisodePlayingStatusConverter::class,
     EpisodeStatusEnumConverter::class,
-    UserEpisodeServerStatusConverter::class,
-    PodcastLicensingEnumConverter::class,
-    BundlePaidTypeConverter::class,
-    TrimModeTypeConverter::class,
-    PodcastsSortTypeConverter::class,
     EpisodesSortTypeConverter::class,
-    AnonymousBumpStat.CustomEventPropsTypeConverter::class
+    PodcastAutoUpNextConverter::class,
+    PodcastLicensingEnumConverter::class,
+    PodcastsSortTypeConverter::class,
+    UserEpisodeServerStatusConverter::class,
+    TrimModeTypeConverter::class,
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun podcastDao(): PodcastDao

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -250,9 +250,9 @@ abstract class PodcastDao {
     abstract suspend fun updateAutoAddToUpNext(autoAddToUpNext: Int, uuid: String)
 
     @Transaction
-    open suspend fun updateAutoAddToUpNexts(autoAddToUpNext: Int, podcastUuids: List<String>) {
+    open suspend fun updateAutoAddToUpNexts(autoAddToUpNext: Podcast.AutoAddUpNext, podcastUuids: List<String>) {
         for (uuid in podcastUuids) {
-            updateAutoAddToUpNext(autoAddToUpNext = autoAddToUpNext, uuid = uuid)
+            updateAutoAddToUpNext(autoAddToUpNext = autoAddToUpNext.databaseInt, uuid = uuid)
         }
     }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -247,12 +247,12 @@ abstract class PodcastDao {
     }
 
     @Query("UPDATE podcasts SET auto_add_to_up_next = :autoAddToUpNext WHERE uuid = :uuid")
-    abstract suspend fun updateAutoAddToUpNext(autoAddToUpNext: Int, uuid: String)
+    abstract suspend fun updateAutoAddToUpNext(autoAddToUpNext: Podcast.AutoAddUpNext, uuid: String)
 
     @Transaction
     open suspend fun updateAutoAddToUpNexts(autoAddToUpNext: Podcast.AutoAddUpNext, podcastUuids: List<String>) {
         for (uuid in podcastUuids) {
-            updateAutoAddToUpNext(autoAddToUpNext = autoAddToUpNext.databaseInt, uuid = uuid)
+            updateAutoAddToUpNext(autoAddToUpNext = autoAddToUpNext, uuid = uuid)
         }
     }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
@@ -51,7 +51,7 @@ data class Podcast(
     @ColumnInfo(name = "subscribed") var isSubscribed: Boolean = false,
     @ColumnInfo(name = "show_notifications") var isShowNotifications: Boolean = false,
     @ColumnInfo(name = "auto_download_status") var autoDownloadStatus: Int = 0,
-    @ColumnInfo(name = "auto_add_to_up_next") var autoAddToUpNext: Int = 0,
+    @ColumnInfo(name = "auto_add_to_up_next") var autoAddToUpNext: AutoAddUpNext = AutoAddUpNext.OFF,
     @ColumnInfo(name = "most_popular_color") var backgroundColor: Int = 0,
     @ColumnInfo(name = "primary_color") var tintColorForLightBg: Int = 0,
     @ColumnInfo(name = "secondary_color") var tintColorForDarkBg: Int = 0,
@@ -89,7 +89,7 @@ data class Podcast(
         PLAY_NEXT(2, "add_first");
 
         companion object {
-            fun fromInt(int: Int) = values().firstOrNull { it.databaseInt == int }
+            fun fromDatabaseInt(int: Int?) = values().firstOrNull { it.databaseInt == int }
         }
     }
 
@@ -110,13 +110,13 @@ data class Podcast(
         get() = autoDownloadStatus == AUTO_DOWNLOAD_NEW_EPISODES
 
     val isAutoAddToUpNextOff: Boolean
-        get() = autoAddToUpNext == AutoAddUpNext.OFF.databaseInt
+        get() = autoAddToUpNext == AutoAddUpNext.OFF
 
     val isAutoAddToUpNextPlayLast: Boolean
-        get() = autoAddToUpNext == AutoAddUpNext.PLAY_LAST.databaseInt
+        get() = autoAddToUpNext == AutoAddUpNext.PLAY_LAST
 
     val isAutoAddToUpNextPlayNext: Boolean
-        get() = autoAddToUpNext == AutoAddUpNext.PLAY_NEXT.databaseInt
+        get() = autoAddToUpNext == AutoAddUpNext.PLAY_NEXT
 
     val adapterId: Long
         get() = UUID.nameUUIDFromBytes(uuid.toByteArray()).mostSignificantBits

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
@@ -83,6 +83,16 @@ data class Podcast(
 
     constructor() : this(uuid = "")
 
+    enum class AutoAddUpNext(val databaseInt: Int, val analyticsValue: String) {
+        OFF(0, "off"),
+        PLAY_LAST(1, "add_last"),
+        PLAY_NEXT(2, "add_first");
+
+        companion object {
+            fun fromInt(int: Int) = values().firstOrNull { it.databaseInt == int }
+        }
+    }
+
     companion object {
 
         const val SYNC_STATUS_NOT_SYNCED = 0
@@ -90,10 +100,6 @@ data class Podcast(
 
         const val AUTO_DOWNLOAD_OFF = 0
         const val AUTO_DOWNLOAD_NEW_EPISODES = 1
-
-        const val AUTO_ADD_TO_UP_NEXT_OFF = 0
-        const val AUTO_ADD_TO_UP_NEXT_PLAY_LAST = 1
-        const val AUTO_ADD_TO_UP_NEXT_PLAY_NEXT = 2
     }
 
     @Transient
@@ -104,13 +110,13 @@ data class Podcast(
         get() = autoDownloadStatus == AUTO_DOWNLOAD_NEW_EPISODES
 
     val isAutoAddToUpNextOff: Boolean
-        get() = autoAddToUpNext == AUTO_ADD_TO_UP_NEXT_OFF
+        get() = autoAddToUpNext == AutoAddUpNext.OFF.databaseInt
 
     val isAutoAddToUpNextPlayLast: Boolean
-        get() = autoAddToUpNext == AUTO_ADD_TO_UP_NEXT_PLAY_LAST
+        get() = autoAddToUpNext == AutoAddUpNext.PLAY_LAST.databaseInt
 
     val isAutoAddToUpNextPlayNext: Boolean
-        get() = autoAddToUpNext == AUTO_ADD_TO_UP_NEXT_PLAY_NEXT
+        get() = autoAddToUpNext == AutoAddUpNext.PLAY_NEXT.databaseInt
 
     val adapterId: Long
         get() = UUID.nameUUIDFromBytes(uuid.toByteArray()).mostSignificantBits

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -71,9 +71,9 @@ interface PodcastManager {
     fun updateAllShowNotifications(showNotifications: Boolean)
     fun updateAllShowNotificationsRx(showNotifications: Boolean): Completable
     fun updateAutoDownloadStatus(podcast: Podcast, autoDownloadStatus: Int)
-    suspend fun updateAutoAddToUpNext(podcast: Podcast, autoAddToUpNext: Int)
-    suspend fun updateAutoAddToUpNexts(podcastUuids: List<String>, autoAddToUpNext: Int)
-    suspend fun updateAutoAddToUpNextsIf(podcastUuids: List<String>, newValue: Int, onlyIfValue: Int)
+    suspend fun updateAutoAddToUpNext(podcast: Podcast, autoAddToUpNext: Podcast.AutoAddUpNext)
+    suspend fun updateAutoAddToUpNexts(podcastUuids: List<String>, autoAddToUpNext: Podcast.AutoAddUpNext)
+    suspend fun updateAutoAddToUpNextsIf(podcastUuids: List<String>, newValue: Podcast.AutoAddUpNext, onlyIfValue: Podcast.AutoAddUpNext)
     fun updateExcludeFromAutoArchive(podcast: Podcast, excludeFromAutoArchive: Boolean)
     fun updateOverrideGlobalEffects(podcast: Podcast, override: Boolean)
     fun updateTrimMode(podcast: Podcast, trimMode: TrimMode)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -560,16 +560,20 @@ class PodcastManagerImpl @Inject constructor(
         podcastDao.updateAutoDownloadStatus(autoDownloadStatus, podcast.uuid)
     }
 
-    override suspend fun updateAutoAddToUpNext(podcast: Podcast, autoAddToUpNext: Int) {
-        podcastDao.updateAutoAddToUpNext(autoAddToUpNext, podcast.uuid)
+    override suspend fun updateAutoAddToUpNext(podcast: Podcast, autoAddToUpNext: Podcast.AutoAddUpNext) {
+        podcastDao.updateAutoAddToUpNext(autoAddToUpNext.databaseInt, podcast.uuid)
     }
 
-    override suspend fun updateAutoAddToUpNexts(podcastUuids: List<String>, autoAddToUpNext: Int) {
+    override suspend fun updateAutoAddToUpNexts(podcastUuids: List<String>, autoAddToUpNext: Podcast.AutoAddUpNext) {
         podcastDao.updateAutoAddToUpNexts(autoAddToUpNext, podcastUuids)
     }
 
-    override suspend fun updateAutoAddToUpNextsIf(podcastUuids: List<String>, newValue: Int, onlyIfValue: Int) {
-        podcastDao.updateAutoAddToUpNextsIf(podcastUuids, newValue, onlyIfValue)
+    override suspend fun updateAutoAddToUpNextsIf(
+        podcastUuids: List<String>,
+        newValue: Podcast.AutoAddUpNext,
+        onlyIfValue: Podcast.AutoAddUpNext
+    ) {
+        podcastDao.updateAutoAddToUpNextsIf(podcastUuids, newValue.databaseInt, onlyIfValue.databaseInt)
     }
 
     override fun updateExcludeFromAutoArchive(podcast: Podcast, excludeFromAutoArchive: Boolean) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -78,7 +78,7 @@ class PodcastManagerImpl @Inject constructor(
                     podcast.syncStatus = Podcast.SYNC_STATUS_NOT_SYNCED
                     podcast.isShowNotifications = false
                     podcast.autoDownloadStatus = Podcast.AUTO_DOWNLOAD_OFF
-                    podcast.autoAddToUpNext = 0
+                    podcast.autoAddToUpNext = Podcast.AutoAddUpNext.OFF
                     podcast.autoArchiveAfterPlaying = 0
                     podcast.autoArchiveInactive = 0
                     podcast.autoArchiveEpisodeLimit = null
@@ -561,7 +561,7 @@ class PodcastManagerImpl @Inject constructor(
     }
 
     override suspend fun updateAutoAddToUpNext(podcast: Podcast, autoAddToUpNext: Podcast.AutoAddUpNext) {
-        podcastDao.updateAutoAddToUpNext(autoAddToUpNext.databaseInt, podcast.uuid)
+        podcastDao.updateAutoAddToUpNext(autoAddToUpNext, podcast.uuid)
     }
 
     override suspend fun updateAutoAddToUpNexts(podcastUuids: List<String>, autoAddToUpNext: Podcast.AutoAddUpNext) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -353,8 +353,8 @@ class Support @Inject constructor(
         return output.toString()
     }
 
-    private fun autoAddToUpNextToString(autoAddToUpNext: Int): String {
-        return when (Podcast.AutoAddUpNext.fromInt(autoAddToUpNext)) {
+    private fun autoAddToUpNextToString(autoAddToUpNext: Podcast.AutoAddUpNext): String {
+        return when (autoAddToUpNext) {
             Podcast.AutoAddUpNext.OFF -> "off"
             Podcast.AutoAddUpNext.PLAY_NEXT -> "to top (play next)"
             Podcast.AutoAddUpNext.PLAY_LAST -> "to bottom (play last)"

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -354,10 +354,10 @@ class Support @Inject constructor(
     }
 
     private fun autoAddToUpNextToString(autoAddToUpNext: Int): String {
-        return when (autoAddToUpNext) {
-            Podcast.AUTO_ADD_TO_UP_NEXT_OFF -> "off"
-            Podcast.AUTO_ADD_TO_UP_NEXT_PLAY_NEXT -> "to top (play next)"
-            Podcast.AUTO_ADD_TO_UP_NEXT_PLAY_LAST -> "to bottom (play last)"
+        return when (Podcast.AutoAddUpNext.fromInt(autoAddToUpNext)) {
+            Podcast.AutoAddUpNext.OFF -> "off"
+            Podcast.AutoAddUpNext.PLAY_NEXT -> "to top (play next)"
+            Podcast.AutoAddUpNext.PLAY_LAST -> "to bottom (play last)"
             else -> "unknown value $autoAddToUpNext"
         }
     }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/PodcastSelectFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/PodcastSelectFragment.kt
@@ -188,7 +188,7 @@ class PodcastSelectFragment : BaseFragment() {
             when (source) {
 
                 PodcastSelectFragmentSource.AUTO_ADD -> {
-                    // TODO
+                    analyticsTracker.track(AnalyticsEvent.SETTINGS_AUTO_ADD_UP_NEXT_PODCASTS_CHANGED, props)
                 }
 
                 PodcastSelectFragmentSource.NOTIFICATIONS -> {


### PR DESCRIPTION
## Description
Adds tracks for the auto add to Up Next settings.

### Adding `AutoAddUpNext` enum

While doing this, I also switched us to using an `AutoAddUpNext` enum in place of passing around `Int`s. To avoid that change requiring a database migration or cause any issues I am using a `TypeConverter` that converts the new enum into the same `Int` values that we were persisting in the database before. That means that there should be no difference as far as sqlite is concerned. 

With that said, I did separate out the parts of this change that directly impacted the database into a separate commit (81ce815ca809d6f8df6d1396bf00fdbd54eb4a64)—I realize that is the slightly riskier change and if you'd like me to revert that part of the PR, just let me know.

The most likely way I could have messed something up with this is by making a simple typo (i.e., passing the `PlayNext` enum when replacing `PlayLast`), so please keep that in mind for that when you look at the code changes.

### Extra "shown" event when returning to screen

I'm getting an extra `settings_auto_add_up_next_shown` event when I go into the "Choose podcasts" screen and then return to the "Auto add to Up Next". This doesn't happen on the Auto Download settings screen, and I'm not exactly sure what the cause is although I suspect it is due to how we're navigating to the PodcastSelectFragment differently in the [AutoAddSettingsFragment](https://github.com/Automattic/pocket-casts-android/blob/81ce815ca809d6f8df6d1396bf00fdbd54eb4a64/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoAddSettingsFragment.kt#L155) compared to the [AutoDownloadSettingsFragment](https://github.com/Automattic/pocket-casts-android/blob/aa9ae49b05e94fae69cdf7c1aa71241a8e0120f9/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt#L223-L226).

I didn't spend a ton of time looking into this because (1) it doesn't seem like a huge issue and (2) the issue will probably go away when these screens get converted to compose, but if you have any ideas for how to fix it, let me know (or if you think it's worth spending more time on this let me know, maybe it's a bigger deal than I'm realizing).

## Testing Instructions

#### 1. Persistence of Auto Add to Up Next setting

Since this PR is touching the persistence of this setting, let's make sure I didn't break anything.

1. Go to Profile tab → ⚙️ → `Auto add to Up Next`
2. Tap on one of your subscribed podcasts and change "Auto Add To"  to a different value.
3. Tap on the Podcasts tab
4. Tap on the podcast you updated in step 2
5. Tap on the ⚙️ 
6. Observe that add to Up Next is toggled on and the Position matches the selection you made in step two ("Top" → "Play Next" and "Bottom" → "Play last").
7. Either (a) toggle "Add to Up Next" off or (b) change the "Position" to a different value.
8. Return to Profile tab → ⚙️ → `Auto add to Up Next`
9. Observe that the position for that podcast has been updated appropriately in the UI

#### 2. Tracks

1. Go to Profile tab → ⚙️ → `Auto add to Up Next`
2. ✅  Observe the event `settings_auto_add_up_next_shown`
3. Tap "Auto add limit" and select a new value
4. ✅ Observe the event `settings_auto_add_up_next_auto_add_limit_changed, Properties: {"value":[number], ... }`
5. Tap "If limit reached" and select a new value
6. ✅ Observe the event `settings_auto_add_up_next_limit_reached_changed, Properties: {"value":"stop_adding"|"only_add_top", ... }`
7. Tap on "Choose podcasts", change the selected podcasts, and tap back
8. ✅ Observe the event `settings_auto_add_up_next_podcasts_changed, Properties: {"number_selected":[number], ... }`
9. Tap on one of the podcasts in the "Auto-add podcasts" section, and change the setting
10. ✅ Oberve the event `settings_auto_add_up_next_podcast_position_option_changed, Properties: {"value":"add_first"|"add_last", ... }`

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews