### PR TITLE
Ask notif permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 7.32
 -----
 * Bug Fixes:
-    *    Notifications Blocked on Android 13
+    *    Ask notifications permission for newly-installed apps on Android 13
          ([#723](https://github.com/Automattic/pocket-casts-android/issues/723)).
 
 7.31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.32
 -----
-
+* Bug Fixes:
+    *    Notifications Blocked on Android 13
+         ([#723](https://github.com/Automattic/pocket-casts-android/issues/723)).
 
 7.31
 -----

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-feature android:name="android.hardware.telephony" android:required="false"/>
 
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,6 @@
     <uses-permission android:name="com.android.vending.BILLING" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1,12 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.ui
 
+import android.Manifest
 import android.app.Activity
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.net.Uri
-import android.Manifest
-import android.content.Context
-import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
@@ -16,7 +15,6 @@ import android.view.WindowManager
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
@@ -217,7 +215,7 @@ class MainActivity :
         ActivityResultContracts.RequestPermission()
     ) { isGranted: Boolean ->
         if (isGranted) {
-            //sendNotification(this)
+            // sendNotification(this)
 
             // Permission is granted. Continue the action or workflow in your
             // app.
@@ -230,7 +228,7 @@ class MainActivity :
         }
     }
 
-    private fun notifPermissionCheck(){
+    private fun notifPermissionCheck() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             when {
                 ContextCompat.checkSelfPermission(
@@ -238,7 +236,7 @@ class MainActivity :
                 ) == PackageManager.PERMISSION_GRANTED -> {
                     // You can use the API that requires the permission.
                     Timber.tag("NOTIFICATION").e("onCreate: PERMISSION GRANTED")
-                    //sendNotification(this)
+                    // sendNotification(this)
                 }
                 shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) -> {
                     Snackbar.make(
@@ -263,7 +261,6 @@ class MainActivity :
             }
         }
     }
-
 
     override fun onCreate(savedInstanceState: Bundle?) {
         Timber.d("Main Activity onCreate")

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -122,7 +122,6 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.addTo
 import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.schedulers.Schedulers
-import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
@@ -131,6 +130,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -230,49 +230,44 @@ class MainActivity :
         }
     }
 
+    private fun notifPermissionCheck(){
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            when {
+                ContextCompat.checkSelfPermission(
+                    this, Manifest.permission.POST_NOTIFICATIONS
+                ) == PackageManager.PERMISSION_GRANTED -> {
+                    // You can use the API that requires the permission.
+                    Timber.tag("NOTIFICATION").e("onCreate: PERMISSION GRANTED")
+                    //sendNotification(this)
+                }
+                shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) -> {
+                    Snackbar.make(
+                        findViewById(R.id.root),
+                        "Notification blocked",
+                        5000
+                    ).setAction("Settings") {
+                        // Responds to click on the action
+                        val intent = Intent(AndroidProviderSettings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        val uri: Uri = Uri.fromParts("package", packageName, null)
+                        intent.data = uri
+                        startActivity(intent)
+                    }.show()
+                }
+                else -> {
+                    Log.e("NOTIFICATION", "onCreate: ask for permissions")
+                    requestPermissionLauncher.launch(
+                        Manifest.permission.POST_NOTIFICATIONS
+                    )
+                }
+            }
+        }
+    }
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         Timber.d("Main Activity onCreate")
         super.onCreate(savedInstanceState)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        when {
-            ContextCompat.checkSelfPermission(
-                this, Manifest.permission.POST_NOTIFICATIONS
-            ) == PackageManager.PERMISSION_GRANTED -> {
-                // You can use the API that requires the permission.
-                Timber.tag("NOTIFICATION").e("onCreate: PERMISSION GRANTED")
-                //sendNotification(this)
-            }
-            shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) -> {
-                Snackbar.make(
-                    findViewById(R.id.root),
-                    "Notification blocked",
-                    Snackbar.LENGTH_LONG
-                ).setAction("Settings") {
-                    // Responds to click on the action
-                    val intent = Intent(AndroidProviderSettings.ACTION_APPLICATION_DETAILS_SETTINGS)
-                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    val uri: Uri = Uri.fromParts("package", packageName, null)
-                    intent.data = uri
-                    startActivity(intent)
-                }.show()
-                //  Toast.makeText(this, "NOT ALLOWED", Toast.LENGTH_SHORT).show()
-            }
-            else -> {
-                Log.e("NOTIFICATION", "onCreate: ask for permissions")
-                // You can directly ask for the permission.
-                // The registered ActivityResultCallback gets the result of this request.
-                //  if (Build.VERSION.SDK_INT >= 33) {
-                //   Log.e(TAG, "onCreate: 33" )
-
-                requestPermissionLauncher.launch(
-                    Manifest.permission.POST_NOTIFICATIONS
-                )
-
-                // }
-            }
-        }
-        }
         theme.setupThemeForConfig(this, resources.configuration)
 
         val showOnboarding = !settings.hasCompletedOnboarding() && !settings.isLoggedIn()
