### PR TITLE
Add option to clear data when logging out of Automotive app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
         ([#819](https://github.com/Automattic/pocket-casts-android/pull/819)).
     *   Fixed missing seek bar in the notification drawer and Android Automotive.
         ([#822](https://github.com/Automattic/pocket-casts-android/pull/822)).
+    *   Added option to clear data when signing out of Android Automotive.
+        ([828](https://github.com/Automattic/pocket-casts-android/pull/828))
 
 7.34
 -----

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -265,8 +265,8 @@ class AccountDetailsFragment : BaseFragment() {
         val themedContext = if (Util.isAutomotive(context)) ContextThemeWrapper(context, CR.style.Theme_Car_NoActionBar) else context
         val builder = AlertDialog.Builder(themedContext)
         builder.setTitle(getString(LR.string.profile_clear_data_question))
-            .setMessage("Would you also like to clear all data from the app?")
-            .setPositiveButton("Just sign out") { _, _ -> performSignOut() }
+            .setMessage(getString(LR.string.profile_clear_data_would_you_also_like_question))
+            .setPositiveButton(getString(LR.string.profile_just_sign_out)) { _, _ -> performSignOut() }
             .setNegativeButton(getString(LR.string.profile_clear_data)) { _, _ ->
                 signOutAndClearData()
             }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -279,7 +279,7 @@ class AccountDetailsFragment : BaseFragment() {
 
         // Block while clearing data so that we don't return to the app until the users data has been cleared
         runBlocking(Dispatchers.IO) {
-            upNextQueue.removeAll()
+            upNextQueue.removeAllIncludingChanges()
 
             playlistManager.resetDb()
             folderManager.deleteAll()

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -290,7 +290,6 @@ class AccountDetailsFragment : BaseFragment() {
             userEpisodeManager.findUserEpisodes().forEach {
                 userEpisodeManager.delete(it, playbackManager)
             }
-            episodeManager.deleteDownloadedEpisodeFiles()
             episodeManager.deleteAll()
         }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -11,7 +11,6 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.account.ChangeEmailFragment
@@ -26,7 +25,13 @@ import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.profile.databinding.FragmentAccountDetailsBinding
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
@@ -38,6 +43,8 @@ import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import java.util.Date
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.cartheme.R as CR
@@ -54,11 +61,17 @@ class AccountDetailsFragment : BaseFragment() {
         }
     }
 
-    @Inject lateinit var settings: Settings
-    @Inject lateinit var userManager: UserManager
+    @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
+    @Inject lateinit var episodeManager: EpisodeManager
+    @Inject lateinit var folderManager: FolderManager
+    @Inject lateinit var playlistManager: PlaylistManager
     @Inject lateinit var playbackManager: PlaybackManager
     @Inject lateinit var podcastManager: PodcastManager
-    @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
+    @Inject lateinit var searchHistoryManager: SearchHistoryManager
+    @Inject lateinit var settings: Settings
+    @Inject lateinit var upNextQueue: UpNextQueue
+    @Inject lateinit var userEpisodeManager: UserEpisodeManager
+    @Inject lateinit var userManager: UserManager
 
     private val viewModel: AccountDetailsViewModel by viewModels()
     private var binding: FragmentAccountDetailsBinding? = null
@@ -242,9 +255,46 @@ class AccountDetailsFragment : BaseFragment() {
         val builder = AlertDialog.Builder(themedContext)
         builder.setTitle(getString(LR.string.profile_sign_out))
             .setMessage(getString(LR.string.profile_sign_out_confirm))
-            .setPositiveButton(getString(LR.string.profile_sign_out)) { _, _ -> performSignOut() }
+            .setPositiveButton(getString(LR.string.profile_sign_out)) { _, _ -> clearDataAlert() }
             .setNegativeButton(getString(LR.string.cancel), null)
             .show()
+    }
+
+    private fun clearDataAlert() {
+        val context = context ?: return
+        val themedContext = if (Util.isAutomotive(context)) ContextThemeWrapper(context, CR.style.Theme_Car_NoActionBar) else context
+        val builder = AlertDialog.Builder(themedContext)
+        builder.setTitle(getString(LR.string.profile_clear_data_question))
+            .setMessage("Would you also like to clear all data from the app?")
+            .setPositiveButton("Just sign out") { _, _ -> performSignOut() }
+            .setNegativeButton(getString(LR.string.profile_clear_data)) { _, _ ->
+                signOutAndClearData()
+            }
+            .show()
+    }
+
+    private fun signOutAndClearData() {
+        // Sign out first to make sure no data changes get synced
+        userManager.signOut(playbackManager, wasInitiatedByUser = true)
+
+        // Block while clearing data so that we don't return to the app until the users data has been cleared
+        runBlocking(Dispatchers.IO) {
+            upNextQueue.removeAll()
+
+            playlistManager.resetDb()
+            folderManager.deleteAll()
+            searchHistoryManager.clearAll()
+
+            podcastManager.deleteAllPodcasts()
+
+            userEpisodeManager.findUserEpisodes().forEach {
+                userEpisodeManager.delete(it, playbackManager)
+            }
+            episodeManager.deleteDownloadedEpisodeFiles()
+            episodeManager.deleteAll()
+        }
+
+        activity?.finish()
     }
 
     private fun performSignOut() {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -650,6 +650,7 @@
     <string name="profile_clear_all">Clear all</string>
     <string name="profile_clear_data">Clear data</string>
     <string name="profile_clear_data_question">Clear data?</string>
+    <string name="profile_clear_data_would_you_also_like_question">Would you also like to clear all data from the app?</string>
     <string name="profile_clear_cannot_be_undone">This action cannot be undone.</string>
     <string name="profile_clear_listening_history">Clear listening history</string>
     <string name="profile_clear_listening_history_title">Clear Listening History</string>
@@ -757,6 +758,7 @@
     <string name="profile_get_plus">Get Pocket Casts Plus to unlock this feature, plus lots more!</string>
     <string name="profile_help_support">Help support Pocket Casts by upgrading your account</string>
     <string name="profile_joined">Joined:</string>
+    <string name="profile_just_sign_out">Just sign out</string>
     <string name="profile_last_refresh">Last refresh: %s ago</string>
     <string name="profile_license_agreement">Pocket Casts values your privacy. This Privacy Policy explains what information we collect about you and why, what we may do with that information and how we handle it. It applies to the iOS and Android Pocket Casts apps, and the Pocket Casts web service with associated macOS and Windows apps (jointly and severally, the Service). By using the Service, you agree to this Privacy Policy. If you turn on push notifications in the app, we store the push token Apple provides us in order to deliver those push notifications to your device. If you buy the web app we store a transaction id for your purchase. If you choose not to create an account, and don&#x2019;t use push notifications, no data is stored about you on our servers. Pocket Casts web service also uses cookies and like technologies to keep you logged in. Should you choose to generate a support request from within the Service, we may generate an attachment containing additional data to assist in addressing your support request which you&#x2019;re welcome to view prior to submission.</string>
     <string name="profile_monthly">Monthly</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -648,6 +648,8 @@
     <string name="profile_change_password_title">Change Password</string>
     <string name="profile_clean_up">Clean up</string>
     <string name="profile_clear_all">Clear all</string>
+    <string name="profile_clear_data">Clear data</string>
+    <string name="profile_clear_data_question">Clear data?</string>
     <string name="profile_clear_cannot_be_undone">This action cannot be undone.</string>
     <string name="profile_clear_listening_history">Clear listening history</string>
     <string name="profile_clear_listening_history_title">Clear Listening History</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -163,6 +163,9 @@ abstract class EpisodeDao {
     @Delete
     abstract fun deleteAll(episode: List<Episode>)
 
+    @Query("DELETE FROM episodes")
+    abstract suspend fun deleteAll()
+
     @Query("DELETE FROM episodes WHERE uuid = :uuid")
     abstract fun deleteByUuid(uuid: String)
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/FolderDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/FolderDao.kt
@@ -25,6 +25,9 @@ abstract class FolderDao {
     @Delete
     abstract suspend fun delete(folder: Folder)
 
+    @Query("DELETE FROM folders")
+    abstract suspend fun deleteAll()
+
     @Query("DELETE FROM folders WHERE uuid = :uuid")
     abstract suspend fun deleteByUuid(uuid: String)
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -57,6 +57,9 @@ abstract class PlaylistDao {
     @Delete
     abstract fun delete(playlist: Playlist)
 
+    @Query("DELETE FROM filters")
+    abstract suspend fun deleteAll()
+
     @Query("DELETE FROM filters WHERE deleted = 1")
     abstract fun deleteDeleted()
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -196,6 +196,9 @@ abstract class PodcastDao {
     @Delete
     abstract fun delete(podcast: Podcast)
 
+    @Query("DELETE FROM podcasts")
+    abstract suspend fun deleteAll()
+
     @Insert(onConflict = REPLACE)
     abstract fun insert(podcast: Podcast): Long
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
@@ -31,6 +31,7 @@ interface UpNextQueue {
     fun changeList(episodes: List<Playable>)
     fun clearUpNext()
     fun removeAll()
+    suspend fun removeAllIncludingChanges()
     fun importServerChanges(episodes: List<Playable>, playbackManager: PlaybackManager, downloadManager: DownloadManager): Completable
     fun contains(uuid: String): Boolean
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
@@ -31,7 +31,6 @@ interface UpNextQueue {
     fun changeList(episodes: List<Playable>)
     fun clearUpNext()
     fun removeAll()
-    suspend fun removeAllEpisodes(episodes: List<Playable>)
     fun importServerChanges(episodes: List<Playable>, playbackManager: PlaybackManager, downloadManager: DownloadManager): Completable
     fun contains(uuid: String): Boolean
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
@@ -245,15 +245,6 @@ class UpNextQueueImpl @Inject constructor(
         saveChanges(UpNextAction.ClearAll)
     }
 
-    /**
-     * Removes all episodes in the list
-     */
-    override suspend fun removeAllEpisodes(episodes: List<Playable>) = withContext(coroutineContext) {
-        episodes.forEach { episode ->
-            removeEpisode(episode)
-        }
-    }
-
     override fun importServerChanges(episodes: List<Playable>, playbackManager: PlaybackManager, downloadManager: DownloadManager): Completable {
         return Completable.fromAction {
             // don't write over the local Up Next with the server version if we are playing an episode

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -108,6 +108,7 @@ interface EpisodeManager {
     fun stopDownloadAndCleanUp(episode: Episode, from: String)
 
     /** Remove methods  */
+    suspend fun deleteAll()
     fun deleteEpisodesWithoutSync(episodes: List<Episode>, playbackManager: PlaybackManager)
 
     fun deleteEpisodeWithoutSync(episode: Episode?, playbackManager: PlaybackManager)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -797,6 +797,10 @@ class EpisodeManagerImpl @Inject constructor(
         }
     }
 
+    override suspend fun deleteAll() {
+        episodeDao.deleteAll()
+    }
+
     override fun deleteDownloadedEpisodeFiles() {
         // remove all the files off the disk, ignore any errors and continue
         try {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManager.kt
@@ -12,6 +12,7 @@ interface FolderManager {
 
     suspend fun create(name: String, color: Int, podcastsSortType: PodcastsSortType, podcastUuids: List<String>): Folder
     suspend fun delete(folder: Folder)
+    suspend fun deleteAll()
     suspend fun upsertSynced(folder: Folder): Folder
     suspend fun deleteSynced(folderUuid: String)
     suspend fun findByUuid(uuid: String): Folder?

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
@@ -74,6 +74,10 @@ class FolderManagerImpl @Inject constructor(
         folderDao.updateDeleted(uuid = folder.uuid, deleted = true, syncModified = System.currentTimeMillis())
     }
 
+    override suspend fun deleteAll() {
+        folderDao.deleteAll()
+    }
+
     override suspend fun deleteSynced(folderUuid: String) {
         folderDao.deleteByUuid(folderUuid)
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
@@ -39,6 +39,7 @@ interface PlaylistManager {
     fun rxUpdateAutoDownloadStatus(playlist: Playlist, autoDownloadEnabled: Boolean, unmeteredOnly: Boolean, powerOnly: Boolean): Completable
 
     fun delete(playlist: Playlist)
+    suspend fun resetDb()
     fun deleteSynced()
     fun deleteSynced(playlist: Playlist)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -265,6 +265,11 @@ class PlaylistManagerImpl @Inject constructor(
         playlistDao.deleteDeleted()
     }
 
+    override suspend fun resetDb() {
+        playlistDao.deleteAll()
+        setupDefaultPlaylists()
+    }
+
     override fun deleteSynced(playlist: Playlist) {
         playlistDao.delete(playlist)
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -110,6 +110,7 @@ interface PodcastManager {
     /** Remove methods  */
     fun checkForUnusedPodcasts(playbackManager: PlaybackManager)
     fun deletePodcastIfUnused(podcast: Podcast, playbackManager: PlaybackManager): Boolean
+    suspend fun deleteAllPodcasts()
     fun unsubscribe(podcastUuid: String, playbackManager: PlaybackManager)
     fun unsubscribeAsync(podcastUuid: String, playbackManager: PlaybackManager)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -338,6 +338,10 @@ class PodcastManagerImpl @Inject constructor(
         return false
     }
 
+    override suspend fun deleteAllPodcasts() {
+        podcastDao.deleteAll()
+    }
+
     override suspend fun findSubscribedUuids(): List<String> {
         return podcastDao.findSubscribedUuids()
     }


### PR DESCRIPTION
## Description

Fixes https://github.com/Automattic/pocket-casts-android/issues/815 by giving users the option to clear their data when they log out on Android Automotive.

I went with the simplest UI approach here of just presenting a second pop-up when the user signs off, asking them if they want to clear their data. This could certainly be done better, but since this is addressing a bit of an edge case, I didn't want to spend too much time over-optimizing it. With that said, if you have a better idea for the UI, please let me know.

## Testing Instructions
1. Sign into a Plus account on Android Automotive. 
2. Make sure the account has:
    1. An episode that is currently playing
    3. Some episodes in the up next queue
    4. Some podcast subscriptions
    5. Some custom filters
    6. Some cloud files that have been uploaded under Profile → Files
    7. Some starred episodes under Profile → Starred
    8. Some listening history under Profile → Listening 
3. Sign out of the account and clear your data (⚙️  → User Profile View → Sign out → Sign out → Clear data)
4. Go through each of the section in Step 2 and verify that there is no data present. Note that because of https://github.com/Automattic/pocket-casts-android/issues/260 you may still see data on a screen until you reload the tab/screen (for example, the Podcasts tab may still show your subscribed podcasts until you switch away from and back to that tab).
5. Repeat Steps 1 & 2
6. Sign out of the account and **DO NOT* clear your data (⚙️  → User Profile View → Sign out → Sign out → Just sign out)
7. Verify that the data from Step 2 has **not** been removed.

## Screenshots or Screencast

https://user-images.githubusercontent.com/4656348/224863473-6341af73-0534-4ec6-b8fe-60255e02f6d7.mov

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack
