### PR TITLE
Enable carousel autoscroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,16 @@
 7.35
 -----
 *   Updates
-    *   The Automotive skip forward and backward time settings were improved.
+    *   The Automotive skip forward and backward time settings were improved
         ([#817](https://github.com/Automattic/pocket-casts-android/pull/817)).
-    *   Fixed Automotive Up Next podcast images not loading.
+    *   Fixed Automotive Up Next podcast images not loading
         ([#819](https://github.com/Automattic/pocket-casts-android/pull/819)).
-    *   Fixed missing seek bar in the notification drawer and Android Automotive.
+    *   Fixed missing seek bar in the notification drawer and Android Automotive
         ([#822](https://github.com/Automattic/pocket-casts-android/pull/822)).
-    *   Added option to clear data when signing out of Android Automotive.
-        ([828](https://github.com/Automattic/pocket-casts-android/pull/828))
+    *   Added option to clear data when signing out of Android Automotive
+        ([828](https://github.com/Automattic/pocket-casts-android/pull/828)).
+    *   Podcast carousel on Discover screen now scrolls automatically
+        ([818](https://github.com/Automattic/pocket-casts-android/pull/818)).
 
 7.34
 -----

--- a/base.gradle
+++ b/base.gradle
@@ -31,7 +31,6 @@ android {
         // Feature Flags
         buildConfigField "boolean", "END_OF_YEAR_ENABLED", "false"
         buildConfigField "boolean", "SINGLE_SIGN_ON_ENABLED", "false"
-        buildConfigField "boolean", "DISCOVER_FEATURED_AUTO_SCROLL", "false"
 
         testInstrumentationRunner project.testInstrumentationRunner
         testApplicationId "au.com.shiftyjelly.pocketcasts.test" + project.name.replace("-", "_")

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -38,7 +38,6 @@ import au.com.shiftyjelly.pocketcasts.discover.viewmodel.PodcastList
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.localization.helper.tryToLocalise
 import au.com.shiftyjelly.pocketcasts.models.entity.Episode
-import au.com.shiftyjelly.pocketcasts.preferences.BuildConfig
 import au.com.shiftyjelly.pocketcasts.repositories.images.into
 import au.com.shiftyjelly.pocketcasts.servers.cdn.ArtworkColors
 import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServerManagerImpl
@@ -216,23 +215,21 @@ internal class DiscoverAdapter(
             recyclerView?.itemAnimator = null
             recyclerView?.addOnScrollListener(scrollListener)
 
-            if (BuildConfig.DISCOVER_FEATURED_AUTO_SCROLL) {
-                autoScrollHelper = AutoScrollHelper {
-                    if (adapter.itemCount == 0) return@AutoScrollHelper
-                    val currentPosition = binding.pageIndicatorView.position
-                    val nextPosition = (currentPosition + 1)
-                        .takeIf { it < adapter.itemCount } ?: 0
-                    MainScope().launch {
-                        if (nextPosition > currentPosition) {
-                            recyclerView?.smoothScrollToPosition(nextPosition)
-                        } else {
-                            /* Jump to the beginning to avoid a backward scroll animation */
-                            recyclerView?.scrollToPosition(nextPosition)
-                        }
-                        binding.pageIndicatorView.position = nextPosition
-                        trackSponsoredListImpression(nextPosition)
-                        trackPageChanged(nextPosition)
+            autoScrollHelper = AutoScrollHelper {
+                if (adapter.itemCount == 0) return@AutoScrollHelper
+                val currentPosition = binding.pageIndicatorView.position
+                val nextPosition = (currentPosition + 1)
+                    .takeIf { it < adapter.itemCount } ?: 0
+                MainScope().launch {
+                    if (nextPosition > currentPosition) {
+                        recyclerView?.smoothScrollToPosition(nextPosition)
+                    } else {
+                        /* Jump to the beginning to avoid a backward scroll animation */
+                        recyclerView?.scrollToPosition(nextPosition)
                     }
+                    binding.pageIndicatorView.position = nextPosition
+                    trackSponsoredListImpression(nextPosition)
+                    trackPageChanged(nextPosition)
                 }
             }
 


### PR DESCRIPTION
## Description
Turning on autoscroll on the Discover carousel by removing the feature flag.

internal ref: p1680117820760509/1680117264.777019-slack-C02ATC80MUM

> **Warning**
> This PR is targeting the 7.35 release branch. Even though we're close to releasing that, I'm thinking we may want to go ahead and cut a new beta so if there is any issue we have a chance to catch it before release, but let me know what you think.

## Testing Instructions
Review the auto scroll testing instructions from https://github.com/Automattic/pocket-casts-android/pull/818

## Screenshots or Screencast 

https://user-images.githubusercontent.com/4656348/228649029-094478c6-c4e8-4bff-8b9f-ac59eb28d163.mov

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack