### PR TITLE
Set up notification channels on watch

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.file.StorageOptions
+import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
@@ -30,6 +31,7 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
 
     @Inject lateinit var downloadManager: DownloadManager
     @Inject lateinit var episodeManager: EpisodeManager
+    @Inject lateinit var notificationHelper: NotificationHelper
     @Inject lateinit var playbackManager: PlaybackManager
     @Inject lateinit var playlistManager: PlaylistManager
     @Inject lateinit var podcastManager: PodcastManager
@@ -57,6 +59,9 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
                 analytics = FirebaseAnalytics.getInstance(this@PocketCastsWearApplication),
                 settings = settings
             )
+
+            notificationHelper.setupNotificationChannels()
+
             withContext(Dispatchers.Default) {
                 playbackManager.setup()
                 downloadManager.setup(episodeManager, podcastManager, playlistManager, playbackManager)


### PR DESCRIPTION
## Description
This sets up the notification channels on the watch so that notifications will now work. Thanks to @ashiagr for [suggesting this fix](https://github.com/Automattic/pocket-casts-android/pull/821#discussion_r1130613461).

## Testing Instructions
1. Trigger a notification from the watch app. I did it by using adding these changes so that tapping on the Now Playing chip would trigger a notification.
2. Observe that the notification is presented.

## Screenshots or Screencast 

[Uploading Screen Recording 2023-03-30 at 1.26.05 PM.mov…](https://user-images.githubusercontent.com/4656348/228917020-cf01b53e-2346-433e-ba16-dc9a006b980a.mov)

## Checklist

- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews