### PR TITLE
Discover carousel: Add auto scroll delay on screen change

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -254,7 +254,8 @@ internal class DiscoverAdapter(
                 /* Manage auto scroll when itemView's visibility changes on going to next screen */
                 addOnGlobalLayoutListener {
                     if (itemView.isShown) {
-                        autoScrollHelper?.startAutoScrollTimer()
+                        /* Start auto scroll with a delay after coming from another screen */
+                        autoScrollHelper?.startAutoScrollTimer(delay = AutoScrollHelper.AUTO_SCROLL_DELAY)
                     } else {
                         autoScrollHelper?.stopAutoScrollTimer()
                     }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -251,10 +251,10 @@ internal class DiscoverAdapter(
                 addOnWindowFocusChangeListener { hasFocus ->
                     if (!hasFocus) autoScrollHelper?.stopAutoScrollTimer()
                 }
-                /* Manage auto scroll when itemView's visibility changes on going to next screen */
+                /* Manage auto scroll when itemView's visibility changes */
                 addOnGlobalLayoutListener {
                     if (itemView.isShown) {
-                        /* Start auto scroll with a delay after coming from another screen */
+                        /* Start auto scroll with a delay when carousel item view is re-shown */
                         autoScrollHelper?.startAutoScrollTimer(delay = AutoScrollHelper.AUTO_SCROLL_DELAY)
                     } else {
                         autoScrollHelper?.stopAutoScrollTimer()


### PR DESCRIPTION
## Description
Adds delay to `Discover` carousel auto-scroll after changing screens.

Fixes #852

> **Warning**
> Targets 7.35


## Testing Instructions

1. Launch the app
2. Go to Discover
3. Go to other screen (Podcasts, Filters, Profile)
4. Go to Discover
5. Notice the carousel auto-scrolls after a delay 

## Screenshots or Screencast 

https://user-images.githubusercontent.com/1405144/228784983-78f6d92e-86d0-4a0a-9852-0d7b638d2d92.mp4

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
