### PR TITLE
Update the playing episode in the media session if the duration changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
         ([#817](https://github.com/Automattic/pocket-casts-android/pull/817)).
     *   Fixed Automotive Up Next podcast images not loading.
         ([#819](https://github.com/Automattic/pocket-casts-android/pull/819)).
+    *   Fixed missing seek bar in the notification drawer and Android Automotive.
+        ([#822](https://github.com/Automattic/pocket-casts-android/pull/822)).
 
 7.34
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
@@ -44,6 +44,19 @@ interface UpNextQueue {
         fun queueSize(): Int {
             return if (this is Loaded) queue.size else 0
         }
+
+        companion object {
+            fun isEqualWithEpisodeCompare(stateOne: State, stateTwo: State, isPlayingEpisodeEqual: (Playable, Playable) -> Boolean): Boolean {
+                return when {
+                    stateOne is Empty && stateTwo is Empty -> true
+                    stateOne is Loaded && stateTwo is Loaded -> {
+                        stateOne.queue.map { it.uuid } == stateTwo.queue.map { it.uuid } &&
+                            isPlayingEpisodeEqual(stateOne.episode, stateTwo.episode)
+                    }
+                    else -> false
+                }
+            }
+        }
     }
 
     fun setup()


### PR DESCRIPTION
## Description
This change fixes the issue when playing an episode without a duration in the feed XML, the seek bar isn't being displayed when using the data from the Media Session. The bug was found in Android Automotive but it's repeatable on mobile too with the notification drawer. The media player reports the episode duration length once it has opened the file and updates the database. This change is now picked up and the media session duration is updated which causes the seek bar to appear.

Fixes https://github.com/Automattic/pocket-casts-android/issues/816

## Testing Instructions

1. Open the mobile app
2. Search for the podcast 'Ted Talk Daily' 
3. Find an episode that has a dash '-' instead of the duration and tap play on the episode
4. ✅ Quickly open the notification drawer. Initially the seek bar won't appear but will once playback starts it will appear.

## Screenshots
<img width="435" alt="Screenshot 2023-03-08 at 3 01 20 pm" src="https://user-images.githubusercontent.com/308331/223620097-dbe95253-330b-4f48-a269-f52a4b3feb5e.png">



