### PR TITLE
Inline search results - Call to actions

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -963,11 +963,15 @@ class MainActivity :
         return true
     }
 
-    override fun onSearchEpisodeClick(episode: Episode, source: EpisodeViewSource) {
+    override fun onSearchEpisodeClick(
+        episodeUuid: String,
+        podcastUuid: String,
+        source: EpisodeViewSource
+    ) {
         openEpisodeDialog(
-            episodeUuid = episode.uuid,
+            episodeUuid = episodeUuid,
             source = source,
-            podcastUuid = episode.podcastUuid,
+            podcastUuid = podcastUuid,
             forceDark = false
         )
     }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -963,6 +963,15 @@ class MainActivity :
         return true
     }
 
+    override fun onSearchEpisodeClick(episode: Episode, source: EpisodeViewSource) {
+        openEpisodeDialog(
+            episodeUuid = episode.uuid,
+            source = source,
+            podcastUuid = episode.podcastUuid,
+            forceDark = false
+        )
+    }
+
     override fun onSearchPodcastClick(podcastUuid: String) {
         val fragment = PodcastFragment.newInstance(podcastUuid)
         addFragment(fragment)

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -245,6 +245,11 @@ class SearchFragment : BaseFragment() {
     }
 
     private fun onEpisodeClick(episodeItem: EpisodeItem) {
+        viewModel.trackSearchResultTapped(
+            source = source,
+            uuid = episodeItem.uuid,
+            type = SearchResultType.EPISODE,
+        )
         val episode = episodeItem.toEpisode()
         searchHistoryViewModel.add(SearchHistoryEntry.fromEpisode(episode, episodeItem.podcastTitle))
         listener?.onSearchEpisodeClick(

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -17,7 +17,6 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
-import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
@@ -49,7 +48,7 @@ class SearchFragment : BaseFragment() {
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     interface Listener {
-        fun onSearchEpisodeClick(episode: Episode, source: EpisodeViewSource)
+        fun onSearchEpisodeClick(episodeUuid: String, podcastUuid: String, source: EpisodeViewSource)
         fun onSearchPodcastClick(podcastUuid: String)
         fun onSearchFolderClick(folderUuid: String)
     }
@@ -122,7 +121,11 @@ class SearchFragment : BaseFragment() {
     private fun navigateFromSearchHistoryEntry(entry: SearchHistoryEntry) {
         searchHistoryViewModel.trackEventForEntry(AnalyticsEvent.SEARCH_HISTORY_ITEM_TAPPED, entry)
         when (entry) {
-            is SearchHistoryEntry.Episode -> Unit // TODO
+            is SearchHistoryEntry.Episode -> listener?.onSearchEpisodeClick(
+                episodeUuid = entry.uuid,
+                podcastUuid = entry.podcastUuid,
+                source = EpisodeViewSource.SEARCH_HISTORY
+            )
             is SearchHistoryEntry.Folder -> listener?.onSearchFolderClick(entry.uuid)
             is SearchHistoryEntry.Podcast -> listener?.onSearchPodcastClick(entry.uuid)
             is SearchHistoryEntry.SearchTerm -> {
@@ -244,7 +247,11 @@ class SearchFragment : BaseFragment() {
     private fun onEpisodeClick(episodeItem: EpisodeItem) {
         val episode = episodeItem.toEpisode()
         searchHistoryViewModel.add(SearchHistoryEntry.fromEpisode(episode, episodeItem.podcastTitle))
-        listener?.onSearchEpisodeClick(episode, EpisodeViewSource.SEARCH)
+        listener?.onSearchEpisodeClick(
+            episodeUuid = episode.uuid,
+            podcastUuid = episode.podcastUuid,
+            source = EpisodeViewSource.SEARCH
+        )
         binding?.searchView?.let { UiUtil.hideKeyboard(it) }
     }
 

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -17,9 +17,12 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
 import au.com.shiftyjelly.pocketcasts.search.SearchViewModel.SearchResultType
 import au.com.shiftyjelly.pocketcasts.search.databinding.FragmentSearchBinding
 import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryClearAllConfirmationDialog
@@ -46,6 +49,7 @@ class SearchFragment : BaseFragment() {
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     interface Listener {
+        fun onSearchEpisodeClick(episode: Episode, source: EpisodeViewSource)
         fun onSearchPodcastClick(podcastUuid: String)
         fun onSearchFolderClick(folderUuid: String)
     }
@@ -222,6 +226,7 @@ class SearchFragment : BaseFragment() {
                 AppThemeWithBackground(theme.activeTheme) {
                     SearchResultsPage(
                         viewModel = viewModel,
+                        onEpisodeClick = ::onEpisodeClick,
                         onPodcastClick = { podcast ->
                             onPodcastClick(podcast)
                         },
@@ -234,6 +239,13 @@ class SearchFragment : BaseFragment() {
                 }
             }
         }
+    }
+
+    private fun onEpisodeClick(episodeItem: EpisodeItem) {
+        val episode = episodeItem.toEpisode()
+        searchHistoryViewModel.add(SearchHistoryEntry.fromEpisode(episode, episodeItem.podcastTitle))
+        listener?.onSearchEpisodeClick(episode, EpisodeViewSource.SEARCH)
+        binding?.searchView?.let { UiUtil.hideKeyboard(it) }
     }
 
     private fun onPodcastClick(podcast: Podcast) {

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
@@ -61,6 +61,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 fun SearchResultsPage(
     viewModel: SearchViewModel,
+    onEpisodeClick: (EpisodeItem) -> Unit,
     onPodcastClick: (Podcast) -> Unit,
     onFolderClick: (Folder, List<Podcast>) -> Unit,
     onScroll: () -> Unit,
@@ -78,6 +79,7 @@ fun SearchResultsPage(
                     if (BuildConfig.SEARCH_IMPROVEMENTS_ENABLED) {
                         SearchResultsView(
                             state = state as SearchState.Results,
+                            onEpisodeClick = onEpisodeClick,
                             onPodcastClick = onPodcastClick,
                             onFolderClick = onFolderClick,
                             onSubscribeToPodcast = { viewModel.onSubscribeToPodcast(it) },
@@ -115,6 +117,7 @@ fun SearchResultsPage(
 @Composable
 private fun SearchResultsView(
     state: SearchState.Results,
+    onEpisodeClick: (EpisodeItem) -> Unit,
     onPodcastClick: (Podcast) -> Unit,
     onFolderClick: (Folder, List<Podcast>) -> Unit,
     onSubscribeToPodcast: (Podcast) -> Unit,
@@ -177,7 +180,7 @@ private fun SearchResultsView(
         ) {
             SearchEpisodeItem(
                 episode = it,
-                onClick = {},
+                onClick = onEpisodeClick,
             )
         }
     }
@@ -354,6 +357,7 @@ fun SearchResultsViewPreview(
                 loading = false,
                 searchTerm = ""
             ),
+            onEpisodeClick = {},
             onPodcastClick = {},
             onFolderClick = { _, _ -> },
             onSubscribeToPodcast = {},

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -66,32 +67,25 @@ fun SearchResultsPage(
     onlySearchRemote: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val state = viewModel.searchResults.collectAsState(
-        SearchState.Results(
-            searchTerm = "",
-            podcasts = emptyList(),
-            episodes = emptyList(),
-            error = null,
-            loading = false
-        )
-    )
+    val state by viewModel.state.collectAsState()
     val loading = viewModel.loading.asFlow().collectAsState(false)
     Column {
-        when (state.value) {
+        when (state) {
             is SearchState.NoResults -> NoResultsView()
             is SearchState.Results -> {
-                val result = state.value as SearchState.Results
+                val result = state as SearchState.Results
                 if (result.error == null || !onlySearchRemote || result.loading) {
                     if (BuildConfig.SEARCH_IMPROVEMENTS_ENABLED) {
                         SearchResultsView(
-                            state = state.value as SearchState.Results,
+                            state = state as SearchState.Results,
                             onPodcastClick = onPodcastClick,
                             onFolderClick = onFolderClick,
+                            onSubscribeToPodcast = { viewModel.onSubscribeToPodcast(it) },
                             onScroll = onScroll,
                         )
                     } else {
                         OldSearchResultsView(
-                            state = state.value as SearchState.Results,
+                            state = state as SearchState.Results,
                             onPodcastClick = onPodcastClick,
                             onFolderClick = onFolderClick,
                             onScroll = onScroll,
@@ -123,6 +117,7 @@ private fun SearchResultsView(
     state: SearchState.Results,
     onPodcastClick: (Podcast) -> Unit,
     onFolderClick: (Folder, List<Podcast>) -> Unit,
+    onSubscribeToPodcast: (Podcast) -> Unit,
     onScroll: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -160,6 +155,7 @@ private fun SearchResultsView(
                             SearchPodcastItem(
                                 podcast = folderItem.podcast,
                                 onClick = { onPodcastClick(folderItem.podcast) },
+                                onSubscribeClick = onSubscribeToPodcast
                             )
                         }
                     }
@@ -360,6 +356,7 @@ fun SearchResultsViewPreview(
             ),
             onPodcastClick = {},
             onFolderClick = { _, _ -> },
+            onSubscribeToPodcast = {},
             onScroll = {},
         )
     }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
@@ -83,14 +83,12 @@ fun SearchResultsPage(
                 val result = state.value as SearchState.Results
                 if (result.error == null || !onlySearchRemote || result.loading) {
                     if (BuildConfig.SEARCH_IMPROVEMENTS_ENABLED) {
-                        if (result.podcasts.isNotEmpty()) {
-                            SearchResultsView(
-                                state = state.value as SearchState.Results,
-                                onPodcastClick = onPodcastClick,
-                                onFolderClick = onFolderClick,
-                                onScroll = onScroll,
-                            )
-                        }
+                        SearchResultsView(
+                            state = state.value as SearchState.Results,
+                            onPodcastClick = onPodcastClick,
+                            onFolderClick = onFolderClick,
+                            onScroll = onScroll,
+                        )
                     } else {
                         OldSearchResultsView(
                             state = state.value as SearchState.Results,
@@ -140,7 +138,9 @@ private fun SearchResultsView(
         modifier = modifier
             .nestedScroll(nestedScrollConnection)
     ) {
-        item { SearchResultsHeaderView(title = stringResource(LR.string.podcasts)) }
+        if (state.podcasts.isNotEmpty()) {
+            item { SearchResultsHeaderView(title = stringResource(LR.string.podcasts)) }
+        }
         item {
             LazyRow(contentPadding = PaddingValues(horizontal = 8.dp)) {
                 items(
@@ -165,13 +165,16 @@ private fun SearchResultsView(
                     }
                 }
             }
-            HorizontalDivider(
-                startIndent = 16.dp,
-                modifier = modifier.padding(top = 20.dp, bottom = 4.dp)
-
-            )
         }
-        item { SearchResultsHeaderView(title = stringResource(LR.string.episodes)) }
+        if (state.episodes.isNotEmpty()) {
+            item {
+                HorizontalDivider(
+                    startIndent = 16.dp,
+                    modifier = modifier.padding(top = 20.dp, bottom = 4.dp)
+                )
+                SearchResultsHeaderView(title = stringResource(LR.string.episodes))
+            }
+        }
         items(
             items = state.episodes,
             key = { it.uuid }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -41,6 +41,7 @@ class SearchViewModel @Inject constructor(
         searchState
     }
     val loading = searchHandler.loading
+    private var source: AnalyticsSource = AnalyticsSource.UNKNOWN
 
     private val _state: MutableStateFlow<SearchState> = MutableStateFlow(
         SearchState.Results(
@@ -97,6 +98,7 @@ class SearchViewModel @Inject constructor(
     }
 
     fun setSource(source: AnalyticsSource) {
+        this.source = source
         searchHandler.setSource(source)
     }
 
@@ -121,6 +123,10 @@ class SearchViewModel @Inject constructor(
                 }
             }
         )?.let { _state.value = it }
+        analyticsTracker.track(
+            AnalyticsEvent.PODCAST_SUBSCRIBED,
+            AnalyticsProp.podcastSubscribed(uuid = podcast.uuid, source = source)
+        )
     }
 
     fun onFragmentPause(isChangingConfigurations: Boolean?) {
@@ -152,6 +158,7 @@ class SearchViewModel @Inject constructor(
         PODCAST_LOCAL_RESULT("podcast_local_result"),
         PODCAST_REMOTE_RESULT("podcast_remote_result"),
         FOLDER("folder"),
+        EPISODE("episode"),
     }
 
     private object AnalyticsProp {
@@ -163,6 +170,9 @@ class SearchViewModel @Inject constructor(
 
         fun searchShownOrDismissed(source: AnalyticsSource) =
             mapOf(SOURCE to source.analyticsValue)
+
+        fun podcastSubscribed(source: AnalyticsSource, uuid: String) =
+            mapOf(SOURCE to "${source.analyticsValue}_search", UUID to uuid)
     }
 }
 

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchEpisodeRow.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchEpisodeRow.kt
@@ -27,7 +27,7 @@ private val IconSize = 56.dp
 @Composable
 fun SearchEpisodeItem(
     episode: EpisodeItem,
-    onClick: (() -> Unit)?,
+    onClick: (EpisodeItem) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -38,7 +38,7 @@ fun SearchEpisodeItem(
             verticalAlignment = Alignment.Top,
             modifier = modifier
                 .fillMaxWidth()
-                .then(if (onClick == null) Modifier else Modifier.clickable { onClick() })
+                .clickable { onClick(episode) }
                 .padding(16.dp)
         ) {
             PodcastImage(

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchPodcastItem.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchPodcastItem.kt
@@ -23,6 +23,7 @@ private val PodcastItemIconSize = 156.dp
 fun SearchPodcastItem(
     podcast: Podcast,
     onClick: (() -> Unit)?,
+    onSubscribeClick: (Podcast) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -36,7 +37,7 @@ fun SearchPodcastItem(
             podcastUuid = podcast.uuid,
             podcastTitle = "",
             podcastSubscribed = podcast.isSubscribed,
-            onSubscribeClick = { /*TODO*/ },
+            onSubscribeClick = { onSubscribeClick(podcast) },
             subscribeButtonSize = 32.dp,
             shadowSize = 0.dp,
             subscribeOnPodcastTap = false

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -39,6 +40,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.folder.FolderImageSmall
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import java.util.UUID
@@ -124,7 +126,11 @@ fun SearchHistoryView(
             key = { requireNotNull(it.id) },
         ) { entry ->
             when (entry) {
-                is SearchHistoryEntry.Episode -> Unit // TODO
+                is SearchHistoryEntry.Episode -> SearchHistoryRow(
+                    content = { SearchHistoryEpisodeView(entry) },
+                    onCloseClick = { onCloseClick(entry) },
+                    onRowClick = { onRowClick(entry) },
+                )
 
                 is SearchHistoryEntry.Folder -> SearchHistoryRow(
                     content = { SearchHistoryFolderView(entry) },
@@ -181,6 +187,51 @@ private fun CloseButton(
             contentDescription = stringResource(NavigationButton.Close.contentDescription),
             tint = MaterialTheme.theme.colors.primaryIcon02
         )
+    }
+}
+
+@Composable
+fun SearchHistoryEpisodeView(
+    entry: SearchHistoryEntry.Episode,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val durationMs = entry.duration * 1000
+    Column {
+        Row(
+            verticalAlignment = Alignment.Top,
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, top = 12.dp, bottom = 12.dp)
+        ) {
+            PodcastImage(
+                uuid = entry.podcastUuid,
+                modifier = modifier.size(IconSize)
+            )
+            val formattedDuration = TimeHelper.getTimeDurationMediumString(durationMs.toInt(), context)
+            val subTitle = stringResource(
+                LR.string.search_history_row_type_episode_subtitle,
+                formattedDuration,
+                entry.podcastTitle
+            )
+            Column(
+                modifier = modifier
+                    .padding(start = 8.dp)
+                    .weight(1f)
+            ) {
+                TextH40(
+                    text = entry.title,
+                    maxLines = 2,
+                    color = MaterialTheme.theme.colors.primaryText01
+                )
+                TextH50(
+                    text = subTitle,
+                    maxLines = 1,
+                    color = MaterialTheme.theme.colors.primaryText02,
+                    modifier = modifier.padding(top = 2.dp)
+                )
+            }
+        }
     }
 }
 

--- a/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModelTest.kt
+++ b/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModelTest.kt
@@ -1,0 +1,66 @@
+package au.com.shiftyjelly.pocketcasts.search
+
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(MockitoJUnitRunner::class)
+class SearchViewModelTest {
+    @Mock
+    private lateinit var searchHandler: SearchHandler
+
+    @Mock
+    private lateinit var searchHistoryManager: SearchHistoryManager
+
+    @Mock
+    private lateinit var podcastManager: PodcastManager
+
+    @Mock
+    private lateinit var analyticsTracker: AnalyticsTrackerWrapper
+
+    private lateinit var viewModel: SearchViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        whenever(searchHandler.searchResults).thenReturn(mock())
+        whenever(searchHandler.loading).thenReturn(mock())
+        viewModel =
+            SearchViewModel(searchHandler, searchHistoryManager, podcastManager, analyticsTracker)
+    }
+
+    @Test
+    fun `given podcast is subscribed, when podcast subscribe plus icon clicked, then podcast is subscribed`() =
+        runTest {
+            val uuid = UUID.randomUUID().toString()
+            viewModel.onSubscribeToPodcast(Podcast(uuid = uuid, isSubscribed = false))
+
+            verify(podcastManager).subscribeToPodcast(podcastUuid = uuid, sync = true)
+        }
+
+    @Test
+    fun `given podcast not subscribed, when podcast subscribe check icon clicked, then podcast remains subscribed`() =
+        runTest {
+            val uuid = UUID.randomUUID().toString()
+            viewModel.onSubscribeToPodcast(Podcast(uuid = uuid, isSubscribed = true))
+
+            verify(podcastManager, never()).subscribeToPodcast(podcastUuid = uuid, sync = true)
+        }
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -199,6 +199,7 @@
     <string name="search_history_clear_all_confirm_button_title">Clear Search History</string>
     <string name="search_history_clear_all_confirmation_message">Are you sure you want to clear all your search history?</string>
     <string name="search_history_recent_searches">Recent searches</string>
+    <string name="search_history_row_type_episode_subtitle">Episode \u2022 %s \u2022 %s</string>
     <string name="search_history_row_type_folder_subtitle">Folder \u2022 %s</string>
     <string name="search_history_row_type_podcast_subtitle">Podcast \u2022 %s</string>
     <string name="search_show_all">Show all</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/EpisodeItem.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/EpisodeItem.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.models.to
 
+import au.com.shiftyjelly.pocketcasts.models.entity.Episode
 import java.util.Date
 
 data class EpisodeItem(
@@ -9,4 +10,13 @@ data class EpisodeItem(
     val publishedAt: Date,
     val podcastUuid: String,
     val podcastTitle: String,
-)
+) {
+    fun toEpisode() =
+        Episode(
+            uuid = uuid,
+            title = title,
+            duration = duration,
+            publishedDate = publishedAt,
+            podcastUuid = podcastUuid
+        )
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/FolderItem.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/FolderItem.kt
@@ -9,13 +9,15 @@ sealed class FolderItem(
     val uuid: String,
     val title: String,
     val addedDate: Date,
-    val sortPosition: Int
+    val sortPosition: Int,
+    val subscribed: Boolean,
 ) {
     data class Podcast(val podcast: PodcastModel) : FolderItem(
         uuid = podcast.uuid,
         title = podcast.title,
         addedDate = podcast.addedDate ?: Date(Long.MIN_VALUE),
-        sortPosition = podcast.sortPosition
+        sortPosition = podcast.sortPosition,
+        subscribed = podcast.isSubscribed,
     ) {
         companion object {
             const val viewTypeId = 0
@@ -25,7 +27,8 @@ sealed class FolderItem(
         uuid = folder.uuid,
         title = folder.name,
         addedDate = folder.addedDate,
-        sortPosition = folder.sortPosition
+        sortPosition = folder.sortPosition,
+        subscribed = true,
     ) {
         companion object {
             const val viewTypeId = 1

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/EpisodeViewSource.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/EpisodeViewSource.kt
@@ -10,6 +10,7 @@ enum class EpisodeViewSource(val value: String) {
     UP_NEXT("up_next"),
     SHARE("share"),
     NOTIFICATION("notification"),
+    SEARCH("search"),
     UNKNOWN("unknown");
 
     companion object {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/EpisodeViewSource.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/EpisodeViewSource.kt
@@ -11,6 +11,7 @@ enum class EpisodeViewSource(val value: String) {
     SHARE("share"),
     NOTIFICATION("notification"),
     SEARCH("search"),
+    SEARCH_HISTORY("search_history"),
     UNKNOWN("unknown");
 
     companion object {


### PR DESCRIPTION
Part of: #787

## Description

This PR adds episode search history row UI (pdeCcb-1iH-p2#comment-1693) and implements actions for
- Subscribe button
- Episode search result row
- Episode search history row

## Testing Instructions

Prerequisites: 
- Enable search improvements feature flag in `base.gradle`
- Select `debug` build variant

#### Podcast Subscribe

1. Go to `Podcasts` tab
2. Search a term 
3. Tap on plus icon for an unsubscribed podcast from podcasts search results
4. ✅ Notice that the podcast is subscribed
5. ✅ Notice in logs `Tracked: podcast_subscribed, Properties: {"source":"podcast_list_search", "uuid":UUID` where `UUID` is uuid of the podcast 
6. Tap on the check icon for the subscribed podcast 
7. ✅ Notice that the podcast remains subscribed (this is done to match the behavior on the `Discover` tab where you can only subscribe a podcast, to unsubscribe you need to go to the podcast details screen where you need to confirm to unsubscribe from it)
8. Go to `Discover` tab
9. Repeat steps 2-5
10.  ✅ Notice in logs `Tracked: podcast_subscribed, Properties: {"source":"discover_search", "uuid":UUID` where `UUID` is uuid of the podcast 

#### Episode Click + Episode Search History

1. Search a term 
2. Tap on an episode result
3. ✅ Notice that the episode details screen is shown for the selected episode
4. ✅ Notice in logs `Tracked: search_result_tapped, Properties: {"source":"podcast_list","uuid":UUID,"result_type":"episode"` and  `Tracked: episode_detail_shown, Properties: {"source":"search",` where `UUID` is uuid of the episode 
5. Go back to see the search history
6. ✅ Notice that the episode is added to the search history 
7. Tap on the episode search history row
8. ✅ Notice that the episode details screen is shown for the selected episode
9. ✅ Notice in logs `Tracked: search_history_item_tapped, Properties: {"source":"podcast_list","type":"episode","uuid":UUID` and  `Tracked: episode_detail_shown, Properties: {"source":"search_history",` where `UUID` is uuid of the episode
10. Go back to search history
11. Tap on cross button for the episode history row
12. ✅ Notice that the episode history row is deleted
13. ✅ Notice in logs `Tracked: search_history_item_delete_button_tapped, Properties: {"source":"podcast_list","type":"episode","uuid":UUID` where `UUID` is uuid of the episode


## Screenshots or Screencast 

https://user-images.githubusercontent.com/1405144/220637628-d34f5f5b-7ec5-4c18-aad9-15aa690f5daa.mp4

/cc @leandroalonso for tracking sources. 

## Checklist
- If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack