### PR TITLE
Search history: Display results

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/SearchHistoryDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/SearchHistoryDaoTest.kt
@@ -243,6 +243,27 @@ class SearchHistoryDaoTest {
         }
     }
 
+    /* SHOW FOLDERS FILTER */
+    @Test
+    fun testFoldersShownInSearchHistory() {
+        val uuid = UUID.randomUUID().toString()
+        runTest {
+            searchHistoryDao.insert(createFolderSearchHistoryItem(uuid))
+
+            assertTrue(findSearchHistory(showFolders = true).size == 1)
+        }
+    }
+
+    @Test
+    fun testFoldersHiddenInSearchHistory() {
+        val uuid = UUID.randomUUID().toString()
+        runTest {
+            searchHistoryDao.insert(createFolderSearchHistoryItem(uuid))
+
+            assertTrue(findSearchHistory(showFolders = false).isEmpty())
+        }
+    }
+
     /* HELPER FUNCTIONS */
     private fun createTermSearchHistoryItem(term: String) =
         SearchHistoryItem(term = term)

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/SearchHistoryDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/SearchHistoryDaoTest.kt
@@ -20,6 +20,7 @@ import java.util.UUID
 
 private const val SEARCH_TERM_TEST1 = "test1"
 private const val SEARCH_TERM_TEST2 = "test2"
+private const val SEARCH_HISTORY_LIMIT = 5
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -44,7 +45,7 @@ class SearchHistoryDaoTest {
     fun testInsertSearchTerm() = runTest {
         searchHistoryDao.insert(createTermSearchHistoryItem(SEARCH_TERM_TEST1))
 
-        assertTrue(searchHistoryDao.findAll().first().term == SEARCH_TERM_TEST1)
+        assertTrue(findSearchHistory().first().term == SEARCH_TERM_TEST1)
     }
 
     @Test
@@ -53,7 +54,7 @@ class SearchHistoryDaoTest {
         runTest {
             searchHistoryDao.insert(createPodcastSearchHistoryItem(uuid))
 
-            assertTrue(searchHistoryDao.findAll().first().podcast?.uuid == uuid)
+            assertTrue(findSearchHistory().first().podcast?.uuid == uuid)
         }
     }
 
@@ -63,7 +64,7 @@ class SearchHistoryDaoTest {
         runTest {
             searchHistoryDao.insert(createFolderSearchHistoryItem(uuid))
 
-            assertTrue(searchHistoryDao.findAll().first().folder?.uuid == uuid)
+            assertTrue(findSearchHistory().first().folder?.uuid == uuid)
         }
     }
 
@@ -73,7 +74,7 @@ class SearchHistoryDaoTest {
         runTest {
             searchHistoryDao.insert(createEpisodeSearchHistoryItem(uuid))
 
-            assertTrue(searchHistoryDao.findAll().first().episode?.uuid == uuid)
+            assertTrue(findSearchHistory().first().episode?.uuid == uuid)
         }
     }
 
@@ -82,10 +83,10 @@ class SearchHistoryDaoTest {
     fun testMultipleInsertSameSearchTerms() {
         runTest {
             searchHistoryDao.insert(createTermSearchHistoryItem(SEARCH_TERM_TEST1))
-            val modifiedPrevious = searchHistoryDao.findAll().first().modified
+            val modifiedPrevious = findSearchHistory().first().modified
             searchHistoryDao.insert(createTermSearchHistoryItem(SEARCH_TERM_TEST1))
 
-            val result = searchHistoryDao.findAll()
+            val result = findSearchHistory()
             assertEquals("Insert should replace, count should be 1", 1, result.size)
             assertTrue(
                 "Replaced search term should be on top",
@@ -100,7 +101,7 @@ class SearchHistoryDaoTest {
             searchHistoryDao.insert(createTermSearchHistoryItem(SEARCH_TERM_TEST1))
             searchHistoryDao.insert(createTermSearchHistoryItem(SEARCH_TERM_TEST2))
 
-            val result = searchHistoryDao.findAll()
+            val result = findSearchHistory()
             assertEquals("Unique search terms should be inserted, count should be 2", 2, result.size)
             assertEquals(
                 "Last search term inserted should be on top",
@@ -115,10 +116,10 @@ class SearchHistoryDaoTest {
         val uuid = UUID.randomUUID().toString()
         runTest {
             searchHistoryDao.insert(createPodcastSearchHistoryItem(uuid = uuid))
-            val modifiedPrevious = searchHistoryDao.findAll().first().modified
+            val modifiedPrevious = findSearchHistory().first().modified
             searchHistoryDao.insert(createPodcastSearchHistoryItem(uuid = uuid))
 
-            val result = searchHistoryDao.findAll()
+            val result = findSearchHistory()
             assertEquals("Same podcast search insert should replace, count should be 1", 1, result.size)
             assertTrue(
                 "Replaced podcast search history item should be on top",
@@ -135,7 +136,7 @@ class SearchHistoryDaoTest {
             searchHistoryDao.insert(createPodcastSearchHistoryItem(uuid1))
             searchHistoryDao.insert(createPodcastSearchHistoryItem(uuid2))
 
-            val result = searchHistoryDao.findAll()
+            val result = findSearchHistory()
             assertEquals("Unique podcast search history should be inserted, count should be 2", 2, result.size)
             assertEquals(
                 "Last podcast search history inserted should be on top",
@@ -150,10 +151,10 @@ class SearchHistoryDaoTest {
         val uuid = UUID.randomUUID().toString()
         runTest {
             searchHistoryDao.insert(createFolderSearchHistoryItem(uuid))
-            val modifiedPrevious = searchHistoryDao.findAll().first().modified
+            val modifiedPrevious = findSearchHistory().first().modified
             searchHistoryDao.insert(createFolderSearchHistoryItem(uuid))
 
-            val result = searchHistoryDao.findAll()
+            val result = findSearchHistory()
             assertEquals("Same folder search insert should replace, count should be 1", 1, result.size)
             assertTrue(
                 "Replaced folder search should be on top",
@@ -170,7 +171,7 @@ class SearchHistoryDaoTest {
             searchHistoryDao.insert(createFolderSearchHistoryItem(uuid1))
             searchHistoryDao.insert(createFolderSearchHistoryItem(uuid2))
 
-            val result = searchHistoryDao.findAll()
+            val result = findSearchHistory()
             assertEquals("Unique folder search history should be inserted, count should be 2", 2, result.size)
             assertEquals(
                 "Last folder search history inserted should be on top",
@@ -185,10 +186,10 @@ class SearchHistoryDaoTest {
         val uuid = UUID.randomUUID().toString()
         runTest {
             searchHistoryDao.insert(createEpisodeSearchHistoryItem(uuid))
-            val modifiedPrevious = searchHistoryDao.findAll().first().modified
+            val modifiedPrevious = findSearchHistory().first().modified
             searchHistoryDao.insert(createEpisodeSearchHistoryItem(uuid))
 
-            val result = searchHistoryDao.findAll()
+            val result = findSearchHistory()
             assertEquals("Same episode insert should replace, count should be 1", 1, result.size)
             assertTrue(
                 "Replaced episode search should be on top",
@@ -205,7 +206,7 @@ class SearchHistoryDaoTest {
             searchHistoryDao.insert(createEpisodeSearchHistoryItem(uuid1))
             searchHistoryDao.insert(createEpisodeSearchHistoryItem(uuid2))
 
-            val result = searchHistoryDao.findAll()
+            val result = findSearchHistory()
             assertEquals("Unique episode search history should be inserted, count should be 2", 2, result.size)
             assertEquals(
                 "Last episode search history inserted should be on top",
@@ -221,9 +222,9 @@ class SearchHistoryDaoTest {
         runTest {
             searchHistoryDao.insert(createTermSearchHistoryItem(SEARCH_TERM_TEST1))
 
-            searchHistoryDao.delete(searchHistoryDao.findAll().first())
+            searchHistoryDao.delete(findSearchHistory().first())
 
-            assertTrue(searchHistoryDao.findAll().isEmpty())
+            assertTrue(findSearchHistory().isEmpty())
         }
     }
 
@@ -238,7 +239,7 @@ class SearchHistoryDaoTest {
 
             searchHistoryDao.deleteAll()
 
-            assertTrue(searchHistoryDao.findAll().isEmpty())
+            assertTrue(findSearchHistory().isEmpty())
         }
     }
 
@@ -267,4 +268,9 @@ class SearchHistoryDaoTest {
                 duration = 0.0,
             )
         )
+
+    private suspend fun findSearchHistory(
+        showFolders: Boolean = true,
+        limit: Int = SEARCH_HISTORY_LIMIT,
+    ) = searchHistoryDao.findAll(showFolders, limit)
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
@@ -73,7 +73,7 @@ class OnboardingRecommendationsSearchViewModel @Inject constructor(
             ) { subscribedUuids, searchState ->
 
                 val podcasts = when (searchState) {
-                    SearchState.NoResults -> emptyList()
+                    is SearchState.NoResults -> emptyList()
                     is SearchState.Results -> {
 
                         // TODO handle loading

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -113,6 +113,7 @@ class SearchFragment : BaseFragment() {
         binding?.let {
             UiUtil.hideKeyboard(it.searchView)
         }
+        viewModel.onFragmentPause(activity?.isChangingConfigurations)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -159,7 +160,7 @@ class SearchFragment : BaseFragment() {
         searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean {
                 viewModel.updateSearchQuery(query)
-                binding.searchHistoryPanel.visibility = View.GONE
+                binding.searchHistoryPanel.hide()
                 UiUtil.hideKeyboard(searchView)
                 return true
             }
@@ -172,7 +173,11 @@ class SearchFragment : BaseFragment() {
                     return true
                 }
                 viewModel.updateSearchQuery(query)
-                binding.searchHistoryPanel.visibility = View.GONE
+                if (characterCount > 0) {
+                    binding.searchHistoryPanel.hide()
+                } else {
+                    binding.searchHistoryPanel.show()
+                }
                 return true
             }
         })
@@ -215,6 +220,9 @@ class SearchFragment : BaseFragment() {
         binding.searchHistoryPanel.setContent {
             AppTheme(theme.activeTheme) {
                 SearchHistoryPage(searchHistoryViewModel)
+                if (viewModel.isFragmentChangingConfigurations && viewModel.showSearchHistory) {
+                    binding.searchHistoryPanel.show()
+                }
             }
         }
 

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -99,6 +99,7 @@ class SearchFragment : BaseFragment() {
         val binding = FragmentSearchBinding.inflate(inflater, container, false)
         binding.setLifecycleOwner { viewLifecycleOwner.lifecycle }
         viewModel.setOnlySearchRemote(onlySearchRemote)
+        searchHistoryViewModel.setOnlySearchRemote(onlySearchRemote)
         binding.viewModel = viewModel
         binding.floating = floating
 
@@ -192,12 +193,13 @@ class SearchFragment : BaseFragment() {
                 listener?.onSearchPodcastClick(podcast.uuid)
                 UiUtil.hideKeyboard(searchView)
             },
-            onFolderClick = { folder ->
+            onFolderClick = { folder, podcasts ->
                 viewModel.trackSearchResultTapped(
                     source = source,
                     uuid = folder.uuid,
                     type = SearchResultType.FOLDER,
                 )
+                searchHistoryViewModel.add(SearchHistoryEntry.fromFolder(folder, podcasts.map { it.uuid }))
                 listener?.onSearchFolderClick(folder.uuid)
                 UiUtil.hideKeyboard(searchView)
             }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -16,10 +16,12 @@ import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.search.SearchViewModel.SearchResultType
 import au.com.shiftyjelly.pocketcasts.search.adapter.PodcastSearchAdapter
 import au.com.shiftyjelly.pocketcasts.search.databinding.FragmentSearchBinding
 import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryPage
+import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryViewModel
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.views.extensions.hide
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
@@ -62,6 +64,7 @@ class SearchFragment : BaseFragment() {
     }
 
     private val viewModel: SearchViewModel by viewModels()
+    private val searchHistoryViewModel: SearchHistoryViewModel by viewModels()
     private var listener: Listener? = null
     private var binding: FragmentSearchBinding? = null
 
@@ -185,6 +188,7 @@ class SearchFragment : BaseFragment() {
                         SearchResultType.PODCAST_LOCAL_RESULT
                     }
                 )
+                searchHistoryViewModel.add(SearchHistoryEntry.fromPodcast(podcast))
                 listener?.onSearchPodcastClick(podcast.uuid)
                 UiUtil.hideKeyboard(searchView)
             },
@@ -208,7 +212,7 @@ class SearchFragment : BaseFragment() {
 
         binding.searchHistoryPanel.setContent {
             AppTheme(theme.activeTheme) {
-                SearchHistoryPage()
+                SearchHistoryPage(searchHistoryViewModel)
             }
         }
 

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -15,9 +15,11 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.search.SearchViewModel.SearchResultType
 import au.com.shiftyjelly.pocketcasts.search.adapter.PodcastSearchAdapter
 import au.com.shiftyjelly.pocketcasts.search.databinding.FragmentSearchBinding
+import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryPage
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.views.extensions.hide
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
@@ -153,6 +155,7 @@ class SearchFragment : BaseFragment() {
         searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean {
                 viewModel.updateSearchQuery(query)
+                binding.searchHistoryPanel.visibility = View.GONE
                 UiUtil.hideKeyboard(searchView)
                 return true
             }
@@ -165,6 +168,7 @@ class SearchFragment : BaseFragment() {
                     return true
                 }
                 viewModel.updateSearchQuery(query)
+                binding.searchHistoryPanel.visibility = View.GONE
                 return true
             }
         })
@@ -201,6 +205,12 @@ class SearchFragment : BaseFragment() {
         recyclerView.adapter = searchAdapter
         recyclerView.itemAnimator = null
         recyclerView.addOnScrollListener(onScrollListener)
+
+        binding.searchHistoryPanel.setContent {
+            AppTheme(theme.activeTheme) {
+                SearchHistoryPage()
+            }
+        }
 
         val noResultsView = binding.noResults
         val searchFailedView = binding.searchFailed

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -1,20 +1,30 @@
 package au.com.shiftyjelly.pocketcasts.search
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.map
+import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
+import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
+import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SearchViewModel @Inject constructor(
     private val searchHandler: SearchHandler,
+    private val searchHistoryManager: SearchHistoryManager,
     private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ViewModel() {
 
-    val searchResults = searchHandler.searchResults
+    val searchResults = searchHandler.searchResults.map { searchState ->
+        val isSearchStarted = (loading.value == true)
+        if (isSearchStarted) saveSearchTerm(searchState.searchTerm)
+        searchState
+    }
     val loading = searchHandler.loading
 
     fun updateSearchQuery(query: String) {
@@ -27,6 +37,12 @@ class SearchViewModel @Inject constructor(
 
     fun setSource(source: AnalyticsSource) {
         searchHandler.setSource(source)
+    }
+
+    private fun saveSearchTerm(term: String) {
+        viewModelScope.launch {
+            searchHistoryManager.add(SearchHistoryEntry.SearchTerm(term = term))
+        }
     }
 
     fun trackSearchResultTapped(
@@ -56,6 +72,12 @@ class SearchViewModel @Inject constructor(
 }
 
 sealed class SearchState {
-    object NoResults : SearchState()
-    data class Results(val list: List<FolderItem>, val loading: Boolean, val error: Throwable?) : SearchState()
+    abstract val searchTerm: String
+    data class NoResults(override val searchTerm: String) : SearchState()
+    data class Results(
+        override val searchTerm: String,
+        val list: List<FolderItem>,
+        val loading: Boolean,
+        val error: Throwable?,
+    ) : SearchState()
 }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -19,10 +19,14 @@ class SearchViewModel @Inject constructor(
     private val searchHistoryManager: SearchHistoryManager,
     private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ViewModel() {
-
+    var isFragmentChangingConfigurations: Boolean = false
+    var showSearchHistory: Boolean = true
     val searchResults = searchHandler.searchResults.map { searchState ->
         val isSearchStarted = (loading.value == true)
-        if (isSearchStarted) saveSearchTerm(searchState.searchTerm)
+        if (isSearchStarted) {
+            saveSearchTerm(searchState.searchTerm)
+            showSearchHistory = false
+        }
         searchState
     }
     val loading = searchHandler.loading
@@ -43,6 +47,10 @@ class SearchViewModel @Inject constructor(
         viewModelScope.launch {
             searchHistoryManager.add(SearchHistoryEntry.SearchTerm(term = term))
         }
+    }
+
+    fun onFragmentPause(isChangingConfigurations: Boolean?) {
+        isFragmentChangingConfigurations = isChangingConfigurations ?: false
     }
 
     fun trackSearchResultTapped(

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/adapter/PodcastSearchAdapter.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/adapter/PodcastSearchAdapter.kt
@@ -13,7 +13,7 @@ import au.com.shiftyjelly.pocketcasts.views.adapter.FolderItemDiffCallback
 class PodcastSearchAdapter(
     val theme: Theme,
     val onPodcastClick: (Podcast) -> Unit,
-    val onFolderClick: (Folder) -> Unit
+    val onFolderClick: (Folder, List<Podcast>) -> Unit
 ) : ListAdapter<FolderItem, RecyclerView.ViewHolder>(FolderItemDiffCallback()) {
 
     override fun getItemId(position: Int): Long {

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/adapter/SearchFolderViewHolder.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/adapter/SearchFolderViewHolder.kt
@@ -12,7 +12,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 class SearchFolderViewHolder(
     val composeView: ComposeView,
     val theme: Theme,
-    val onFolderClick: (Folder) -> Unit
+    val onFolderClick: (Folder, List<Podcast>) -> Unit
 ) : RecyclerView.ViewHolder(composeView) {
 
     init {
@@ -24,7 +24,7 @@ class SearchFolderViewHolder(
     fun bind(folder: Folder, podcasts: List<Podcast>) {
         composeView.setContent {
             AppTheme(theme.activeTheme) {
-                SearchFolderRow(folder, podcasts, onClick = { onFolderClick(folder) })
+                SearchFolderRow(folder, podcasts, onClick = { onFolderClick(folder, podcasts) })
             }
         }
     }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
@@ -12,23 +12,28 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.compose.folder.FolderImageSmall
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import java.util.UUID
@@ -57,7 +62,10 @@ fun SearchHistoryView(
                 when (entry) {
                     is SearchHistoryEntry.Episode -> Unit // TODO
 
-                    is SearchHistoryEntry.Folder -> Unit // TODO
+                    is SearchHistoryEntry.Folder -> SearchHistoryRow(
+                        content = { SearchHistoryFolderView(entry) },
+                        onCloseClick = { onCloseClick(entry) }
+                    )
 
                     is SearchHistoryEntry.Podcast -> SearchHistoryRow(
                         content = { SearchHistoryPodcastView(entry) },
@@ -109,6 +117,62 @@ private fun CloseButton(
 }
 
 @Composable
+fun SearchHistoryFolderView(
+    entry: SearchHistoryEntry.Folder,
+    modifier: Modifier = Modifier,
+) {
+    val color = MaterialTheme.theme.colors.getFolderColor(entry.color)
+    Column {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.theme.colors.primaryUi01)
+                .padding(horizontal = 16.dp)
+
+        ) {
+            Box(modifier = Modifier.padding(top = 4.dp, end = 12.dp, bottom = 4.dp)) {
+                FolderImageSmall(
+                    color = color,
+                    podcastUuids = entry.podcastIds,
+                    folderImageSize = 54.dp,
+                    podcastImageSize = 22.dp
+                )
+            }
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = entry.title,
+                    fontSize = 16.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    color = MaterialTheme.theme.colors.primaryText01,
+                    modifier = Modifier.padding(bottom = 2.dp)
+                )
+                val podcastCount = if (entry.podcastIds.size == 1) {
+                    stringResource(R.string.podcasts_singular)
+                } else {
+                    stringResource(
+                        R.string.podcasts_plural,
+                        entry.podcastIds.size
+                    )
+                }
+                Text(
+                    text = podcastCount,
+                    fontSize = 13.sp,
+                    letterSpacing = 0.2.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = MaterialTheme.theme.colors.primaryText02,
+                    modifier = Modifier.padding(top = 2.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
 fun SearchHistoryPodcastView(
     entry: SearchHistoryEntry.Podcast,
     modifier: Modifier = Modifier,
@@ -155,6 +219,12 @@ fun SearchHistoryViewPreview(
         SearchHistoryView(
             state = SearchHistoryViewModel.State(
                 entries = listOf(
+                    SearchHistoryEntry.Folder(
+                        uuid = UUID.randomUUID().toString(),
+                        title = "Folder",
+                        color = 0,
+                        podcastIds = emptyList()
+                    ),
                     SearchHistoryEntry.Podcast(
                         uuid = UUID.randomUUID().toString(),
                         title = "Title",

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
@@ -1,7 +1,168 @@
 package au.com.shiftyjelly.pocketcasts.search.searchhistory
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
+import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import java.util.UUID
+
+private val IconSize = 64.dp
+@Composable
+internal fun SearchHistoryPage(
+    viewModel: SearchHistoryViewModel
+) {
+    val state by viewModel.state.collectAsState()
+    SearchHistoryView(
+        state = state,
+        onCloseClick = { viewModel.remove(it) }
+    )
+    viewModel.start()
+}
 
 @Composable
-internal fun SearchHistoryPage() {
+fun SearchHistoryView(
+    state: SearchHistoryViewModel.State,
+    onCloseClick: (SearchHistoryEntry) -> Unit,
+) {
+    LazyColumn {
+        state.entries.forEach { entry ->
+            item {
+                when (entry) {
+                    is SearchHistoryEntry.Episode -> Unit // TODO
+
+                    is SearchHistoryEntry.Folder -> Unit // TODO
+
+                    is SearchHistoryEntry.Podcast -> SearchHistoryRow(
+                        content = { SearchHistoryPodcastView(entry) },
+                        onCloseClick = { onCloseClick(entry) }
+                    )
+
+                    is SearchHistoryEntry.SearchTerm -> Unit // TODO
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SearchHistoryRow(
+    onCloseClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit = {},
+) {
+    Column(
+        modifier = modifier.background(color = MaterialTheme.theme.colors.primaryUi01)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .clickable { /*TODO*/ }
+                .fillMaxWidth()
+        ) {
+            Box(Modifier.weight(weight = 1f, fill = true)) {
+                content.invoke()
+            }
+            CloseButton(onCloseClick)
+        }
+        HorizontalDivider(startIndent = 16.dp)
+    }
+}
+
+@Composable
+private fun CloseButton(
+    onCloseClick: () -> Unit,
+) {
+    IconButton(onClick = onCloseClick) {
+        Icon(
+            imageVector = NavigationButton.Close.image,
+            contentDescription = stringResource(NavigationButton.Close.contentDescription),
+            tint = MaterialTheme.theme.colors.primaryIcon02
+        )
+    }
+}
+
+@Composable
+fun SearchHistoryPodcastView(
+    entry: SearchHistoryEntry.Podcast,
+    modifier: Modifier = Modifier,
+) {
+    Column {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+        ) {
+            PodcastImage(
+                uuid = entry.uuid,
+                modifier = modifier
+                    .size(IconSize)
+                    .padding(top = 4.dp, end = 12.dp, bottom = 4.dp)
+            )
+            Column(
+                modifier = modifier
+                    .padding(end = 16.dp)
+                    .weight(1f)
+            ) {
+                TextP40(
+                    text = entry.title,
+                    maxLines = 1,
+                    color = MaterialTheme.theme.colors.primaryText01
+                )
+                TextP50(
+                    text = entry.author,
+                    maxLines = 1,
+                    color = MaterialTheme.theme.colors.primaryText02
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun SearchHistoryViewPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppTheme(themeType) {
+        SearchHistoryView(
+            state = SearchHistoryViewModel.State(
+                entries = listOf(
+                    SearchHistoryEntry.Podcast(
+                        uuid = UUID.randomUUID().toString(),
+                        title = "Title",
+                        author = "Author",
+                    ),
+                )
+            ),
+            onCloseClick = {}
+        )
+    }
 }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.search.searchhistory
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal fun SearchHistoryPage() {
+}

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -72,7 +73,10 @@ fun SearchHistoryView(
                         onCloseClick = { onCloseClick(entry) }
                     )
 
-                    is SearchHistoryEntry.SearchTerm -> Unit // TODO
+                    is SearchHistoryEntry.SearchTerm -> SearchHistoryRow(
+                        content = { SearchHistoryTermView(entry) },
+                        onCloseClick = { onCloseClick(entry) }
+                    )
                 }
             }
         }
@@ -210,6 +214,42 @@ fun SearchHistoryPodcastView(
     }
 }
 
+@Composable
+fun SearchHistoryTermView(
+    entry: SearchHistoryEntry.SearchTerm,
+    modifier: Modifier = Modifier,
+) {
+    Column {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.theme.colors.primaryUi01)
+                .padding(horizontal = 16.dp)
+        ) {
+            Box(
+                modifier = modifier.size(IconSize),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    painter = painterResource(id = au.com.shiftyjelly.pocketcasts.images.R.drawable.ic_search),
+                    contentDescription = null,
+                    tint = MaterialTheme.theme.colors.primaryIcon02
+                )
+            }
+            Box(
+                modifier = modifier.weight(1f)
+            ) {
+                TextP40(
+                    text = entry.term,
+                    color = MaterialTheme.theme.colors.primaryText01,
+                    modifier = modifier.padding(vertical = 20.dp)
+                )
+            }
+        }
+    }
+}
+
 @Preview
 @Composable
 fun SearchHistoryViewPreview(
@@ -229,6 +269,9 @@ fun SearchHistoryViewPreview(
                         uuid = UUID.randomUUID().toString(),
                         title = "Title",
                         author = "Author",
+                    ),
+                    SearchHistoryEntry.SearchTerm(
+                        term = "Search Term"
                     ),
                 )
             ),

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModel.kt
@@ -1,0 +1,8 @@
+package au.com.shiftyjelly.pocketcasts.search.searchhistory
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class SearchHistoryViewModel @Inject constructor() : ViewModel()

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModel.kt
@@ -1,8 +1,54 @@
 package au.com.shiftyjelly.pocketcasts.search.searchhistory
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
+import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+private const val SEARCH_HISTORY_LIMIT = 5
+
 @HiltViewModel
-class SearchHistoryViewModel @Inject constructor() : ViewModel()
+class SearchHistoryViewModel @Inject constructor(
+    private val searchHistoryManager: SearchHistoryManager,
+) : ViewModel() {
+    private val mutableState = MutableStateFlow(
+        State(entries = emptyList())
+    )
+    val state: StateFlow<State> = mutableState
+
+    data class State(
+        val entries: List<SearchHistoryEntry>,
+    )
+
+    fun start() {
+        viewModelScope.launch {
+            loadSearchHistory()
+        }
+    }
+
+    private suspend fun loadSearchHistory() {
+        val entries = searchHistoryManager.findAll(
+            showFolders = false,
+            limit = SEARCH_HISTORY_LIMIT
+        )
+        mutableState.value = mutableState.value.copy(entries = entries)
+    }
+
+    fun add(entry: SearchHistoryEntry) {
+        viewModelScope.launch {
+            searchHistoryManager.add(entry)
+        }
+    }
+
+    fun remove(entry: SearchHistoryEntry) {
+        viewModelScope.launch {
+            searchHistoryManager.remove(entry)
+            loadSearchHistory()
+        }
+    }
+}

--- a/modules/features/search/src/main/res/layout/fragment_search.xml
+++ b/modules/features/search/src/main/res/layout/fragment_search.xml
@@ -50,6 +50,11 @@
 
         </FrameLayout>
 
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/searchHistoryPanel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
         <LinearLayout
             android:id="@+id/resultPanel"
             android:layout_width="match_parent"

--- a/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModelTest.kt
+++ b/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModelTest.kt
@@ -1,0 +1,115 @@
+package au.com.shiftyjelly.pocketcasts.search.searchhistory
+
+import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
+import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import io.reactivex.Flowable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Date
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(MockitoJUnitRunner::class)
+class SearchHistoryViewModelTest {
+    @Mock
+    private lateinit var userManager: UserManager
+
+    @Mock
+    private lateinit var searchHistoryManager: SearchHistoryManager
+
+    private val subscriptionStatusPlus = SubscriptionStatus.Plus(
+        expiry = Date(),
+        autoRenew = true,
+        giftDays = 0,
+        frequency = SubscriptionFrequency.MONTHLY,
+        platform = SubscriptionPlatform.ANDROID,
+        subscriptionList = emptyList(),
+        type = SubscriptionType.PLUS,
+        index = 0
+    )
+
+    private val subscriptionStatusFree = SubscriptionStatus.Free()
+
+    @Before
+    fun setUp() = runTest {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @Test
+    fun `given plus user and local + remote search, when search history shown, then folders included`() =
+        runTest {
+            val viewModel = initViewModel(isPlusUser = true, isOnlySearchRemote = false)
+
+            viewModel.start()
+
+            verify(searchHistoryManager).findAll(showFolders = eq(true), limit = anyInt())
+        }
+
+    @Test
+    fun `given free user and local + remote only search, when search history shown, then folders not included`() =
+        runTest {
+            val viewModel = initViewModel(isPlusUser = false, isOnlySearchRemote = true)
+
+            viewModel.start()
+
+            verify(searchHistoryManager).findAll(showFolders = eq(false), limit = anyInt())
+        }
+
+    @Test
+    fun `given plus user and remote only search, when search history shown, then folders not included`() =
+        runTest {
+            val viewModel = initViewModel(isPlusUser = true, isOnlySearchRemote = true)
+
+            viewModel.start()
+
+            verify(searchHistoryManager).findAll(showFolders = eq(false), limit = anyInt())
+        }
+
+    @Test
+    fun `given free user and remote only search, when search history shown, then folders not included`() =
+        runTest {
+            val viewModel = initViewModel(isPlusUser = false, isOnlySearchRemote = true)
+
+            viewModel.start()
+
+            verify(searchHistoryManager).findAll(showFolders = eq(false), limit = anyInt())
+        }
+
+    private suspend fun initViewModel(
+        isPlusUser: Boolean = false,
+        isOnlySearchRemote: Boolean = false,
+    ): SearchHistoryViewModel {
+        whenever(userManager.getSignInState())
+            .thenReturn(
+                Flowable.just(
+                    SignInState.SignedIn(
+                        email = "",
+                        subscriptionStatus = if (isPlusUser) subscriptionStatusPlus else subscriptionStatusFree
+                    )
+                )
+            )
+        whenever(searchHistoryManager.findAll(showFolders = anyBoolean(), limit = anyInt()))
+            .thenReturn(mock())
+        val viewModel = SearchHistoryViewModel(searchHistoryManager, userManager)
+        viewModel.setOnlySearchRemote(isOnlySearchRemote)
+        return viewModel
+    }
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalDivider.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalDivider.kt
@@ -7,17 +7,22 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 
 @Composable
-fun HorizontalDivider(modifier: Modifier = Modifier) {
+fun HorizontalDivider(
+    modifier: Modifier = Modifier,
+    startIndent: Dp = 0.dp
+) {
     Divider(
         modifier = modifier,
         color = MaterialTheme.theme.colors.primaryUi05,
-        thickness = 1.dp
+        thickness = 1.dp,
+        startIndent = startIndent
     )
 }
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImageSmall.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImageSmall.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 
@@ -27,17 +28,21 @@ private val gradientBottom = Color(0xFF000000)
 private val topPodcastImageGradient = listOf(Color(0x00000000), Color(0x16000000))
 private val bottomPodcastImageGradient = listOf(Color(0x16000000), Color(0x33000000))
 
+private val FolderImageSize = 64.dp
+private val PodcastImageSize = 26.dp
 @Composable
 fun FolderImageSmall(
     color: Color,
     podcastUuids: List<String>,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    folderImageSize: Dp = FolderImageSize,
+    podcastImageSize: Dp = PodcastImageSize,
 ) {
     Card(
         elevation = 2.dp,
         shape = RoundedCornerShape(4.dp),
         backgroundColor = color,
-        modifier = modifier.size(64.dp)
+        modifier = modifier.size(folderImageSize)
     ) {
         Box(
             contentAlignment = Alignment.Center
@@ -53,24 +58,23 @@ fun FolderImageSmall(
                             )
                         )
                     )
-                    .size(64.dp)
+                    .size(folderImageSize)
             ) {}
             Row(horizontalArrangement = Arrangement.Center) {
-                val imageSize = 26.dp
                 val imagePadding = 2.dp
                 Column(horizontalAlignment = Alignment.End) {
                     FolderPodcastImage(
                         uuid = podcastUuids.getOrNull(0),
                         color = color,
                         gradientColor = topPodcastImageGradient,
-                        modifier = Modifier.size(imageSize)
+                        modifier = Modifier.size(podcastImageSize)
                     )
                     Spacer(modifier = Modifier.height(imagePadding))
                     FolderPodcastImage(
                         uuid = podcastUuids.getOrNull(2),
                         color = color,
                         gradientColor = bottomPodcastImageGradient,
-                        modifier = Modifier.size(imageSize)
+                        modifier = Modifier.size(podcastImageSize)
                     )
                 }
                 Spacer(modifier = Modifier.width(imagePadding))
@@ -79,14 +83,14 @@ fun FolderImageSmall(
                         uuid = podcastUuids.getOrNull(1),
                         color = color,
                         gradientColor = topPodcastImageGradient,
-                        modifier = Modifier.size(imageSize)
+                        modifier = Modifier.size(podcastImageSize)
                     )
                     Spacer(modifier = Modifier.height(imagePadding))
                     FolderPodcastImage(
                         uuid = podcastUuids.getOrNull(3),
                         color = color,
                         gradientColor = bottomPodcastImageGradient,
-                        modifier = Modifier.size(imageSize)
+                        modifier = Modifier.size(podcastImageSize)
                     )
                 }
             }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/SearchHistoryDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/SearchHistoryDao.kt
@@ -9,8 +9,13 @@ import au.com.shiftyjelly.pocketcasts.models.entity.SearchHistoryItem
 
 @Dao
 abstract class SearchHistoryDao {
-    @Query("SELECT * FROM search_history ORDER BY modified DESC LIMIT :limit")
-    abstract suspend fun findAll(limit: Int = 10): List<SearchHistoryItem>
+    @Query(
+        "SELECT * FROM search_history " +
+            "WHERE CASE when :showFolders then 1 else folder_uuid is NULL END " +
+            "ORDER BY modified DESC " +
+            "LIMIT :limit"
+    )
+    abstract suspend fun findAll(showFolders: Boolean, limit: Int): List<SearchHistoryItem>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract suspend fun insert(searchHistoryItem: SearchHistoryItem)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SearchHistoryEntry.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SearchHistoryEntry.kt
@@ -54,7 +54,7 @@ sealed class SearchHistoryEntry(
                 uuid = uuid,
                 title = title,
                 color = color,
-                podcastIds = podcastIds.joinToString()
+                podcastIds = podcastIds.joinToString(separator = ",")
             )
         )
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SearchHistoryEntry.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SearchHistoryEntry.kt
@@ -1,0 +1,133 @@
+package au.com.shiftyjelly.pocketcasts.models.to
+
+import au.com.shiftyjelly.pocketcasts.models.entity.SearchHistoryItem
+import java.util.Date
+import au.com.shiftyjelly.pocketcasts.models.entity.Episode as EpisodeModel
+import au.com.shiftyjelly.pocketcasts.models.entity.Folder as FolderModel
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast as PodcastModel
+
+sealed class SearchHistoryEntry(
+    val id: Long? = null,
+) {
+    class Episode(
+        id: Long? = null,
+        val uuid: String,
+        val title: String,
+        val publishedDate: Date,
+        val duration: Double,
+    ) : SearchHistoryEntry(id = id)
+
+    class Folder(
+        id: Long? = null,
+        val uuid: String,
+        val title: String,
+        val color: Int,
+        val podcastIds: List<String>,
+    ) : SearchHistoryEntry(id = id)
+
+    class Podcast(
+        id: Long? = null,
+        val uuid: String,
+        val title: String,
+        val author: String,
+    ) : SearchHistoryEntry(id = id)
+
+    class SearchTerm(
+        id: Long? = null,
+        val term: String,
+    ) : SearchHistoryEntry(id = id)
+
+    fun toSearchHistoryItem() = when (this) {
+        is Episode -> SearchHistoryItem(
+            id = id,
+            episode = SearchHistoryItem.Episode(
+                uuid = uuid,
+                title = title,
+                publishedDate = publishedDate,
+                duration = duration
+            )
+        )
+
+        is Folder -> SearchHistoryItem(
+            id = id,
+            folder = SearchHistoryItem.Folder(
+                uuid = uuid,
+                title = title,
+                color = color,
+                podcastIds = podcastIds.joinToString()
+            )
+        )
+
+        is Podcast -> SearchHistoryItem(
+            id = id,
+            podcast = SearchHistoryItem.Podcast(
+                uuid = uuid,
+                title = title,
+                author = author
+            )
+        )
+
+        is SearchTerm -> SearchHistoryItem(
+            id = id,
+            term = term
+        )
+    }
+
+    companion object {
+        fun fromEpisode(episode: EpisodeModel) = Episode(
+            uuid = episode.uuid,
+            title = episode.title,
+            publishedDate = episode.publishedDate,
+            duration = episode.duration
+        )
+
+        fun fromFolder(folder: FolderModel, podcastIds: List<String>) = Folder(
+            uuid = folder.uuid,
+            title = folder.name,
+            color = folder.color,
+            podcastIds = podcastIds
+        )
+
+        fun fromPodcast(podcast: PodcastModel) = Podcast(
+            uuid = podcast.uuid,
+            title = podcast.title,
+            author = podcast.author
+        )
+
+        fun fromSearchHistoryItem(item: SearchHistoryItem) = when {
+            item.episode != null -> {
+                val episode = item.episode as SearchHistoryItem.Episode
+                Episode(
+                    id = item.id,
+                    uuid = episode.uuid,
+                    title = episode.title,
+                    publishedDate = episode.publishedDate,
+                    duration = episode.duration
+                )
+            }
+
+            item.folder != null -> {
+                val folder = item.folder as SearchHistoryItem.Folder
+                Folder(
+                    id = item.id,
+                    uuid = folder.uuid,
+                    title = folder.title,
+                    color = folder.color,
+                    podcastIds = folder.podcastIds.split(",")
+                )
+            }
+
+            item.podcast != null -> {
+                val podcast = item.podcast as SearchHistoryItem.Podcast
+                Podcast(
+                    id = item.id,
+                    uuid = podcast.uuid,
+                    title = podcast.title,
+                    author = podcast.author
+                )
+            }
+
+            else -> SearchTerm(id = item.id, term = item.term ?: "")
+        }
+    }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SearchHistoryEntry.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SearchHistoryEntry.kt
@@ -127,7 +127,9 @@ sealed class SearchHistoryEntry(
                 )
             }
 
-            else -> SearchTerm(id = item.id, term = item.term ?: "")
+            item.term != null -> SearchTerm(id = item.id, term = item.term as String)
+
+            else -> throw IllegalStateException("Unknown search history item")
         }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
@@ -27,6 +27,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManagerImpl
+import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
+import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
@@ -116,4 +118,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun provideEndOfYearManager(endOfYearManagerImpl: EndOfYearManagerImpl): EndOfYearManager
+
+    @Binds
+    @Singleton
+    abstract fun provideSearchHistoryManager(searchHistoryManagerImpl: SearchHistoryManagerImpl): SearchHistoryManager
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/searchhistory/SearchHistoryManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/searchhistory/SearchHistoryManager.kt
@@ -1,3 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.repositories.searchhistory
 
-interface SearchHistoryManager
+import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
+
+interface SearchHistoryManager {
+    suspend fun findAll(showFolders: Boolean, limit: Int): List<SearchHistoryEntry>
+    suspend fun add(entry: SearchHistoryEntry)
+    suspend fun remove(entry: SearchHistoryEntry)
+    suspend fun clearAll()
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/searchhistory/SearchHistoryManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/searchhistory/SearchHistoryManager.kt
@@ -1,0 +1,3 @@
+package au.com.shiftyjelly.pocketcasts.repositories.searchhistory
+
+interface SearchHistoryManager

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/searchhistory/SearchHistoryManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/searchhistory/SearchHistoryManagerImpl.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.searchhistory
 
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
+import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import javax.inject.Inject
@@ -13,4 +14,24 @@ class SearchHistoryManagerImpl @Inject constructor(
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
     private val searchHistoryDao = appDatabase.searchHistoryDao()
+
+    override suspend fun findAll(
+        showFolders: Boolean,
+        limit: Int,
+    ): List<SearchHistoryEntry> {
+        val items = searchHistoryDao.findAll(showFolders, limit)
+        return items.map { SearchHistoryEntry.fromSearchHistoryItem(it) }
+    }
+
+    override suspend fun add(entry: SearchHistoryEntry) {
+        searchHistoryDao.insert(entry.toSearchHistoryItem())
+    }
+
+    override suspend fun remove(entry: SearchHistoryEntry) {
+        searchHistoryDao.delete(entry.toSearchHistoryItem())
+    }
+
+    override suspend fun clearAll() {
+        searchHistoryDao.deleteAll()
+    }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/searchhistory/SearchHistoryManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/searchhistory/SearchHistoryManagerImpl.kt
@@ -1,0 +1,16 @@
+package au.com.shiftyjelly.pocketcasts.repositories.searchhistory
+
+import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
+
+class SearchHistoryManagerImpl @Inject constructor(
+    appDatabase: AppDatabase,
+) : SearchHistoryManager, CoroutineScope {
+
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.Default
+    private val searchHistoryDao = appDatabase.searchHistoryDao()
+}


### PR DESCRIPTION
Part of #752 

## Description

This PR 
- Creates a new page to display the search history
- Adds selected podcast from the search results list to search history
- Adds selected folder from the search results list to search history 
   (** folder search history is displayed conditionally based on subscription state and selected tab - Podcasts or Discover)
- Adds search term to search history
- Displays search results
- Adds X button click action

Notes:
- Ignore UI, it does not meet the spec yet
- Episode search, search history row click action, clear all are not added, they'll be taken up separately 

## Testing Instructions

#### Folder Search - Plus Account (Podcasts and Discover tabs)
- Login with a Plus account having folders
- Go to Podcasts tab and search for a folder 
- Tap folder in search results
- Go back to Podcasts screen and tap search button again
- ✅ Notice that folder is shown in search history
- Go to Discover tab
- Tap search button
- ✅ Notice that folder although present in db is not shown in search history as Discover tab doesn't display folders

#### Folder Search - Free Account
- Remove Plus subscription for the above account
- Continue from the last test and go to Podcasts tab
- Tap search button
-  ✅ Notice that folder although present in db is not shown in search history as free account doesn't have access to folders

#### Podcast Search
- Go to Podcasts tab and search for a podcast 
- Tap a podcast in search results
- Go back to Podcasts screen and tap search button again
- ✅ Notice that podcast is shown in search history

#### Search Term
- Go to Podcasts tab and search a term
- ✅ Notice that search term is saved on debounce
- Go back to Podcasts screen and tap search button again
- ✅ Notice that searched term is shown in search history

#### Orientation change
- Go to Podcasts tab and search a term
- Go to search history
- Rotate device
- ✅ Notice that searched history is retained
- Search a term
- When result results appear, clear search query
- ✅ Notice that searched history is reshown

#### Remove search history
- Go to search history
- Tap X on a search history row
- Notice that the item is removed from the search history

## Screenshots or Screencast 

https://user-images.githubusercontent.com/1405144/217818207-f8ae86a3-f7b1-46aa-ad21-07e06eea7653.mp4

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
