### PR TITLE
Fix Automotive Up Next podcast images not loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Updates
     *   The Automotive skip forward and backward time settings were improved.
         ([#817](https://github.com/Automattic/pocket-casts-android/pull/817)).
+    *   Fixed Automotive Up Next podcast images not loading.
+        ([#819](https://github.com/Automattic/pocket-casts-android/pull/819)).
 
 7.34
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -226,7 +226,7 @@ class MediaSessionManager(
         }
     }
 
-    fun updateUpNext(upNext: UpNextQueue.State) {
+    private fun updateUpNext(upNext: UpNextQueue.State) {
         try {
             mediaSession.setQueueTitle("Up Next")
             if (upNext is UpNextQueue.State.Loaded) {
@@ -236,11 +236,13 @@ class MediaSessionManager(
                     val podcastUuid = if (episode is Episode) episode.podcastUuid else null
                     val podcast = podcastUuid?.let { podcastManager.findPodcastByUuid(it) }
                     val podcastTitle = episode.displaySubtitle(podcast)
+                    val localUri = AutoConverter.getBitmapUriForPodcast(podcast, episode, context)
                     val description = MediaDescriptionCompat.Builder()
                         .setDescription(episode.episodeDescription)
                         .setTitle(episode.title)
                         .setSubtitle(podcastTitle)
                         .setMediaId(episode.uuid)
+                        .setIconUri(localUri)
                         .build()
 
                     return@map MediaSessionCompat.QueueItem(description, episode.adapterId)


### PR DESCRIPTION
## Description
When opening the Up Next list in the Automotive app the podcast artwork wasn't loading, this change fixes that.

Fixes https://github.com/Automattic/pocket-casts-android/issues/813

## Testing Instructions
1. Load the mobile app into a mobile emulator
2. Login or create an account
3. Add multiple episodes to the Up Next
4. Make sure the Up Next has synced to the server
5. Load the Automotive app into an Automotive emulator
6. Tap the settings cog
7. Sign into the account
8. Tap to open the full screen player
9. Tap the Up Next list icon
10. ✅  Verify the episode artwork is displayed.

## Screenshots
| Before | After |
| --- | --- |
| ![Screenshot_20230307_234612](https://user-images.githubusercontent.com/308331/223434630-fe8281b7-e58c-4ebe-9179-ee0be930b7ae.png) | ![Screenshot_20230307_234716](https://user-images.githubusercontent.com/308331/223434683-e18993cd-f729-4f99-be9e-268010d2de10.png) |
| ![Screenshot_20230307_234621](https://user-images.githubusercontent.com/308331/223434814-a2230d70-947e-4a62-ac91-2a68486e14ca.png) | ![Screenshot_20230307_234724](https://user-images.githubusercontent.com/308331/223434779-a295e398-cf6f-4c24-bc38-02214f0d5bbc.png) |
