### PR TITLE
Inline search results - podcasts and episodes

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
@@ -79,7 +79,7 @@ class OnboardingRecommendationsSearchViewModel @Inject constructor(
                         // TODO handle loading
                         // TODO handle error
 
-                        searchState.list
+                        searchState.podcasts
                             .filterIsInstance<FolderItem.Podcast>()
                             .map {
                                 PodcastResult(

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -30,6 +30,7 @@ import java.util.Date
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
+private const val MAX_ITEM_COUNT = 20
 val dummyEpisodeItem = EpisodeItem(
     uuid = "6946de68-7fa7-48b0-9066-a7d6e1be2c07",
     title = "Society's Challenges",
@@ -174,8 +175,20 @@ class SearchHandler @Inject constructor(
                 }
                 SearchState.Results(
                     searchTerm = searchTerm.string,
-                    podcasts = searchPodcastsResult,
-                    episodes = searchEpisodesResult,
+                    podcasts = searchPodcastsResult.take(
+                        if (BuildConfig.SEARCH_IMPROVEMENTS_ENABLED) {
+                            minOf(MAX_ITEM_COUNT, searchPodcastsResult.size)
+                        } else {
+                            searchPodcastsResult.size
+                        }
+                    ),
+                    episodes = searchEpisodesResult.take(
+                        if (BuildConfig.SEARCH_IMPROVEMENTS_ENABLED) {
+                            minOf(MAX_ITEM_COUNT, searchEpisodesResult.size)
+                        } else {
+                            searchEpisodesResult.size
+                        }
+                    ),
                     loading = loading,
                     error = serverSearchResults.error
                 )

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -156,7 +156,7 @@ class SearchHandler @Inject constructor(
 
     private val searchFlowable = Observables.combineLatest(searchQuery, subscribedPodcastUuids, localResults, serverSearchResults, loadingObservable) { searchTerm, subscribedPodcastUuids, localResults, serverSearchResults, loading ->
         if (searchTerm.string.isBlank()) {
-            SearchState.Results(searchTerm = searchTerm.string, list = emptyList(), episodeItems = emptyList(), loading = loading, error = null)
+            SearchState.Results(searchTerm = searchTerm.string, podcasts = emptyList(), episodes = emptyList(), loading = loading, error = null)
         } else {
             // set if the podcast is subscribed so we can show a tick
             val serverResults = serverSearchResults.podcastSearch.searchResults.map { podcast -> FolderItem.Podcast(podcast) }
@@ -173,8 +173,8 @@ class SearchHandler @Inject constructor(
                 }
                 SearchState.Results(
                     searchTerm = searchTerm.string,
-                    list = searchResults,
-                    episodeItems = serverSearchResults.episodeSearch.episodes,
+                    podcasts = searchResults,
+                    episodes = serverSearchResults.episodeSearch.episodes,
                     loading = loading,
                     error = serverSearchResults.error
                 )
@@ -188,8 +188,8 @@ class SearchHandler @Inject constructor(
             analyticsTracker.track(AnalyticsEvent.SEARCH_FAILED, AnalyticsProp.sourceMap(source))
             SearchState.Results(
                 searchTerm = searchQuery.value?.string ?: "",
-                list = emptyList(),
-                episodeItems = emptyList(),
+                podcasts = emptyList(),
+                episodes = emptyList(),
                 loading = false,
                 error = exception
             )

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -6,7 +6,6 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
-import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
@@ -17,7 +16,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.servers.ServerManager
 import au.com.shiftyjelly.pocketcasts.servers.discover.GlobalServerSearch
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
-import au.com.shiftyjelly.pocketcasts.utils.extensions.parseIsoDate
 import com.jakewharton.rxrelay2.BehaviorRelay
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Observable
@@ -26,19 +24,10 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.rxkotlin.Observables
 import io.reactivex.schedulers.Schedulers
 import timber.log.Timber
-import java.util.Date
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 private const val MAX_ITEM_COUNT = 20
-val dummyEpisodeItem = EpisodeItem(
-    uuid = "6946de68-7fa7-48b0-9066-a7d6e1be2c07",
-    title = "Society's Challenges",
-    duration = 4004.0,
-    publishedAt = "2022-10-28T03:00:00Z".parseIsoDate() ?: Date(),
-    podcastUuid = "e7a6f7d0-02f2-0133-1c51-059c869cc4eb",
-    podcastTitle = "Material"
-)
 class SearchHandler @Inject constructor(
     val serverManager: ServerManager,
     val podcastManager: PodcastManager,

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
@@ -66,8 +66,8 @@ fun SearchResultsPage(
     val state = viewModel.searchResults.collectAsState(
         SearchState.Results(
             searchTerm = "",
-            list = emptyList(),
-            episodeItems = emptyList(),
+            podcasts = emptyList(),
+            episodes = emptyList(),
             error = null,
             loading = false
         )
@@ -80,7 +80,7 @@ fun SearchResultsPage(
                 val result = state.value as SearchState.Results
                 if (result.error == null || !onlySearchRemote || result.loading) {
                     if (BuildConfig.SEARCH_IMPROVEMENTS_ENABLED) {
-                        if (result.list.isNotEmpty()) {
+                        if (result.podcasts.isNotEmpty()) {
                             SearchResultsView(
                                 state = state.value as SearchState.Results,
                                 onPodcastClick = onPodcastClick,
@@ -141,7 +141,7 @@ private fun SearchResultsView(
         item {
             LazyRow(contentPadding = PaddingValues(horizontal = 8.dp),) {
                 items(
-                    items = state.list,
+                    items = state.podcasts,
                     key = { it.adapterId }
                 ) { folderItem ->
                     when (folderItem) {
@@ -164,7 +164,7 @@ private fun SearchResultsView(
             }
         }
         item { SearchResultsHeaderView(title = stringResource(LR.string.episodes)) }
-        state.episodeItems.forEach {
+        state.episodes.forEach {
             item {
                 SearchEpisodeItem(
                     episode = it,
@@ -224,7 +224,7 @@ private fun OldSearchResultsView(
             .nestedScroll(nestedScrollConnection)
     ) {
         items(
-            items = state.list,
+            items = state.podcasts,
             key = { it.adapterId }
         ) { folderItem ->
             when (folderItem) {
@@ -310,7 +310,7 @@ fun SearchResultsViewPreview(
     AppThemeWithBackground(themeType) {
         SearchResultsView(
             state = SearchState.Results(
-                list = listOf(
+                podcasts = listOf(
                     FolderItem.Folder(
                         folder = Folder(
                             uuid = UUID.randomUUID().toString(),
@@ -328,7 +328,7 @@ fun SearchResultsViewPreview(
                         podcast = Podcast(uuid = UUID.randomUUID().toString(), title = "Podcast", author = "Author")
                     )
                 ),
-                episodeItems = listOf(dummyEpisodeItem),
+                episodes = listOf(dummyEpisodeItem),
                 error = null,
                 loading = false,
                 searchTerm = ""
@@ -348,7 +348,7 @@ fun OldSearchResultsViewPreview(
     AppThemeWithBackground(themeType) {
         OldSearchResultsView(
             state = SearchState.Results(
-                list = listOf(
+                podcasts = listOf(
                     FolderItem.Folder(
                         folder = Folder(
                             uuid = UUID.randomUUID().toString(),
@@ -366,7 +366,7 @@ fun OldSearchResultsViewPreview(
                         podcast = Podcast(uuid = UUID.randomUUID().toString(), title = "Podcast", author = "Author")
                     )
                 ),
-                episodeItems = emptyList(),
+                episodes = emptyList(),
                 error = null,
                 loading = false,
                 searchTerm = ""

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
@@ -45,6 +45,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.search.component.SearchEpisodeItem
+import au.com.shiftyjelly.pocketcasts.search.component.SearchFolderItem
 import au.com.shiftyjelly.pocketcasts.search.component.SearchFolderRow
 import au.com.shiftyjelly.pocketcasts.search.component.SearchPodcastItem
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -116,7 +117,6 @@ fun SearchResultsPage(
     }
 }
 
-@Suppress("UNUSED_PARAMETER")
 @Composable
 private fun SearchResultsView(
     state: SearchState.Results,
@@ -146,6 +146,11 @@ private fun SearchResultsView(
                 ) { folderItem ->
                     when (folderItem) {
                         is FolderItem.Folder -> {
+                            SearchFolderItem(
+                                folder = folderItem.folder,
+                                podcasts = folderItem.podcasts,
+                                onClick = { onFolderClick(folderItem.folder, folderItem.podcasts) }
+                            )
                         }
 
                         is FolderItem.Podcast -> {

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -43,6 +44,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
+import au.com.shiftyjelly.pocketcasts.search.component.SearchEpisodeItem
 import au.com.shiftyjelly.pocketcasts.search.component.SearchFolderRow
 import au.com.shiftyjelly.pocketcasts.search.component.SearchPodcastItem
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -64,6 +66,7 @@ fun SearchResultsPage(
         SearchState.Results(
             searchTerm = "",
             list = emptyList(),
+            episodeItems = emptyList(),
             error = null,
             loading = false
         )
@@ -136,7 +139,7 @@ private fun SearchResultsView(
     ) {
         item { SearchResultsHeaderView(title = stringResource(LR.string.podcasts)) }
         item {
-            LazyRow {
+            LazyRow(contentPadding = PaddingValues(horizontal = 8.dp),) {
                 items(
                     items = state.list,
                     key = { it.adapterId }
@@ -156,6 +159,14 @@ private fun SearchResultsView(
             }
         }
         item { SearchResultsHeaderView(title = stringResource(LR.string.episodes)) }
+        state.episodeItems.forEach {
+            item {
+                SearchEpisodeItem(
+                    episode = it,
+                    onClick = {},
+                )
+            }
+        }
     }
 }
 
@@ -312,6 +323,7 @@ fun SearchResultsViewPreview(
                         podcast = Podcast(uuid = UUID.randomUUID().toString(), title = "Podcast", author = "Author")
                     )
                 ),
+                episodeItems = listOf(dummyEpisodeItem),
                 error = null,
                 loading = false,
                 searchTerm = ""
@@ -349,6 +361,7 @@ fun OldSearchResultsViewPreview(
                         podcast = Podcast(uuid = UUID.randomUUID().toString(), title = "Podcast", author = "Author")
                     )
                 ),
+                episodeItems = emptyList(),
                 error = null,
                 loading = false,
                 searchTerm = ""

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.asFlow
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastItem
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
@@ -164,6 +165,11 @@ private fun SearchResultsView(
                     }
                 }
             }
+            HorizontalDivider(
+                startIndent = 16.dp,
+                modifier = modifier.padding(top = 20.dp, bottom = 4.dp)
+
+            )
         }
         item { SearchResultsHeaderView(title = stringResource(LR.string.episodes)) }
         state.episodes.forEach {

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
@@ -142,7 +142,7 @@ private fun SearchResultsView(
     ) {
         item { SearchResultsHeaderView(title = stringResource(LR.string.podcasts)) }
         item {
-            LazyRow(contentPadding = PaddingValues(horizontal = 8.dp),) {
+            LazyRow(contentPadding = PaddingValues(horizontal = 8.dp)) {
                 items(
                     items = state.podcasts,
                     key = { it.adapterId }
@@ -172,13 +172,14 @@ private fun SearchResultsView(
             )
         }
         item { SearchResultsHeaderView(title = stringResource(LR.string.episodes)) }
-        state.episodes.forEach {
-            item {
-                SearchEpisodeItem(
-                    episode = it,
-                    onClick = {},
-                )
-            }
+        items(
+            items = state.episodes,
+            key = { it.uuid }
+        ) {
+            SearchEpisodeItem(
+                episode = it,
+                onClick = {},
+            )
         }
     }
 }
@@ -191,7 +192,7 @@ private fun SearchResultsHeaderView(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(start = 16.dp, top = 8.dp, end = 4.dp,),
+            .padding(start = 16.dp, top = 8.dp, end = 4.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         TextH20(
@@ -282,7 +283,7 @@ private fun MessageView(
     @DrawableRes imageResId: Int,
     @StringRes titleResId: Int,
     @StringRes summaryResId: Int,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
@@ -333,7 +334,11 @@ fun SearchResultsViewPreview(
                         podcasts = listOf(Podcast(uuid = UUID.randomUUID().toString()))
                     ),
                     FolderItem.Podcast(
-                        podcast = Podcast(uuid = UUID.randomUUID().toString(), title = "Podcast", author = "Author")
+                        podcast = Podcast(
+                            uuid = UUID.randomUUID().toString(),
+                            title = "Podcast",
+                            author = "Author"
+                        )
                     )
                 ),
                 episodes = listOf(
@@ -380,7 +385,11 @@ fun OldSearchResultsViewPreview(
                         podcasts = listOf(Podcast(uuid = UUID.randomUUID().toString()))
                     ),
                     FolderItem.Podcast(
-                        podcast = Podcast(uuid = UUID.randomUUID().toString(), title = "Podcast", author = "Author")
+                        podcast = Podcast(
+                            uuid = UUID.randomUUID().toString(),
+                            title = "Podcast",
+                            author = "Author"
+                        )
                     )
                 ),
                 episodes = emptyList(),

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
@@ -42,6 +42,7 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.search.component.SearchEpisodeItem
@@ -49,6 +50,7 @@ import au.com.shiftyjelly.pocketcasts.search.component.SearchFolderItem
 import au.com.shiftyjelly.pocketcasts.search.component.SearchFolderRow
 import au.com.shiftyjelly.pocketcasts.search.component.SearchPodcastItem
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.extensions.parseIsoDate
 import java.util.Date
 import java.util.UUID
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -328,7 +330,16 @@ fun SearchResultsViewPreview(
                         podcast = Podcast(uuid = UUID.randomUUID().toString(), title = "Podcast", author = "Author")
                     )
                 ),
-                episodes = listOf(dummyEpisodeItem),
+                episodes = listOf(
+                    EpisodeItem(
+                        uuid = "6946de68-7fa7-48b0-9066-a7d6e1be2c07",
+                        title = "Society's Challenges",
+                        duration = 4004.0,
+                        publishedAt = "2022-10-28T03:00:00Z".parseIsoDate() ?: Date(),
+                        podcastUuid = "e7a6f7d0-02f2-0133-1c51-059c869cc4eb",
+                        podcastTitle = "Material"
+                    )
+                ),
                 error = null,
                 loading = false,
                 searchTerm = ""

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
@@ -99,6 +100,7 @@ sealed class SearchState {
     data class Results(
         override val searchTerm: String,
         val list: List<FolderItem>,
+        val episodeItems: List<EpisodeItem>,
         val loading: Boolean,
         val error: Throwable?,
     ) : SearchState()

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -99,8 +99,8 @@ sealed class SearchState {
     data class NoResults(override val searchTerm: String) : SearchState()
     data class Results(
         override val searchTerm: String,
-        val list: List<FolderItem>,
-        val episodeItems: List<EpisodeItem>,
+        val podcasts: List<FolderItem>,
+        val episodes: List<EpisodeItem>,
         val loading: Boolean,
         val error: Throwable?,
     ) : SearchState()

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchEpisodeRow.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchEpisodeRow.kt
@@ -1,0 +1,72 @@
+package au.com.shiftyjelly.pocketcasts.search.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.TextC50
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH60
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
+import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
+import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
+
+private val IconSize = 56.dp
+
+@Composable
+fun SearchEpisodeItem(
+    episode: EpisodeItem,
+    onClick: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val durationMs = episode.duration * 1000
+    val dateFormatter = RelativeDateFormatter(context)
+    Column {
+        Row(
+            verticalAlignment = Alignment.Top,
+            modifier = modifier
+                .fillMaxWidth()
+                .then(if (onClick == null) Modifier else Modifier.clickable { onClick() })
+                .padding(16.dp)
+        ) {
+            PodcastImage(
+                uuid = episode.podcastUuid,
+                modifier = modifier
+                    .size(IconSize)
+                    .padding(top = 4.dp, end = 12.dp, bottom = 4.dp)
+            )
+            Column(
+                modifier = modifier
+                    .padding(end = 16.dp)
+                    .weight(1f)
+            ) {
+                TextC50(
+                    text = dateFormatter.format(episode.publishedAt),
+                    maxLines = 1,
+                )
+                TextH40(
+                    text = episode.title,
+                    maxLines = 2,
+                )
+                TextH60(
+                    text = TimeHelper.getTimeDurationMediumString(durationMs.toInt(), context),
+                    maxLines = 1,
+                    color = MaterialTheme.theme.colors.primaryText02
+                )
+            }
+        }
+        HorizontalDivider(startIndent = 16.dp)
+    }
+}

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchFolderItem.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchFolderItem.kt
@@ -1,0 +1,108 @@
+package au.com.shiftyjelly.pocketcasts.search.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
+import au.com.shiftyjelly.pocketcasts.compose.folder.FolderImageSmall
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.images.R
+import au.com.shiftyjelly.pocketcasts.models.entity.Folder
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+private val FolderImageSize = 156.dp
+private val PodcastImageSize = 68.dp
+private val SubscribeIconSize = 32.dp
+
+@Composable
+fun SearchFolderItem(
+    folder: Folder,
+    podcasts: List<Podcast>,
+    onClick: (() -> Unit)?,
+    modifier: Modifier = Modifier
+) {
+    val color = MaterialTheme.theme.colors.getFolderColor(folder.color)
+    Column(
+        modifier = modifier
+            .width(FolderImageSize + 16.dp)
+            .then(if (onClick == null) Modifier else Modifier.clickable { onClick() })
+            .padding(8.dp)
+    ) {
+        BoxWithConstraints(
+            modifier = modifier.aspectRatio(1f),
+            contentAlignment = Alignment.Center
+        ) {
+            FolderImageSmall(
+                color = color,
+                podcastUuids = podcasts.map { it.uuid },
+                folderImageSize = FolderImageSize,
+                podcastImageSize = PodcastImageSize
+            )
+
+            val buttonBackgroundColor = Color.Black.copy(alpha = 0.4f)
+            Box(
+                contentAlignment = Alignment.BottomEnd,
+                modifier = Modifier.fillMaxSize().padding(8.dp)
+            ) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .size(SubscribeIconSize)
+                        .clip(CircleShape)
+                        .background(buttonBackgroundColor)
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_tick),
+                        contentDescription = stringResource(LR.string.podcast_subscribed),
+                        tint = Color.White,
+                        modifier = Modifier.size(SubscribeIconSize / 1.25f)
+                    )
+                }
+            }
+        }
+
+        Column(
+            modifier = modifier
+                .padding(top = 10.dp)
+        ) {
+            TextH40(
+                text = folder.name,
+                maxLines = 1,
+            )
+            val podcastCount = if (podcasts.size == 1) {
+                stringResource(LR.string.podcasts_singular)
+            } else {
+                stringResource(
+                    LR.string.podcasts_plural,
+                    podcasts.size
+                )
+            }
+            TextH50(
+                text = podcastCount,
+                maxLines = 1,
+                color = MaterialTheme.theme.colors.primaryText02,
+                modifier = Modifier.padding(top = 2.dp)
+            )
+        }
+    }
+}

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchPodcastItem.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchPodcastItem.kt
@@ -1,0 +1,57 @@
+package au.com.shiftyjelly.pocketcasts.search.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
+import au.com.shiftyjelly.pocketcasts.compose.podcast.PodcastSubscribeImage
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+
+private val PodcastItemIconSize = 156.dp
+
+@Composable
+fun SearchPodcastItem(
+    podcast: Podcast,
+    onClick: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .semantics(mergeDescendants = true) {}
+            .width(PodcastItemIconSize + 16.dp)
+            .then(if (onClick == null) Modifier else Modifier.clickable { onClick() })
+            .padding(8.dp)
+    ) {
+        PodcastSubscribeImage(
+            podcastUuid = podcast.uuid,
+            podcastTitle = "",
+            podcastSubscribed = podcast.isSubscribed,
+            onSubscribeClick = { /*TODO*/ },
+            subscribeButtonSize = 32.dp,
+            shadowSize = 0.dp,
+            subscribeOnPodcastTap = false
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        TextH40(
+            text = podcast.title,
+            maxLines = 1,
+        )
+        TextH50(
+            text = podcast.author,
+            maxLines = 1,
+            color = MaterialTheme.theme.colors.primaryText02
+        )
+    }
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
@@ -306,6 +306,26 @@ fun TextH70(
 }
 
 @Composable
+fun TextC50(
+    text: String,
+    modifier: Modifier = Modifier,
+    maxLines: Int = Int.MAX_VALUE
+) {
+    Text(
+        text = text.uppercase(Locale.getDefault()),
+        color = MaterialTheme.theme.colors.primaryText02,
+        fontFamily = FontFamily.SansSerif,
+        fontSize = 13.sp,
+        fontWeight = FontWeight.Bold,
+        lineHeight = 19.sp,
+        letterSpacing = 0.6.sp,
+        maxLines = maxLines,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier
+    )
+}
+
+@Composable
 fun TextC70(
     text: String,
     modifier: Modifier = Modifier,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
@@ -316,7 +316,7 @@ fun TextC50(
         color = MaterialTheme.theme.colors.primaryText02,
         fontFamily = FontFamily.SansSerif,
         fontSize = 13.sp,
-        fontWeight = FontWeight.Bold,
+        fontWeight = FontWeight.W700,
         lineHeight = 19.sp,
         letterSpacing = 0.6.sp,
         maxLines = maxLines,
@@ -373,6 +373,7 @@ private fun TextStylesPreview() {
         TextP50("P50")
         TextP60("P60")
         TextH70("H70")
+        TextC50("C50")
         TextC70("C70")
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/PodcastSubscribeImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/PodcastSubscribeImage.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
@@ -35,20 +36,28 @@ fun PodcastSubscribeImage(
     podcastTitle: String,
     podcastSubscribed: Boolean,
     onSubscribeClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    subscribeButtonSize: Dp = 20.dp,
+    shadowSize: Dp = 1.dp,
+    subscribeOnPodcastTap: Boolean = true,
 ) {
-    BoxWithConstraints(
-        modifier = modifier
-            .aspectRatio(1f)
+    val onClickLabel = if (podcastSubscribed) {
+        stringResource(LR.string.unsubscribe)
+    } else {
+        stringResource(LR.string.subscribe)
+    }
+    var rootModifier = modifier
+        .aspectRatio(1f)
+        .semantics(mergeDescendants = true) {}
+    if (subscribeOnPodcastTap) {
+        rootModifier = rootModifier
             .clickable(
-                onClickLabel = if (podcastSubscribed) {
-                    stringResource(LR.string.unsubscribe)
-                } else {
-                    stringResource(LR.string.subscribe)
-                },
+                onClickLabel = onClickLabel,
                 onClick = onSubscribeClick
             )
-            .semantics(mergeDescendants = true) {},
+    }
+    BoxWithConstraints(
+        modifier = rootModifier,
         contentAlignment = Alignment.Center
     ) {
         PodcastImage(
@@ -59,16 +68,27 @@ fun PodcastSubscribeImage(
         )
 
         val buttonBackgroundColor = Color.Black.copy(alpha = 0.4f)
+
+        val iconSize = subscribeButtonSize / 1.25f
+        var iconModifier = Modifier.size(iconSize)
+        if (!subscribeOnPodcastTap) {
+            iconModifier = iconModifier.clickable(
+                onClickLabel = onClickLabel,
+                onClick = onSubscribeClick
+            )
+        }
         Box(
             contentAlignment = Alignment.BottomEnd,
-            modifier = Modifier.fillMaxSize().padding(8.dp)
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(8.dp)
         ) {
             if (podcastSubscribed) {
                 Box(
                     contentAlignment = Alignment.Center,
                     modifier = Modifier
-                        .shadow(2.dp, shape = CircleShape)
-                        .size(20.dp)
+                        .shadow(shadowSize, shape = CircleShape)
+                        .size(subscribeButtonSize)
                         .clip(CircleShape)
                         .background(buttonBackgroundColor)
                 ) {
@@ -76,15 +96,15 @@ fun PodcastSubscribeImage(
                         painter = painterResource(IR.drawable.ic_tick),
                         contentDescription = stringResource(LR.string.podcast_subscribed),
                         tint = Color.White,
-                        modifier = Modifier.size(16.dp)
+                        modifier = iconModifier
                     )
                 }
             } else {
                 Box(
                     contentAlignment = Alignment.Center,
                     modifier = Modifier
-                        .shadow(1.dp, shape = CircleShape)
-                        .size(20.dp)
+                        .shadow(shadowSize, shape = CircleShape)
+                        .size(subscribeButtonSize)
                         .clip(CircleShape)
                         .background(buttonBackgroundColor)
                 ) {
@@ -92,7 +112,7 @@ fun PodcastSubscribeImage(
                         painter = painterResource(IR.drawable.ic_add_black_24dp),
                         contentDescription = stringResource(LR.string.podcast_not_subscribed),
                         tint = Color.White,
-                        modifier = Modifier.size(16.dp)
+                        modifier = iconModifier
                     )
                 }
             }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/EpisodeItem.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/EpisodeItem.kt
@@ -1,0 +1,12 @@
+package au.com.shiftyjelly.pocketcasts.models.to
+
+import java.util.Date
+
+data class EpisodeItem(
+    val uuid: String,
+    val title: String,
+    val duration: Double,
+    val publishedAt: Date,
+    val podcastUuid: String,
+    val podcastTitle: String,
+)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/discover/EpisodeSearch.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/discover/EpisodeSearch.kt
@@ -1,0 +1,8 @@
+package au.com.shiftyjelly.pocketcasts.servers.discover
+
+import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
+import java.io.Serializable
+
+data class EpisodeSearch(
+    val episodes: List<EpisodeItem> = emptyList(),
+) : Serializable

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/discover/GlobalServerSearch.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/discover/GlobalServerSearch.kt
@@ -1,0 +1,10 @@
+package au.com.shiftyjelly.pocketcasts.servers.discover
+
+import java.io.Serializable
+
+data class GlobalServerSearch(
+    val searchTerm: String = "",
+    val error: Throwable? = null,
+    val podcastSearch: PodcastSearch = PodcastSearch(),
+    val episodeSearch: EpisodeSearch = EpisodeSearch(),
+) : Serializable

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/discover/PodcastSearch.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/discover/PodcastSearch.kt
@@ -1,10 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.servers.discover
 
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
 import java.io.Serializable
 
 data class PodcastSearch(
     var searchResults: MutableList<Podcast> = mutableListOf(),
+    var searchEpisodesResults: MutableList<EpisodeItem> = mutableListOf(),
     var searchTerm: String = "",
     var isUrl: Boolean = false,
     val error: Throwable? = null

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServer.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.servers.podcast
 
+import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import io.reactivex.Single
@@ -8,6 +9,7 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
+import java.util.Date
 
 @JsonClass(generateAdapter = true)
 data class SearchBody(@field:Json(name = "podcastuuid") val podcastuuid: String, @field:Json(name = "searchterm") val searchterm: String)
@@ -17,6 +19,33 @@ data class SearchResultBody(@field:Json(name = "episodes") val episodes: List<Se
 
 @JsonClass(generateAdapter = true)
 data class SearchResult(@field:Json(name = "uuid") val uuid: String)
+
+@JsonClass(generateAdapter = true)
+data class SearchEpisodesBody(@field:Json(name = "term") val term: String)
+
+@JsonClass(generateAdapter = true)
+data class SearchEpisodesResultBody(@field:Json(name = "episodes") val episodes: List<SearchEpisodeResult>)
+
+@JsonClass(generateAdapter = true)
+data class SearchEpisodeResult(
+    @field:Json(name = "uuid") val uuid: String,
+    @field:Json(name = "title") val title: String?,
+    @field:Json(name = "duration") val duration: Double?,
+    @field:Json(name = "published_date") val publishedAt: Date?,
+    @field:Json(name = "podcast_uuid") val podcastUuid: String,
+    @field:Json(name = "podcast_title") val podcastTitle: String?,
+) {
+    fun toEpisodeItem(): EpisodeItem {
+        return EpisodeItem(
+            uuid = uuid,
+            title = title ?: "",
+            duration = duration ?: 0.0,
+            publishedAt = publishedAt ?: Date(),
+            podcastUuid = podcastUuid,
+            podcastTitle = podcastTitle ?: ""
+        )
+    }
+}
 
 interface PodcastCacheServer {
     @GET("/mobile/podcast/full/{podcastUuid}/{pageNumber}/{sortOption}/{episodeLimit}")
@@ -30,4 +59,7 @@ interface PodcastCacheServer {
 
     @POST("/mobile/podcast/episode/search")
     fun searchPodcastForEpisodes(@Body searchBody: SearchBody): Single<SearchResultBody>
+
+    @POST("/episode/search")
+    fun searchEpisodes(@Body body: SearchEpisodesBody): Single<SearchEpisodesResultBody>
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManager.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.servers.podcast
 
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.servers.discover.EpisodeSearch
 import io.reactivex.Single
 import retrofit2.Response
 
@@ -8,5 +9,6 @@ interface PodcastCacheServerManager {
     fun getPodcast(podcastUuid: String, pageNumber: Int = 0, sortOption: Int = 3, episodeLimit: Int = 0): Single<Podcast>
     fun getPodcastAndEpisode(podcastUuid: String, episodeUuid: String): Single<Podcast>
     fun searchEpisodes(podcastUuid: String, searchTerm: String): Single<List<String>>
+    fun searchEpisodes(searchTerm: String): Single<EpisodeSearch>
     fun getPodcastResponse(podcastUuid: String, pageNumber: Int = 0, sortOption: Int = 3, episodeLimit: Int = 0): Single<Response<PodcastResponse>>
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.servers.podcast
 
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.servers.di.PodcastCacheServerRetrofit
+import au.com.shiftyjelly.pocketcasts.servers.discover.EpisodeSearch
 import io.reactivex.Single
 import retrofit2.Response
 import retrofit2.Retrofit
@@ -26,5 +27,11 @@ class PodcastCacheServerManagerImpl @Inject constructor(@PodcastCacheServerRetro
 
     override fun searchEpisodes(podcastUuid: String, searchTerm: String): Single<List<String>> {
         return server.searchPodcastForEpisodes(SearchBody(podcastUuid, searchTerm)).map { it.episodes.map { it.uuid } }
+    }
+
+    override fun searchEpisodes(searchTerm: String): Single<EpisodeSearch> {
+        return server.searchEpisodes(SearchEpisodesBody(searchTerm)).map {
+            EpisodeSearch(it.episodes.map { result -> result.toEpisodeItem() })
+        }
     }
 }


### PR DESCRIPTION
Part of: #787

## Description

This PR 
- Adds podcasts and episodes layout to the new search view
- Adds episodes from the search episodes endpoint

## Testing Instructions

#### Feature flag - On

1. Enable search improvements feature flag in `base.gradle`
2. Select `debug` build variant
3. Go to `Podcasts` tab
4. Search a term
5. ✅ Notice that the first 20 podcasts search results are shown under `Podcasts` heading
    * Subscribed podcasts and folders are shown under the Podcasts section (pdeCcb-Xe-p2#comment-1431)
6. ✅ Notice that the first 20 (server) episodes search results are shown under `Episodes` heading
7. Go to `Discover` tab
8. ✅ Notice that only server results are shown for both podcasts and episodes 

#### Feature flag - Off

1. Disable search improvements feature flag in `base.gradle`
2. ✅ Notice that old search works as expected

Note that
* Local episodes not added
* Following actions are not working
   * subscribe 
   * show all 
   * episode click
* Search failed/ No results found views are not updated 
* I'll create a separate PR for a final design review.

## Screenshots or Screencast 

<img width=320 src="https://user-images.githubusercontent.com/1405144/220366699-8d42ae2c-11ef-4d9d-82c3-dabaadcf2c42.png"/>


## Checklist
-  If this is a user-facing change, I have added an entry in CHANGELOG.md
- I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack