### PR TITLE
Improving the Automotive account pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.34
 -----
-
+*   Updates
+    *   Improved the Automotive account page styles
+        ([#798](https://github.com/Automattic/pocket-casts-android/pull/798)).
 
 7.33
 -----

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
@@ -2,7 +2,9 @@ package au.com.shiftyjelly.pocketcasts
 
 import android.annotation.SuppressLint
 import android.app.Application
+import android.app.UiModeManager
 import android.util.Log
+import androidx.core.content.getSystemService
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import au.com.shiftyjelly.pocketcasts.account.AccountAuth
@@ -82,6 +84,9 @@ class AutomotiveApplication : Application(), Configuration.Provider {
         userEpisodeManager.monitorUploads(applicationContext)
         downloadManager.beginMonitoringWorkManager(applicationContext)
         userManager.beginMonitoringAccountManager(playbackManager)
+
+        // force the Automotive app into car mode as some car companies send the UI mode as normal, this makes sure the car resources such as layout-car are used.
+        this.getSystemService<UiModeManager>()?.enableCarMode(0)
     }
 
     override fun onTerminate() {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountActivity.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountActivity.kt
@@ -43,8 +43,14 @@ class AccountActivity : AppCompatActivity() {
         val view = binding.root
         setContentView(view)
 
+        val navController = findNavController(R.id.nav_host_fragment)
+        binding.carHeader?.btnClose?.setOnClickListener {
+            if (!navController.popBackStack()) {
+                finish()
+            }
+        }
+
         if (savedInstanceState == null) {
-            val navController = findNavController(R.id.nav_host_fragment)
             val navInflater = navController.navInflater
             val graph = navInflater.inflate(R.navigation.account_nav_graph)
             val arguments = Bundle()
@@ -78,7 +84,6 @@ class AccountActivity : AppCompatActivity() {
             val navConfiguration = AppBarConfiguration(navController.graph)
             binding.toolbar?.setupWithNavController(navController, navConfiguration)
             binding.toolbar?.setNavigationOnClickListener { _ -> onBackPressed() }
-            binding.carHeader?.btnClose?.setOnClickListener { onBackPressed() }
 
             navController.addOnDestinationChangedListener { _, destination, _ ->
                 destination.trackShown()

--- a/modules/features/account/src/main/res/layout-car/fragment_create_email.xml
+++ b/modules/features/account/src/main/res/layout-car/fragment_create_email.xml
@@ -61,9 +61,9 @@
         android:layout_marginStart="220dp"
         android:layout_marginTop="96dp"
         android:layout_marginEnd="220dp"
+        app:hintTextAppearance="@style/TextAppearanceCarHint"
         app:layout_constraintBottom_toTopOf="@+id/passwordLayout"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/lblSignIn">
 
@@ -88,9 +88,9 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="56dp"
+        app:hintTextAppearance="@style/TextAppearanceCarHint"
         app:layout_constraintBottom_toTopOf="@+id/lblPasswordRequirements"
         app:layout_constraintEnd_toEndOf="@id/emailLayout"
-        app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="@id/emailLayout"
         app:layout_constraintTop_toBottomOf="@+id/emailLayout"
         app:passwordToggleEnabled="true">
@@ -136,7 +136,6 @@
         app:cornerRadius="12dp"
         app:layout_constraintTop_toBottomOf="@id/lblPasswordRequirements"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toBottomOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/modules/features/account/src/main/res/layout-car/fragment_reset_password.xml
+++ b/modules/features/account/src/main/res/layout-car/fragment_reset_password.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/mainLayout"
+    android:background="?attr/primary_ui_01"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/emailLayout"
+            style="@style/PCTextInputLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            app:hintTextAppearance="@style/TextAppearanceCarHint"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/txtEmail"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:drawablePadding="8dp"
+                android:hint="@string/profile_email"
+                android:inputType="textEmailAddress"
+                android:textAppearance="@style/TextAppearance.Car.Body2"
+                android:textColor="?attr/primary_text_02" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <TextView
+            android:id="@+id/txtError"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_weight="1"
+            android:textAppearance="@style/H40"
+            android:textColor="?attr/support_05"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/emailLayout"
+            tools:text="Error" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnConfirm"
+            style="@style/MaterialButtonStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:fontFamily="sans-serif-medium"
+            android:letterSpacing="0.02"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:text="@string/profile_confirm"
+            android:textAllCaps="false"
+            android:textSize="@dimen/car_body2_size"
+            app:cornerRadius="12dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/txtError" />
+
+        <ProgressBar
+            android:id="@+id/progress"
+            style="@style/Widget.AppCompat.ProgressBar"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="32dp"
+            android:elevation="10dp"
+            android:indeterminate="true"
+            android:indeterminateTint="?attr/primary_interactive_01"
+            app:layout_constraintBottom_toBottomOf="@+id/btnConfirm"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/btnConfirm" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</ScrollView>

--- a/modules/features/account/src/main/res/layout-car/fragment_sign_in.xml
+++ b/modules/features/account/src/main/res/layout-car/fragment_sign_in.xml
@@ -20,38 +20,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@+id/btnSignIn" />
 
-    <Button
-        android:id="@+id/btnReset"
-        style="@style/Widget.MaterialComponents.Button.TextButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="120dp"
-        android:layout_marginEnd="8dp"
-        android:text="@string/profile_forgot_your_password"
-        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
-        android:textColor="?attr/primary_interactive_01"
-        app:layout_constraintBottom_toTopOf="@+id/btnSignIn"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/txtError" />
-
-    <TextView
-        android:id="@+id/txtError"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="4dp"
-        android:layout_weight="1"
-        android:textAppearance="@style/TextAppearance.Car.Body1"
-        android:textColor="?attr/support_05"
-        app:layout_constraintBottom_toTopOf="@+id/btnReset"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/passwordLayout"
-        tools:text="Error" />
-
     <TextView
         android:id="@+id/lblSignIn"
         style="?attr/primary_text_01"
@@ -78,6 +46,7 @@
         android:layout_marginStart="220dp"
         android:layout_marginTop="96dp"
         android:layout_marginEnd="220dp"
+        app:hintTextAppearance="@style/TextAppearanceCarHint"
         app:layout_constraintBottom_toTopOf="@+id/passwordLayout"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
@@ -105,6 +74,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="56dp"
+        app:hintTextAppearance="@style/TextAppearanceCarHint"
         app:layout_constraintBottom_toTopOf="@+id/txtError"
         app:layout_constraintEnd_toEndOf="@id/emailLayout"
         app:layout_constraintHorizontal_bias="0.5"
@@ -126,6 +96,38 @@
             app:passwordToggleEnabled="true" />
 
     </com.google.android.material.textfield.TextInputLayout>
+
+    <TextView
+        android:id="@+id/txtError"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="4dp"
+        android:layout_weight="1"
+        android:textAppearance="@style/TextAppearance.Car.Body1"
+        android:textColor="?attr/support_05"
+        app:layout_constraintBottom_toTopOf="@+id/btnReset"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/passwordLayout"
+        tools:text="Error" />
+
+    <Button
+        android:id="@+id/btnReset"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="120dp"
+        android:layout_marginEnd="8dp"
+        android:text="@string/profile_forgot_your_password"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+        android:textColor="?attr/primary_interactive_01"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toTopOf="@+id/btnSignIn"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/txtError" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btnSignIn"

--- a/modules/features/account/src/main/res/layout-land-car/fragment_create_email.xml
+++ b/modules/features/account/src/main/res/layout-land-car/fragment_create_email.xml
@@ -63,11 +63,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="220dp"
-            android:layout_marginTop="32dp"
+            android:layout_marginTop="16dp"
             android:layout_marginEnd="220dp"
+            app:hintTextAppearance="@style/TextAppearanceCarHint"
             app:layout_constraintBottom_toTopOf="@+id/passwordLayout"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/lblSignIn">
 
@@ -76,7 +76,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:drawableStart="@drawable/ic_mail"
-                android:drawableEnd="@drawable/ic_about_star"
                 android:drawablePadding="16dp"
                 android:hint="@string/profile_email"
                 android:inputType="textEmailAddress"
@@ -91,10 +90,10 @@
             style="@style/PCTextInputLayout"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="32dp"
+            android:layout_marginTop="16dp"
+            app:hintTextAppearance="@style/TextAppearanceCarHint"
             app:layout_constraintBottom_toTopOf="@+id/lblPasswordRequirements"
             app:layout_constraintEnd_toEndOf="@id/emailLayout"
-            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="@id/emailLayout"
             app:layout_constraintTop_toBottomOf="@+id/emailLayout"
             app:passwordToggleEnabled="true">
@@ -129,7 +128,7 @@
             style="@style/MaterialButtonStyle"
             android:layout_width="591dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="50dp"
+            android:layout_marginTop="30dp"
             android:fontFamily="sans-serif-medium"
             android:letterSpacing="0.02"
             android:paddingTop="16dp"
@@ -140,7 +139,6 @@
             app:cornerRadius="12dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/lblPasswordRequirements" />
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/modules/features/account/src/main/res/layout-land-car/fragment_sign_in.xml
+++ b/modules/features/account/src/main/res/layout-land-car/fragment_sign_in.xml
@@ -23,46 +23,12 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@+id/btnSignIn" />
 
-        <Button
-            android:id="@+id/btnReset"
-            style="@style/Widget.MaterialComponents.Button.TextButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="8dp"
-            android:text="@string/profile_forgot_your_password"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
-            android:textColor="?attr/primary_interactive_01"
-            app:layout_constraintBottom_toTopOf="@+id/btnSignIn"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/txtError" />
-
-        <TextView
-            android:id="@+id/txtError"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="4dp"
-            android:layout_weight="1"
-            android:textAppearance="@style/TextAppearance.Car.Body1"
-            android:textColor="?attr/support_05"
-            android:visibility="gone"
-            app:layout_constraintBottom_toTopOf="@+id/btnReset"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/passwordLayout"
-            tools:text="Error" />
-
         <TextView
             android:id="@+id/lblSignIn"
             style="?attr/primary_text_01"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="24dp"
-            android:layout_marginTop="8dp"
             android:layout_marginEnd="24dp"
             android:gravity="center_horizontal"
             android:text="@string/profile_sign_in"
@@ -80,11 +46,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="220dp"
-            android:layout_marginTop="32dp"
+            android:layout_marginTop="16dp"
             android:layout_marginEnd="220dp"
+            app:hintTextAppearance="@style/TextAppearanceCarHint"
             app:layout_constraintBottom_toTopOf="@+id/passwordLayout"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/lblSignIn">
 
@@ -93,7 +59,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:drawableStart="@drawable/ic_mail"
-                android:drawableEnd="@drawable/ic_about_star"
                 android:drawablePadding="16dp"
                 android:hint="@string/profile_email"
                 android:inputType="textEmailAddress"
@@ -108,10 +73,10 @@
             style="@style/PCTextInputLayout"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="32dp"
+            android:layout_marginTop="16dp"
+            app:hintTextAppearance="@style/TextAppearanceCarHint"
             app:layout_constraintBottom_toTopOf="@+id/txtError"
             app:layout_constraintEnd_toEndOf="@id/emailLayout"
-            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="@id/emailLayout"
             app:layout_constraintTop_toBottomOf="@+id/emailLayout"
             app:passwordToggleEnabled="true">
@@ -131,6 +96,39 @@
 
         </com.google.android.material.textfield.TextInputLayout>
 
+        <TextView
+            android:id="@+id/txtError"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="4dp"
+            android:layout_weight="1"
+            android:textAppearance="@style/TextAppearance.Car.Body1"
+            android:textColor="?attr/support_05"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@+id/btnReset"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/passwordLayout"
+            tools:text="Error" />
+
+        <Button
+            android:id="@+id/btnReset"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="8dp"
+            android:text="@string/profile_forgot_your_password"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+            android:textColor="?attr/primary_interactive_01"
+            android:textSize="24sp"
+            app:layout_constraintBottom_toTopOf="@+id/btnSignIn"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/txtError" />
+
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btnSignIn"
             style="@style/MaterialButtonStyle"
@@ -147,7 +145,6 @@
             app:cornerRadius="12dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/btnReset" />
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
@@ -23,6 +23,7 @@ import au.com.shiftyjelly.pocketcasts.ui.BuildConfig
 import au.com.shiftyjelly.pocketcasts.ui.R
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.utils.Util
 import javax.inject.Inject
 import javax.inject.Singleton
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -229,7 +230,7 @@ class Theme @Inject constructor(
     }
 
     fun setupThemeForConfig(activity: AppCompatActivity, configuration: Configuration) {
-        if (getUseSystemTheme()) {
+        if (getUseSystemTheme() && !Util.isAutomotive(activity)) {
             val theme = when (configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) {
                 Configuration.UI_MODE_NIGHT_NO -> {
                     getPreferredLightFromPreferences()

--- a/modules/services/ui/src/main/res/values/styles.xml
+++ b/modules/services/ui/src/main/res/values/styles.xml
@@ -164,4 +164,8 @@
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">50%</item>
     </style>
+
+    <style name="TextAppearanceCarHint">
+        <item name="android:textSize">20sp</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Description
This change does the following:
- Forces the Automotive app into car mode as some car companies don't set this and our car layout resources aren't picked up.
- The font sizes for the hint text have increased on the account pages.
- Improved the UI on the forgotten password page.
- Made sure only the dark theme is used in the Automotive version.

Fixes https://github.com/Automattic/pocket-casts-android/issues/786

## Testing Instructions
- Deploy the automotive app to the Automotive emulator
- Open Pocket Casts
- Tap the settings cog
- Tap "Set Up Account" option
- Tap "Create account"
- ✅ Verify the page looks better
- Tap back and the "Sign in"
- ✅ Verify the page looks better
- Tap "I forgot my password"
- ✅ Verify the page looks better

## Screenshots 
| Before | After |
| --- | --- |
| ![Screenshot_20230224_155050](https://user-images.githubusercontent.com/308331/221099669-7a24775d-21eb-474e-a360-1776ea007b30.png) | ![Screenshot_20230224_155241](https://user-images.githubusercontent.com/308331/221099742-3a4135d6-8daa-416a-a314-7a2a9807fe6d.png) |
| ![Screenshot_20230224_155058](https://user-images.githubusercontent.com/308331/221099698-c120bb31-f446-4af8-a360-83abb56a8950.png) | ![Screenshot_20230224_155250](https://user-images.githubusercontent.com/308331/221099754-bbb43763-3cc4-47dd-8430-f702ae855dff.png) |
