### PR TITLE
Fix search results scroll position

### DIFF
--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -194,6 +194,9 @@ class SearchFragment : BaseFragment() {
                 val characterCount = query.length
                 val lowerCaseSearch = query.lowercase()
                 if ((characterCount == 1 && lowerCaseSearch.startsWith("h")) || (characterCount == 2 && lowerCaseSearch.startsWith("ht")) || (characterCount == 3 && lowerCaseSearch.startsWith("htt")) || lowerCaseSearch.startsWith("http")) {
+                    if ((viewModel.state.value as? SearchState.Results)?.podcasts?.isNotEmpty() == true) {
+                        binding.searchHistoryPanel.hide()
+                    }
                     return true
                 }
                 viewModel.updateSearchQuery(query)

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -130,7 +130,7 @@ class SearchHandler @Inject constructor(
                     }
                     .toObservable()
 
-                if (settings.isFeatureFlagSearchImprovementsEnabled()) {
+                if (settings.isFeatureFlagSearchImprovementsEnabled() && !it.startsWith("http")) {
                     val episodesServerSearch = cacheServerManager
                         .searchEpisodes(it)
                         .map { episodeSearch ->

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchInlineResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchInlineResultsPage.kt
@@ -146,6 +146,8 @@ private fun SearchResultsView(
     val podcastsRowState = rememberLazyListState()
     val episodesRowState = rememberLazyListState()
     LaunchedEffect(key1 = state.podcasts) {
+        // Only reset the scroll state if we have podcasts and they are different. This prevents resetting the
+        // scroll state when navigating back to the search results after tapping on one of the results.
         if (state.podcasts.isNotEmpty() && state.podcasts != podcasts) {
             podcastsRowState.scrollToItem(0)
         }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchInlineResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchInlineResultsPage.kt
@@ -15,9 +15,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -139,7 +141,20 @@ private fun SearchResultsView(
             }
         }
     }
+    val podcastsRowState = rememberLazyListState()
+    val episodesRowState = rememberLazyListState()
+    LaunchedEffect(key1 = state.podcasts) {
+        if (state.podcasts.isNotEmpty()) {
+            podcastsRowState.scrollToItem(0)
+        }
+    }
+    LaunchedEffect(key1 = state.episodes) {
+        if (state.episodes.isNotEmpty()) {
+            episodesRowState.scrollToItem(0)
+        }
+    }
     LazyColumn(
+        state = episodesRowState,
         modifier = modifier
             .nestedScroll(nestedScrollConnection)
     ) {
@@ -152,10 +167,13 @@ private fun SearchResultsView(
             }
         }
         item {
-            LazyRow(contentPadding = PaddingValues(horizontal = 8.dp)) {
+            LazyRow(
+                state = podcastsRowState,
+                contentPadding = PaddingValues(horizontal = 8.dp)
+            ) {
                 items(
                     items = state.podcasts.take(minOf(MAX_ITEM_COUNT, state.podcasts.size)),
-                    key = { it.adapterId }
+                    key = { it.uuid }
                 ) { folderItem ->
                     when (folderItem) {
                         is FolderItem.Folder -> {

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchInlineResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchInlineResultsPage.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -141,10 +142,11 @@ private fun SearchResultsView(
             }
         }
     }
+    val podcasts by remember { mutableStateOf(state.podcasts) }
     val podcastsRowState = rememberLazyListState()
     val episodesRowState = rememberLazyListState()
     LaunchedEffect(key1 = state.podcasts) {
-        if (state.podcasts.isNotEmpty()) {
+        if (state.podcasts.isNotEmpty() && state.podcasts != podcasts) {
             podcastsRowState.scrollToItem(0)
         }
     }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -91,6 +91,7 @@ class SearchViewModel @Inject constructor(
     }
 
     fun updateSearchQuery(query: String, immediate: Boolean = false) {
+        if (_state.value.searchTerm == query) return
         searchHandler.updateSearchQuery(query, immediate)
     }
 

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -91,6 +91,7 @@ class SearchViewModel @Inject constructor(
     }
 
     fun updateSearchQuery(query: String, immediate: Boolean = false) {
+        // Prevent updating the search query when navigating back to the search results after tapping on a result.
         if (_state.value.searchTerm == query) return
         searchHandler.updateSearchQuery(query, immediate)
     }


### PR DESCRIPTION
## Description

This PR 
- Updates scroll position to the start of the list on a new search
- Hides episodes on RSS podcast feed search

> **Warning**
> Targets release/7.35

## Testing Instructions
Prerequisite: Enable search improvements (if you do not have valid `google-services.json`, return `true` from `isFeatureFlagSearchImprovementsEnabled()`)

#### Scroll position 
1. Go to podcasts or discover tab search bar
2. Search for a term
3. Notice that search results are shown
4. Scroll horizontally through the podcasts search results row so that the first visible item is not the first podcast in the search results
5. Update search term 
6. ✅ Notice that the updated podcasts search results row scrolls to the first podcast in the results
7. Scroll vertically so that the first visible episode is not the first episode in the search results
8. Update search term 
9. ✅ Notice that the updated search results row scrolls to the first item in the vertical list
10. Repeat step 4
11. Tap on a visible podcast
12. Navigate back to the search results screen
13. ✅ Notice that the scroll position is retained

## Screencast 

https://user-images.githubusercontent.com/1405144/228492780-0745a4f9-3a86-4c73-a15c-dcca8f1ee957.mp4


#### Hide episodes from RSS podcast feed search
1. Go to podcasts or discover tab search bar
2. Search for a RSS podcast feed
3. ✅ Notice that episodes are not shown and only the podcast for the RSS feed is shown in search results

## Screencast 
https://user-images.githubusercontent.com/1405144/228492829-9c7b222e-c13d-4246-bb70-581e1ea98cca.mp4
