### PR TITLE
Beta fix: Update search bar hint text

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditPodcastsPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditPodcastsPage.kt
@@ -142,6 +142,7 @@ private fun SearchSortBar(searchText: String, onSearchTextChanged: (String) -> U
     ) {
         SearchBar(
             text = searchText,
+            placeholder = stringResource(LR.string.search_podcasts),
             onTextChanged = onSearchTextChanged,
             modifier = Modifier
                 .padding(start = 16.dp)

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -195,6 +195,7 @@
     <string name="search_no_podcasts_found">No podcasts found</string>
     <string name="search_no_podcasts_found_summary">Try more general or different keywords.</string>
     <string name="search_podcasts_or_add_url">Search podcasts or add RSS URL</string>
+    <string name="search_podcasts">Search podcasts </string>
     <string name="search_hint">Search by podcast name</string>
     <string name="search_history_clear_all_confirm_button_title">Clear Search History</string>
     <string name="search_history_clear_all_confirmation_message">Are you sure you want to clear all your search history?</string>


### PR DESCRIPTION
## Description
This fixes hint text for the search bar on create folder screen

## Testing Instructions
1. Launch the app and log in with a plus account
2. Go to the podcasts screen and tap on the plus folder in the app bar
3. Notice that the search bar on the "Create folder "screen has the correct hint text

## Screenshots or Screencast 
<img src="https://user-images.githubusercontent.com/1405144/221473836-ada0deb6-6dcf-4545-9866-94b54e2861a2.png" width = 320/>

