### PR TITLE
Full screen search results

### DIFF
--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchEpisodeResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchEpisodeResultsPage.kt
@@ -6,9 +6,11 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.res.stringResource
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
 import au.com.shiftyjelly.pocketcasts.search.component.SearchEpisodeItem
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun SearchEpisodeResultsPage(
@@ -19,7 +21,7 @@ fun SearchEpisodeResultsPage(
     val state by viewModel.state.collectAsState()
     Column {
         ThemedTopAppBar(
-            title = "All episodes",
+            title = stringResource(LR.string.search_results_all_episodes),
             bottomShadow = true,
             onNavigationClick = { onBackClick() },
         )

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchEpisodeResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchEpisodeResultsPage.kt
@@ -1,19 +1,49 @@
 package au.com.shiftyjelly.pocketcasts.search
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
+import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
+import au.com.shiftyjelly.pocketcasts.search.component.SearchEpisodeItem
 
 @Composable
 fun SearchEpisodeResultsPage(
-    @Suppress("UNUSED_PARAMETER") viewModel: SearchViewModel,
+    viewModel: SearchViewModel,
     onBackClick: () -> Unit,
+    onEpisodeClick: (EpisodeItem) -> Unit,
 ) {
+    val state by viewModel.state.collectAsState()
     Column {
         ThemedTopAppBar(
             title = "All episodes",
             bottomShadow = true,
             onNavigationClick = { onBackClick() },
         )
+        SearchEpisodeResultsView(
+            state = state as SearchState.Results,
+            onEpisodeClick = onEpisodeClick,
+        )
+    }
+}
+
+@Composable
+private fun SearchEpisodeResultsView(
+    state: SearchState.Results,
+    onEpisodeClick: (EpisodeItem) -> Unit,
+) {
+    LazyColumn {
+        items(
+            items = state.episodes,
+            key = { it.uuid }
+        ) {
+            SearchEpisodeItem(
+                episode = it,
+                onClick = onEpisodeClick,
+            )
+        }
     }
 }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchEpisodeResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchEpisodeResultsPage.kt
@@ -1,0 +1,19 @@
+package au.com.shiftyjelly.pocketcasts.search
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
+
+@Composable
+fun SearchEpisodeResultsPage(
+    @Suppress("UNUSED_PARAMETER") viewModel: SearchViewModel,
+    onBackClick: () -> Unit,
+) {
+    Column {
+        ThemedTopAppBar(
+            title = "All episodes",
+            bottomShadow = true,
+            onNavigationClick = { onBackClick() },
+        )
+    }
+}

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -225,11 +225,11 @@ class SearchFragment : BaseFragment() {
                 }
             }
         }
-        binding.searchResults.apply {
+        binding.searchInlineResults.apply {
             ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
             setContent {
                 AppThemeWithBackground(theme.activeTheme) {
-                    SearchResultsPage(
+                    SearchInlineResultsPage(
                         viewModel = viewModel,
                         onEpisodeClick = ::onEpisodeClick,
                         onPodcastClick = ::onPodcastClick,
@@ -288,7 +288,7 @@ class SearchFragment : BaseFragment() {
     private fun onShowAllClick(resultsType: ResultsType) {
         val fragment = SearchResultsFragment.newInstance(resultsType, onlySearchRemote, source)
         childFragmentManager.beginTransaction()
-            .replace(UR.id.frameChildFragment, fragment)
+            .replace(R.id.searchResults, fragment)
             .addToBackStack(SEARCH_RESULTS_TAG)
             .commit()
     }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -287,7 +287,7 @@ class SearchFragment : BaseFragment() {
     }
 
     private fun onShowAllClick(resultsType: ResultsType) {
-        val fragment = SearchResultsFragment.newInstance(resultsType)
+        val fragment = SearchResultsFragment.newInstance(resultsType, onlySearchRemote, source)
         (activity as? FragmentHostListener)?.addFragment(fragment)
     }
 

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -11,7 +11,6 @@ import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import androidx.appcompat.widget.SearchView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
@@ -30,7 +29,6 @@ import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryClearAll
 import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryPage
 import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryViewModel
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
-import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.extensions.hide
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.extensions.showKeyboard
@@ -45,6 +43,7 @@ private const val ARG_FLOATING = "arg_floating"
 private const val ARG_ONLY_SEARCH_REMOTE = "arg_only_search_remote"
 private const val ARG_SOURCE = "arg_source"
 private const val SEARCH_HISTORY_CLEAR_ALL_CONFIRMATION_DIALOG_TAG = "search_history_clear_all_confirmation_dialog"
+private const val SEARCH_RESULTS_TAG = "search_results"
 
 @AndroidEntryPoint
 class SearchFragment : BaseFragment() {
@@ -73,7 +72,7 @@ class SearchFragment : BaseFragment() {
         }
     }
 
-    private val viewModel: SearchViewModel by activityViewModels()
+    private val viewModel: SearchViewModel by viewModels()
     private val searchHistoryViewModel: SearchHistoryViewModel by viewModels()
     private var listener: Listener? = null
     private var binding: FragmentSearchBinding? = null
@@ -288,7 +287,10 @@ class SearchFragment : BaseFragment() {
 
     private fun onShowAllClick(resultsType: ResultsType) {
         val fragment = SearchResultsFragment.newInstance(resultsType, onlySearchRemote, source)
-        (activity as? FragmentHostListener)?.addFragment(fragment)
+        childFragmentManager.beginTransaction()
+            .replace(UR.id.frameChildFragment, fragment)
+            .addToBackStack(SEARCH_RESULTS_TAG)
+            .commit()
     }
 
     override fun onBackPressed(): Boolean {

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -11,6 +11,7 @@ import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import androidx.appcompat.widget.SearchView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
@@ -22,12 +23,14 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
+import au.com.shiftyjelly.pocketcasts.search.SearchResultsFragment.Companion.ResultsType
 import au.com.shiftyjelly.pocketcasts.search.SearchViewModel.SearchResultType
 import au.com.shiftyjelly.pocketcasts.search.databinding.FragmentSearchBinding
 import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryClearAllConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryPage
 import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryViewModel
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.extensions.hide
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.extensions.showKeyboard
@@ -70,7 +73,7 @@ class SearchFragment : BaseFragment() {
         }
     }
 
-    private val viewModel: SearchViewModel by viewModels()
+    private val viewModel: SearchViewModel by activityViewModels()
     private val searchHistoryViewModel: SearchHistoryViewModel by viewModels()
     private var listener: Listener? = null
     private var binding: FragmentSearchBinding? = null
@@ -230,12 +233,9 @@ class SearchFragment : BaseFragment() {
                     SearchResultsPage(
                         viewModel = viewModel,
                         onEpisodeClick = ::onEpisodeClick,
-                        onPodcastClick = { podcast ->
-                            onPodcastClick(podcast)
-                        },
-                        onFolderClick = { folder, podcasts ->
-                            onFolderClick(folder, podcasts)
-                        },
+                        onPodcastClick = ::onPodcastClick,
+                        onFolderClick = ::onFolderClick,
+                        onShowAllCLick = ::onShowAllClick,
                         onScroll = { UiUtil.hideKeyboard(searchView) },
                         onlySearchRemote = onlySearchRemote
                     )
@@ -284,6 +284,11 @@ class SearchFragment : BaseFragment() {
         searchHistoryViewModel.add(SearchHistoryEntry.fromFolder(folder, podcasts.map { it.uuid }))
         listener?.onSearchFolderClick(folder.uuid)
         binding?.searchView?.let { UiUtil.hideKeyboard(it) }
+    }
+
+    private fun onShowAllClick(resultsType: ResultsType) {
+        val fragment = SearchResultsFragment.newInstance(resultsType)
+        (activity as? FragmentHostListener)?.addFragment(fragment)
     }
 
     override fun onBackPressed(): Boolean {

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -27,7 +27,6 @@ import timber.log.Timber
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
-private const val MAX_ITEM_COUNT = 20
 class SearchHandler @Inject constructor(
     val serverManager: ServerManager,
     val podcastManager: PodcastManager,
@@ -164,20 +163,8 @@ class SearchHandler @Inject constructor(
                 }
                 SearchState.Results(
                     searchTerm = searchTerm.string,
-                    podcasts = searchPodcastsResult.take(
-                        if (BuildConfig.SEARCH_IMPROVEMENTS_ENABLED) {
-                            minOf(MAX_ITEM_COUNT, searchPodcastsResult.size)
-                        } else {
-                            searchPodcastsResult.size
-                        }
-                    ),
-                    episodes = searchEpisodesResult.take(
-                        if (BuildConfig.SEARCH_IMPROVEMENTS_ENABLED) {
-                            minOf(MAX_ITEM_COUNT, searchEpisodesResult.size)
-                        } else {
-                            searchEpisodesResult.size
-                        }
-                    ),
+                    podcasts = searchPodcastsResult,
+                    episodes = searchEpisodesResult,
                     loading = loading,
                     error = serverSearchResults.error
                 )

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchInlineResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchInlineResultsPage.kt
@@ -59,6 +59,7 @@ import java.util.UUID
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
+private const val MAX_ITEM_COUNT = 20
 @Composable
 fun SearchInlineResultsPage(
     viewModel: SearchViewModel,
@@ -79,7 +80,7 @@ fun SearchInlineResultsPage(
                 val result = state as SearchState.Results
                 if (result.error == null || !onlySearchRemote || result.loading) {
                     if (BuildConfig.SEARCH_IMPROVEMENTS_ENABLED) {
-                        SearchPodcastResultsView(
+                        SearchResultsView(
                             state = state as SearchState.Results,
                             onEpisodeClick = onEpisodeClick,
                             onPodcastClick = onPodcastClick,
@@ -118,7 +119,7 @@ fun SearchInlineResultsPage(
 }
 
 @Composable
-private fun SearchPodcastResultsView(
+private fun SearchResultsView(
     state: SearchState.Results,
     onEpisodeClick: (EpisodeItem) -> Unit,
     onPodcastClick: (Podcast) -> Unit,
@@ -151,7 +152,7 @@ private fun SearchPodcastResultsView(
         item {
             LazyRow(contentPadding = PaddingValues(horizontal = 8.dp)) {
                 items(
-                    items = state.podcasts,
+                    items = state.podcasts.take(minOf(MAX_ITEM_COUNT, state.podcasts.size)),
                     key = { it.adapterId }
                 ) { folderItem ->
                     when (folderItem) {
@@ -191,7 +192,7 @@ private fun SearchPodcastResultsView(
             }
         }
         items(
-            items = state.episodes,
+            items = state.episodes.take(minOf(MAX_ITEM_COUNT, state.episodes.size)),
             key = { it.uuid }
         ) {
             SearchEpisodeItem(
@@ -336,7 +337,7 @@ fun SearchResultsViewPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppThemeWithBackground(themeType) {
-        SearchPodcastResultsView(
+        SearchResultsView(
             state = SearchState.Results(
                 podcasts = listOf(
                     FolderItem.Folder(

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchInlineResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchInlineResultsPage.kt
@@ -60,7 +60,7 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
-fun SearchResultsPage(
+fun SearchInlineResultsPage(
     viewModel: SearchViewModel,
     onEpisodeClick: (EpisodeItem) -> Unit,
     onPodcastClick: (Podcast) -> Unit,

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchInlineResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchInlineResultsPage.kt
@@ -167,7 +167,11 @@ private fun SearchPodcastResultsView(
                             SearchPodcastItem(
                                 podcast = folderItem.podcast,
                                 onClick = { onPodcastClick(folderItem.podcast) },
-                                onSubscribeClick = onSubscribeToPodcast
+                                onSubscribeClick = if (!folderItem.podcast.isSubscribed) {
+                                    { onSubscribeToPodcast(folderItem.podcast) }
+                                } else {
+                                    null
+                                }
                             )
                         }
                     }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchPodcastResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchPodcastResultsPage.kt
@@ -69,6 +69,7 @@ private fun SearchPodcastResultsView(
                         subscribed = folderItem.podcast.isSubscribed,
                         showSubscribed = true,
                         showPlusIfUnsubscribed = true,
+                        maxLines = 2,
                         onClick = { onPodcastClick(folderItem.podcast) },
                         onSubscribeClick = { onSubscribeClick(folderItem.podcast) },
                         modifier = Modifier

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchPodcastResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchPodcastResultsPage.kt
@@ -1,19 +1,79 @@
 package au.com.shiftyjelly.pocketcasts.search
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastItem
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.entity.Folder
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
+import au.com.shiftyjelly.pocketcasts.search.component.SearchFolderRow
 
 @Composable
 fun SearchPodcastResultsPage(
-    @Suppress("UNUSED_PARAMETER") viewModel: SearchViewModel,
+    viewModel: SearchViewModel,
+    onFolderClick: (Folder, List<Podcast>) -> Unit,
+    onPodcastClick: (Podcast) -> Unit,
     onBackClick: () -> Unit,
 ) {
+    val state by viewModel.state.collectAsState()
     Column {
         ThemedTopAppBar(
             title = "All podcasts",
             bottomShadow = true,
             onNavigationClick = { onBackClick() },
         )
+        SearchPodcastResultsView(
+            state = state as SearchState.Results,
+            onFolderClick = onFolderClick,
+            onPodcastClick = onPodcastClick,
+            onSubscribeClick = { viewModel.onSubscribeToPodcast(it) },
+        )
+    }
+}
+
+@Composable
+private fun SearchPodcastResultsView(
+    state: SearchState.Results,
+    onFolderClick: (Folder, List<Podcast>) -> Unit,
+    onPodcastClick: (Podcast) -> Unit,
+    onSubscribeClick: (Podcast) -> Unit
+) {
+    LazyColumn {
+        items(
+            items = state.podcasts,
+            key = { it.adapterId }
+        ) { folderItem ->
+            when (folderItem) {
+                is FolderItem.Folder -> {
+                    SearchFolderRow(
+                        folder = folderItem.folder,
+                        podcasts = folderItem.podcasts,
+                        onClick = { onFolderClick(folderItem.folder, folderItem.podcasts) }
+                    )
+                }
+
+                is FolderItem.Podcast -> {
+                    PodcastItem(
+                        podcast = folderItem.podcast,
+                        subscribed = folderItem.podcast.isSubscribed,
+                        showSubscribed = true,
+                        showPlusIfUnsubscribed = true,
+                        onClick = { onPodcastClick(folderItem.podcast) },
+                        onSubscribeClick = { onSubscribeClick(folderItem.podcast) },
+                        modifier = Modifier
+                            .background(color = MaterialTheme.theme.colors.primaryUi01)
+                    )
+                }
+            }
+        }
     }
 }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchPodcastResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchPodcastResultsPage.kt
@@ -52,14 +52,14 @@ private fun SearchPodcastResultsView(
     LazyColumn {
         items(
             items = state.podcasts,
-            key = { it.adapterId }
+            key = { it.adapterId },
         ) { folderItem ->
             when (folderItem) {
                 is FolderItem.Folder -> {
                     SearchFolderRow(
                         folder = folderItem.folder,
                         podcasts = folderItem.podcasts,
-                        onClick = { onFolderClick(folderItem.folder, folderItem.podcasts) }
+                        onClick = { onFolderClick(folderItem.folder, folderItem.podcasts) },
                     )
                 }
 

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchPodcastResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchPodcastResultsPage.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastItem
 import au.com.shiftyjelly.pocketcasts.compose.theme
@@ -16,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.search.component.SearchFolderRow
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun SearchPodcastResultsPage(
@@ -27,7 +29,7 @@ fun SearchPodcastResultsPage(
     val state by viewModel.state.collectAsState()
     Column {
         ThemedTopAppBar(
-            title = "All podcasts",
+            title = stringResource(LR.string.search_results_all_podcasts),
             bottomShadow = true,
             onNavigationClick = { onBackClick() },
         )

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchPodcastResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchPodcastResultsPage.kt
@@ -71,7 +71,7 @@ private fun SearchPodcastResultsView(
                         showPlusIfUnsubscribed = true,
                         maxLines = 2,
                         onClick = { onPodcastClick(folderItem.podcast) },
-                        onSubscribeClick = { onSubscribeClick(folderItem.podcast) },
+                        onPlusClick = { onSubscribeClick(folderItem.podcast) },
                         modifier = Modifier
                             .background(color = MaterialTheme.theme.colors.primaryUi01)
                     )

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchPodcastResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchPodcastResultsPage.kt
@@ -1,0 +1,19 @@
+package au.com.shiftyjelly.pocketcasts.search
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
+
+@Composable
+fun SearchPodcastResultsPage(
+    @Suppress("UNUSED_PARAMETER") viewModel: SearchViewModel,
+    onBackClick: () -> Unit,
+) {
+    Column {
+        ThemedTopAppBar(
+            title = "All podcasts",
+            bottomShadow = true,
+            onNavigationClick = { onBackClick() },
+        )
+    }
+}

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsFragment.kt
@@ -1,0 +1,77 @@
+package au.com.shiftyjelly.pocketcasts.search
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.activityViewModels
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+private const val ARG_TYPE = "arg_type"
+
+@AndroidEntryPoint
+class SearchResultsFragment : BaseFragment() {
+    private val viewModel by activityViewModels<SearchViewModel>()
+
+    val type: ResultsType
+        get() = ResultsType.fromString(arguments?.getString(ARG_TYPE))
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = ComposeView(requireContext()).apply {
+        setContent {
+            AppThemeWithBackground(theme.activeTheme) {
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+                when (type) {
+                    ResultsType.PODCASTS -> {
+                        SearchPodcastResultsPage(
+                            viewModel = viewModel,
+                            onBackClick = ::onBackClick,
+                        )
+                    }
+
+                    ResultsType.EPISODES -> {
+                        SearchEpisodeResultsPage(
+                            viewModel = viewModel,
+                            onBackClick = ::onBackClick,
+                        )
+                    }
+
+                    ResultsType.UNKNOWN -> throw IllegalStateException("Unknown search results type")
+                }
+            }
+        }
+    }
+
+    private fun onBackClick() {
+        @Suppress("DEPRECATION")
+        activity?.onBackPressed()
+    }
+
+    companion object {
+        enum class ResultsType(val value: String) {
+            PODCASTS("podcasts"),
+            EPISODES("episodes"),
+            UNKNOWN("unknown");
+
+            companion object {
+                fun fromString(value: String?) =
+                    ResultsType.values().find { it.value == value } ?: UNKNOWN
+            }
+        }
+
+        fun newInstance(type: ResultsType): SearchResultsFragment {
+            val fragment = SearchResultsFragment()
+            val arguments = Bundle().apply {
+                putString(ARG_TYPE, type.value)
+            }
+            fragment.arguments = arguments
+            return fragment
+        }
+    }
+}

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsFragment.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -24,7 +23,7 @@ private const val ARG_SOURCE = "arg_source"
 private const val ARG_TYPE = "arg_type"
 @AndroidEntryPoint
 class SearchResultsFragment : BaseFragment() {
-    private val viewModel by activityViewModels<SearchViewModel>()
+    private val viewModel by viewModels<SearchViewModel>({ requireParentFragment() })
     private val searchHistoryViewModel by viewModels<SearchHistoryViewModel>()
     private var listener: SearchFragment.Listener? = null
 
@@ -117,8 +116,7 @@ class SearchResultsFragment : BaseFragment() {
     }
 
     private fun onBackClick() {
-        @Suppress("DEPRECATION")
-        activity?.onBackPressed()
+        parentFragmentManager.popBackStack()
     }
 
     companion object {

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsFragment.kt
@@ -1,23 +1,49 @@
 package au.com.shiftyjelly.pocketcasts.search
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.models.entity.Folder
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
+import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
+import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryViewModel
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 
+private const val ARG_ONLY_SEARCH_REMOTE = "arg_only_search_remote"
+private const val ARG_SOURCE = "arg_source"
 private const val ARG_TYPE = "arg_type"
-
 @AndroidEntryPoint
 class SearchResultsFragment : BaseFragment() {
     private val viewModel by activityViewModels<SearchViewModel>()
+    private val searchHistoryViewModel by viewModels<SearchHistoryViewModel>()
+    private var listener: SearchFragment.Listener? = null
 
-    val type: ResultsType
+    private val onlySearchRemote: Boolean
+        get() = arguments?.getBoolean(ARG_ONLY_SEARCH_REMOTE) ?: false
+    private val source: AnalyticsSource
+        get() = AnalyticsSource.fromString(arguments?.getString(ARG_SOURCE))
+    private val type: ResultsType
         get() = ResultsType.fromString(arguments?.getString(ARG_TYPE))
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        listener = context as SearchFragment.Listener
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        listener = null
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -31,6 +57,8 @@ class SearchResultsFragment : BaseFragment() {
                     ResultsType.PODCASTS -> {
                         SearchPodcastResultsPage(
                             viewModel = viewModel,
+                            onFolderClick = ::onFolderClick,
+                            onPodcastClick = ::onPodcastClick,
                             onBackClick = ::onBackClick,
                         )
                     }
@@ -46,6 +74,45 @@ class SearchResultsFragment : BaseFragment() {
                 }
             }
         }
+    }
+
+    private fun onEpisodeClick(episodeItem: EpisodeItem) {
+        viewModel.trackSearchResultTapped(
+            source = source,
+            uuid = episodeItem.uuid,
+            type = SearchViewModel.SearchResultType.EPISODE,
+        )
+        val episode = episodeItem.toEpisode()
+        searchHistoryViewModel.add(SearchHistoryEntry.fromEpisode(episode, episodeItem.podcastTitle))
+        listener?.onSearchEpisodeClick(
+            episodeUuid = episode.uuid,
+            podcastUuid = episode.podcastUuid,
+            source = EpisodeViewSource.SEARCH
+        )
+    }
+
+    private fun onFolderClick(folder: Folder, podcasts: List<Podcast>) {
+        viewModel.trackSearchResultTapped(
+            source = source,
+            uuid = folder.uuid,
+            type = SearchViewModel.SearchResultType.FOLDER,
+        )
+        searchHistoryViewModel.add(SearchHistoryEntry.fromFolder(folder, podcasts.map { it.uuid }))
+        listener?.onSearchFolderClick(folder.uuid)
+    }
+
+    private fun onPodcastClick(podcast: Podcast) {
+        viewModel.trackSearchResultTapped(
+            source = source,
+            uuid = podcast.uuid,
+            type = if (onlySearchRemote || !podcast.isSubscribed) {
+                SearchViewModel.SearchResultType.PODCAST_REMOTE_RESULT
+            } else {
+                SearchViewModel.SearchResultType.PODCAST_LOCAL_RESULT
+            }
+        )
+        searchHistoryViewModel.add(SearchHistoryEntry.fromPodcast(podcast))
+        listener?.onSearchPodcastClick(podcast.uuid)
     }
 
     private fun onBackClick() {
@@ -65,10 +132,16 @@ class SearchResultsFragment : BaseFragment() {
             }
         }
 
-        fun newInstance(type: ResultsType): SearchResultsFragment {
+        fun newInstance(
+            type: ResultsType,
+            onlySearchRemote: Boolean = false,
+            source: AnalyticsSource
+        ): SearchResultsFragment {
             val fragment = SearchResultsFragment()
             val arguments = Bundle().apply {
                 putString(ARG_TYPE, type.value)
+                putBoolean(ARG_ONLY_SEARCH_REMOTE, onlySearchRemote)
+                putString(ARG_SOURCE, source.analyticsValue)
             }
             fragment.arguments = arguments
             return fragment

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsFragment.kt
@@ -67,6 +67,7 @@ class SearchResultsFragment : BaseFragment() {
                         SearchEpisodeResultsPage(
                             viewModel = viewModel,
                             onBackClick = ::onBackClick,
+                            onEpisodeClick = ::onEpisodeClick
                         )
                     }
 

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsFragment.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.search
 import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -16,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
 import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryViewModel
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import dagger.hilt.android.AndroidEntryPoint
 
 private const val ARG_ONLY_SEARCH_REMOTE = "arg_only_search_remote"
@@ -73,6 +75,13 @@ class SearchResultsFragment : BaseFragment() {
                     ResultsType.UNKNOWN -> throw IllegalStateException("Unknown search results type")
                 }
             }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.post {
+            UiUtil.hideKeyboard(view)
         }
     }
 

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsPage.kt
@@ -47,6 +47,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
+import au.com.shiftyjelly.pocketcasts.search.SearchResultsFragment.Companion.ResultsType
 import au.com.shiftyjelly.pocketcasts.search.component.SearchEpisodeItem
 import au.com.shiftyjelly.pocketcasts.search.component.SearchFolderItem
 import au.com.shiftyjelly.pocketcasts.search.component.SearchFolderRow
@@ -64,6 +65,7 @@ fun SearchResultsPage(
     onEpisodeClick: (EpisodeItem) -> Unit,
     onPodcastClick: (Podcast) -> Unit,
     onFolderClick: (Folder, List<Podcast>) -> Unit,
+    onShowAllCLick: (ResultsType) -> Unit,
     onScroll: () -> Unit,
     onlySearchRemote: Boolean,
     modifier: Modifier = Modifier,
@@ -77,11 +79,12 @@ fun SearchResultsPage(
                 val result = state as SearchState.Results
                 if (result.error == null || !onlySearchRemote || result.loading) {
                     if (BuildConfig.SEARCH_IMPROVEMENTS_ENABLED) {
-                        SearchResultsView(
+                        SearchPodcastResultsView(
                             state = state as SearchState.Results,
                             onEpisodeClick = onEpisodeClick,
                             onPodcastClick = onPodcastClick,
                             onFolderClick = onFolderClick,
+                            onShowAllCLick = onShowAllCLick,
                             onSubscribeToPodcast = { viewModel.onSubscribeToPodcast(it) },
                             onScroll = onScroll,
                         )
@@ -115,11 +118,12 @@ fun SearchResultsPage(
 }
 
 @Composable
-private fun SearchResultsView(
+private fun SearchPodcastResultsView(
     state: SearchState.Results,
     onEpisodeClick: (EpisodeItem) -> Unit,
     onPodcastClick: (Podcast) -> Unit,
     onFolderClick: (Folder, List<Podcast>) -> Unit,
+    onShowAllCLick: (ResultsType) -> Unit,
     onSubscribeToPodcast: (Podcast) -> Unit,
     onScroll: () -> Unit,
     modifier: Modifier = Modifier,
@@ -137,7 +141,12 @@ private fun SearchResultsView(
             .nestedScroll(nestedScrollConnection)
     ) {
         if (state.podcasts.isNotEmpty()) {
-            item { SearchResultsHeaderView(title = stringResource(LR.string.podcasts)) }
+            item {
+                SearchResultsHeaderView(
+                    title = stringResource(LR.string.podcasts),
+                    onShowAllCLick = { onShowAllCLick(ResultsType.PODCASTS) },
+                )
+            }
         }
         item {
             LazyRow(contentPadding = PaddingValues(horizontal = 8.dp)) {
@@ -171,7 +180,10 @@ private fun SearchResultsView(
                     startIndent = 16.dp,
                     modifier = modifier.padding(top = 20.dp, bottom = 4.dp)
                 )
-                SearchResultsHeaderView(title = stringResource(LR.string.episodes))
+                SearchResultsHeaderView(
+                    title = stringResource(LR.string.episodes),
+                    onShowAllCLick = { onShowAllCLick(ResultsType.EPISODES) },
+                )
             }
         }
         items(
@@ -189,6 +201,7 @@ private fun SearchResultsView(
 @Composable
 private fun SearchResultsHeaderView(
     title: String,
+    onShowAllCLick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -207,7 +220,7 @@ private fun SearchResultsHeaderView(
             color = MaterialTheme.theme.colors.support03,
             fontWeight = FontWeight.W700,
             modifier = modifier
-                .clickable { /* TODO */ }
+                .clickable { onShowAllCLick() }
                 .padding(12.dp)
         )
     }
@@ -319,7 +332,7 @@ fun SearchResultsViewPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppThemeWithBackground(themeType) {
-        SearchResultsView(
+        SearchPodcastResultsView(
             state = SearchState.Results(
                 podcasts = listOf(
                     FolderItem.Folder(
@@ -360,6 +373,7 @@ fun SearchResultsViewPreview(
             onEpisodeClick = {},
             onPodcastClick = {},
             onFolderClick = { _, _ -> },
+            onShowAllCLick = {},
             onSubscribeToPodcast = {},
             onScroll = {},
         )

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchFolderRow.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchFolderRow.kt
@@ -9,16 +9,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.compose.folder.FolderImageSmall
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
@@ -36,21 +35,17 @@ fun SearchFolderRow(folder: Folder, podcasts: List<Podcast>, onClick: (() -> Uni
             modifier = modifier
                 .fillMaxWidth()
                 .background(MaterialTheme.theme.colors.primaryUi01)
-                .padding(horizontal = 16.dp)
                 .then(if (onClick == null) Modifier else Modifier.clickable { onClick() })
         ) {
-            Box(modifier = Modifier.padding(top = 4.dp, end = 12.dp, bottom = 4.dp)) {
+            Box(modifier = Modifier.padding(start = 16.dp, top = 8.dp, end = 12.dp, bottom = 8.dp)) {
                 FolderImageSmall(color = color, podcastUuids = podcastUuids)
             }
             Column(
                 modifier = Modifier.weight(1f)
             ) {
-                Text(
+                TextH40(
                     text = folder.name,
-                    fontSize = 16.sp,
                     maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                    color = MaterialTheme.theme.colors.primaryText01,
                     modifier = Modifier.padding(bottom = 2.dp)
                 )
                 val podcastCount = if (podcastUuids.size == 1) {
@@ -58,12 +53,9 @@ fun SearchFolderRow(folder: Folder, podcasts: List<Podcast>, onClick: (() -> Uni
                 } else {
                     stringResource(LR.string.podcasts_plural, podcastUuids.size)
                 }
-                Text(
+                TextH50(
                     text = podcastCount,
-                    fontSize = 13.sp,
-                    letterSpacing = 0.2.sp,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
                     color = MaterialTheme.theme.colors.primaryText02,
                     modifier = Modifier.padding(top = 2.dp)
                 )
@@ -71,9 +63,10 @@ fun SearchFolderRow(folder: Folder, podcasts: List<Podcast>, onClick: (() -> Uni
             Icon(
                 painter = painterResource(id = IR.drawable.ic_tick),
                 contentDescription = stringResource(LR.string.podcast_subscribed),
-                tint = MaterialTheme.theme.colors.support02
+                tint = MaterialTheme.theme.colors.support02,
+                modifier = Modifier.padding(end = 16.dp)
             )
         }
-        HorizontalDivider()
+        HorizontalDivider(startIndent = 16.dp)
     }
 }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchPodcastItem.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchPodcastItem.kt
@@ -23,7 +23,7 @@ private val PodcastItemIconSize = 156.dp
 fun SearchPodcastItem(
     podcast: Podcast,
     onClick: (() -> Unit)?,
-    onSubscribeClick: (Podcast) -> Unit,
+    onSubscribeClick: ((Podcast) -> Unit)?,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -37,7 +37,11 @@ fun SearchPodcastItem(
             podcastUuid = podcast.uuid,
             podcastTitle = "",
             podcastSubscribed = podcast.isSubscribed,
-            onSubscribeClick = { onSubscribeClick(podcast) },
+            onSubscribeClick = if (onSubscribeClick != null) {
+                { onSubscribeClick(podcast) }
+            } else {
+                null
+            },
             subscribeButtonSize = 32.dp,
             shadowSize = 0.dp,
             subscribeOnPodcastTap = false

--- a/modules/features/search/src/main/res/layout/fragment_search.xml
+++ b/modules/features/search/src/main/res/layout/fragment_search.xml
@@ -59,9 +59,7 @@
             <androidx.compose.ui.platform.ComposeView
                 android:id="@+id/searchInlineResults"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingTop="8dp"
-                android:paddingBottom="8dp"/>
+                android:layout_height="wrap_content"/>
 
         </LinearLayout>
 

--- a/modules/features/search/src/main/res/layout/fragment_search.xml
+++ b/modules/features/search/src/main/res/layout/fragment_search.xml
@@ -9,56 +9,67 @@
             type="boolean" />
     </data>
 
-    <LinearLayout
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:background="?attr/primary_ui_01"
-        tools:context=".SearchFragment">
+        android:layout_height="match_parent">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:background="?attr/primary_ui_01"
+            tools:context=".SearchFragment">
+
+            <FrameLayout
+                android:id="@+id/floatingLayout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingStart="16dp"
+                android:paddingTop="@{floating ? @dimen/search_box_floating_top : 0}"
+                android:background="?attr/secondary_ui_01">
+
+                <androidx.appcompat.widget.SearchView
+                    android:id="@+id/searchView"
+                    android:layout_width="match_parent"
+                    android:layout_height="?android:attr/actionBarSize"
+                    android:hint="@string/search_podcasts_or_add_url"
+                    android:textColorHint="?attr/secondary_text_02"
+                    android:paddingStart="40dp"
+                    android:paddingEnd="8dp"
+                    app:searchIcon="@null"
+                    android:theme="@style/Widget.AppCompat.SearchView.PCAccent"
+                    android:textColor="?attr/secondary_text_01" />
+
+                <ImageButton
+                    android:id="@+id/backButton"
+                    android:layout_width="44dp"
+                    android:layout_height="44dp"
+                    android:layout_marginTop="6dp"
+                    android:layout_marginStart="6dp"
+                    android:src="@drawable/ic_arrow_back_24dp"
+                    android:tint="?attr/secondary_icon_01"
+                    android:background="?android:attr/actionBarItemBackground" />
+
+            </FrameLayout>
+
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/searchHistoryPanel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/searchResults"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp"/>
+
+        </LinearLayout>
 
         <FrameLayout
-            android:id="@+id/floatingLayout"
+            android:id="@+id/frameChildFragment"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingStart="16dp"
-            android:paddingTop="@{floating ? @dimen/search_box_floating_top : 0}"
-            android:background="?attr/secondary_ui_01">
+            android:layout_height="match_parent" />
 
-            <androidx.appcompat.widget.SearchView
-                android:id="@+id/searchView"
-                android:layout_width="match_parent"
-                android:layout_height="?android:attr/actionBarSize"
-                android:hint="@string/search_podcasts_or_add_url"
-                android:textColorHint="?attr/secondary_text_02"
-                android:paddingStart="40dp"
-                android:paddingEnd="8dp"
-                app:searchIcon="@null"
-                android:theme="@style/Widget.AppCompat.SearchView.PCAccent"
-                android:textColor="?attr/secondary_text_01" />
+    </FrameLayout>
 
-            <ImageButton
-                android:id="@+id/backButton"
-                android:layout_width="44dp"
-                android:layout_height="44dp"
-                android:layout_marginTop="6dp"
-                android:layout_marginStart="6dp"
-                android:src="@drawable/ic_arrow_back_24dp"
-                android:tint="?attr/secondary_icon_01"
-                android:background="?android:attr/actionBarItemBackground" />
-
-        </FrameLayout>
-
-        <androidx.compose.ui.platform.ComposeView
-            android:id="@+id/searchHistoryPanel"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-
-        <androidx.compose.ui.platform.ComposeView
-            android:id="@+id/searchResults"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="8dp"
-            android:paddingBottom="8dp"/>
-
-    </LinearLayout>
 </layout>

--- a/modules/features/search/src/main/res/layout/fragment_search.xml
+++ b/modules/features/search/src/main/res/layout/fragment_search.xml
@@ -57,7 +57,7 @@
                 android:layout_height="wrap_content" />
 
             <androidx.compose.ui.platform.ComposeView
-                android:id="@+id/searchResults"
+                android:id="@+id/searchInlineResults"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:paddingTop="8dp"
@@ -66,7 +66,7 @@
         </LinearLayout>
 
         <FrameLayout
-            android:id="@+id/frameChildFragment"
+            android:id="@+id/searchResults"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
@@ -32,6 +32,7 @@ fun PodcastItem(
     showSubscribed: Boolean = false,
     showPlusIfUnsubscribed: Boolean = false,
     showDivider: Boolean = true,
+    onSubscribeClick: (() -> Unit)? = null,
 ) {
     Column {
         Row(
@@ -72,7 +73,10 @@ fun PodcastItem(
                 Icon(
                     painter = painterResource(IR.drawable.plus_simple),
                     contentDescription = stringResource(LR.string.subscribe),
-                    tint = MaterialTheme.theme.colors.primaryIcon02
+                    tint = MaterialTheme.theme.colors.primaryIcon02,
+                    modifier = modifier
+                        .then(if (onSubscribeClick == null) Modifier else Modifier.clickable { onSubscribeClick() })
+
                 )
             }
         }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
@@ -32,7 +32,7 @@ fun PodcastItem(
     showSubscribed: Boolean = false,
     showPlusIfUnsubscribed: Boolean = false,
     showDivider: Boolean = true,
-    onSubscribeClick: (() -> Unit)? = null,
+    onPlusClick: (() -> Unit)? = null,
     maxLines: Int = 1,
 ) {
     Column {
@@ -77,7 +77,7 @@ fun PodcastItem(
                     contentDescription = stringResource(LR.string.subscribe),
                     tint = MaterialTheme.theme.colors.primaryIcon02,
                     modifier = modifier
-                        .then(if (onSubscribeClick == null) Modifier else Modifier.clickable { onSubscribeClick() })
+                        .then(if (onPlusClick == null) Modifier else Modifier.clickable { onPlusClick() })
 
                 )
             }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
@@ -33,6 +33,7 @@ fun PodcastItem(
     showPlusIfUnsubscribed: Boolean = false,
     showDivider: Boolean = true,
     onSubscribeClick: (() -> Unit)? = null,
+    maxLines: Int = 1,
 ) {
     Column {
         Row(
@@ -54,7 +55,7 @@ fun PodcastItem(
             ) {
                 TextH40(
                     text = podcast.title,
-                    maxLines = 1,
+                    maxLines = maxLines,
                     color = MaterialTheme.theme.colors.primaryText01
                 )
                 TextH50(

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
@@ -40,7 +40,7 @@ fun PodcastItem(
             modifier = modifier
                 .fillMaxWidth()
                 .then(if (onClick == null) Modifier else Modifier.clickable { onClick() })
-                .padding(horizontal = 16.dp)
+                .padding(horizontal = 16.dp, vertical = 8.dp)
         ) {
             PodcastImage(
                 uuid = podcast.uuid,
@@ -52,15 +52,16 @@ fun PodcastItem(
                     .padding(end = 16.dp)
                     .weight(1f)
             ) {
-                TextP40(
+                TextH40(
                     text = podcast.title,
                     maxLines = 1,
                     color = MaterialTheme.theme.colors.primaryText01
                 )
-                TextP50(
+                TextH50(
                     text = podcast.author,
                     maxLines = 1,
-                    color = MaterialTheme.theme.colors.primaryText02
+                    color = MaterialTheme.theme.colors.primaryText02,
+                    modifier = Modifier.padding(top = 2.dp)
                 )
             }
             if (subscribed && showSubscribed) {
@@ -81,7 +82,7 @@ fun PodcastItem(
             }
         }
         if (showDivider) {
-            HorizontalDivider()
+            HorizontalDivider(startIndent = 16.dp)
         }
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/PodcastSubscribeImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/PodcastSubscribeImage.kt
@@ -35,7 +35,7 @@ fun PodcastSubscribeImage(
     podcastUuid: String,
     podcastTitle: String,
     podcastSubscribed: Boolean,
-    onSubscribeClick: () -> Unit,
+    onSubscribeClick: (() -> Unit)?,
     modifier: Modifier = Modifier,
     subscribeButtonSize: Dp = 20.dp,
     shadowSize: Dp = 1.dp,
@@ -50,11 +50,15 @@ fun PodcastSubscribeImage(
         .aspectRatio(1f)
         .semantics(mergeDescendants = true) {}
     if (subscribeOnPodcastTap) {
-        rootModifier = rootModifier
-            .clickable(
-                onClickLabel = onClickLabel,
-                onClick = onSubscribeClick
-            )
+        rootModifier = if (onSubscribeClick != null) {
+            rootModifier
+                .clickable(
+                    onClickLabel = onClickLabel,
+                    onClick = onSubscribeClick
+                )
+        } else {
+            rootModifier
+        }
     }
     BoxWithConstraints(
         modifier = rootModifier,
@@ -72,10 +76,14 @@ fun PodcastSubscribeImage(
         val iconSize = subscribeButtonSize / 1.25f
         var iconModifier = Modifier.size(iconSize)
         if (!subscribeOnPodcastTap) {
-            iconModifier = iconModifier.clickable(
-                onClickLabel = onClickLabel,
-                onClick = onSubscribeClick
-            )
+            iconModifier = if (onSubscribeClick != null) {
+                iconModifier.clickable(
+                    onClickLabel = onClickLabel,
+                    onClick = onSubscribeClick
+                )
+            } else {
+                iconModifier
+            }
         }
         Box(
             contentAlignment = Alignment.BottomEnd,

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -202,6 +202,8 @@
     <string name="search_history_row_type_episode_subtitle">Episode \u2022 %s \u2022 %s</string>
     <string name="search_history_row_type_folder_subtitle">Folder \u2022 %s</string>
     <string name="search_history_row_type_podcast_subtitle">Podcast \u2022 %s</string>
+    <string name="search_results_all_episodes">All episodes</string>
+    <string name="search_results_all_podcasts">All podcasts</string>
     <string name="search_show_all">Show all</string>
 
     <string name="time_short_hours">%dh</string>
@@ -290,6 +292,7 @@
     <!-- Podcasts -->
 
     <string name="podcasts">Podcasts</string>
+    <string name="podcasts_all">All podcasts</string>
     <string name="podcasts_archive" translatable="false">@string/archive</string>
     <string name="podcasts_badges_all_unfinished">All unfinished</string>
     <string name="podcasts_badges_off">Off</string>


### PR DESCRIPTION
Part of #805 

## Description
This adds full-screen search results for podcasts and episodes.

## Testing Instructions

Prerequisites: 
- Enable search improvements feature flag in `base.gradle`
- Select `debug` build variant

#### All Podcasts

1. Go to `Podcasts` or `Discover` tab
2. Search a term that returns podcasts and episodes
3. Tap on "Show all" from the podcasts section
4. ✅ Notice that all podcast search results are shown
5. Tap on plus (subscribe) button
6. ✅ Notice that podcast is subscribed (** To unsubscribe, you'll need to go to the details screen that displays a confirmation dialog before unsubscribing)
9. Tap on a podcast
10. ✅ Notice that podcast details are shown
11. Go back to see the search history
12. ✅ Notice that the podcast is added to search history

#### All Episodes

1. Go to `Podcasts` or `Discover` tab
2. Search a term that returns podcasts and episodes
3. Tap on "Show all" from the episodes section
4. ✅ Notice that all episodes search results are shown
5. Tap on an episode
6. ✅ Notice that episode details are shown
7. Go back to see the search history
8. ✅ Notice that the episode is added to search history

#### Note 
Shared apk for design review: pdeCcb-1iH-p2#comment-1749

## Screenshots or Screencast 
All podcasts | All episodes
---| ----
![all_podcasts](https://user-images.githubusercontent.com/1405144/221511668-5a02d312-c973-4e1f-9362-30663065a243.png) | ![all_episodes](https://user-images.githubusercontent.com/1405144/221511732-7feeae4d-bcdb-47ea-9de0-9405b89ff2a4.png)


## Checklist
- If this is a user-facing change, I have added an entry in CHANGELOG.md
- I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack