### PR TITLE
Add track for when discover is shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,4 +347,3 @@
         ([#3148](https://github.com/shiftyjelly/pocketcasts-android/issues/3148)).
     *   Fix create account next button not working when using 1Password
         ([#3167](https://github.com/shiftyjelly/pocketcasts-android/issues/3167)).
-

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -48,7 +48,6 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
 
     override fun onResume() {
         super.onResume()
-        viewModel.onShown()
     }
 
     override fun onPause() {
@@ -130,6 +129,8 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
         if (viewModel.state.value !is DiscoverState.DataLoaded) {
             viewModel.loadData(resources)
         }
+
+        viewModel.onShown()
 
         return binding?.root
     }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -46,6 +46,16 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
     private var adapter: DiscoverAdapter? = null
     private var binding: FragmentDiscoverBinding? = null
 
+    override fun onResume() {
+        super.onResume()
+        viewModel.onShown()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        viewModel.onFragmentPause(activity?.isChangingConfigurations)
+    }
+
     override fun onPodcastClicked(podcast: DiscoverPodcast, listUuid: String?) {
         val fragment = PodcastFragment.newInstance(podcastUuid = podcast.uuid, fromListUuid = listUuid)
         (activity as FragmentHostListener).addFragment(fragment)

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -3,7 +3,9 @@ package au.com.shiftyjelly.pocketcasts.discover.viewmodel
 import android.content.res.Resources
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -38,13 +40,25 @@ class DiscoverViewModel @Inject constructor(
     val podcastManager: PodcastManager,
     val episodeManager: EpisodeManager,
     val playbackManager: PlaybackManager,
-    val userManager: UserManager
+    val userManager: UserManager,
+    val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ViewModel() {
     private val disposables = CompositeDisposable()
     private val playbackSource = AnalyticsSource.DISCOVER
     val state = MutableLiveData<DiscoverState>().apply { value = DiscoverState.Loading }
     var currentRegionCode: String? = settings.getDiscoveryCountryCode()
     var replacements = emptyMap<String, String>()
+    private var isFragmentChangingConfigurations: Boolean = false
+
+    fun onShown() {
+        if (!isFragmentChangingConfigurations) {
+            analyticsTracker.track(AnalyticsEvent.DISCOVER_SHOWN)
+        }
+    }
+
+    fun onFragmentPause(isChangingConfigurations: Boolean?) {
+        isFragmentChangingConfigurations = isChangingConfigurations ?: false
+    }
 
     fun loadData(resources: Resources) {
         val feed = repository.getDiscoverFeed()

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -254,6 +254,7 @@ enum class AnalyticsEvent(val key: String) {
     FILTER_UPDATED("filter_updated"),
 
     /* Discover */
+    DISCOVER_SHOWN("discover_shown"),
     DISCOVER_CATEGORY_SHOWN("discover_category_shown"),
     DISCOVER_FEATURED_PODCAST_TAPPED("discover_featured_podcast_tapped"),
     DISCOVER_FEATURED_PODCAST_SUBSCRIBED("discover_featured_podcast_subscribed"),


### PR DESCRIPTION
## Description
Adds the `discover_shown` event.

## Testing Instructions
1. Open the PC app
2. Navigate to the discover page if you're not already there
3. ✅ Observe the event `discover_shown`
4. Change the screen orientation
5. Observe that the `discover_shown` event is _not_ sent
6. Background the app
7. Reopen the app
8. ✅ Observe the event `discover_shown` is sent again

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews