### PR TITLE
Track not now button tap

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingPlusFeaturesPage.kt
@@ -88,7 +88,7 @@ internal fun OnboardingPlusFeaturesPage(
 
     @Suppress("NAME_SHADOWING")
     val onNotNowPressed = {
-        viewModel.onDismiss(flow, source)
+        viewModel.onNotNow(flow, source)
         onNotNowPressed()
     }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingPlusFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingPlusFeaturesViewModel.kt
@@ -43,6 +43,10 @@ class OnboardingPlusFeaturesViewModel @Inject constructor(
         analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_DISMISSED, analyticsProps(flow, source))
     }
 
+    fun onNotNow(flow: OnboardingFlow, source: OnboardingUpgradeSource) {
+        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_NOT_NOW_BUTTON_TAPPED, analyticsProps(flow, source))
+    }
+
     fun onUpgradePressed(flow: OnboardingFlow, source: OnboardingUpgradeSource) {
         analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_UPGRADE_BUTTON_TAPPED, analyticsProps(flow, source))
     }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -23,6 +23,7 @@ enum class AnalyticsEvent(val key: String) {
     PLUS_PROMOTION_SHOWN("plus_promotion_shown"),
     PLUS_PROMOTION_DISMISSED("plus_promotion_dismissed"),
     PLUS_PROMOTION_UPGRADE_BUTTON_TAPPED("plus_promotion_upgrade_button_tapped"),
+    PLUS_PROMOTION_NOT_NOW_BUTTON_TAPPED("plus_promotion_not_now_button_tapped"),
 
     /* Setup Account */
     SETUP_ACCOUNT_SHOWN("setup_account_shown"),


### PR DESCRIPTION
## Description
This changes the event name for the plus upgrade button tap.

## Testing Instructions
1. With a free account, tap on the folder upgrade icon on the Podcasts tab
2. On the Plus upgrade page, tap "Not now"
3. Observe the event `plus_promotion_not_now_button_tapped, Properties: {"flow":"plus_upsell","source":"folders", ... }`

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews

