### PR TITLE
Load carousel sponsored podcasts

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
@@ -12,6 +12,7 @@ import au.com.shiftyjelly.pocketcasts.discover.R
 import au.com.shiftyjelly.pocketcasts.discover.extensions.updateSubscribeButtonIcon
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private val differ: DiffUtil.ItemCallback<Any> = object : DiffUtil.ItemCallback<Any>() {
     override fun areItemsTheSame(oldItem: Any, newItem: Any): Boolean {
@@ -42,8 +43,15 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
     override fun onBindViewHolder(holder: CarouselItemViewHolder, position: Int) {
         val podcast = getItem(position)
         if (podcast is DiscoverPodcast) {
+            val context = holder.itemView.context
+            val tagLineText = if (podcast.isSponsored) {
+                context.getString(LR.string.discover_sponsored)
+            } else {
+                pillText
+            }
             holder.podcast = podcast
-            holder.setTaglineText(pillText)
+
+            holder.setTaglineText(tagLineText)
             holder.itemView.setOnClickListener {
                 onPodcastClicked(podcast, null) // no analytics for carousel
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -432,7 +432,7 @@ internal class DiscoverAdapter(
                                 .take(featuredLimit)
                                 .toMutableList()
                             sponsoredPodcastList.forEach { sponsoredPodcast ->
-                                mutableList.addSafely(sponsoredPodcast.podcast, sponsoredPodcast.position)
+                                mutableList.addSafely(sponsoredPodcast.podcast.copy(isSponsored = true), sponsoredPodcast.position)
                             }
                             Flowable.fromIterable(mutableList.toList())
                                 .concatMap { discoverPodcast ->

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -146,7 +146,15 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
         val recyclerView = binding?.recyclerView ?: return
         recyclerView.layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
         if (adapter == null) {
-            adapter = DiscoverAdapter(viewModel.repository, staticServerManager, this, theme, viewModel::loadPodcastList, analyticsTracker)
+            adapter = DiscoverAdapter(
+                service = viewModel.repository,
+                staticServerManager = staticServerManager,
+                listener = this,
+                theme = theme,
+                loadPodcastList = viewModel::loadPodcastList,
+                loadCarouselSponsoredPodcastList = viewModel::loadCarouselSponsoredPodcasts,
+                analyticsTracker = analyticsTracker
+            )
         }
         recyclerView.adapter = adapter
         recyclerView.itemAnimator = null

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1397,6 +1397,7 @@
     <string name="discover_popular_in">Popular in %s</string>
     <string name="discover_button_play_episode">Play Episode</string>
     <string name="discover_button_play_trailer">Play Trailer</string>
+    <string name="discover_sponsored">Sponsored</string>
 
     <!-- Server errors -->
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModel.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModel.kt
@@ -62,7 +62,8 @@ data class DiscoverRow(
     @field:Json(name = "uuid") override val listUuid: String?,
     @field:Json(name = "regions") val regions: List<String>,
     @field:Json(name = "sponsored") val sponsored: Boolean = false,
-    @field:Json(name = "curated") override val curated: Boolean = false
+    @field:Json(name = "curated") override val curated: Boolean = false,
+    @field:Json(name = "sponsored_podcasts") val sponsoredPodcasts: List<SponsoredPodcast> = emptyList(),
 ) : NetworkLoadableList {
 
     override fun transformWithReplacements(replacements: Map<String, String>, resources: Resources): DiscoverRow {
@@ -83,9 +84,29 @@ data class DiscoverRow(
 
         newExpandedTopItemLabel = newExpandedTopItemLabel?.tryToLocalise(resources)
 
-        return DiscoverRow(id, type, displayStyle, expandedStyle, newExpandedTopItemLabel, newTitle, newSource, listUuid, regions, sponsored, curated)
+        return DiscoverRow(
+            id = id,
+            type = type,
+            displayStyle = displayStyle,
+            expandedStyle = expandedStyle,
+            expandedTopItemLabel = newExpandedTopItemLabel,
+            title = newTitle,
+            source = newSource,
+            listUuid = listUuid,
+            regions = regions,
+            sponsored = sponsored,
+            curated = curated,
+            sponsoredPodcasts = sponsoredPodcasts
+        )
     }
 }
+
+@Parcelize
+@JsonClass(generateAdapter = true)
+data class SponsoredPodcast(
+    @field:Json(name = "position") val position: Int?,
+    @field:Json(name = "source") val source: String?,
+) : Parcelable
 
 @JsonClass(generateAdapter = true)
 data class ListFeed(

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModel.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModel.kt
@@ -189,6 +189,7 @@ data class DiscoverPodcast(
     @field:Json(name = "language") val language: String?,
     @field:Json(name = "media_type") val mediaType: String?,
     val isSubscribed: Boolean = false,
+    val isSponsored: Boolean = false,
     @ColorInt var color: Int = 0
 ) : Parcelable {
     fun updateIsSubscribed(value: Boolean): DiscoverPodcast {


### PR DESCRIPTION
## Description
This PR prepares the Discover Carousel to be able to show sponsored podcasts.

iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/755

**Tracks will be tackled in a separate task.**

## Testing Instructions
1. Switch to `debug` build variant
2. ✅ Make sure that `Discover` tab -> `Featured` carousel appears just fine
3. Go to `ListWebService.kt` and change line 12 to `@GET("/discover/{platform}/content-carousel.json")` (so it will use the mock)
4. Run the app
5. ✅ The carousel should appear. All the items should display the "Featured" label except the first and the fourth, which displays "Sponsored"
