### PR TITLE
Track pull to refresh

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -218,6 +218,10 @@ class PodcastsViewModel
     }
 
     fun refreshPodcasts() {
+        analyticsTracker.track(
+            AnalyticsEvent.PULLED_TO_REFRESH,
+            mapOf("source" to "podcasts_list")
+        )
         podcastManager.refreshPodcasts("Pull down")
     }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -165,11 +165,11 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             }
         )
 
-        viewModel.refreshFiles()
+        viewModel.refreshFiles(userInitiated = false)
 
         binding?.swipeRefreshLayout?.let {
             it.setOnRefreshListener {
-                viewModel.refreshFiles()
+                viewModel.refreshFiles(userInitiated = true)
                 it.isRefreshing = false
             }
         }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
@@ -43,7 +43,19 @@ class CloudFilesViewModel @Inject constructor(
     val accountUsage = LiveDataReactiveStreams.fromPublisher(userEpisodeManager.observeAccountUsage())
     val signInState = LiveDataReactiveStreams.fromPublisher(userManager.getSignInState())
 
-    fun refreshFiles() {
+    fun refreshFiles(userInitiated: Boolean) {
+        if (userInitiated) {
+            analyticsTracker.track(
+                AnalyticsEvent.PULLED_TO_REFRESH,
+                mapOf(
+                    "source" to when (cloudFilesList.value?.isEmpty()) {
+                        true -> "no_files"
+                        false -> "files"
+                        else -> "unknown"
+                    }
+                )
+            )
+        }
         userEpisodeManager.syncFilesInBackground(playbackManager)
     }
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -24,6 +24,9 @@ enum class AnalyticsEvent(val key: String) {
     PLUS_PROMOTION_DISMISSED("plus_promotion_dismissed"),
     PLUS_PROMOTION_UPGRADE_BUTTON_TAPPED("plus_promotion_upgrade_button_tapped"),
 
+    /* Pull to refresh */
+    PULLED_TO_REFRESH("pulled_to_refresh"),
+
     /* Setup Account */
     SETUP_ACCOUNT_SHOWN("setup_account_shown"),
     SETUP_ACCOUNT_DISMISSED("setup_account_dismissed"),


### PR DESCRIPTION
## Description
Add track for pull to refresh.

## Testing Instructions
1. Start the app
2. Log in with a Plus account
3. Make sure you are subscribed to at least 1 podcast
4. Go to the podcasts tab
5. Pull to refresh
6. ✅ Observe the event. `pulled_to_refresh, Properties: {"source":"podcasts_list", ... }`
7. Go to the Profile tab → Files
8. Pull to refresh
9. ✅ Observe the event `pulled_to_refresh`. The `source` property will vary depending on whether you have any files. If you have files, it should be "files" and if you do not it should be "no_files".

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews