### PR TITLE
Update scroll position indicator from blue to gray-white

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearAppTheme.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearAppTheme.kt
@@ -41,7 +41,7 @@ private fun buildWearMaterialColors(colors: ThemeColors): Colors {
         error = colors.support05,
         onPrimary = colors.primaryInteractive02,
         onSecondary = colors.primaryInteractive02,
-        onBackground = colors.secondaryIcon01,
+        onBackground = colors.secondaryIcon02,
         onSurface = colors.primaryText01,
         onError = colors.secondaryIcon01,
     )

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearColors.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearColors.kt
@@ -1,0 +1,9 @@
+package au.com.shiftyjelly.pocketcasts.wear.theme
+
+import androidx.compose.ui.graphics.Color
+
+object WearColors {
+    val FF202124 = Color(0xFF202124)
+    val FFA1E7B0 = Color(0xFFA1E7B0)
+    val FFDADCE0 = Color(0xFFDADCE0)
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight.Companion.W700
@@ -25,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.DownloadButtonState
 import au.com.shiftyjelly.pocketcasts.utils.Util
+import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
@@ -70,7 +70,7 @@ fun EpisodeScreen(
             TextP50(
                 text = podcast.title,
                 maxLines = 1,
-                color = Color(0xFFDADCE0),
+                color = WearColors.FFDADCE0,
                 lineHeight = headingLineHeight,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.padding(horizontal = 8.dp)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/NotificationScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/NotificationScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -21,6 +20,7 @@ import androidx.wear.compose.material.Icon
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
+import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
 import kotlinx.coroutines.delay
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 
@@ -46,7 +46,7 @@ fun NotificationScreen(
     ) {
         Icon(
             painter = painterResource(IR.drawable.ic_check_black_24dp),
-            tint = Color(0xFFA1E7B0),
+            tint = WearColors.FFA1E7B0,
             contentDescription = null,
             modifier = Modifier.size(52.dp)
         )

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/ObtainConfirmationScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/ObtainConfirmationScreen.kt
@@ -57,7 +57,7 @@ fun ObtainConfirmationScreen(
                 Box(
                     contentAlignment = Alignment.Center,
                     modifier = Modifier
-                        .background(color = WearColors.FF202124) // FIXME
+                        .background(color = WearColors.FF202124)
                         .clip(CircleShape)
                         .fillMaxSize()
                 ) {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/ObtainConfirmationScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/ObtainConfirmationScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.Icon
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -56,7 +57,7 @@ fun ObtainConfirmationScreen(
                 Box(
                     contentAlignment = Alignment.Center,
                     modifier = Modifier
-                        .background(color = Color(0xFF202124)) // FIXME
+                        .background(color = WearColors.FF202124) // FIXME
                         .clip(CircleShape)
                         .fillMaxSize()
                 ) {


### PR DESCRIPTION
## Description
Updates the scroll position indicator on the watch app from blue to gray. This change was suggested by @geekygecko , and I agree that the blue doesn't really seem to fit. This fix will obviously change more than just the position indicator, but I don't think we necessarily want the blue color anywhere in the watch app currently, so removing it in other places as well seems fine. I'm sure we'll be revisiting how to handle the theming in the watch app again before this ships.

This PR also extracts out some of the raw color declarations we had for wear to a single location (`WearColors`). I don't think moving these colors to a single file is a great solution, but I hope it's at least a (very) small step in the right direction and will, I hope, make it easier to further improve how we handle colors in the watch app in the future.

## Testing Instructions
Verify that when scrolling lists in the app, the scroll indicator is gray instead of blue.

## Screenshots or Screencast 

| Before | After |
| --- | --- |
| ![Screenshot 2023-03-30 at 2 47 23 PM](https://user-images.githubusercontent.com/4656348/228934631-caa73a76-9511-4d05-b999-aa414f87c5c8.png) | ![Screenshot 2023-03-30 at 2 50 50 PM](https://user-images.githubusercontent.com/4656348/228935318-1672a25b-cdcd-4616-8637-1a443796cc88.png) |


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
