### PR TITLE
Search minor updates

### DIFF
--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -288,6 +288,7 @@ class SearchFragment : BaseFragment() {
     }
 
     private fun onShowAllClick(resultsType: ResultsType) {
+        viewModel.trackSearchListShown(source, resultsType)
         val fragment = SearchResultsFragment.newInstance(resultsType, onlySearchRemote, source)
         childFragmentManager.beginTransaction()
             .replace(R.id.searchResults, fragment)

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
+import au.com.shiftyjelly.pocketcasts.search.SearchResultsFragment.Companion.ResultsType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -154,6 +155,13 @@ class SearchViewModel @Inject constructor(
         )
     }
 
+    fun trackSearchListShown(source: AnalyticsSource, type: ResultsType) {
+        analyticsTracker.track(
+            AnalyticsEvent.SEARCH_LIST_SHOWN,
+            AnalyticsProp.searchListShown(source = source, type = type)
+        )
+    }
+
     enum class SearchResultType(val value: String) {
         PODCAST_LOCAL_RESULT("podcast_local_result"),
         PODCAST_REMOTE_RESULT("podcast_remote_result"),
@@ -165,6 +173,8 @@ class SearchViewModel @Inject constructor(
         private const val SOURCE = "source"
         private const val UUID = "uuid"
         private const val RESULT_TYPE = "result_type"
+        private const val DISPLAYING = "displaying"
+
         fun searchResultTapped(source: AnalyticsSource, uuid: String, type: SearchResultType) =
             mapOf(SOURCE to source.analyticsValue, UUID to uuid, RESULT_TYPE to type.value)
 
@@ -173,6 +183,9 @@ class SearchViewModel @Inject constructor(
 
         fun podcastSubscribed(source: AnalyticsSource, uuid: String) =
             mapOf(SOURCE to "${source.analyticsValue}_search", UUID to uuid)
+
+        fun searchListShown(source: AnalyticsSource, type: ResultsType) =
+            mapOf(SOURCE to source.analyticsValue, DISPLAYING to type.value)
     }
 }
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -522,6 +522,9 @@ enum class AnalyticsEvent(val key: String) {
     SEARCH_FAILED("search_failed"),
     SEARCH_RESULT_TAPPED("search_result_tapped"),
 
+    /* Search - Full List */
+    SEARCH_LIST_SHOWN("search_list_shown"),
+
     /* Search History */
     SEARCH_HISTORY_CLEARED("search_history_cleared"),
     SEARCH_HISTORY_ITEM_TAPPED("search_history_item_tapped"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/searchhistory/SearchHistoryManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/searchhistory/SearchHistoryManagerImpl.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.Dispatchers
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
-private const val MAX_HISTORY_COUNT = 250
+private const val MAX_HISTORY_COUNT = 20
 
 class SearchHistoryManagerImpl @Inject constructor(
     appDatabase: AppDatabase,


### PR DESCRIPTION
## Description

1. Reduces search history max count to match with iOS (p1678446938002359/1678387434.322809-slack-C03JCLLR9C3)
2. Adds `search_list_shown` track (https://github.com/Automattic/pocket-casts-ios/pull/774#issuecomment-1468243355).

> **Warning**
> Targets release/7.34

## Testing Instructions

#### Change 1
It doesn't require any manual testing, it is covered by `testInsertTooManyItemsKeepsMostRecent` test.

#### Change 2

1. Tap on the search bar in `Discover` or `Podcasts`
2. Search for something
3. Tap "Show all" on Podcasts
4. ✅ search_list_shown should be tracked with correct source (discover or podcast_list) and displaying: podcasts
5. Go back, tap "Show all" for Episodes
6. ✅ search_list_shown should be tracked with correct source (discover or podcast_list) and displaying: episodes
