### PR TITLE
Track signout on token refresh failure notification

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -19,6 +19,9 @@ enum class AnalyticsEvent(val key: String) {
     USER_ACCOUNT_CREATION_FAILED("user_account_creation_failed"),
     USER_SIGNED_OUT("user_signed_out"),
 
+    /* Signed out alert */
+    SIGNED_OUT_ALERT_SHOWN("signed_out_alert_shown"),
+
     /* Plus Upsell */
     PLUS_PROMOTION_SHOWN("plus_promotion_shown"),
     PLUS_PROMOTION_DISMISSED("plus_promotion_dismissed"),

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -396,8 +396,8 @@ interface Settings {
     fun getSyncPassword(): String?
     fun getSyncUuid(): String?
     fun getSyncRefreshToken(): String?
-    fun getSyncToken(tokenErrorUiTracker: TokenErrorUiTracker): String?
-    suspend fun getSyncTokenSuspend(tokenErrorUiTracker: TokenErrorUiTracker): String?
+    fun getSyncToken(onTokenErrorUiShown: () -> Unit): String?
+    suspend fun getSyncTokenSuspend(onTokenErrorUiShown: () -> Unit): String?
     fun isLoggedIn(): Boolean
     fun clearPlusPreferences()
     fun getUsedAccountManager(): Boolean
@@ -615,5 +615,3 @@ interface Settings {
     fun isNotificationsDisabledMessageShown(): Boolean
     fun setNotificationsDisabledMessageShown(value: Boolean)
 }
-
-data class TokenErrorUiTracker(val onShowError: () -> Unit)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -396,8 +396,8 @@ interface Settings {
     fun getSyncPassword(): String?
     fun getSyncUuid(): String?
     fun getSyncRefreshToken(): String?
-    fun getSyncToken(): String?
-    suspend fun getSyncTokenSuspend(): String?
+    fun getSyncToken(tokenErrorUiTracker: TokenErrorUiTracker): String?
+    suspend fun getSyncTokenSuspend(tokenErrorUiTracker: TokenErrorUiTracker): String?
     fun isLoggedIn(): Boolean
     fun clearPlusPreferences()
     fun getUsedAccountManager(): Boolean
@@ -615,3 +615,5 @@ interface Settings {
     fun isNotificationsDisabledMessageShown(): Boolean
     fun setNotificationsDisabledMessageShown(value: Boolean)
 }
+
+data class TokenErrorUiTracker(val onShowError: () -> Unit)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -615,11 +615,11 @@ class SettingsImpl @Inject constructor(
         return peekToken()
     }
 
-    override fun getSyncToken(tokenErrorUiTracker: TokenErrorUiTracker): String? = runBlocking {
-        getSyncTokenSuspend(tokenErrorUiTracker)
+    override fun getSyncToken(onTokenErrorUiShown: () -> Unit): String? = runBlocking {
+        getSyncTokenSuspend(onTokenErrorUiShown)
     }
 
-    override suspend fun getSyncTokenSuspend(tokenErrorUiTracker: TokenErrorUiTracker): String? {
+    override suspend fun getSyncTokenSuspend(onTokenErrorUiShown: () -> Unit): String? {
         val manager = AccountManager.get(context)
         val account = manager.pocketCastsAccount() ?: return null
 
@@ -643,7 +643,7 @@ class SettingsImpl @Inject constructor(
                         @Suppress("DEPRECATION")
                         bundle.getParcelable(AccountManager.KEY_INTENT) as? Intent
                     }
-                    intent?.let { showSignInErrorNotification(it, tokenErrorUiTracker) }
+                    intent?.let { showSignInErrorNotification(it, onTokenErrorUiShown) }
                     throw SecurityException("Token could not be refreshed")
                 } else {
                     token
@@ -655,8 +655,8 @@ class SettingsImpl @Inject constructor(
         }
     }
 
-    private fun showSignInErrorNotification(intent: Intent, tokenErrorUiTracker: TokenErrorUiTracker) {
-        tokenErrorUiTracker.onShowError()
+    private fun showSignInErrorNotification(intent: Intent, onTokenErrorUiShown: () -> Unit) {
+        onTokenErrorUiShown()
         val pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT.or(PendingIntent.FLAG_IMMUTABLE))
         val notification = NotificationCompat.Builder(context, NotificationChannel.NOTIFICATION_CHANNEL_ID_SIGN_IN_ERROR.id)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -615,11 +615,11 @@ class SettingsImpl @Inject constructor(
         return peekToken()
     }
 
-    override fun getSyncToken(): String? = runBlocking {
-        getSyncTokenSuspend()
+    override fun getSyncToken(tokenErrorUiTracker: TokenErrorUiTracker): String? = runBlocking {
+        getSyncTokenSuspend(tokenErrorUiTracker)
     }
 
-    override suspend fun getSyncTokenSuspend(): String? {
+    override suspend fun getSyncTokenSuspend(tokenErrorUiTracker: TokenErrorUiTracker): String? {
         val manager = AccountManager.get(context)
         val account = manager.pocketCastsAccount() ?: return null
 
@@ -643,7 +643,7 @@ class SettingsImpl @Inject constructor(
                         @Suppress("DEPRECATION")
                         bundle.getParcelable(AccountManager.KEY_INTENT) as? Intent
                     }
-                    intent?.let { showSignInErrorNotification(it) }
+                    intent?.let { showSignInErrorNotification(it, tokenErrorUiTracker) }
                     throw SecurityException("Token could not be refreshed")
                 } else {
                     token
@@ -655,7 +655,8 @@ class SettingsImpl @Inject constructor(
         }
     }
 
-    private fun showSignInErrorNotification(intent: Intent) {
+    private fun showSignInErrorNotification(intent: Intent, tokenErrorUiTracker: TokenErrorUiTracker) {
+        tokenErrorUiTracker.onShowError()
         val pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT.or(PendingIntent.FLAG_IMMUTABLE))
         val notification = NotificationCompat.Builder(context, NotificationChannel.NOTIFICATION_CHANNEL_ID_SIGN_IN_ERROR.id)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
@@ -327,12 +327,6 @@ open class SyncServerManager @Inject constructor(
         cache.evictAll()
     }
 
-    fun cancelSupporterSubscription(subscriptionUuid: String): Single<Response<Void>> {
-        return getCacheTokenOrLogin {
-            server.cancelSubscription(addBearer(it), SupporterCancelRequest(subscriptionUuid))
-        }
-    }
-
     private suspend fun <T : Any> getCacheTokenOrLoginSuspend(serverCall: suspend (token: String) -> T): T {
         if (settings.isLoggedIn()) {
             return try {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.HistorySyncRequest
 import au.com.shiftyjelly.pocketcasts.models.to.HistorySyncResponse
 import au.com.shiftyjelly.pocketcasts.models.to.StatsBundle
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.TokenErrorUiTracker
 import au.com.shiftyjelly.pocketcasts.servers.di.SyncServerCache
 import au.com.shiftyjelly.pocketcasts.servers.di.SyncServerRetrofit
 import au.com.shiftyjelly.pocketcasts.servers.sync.forgotpassword.ForgotPasswordRequest
@@ -45,7 +46,8 @@ open class SyncServerManager @Inject constructor(
     @SyncServerRetrofit retrofit: Retrofit,
     val settings: Settings,
     @SyncServerCache val cache: Cache,
-    private val analyticsTracker: AnalyticsTrackerWrapper
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val tokenErrorUiTracker: TokenErrorUiTracker,
 ) {
 
     companion object {
@@ -334,7 +336,7 @@ open class SyncServerManager @Inject constructor(
     private suspend fun <T : Any> getCacheTokenOrLoginSuspend(serverCall: suspend (token: String) -> T): T {
         if (settings.isLoggedIn()) {
             return try {
-                val token = settings.getSyncTokenSuspend() ?: refreshTokenSuspend()
+                val token = settings.getSyncTokenSuspend(tokenErrorUiTracker) ?: refreshTokenSuspend()
                 serverCall(token)
             } catch (ex: Exception) {
                 // refresh invalid
@@ -359,7 +361,7 @@ open class SyncServerManager @Inject constructor(
 
     private fun <T : Any> getCacheTokenOrLogin(serverCall: (token: String) -> Single<T>): Single<T> {
         if (settings.isLoggedIn()) {
-            return Single.fromCallable { settings.getSyncToken() ?: throw RuntimeException("Failed to get token") }
+            return Single.fromCallable { settings.getSyncToken(tokenErrorUiTracker) ?: throw RuntimeException("Failed to get token") }
                 .flatMap { token -> serverCall(token) }
                 // refresh invalid
                 .onErrorResumeNext { throwable ->
@@ -385,12 +387,12 @@ open class SyncServerManager @Inject constructor(
 
     private suspend fun refreshTokenSuspend(): String {
         settings.invalidateToken()
-        return settings.getSyncTokenSuspend() ?: throw Exception("Failed to get refresh token")
+        return settings.getSyncTokenSuspend(tokenErrorUiTracker) ?: throw Exception("Failed to get refresh token")
     }
 
     private fun refreshToken(): Single<String> {
         settings.invalidateToken()
-        return Single.fromCallable { settings.getSyncToken() ?: throw RuntimeException("Failed to get token") }
+        return Single.fromCallable { settings.getSyncToken(tokenErrorUiTracker) ?: throw RuntimeException("Failed to get token") }
             .doOnError {
                 LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, it, "Refresh token threw an error.")
             }


### PR DESCRIPTION
## Description
Tracks when the you-ve-been-signed-out screen. is presented because the token refresh fails.

This turned out to be trickier than I expected because this notification originates from the settings module, but the analytics module depends on the settings module, so I can't directly make the analytics call from the settings module. Instead, I'm passing a function from the server module to be invoked when the UI is presented.

## Testing Instructions
1. The easiest way to trigger this condition is to build with [this change](https://gist.github.com/mchowning/7e56ca55560fa6007c6c147284dcb455) so that we request an invalid token.
2. Attempt to log in to an account from in the app
3. Observe the sign in error notification is presented
4. Observe the event: `signed_out_alert_shown`. Note that the event actually gets fired three times, but I'm not sure there's a good way to avoid that, and it looks like it is very possibly a consequence of how we're forcing the error—you'll see that there are also three `user_signed_in` events, but if you sign in without the code change from step 1, then only one user_signed_in event gets fired. If you know of a better way to test this error scenario that might not cause this side effect, let me know. Just noting that if we really want to avoid the multiple events here, [this](https://gist.github.com/mchowning/333b28beaa59efabefe3e77a4468bc44) is one possible (but hacky) approach that seemed to work in some limited testing.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews