### PR TITLE
Correct request parameter name for user/token endpoint

### DIFF
--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/login/LoginTokenRequest.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/login/LoginTokenRequest.kt
@@ -6,5 +6,5 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class LoginTokenRequest(
     @field:Json(name = "grant_type") val grantType: String = "refresh_token",
-    @field:Json(name = "refresh_code") val refreshCode: String
+    @field:Json(name = "refresh_token") val refreshCode: String
 )


### PR DESCRIPTION
## Description
Just a simple update to a parameter name to match what the sync server is expecting.

## Testing Instructions
I don't believe we're actively using the user/token in the app yet, so I don't think there's anything to test. Just check this parameter name against the swagger docs and server code.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews