### PR TITLE
Update lifecycle and core dependencies

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.ui
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
@@ -42,9 +42,9 @@ class MainActivityViewModel
             Timber.d("Updated playback state from ${it.lastChangeFrom} is playing ${it.isPlaying}")
         }
         .toFlowable(BackpressureStrategy.LATEST)
-    val playbackState = LiveDataReactiveStreams.fromPublisher(playbackStateRx)
+    val playbackState = playbackStateRx.toLiveData()
 
-    val signInState: LiveData<SignInState> = LiveDataReactiveStreams.fromPublisher(userManager.getSignInState())
+    val signInState: LiveData<SignInState> = userManager.getSignInState().toLiveData()
     val isSignedIn: Boolean
         get() = signInState.value?.isSignedIn ?: false
 

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsFragment.kt
@@ -6,7 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.LiveDataReactiveStreams
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.account.AccountActivity
 import au.com.shiftyjelly.pocketcasts.databinding.FragmentAutomotiveSettingsBinding
 import au.com.shiftyjelly.pocketcasts.profile.AccountDetailsFragment
@@ -30,24 +30,26 @@ class AutomotiveSettingsFragment : Fragment() {
 
         val userView = binding.userView
 
-        LiveDataReactiveStreams.fromPublisher(userManager.getSignInState()).observe(viewLifecycleOwner) { signInState ->
-            val loggedIn = signInState.isSignedIn
+        userManager.getSignInState()
+            .toLiveData()
+            .observe(viewLifecycleOwner) { signInState ->
+                val loggedIn = signInState.isSignedIn
 
-            if ((userView.signedInState != null && userView.signedInState?.isSignedIn == false) && loggedIn) {
-                // We have to close after signing in to meet Google UX requirements
-                activity?.finish()
-            }
+                if ((userView.signedInState != null && userView.signedInState?.isSignedIn == false) && loggedIn) {
+                    // We have to close after signing in to meet Google UX requirements
+                    activity?.finish()
+                }
 
-            userView.signedInState = signInState
-            userView.setOnClickListener {
-                if (loggedIn) {
-                    val fragment = AccountDetailsFragment.newInstance()
-                    (activity as? AutomotiveSettingsActivity)?.addFragment(fragment)
-                } else {
-                    signIn()
+                userView.signedInState = signInState
+                userView.setOnClickListener {
+                    if (loggedIn) {
+                        val fragment = AccountDetailsFragment.newInstance()
+                        (activity as? AutomotiveSettingsActivity)?.addFragment(fragment)
+                    } else {
+                        signIn()
+                    }
                 }
             }
-        }
     }
 
     fun signIn() {

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -4,8 +4,8 @@ import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.Observer
+import androidx.lifecycle.toLiveData
 import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
@@ -73,13 +73,13 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), SharedP
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        refreshObservable = LiveDataReactiveStreams.fromPublisher(
+        refreshObservable =
             settings.refreshStateObservable
                 .toFlowable(BackpressureStrategy.LATEST)
                 .switchMap { state ->
                     Flowable.interval(500, TimeUnit.MILLISECONDS).switchMap { Flowable.just(state) }
                 }
-        )
+                .toLiveData()
         refreshObservable?.observe(viewLifecycleOwner, this)
     }
 
@@ -89,8 +89,8 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), SharedP
         refreshObservable?.removeObserver(this)
     }
 