@@ -284,6 +279,7 @@ class MainActivity :
         binding = ActivityMainBinding.inflate(layoutInflater)
         val view = binding.root
         setContentView(view)
+        notifPermissionCheck()
 
         lifecycleScope.launchWhenCreated {
             val isEligible = viewModel.isEndOfYearStoriesEligible()

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -31,6 +31,8 @@
     <string name="more">More</string>
     <string name="more_options">More options</string>
     <string name="next_episode">Next episode</string>
+    <string name="notifications_blocked_warning">Notifications are blocked. You can update permission through Settings.</string>
+    <string name="notifications_blocked_warning_snackbar_action" translatable="false">@string/update</string>
     <string name="ok">OK</string>
     <string name="options">Options</string>
     <string name="pause">Pause</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -129,6 +129,8 @@ interface Settings {
         const val INTENT_LINK_PROMO_CODE = "pktc://redeem/promo/"
 
         const val LOG_TAG_AUTO = "PocketCastsAuto"
+
+        const val NOTIFICATIONS_DISABLED_MESSAGE_SHOWN = "notificationsDisabledMessageShown"
     }
 
     enum class NotificationChannel(val id: String) {
@@ -609,4 +611,7 @@ interface Settings {
 
     fun areCustomMediaActionsVisible(): Boolean
     fun setCustomMediaActionsVisible(value: Boolean)
+
+    fun isNotificationsDisabledMessageShown(): Boolean
+    fun setNotificationsDisabledMessageShown(value: Boolean)
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -24,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.DEFAULT_MAX_AUTO_ADD_LIMIT
+import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.NOTIFICATIONS_DISABLED_MESSAGE_SHOWN
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.SETTINGS_ENCRYPT_SECRET
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationControls
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.NotificationChannel
@@ -1502,5 +1503,12 @@ class SettingsImpl @Inject constructor(
     override fun setCustomMediaActionsVisible(value: Boolean) {
         setBoolean(CUSTOM_MEDIA_ACTIONS_VISIBLE_KEY, value)
         customMediaActionsVisibilityFlow.update { value }
+    }
+
+    override fun isNotificationsDisabledMessageShown() =
+        getBoolean(NOTIFICATIONS_DISABLED_MESSAGE_SHOWN, false)
+
+    override fun setNotificationsDisabledMessageShown(value: Boolean) {
+        setBoolean(NOTIFICATIONS_DISABLED_MESSAGE_SHOWN, value)
     }
 }


### PR DESCRIPTION
## Description
This pull request is a implementation proposal regarding issue #723. The authorization check for notifications will be done upon starting the MainActivity (after the login and register interface), and will only run on devices equipped with Android 13 and higher.
Hope this works for you!😊

CC: @lucile98-ode (thanks for the help)

Fixes #723 

## Testing Instructions
1. Open the app
2. Register or login (or skip this step, it doesn't matter)
3. The app asks permission for sending notifications (won't show on your screen if you already launched with Android 13 and already approved this permission)

## Screenshots or Screencast 
![image](https://user-images.githubusercontent.com/45591509/216788328-f0f41792-295e-48e9-85a3-72db2d2c18f9.png)


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
