### PR TITLE
Episode grouping and sorting tracks

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -245,6 +245,19 @@ class PodcastViewModel
         launch {
             podcast.value?.let {
                 podcastManager.updateEpisodesSortType(it, episodesSortType)
+                analyticsTracker.track(
+                    AnalyticsEvent.PODCASTS_SCREEN_SORT_ORDER_CHANGED,
+                    mapOf(
+                        "sort_order" to when (episodesSortType) {
+                            EpisodesSortType.EPISODES_SORT_BY_DATE_ASC -> "oldest_to_newest"
+                            EpisodesSortType.EPISODES_SORT_BY_DATE_DESC -> "newest_to_oldest"
+                            EpisodesSortType.EPISODES_SORT_BY_LENGTH_ASC -> "shortest_to_longest"
+                            EpisodesSortType.EPISODES_SORT_BY_LENGTH_DESC -> "longest_to_shortest"
+                            EpisodesSortType.EPISODES_SORT_BY_TITLE_ASC -> "title_a_to_z"
+                            EpisodesSortType.EPISODES_SORT_BY_TITLE_DESC -> "title_z_to_a"
+                        }
+                    )
+                )
             }
         }
     }
@@ -253,6 +266,18 @@ class PodcastViewModel
         launch {
             podcast.value?.let {
                 podcastManager.updateGrouping(it, grouping)
+                analyticsTracker.track(
+                    AnalyticsEvent.PODCASTS_SCREEN_EPISODE_GROUPING_CHANGED,
+                    mapOf(
+                        "value" to when (grouping) {
+                            PodcastGrouping.None -> "none"
+                            PodcastGrouping.Downloaded -> "downloaded"
+                            PodcastGrouping.Season -> "season"
+                            PodcastGrouping.Unplayed -> "unplayed"
+                            PodcastGrouping.Starred -> "starred"
+                        }
+                    )
+                )
             }
         }
     }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -200,6 +200,8 @@ enum class AnalyticsEvent(val key: String) {
     PODCAST_SCREEN_TOGGLE_ARCHIVED("podcast_screen_toggle_archived"),
     PODCAST_SCREEN_TOGGLE_SUMMARY("podcast_screen_toggle_summary"),
     PODCAST_SCREEN_SHARE_TAPPED("podcast_screen_share_tapped"),
+    PODCASTS_SCREEN_SORT_ORDER_CHANGED("podcasts_screen_sort_order_changed"),
+    PODCASTS_SCREEN_EPISODE_GROUPING_CHANGED("podcasts_screen_episode_grouping_changed"),
 
     /* Podcast Settings */
     PODCAST_SETTINGS_FEED_ERROR_TAPPED("podcast_settings_feed_error_tapped"),


### PR DESCRIPTION
## Description
Adding tracks for episode sorting and grouping

## Testing Instructions
1. Open up the episode listing page for a podcast
2. Tap the `⋮`
3. Change the sorting of the episodes
4. Observe the event `podcasts_screen_sort_order_changed, Properties: {"sort_order":___, ... }`
5. Tap the `⋮` again
6. Change the grouping
7. Obseve the event `podcasts_screen_episode_grouping_changed, Properties: {"value":_____, ... }`

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