-    override fun onChanged(state: RefreshState) {
-        updateRefreshSummary(state)
+    override fun onChanged(value: RefreshState) {
+        updateRefreshSummary(value)
     }
 
     private fun updateRefreshSummary(state: RefreshState) {

--- a/base.gradle
+++ b/base.gradle
@@ -286,4 +286,11 @@ dependencies {
     androidTestImplementation androidLibs.accessibilityTestFramework
 
     coreLibraryDesugaring androidLibs.desugarJdk
+
+    constraints {
+        // Avoid duplicate class compile failure: https://stackoverflow.com/a/75298544/1910286
+        implementation(libs.kotlinJdk8) {
+            because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
+        }
+    }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -120,7 +120,7 @@ project.ext {
             firebaseAnalytics: "com.google.firebase:firebase-analytics-ktx",
             firebaseConfig: "com.google.firebase:firebase-config-ktx",
             constraintLayout: "androidx.constraintlayout:constraintlayout:2.1.4",
-            ktx: "androidx.core:core-ktx:1.8.0",
+            ktx: "androidx.core:core-ktx:1.9.0",
             ktxFragment: "androidx.fragment:fragment-ktx:1.5.2",
             ktxPreference: "androidx.preference:preference-ktx:1.2.0",
             annotations: "androidx.annotation:annotation:1.3.0",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -88,7 +88,7 @@ project.ext {
     versionGlide = '4.13.2'
     versionHilt = '2.43.2'
     versionKotlinCoroutines = '1.6.4'
-    versionLifecycle = '2.5.1'
+    versionLifecycle = '2.6.0'
     versionMoshi = '1.13.0'
     versionNavigation = '2.5.1'
     versionPaging = '3.1.1'
@@ -180,6 +180,7 @@ project.ext {
 
     libs = [
             kotlin: "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version",
+            kotlinJdk8: "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10",
             kotlinCoroutines: "org.jetbrains.kotlinx:kotlinx-coroutines-core:$versionKotlinCoroutines",
             kotlinCoroutinesAndroid: "org.jetbrains.kotlinx:kotlinx-coroutines-android:$versionKotlinCoroutines",
             kotlinCoroutinesPlayServices: "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$versionKotlinCoroutines",

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/AccountFragmentViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/AccountFragmentViewModel.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.account.viewmodel
 
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -10,5 +10,5 @@ import javax.inject.Inject
 class AccountFragmentViewModel @Inject constructor(
     userManager: UserManager
 ) : ViewModel() {
-    val signInState = LiveDataReactiveStreams.fromPublisher(userManager.getSignInState())
+    val signInState = userManager.getSignInState().toLiveData()
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterViewModel.kt
@@ -1,9 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.filters
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
@@ -133,18 +133,22 @@ class CreateFilterViewModel @Inject constructor(
         }
 
         playlist = if (playlistUUID != null) {
-            LiveDataReactiveStreams.fromPublisher(playlistManager.findByUuidRx(playlistUUID).subscribeOn(Schedulers.io()).observeOn(AndroidSchedulers.mainThread()).toFlowable())
+            playlistManager.findByUuidRx(playlistUUID)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .toFlowable()
         } else {
             val newFilter = createFilter("", 0, 0)
-            LiveDataReactiveStreams.fromPublisher(playlistManager.observeByUuid(newFilter.uuid))
-        }
+            playlistManager.observeByUuid(newFilter.uuid)
+        }.toLiveData()
 
         hasBeenInitialised = true
     }
 
-    fun observeFilter(filter: Playlist): LiveData<List<Episode>> {
-        return LiveDataReactiveStreams.fromPublisher(playlistManager.observeEpisodesPreview(filter, episodeManager, playbackManager))
-    }
+    fun observeFilter(filter: Playlist): LiveData<List<Episode>> =
+        playlistManager
+            .observeEpisodesPreview(filter, episodeManager, playbackManager)
+            .toLiveData()
 
     fun updateDownloadLimit(limit: Int) {
         userChangedAutoDownloadEpisodeCount.recordUserChange()

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -1,9 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.filters
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
@@ -90,7 +90,7 @@ class FilterEpisodeListViewModel @Inject constructor(
             }
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeOn(Schedulers.io())
-        episodesList = LiveDataReactiveStreams.fromPublisher(episodes)
+        episodesList = episodes.toLiveData()
     }
 
     fun deletePlaylist() {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.filters
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
@@ -35,9 +35,7 @@ class FiltersFragmentViewModel @Inject constructor(
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
 
-    val filters: LiveData<List<Playlist>> = LiveDataReactiveStreams.fromPublisher(
-        playlistManager.observeAll()
-    )
+    val filters: LiveData<List<Playlist>> = playlistManager.observeAll().toLiveData()
 
     val countGenerator = { playlist: Playlist ->
         playlistManager.countEpisodesRx(playlist, episodeManager, playbackManager).onErrorReturn { 0 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ChaptersFragment.kt
@@ -9,7 +9,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.SimpleItemAnimator
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
@@ -19,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -54,8 +57,11 @@ class ChaptersFragment : BaseFragment(), ChapterListener {
             adapter.submitList(it.chapters)
             view.setBackgroundColor(it.podcastHeader.backgroundColor)
         }
-        viewLifecycleOwner.lifecycleScope.launchWhenStarted {
-            playerViewModel.showPlayerFlow.collect { showPlayer() }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                playerViewModel.showPlayerFlow.collect { showPlayer() }
+            }
         }
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/VideoViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/VideoViewModel.kt
@@ -2,9 +2,9 @@ package au.com.shiftyjelly.pocketcasts.player.viewmodel
 
 import android.os.Build
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
@@ -21,7 +21,9 @@ class VideoViewModel @Inject constructor(
     private val playbackManager: PlaybackManager
 ) : ViewModel() {
 
-    val playbackState: LiveData<PlaybackState> = LiveDataReactiveStreams.fromPublisher(playbackManager.playbackStateRelay.toFlowable(BackpressureStrategy.LATEST))
+    val playbackState: LiveData<PlaybackState> = playbackManager.playbackStateRelay
+        .toFlowable(BackpressureStrategy.LATEST)
+        .toLiveData()
 
     private var hideControlsTimer: Disposable? = null
     private var lastTimeHidingControls = 0L

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
@@ -41,7 +41,7 @@ class ProfileEpisodeListViewModel @Inject constructor(
             is ProfileEpisodeListFragment.Mode.History -> episodeManager.observePlaybackHistoryEpisodes()
         }
 
-        episodeList = LiveDataReactiveStreams.fromPublisher(episodeListFlowable)
+        episodeList = episodeListFlowable.toLiveData()
     }
 
     @Suppress("UNUSED_PARAMETER")

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -3,10 +3,10 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.episode
 import android.content.Context
 import androidx.annotation.ColorInt
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.map
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
@@ -61,7 +61,7 @@ class EpisodeFragmentViewModel @Inject constructor(
     lateinit var state: LiveData<EpisodeFragmentState>
     val showNotes: MutableLiveData<String> = MutableLiveData()
     lateinit var inUpNext: LiveData<Boolean>
-    val isPlaying: LiveData<Boolean> = Transformations.map(playbackManager.playbackStateLive) {
+    val isPlaying: LiveData<Boolean> = playbackManager.playbackStateLive.map {
         it.episodeUuid == episode?.uuid && it.isPlaying
     }
 
@@ -120,11 +120,11 @@ class EpisodeFragmentViewModel @Inject constructor(
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeOn(Schedulers.io())
 
-        state = LiveDataReactiveStreams.fromPublisher(stateObservable)
+        state = stateObservable.toLiveData()
 
         val inUpNextObservable = playbackManager.upNextQueue.changesObservable.toFlowable(BackpressureStrategy.LATEST)
             .map { upNext -> (upNext is UpNextQueue.State.Loaded) && (upNext.episode == episode || upNext.queue.map { it.uuid }.contains(episodeUUID)) }
-        inUpNext = LiveDataReactiveStreams.fromPublisher(inUpNextObservable)
+        inUpNext = inUpNextObservable.toLiveData()
     }
 
     override fun onCleared() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveViewModel.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.podcast
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -29,7 +29,10 @@ class PodcastAutoArchiveViewModel @Inject constructor(
     }
 
     fun setup(podcastUUID: String) {
-        podcast = LiveDataReactiveStreams.fromPublisher(podcastManager.observePodcastByUuid(podcastUUID).subscribeOn(Schedulers.io()))
+        podcast = podcastManager
+            .observePodcastByUuid(podcastUUID)
+            .subscribeOn(Schedulers.io())
+            .toLiveData()
     }
 
     fun updateGlobalOverride(checked: Boolean) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListIncomingViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListIncomingViewModel.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.share
 
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
@@ -28,12 +28,12 @@ class ShareListIncomingViewModel
 ) : ViewModel(), CoroutineScope {
     var isFragmentChangingConfigurations: Boolean = false
     val share = MutableLiveData<ShareState>()
-    val subscribedUuids = LiveDataReactiveStreams.fromPublisher(
+    val subscribedUuids =
         podcastManager.getSubscribedPodcastUuids()
             .subscribeOn(Schedulers.io())
             .toFlowable()
             .mergeWith(podcastManager.observePodcastSubscriptions())
-    )
+            .toLiveData()
 
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.viewmodel
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
@@ -36,7 +36,10 @@ class PodcastEffectsViewModel
     lateinit var podcast: LiveData<Podcast>
 
     fun loadPodcast(uuid: String) {
-        podcast = LiveDataReactiveStreams.fromPublisher(podcastManager.observePodcastByUuid(uuid).subscribeOn(Schedulers.io()))
+        podcast = podcastManager
+            .observePodcastByUuid(uuid)
+            .subscribeOn(Schedulers.io())
+            .toLiveData()
     }
 
     fun updateOverrideGlobalEffects(override: Boolean) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.viewmodel
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
@@ -42,24 +42,27 @@ class PodcastSettingsViewModel @Inject constructor(
     lateinit var includedFilters: LiveData<List<Playlist>>
     lateinit var availableFilters: LiveData<List<Playlist>>
 
-    val globalSettings = LiveDataReactiveStreams.fromPublisher(
-        settings.autoAddUpNextLimit.toFlowable(BackpressureStrategy.LATEST)
-            .combineLatest(settings.autoAddUpNextLimitBehaviour.toFlowable(BackpressureStrategy.LATEST))
-    )
+    val globalSettings = settings.autoAddUpNextLimit
+        .toFlowable(BackpressureStrategy.LATEST)
+        .combineLatest(settings.autoAddUpNextLimitBehaviour.toFlowable(BackpressureStrategy.LATEST))
+        .toLiveData()
 
     fun loadPodcast(uuid: String) {
         this.podcastUuid = uuid
-        podcast = LiveDataReactiveStreams.fromPublisher(podcastManager.observePodcastByUuid(uuid).subscribeOn(Schedulers.io()))
+        podcast = podcastManager
+            .observePodcastByUuid(uuid)
+            .subscribeOn(Schedulers.io())
+            .toLiveData()
 
         val filters = playlistManager.observeAll().map {
             it.filter { filter -> filter.podcastUuidList.contains(uuid) }
         }
-        includedFilters = LiveDataReactiveStreams.fromPublisher(filters)
+        includedFilters = filters.toLiveData()
 
         val availablePodcastFilters = playlistManager.observeAll().map {
             it.filter { filter -> !filter.allPodcasts }
         }
-        availableFilters = LiveDataReactiveStreams.fromPublisher(availablePodcastFilters)
+        availableFilters = availablePodcastFilters.toLiveData()
     }
 
     fun isAutoAddToUpNextOn(): Boolean {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import android.content.res.Resources
 import android.widget.Toast
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
@@ -75,18 +75,16 @@ class PodcastViewModel
     lateinit var podcastUuid: String
     lateinit var episodes: LiveData<EpisodeState>
     val groupedEpisodes: MutableLiveData<List<List<Episode>>> = MutableLiveData()
-    val signInState = LiveDataReactiveStreams.fromPublisher(userManager.getSignInState())
+    val signInState = userManager.getSignInState().toLiveData()
 
     val tintColor = MutableLiveData<Int>()
     val observableHeaderExpanded = MutableLiveData<Boolean>()
     private val searchQueryRelay = BehaviorRelay.create<String>()
         .apply { accept("") }
 
-    val castConnected = LiveDataReactiveStreams.fromPublisher(
-        castManager.isConnectedObservable.toFlowable(
-            BackpressureStrategy.LATEST
-        )
-    )
+    val castConnected = castManager.isConnectedObservable
+        .toFlowable(BackpressureStrategy.LATEST)
+        .toLiveData()
 
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
@@ -166,7 +164,7 @@ class PodcastViewModel
             }
             .observeOn(AndroidSchedulers.mainThread())
 
-        episodes = LiveDataReactiveStreams.fromPublisher(episodeStateFlowable)
+        episodes = episodeStateFlowable.toLiveData()
     }
 
     override fun onCleared() {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
@@ -1,10 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.profile
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.NewsletterSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
@@ -58,19 +58,21 @@ class AccountDetailsViewModel
             Optional.empty()
         }
     }
-    val signInState = LiveDataReactiveStreams.fromPublisher(userManager.getSignInState())
-    val viewState: LiveData<Triple<SignInState, Subscription?, DeleteAccountState>> = LiveDataReactiveStreams
-        .fromPublisher(userManager.getSignInState().combineLatest(subscription))
-        .combineLatest(deleteAccountState)
-        .map { Triple(it.first.first, it.first.second.get(), it.second) }
+    val signInState = userManager.getSignInState().toLiveData()
+    val viewState: LiveData<Triple<SignInState, Subscription?, DeleteAccountState>> =
+        userManager.getSignInState()
+            .combineLatest(subscription)
+            .toLiveData()
+            .combineLatest(deleteAccountState)
+            .map { Triple(it.first.first, it.first.second.get(), it.second) }
 
     val accountStartDate: LiveData<Date> = MutableLiveData<Date>().apply { value = Date(statsManager.statsStartTime) }
 
-    val marketingOptInState: LiveData<Boolean> = LiveDataReactiveStreams.fromPublisher(
+    val marketingOptInState: LiveData<Boolean> =
         settings.marketingOptObservable
             .distinctUntilChanged()
             .toFlowable(BackpressureStrategy.LATEST)
-    )
+            .toLiveData()
 
     fun deleteAccount() {
         syncServerManager.deleteAccount()

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -16,7 +16,9 @@ import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.core.widget.TextViewCompat
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -47,6 +49,7 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.Date
 import javax.inject.Inject
@@ -155,9 +158,11 @@ class ProfileFragment : BaseFragment() {
             true
         }
 
-        lifecycleScope.launchWhenStarted {
-            val isEligible = viewModel.isEndOfYearStoriesEligible()
-            binding.setupEndOfYearPromptCard(isEligible)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                val isEligible = viewModel.isEndOfYearStoriesEligible()
+                binding.setupEndOfYearPromptCard(isEligible)
+            }
         }
 
         viewModel.podcastCount.observe(viewLifecycleOwner) {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
@@ -1,9 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.profile
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -24,18 +24,19 @@ class ProfileViewModel @Inject constructor(
     private val endOfYearManager: EndOfYearManager
 ) : ViewModel() {
     var isFragmentChangingConfigurations: Boolean = false
-    val podcastCount: LiveData<Int> = LiveDataReactiveStreams.fromPublisher(podcastManager.observeCountSubscribed())
+    val podcastCount: LiveData<Int> = podcastManager.observeCountSubscribed().toLiveData()
     val daysListenedCount: MutableLiveData<Long> = MutableLiveData()
     val daysSavedCount: MutableLiveData<Long> = MutableLiveData()
 
     val isSignedIn: Boolean
         get() = signInState.value?.isSignedIn ?: false
 
-    val signInState: LiveData<SignInState> = LiveDataReactiveStreams.fromPublisher(userManager.getSignInState())
+    val signInState: LiveData<SignInState> = userManager.getSignInState().toLiveData()
 
-    val refreshObservable: LiveData<RefreshState> = LiveDataReactiveStreams.fromPublisher(
-        settings.refreshStateObservable.toFlowable(BackpressureStrategy.LATEST)
-    )
+    val refreshObservable: LiveData<RefreshState> =
+        settings.refreshStateObservable
+            .toFlowable(BackpressureStrategy.LATEST)
+            .toLiveData()
 
     suspend fun isEndOfYearStoriesEligible() = endOfYearManager.isEligibleForStories()
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileViewModel.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.profile.cloud
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
@@ -20,7 +20,7 @@ class AddFileViewModel @Inject constructor(
     val userEpisodeManager: UserEpisodeManager
 ) : ViewModel() {
 
-    val signInState: LiveData<SignInState> = LiveDataReactiveStreams.fromPublisher(userManager.getSignInState())
+    val signInState: LiveData<SignInState> = userManager.getSignInState().toLiveData()
 
     suspend fun updateImageOnServer(userEpisode: UserEpisode, imageFile: File) = withContext(Dispatchers.IO) {
         userEpisodeManager.uploadImageToServer(userEpisode, imageFile).await()

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.profile.cloud
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
@@ -40,7 +40,7 @@ class CloudBottomSheetViewModel @Inject constructor(
     userManager: UserManager
 ) : ViewModel() {
     lateinit var state: LiveData<BottomSheetState>
-    var signInState = LiveDataReactiveStreams.fromPublisher(userManager.getSignInState())
+    var signInState = userManager.getSignInState().toLiveData()
     private val source = AnalyticsSource.FILES
 
     fun setup(uuid: String) {
@@ -50,7 +50,7 @@ class CloudBottomSheetViewModel @Inject constructor(
         val combined = Flowables.combineLatest(episodeFlowable, inUpNextFlowable, isPlayingFlowable) { episode, inUpNext, isPlaying ->
             BottomSheetState(episode, inUpNext, isPlaying)
         }
-        state = LiveDataReactiveStreams.fromPublisher(combined)
+        state = combined.toLiveData()
     }
 
     fun getDeleteStateOnDeleteClick(episode: UserEpisode): DeleteState {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.profile.cloud
 
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
@@ -39,9 +39,9 @@ class CloudFilesViewModel @Inject constructor(
 
     val sortOrderRelay = BehaviorRelay.create<Settings.CloudSortOrder>().apply { accept(settings.getCloudSortOrder()) }
     val sortedCloudFiles = sortOrderRelay.toFlowable(BackpressureStrategy.LATEST).switchMap { userEpisodeManager.observeUserEpisodesSorted(it) }
-    val cloudFilesList = LiveDataReactiveStreams.fromPublisher(sortedCloudFiles)
-    val accountUsage = LiveDataReactiveStreams.fromPublisher(userEpisodeManager.observeAccountUsage())
-    val signInState = LiveDataReactiveStreams.fromPublisher(userManager.getSignInState())
+    val cloudFilesList = sortedCloudFiles.toLiveData()
+    val accountUsage = userEpisodeManager.observeAccountUsage().toLiveData()
+    val signInState = userManager.getSignInState().toLiveData()
 
     fun refreshFiles(userInitiated: Boolean) {
         if (userInitiated) {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.profile.cloud
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
@@ -18,7 +18,7 @@ class CloudSettingsViewModel @Inject constructor(
     userManager: UserManager,
 ) : ViewModel() {
 
-    val signInState: LiveData<SignInState> = LiveDataReactiveStreams.fromPublisher(userManager.getSignInState())
+    val signInState: LiveData<SignInState> = userManager.getSignInState().toLiveData()
 
     private var isFragmentChangingConfigurations: Boolean = false
 

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -103,7 +103,7 @@ class SearchFragment : BaseFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         val binding = FragmentSearchBinding.inflate(inflater, container, false)
-        binding.setLifecycleOwner { viewLifecycleOwner.lifecycle }
+        binding.lifecycleOwner = viewLifecycleOwner
         viewModel.setOnlySearchRemote(onlySearchRemote)
         searchHistoryViewModel.setOnlySearchRemote(onlySearchRemote)
         searchHistoryViewModel.setSource(source)

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.search
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
@@ -200,8 +200,8 @@ class SearchHandler @Inject constructor(
         .observeOn(AndroidSchedulers.mainThread())
         .toFlowable(BackpressureStrategy.LATEST)
 
-    val searchResults: LiveData<SearchState> = LiveDataReactiveStreams.fromPublisher(searchFlowable)
-    val loading: LiveData<Boolean> = LiveDataReactiveStreams.fromPublisher(loadingObservable.toFlowable(BackpressureStrategy.LATEST))
+    val searchResults: LiveData<SearchState> = searchFlowable.toLiveData()
+    val loading: LiveData<Boolean> = loadingObservable.toFlowable(BackpressureStrategy.LATEST).toLiveData()
 
     fun updateSearchQuery(query: String, immediate: Boolean = false) {
         searchQuery.accept(Query(query, immediate))

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/MediaNotificationControlsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/MediaNotificationControlsFragment.kt
@@ -22,7 +22,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.core.view.isVisible
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.ListAdapter
@@ -46,6 +48,7 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.views.extensions.setRippleBackground
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.Collections
 import javax.inject.Inject
@@ -115,14 +118,16 @@ class MediaNotificationControlsFragment : BaseFragment(), MediaActionTouchCallba
         itemTouchHelper = ItemTouchHelper(callback)
         itemTouchHelper.attachToRecyclerView(recyclerView)
 
-        viewLifecycleOwner.lifecycleScope.launchWhenStarted {
-            settings.defaultMediaNotificationControlsFlow.collect {
-                val itemsPlusTitles = mutableListOf<Any>()
-                itemsPlusTitles.addAll(it)
-                itemsPlusTitles.add(3, otherActionsTitle)
-                itemsPlusTitles.add(0, mediaTitle)
-                items = itemsPlusTitles
-                adapter.submitList(items)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                settings.defaultMediaNotificationControlsFlow.collect {
+                    val itemsPlusTitles = mutableListOf<Any>()
+                    itemsPlusTitles.addAll(it)
+                    itemsPlusTitles.add(3, otherActionsTitle)
+                    itemsPlusTitles.add(0, mediaTitle)
+                    items = itemsPlusTitles
+                    adapter.submitList(items)
+                }
             }
         }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlusSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlusSettingsFragment.kt
@@ -10,7 +10,7 @@ import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.lifecycle.LiveDataReactiveStreams
+import androidx.lifecycle.toLiveData
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
@@ -57,68 +57,70 @@ class PlusSettingsFragment : BaseFragment() {
 
         val recyclerView = binding.recyclerView
 
-        LiveDataReactiveStreams.fromPublisher(subscriptionManager.observeProductDetails()).observe(viewLifecycleOwner) { productDetailsState ->
-            val subscriptions = when (productDetailsState) {
-                is ProductDetailsState.Error -> null
-                is ProductDetailsState.Loaded -> productDetailsState.productDetails.mapNotNull {
-                    Subscription.fromProductDetails(
-                        productDetails = it,
-                        isFreeTrialEligible = subscriptionManager.isFreeTrialEligible()
-                    )
+        subscriptionManager.observeProductDetails()
+            .toLiveData()
+            .observe(viewLifecycleOwner) { productDetailsState ->
+                val subscriptions = when (productDetailsState) {
+                    is ProductDetailsState.Error -> null
+                    is ProductDetailsState.Loaded -> productDetailsState.productDetails.mapNotNull {
+                        Subscription.fromProductDetails(
+                            productDetails = it,
+                            isFreeTrialEligible = subscriptionManager.isFreeTrialEligible()
+                        )
+                    }
                 }
+
+                val headerText = PlusSection.TextBlock(LR.string.plus_description_title, LR.string.plus_description_body)
+                val feature1 = PlusSection.Feature(R.drawable.ic_desktop_apps, LR.string.plus_desktop_apps, LR.string.plus_desktop_apps_body)
+                val feature2 = PlusSection.Feature(R.drawable.ic_cloud_storage, LR.string.plus_cloud_storage, LR.string.plus_cloud_storage_body)
+                val feature3 = PlusSection.Feature(R.drawable.ic_themes_icons, LR.string.plus_themes_icons, LR.string.plus_themes_icons_body)
+                val feature4 = PlusSection.Feature(R.drawable.plus_folder, LR.string.plus_folder, LR.string.plus_folder_body)
+                val upgrade = PlusSection.UpgradeButton(
+                    subscriptions = subscriptions,
+                    onClick = {
+                        analyticsTracker.track(AnalyticsEvent.SETTINGS_PLUS_UPGRADE_BUTTON_TAPPED)
+                        val flow = if (settings.isLoggedIn()) {
+                            OnboardingFlow.PlusAccountUpgrade(OnboardingUpgradeSource.PLUS_DETAILS)
+                        } else {
+                            OnboardingFlow.PlusAccountUpgradeNeedsLogin
+                        }
+                        OnboardingLauncher.openOnboardingFlow(activity, flow)
+                    }
+                )
+                val link = PlusSection.LinkBlock(
+                    icon = theme.verticalPlusLogoRes(),
+                    body = LR.string.plus_description_body,
+                    linkText = LR.string.plus_learn_more_about_plus,
+                    onClick = {
+                        analyticsTracker.track(AnalyticsEvent.SETTINGS_PLUS_LEARN_MORE_TAPPED)
+                        context?.let { context ->
+                            val intent =
+                                WebViewActivity.newInstance(context, "Learn More", Settings.INFO_LEARN_MORE_URL)
+                            context.startActivity(intent)
+                        }
+                    }
+                )
+
+                val sections = listOf(
+                    PlusSection.Header,
+                    headerText,
+                    upgrade,
+                    PlusSection.Divider,
+                    feature1,
+                    feature2,
+                    feature3,
+                    feature4,
+                    PlusSection.Divider,
+                    link,
+                    upgrade
+                )
+
+                val adapter = PlusAdapter()
+                recyclerView.adapter = adapter
+                recyclerView.layoutManager = LinearLayoutManager(rootView.context, LinearLayoutManager.VERTICAL, false)
+
+                adapter.submitList(sections)
             }
-
-            val headerText = PlusSection.TextBlock(LR.string.plus_description_title, LR.string.plus_description_body)
-            val feature1 = PlusSection.Feature(R.drawable.ic_desktop_apps, LR.string.plus_desktop_apps, LR.string.plus_desktop_apps_body)
-            val feature2 = PlusSection.Feature(R.drawable.ic_cloud_storage, LR.string.plus_cloud_storage, LR.string.plus_cloud_storage_body)
-            val feature3 = PlusSection.Feature(R.drawable.ic_themes_icons, LR.string.plus_themes_icons, LR.string.plus_themes_icons_body)
-            val feature4 = PlusSection.Feature(R.drawable.plus_folder, LR.string.plus_folder, LR.string.plus_folder_body)
-            val upgrade = PlusSection.UpgradeButton(
-                subscriptions = subscriptions,
-                onClick = {
-                    analyticsTracker.track(AnalyticsEvent.SETTINGS_PLUS_UPGRADE_BUTTON_TAPPED)
-                    val flow = if (settings.isLoggedIn()) {
-                        OnboardingFlow.PlusAccountUpgrade(OnboardingUpgradeSource.PLUS_DETAILS)
-                    } else {
-                        OnboardingFlow.PlusAccountUpgradeNeedsLogin
-                    }
-                    OnboardingLauncher.openOnboardingFlow(activity, flow)
-                }
-            )
-            val link = PlusSection.LinkBlock(
-                icon = theme.verticalPlusLogoRes(),
-                body = LR.string.plus_description_body,
-                linkText = LR.string.plus_learn_more_about_plus,
-                onClick = {
-                    analyticsTracker.track(AnalyticsEvent.SETTINGS_PLUS_LEARN_MORE_TAPPED)
-                    context?.let { context ->
-                        val intent =
-                            WebViewActivity.newInstance(context, "Learn More", Settings.INFO_LEARN_MORE_URL)
-                        context.startActivity(intent)
-                    }
-                }
-            )
-
-            val sections = listOf(
-                PlusSection.Header,
-                headerText,
-                upgrade,
-                PlusSection.Divider,
-                feature1,
-                feature2,
-                feature3,
-                feature4,
-                PlusSection.Divider,
-                link,
-                upgrade
-            )
-
-            val adapter = PlusAdapter()
-            recyclerView.adapter = adapter
-            recyclerView.layoutManager = LinearLayoutManager(rootView.context, LinearLayoutManager.VERTICAL, false)
-
-            adapter.submitList(sections)
-        }
 
         return binding.root
     }
@@ -128,8 +130,8 @@ class PlusSettingsFragment : BaseFragment() {
 
         binding?.toolbar?.setup(title = getString(LR.string.pocket_casts_plus), navigationIcon = BackArrow, activity = activity, theme = theme)
 
-        LiveDataReactiveStreams
-            .fromPublisher(userManager.getSignInState())
+        userManager.getSignInState()
+            .toLiveData()
             .observe(viewLifecycleOwner) { signInState ->
                 // If the user has gone through the upgraded to Plus, we no longer want
                 // to present this screen since it is asking them to sign up for Plus

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/StorageSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/StorageSettingsFragment.kt
@@ -11,13 +11,16 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.repositories.file.StorageOptions
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.StorageSettingsViewModel
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class StorageSettingsFragment : BaseFragment() {
@@ -53,10 +56,12 @@ class StorageSettingsFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewLifecycleOwner.lifecycleScope.launchWhenStarted {
-            viewModel.permissionRequest.collect { permissionRequest ->
-                if (permissionRequest == Manifest.permission.WRITE_EXTERNAL_STORAGE) {
-                    requestPermissionLauncher.launch(permissionRequest)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.permissionRequest.collect { permissionRequest ->
+                    if (permissionRequest == Manifest.permission.WRITE_EXTERNAL_STORAGE) {
+                        requestPermissionLauncher.launch(permissionRequest)
+                    }
                 }
             }
         }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoAddSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoAddSettingsViewModel.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.settings.viewmodel
 
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
@@ -36,11 +36,11 @@ class AutoAddSettingsViewModel @Inject constructor(
         isFragmentChangingConfigurations = isChangingConfigurations ?: false
     }
 
-    val autoAddPodcasts = LiveDataReactiveStreams.fromPublisher(
+    val autoAddPodcasts =
         podcastManager.observeAutoAddToUpNextPodcasts()
             .combineLatest(settings.autoAddUpNextLimit.toFlowable(BackpressureStrategy.LATEST), settings.autoAddUpNextLimitBehaviour.toFlowable(BackpressureStrategy.LATEST))
             .map { AutoAddSettingsState(it.first, it.second, it.third) }
-    )
+            .toLiveData()
 
     fun updatePodcast(podcast: Podcast, autoAddOption: Podcast.AutoAddUpNext) {
         viewModelScope.launch {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
@@ -2,9 +2,9 @@ package au.com.shiftyjelly.pocketcasts.settings.viewmodel
 
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
@@ -26,10 +26,10 @@ class SettingsAppearanceViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ViewModel() {
 
-    val signInState: LiveData<SignInState> = LiveDataReactiveStreams.fromPublisher(userManager.getSignInState())
+    val signInState: LiveData<SignInState> = userManager.getSignInState().toLiveData()
     val createAccountState = MutableLiveData<SettingsAppearanceState>().apply { value = SettingsAppearanceState.Empty }
-    val showArtworkOnLockScreen = MutableLiveData<Boolean>(settings.showArtworkOnLockScreen())
-    val useEmbeddedArtwork = MutableLiveData<Boolean>(settings.getUseEmbeddedArtwork())
+    val showArtworkOnLockScreen = MutableLiveData(settings.showArtworkOnLockScreen())
+    val useEmbeddedArtwork = MutableLiveData(settings.getUseEmbeddedArtwork())
 
     var changeThemeType: Pair<Theme.ThemeType?, Theme.ThemeType?> = Pair(null, null)
     var changeAppIconType: Pair<AppIcon.AppIconType?, AppIcon.AppIconType?> = Pair(null, null)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
@@ -6,7 +6,7 @@ import android.content.Context
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.LiveDataReactiveStreams
+import androidx.lifecycle.toLiveData
 import androidx.work.Constraints
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequestBuilder
@@ -120,7 +120,7 @@ class DownloadManagerImpl @Inject constructor(
             cleanUpStaleDownloads(workManager)
         }
 
-        val episodeLiveData = LiveDataReactiveStreams.fromPublisher(episodeFlowable)
+        val episodeLiveData = episodeFlowable.toLiveData()
         workManagerListener = workManager.getWorkInfosByTagLiveData(DownloadManager.WORK_MANAGER_DOWNLOAD_TAG).combineLatest(episodeLiveData)
 
         workManagerListener?.observeForever { (tasks, episodeUuids) ->

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -10,7 +10,7 @@ import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
-import androidx.lifecycle.LiveDataReactiveStreams
+import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
@@ -135,11 +135,7 @@ open class PlaybackManager @Inject constructor(
         Log.d(Settings.LOG_TAG_AUTO, "Init playback state")
         return@lazy relay
     }
-    val playbackStateLive = LiveDataReactiveStreams.fromPublisher(
-        playbackStateRelay.toFlowable(
-            BackpressureStrategy.LATEST
-        )
-    )
+    val playbackStateLive = playbackStateRelay.toFlowable(BackpressureStrategy.LATEST).toLiveData()
 
     private var updateCount = 0
     private var resettingPlayer = false

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -8,8 +8,8 @@ import android.os.Build
 import android.util.DisplayMetrics
 import android.view.WindowManager
 import androidx.core.text.HtmlCompat
-import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.toPublisher
 import androidx.work.WorkManager
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
@@ -233,7 +233,10 @@ class Support @Inject constructor(
             output.append(eol)
 
             output.append("Work Manager Tasks").append(eol)
-            val workInfos = LiveDataReactiveStreams.toPublisher(ProcessLifecycleOwner.get(), WorkManager.getInstance(context).getWorkInfosByTagLiveData(DownloadManager.WORK_MANAGER_DOWNLOAD_TAG)).awaitFirst()
+            val workInfos = WorkManager.getInstance(context)
+                .getWorkInfosByTagLiveData(DownloadManager.WORK_MANAGER_DOWNLOAD_TAG)
+                .toPublisher(ProcessLifecycleOwner.get())
+                .awaitFirst()
             workInfos.forEach { workInfo ->
                 output.append(workInfo.toString()).append(" Attempt=").append(workInfo.runAttemptCount).append(eol)
             }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/LiveDataUtil.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/LiveDataUtil.kt
@@ -29,9 +29,9 @@ fun <T> LiveData<T>.observeOnce(lifecycleOwner: LifecycleOwner, observer: Observ
     observe(
         lifecycleOwner,
         object : Observer<T> {
-            override fun onChanged(t: T) {
+            override fun onChanged(value: T) {
                 removeObserver(this)
-                observer.onChanged(t)
+                observer.onChanged(value)
             }
         }
     )

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectFragment.kt
@@ -5,7 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
-import androidx.lifecycle.LiveDataReactiveStreams
+import androidx.lifecycle.toLiveData
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.SimpleItemAnimator
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
@@ -75,7 +75,7 @@ class MultiSelectFragment : BaseFragment(), MultiSelectTouchCallback.ItemTouchHe
         itemTouchHelper = ItemTouchHelper(callback)
         itemTouchHelper.attachToRecyclerView(recyclerView)
 
-        LiveDataReactiveStreams.fromPublisher(settings.multiSelectItemsObservable.toFlowable(BackpressureStrategy.LATEST))
+        settings.multiSelectItemsObservable.toFlowable(BackpressureStrategy.LATEST).toLiveData()
             .observe(viewLifecycleOwner) {
                 val multiSelectActions: MutableList<Any> = MultiSelectAction.listFromIds(it).toMutableList()
 


### PR DESCRIPTION
> **Note**
> This PR builds on the `update/remove-unused-upnextepisodeviewmodel` branch, so let's merge [that PR](https://github.com/Automattic/pocket-casts-android/pull/837) before this one.

## Description
When updating to the latest version of horologist for the watch app, the `core-ktx` and the `lifecycle` libraries get updated as well. The `core-ktx` update doesn't require any changes, but the `lifecycle` update required a lot of changes, so this is to separate those changes out into its own PR. I'm targeting `main` with this PR because I'm planning to merge `add/wear` into `main` soon.

Most of the changes are pretty safe and automatic. The only change that I think could go wrong is where I replace the `launchWhenX` events. I followed the same pattern [Google used when updating the data store library](https://android-review.googlesource.com/c/platform/frameworks/support/+/2293558/5/datastore/datastore-sampleapp/src/main/java/com/example/datastoresampleapp/SettingsFragment.kt), but it would be good to take a closer look at those changes to make sure I'm not using an incorrect lifecycle owner or something.

Here are the release notes for [lifecycle](https://developer.android.com/jetpack/androidx/releases/lifecycle) and [core](https://developer.android.com/jetpack/androidx/releases/core#1.9.0) if you want to take a look.

## Testing Instructions
Just some general smoke testing.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews

