### PR TITLE
Chromecast tracks

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -45,6 +45,7 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.ChromeCastButton.Shown
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
 import au.com.shiftyjelly.pocketcasts.views.helper.ToolbarColors
@@ -187,7 +188,7 @@ class FilterEpisodeListFragment : BaseFragment() {
             toolbar = toolbar,
             title = arguments?.getString(ARG_PLAYLIST_TITLE),
             menu = R.menu.menu_filter,
-            setupChromeCast = true,
+            chromeCastButton = Shown(chromeCastAnalytics),
             navigationIcon = BackArrow,
             toolbarColors = null
         )

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.ChromeCastButton.Shown
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.None
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -69,7 +70,7 @@ class FiltersFragment : BaseFragment(), CoroutineScope, Toolbar.OnMenuItemClickL
             toolbar = binding.toolbar,
             title = getString(LR.string.filters),
             menu = R.menu.menu_filters,
-            setupChromeCast = true,
+            chromeCastButton = Shown(chromeCastAnalytics),
             navigationIcon = None
         )
         binding.toolbar.setOnMenuItemClickListener(this)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -174,10 +174,15 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         binding.videoView.playbackManager = playbackManager
         binding.videoView.setOnClickListener { onFullScreenVideoClick() }
 
-        CastButtonFactory.setUpMediaRouteButton(binding.root.context, binding.castButton)
-        binding.castButton.setAlwaysVisible(true)
-        binding.castButton.updateColor(ThemeColor.playerContrast03(theme.activeTheme))
-        binding.castButton.setOnClickListener { trackShelfAction(ShelfItem.Cast.analyticsValue) }
+        with(binding.castButton) {
+            CastButtonFactory.setUpMediaRouteButton(binding.root.context, this)
+            setAlwaysVisible(true)
+            updateColor(ThemeColor.playerContrast03(theme.activeTheme))
+            setOnClickListener {
+                trackShelfAction(ShelfItem.Cast.analyticsValue)
+                chromeCastAnalytics.trackChromeCastViewShown()
+            }
+        }
 
         setupUpNextDrag(view, binding.topView)
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
@@ -12,6 +12,7 @@ import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentShelfBottomShee
 import au.com.shiftyjelly.pocketcasts.player.view.ShelfFragment.Companion.AnalyticsProp
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
+import au.com.shiftyjelly.pocketcasts.repositories.chromecast.ChromeCastAnalytics
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.views.extensions.applyColor
@@ -25,6 +26,7 @@ import javax.inject.Inject
 class ShelfBottomSheet : BaseDialogFragment() {
     @Inject lateinit var castManager: CastManager
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
+    @Inject lateinit var chromeCastAnalytics: ChromeCastAnalytics
 
     override val statusBarColor: StatusBarColor? = null
 
@@ -66,6 +68,9 @@ class ShelfBottomSheet : BaseDialogFragment() {
         }
 
         CastButtonFactory.setUpMediaRouteButton(view.context, binding.mediaRouteButton)
+        binding.mediaRouteButton.setOnClickListener {
+            chromeCastAnalytics.trackChromeCastViewShown()
+        }
     }
 
     private fun onClick(item: ShelfItem) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -504,7 +504,9 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                 activity?.onBackPressed()
             }
             val iconColor = it.context.getThemeColor(UR.attr.contrast_01)
-            it.menu.setupChromeCastButton(context)
+            it.menu.setupChromeCastButton(context) {
+                chromeCastAnalytics.trackChromeCastViewShown()
+            }
             it.menu.tintIcons(iconColor)
             it.navigationIcon?.setTint(iconColor)
             it.navigationContentDescription = getString(LR.string.back)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -40,6 +40,7 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.adapter.PodcastTouchCallback
 import au.com.shiftyjelly.pocketcasts.views.extensions.showIf
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.ChromeCastButton.Shown
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon
 import au.com.shiftyjelly.pocketcasts.views.helper.ToolbarColors
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
@@ -181,7 +182,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         setupToolbarAndStatusBar(
             toolbar = toolbar,
             menu = R.menu.podcasts_menu,
-            setupChromeCast = true
+            chromeCastButton = Shown(chromeCastAnalytics),
         )
         toolbar.setOnMenuItemClickListener(this)
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -38,6 +38,7 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.ChromeCastButton.Shown
 import au.com.shiftyjelly.pocketcasts.views.helper.CloudDeleteHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
@@ -112,7 +113,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             navigationIcon = BackArrow,
             activity = activity,
             theme = theme,
-            setupChromeCast = true,
+            chromeCastButton = Shown(chromeCastAnalytics),
             menu = R.menu.menu_cloudfiles
         )
         binding?.toolbar?.setOnMenuItemClickListener(this)

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -493,4 +493,9 @@ enum class AnalyticsEvent(val key: String) {
     SEARCH_PERFORMED("search_performed"),
     SEARCH_FAILED("search_failed"),
     SEARCH_RESULT_TAPPED("search_result_tapped"),
+
+    /* Chromecast */
+    CHROMECAST_VIEW_SHOWN("chromecast_view_shown"),
+    CHROMECAST_STARTED_CASTING("chromecast_started_casting"),
+    CHROMECAST_STOPPED_CASTING("chromecast_stopped_casting"),
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/CastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/CastManagerImpl.kt
@@ -2,6 +2,8 @@ package au.com.shiftyjelly.pocketcasts.repositories.chromecast
 
 import android.content.Context
 import androidx.core.content.ContextCompat
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.google.android.gms.cast.framework.CastContext
 import com.google.android.gms.cast.framework.Session
@@ -16,7 +18,10 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
 
-class CastManagerImpl @Inject constructor(@ApplicationContext private val context: Context) : CastManager {
+class CastManagerImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+) : CastManager {
 
     private val sessionManagerListener = CastSessionManagerListener()
     private var sessionListener: CastManager.SessionListener? = null
@@ -108,6 +113,7 @@ class CastManagerImpl @Inject constructor(@ApplicationContext private val contex
 
         override fun onSessionStarted(session: Session, s: String) {
             Timber.i("Cast Session onSessionStarted")
+            analyticsTracker.track(AnalyticsEvent.CHROMECAST_STARTED_CASTING)
             sessionListener?.sessionStarted()
             isConnectedObservable.accept(true)
         }
@@ -122,6 +128,7 @@ class CastManagerImpl @Inject constructor(@ApplicationContext private val contex
 
         override fun onSessionEnded(session: Session, i: Int) {
             Timber.i("Cast Session onSessionEnded")
+            analyticsTracker.track(AnalyticsEvent.CHROMECAST_STOPPED_CASTING)
             sessionListener?.sessionEnded()
             isConnectedObservable.accept(false)
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/ChromeCastAnalytics.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/ChromeCastAnalytics.kt
@@ -1,0 +1,24 @@
+package au.com.shiftyjelly.pocketcasts.repositories.chromecast
+
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class ChromeCastAnalytics @Inject constructor(
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val castManager: CastManager,
+) {
+    fun trackChromeCastViewShown() {
+        @OptIn(DelicateCoroutinesApi::class)
+        GlobalScope.launch {
+            val isConnected = castManager.isConnected()
+            analyticsTracker.track(
+                AnalyticsEvent.CHROMECAST_VIEW_SHOWN,
+                mapOf("is_connected" to isConnected)
+            )
+        }
+    }
+}

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/Menu.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/Menu.kt
@@ -39,15 +39,16 @@ fun Menu.tintIcons(@ColorInt color: Int, excludeMenuItems: List<Int>? = null) {
     }
 }
 
-fun Menu.findChromeCastItem(): MenuItem? {
+private fun Menu.findChromeCastItem(): MenuItem? {
     return this.children.firstOrNull { it.actionView is MediaRouteButton }
 }
 
-fun Menu.setupChromeCastButton(context: Context?) {
+fun Menu.setupChromeCastButton(context: Context?, onClick: () -> Unit) {
     context ?: return
     try {
         val menuItem = findChromeCastItem() ?: return
         CastButtonFactory.setUpMediaRouteButton(context, this, menuItem.itemId)
+        menuItem.actionView?.setOnClickListener { onClick() }
     } catch (e: Throwable) {
         Timber.e(e)
     }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/Toolbar.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/Toolbar.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getTintedDrawable
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.ChromeCastButton
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.None
 import au.com.shiftyjelly.pocketcasts.views.helper.ToolbarColors
@@ -23,7 +24,7 @@ fun Toolbar.updateColors(toolbarColors: ToolbarColors, navigationIcon: Navigatio
 fun Toolbar.setup(
     title: String? = null,
     @MenuRes menu: Int? = null,
-    setupChromeCast: Boolean = false,
+    chromeCastButton: ChromeCastButton = ChromeCastButton.None,
     navigationIcon: NavigationIcon = None,
     onNavigationClick: (() -> Unit)? = null,
     activity: Activity?,
@@ -37,8 +38,12 @@ fun Toolbar.setup(
         this.menu.clear()
         inflateMenu(menu)
     }
-    if (setupChromeCast) {
-        setupChromeCastButton(context)
+    when (chromeCastButton) {
+        ChromeCastButton.None -> {}
+        is ChromeCastButton.Shown ->
+            setupChromeCastButton(context) {
+                chromeCastButton.chromeCastAnalytics.trackChromeCastViewShown()
+            }
     }
     if (toolbarColors != null) {
         updateColors(toolbarColors = toolbarColors, navigationIcon = navigationIcon)
@@ -64,6 +69,6 @@ fun Toolbar.setup(
     }
 }
 
-fun Toolbar.setupChromeCastButton(context: Context?) {
-    menu.setupChromeCastButton(context)
+fun Toolbar.setupChromeCastButton(context: Context?, onClick: () -> Unit) {
+    menu.setupChromeCastButton(context, onClick)
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseFragment.kt
@@ -7,12 +7,14 @@ import androidx.annotation.ColorInt
 import androidx.annotation.MenuRes
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
+import au.com.shiftyjelly.pocketcasts.repositories.chromecast.ChromeCastAnalytics
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.extensions.tintIcons
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.ChromeCastButton
 import au.com.shiftyjelly.pocketcasts.views.helper.HasBackstack
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.None
@@ -30,6 +32,7 @@ open class BaseFragment : Fragment(), CoroutineScope, HasBackstack {
     open var statusBarColor: StatusBarColor = StatusBarColor.Light
 
     @Inject lateinit var theme: Theme
+    @Inject lateinit var chromeCastAnalytics: ChromeCastAnalytics
 
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Main
@@ -72,7 +75,7 @@ open class BaseFragment : Fragment(), CoroutineScope, HasBackstack {
         toolbar: Toolbar,
         title: String? = null,
         @MenuRes menu: Int? = null,
-        setupChromeCast: Boolean = false,
+        chromeCastButton: ChromeCastButton = ChromeCastButton.None,
         navigationIcon: NavigationIcon = None,
         onNavigationClick: (() -> Unit)? = null,
         toolbarColors: ToolbarColors? = ToolbarColors.Theme(theme = theme, context = toolbar.context)
@@ -80,7 +83,7 @@ open class BaseFragment : Fragment(), CoroutineScope, HasBackstack {
         toolbar.setup(
             title = title,
             menu = menu,
-            setupChromeCast = setupChromeCast,
+            chromeCastButton = chromeCastButton,
             navigationIcon = navigationIcon,
             onNavigationClick = onNavigationClick,
             activity = activity,

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseFragmentToolbar.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseFragmentToolbar.kt
@@ -1,0 +1,10 @@
+package au.com.shiftyjelly.pocketcasts.views.fragments
+
+import au.com.shiftyjelly.pocketcasts.repositories.chromecast.ChromeCastAnalytics
+
+object BaseFragmentToolbar {
+    sealed class ChromeCastButton {
+        class Shown(val chromeCastAnalytics: ChromeCastAnalytics) : ChromeCastButton()
+        object None : ChromeCastButton()
+    }
+}


### PR DESCRIPTION
## Description
Adding tracks for chromecasting from the app.

## Testing Instructions

#### 1. Verify full flow
1. With a chromecast device available on your local wireless network...
2. Go to the Podcasts tab
3. Tap the chromecast icon in the toolbar (this will only appear if there are chromecast devices available)
4. ✅ Observe the event `chromecast_view_shown, Properties: {"is_connected":false, ... }`
5. Select a speaker to cast to
6. ✅ Observe the event `chromecast_started_casting`
7. Tap the chromecast icon again
8. ✅ Observe the event `chromecast_view_shown, Properties: {"is_connected":true, ... }`
9. Tap "Stop casting"
10. ✅ Observe the event `chromecast_stopped_casting`

#### 2. Verify other places we can chromecast from

In each of the following, verify that tapping on the chromecast icon sends the event `chromecast_view_shown, Properties: {"is_connected":true|false, ... }`.

1. Toolbar on the page for a specific podcast (similar to the toolbar on the Podcasts tab)
2. Full screen player with the chromecast button in the bottom shelf (you may have to move it here from the overflow menu)
3. Full screen player with the chromecast button in the overflow menu (you may have to move it here from the bottom shelf)

2 & 3 are listed separately because they involve different code paths. It looks like these are all the places that you can start chromecasting from, but let me know if you know of any others.

<details>
<summary>Here's a video of me triggering the relevant views.</summary>

https://user-images.githubusercontent.com/4656348/217907487-11bbfde3-1c55-4ceb-bbc7-350c7ca328bb.mov

</details>

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews