### PR TITLE
Log playback state exception in Sentry

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -46,6 +46,7 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.EpisodeSyncRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.EpisodeSyncResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServerManager
 import au.com.shiftyjelly.pocketcasts.utils.Network
+import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isPositive
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -878,6 +879,11 @@ open class PlaybackManager @Inject constructor(
                 } else {
                     event.message
                 }
+                val isAutomotive = Util.isAutomotive(application)
+                SentryHelper.recordException(
+                    message = "Illegal playback state encountered for episode uuid ${episode?.uuid}, isAutomotive $isAutomotive}: ",
+                    throwable = event.error ?: IllegalStateException(event.message)
+                )
                 playbackStateRelay.accept(playbackState.copy(state = PlaybackState.State.ERROR, lastErrorMessage = errorMessage, lastChangeFrom = "onPlayerError"))
             }
         }


### PR DESCRIPTION
## Description
This logs playback state exception in Sentry as part of https://github.com/Automattic/pocket-casts-android/issues/272#issuecomment-1477121237 to explore further patreon podcast not playing consistently in Automotive.

> **Warning**
> Targets release/7.35

## Testing Instructions
I tested it by throwing a playback error explicitly in a release build variant:

<img width = 400 src ="https://user-images.githubusercontent.com/1405144/228512778-20f2d5f4-f22a-4b62-ab40-aea6f955d1fd.png"/>

