### PR TITLE
Carousel sponsored podcast tracks

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
@@ -53,17 +53,38 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
 
             holder.setTaglineText(tagLineText)
             holder.itemView.setOnClickListener {
-                onPodcastClicked(podcast, null) // no analytics for carousel
+                onPodcastClicked(podcast, podcast.listId) // no analytics for carousel
 
-                FirebaseAnalyticsTracker.openedFeaturedPodcast()
-                analyticsTracker.track(AnalyticsEvent.DISCOVER_FEATURED_PODCAST_TAPPED, AnalyticsProp.featuredPodcastTapped(podcast.uuid))
+                if (podcast.listId != null) {
+                    val listId = podcast.listId as String
+                    FirebaseAnalyticsTracker.podcastTappedFromList(listId, podcast.uuid)
+                    analyticsTracker.track(
+                        AnalyticsEvent.DISCOVER_LIST_PODCAST_TAPPED,
+                        AnalyticsProp.sponsoredPodcastTapped(listId, podcast.uuid)
+                    )
+                } else {
+                    FirebaseAnalyticsTracker.openedFeaturedPodcast()
+                    analyticsTracker.track(
+                        AnalyticsEvent.DISCOVER_FEATURED_PODCAST_TAPPED,
+                        AnalyticsProp.featuredPodcastTapped(podcast.uuid)
+                    )
+                }
             }
             holder.btnSubscribe.setOnClickListener {
                 holder.btnSubscribe.updateSubscribeButtonIcon(subscribed = true)
                 onPodcastSubscribe(podcast, null) // no analytics for carousel
 
-                FirebaseAnalyticsTracker.subscribedToFeaturedPodcast()
-                analyticsTracker.track(AnalyticsEvent.DISCOVER_FEATURED_PODCAST_SUBSCRIBED, AnalyticsProp.featuredPodcastSubscribed(podcast.uuid))
+                if (podcast.listId != null) {
+                    val listId = podcast.listId as String
+                    FirebaseAnalyticsTracker.podcastSubscribedFromList(listId, podcast.uuid)
+                    analyticsTracker.track(
+                        AnalyticsEvent.DISCOVER_LIST_PODCAST_SUBSCRIBED,
+                        AnalyticsProp.sponsoredPodcastSubscribed(listId, podcast.uuid)
+                    )
+                } else {
+                    FirebaseAnalyticsTracker.subscribedToFeaturedPodcast()
+                    analyticsTracker.track(AnalyticsEvent.DISCOVER_FEATURED_PODCAST_SUBSCRIBED, AnalyticsProp.featuredPodcastSubscribed(podcast.uuid))
+                }
                 analyticsTracker.track(AnalyticsEvent.PODCAST_SUBSCRIBED, AnalyticsProp.podcastSubscribed(AnalyticsSource.DISCOVER, podcast.uuid))
             }
         } else {
@@ -73,9 +94,13 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
 
     companion object {
         private object AnalyticsProp {
+            const val LIST_ID_KEY = "list_id"
             private const val PODCAST_UUID_KEY = "podcast_uuid"
             private const val SOURCE_KEY = "source"
             private const val UUID_KEY = "uuid"
+
+            fun sponsoredPodcastTapped(listId: String, uuid: String) = mapOf(LIST_ID_KEY to listId, PODCAST_UUID_KEY to uuid)
+            fun sponsoredPodcastSubscribed(listId: String, uuid: String) = mapOf(LIST_ID_KEY to listId, PODCAST_UUID_KEY to uuid)
             fun featuredPodcastTapped(uuid: String) = mapOf(PODCAST_UUID_KEY to uuid)
             fun featuredPodcastSubscribed(uuid: String) = mapOf(PODCAST_UUID_KEY to uuid)
             fun podcastSubscribed(source: AnalyticsSource, uuid: String) =

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -414,7 +414,7 @@ internal class DiscoverAdapter(
                                 .take(featuredLimit)
                                 .toMutableList()
                             sponsoredPodcastList.forEach { sponsoredPodcast ->
-                                mutableList.addSafely(sponsoredPodcast.podcast.copy(isSponsored = true), sponsoredPodcast.position)
+                                mutableList.addSafely(sponsoredPodcast.podcast.copy(isSponsored = true, listId = sponsoredPodcast.listId), sponsoredPodcast.position)
                             }
                             Flowable.fromIterable(mutableList.toList())
                                 .concatMap { discoverPodcast ->

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -84,6 +84,7 @@ private const val MAX_ROWS_SMALL_LIST = 20
 private const val CURRENT_PAGE = "current_page"
 private const val TOTAL_PAGES = "total_pages"
 private const val INITIAL_PREFETCH_COUNT = 1
+private const val LIST_ID = "list_id"
 
 internal data class ChangeRegionRow(val region: DiscoverRegion)
 
@@ -175,6 +176,7 @@ internal class DiscoverAdapter(
     }
 
     inner class CarouselListViewHolder(var binding: RowCarouselListBinding) : NetworkLoadableViewHolder(binding.root) {
+        private var listIdImpressionTracked = mutableListOf<String>()
         private var autoScrollHelper: AutoScrollHelper? = null
         private val scrollListener = object : OnScrollListener() {
             private var draggingStarted: Boolean = false
@@ -228,6 +230,7 @@ internal class DiscoverAdapter(
                             recyclerView?.scrollToPosition(nextPosition)
                         }
                         binding.pageIndicatorView.position = nextPosition
+                        trackSponsoredListImpression(nextPosition)
                         trackPageChanged(nextPosition)
                     }
                 }
@@ -239,6 +242,7 @@ internal class DiscoverAdapter(
                 /* Page just snapped, skip auto scroll */
                 autoScrollHelper?.skipAutoScroll()
                 binding.pageIndicatorView.position = position
+                trackSponsoredListImpression(position)
                 trackPageChanged(position)
             }
 
@@ -264,8 +268,10 @@ internal class DiscoverAdapter(
         override fun onRestoreInstanceState(state: Parcelable?) {
             super.onRestoreInstanceState(state)
             recyclerView?.post {
-                binding.pageIndicatorView.position = scrollingLayoutManager.findFirstVisibleItemPosition()
-                recyclerView.scrollToPosition(binding.pageIndicatorView.position)
+                val position = scrollingLayoutManager.findFirstVisibleItemPosition()
+                binding.pageIndicatorView.position = position
+                recyclerView.scrollToPosition(position)
+                trackSponsoredListImpression(position)
             }
         }
 
@@ -274,6 +280,19 @@ internal class DiscoverAdapter(
                 AnalyticsEvent.DISCOVER_FEATURED_PAGE_CHANGED,
                 mapOf(CURRENT_PAGE to position, TOTAL_PAGES to adapter.itemCount)
             )
+        }
+
+        private fun trackSponsoredListImpression(position: Int) {
+            val discoverPodcast = adapter.currentList[position] as? DiscoverPodcast
+            discoverPodcast?.listId?.let {
+                if (listIdImpressionTracked.contains(it)) return
+                FirebaseAnalyticsTracker.listImpression(it)
+                analyticsTracker.track(
+                    AnalyticsEvent.DISCOVER_LIST_IMPRESSION,
+                    mapOf(LIST_ID to it)
+                )
+                listIdImpressionTracked.add(it)
+            }
         }
     }
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModel.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModel.kt
@@ -125,7 +125,8 @@ data class ListFeed(
     @field:Json(name = "promotion") var promotion: DiscoverPromotion?,
     @field:Json(name = "payment") val payment: ListPayment? = null,
     @field:Json(name = "paid") val paid: Boolean? = false,
-    @field:Json(name = "author") val author: String? = null
+    @field:Json(name = "author") val author: String? = null,
+    @field:Json(name = "list_id") val listId: String? = null
 ) {
     val displayList: List<Any>
         get() {
@@ -190,6 +191,7 @@ data class DiscoverPodcast(
     @field:Json(name = "media_type") val mediaType: String?,
     val isSubscribed: Boolean = false,
     val isSponsored: Boolean = false,
+    val listId: String? = null, // for carousel sponsored podcast
     @ColorInt var color: Int = 0
 ) : Parcelable {
     fun updateIsSubscribed(value: Boolean): DiscoverPodcast {


### PR DESCRIPTION
This adds tracks for the sponsored podcasts on the Discover Carousel.

## To test

1. Switch to `Debug` build variant 
2. Go to `ListWebService.kt `and change line 12 to `@GET("/discover/{platform}/content-carousel.json")` (so it will use the mock)
3. Run the app
4. Open `Discover`
5. ✅ `discover_list_impression ["list_id": "59b88279-f856-4448-9422-8680d4181704"]` should be tracked for Tracks and Firebase
6. ✅ Swipe the carousel, once the next Sponsored podcast is shown `discover_list_impression ["list_id": "e46179c2-4ef7-4ac4-9138-700fe80e2ef2"]` should be tracked for Tracks and Firebase
7. Subscribe to the first sponsored podcast
8. ✅ `discover_list_podcast_subscribe ["podcast_uuid": "f27fe110-584a-0137-f266-1d245fc5f9cf", "list_id": "59b88279-f856-4448-9422-8680d4181704"]` should be tracked for Tracks and Firebase
9. Tap the first sponsored podcast
10. ✅ `discover_list_podcast_tap ["list_id": "59b88279-f856-4448-9422-8680d4181704", "podcast_uuid": "f27fe110-584a-0137-f266-1d245fc5f9cf"]` should be tracked for Tracks and Firebase
11. Play an episode for the podcast you just tapped
12. ✅ `Tracked: discover_list_episode_play ["list_id": "59b88279-f856-4448-9422-8680d4181704", "podcast_uuid": "f27fe110-584a-0137-f266-1d245fc5f9cf"]` should be tracked for Tracks and Firebase