### PR TITLE
Tell media router to discover cast devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 7.33
 -----
 
+* Bug Fixes:
+    *    Improve discovery of chromecast devices.
+         ([#780](https://github.com/Automattic/pocket-casts-android/issues/780)).
 
 7.32
 -----


### PR DESCRIPTION
## Description
This updates the app to ask the `MediRouter` to check for available Chromecast devices. This avoids the chromecast button disappearing because the `MediaRouterButton` will automatically hide itself if it thinks there aren't any chromecast devices available.

I'm making these changes based on the documentation for `MediaRouteActionProvider` available [here](https://developer.android.com/reference/kotlin/androidx/mediarouter/app/MediaRouteActionProvider).

Fixes #777 

## Testing Instructions
1. Connect your device to a wireless network with at least one chromecast device available (I have multiple chromecast devices on my network, I'm not sure if that is necessary to cause the underlying bug).
2. Go to the Podcasts tab
3. ✅ Observe that the chromecast button is visible (possibly after a very short delay)
4. Background the app and reopen it
5. ✅ Observe that the chromecast button is visible (possibly after a very short delay)
6. Repeat steps 4 and 5 a few times.

## Screenshots or Screencast 

| Before | After |
| --- | --- |
| <video src="https://user-images.githubusercontent.com/4656348/219412807-221c79c9-0166-4f2e-aa43-3a6c0ca34179.mov" /> |  <video src="https://user-images.githubusercontent.com/4656348/219412829-0d64027a-a7c1-4e0f-aca3-9162e8ecc3ff.mov" /> |


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews