### PR TITLE
Search history: Navigation and Clear All

### DIFF
--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -116,6 +116,15 @@ class SearchFragment : BaseFragment() {
         viewModel.onFragmentPause(activity?.isChangingConfigurations)
     }
 
+    private fun navigateFromSearchHistoryEntry(entry: SearchHistoryEntry) {
+        when (entry) {
+            is SearchHistoryEntry.Episode -> Unit // TODO
+            is SearchHistoryEntry.Folder -> listener?.onSearchFolderClick(entry.uuid)
+            is SearchHistoryEntry.Podcast -> listener?.onSearchPodcastClick(entry.uuid)
+            is SearchHistoryEntry.SearchTerm -> binding?.searchView?.setQuery(entry.term, true)
+        }
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -219,7 +228,10 @@ class SearchFragment : BaseFragment() {
 
         binding.searchHistoryPanel.setContent {
             AppTheme(theme.activeTheme) {
-                SearchHistoryPage(searchHistoryViewModel)
+                SearchHistoryPage(
+                    viewModel = searchHistoryViewModel,
+                    onClick = ::navigateFromSearchHistoryEntry
+                )
                 if (viewModel.isFragmentChangingConfigurations && viewModel.showSearchHistory) {
                     binding.searchHistoryPanel.show()
                 }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -20,6 +20,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.search.SearchViewModel.SearchResultType
 import au.com.shiftyjelly.pocketcasts.search.adapter.PodcastSearchAdapter
 import au.com.shiftyjelly.pocketcasts.search.databinding.FragmentSearchBinding
+import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryClearAllConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryPage
 import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryViewModel
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
@@ -36,6 +37,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 private const val ARG_FLOATING = "arg_floating"
 private const val ARG_ONLY_SEARCH_REMOTE = "arg_only_search_remote"
 private const val ARG_SOURCE = "arg_source"
+private const val SEARCH_HISTORY_CLEAR_ALL_CONFIRMATION_DIALOG_TAG = "search_history_clear_all_confirmation_dialog"
 
 @AndroidEntryPoint
 class SearchFragment : BaseFragment() {
@@ -230,7 +232,13 @@ class SearchFragment : BaseFragment() {
             AppTheme(theme.activeTheme) {
                 SearchHistoryPage(
                     viewModel = searchHistoryViewModel,
-                    onClick = ::navigateFromSearchHistoryEntry
+                    onClick = ::navigateFromSearchHistoryEntry,
+                    onShowClearAllConfirmation = {
+                        SearchHistoryClearAllConfirmationDialog(
+                            context = this@SearchFragment.requireContext(),
+                            onConfirm = { searchHistoryViewModel.clearAll() }
+                        ).show(parentFragmentManager, SEARCH_HISTORY_CLEAR_ALL_CONFIRMATION_DIALOG_TAG)
+                    }
                 )
                 if (viewModel.isFragmentChangingConfigurations && viewModel.showSearchHistory) {
                     binding.searchHistoryPanel.show()

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryClearAllConfirmationDialog.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryClearAllConfirmationDialog.kt
@@ -1,0 +1,19 @@
+package au.com.shiftyjelly.pocketcasts.search.searchhistory
+
+import android.content.Context
+import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import au.com.shiftyjelly.pocketcasts.views.R as VR
+
+class SearchHistoryClearAllConfirmationDialog(
+    context: Context,
+    onConfirm: () -> Unit,
+) : ConfirmationDialog() {
+    init {
+        setTitle(context.getString(LR.string.clear_all))
+        setSummary(context.getString(LR.string.search_history_clear_all_confirmation_message))
+        setIconId(VR.drawable.ic_delete)
+        setButtonType(ButtonType.Danger(context.getString(LR.string.delete)))
+        setOnConfirm { onConfirm() }
+    }
+}

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
@@ -45,13 +45,15 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 private val IconSize = 64.dp
 @Composable
 internal fun SearchHistoryPage(
-    viewModel: SearchHistoryViewModel
+    viewModel: SearchHistoryViewModel,
+    onClick: (SearchHistoryEntry) -> Unit,
 ) {
     val state by viewModel.state.collectAsState()
     SearchHistoryView(
         state = state,
         onCloseClick = { viewModel.remove(it) },
-        onClearAllClick = { viewModel.clearAll() }
+        onClearAllClick = { viewModel.clearAll() },
+        onRowClick = onClick,
     )
     viewModel.start()
 }
@@ -61,6 +63,7 @@ fun SearchHistoryView(
     state: SearchHistoryViewModel.State,
     onCloseClick: (SearchHistoryEntry) -> Unit,
     onClearAllClick: () -> Unit,
+    onRowClick: (SearchHistoryEntry) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(
@@ -95,17 +98,20 @@ fun SearchHistoryView(
 
                     is SearchHistoryEntry.Folder -> SearchHistoryRow(
                         content = { SearchHistoryFolderView(entry) },
-                        onCloseClick = { onCloseClick(entry) }
+                        onCloseClick = { onCloseClick(entry) },
+                        onRowClick = { onRowClick(entry) },
                     )
 
                     is SearchHistoryEntry.Podcast -> SearchHistoryRow(
                         content = { SearchHistoryPodcastView(entry) },
-                        onCloseClick = { onCloseClick(entry) }
+                        onCloseClick = { onCloseClick(entry) },
+                        onRowClick = { onRowClick(entry) },
                     )
 
                     is SearchHistoryEntry.SearchTerm -> SearchHistoryRow(
                         content = { SearchHistoryTermView(entry) },
-                        onCloseClick = { onCloseClick(entry) }
+                        onCloseClick = { onCloseClick(entry) },
+                        onRowClick = { onRowClick(entry) },
                     )
                 }
             }
@@ -116,6 +122,7 @@ fun SearchHistoryView(
 @Composable
 fun SearchHistoryRow(
     onCloseClick: () -> Unit,
+    onRowClick: () -> Unit,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit = {},
 ) {
@@ -123,7 +130,7 @@ fun SearchHistoryRow(
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = modifier
-                .clickable { /*TODO*/ }
+                .clickable { onRowClick() }
                 .fillMaxWidth()
         ) {
             Box(Modifier.weight(weight = 1f, fill = true)) {
@@ -305,6 +312,7 @@ fun SearchHistoryViewPreview(
             ),
             onCloseClick = {},
             onClearAllClick = {},
+            onRowClick = {},
         )
     }
 }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
@@ -43,16 +43,24 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private val IconSize = 64.dp
+private const val CLEAR_ALL_THRESHOLD = 3
 @Composable
 internal fun SearchHistoryPage(
     viewModel: SearchHistoryViewModel,
     onClick: (SearchHistoryEntry) -> Unit,
+    onShowClearAllConfirmation: () -> Unit,
 ) {
     val state by viewModel.state.collectAsState()
     SearchHistoryView(
         state = state,
         onCloseClick = { viewModel.remove(it) },
-        onClearAllClick = { viewModel.clearAll() },
+        onClearAllClick = {
+            if (state.entries.size > CLEAR_ALL_THRESHOLD) {
+                onShowClearAllConfirmation()
+            } else {
+                viewModel.clearAll()
+            }
+        },
         onRowClick = onClick,
     )
     viewModel.start()

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
@@ -29,15 +29,18 @@ import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.folder.FolderImageSmall
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import java.util.UUID
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private val IconSize = 64.dp
 @Composable
@@ -47,7 +50,8 @@ internal fun SearchHistoryPage(
     val state by viewModel.state.collectAsState()
     SearchHistoryView(
         state = state,
-        onCloseClick = { viewModel.remove(it) }
+        onCloseClick = { viewModel.remove(it) },
+        onClearAllClick = { viewModel.clearAll() }
     )
     viewModel.start()
 }
@@ -56,8 +60,34 @@ internal fun SearchHistoryPage(
 fun SearchHistoryView(
     state: SearchHistoryViewModel.State,
     onCloseClick: (SearchHistoryEntry) -> Unit,
+    onClearAllClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    LazyColumn {
+    LazyColumn(
+        modifier = modifier.background(color = MaterialTheme.theme.colors.primaryUi01)
+    ) {
+        if (state.entries.isNotEmpty()) {
+            item {
+                Row(
+                    modifier = modifier
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, top = 8.dp, end = 16.dp, bottom = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TextH20(
+                        text = stringResource(LR.string.search_history_recent_searches),
+                        color = MaterialTheme.theme.colors.primaryText01,
+                        modifier = modifier.weight(1f)
+
+                    )
+                    TextH40(
+                        text = stringResource(LR.string.clear_all).uppercase(),
+                        color = MaterialTheme.theme.colors.support03,
+                        modifier = modifier.clickable { onClearAllClick() }
+                    )
+                }
+            }
+        }
         state.entries.forEach { entry ->
             item {
                 when (entry) {
@@ -89,9 +119,7 @@ fun SearchHistoryRow(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit = {},
 ) {
-    Column(
-        modifier = modifier.background(color = MaterialTheme.theme.colors.primaryUi01)
-    ) {
+    Column {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = modifier
@@ -155,10 +183,10 @@ fun SearchHistoryFolderView(
                     modifier = Modifier.padding(bottom = 2.dp)
                 )
                 val podcastCount = if (entry.podcastIds.size == 1) {
-                    stringResource(R.string.podcasts_singular)
+                    stringResource(LR.string.podcasts_singular)
                 } else {
                     stringResource(
-                        R.string.podcasts_plural,
+                        LR.string.podcasts_plural,
                         entry.podcastIds.size
                     )
                 }
@@ -232,7 +260,7 @@ fun SearchHistoryTermView(
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
-                    painter = painterResource(id = au.com.shiftyjelly.pocketcasts.images.R.drawable.ic_search),
+                    painter = painterResource(id = IR.drawable.ic_search),
                     contentDescription = null,
                     tint = MaterialTheme.theme.colors.primaryIcon02
                 )
@@ -275,7 +303,8 @@ fun SearchHistoryViewPreview(
                     ),
                 )
             ),
-            onCloseClick = {}
+            onCloseClick = {},
+            onClearAllClick = {},
         )
     }
 }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModel.kt
@@ -65,4 +65,11 @@ class SearchHistoryViewModel @Inject constructor(
             loadSearchHistory()
         }
     }
+
+    fun clearAll() {
+        viewModelScope.launch {
+            searchHistoryManager.clearAll()
+            loadSearchHistory()
+        }
+    }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -194,6 +194,7 @@
     <string name="search_no_podcasts_found_summary">Try more general or different keywords.</string>
     <string name="search_podcasts">Search podcasts</string>
     <string name="search_hint">Search by podcast name</string>
+    <string name="search_history_clear_all_confirmation_message">Are you sure you want to clear all your search history?</string>
     <string name="search_history_recent_searches">Recent searches</string>
 
     <string name="time_short_hours">%dh</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -194,6 +194,7 @@
     <string name="search_no_podcasts_found_summary">Try more general or different keywords.</string>
     <string name="search_podcasts">Search podcasts</string>
     <string name="search_hint">Search by podcast name</string>
+    <string name="search_history_recent_searches">Recent searches</string>
 
     <string name="time_short_hours">%dh</string>
     <string name="time_short_hours_minutes">%1$dh %2$dm</string>


### PR DESCRIPTION
Part of #752
## Description

This adds 
- Navigation for search history item
- Clear all header and a confirmation dialog with a search history threshold (size > 3).

Note: Ignore UI, it doesn't exactly match the specs.

## Testing Instructions
- Build a search history of different types (podcast/ folder/ search term) of at least 4 items 
- Tap on each search history item separately
- ✅ Notice that the appropriate page is opened for podcast, folder and the search is re-triggered for the search term
- Return to search history and tap on Clear All
- ✅ Notice that a confirmation dialog is shown (count > search history threshold)
- Tap on Delete button in the dialog
- ✅ Notice that search history is cleared
- Search another query
- Tap on Clear All
- ✅ Notice that search history is cleared (no dialog shown since count < threshold)

## Screenshots or Screencast 
https://user-images.githubusercontent.com/1405144/218105561-de46cbd4-9fc6-49f4-a85b-7c2b5449fbdb.mp4

## Checklist
- If this is a user-facing change, I have added an entry in CHANGELOG.md
- I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
