### PR TITLE
Adds toast message in case of ActivityNotFoundException on link click

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1605,4 +1605,5 @@
     <string name="filter_id_description">An unique ID that represents the filter. Can be used on the \'Query Filter Episodes\' action.</string>
     <string name="filter_title">Filter Title</string>
     <string name="filter_id_or_title">Filter ID or Title</string>
+    <string name="error_opening_links_activity_not_found">You may not have the proper app for viewing this content.</string>
 </resources>

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
@@ -4,9 +4,11 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import au.com.shiftyjelly.pocketcasts.preferences.BuildConfig
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.localization.R
 import java.io.UnsupportedEncodingException
 import java.net.URLDecoder
 import java.util.Arrays
@@ -93,8 +95,16 @@ object IntentUtil {
         var urlFound: String = url ?: return true
         val urlLower = urlFound.lowercase()
         if (urlLower.startsWith("http://") || urlLower.startsWith("https://") || urlLower.startsWith("ftp://") || urlLower.startsWith("market://")) {
-            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(urlFound)))
-            return true
+            try {
+                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(urlFound)))
+                return true
+            } catch (e: ActivityNotFoundException) {
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.error_opening_links_activity_not_found),
+                    Toast.LENGTH_LONG
+                ).show()
+            }
         }
         if (urlFound.startsWith("mailto:")) {
             try {


### PR DESCRIPTION
## Description
When clicking on a URL, the app attempts to launch the default browser Activity. In cases where the browser is disabled the app crashes because the ActivityNotFoundException is not handled. 

Fixes App Crashes When Opening Links without Browser Access #762 

## Testing Instructions
1. Disable browser access for the device using a filter or similar
2. Click on a link in the app, such as one in an episode's notes
3. The app should no longer crash and show a toast message instead

## Screenshots or Screencast 
![image](https://user-images.githubusercontent.com/85636562/218824117-2ed474d2-663d-4a26-9dfe-c993f15c402a.png)

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
