### PR TITLE
Add higher CI priority to release builds

### DIFF
--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -11,6 +11,7 @@ steps:
   - label: "Gradle Wrapper Validation"
     command: |
       validate_gradle_wrapper
+    priority: 1
     plugins: *common_plugins
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
@@ -18,6 +19,7 @@ steps:
 
   - label: "🛠 Release Build"
     command: ".buildkite/commands/release-build.sh"
+    priority: 1
     plugins: *common_plugins
     notify:
       - slack: "#build-and-ship"


### PR DESCRIPTION
### Summary of changes:

This PR increases the priority of release builds on Buildkite. This will be useful so that release builds won't get delayed if the CI queue gets backed up. The default priority of a build is 0, so increasing the release builds to 1 will put them before other builds: https://buildkite.com/docs/pipelines/managing-priorities