### PR TITLE
Add shown even to help fragment

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
@@ -17,11 +17,13 @@ import android.widget.Button
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.support.Support
 import au.com.shiftyjelly.pocketcasts.settings.status.StatusFragment
+import au.com.shiftyjelly.pocketcasts.settings.viewmodel.HelpViewModel
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.extensions.findToolbar
@@ -43,6 +45,8 @@ class HelpFragment : Fragment(), HasBackstack, Toolbar.OnMenuItemClickListener {
     @Inject lateinit var settings: Settings
     @Inject lateinit var theme: Theme
     @Inject lateinit var support: Support
+
+    val viewModel by viewModels<HelpViewModel>()
 
     private var webView: WebView? = null
     private var loadedUrl: String? = null
@@ -67,10 +71,10 @@ class HelpFragment : Fragment(), HasBackstack, Toolbar.OnMenuItemClickListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         savedInstanceState?.let {
             loadedUrl = savedInstanceState.getString("url")
         }
+        viewModel.onShown()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -117,6 +121,11 @@ class HelpFragment : Fragment(), HasBackstack, Toolbar.OnMenuItemClickListener {
             }
         }
         return false
+    }
+
+    override fun onPause() {
+        super.onPause()
+        viewModel.onFragmentPause(activity?.isChangingConfigurations)
     }
 
     override fun getBackstackCount(): Int {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/HelpViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/HelpViewModel.kt
@@ -1,0 +1,25 @@
+package au.com.shiftyjelly.pocketcasts.settings.viewmodel
+
+import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class HelpViewModel @Inject constructor(
+    private val analyticsTracker: AnalyticsTrackerWrapper
+) : ViewModel() {
+
+    private var isFragmentChangingConfigurations = false
+
+    fun onShown() {
+        if (!isFragmentChangingConfigurations) {
+            analyticsTracker.track(AnalyticsEvent.SETTINGS_HELP_SHOWN)
+        }
+    }
+
+    fun onFragmentPause(isChangingConfigurations: Boolean?) {
+        isFragmentChangingConfigurations = isChangingConfigurations ?: false
+    }
+}

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -446,6 +446,9 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_SHOW_CUSTOM_TOGGLED("settings_general_media_notification_controls_show_custom_toggled"),
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_ORDER_CHANGED("settings_general_media_notification_controls_order_changed"),
 
+    /* Settings - Help */
+    SETTINGS_HELP_SHOWN("settings_help_shown"),
+
     /* Settings - Notifications */
     SETTINGS_NOTIFICATIONS_SHOWN("settings_notifications_shown"),
     SETTINGS_NOTIFICATIONS_NEW_EPISODES_TOGGLED("settings_notifications_new_episodes_toggled"),


### PR DESCRIPTION
## Description
Adds the shown event for the Help screen in settings.

## Testing Instructions
1. Go to the Profile tab → ⚙️  → `Help & feedback`
2. Observe that the event `settings_help_shown` is sent
3. Verify the event is not resent with configuration changes

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews