### PR TITLE
Search results - Design review and improvements

### DIFF
--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -131,7 +131,6 @@ class SearchFragment : BaseFragment() {
             is SearchHistoryEntry.Folder -> listener?.onSearchFolderClick(entry.uuid)
             is SearchHistoryEntry.Podcast -> listener?.onSearchPodcastClick(entry.uuid)
             is SearchHistoryEntry.SearchTerm -> {
-                viewModel.updateSearchQuery(query = entry.term, immediate = true)
                 binding?.let {
                     it.searchView.setQuery(entry.term, true)
                     it.searchHistoryPanel.hide()
@@ -182,7 +181,7 @@ class SearchFragment : BaseFragment() {
 
         searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean {
-                viewModel.updateSearchQuery(query)
+                viewModel.updateSearchQuery(query, immediate = true)
                 binding.searchHistoryPanel.hide()
                 UiUtil.hideKeyboard(searchView)
                 return true

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -128,7 +128,6 @@ class SearchHandler @Inject constructor(
                         globalSearch = globalSearch.copy(podcastSearch = podcastSearch)
                         globalSearch
                     }
-                    .subscribeOn(Schedulers.io())
                     .toObservable()
 
                 if (BuildConfig.SEARCH_IMPROVEMENTS_ENABLED) {
@@ -138,8 +137,6 @@ class SearchHandler @Inject constructor(
                             globalSearch = globalSearch.copy(episodeSearch = episodeSearch)
                             globalSearch
                         }
-                        .subscribeOn(Schedulers.io())
-                        .toObservable()
 
                     podcastServerSearch.mergeWith(episodesServerSearch)
                 } else {

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -131,17 +131,20 @@ class SearchHandler @Inject constructor(
                     .subscribeOn(Schedulers.io())
                     .toObservable()
 
-                val episodesServerSearch = cacheServerManager
-                    .searchEpisodes(it)
-                    .map { episodeSearch ->
-                        globalSearch = globalSearch.copy(episodeSearch = episodeSearch)
-                        globalSearch
-                    }
-                    .subscribeOn(Schedulers.io())
-                    .toObservable()
+                if (BuildConfig.SEARCH_IMPROVEMENTS_ENABLED) {
+                    val episodesServerSearch = cacheServerManager
+                        .searchEpisodes(it)
+                        .map { episodeSearch ->
+                            globalSearch = globalSearch.copy(episodeSearch = episodeSearch)
+                            globalSearch
+                        }
+                        .subscribeOn(Schedulers.io())
+                        .toObservable()
 
-                podcastServerSearch
-                    .mergeWith(episodesServerSearch)
+                    podcastServerSearch.mergeWith(episodesServerSearch)
+                } else {
+                    podcastServerSearch
+                }
                     .subscribeOn(Schedulers.io())
                     .onErrorReturn { exception ->
                         GlobalServerSearch(error = exception)

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -169,7 +169,11 @@ class SearchHandler @Inject constructor(
             val searchPodcastsResult = (localPodcastsResult + serverPodcastsResult).distinctBy { it.uuid }
             val searchEpisodesResult = serverSearchResults.episodeSearch.episodes
 
-            if (serverSearchResults.searchTerm.isEmpty() || (searchPodcastsResult.isNotEmpty() || searchEpisodesResult.isNotEmpty()) || serverSearchResults.error != null) {
+            val hasResults =
+                serverSearchResults.searchTerm.isEmpty() || // if the search term is empty, we don't have "no results"
+                    (searchPodcastsResult.isNotEmpty() || searchEpisodesResult.isNotEmpty()) || // check if there are any results
+                    serverSearchResults.error != null // an error is a result
+            if (hasResults) {
                 serverSearchResults.error?.let {
                     analyticsTracker.track(AnalyticsEvent.SEARCH_FAILED, AnalyticsProp.sourceMap(source))
                 }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchInlineResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchInlineResultsPage.kt
@@ -179,12 +179,16 @@ private fun SearchResultsView(
                 }
             }
         }
-        if (state.episodes.isNotEmpty()) {
+        if (state.podcasts.isNotEmpty() && state.episodes.isNotEmpty()) {
             item {
                 HorizontalDivider(
                     startIndent = 16.dp,
                     modifier = modifier.padding(top = 20.dp, bottom = 4.dp)
                 )
+            }
+        }
+        if (state.episodes.isNotEmpty()) {
+            item {
                 SearchResultsHeaderView(
                     title = stringResource(LR.string.episodes),
                     onShowAllCLick = { onShowAllCLick(ResultsType.EPISODES) },

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchEpisodeRow.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchEpisodeRow.kt
@@ -43,13 +43,11 @@ fun SearchEpisodeItem(
         ) {
             PodcastImage(
                 uuid = episode.podcastUuid,
-                modifier = modifier
-                    .size(IconSize)
-                    .padding(top = 4.dp, end = 12.dp, bottom = 4.dp)
+                modifier = modifier.size(IconSize),
             )
             Column(
                 modifier = modifier
-                    .padding(end = 16.dp)
+                    .padding(start = 12.dp, end = 16.dp)
                     .weight(1f)
             ) {
                 TextC50(

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
@@ -20,7 +20,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-private val PodcastItemIconSize = 64.dp
+private val PodcastItemIconSize = 56.dp
 
 @Composable
 fun PodcastItem(
@@ -45,12 +45,11 @@ fun PodcastItem(
         ) {
             PodcastImage(
                 uuid = podcast.uuid,
-                modifier = modifier.size(iconSize)
-                    .padding(top = 4.dp, end = 12.dp, bottom = 4.dp)
+                modifier = modifier.size(iconSize),
             )
             Column(
                 modifier = modifier
-                    .padding(end = 16.dp)
+                    .padding(start = 12.dp, end = 16.dp)
                     .weight(1f)
             ) {
                 TextH40(

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImageSmall.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImageSmall.kt
@@ -28,8 +28,8 @@ private val gradientBottom = Color(0xFF000000)
 private val topPodcastImageGradient = listOf(Color(0x00000000), Color(0x16000000))
 private val bottomPodcastImageGradient = listOf(Color(0x16000000), Color(0x33000000))
 
-private val FolderImageSize = 64.dp
-private val PodcastImageSize = 26.dp
+private val FolderImageSize = 56.dp
+private val PodcastImageSize = 23.dp
 @Composable
 fun FolderImageSmall(
     color: Color,


### PR DESCRIPTION
Part of #787 and #805

## Description

This 
- Addresses search results design review comments: pdeCcb-1iH-p2#comment-1756 and
- Displays podcast and episode search results as they become available.

Prerequisites: 
- Enable search improvements feature flag in `base.gradle`
- Select `debug` build variant

## Testing Instructions
- Launch the app and connect to the debugger
- Filter for `.pocketcasts.net` in logs
- Go to `Discover` tab
- Search a term
- Notice that podcast and episode search results are shown as they become available ([logs](https://user-images.githubusercontent.com/1405144/222134280-de57ab89-bdb0-4ad8-a845-054cbb671b6b.png)) in search results.

## Screenshots or Screencast 

https://user-images.githubusercontent.com/1405144/222135053-bbbe3122-226d-46ea-8b1e-62d0274b66e6.mp4

#### Updated screenshots

![out](https://user-images.githubusercontent.com/1405144/222139543-787be17e-4ad7-4b25-b365-9218dc170f80.png)



