### PR TITLE
File settings tracks

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileViewModel.kt
@@ -20,9 +20,6 @@ class AddFileViewModel @Inject constructor(
     val userEpisodeManager: UserEpisodeManager
 ) : ViewModel() {
 
-    val isSignedIn: Boolean
-        get() = signInState.value?.isSignedIn ?: false
-
     val signInState: LiveData<SignInState> = LiveDataReactiveStreams.fromPublisher(userManager.getSignInState())
 
     suspend fun updateImageOnServer(userEpisode: UserEpisode, imageFile: File) = withContext(Dispatchers.IO) {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
@@ -32,8 +32,13 @@ class CloudSettingsFragment : BaseFragment() {
 
     @Inject lateinit var settings: Settings
 
-    private val viewModel: AddFileViewModel by viewModels()
+    private val viewModel by viewModels<CloudSettingsViewModel>()
     private var binding: FragmentCloudSettingsBinding? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        viewModel.onShown()
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentCloudSettingsBinding.inflate(inflater, container, false)
@@ -128,6 +133,11 @@ class CloudSettingsFragment : BaseFragment() {
         ).forEach {
             it.setOnClickListener { openUpgradeSheet() }
         }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        viewModel.onFragmentPause(activity?.isChangingConfigurations)
     }
 
     private fun openUpgradeSheet() {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
@@ -86,37 +86,37 @@ class CloudSettingsFragment : BaseFragment() {
         with(binding.swtAutoAddToUpNext) {
             isChecked = settings.getCloudAddToUpNext()
             setOnCheckedChangeListener { _, isChecked ->
-                settings.setCloudAddToUpNext(isChecked)
+                viewModel.setAddToUpNext(isChecked)
             }
         }
         with(binding.swtDeleteLocalFileAfterPlaying) {
-            isChecked = settings.getCloudDeleteAfterPlaying()
+            isChecked = settings.getDeleteLocalFileAfterPlaying()
             setOnCheckedChangeListener { _, isChecked ->
-                settings.setCloudDeleteAfterPlaying(isChecked)
+                viewModel.setDeleteLocalFileAfterPlaying(isChecked)
             }
         }
         with(binding.swtDeleteCloudFileAfterPlaying) {
-            isChecked = settings.getCloudDeleteCloudAfterPlaying()
+            isChecked = settings.getDeleteCloudFileAfterPlaying()
             setOnCheckedChangeListener { _, isChecked ->
-                settings.setCloudDeleteCloudAfterPlaying(isChecked)
+                viewModel.setDeleteCloudFileAfterPlaying(isChecked)
             }
         }
         with(binding.swtAutoUploadToCloud) {
             isChecked = settings.getCloudAutoUpload()
             setOnCheckedChangeListener { _, isChecked ->
-                settings.setCloudAutoUpload(isChecked)
+                viewModel.setCloudAutoUpload(isChecked)
             }
         }
         with(binding.swtAutoDownloadFromCloud) {
             isChecked = settings.getCloudAutoDownload()
             setOnCheckedChangeListener { _, isChecked ->
-                settings.setCloudAutoDownload(isChecked)
+                viewModel.setCloudAutoDownload(isChecked)
             }
         }
         with(binding.swtCloudOnlyOnWiFi) {
             isChecked = settings.getCloudOnlyWifi()
             setOnCheckedChangeListener { _, isChecked ->
-                settings.setCloudOnlyWifi(isChecked)
+                viewModel.setCloudOnlyWifi(isChecked)
             }
         }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
@@ -1,0 +1,34 @@
+package au.com.shiftyjelly.pocketcasts.profile.cloud
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.LiveDataReactiveStreams
+import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class CloudSettingsViewModel @Inject constructor(
+    userManager: UserManager,
+    val userEpisodeManager: UserEpisodeManager,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+) : ViewModel() {
+
+    val signInState: LiveData<SignInState> = LiveDataReactiveStreams.fromPublisher(userManager.getSignInState())
+
+    private var isFragmentChangingConfigurations: Boolean = false
+
+    fun onShown() {
+        if (!isFragmentChangingConfigurations) {
+            analyticsTracker.track(AnalyticsEvent.SETTINGS_FILES_SHOWN)
+        }
+    }
+
+    fun onFragmentPause(isChangingConfigurations: Boolean?) {
+        isFragmentChangingConfigurations = isChangingConfigurations ?: false
+    }
+}

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
@@ -6,16 +6,16 @@ import androidx.lifecycle.ViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
 class CloudSettingsViewModel @Inject constructor(
-    userManager: UserManager,
-    val userEpisodeManager: UserEpisodeManager,
     private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val settings: Settings,
+    userManager: UserManager,
 ) : ViewModel() {
 
     val signInState: LiveData<SignInState> = LiveDataReactiveStreams.fromPublisher(userManager.getSignInState())
@@ -30,5 +30,53 @@ class CloudSettingsViewModel @Inject constructor(
 
     fun onFragmentPause(isChangingConfigurations: Boolean?) {
         isFragmentChangingConfigurations = isChangingConfigurations ?: false
+    }
+
+    fun setAddToUpNext(enabled: Boolean) {
+        settings.setCloudAddToUpNext(enabled)
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_FILES_AUTO_ADD_UP_NEXT_TOGGLED,
+            mapOf("enabled" to enabled)
+        )
+    }
+
+    fun setDeleteLocalFileAfterPlaying(enabled: Boolean) {
+        settings.setDeleteLocalFileAfterPlaying(enabled)
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_FILES_DELETE_LOCAL_FILE_AFTER_PLAYING_TOGGLED,
+            mapOf("enabled" to enabled)
+        )
+    }
+
+    fun setDeleteCloudFileAfterPlaying(enabled: Boolean) {
+        settings.setDeleteCloudFileAfterPlaying(enabled)
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_FILES_DELETE_CLOUD_FILE_AFTER_PLAYING_TOGGLED,
+            mapOf("enabled" to enabled)
+        )
+    }
+
+    fun setCloudAutoUpload(enabled: Boolean) {
+        settings.setCloudAutoUpload(enabled)
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_FILES_AUTO_UPLOAD_TO_CLOUD_TOGGLED,
+            mapOf("enabled" to enabled)
+        )
+    }
+
+    fun setCloudAutoDownload(enabled: Boolean) {
+        settings.setCloudAutoDownload(enabled)
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_FILES_AUTO_DOWNLOAD_FROM_CLOUD_TOGGLED,
+            mapOf("enabled" to enabled)
+        )
+    }
+
+    fun setCloudOnlyWifi(enabled: Boolean) {
+        settings.setCloudOnlyWifi(enabled)
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_FILES_ONLY_ON_WIFI_TOGGLED,
+            mapOf("enabled" to enabled)
+        )
     }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -439,6 +439,12 @@ enum class AnalyticsEvent(val key: String) {
 
     /* Settings - Files */
     SETTINGS_FILES_SHOWN("settings_files_shown"),
+    SETTINGS_FILES_AUTO_ADD_UP_NEXT_TOGGLED("settings_files_auto_add_up_next_toggled"),
+    SETTINGS_FILES_DELETE_LOCAL_FILE_AFTER_PLAYING_TOGGLED("settings_files_delete_local_file_after_playing_toggled"),
+    SETTINGS_FILES_DELETE_CLOUD_FILE_AFTER_PLAYING_TOGGLED("settings_files_delete_cloud_file_after_playing_toggled"),
+    SETTINGS_FILES_AUTO_UPLOAD_TO_CLOUD_TOGGLED("settings_files_auto_upload_to_cloud_toggled"),
+    SETTINGS_FILES_AUTO_DOWNLOAD_FROM_CLOUD_TOGGLED("settings_files_auto_download_from_cloud_toggled"),
+    SETTINGS_FILES_ONLY_ON_WIFI_TOGGLED("settings_files_only_on_wifi_toggled"),
 
     /* Settings - General */
     SETTINGS_GENERAL_SHOWN("settings_general_shown"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -437,6 +437,9 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_AUTO_DOWNLOAD_STOP_ALL_DOWNLOADS("settings_auto_download_stop_all_downloads"),
     SETTINGS_AUTO_DOWNLOAD_CLEAR_DOWNLOAD_ERRORS("settings_auto_download_clear_download_errors"),
 
+    /* Settings - Files */
+    SETTINGS_FILES_SHOWN("settings_files_shown"),
+
     /* Settings - General */
     SETTINGS_GENERAL_SHOWN("settings_general_shown"),
     SETTINGS_GENERAL_ROW_ACTION_CHANGED("settings_general_row_action_changed"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -640,7 +640,7 @@
     <string name="profile_cloud_add_to_up_next" translatable="false">@string/add_to_up_next</string>
     <string name="profile_cloud_after_playing">After playing</string>
     <string name="profile_cloud_all_files_added">All files added to your files will be added to Up Next.</string>
-    <string name="profile_cloud_auto_add_to_up_next">Auto Add To Up Next</string>
+    <string name="profile_cloud_auto_add_to_up_next">Auto add to Up Next</string>
     <string name="profile_cloud_auto_download_from_cloud">Auto download from cloud</string>
     <string name="profile_cloud_auto_upload_to_cloud">Auto upload to cloud</string>
     <string name="profile_cloud_cancel_upload">Cancel upload</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -522,16 +522,16 @@ interface Settings {
     fun getCloudSortOrder(): CloudSortOrder
     fun getCloudAddToUpNext(): Boolean
     fun setCloudAddToUpNext(value: Boolean)
-    fun getCloudDeleteAfterPlaying(): Boolean
-    fun setCloudDeleteAfterPlaying(value: Boolean)
+    fun getDeleteLocalFileAfterPlaying(): Boolean
+    fun setDeleteLocalFileAfterPlaying(value: Boolean)
+    fun getDeleteCloudFileAfterPlaying(): Boolean
+    fun setDeleteCloudFileAfterPlaying(value: Boolean)
     fun getCloudAutoUpload(): Boolean
     fun setCloudAutoUpload(value: Boolean)
     fun getCloudAutoDownload(): Boolean
     fun setCloudAutoDownload(value: Boolean)
     fun getCachedSubscription(): SubscriptionStatus?
     fun setCachedSubscription(subscriptionStatus: SubscriptionStatus?)
-    fun getCloudDeleteCloudAfterPlaying(): Boolean
-    fun setCloudDeleteCloudAfterPlaying(value: Boolean)
     fun getCloudOnlyWifi(): Boolean
     fun setCloudOnlyWifi(value: Boolean)
     fun getAppIconId(): String?

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -739,7 +739,7 @@ class SettingsImpl @Inject constructor(
     }
 
     override fun clearPlusPreferences() {
-        setCloudDeleteCloudAfterPlaying(false)
+        setDeleteCloudFileAfterPlaying(false)
         setCloudAutoUpload(false)
         setCloudAutoDownload(false)
         setCloudOnlyWifi(false)
@@ -1243,19 +1243,19 @@ class SettingsImpl @Inject constructor(
         setBoolean("cloudUpNext", value)
     }
 
-    override fun getCloudDeleteAfterPlaying(): Boolean {
+    override fun getDeleteLocalFileAfterPlaying(): Boolean {
         return getBoolean("cloudDeleteAfterPlaying", false)
     }
 
-    override fun setCloudDeleteAfterPlaying(value: Boolean) {
+    override fun setDeleteLocalFileAfterPlaying(value: Boolean) {
         setBoolean("cloudDeleteAfterPlaying", value)
     }
 
-    override fun getCloudDeleteCloudAfterPlaying(): Boolean {
+    override fun getDeleteCloudFileAfterPlaying(): Boolean {
         return getBoolean("cloudDeleteCloudAfterPlaying", false)
     }
 
-    override fun setCloudDeleteCloudAfterPlaying(value: Boolean) {
+    override fun setDeleteCloudFileAfterPlaying(value: Boolean) {
         setBoolean("cloudDeleteCloudAfterPlaying", value)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -557,7 +557,7 @@ class UserEpisodeManagerImpl @Inject constructor(
     }
 
     override suspend fun deletePlayedEpisodeIfReq(episode: UserEpisode, playbackManager: PlaybackManager) {
-        if (settings.getCloudDeleteAfterPlaying()) {
+        if (settings.getDeleteLocalFileAfterPlaying()) {
             deleteFilesForEpisode(episode)
             userEpisodeDao.updateEpisodeStatus(episode.uuid, EpisodeStatusEnum.NOT_DOWNLOADED)
 
@@ -566,7 +566,7 @@ class UserEpisodeManagerImpl @Inject constructor(
             }
         }
 
-        if (settings.getCloudDeleteCloudAfterPlaying() && episode.serverStatus == UserEpisodeServerStatus.UPLOADED) {
+        if (settings.getDeleteCloudFileAfterPlaying() && episode.serverStatus == UserEpisodeServerStatus.UPLOADED) {
             removeFromCloud(episode)
             if (!episode.isDownloaded) {
                 delete(episode, playbackManager)


### PR DESCRIPTION
## Description
Adding tracks for the file setting screen.

## Testing Instructions
1. Log into a Plus account
2. Go to the Profile tab → `Files` → click on `⋮` → `File settings`
3. ✅ Observe the event `settings_files_shown`
4. Toggle "Auto add to Up Next"
5. ✅ Observe the event `settings_files_auto_add_up_next_toggled, Properties: {"enabled":true|false, ... }`
6. Toggle "Delete local file"
7. ✅ Observe the event `settings_files_delete_local_file_after_playing_toggled, Properties: {"enabled":true|false, ... }`
8. Toggle "Delete cloud file"
9. ✅ Observe the event `settings_files_delete_cloud_file_after_playing_toggled, Properties: {"enabled":true|false, ... }`
10. Toggle "Auto upload to cloud"
11. ✅ Observe the event `settings_files_auto_upload_to_cloud_toggled, Properties: {"enabled":true|false, ... }`
12. Toggle "Auto download from cloud"
13. ✅ Observe the event `settings_files_auto_download_from_cloud_toggled, Properties: {"enabled":true|false, ... }`
14. Toggle "Only on WiFi"
15. ✅ Observe the event `settings_files_only_on_wifi_toggled, Properties: {"enabled":true|false, ... }`


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews