### PR TITLE
Improve the Automotive skip settings input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.35
 -----
-
+*   Updates
+    *   The Automotive skip forward and backward time settings were improved.
+        ([#817](https://github.com/Automattic/pocket-casts-android/pull/817)).
 
 7.34
 -----

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -16,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
+import au.com.shiftyjelly.pocketcasts.views.extensions.setInputAsSeconds
 import dagger.hilt.android.AndroidEntryPoint
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
@@ -31,10 +32,19 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), SharedP
     @Inject lateinit var podcastManager: PodcastManager
 
     private var preferenceRefreshNow: Preference? = null
+    private var preferenceSkipForward: EditTextPreference? = null
+    private var preferenceSkipBackward: EditTextPreference? = null
     private var refreshObservable: LiveData<RefreshState>? = null
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.preferences_auto)
+
+        preferenceSkipForward = preferenceManager.findPreference<EditTextPreference>(Settings.PREFERENCE_SKIP_FORWARD)?.apply {
+            setInputAsSeconds()
+        }
+        preferenceSkipBackward = preferenceManager.findPreference<EditTextPreference>(Settings.PREFERENCE_SKIP_BACKWARD)?.apply {
+            setInputAsSeconds()
+        }
 
         changeSkipTitles()
         setupRefreshNow()
@@ -110,9 +120,9 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), SharedP
 
     private fun changeSkipTitles() {
         val skipForwardSummary = resources.getStringPluralSeconds(settings.getSkipForwardInSecs())
-        preferenceManager.findPreference<EditTextPreference>(Settings.PREFERENCE_SKIP_FORWARD)?.summary = skipForwardSummary
+        preferenceSkipForward?.summary = skipForwardSummary
         val skipBackwardSummary = resources.getStringPluralSeconds(settings.getSkipBackwardInSecs())
-        preferenceManager.findPreference<EditTextPreference>(Settings.PREFERENCE_SKIP_BACKWARD)?.summary = skipBackwardSummary
+        preferenceSkipBackward?.summary = skipBackwardSummary
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {


### PR DESCRIPTION
## Description
When entering skip forward and backward times in the Automotive settings area the enter / submit button adds new lines to the skip value, this change fixes that.

## Testing Instructions
1. Load the Automotive app into an Automotive emulator
2. Tap on the settings cog
3. Tap Skip forward time
4. Change the time amount
5. ✅  Verify you can't tap the blue button tick button to add new lines to the amount

## Screenshots

| Before | After |
| --- | --- |
| ![Screenshot_20230307_155241](https://user-images.githubusercontent.com/308331/223328228-b240af63-4db8-4aad-9627-44253d0613cf.png) | ![Screenshot_20230307_155454](https://user-images.githubusercontent.com/308331/223328359-cccb2e68-08e0-4338-a584-22922b18cc03.png) |

