### PR TITLE
Add auto scroll to discover featured carousal

### DIFF
--- a/base.gradle
+++ b/base.gradle
@@ -31,6 +31,7 @@ android {
         // Feature Flags
         buildConfigField "boolean", "END_OF_YEAR_ENABLED", "false"
         buildConfigField "boolean", "SINGLE_SIGN_ON_ENABLED", "false"
+        buildConfigField "boolean", "DISCOVER_FEATURED_AUTO_SCROLL", "false"
 
         testInstrumentationRunner project.testInstrumentationRunner
         testApplicationId "au.com.shiftyjelly.pocketcasts.test" + project.name.replace("-", "_")

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/util/AutoScrollHelper.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/util/AutoScrollHelper.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.discover.util
 import java.util.Timer
 import java.util.TimerTask
 
-private const val AUTO_SCROLL_INTERVAL = 3000L
+private const val AUTO_SCROLL_INTERVAL = 5000L
 
 class AutoScrollHelper(private val onAutoScrollCompleted: () -> Unit) {
     private var autoScrollTimer: Timer? = null
@@ -35,6 +35,6 @@ class AutoScrollHelper(private val onAutoScrollCompleted: () -> Unit) {
     }
 
     companion object {
-        const val AUTO_SCROLL_DELAY = 1000L
+        const val AUTO_SCROLL_DELAY = 5000L
     }
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/util/AutoScrollHelper.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/util/AutoScrollHelper.kt
@@ -1,0 +1,36 @@
+package au.com.shiftyjelly.pocketcasts.discover.util
+
+import java.util.Timer
+import java.util.TimerTask
+
+private const val AUTO_SCROLL_INTERVAL = 3000L
+
+class AutoScrollHelper(private val onAutoScrollCompleted: () -> Unit) {
+    private var autoScrollTimer: Timer? = null
+    private var autoScrollTimerTask: TimerTask? = null
+    private var skipAutoScroll = false
+
+    fun startAutoScrollTimer() {
+        if (autoScrollTimerTask != null) return
+        autoScrollTimerTask = object : TimerTask() {
+            override fun run() {
+                if (!skipAutoScroll) onAutoScrollCompleted()
+                skipAutoScroll = false
+            }
+        }
+        autoScrollTimer = Timer().apply {
+            schedule(autoScrollTimerTask, 0, AUTO_SCROLL_INTERVAL)
+        }
+    }
+
+    fun stopAutoScrollTimer() {
+        autoScrollTimer?.cancel()
+        autoScrollTimerTask?.cancel()
+        autoScrollTimer = null
+        autoScrollTimerTask = null
+    }
+
+    fun skipAutoScroll() {
+        skipAutoScroll = true
+    }
+}

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/util/AutoScrollHelper.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/util/AutoScrollHelper.kt
@@ -10,7 +10,7 @@ class AutoScrollHelper(private val onAutoScrollCompleted: () -> Unit) {
     private var autoScrollTimerTask: TimerTask? = null
     private var skipAutoScroll = false
 
-    fun startAutoScrollTimer() {
+    fun startAutoScrollTimer(delay: Long = 0L) {
         if (autoScrollTimerTask != null) return
         autoScrollTimerTask = object : TimerTask() {
             override fun run() {
@@ -19,7 +19,7 @@ class AutoScrollHelper(private val onAutoScrollCompleted: () -> Unit) {
             }
         }
         autoScrollTimer = Timer().apply {
-            schedule(autoScrollTimerTask, 0, AUTO_SCROLL_INTERVAL)
+            schedule(autoScrollTimerTask, delay, AUTO_SCROLL_INTERVAL)
         }
     }
 
@@ -32,5 +32,9 @@ class AutoScrollHelper(private val onAutoScrollCompleted: () -> Unit) {
 
     fun skipAutoScroll() {
         skipAutoScroll = true
+    }
+
+    companion object {
+        const val AUTO_SCROLL_DELAY = 1000L
     }
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/util/ScrollingLinearLayoutManager.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/util/ScrollingLinearLayoutManager.kt
@@ -1,0 +1,33 @@
+package au.com.shiftyjelly.pocketcasts.discover.util
+
+import android.content.Context
+import android.util.DisplayMetrics
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.LinearSmoothScroller
+import androidx.recyclerview.widget.RecyclerView
+
+/* Increases scrolling speed of recyclerView.smoothScrollToPosition(position) */
+class ScrollingLinearLayoutManager(
+    context: Context?,
+    orientation: Int,
+    reverseLayout: Boolean,
+) : LinearLayoutManager(context, orientation, reverseLayout) {
+    override fun smoothScrollToPosition(
+        recyclerView: RecyclerView,
+        state: RecyclerView.State,
+        position: Int,
+    ) {
+        val linearSmoothScroller: LinearSmoothScroller =
+            object : LinearSmoothScroller(recyclerView.context) {
+                override fun calculateSpeedPerPixel(displayMetrics: DisplayMetrics): Float {
+                    return MILLISECONDS_PER_INCH / displayMetrics.densityDpi
+                }
+            }
+        linearSmoothScroller.targetPosition = position
+        startSmoothScroll(linearSmoothScroller)
+    }
+
+    companion object {
+        private const val MILLISECONDS_PER_INCH = 100f // default is 25f (bigger = slower)
+    }
+}

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/util/ScrollingLinearLayoutManager.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/util/ScrollingLinearLayoutManager.kt
@@ -6,7 +6,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.LinearSmoothScroller
 import androidx.recyclerview.widget.RecyclerView
 
-/* Increases scrolling speed of recyclerView.smoothScrollToPosition(position) */
+/*
+1. Increases scrolling speed of recyclerView.smoothScrollToPosition(position)
+2. Sets custom extra layout space for pre caching an extra page
+*/
 class ScrollingLinearLayoutManager(
     context: Context?,
     orientation: Int,
@@ -25,6 +28,13 @@ class ScrollingLinearLayoutManager(
             }
         linearSmoothScroller.targetPosition = position
         startSmoothScroll(linearSmoothScroller)
+    }
+
+    /* By default, LinearLayoutManager lays out 1 extra page of items while smooth scrolling, in the direction of the scroll.
+       This behavior is overridden to lay out an extra page even on a manual swipe. */
+    override fun calculateExtraLayoutSpace(state: RecyclerView.State, extraLayoutSpace: IntArray) {
+        extraLayoutSpace[0] = 0
+        extraLayoutSpace[1] = this.width
     }
 
     companion object {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -79,7 +79,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 private const val MAX_ROWS_SMALL_LIST = 20
 private const val CURRENT_PAGE = "current_page"
 private const val TOTAL_PAGES = "total_pages"
-private const val INITIAL_PREFETCH_COUNT = 3
+private const val INITIAL_PREFETCH_COUNT = 1
 
 internal data class ChangeRegionRow(val region: DiscoverRegion)
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -182,7 +182,8 @@ internal class DiscoverAdapter(
                     }
                     RecyclerView.SCROLL_STATE_IDLE -> {
                         if (draggingStarted) {
-                            autoScrollHelper?.startAutoScrollTimer()
+                            /* Start auto scroll with a delay after a manual swipe */
+                            autoScrollHelper?.startAutoScrollTimer(delay = AutoScrollHelper.AUTO_SCROLL_DELAY)
                             draggingStarted = false
                         }
                     }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -29,6 +29,7 @@ import au.com.shiftyjelly.pocketcasts.discover.databinding.RowSingleEpisodeBindi
 import au.com.shiftyjelly.pocketcasts.discover.databinding.RowSinglePodcastBinding
 import au.com.shiftyjelly.pocketcasts.discover.extensions.updateSubscribeButtonIcon
 import au.com.shiftyjelly.pocketcasts.discover.util.AutoScrollHelper
+import au.com.shiftyjelly.pocketcasts.discover.util.ScrollingLinearLayoutManager
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.EPISODE_UUID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.LIST_ID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.PODCAST_UUID_KEY
@@ -191,13 +192,17 @@ internal class DiscoverAdapter(
 
         val adapter = CarouselListRowAdapter(null, theme, listener::onPodcastClicked, listener::onPodcastSubscribe, analyticsTracker)
 
-        private val linearLayoutManager =
-            LinearLayoutManager(itemView.context, RecyclerView.HORIZONTAL, false).apply {
+        private val scrollingLayoutManager =
+            ScrollingLinearLayoutManager(
+                itemView.context,
+                RecyclerView.HORIZONTAL,
+                false
+            ).apply {
                 initialPrefetchItemCount = INITIAL_PREFETCH_COUNT
             }
 
         init {
-            recyclerView?.layoutManager = linearLayoutManager
+            recyclerView?.layoutManager = scrollingLayoutManager
             recyclerView?.itemAnimator = null
             recyclerView?.addOnScrollListener(scrollListener)
 
@@ -243,7 +248,7 @@ internal class DiscoverAdapter(
         override fun onRestoreInstanceState(state: Parcelable?) {
             super.onRestoreInstanceState(state)
             recyclerView?.post {
-                binding.pageIndicatorView.position = linearLayoutManager.findFirstVisibleItemPosition()
+                binding.pageIndicatorView.position = scrollingLayoutManager.findFirstVisibleItemPosition()
                 recyclerView.scrollToPosition(binding.pageIndicatorView.position)
             }
         }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -76,6 +76,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 private const val MAX_ROWS_SMALL_LIST = 20
 private const val CURRENT_PAGE = "current_page"
 private const val TOTAL_PAGES = "total_pages"
+private const val INITIAL_PREFETCH_COUNT = 3
 
 internal data class ChangeRegionRow(val region: DiscoverRegion)
 
@@ -192,7 +193,7 @@ internal class DiscoverAdapter(
 
         private val linearLayoutManager =
             LinearLayoutManager(itemView.context, RecyclerView.HORIZONTAL, false).apply {
-                initialPrefetchItemCount = 1
+                initialPrefetchItemCount = INITIAL_PREFETCH_COUNT
             }
 
         init {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -36,6 +36,7 @@ import au.com.shiftyjelly.pocketcasts.discover.viewmodel.PodcastList
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.localization.helper.tryToLocalise
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
+import au.com.shiftyjelly.pocketcasts.preferences.BuildConfig
 import au.com.shiftyjelly.pocketcasts.repositories.images.into
 import au.com.shiftyjelly.pocketcasts.servers.cdn.ArtworkColors
 import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServerManagerImpl
@@ -199,13 +200,15 @@ internal class DiscoverAdapter(
             recyclerView?.itemAnimator = null
             recyclerView?.addOnScrollListener(scrollListener)
 
-            autoScrollHelper = AutoScrollHelper {
-                if (adapter.itemCount == 0) return@AutoScrollHelper
-                val nextPosition = (binding.pageIndicatorView.position + 1)
-                    .takeIf { it < adapter.itemCount } ?: 0
-                recyclerView?.smoothScrollToPosition(nextPosition)
-                binding.pageIndicatorView.position = nextPosition
-                trackPageChanged(nextPosition)
+            if (BuildConfig.DISCOVER_FEATURED_AUTO_SCROLL) {
+                autoScrollHelper = AutoScrollHelper {
+                    if (adapter.itemCount == 0) return@AutoScrollHelper
+                    val nextPosition = (binding.pageIndicatorView.position + 1)
+                        .takeIf { it < adapter.itemCount } ?: 0
+                    recyclerView?.smoothScrollToPosition(nextPosition)
+                    binding.pageIndicatorView.position = nextPosition
+                    trackPageChanged(nextPosition)
+                }
             }
 
             val snapHelper = HorizontalPeekSnapHelper(0)


### PR DESCRIPTION
## Description
This adds auto scroll to discover featured carousal

## Testing Instructions

**No auto scroll on default**
1. Launch the app
2. Open Discover 
3. Notice the Featured Carousel doesn't auto scroll 

**Auto Scroll**

1. Enable `DISCOVER_FEATURED_AUTO_SCROLL` feature flag in `base.gradle`
2. Open Discover 
3. Watch the Featured carousel auto scroll 
4. Watch that on the last item the carousel returns to the first item 

**Auto scroll and manual scroll**
1. Swipe to scroll the carousel forward or backwards
2. See the autoscroll continues to the next item as expected

Additionally, test that the auto-scroll timer doesn't keep running when the app is backgrounded or moving to another screen.

## Screenshots or Screencast 

https://user-images.githubusercontent.com/1405144/223427758-5cc81be9-4dc0-444b-a2e2-528003072f11.mp4

