### PR TITLE
Search Improvements - Add remote feature flag

### DIFF
--- a/base.gradle
+++ b/base.gradle
@@ -31,7 +31,6 @@ android {
         // Feature Flags
         buildConfigField "boolean", "END_OF_YEAR_ENABLED", "false"
         buildConfigField "boolean", "SINGLE_SIGN_ON_ENABLED", "false"
-        buildConfigField "boolean", "SEARCH_IMPROVEMENTS_ENABLED", "false"
 
         testInstrumentationRunner project.testInstrumentationRunner
         testApplicationId "au.com.shiftyjelly.pocketcasts.test" + project.name.replace("-", "_")

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -22,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.search.SearchResultsFragment.Companion.ResultsType
 import au.com.shiftyjelly.pocketcasts.search.SearchViewModel.SearchResultType
 import au.com.shiftyjelly.pocketcasts.search.databinding.FragmentSearchBinding
@@ -48,6 +49,7 @@ private const val SEARCH_RESULTS_TAG = "search_results"
 @AndroidEntryPoint
 class SearchFragment : BaseFragment() {
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
+    @Inject lateinit var settings: Settings
 
     interface Listener {
         fun onSearchEpisodeClick(episodeUuid: String, podcastUuid: String, source: EpisodeViewSource)
@@ -235,7 +237,8 @@ class SearchFragment : BaseFragment() {
                         onFolderClick = ::onFolderClick,
                         onShowAllCLick = ::onShowAllClick,
                         onScroll = { UiUtil.hideKeyboard(searchView) },
-                        onlySearchRemote = onlySearchRemote
+                        onlySearchRemote = onlySearchRemote,
+                        settings = settings
                     )
                 }
             }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -130,7 +130,7 @@ class SearchHandler @Inject constructor(
                     }
                     .toObservable()
 
-                if (BuildConfig.SEARCH_IMPROVEMENTS_ENABLED) {
+                if (settings.isFeatureFlagSearchImprovementsEnabled()) {
                     val episodesServerSearch = cacheServerManager
                         .searchEpisodes(it)
                         .map { episodeSearch ->

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchInlineResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchInlineResultsPage.kt
@@ -47,6 +47,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.search.SearchResultsFragment.Companion.ResultsType
 import au.com.shiftyjelly.pocketcasts.search.component.SearchEpisodeItem
 import au.com.shiftyjelly.pocketcasts.search.component.SearchFolderItem
@@ -69,6 +70,7 @@ fun SearchInlineResultsPage(
     onShowAllCLick: (ResultsType) -> Unit,
     onScroll: () -> Unit,
     onlySearchRemote: Boolean,
+    settings: Settings,
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsState()
@@ -79,7 +81,7 @@ fun SearchInlineResultsPage(
             is SearchState.Results -> {
                 val result = state as SearchState.Results
                 if (result.error == null || !onlySearchRemote || result.loading) {
-                    if (BuildConfig.SEARCH_IMPROVEMENTS_ENABLED) {
+                    if (settings.isFeatureFlagSearchImprovementsEnabled()) {
                         SearchResultsView(
                             state = state as SearchState.Results,
                             onEpisodeClick = onEpisodeClick,

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/FirebaseConfig.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/FirebaseConfig.kt
@@ -5,10 +5,12 @@ object FirebaseConfig {
     const val PODCAST_SEARCH_DEBOUNCE_MS = "podcast_search_debounce_ms"
     const val EPISODE_SEARCH_DEBOUNCE_MS = "episode_search_debounce_ms"
     const val CLOUD_STORAGE_LIMIT = "custom_storage_limit_gb"
+    const val FEATURE_FLAG_SEARCH_IMPROVEMENTS = "feature_flag_search_improvements"
     val defaults = mapOf(
         PERIODIC_SAVE_TIME_MS to 60000L,
         PODCAST_SEARCH_DEBOUNCE_MS to 2000L,
         EPISODE_SEARCH_DEBOUNCE_MS to 2000L,
-        CLOUD_STORAGE_LIMIT to 10L
+        CLOUD_STORAGE_LIMIT to 10L,
+        FEATURE_FLAG_SEARCH_IMPROVEMENTS to false
     )
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -501,6 +501,7 @@ interface Settings {
     fun getPeriodicSaveTimeMs(): Long
     fun getPodcastSearchDebounceMs(): Long
     fun getEpisodeSearchDebounceMs(): Long
+    fun isFeatureFlagSearchImprovementsEnabled(): Boolean
     fun defaultPodcastGrouping(): PodcastGrouping
     fun setDefaultPodcastGrouping(podcastGrouping: PodcastGrouping)
     fun setSkipForwardInSec(value: Int)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1189,9 +1189,13 @@ class SettingsImpl @Inject constructor(
         return getRemoteConfigLong(FirebaseConfig.EPISODE_SEARCH_DEBOUNCE_MS)
     }
 
+    override fun isFeatureFlagSearchImprovementsEnabled(): Boolean {
+        return firebaseRemoteConfig.getBoolean(FirebaseConfig.FEATURE_FLAG_SEARCH_IMPROVEMENTS)
+    }
+
     private fun getRemoteConfigLong(key: String): Long {
         val value = firebaseRemoteConfig.getLong(key)
-        return if (value == 0L) (FirebaseConfig.defaults[key] ?: 0L) else value
+        return if (value == 0L) (FirebaseConfig.defaults[key] as? Long ?: 0L) else value
     }
 
     override fun getUpNextSwipeAction(): Settings.UpNextAction {


### PR DESCRIPTION
## Description

This adds a remote feature flag for the search improvement feature.

## Testing Instructions

Prerequisite:
Replace `api_key` for client app with package `au.com.shiftyjelly.pocketcasts.debug` inside `app/google_services.json` with the API key for the debug app. 

1. Install release build 
2. Go to `Discover` tab
3. Search a term
4. Notice that both podcasts and episodes are shown in search results
5. Go to Firebase console
6. Set `feature_flag_search_improvements` to `false` for "Development App" and publish changes
7. Set `setMinimumFetchIntervalInSeconds` to 1 sec for `FirebaseRemoteConfigSettings` inside `SettingsImpl.kt`
8. Reinstall the app
9. Repeat steps 1-3
10. Notice that only podcasts are shown in search results in a vertical layout
11. Go back to Firebase console, reset `feature_flag_search_improvements` to `true` for "Development App" and publish changes

#### Optional

1. Install release build (signed with production key)
2. Go to `Discover` tab
3. Search a term
4. Notice that only podcasts are shown in search results in a vertical layout
5. Go to Firebase console
6. Set `feature_flag_search_improvements` to `true` for "Android App"  and publish changes
7. Set `setMinimumFetchIntervalInSeconds` to 1 sec for `FirebaseRemoteConfigSettings` inside `SettingsImpl.kt`
8. Reinstall the app
9. Repeat steps 1-3
10. Notice that both podcasts and episodes are shown in search results
11. Go back to Firebase console, reset `feature_flag_search_improvements` to `false` for "Android App" and publish changes
