### PR TITLE
Add watch settings screen with metered data warning

### DIFF
--- a/modules/services/images/src/main/res/drawable/signin.xml
+++ b/modules/services/images/src/main/res/drawable/signin.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M9.793,7.293C10.183,6.902 10.817,6.902 11.207,7.293L15.207,11.293L15.914,12L15.207,12.707L11.207,16.707C10.817,17.098 10.183,17.098 9.793,16.707C9.402,16.317 9.402,15.683 9.793,15.293L12.086,13H3C2.448,13 2,12.552 2,12C2,11.448 2.448,11 3,11H12.086L9.793,8.707C9.402,8.317 9.402,7.683 9.793,7.293Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M6,5C6,3.895 6.895,3 8,3H17C18.105,3 19,3.895 19,5V19C19,20.105 18.105,21 17,21H8C6.895,21 6,20.105 6,19V18C6,17.448 6.448,17 7,17C7.552,17 8,17.448 8,18V19H17V5H8V6C8,6.552 7.552,7 7,7C6.448,7 6,6.552 6,6V5Z"
+      android:strokeAlpha="0.5"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"
+      android:fillAlpha="0.5"/>
+</vector>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
 
     <string name="empty" translatable="false" />
 
+    <string name="account">Account</string>
     <string name="add_to_up_next">Add to Up Next</string>
     <string name="archive">Archive</string>
     <string name="unarchive">Unarchive</string>
@@ -25,6 +26,8 @@
     <string name="go_to_podcast">Go to podcast</string>
     <string name="go_to_files">Go to files</string>
     <string name="in_progress">In progress</string>
+    <string name="log_in">Log in</string>
+    <string name="log_out">Log out</string>
     <string name="mark_as_played">Mark as played</string>
     <string name="mark_as_unplayed">Mark as unplayed</string>
     <string name="mark_played">Mark played</string>
@@ -192,6 +195,7 @@
     <string name="stream_warning_title_not_wifi" translatable="false">@string/youre_not_on_wifi</string>
     <string name="stream_warning_title_metered_wifi" translatable="false">@string/youre_on_metered_wifi</string>
     <string name="stream_warning_summary">Streaming this episode will use data.</string>
+    <string name="stream_warning_summary_short">Streaming will use data. Proceed?</string>
     <string name="stream_warning_button">Stream Anyway</string>
 
     <string name="search_no_podcasts_found">No podcasts found</string>
@@ -1054,6 +1058,7 @@
     <string name="settings_media_notification_controls_title_play_next" translatable="false">@string/play_next</string>
     <string name="settings_media_notification_controls_title_playback_speed" translatable="false">@string/playback_speed</string>
     <string name="settings_media_notification_controls_title_star" translatable="false">@string/star</string>
+    <string name="settings_metered_data_warning">Metered data warning</string>
     <string name="settings_no_thanks">No thanks</string>
     <string name="settings_notifications_new_episodes">New Episodes</string>
     <string name="settings_notification_actions">Actions</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1366,7 +1366,13 @@ open class PlaybackManager @Inject constructor(
 
         episodeSubscription?.dispose()
         if (!episode.isDownloaded) {
-            if (!Util.isCarUiMode(application) && settings.warnOnMeteredNetwork() && !Network.isUnmeteredConnection(application) && !forceStream && play) {
+            if (!Util.isCarUiMode(application) &&
+                !Util.isWearOs(application) && // The watch handles these warnings before this is called
+                settings.warnOnMeteredNetwork() &&
+                !Network.isUnmeteredConnection(application) &&
+                !forceStream &&
+                play
+            ) {
                 sendDataWarningNotification(episode)
                 val previousPlaybackState = playbackStateRelay.blockingFirst()
                 val playbackState = PlaybackState(

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -5,6 +5,15 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.VIBRATE"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.BLUETOOTH"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="com.android.vending.CHECK_LICENSE"/>
+    <uses-permission android:name="com.android.vending.BILLING" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <uses-feature android:name="android.hardware.type.watch" />
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -4,8 +4,11 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
@@ -13,13 +16,17 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 import au.com.shiftyjelly.pocketcasts.wear.ui.FilesScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.FiltersScreen
+import au.com.shiftyjelly.pocketcasts.wear.ui.SettingsScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.UpNextScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.WatchListScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.authenticationGraph
+import au.com.shiftyjelly.pocketcasts.wear.ui.authenticationSubGraph
 import au.com.shiftyjelly.pocketcasts.wear.ui.downloads.DownloadsScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.episode.EpisodeScreenFlow
 import au.com.shiftyjelly.pocketcasts.wear.ui.episode.EpisodeScreenFlow.episodeGraph
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.NowPlayingScreen
+import au.com.shiftyjelly.pocketcasts.wear.ui.player.NowPlayingViewModel
+import au.com.shiftyjelly.pocketcasts.wear.ui.player.StreamingConfirmationScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcast.PodcastScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcasts.PodcastsScreen
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
@@ -59,11 +66,40 @@ fun WearApp(themeType: Theme.ThemeType) {
                 WatchListScreen(navController::navigate, it.scrollableState)
             }
 
-            composable(NowPlayingScreen.route) { viewModel ->
-                viewModel.timeTextMode = NavScaffoldViewModel.TimeTextMode.Off
+            composable(NowPlayingScreen.route) {
+                it.timeTextMode = NavScaffoldViewModel.TimeTextMode.Off
+
+                // Listen for results from streaming confirmation screen
+                navController.currentBackStackEntry?.savedStateHandle
+                    ?.getStateFlow<StreamingConfirmationScreen.Result?>(StreamingConfirmationScreen.resultKey, null)
+                    ?.collectAsStateWithLifecycle()?.value?.let { streamingConfirmationResult ->
+                        val viewModel = hiltViewModel<NowPlayingViewModel>()
+                        LaunchedEffect(streamingConfirmationResult) {
+                            viewModel.onStreamingConfirmationResult(streamingConfirmationResult)
+                            // Clear result once consumed
+                            navController.currentBackStackEntry?.savedStateHandle
+                                ?.remove<StreamingConfirmationScreen.Result?>(StreamingConfirmationScreen.resultKey)
+                        }
+                    }
+
                 NowPlayingScreen(
                     navigateToEpisode = { episodeUuid ->
                         navController.navigate(EpisodeScreenFlow.navigateRoute(episodeUuid))
+                    },
+                    showStreamingConfirmation = { navController.navigate(StreamingConfirmationScreen.route) },
+                )
+            }
+
+            composable(StreamingConfirmationScreen.route) {
+                it.timeTextMode = NavScaffoldViewModel.TimeTextMode.Off
+
+                StreamingConfirmationScreen(
+                    onFinished = { result ->
+                        navController.previousBackStackEntry?.savedStateHandle?.set(
+                            StreamingConfirmationScreen.resultKey,
+                            result
+                        )
+                        navController.popBackStack()
                     },
                 )
             }
@@ -125,6 +161,13 @@ fun WearApp(themeType: Theme.ThemeType) {
             }
 
             composable(FilesScreen.route) { FilesScreen() }
+
+            scrollable(SettingsScreen.route) {
+                SettingsScreen(
+                    scrollState = it.columnState,
+                    signInClick = { navController.navigate(authenticationSubGraph) },
+                )
+            }
 
             authenticationGraph(navController)
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearColors.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearColors.kt
@@ -5,5 +5,6 @@ import androidx.compose.ui.graphics.Color
 object WearColors {
     val FF202124 = Color(0xFF202124)
     val FFA1E7B0 = Color(0xFFA1E7B0)
+    val FFBDC1C6 = Color(0xFFBDC1C6)
     val FFDADCE0 = Color(0xFFDADCE0)
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/SettingsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/SettingsScreen.kt
@@ -1,0 +1,180 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.ToggleChip
+import androidx.wear.compose.material.ToggleChipDefaults
+import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
+import au.com.shiftyjelly.pocketcasts.wear.theme.theme
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.ChipScreenHeader
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.ChipSectionHeader
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+object SettingsScreen {
+    const val route = "settings_screen"
+}
+
+@Composable
+fun SettingsScreen(
+    scrollState: ScalingLazyColumnState,
+    signInClick: () -> Unit,
+) {
+
+    val viewModel = hiltViewModel<SettingsViewModel>()
+    val state by viewModel.state.collectAsState()
+
+    Content(
+        scrollState = scrollState,
+        state = state,
+        onWarnOnMeteredChanged = { viewModel.setWarnOnMeteredNetwork(it) },
+        signInClick = signInClick,
+        onSignOutClicked = viewModel::signOut,
+    )
+}
+
+@Composable
+private fun Content(
+    scrollState: ScalingLazyColumnState,
+    state: SettingsViewModel.State,
+    onWarnOnMeteredChanged: (Boolean) -> Unit,
+    signInClick: () -> Unit,
+    onSignOutClicked: () -> Unit,
+) {
+    ScalingLazyColumn(columnState = scrollState) {
+
+        item {
+            ChipScreenHeader(LR.string.settings)
+        }
+
+        item {
+            ToggleChip(
+                label = stringResource(LR.string.settings_metered_data_warning),
+                checked = state.showDataWarning,
+                onCheckedChanged = onWarnOnMeteredChanged,
+            )
+        }
+
+        item {
+            ChipSectionHeader(LR.string.account)
+        }
+
+        item {
+            val signInState = state.signInState
+            when (signInState) {
+                is SignInState.SignedIn -> {
+                    WatchListChip(
+                        titleRes = LR.string.log_out,
+                        secondaryLabel = signInState.email,
+                        iconRes = IR.drawable.ic_signout,
+                        onClick = onSignOutClicked,
+                    )
+                }
+                is SignInState.SignedOut -> {
+                    WatchListChip(
+                        titleRes = LR.string.log_in,
+                        iconRes = IR.drawable.signin,
+                        onClick = signInClick,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ToggleChip(
+    label: String,
+    checked: Boolean,
+    onCheckedChanged: (Boolean) -> Unit,
+) {
+    val color = MaterialTheme.theme.colors.support05
+    ToggleChip(
+        checked = checked,
+        onCheckedChange = { onCheckedChanged(it) },
+        label = {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.button,
+            )
+        },
+        toggleControl = {
+            Icon(
+                imageVector = ToggleChipDefaults.switchIcon(checked),
+                contentDescription = stringResource(if (checked) LR.string.on else LR.string.off),
+                modifier = Modifier
+            )
+        },
+        colors = ToggleChipDefaults.toggleChipColors(
+            checkedEndBackgroundColor = color.copy(alpha = 0.32f),
+            checkedToggleControlColor = color,
+        ),
+        modifier = Modifier.fillMaxWidth()
+    )
+}
+
+@Preview(
+    widthDp = 200,
+    heightDp = 200,
+    uiMode = Configuration.UI_MODE_TYPE_WATCH,
+)
+@Composable
+private fun SettingsScreenPreview_unchecked() {
+    WearAppTheme(Theme.ThemeType.DARK) {
+        Content(
+            scrollState = ScalingLazyColumnState(),
+            state = SettingsViewModel.State(
+                signInState = SignInState.SignedIn(
+                    email = "matt@pocketcasts.com",
+                    subscriptionStatus = SubscriptionStatus.Free(),
+                ),
+                showDataWarning = false,
+            ),
+            signInClick = {},
+            onWarnOnMeteredChanged = {},
+            onSignOutClicked = {}
+
+        )
+    }
+}
+
+@Preview(
+    widthDp = 200,
+    heightDp = 200,
+    uiMode = Configuration.UI_MODE_TYPE_WATCH,
+)
+@Composable
+private fun SettingsScreenPreview_checked() {
+    WearAppTheme(Theme.ThemeType.DARK) {
+        Content(
+            scrollState = ScalingLazyColumnState(),
+            state = SettingsViewModel.State(
+                signInState = SignInState.SignedIn(
+                    email = "matt@pocketcasts.com",
+                    subscriptionStatus = SubscriptionStatus.Free(),
+                ),
+                showDataWarning = true,
+            ),
+            signInClick = {},
+            onWarnOnMeteredChanged = {},
+            onSignOutClicked = {}
+
+        )
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/SettingsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/SettingsViewModel.kt
@@ -1,0 +1,62 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.reactive.asFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val playbackManager: PlaybackManager,
+    private val userManager: UserManager,
+    private val settings: Settings,
+) : ViewModel() {
+
+    data class State(
+        val signInState: SignInState,
+        val showDataWarning: Boolean,
+    )
+
+    private val _state = MutableStateFlow(
+        State(
+            signInState = userManager.getSignInState().blockingFirst(),
+            showDataWarning = settings.warnOnMeteredNetwork(),
+        )
+    )
+    val state = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            userManager.getSignInState()
+                .asFlow()
+                .collectLatest { signInState ->
+                    _state.update { it.copy(signInState = signInState) }
+                }
+        }
+    }
+
+    fun setWarnOnMeteredNetwork(warnOnMeteredNetwork: Boolean) {
+        settings.setWarnOnMeteredNetwork(warnOnMeteredNetwork)
+        _state.update { it.copy(showDataWarning = warnOnMeteredNetwork) }
+    }
+
+    fun signOut() {
+        userManager.signOut(
+            playbackManager = playbackManager,
+            wasInitiatedByUser = true
+        )
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
@@ -51,11 +51,9 @@ object WatchListScreen {
 fun WatchListScreen(
     navigateToRoute: (String) -> Unit,
     scrollState: ScalingLazyListState,
-    viewModel: WatchListViewModel = hiltViewModel(),
     upNextViewModel: UpNextViewModel = hiltViewModel(),
 ) {
 
-    val signInState by viewModel.signInState.subscribeAsState(null)
     val upNextState by upNextViewModel.upNextQueue.subscribeAsState(null)
 
     ScalingLazyColumn(
@@ -70,26 +68,6 @@ fun WatchListScreen(
                 color = MaterialTheme.colors.primary,
                 text = stringResource(LR.string.app_name)
             )
-        }
-
-        item {
-            when (signInState?.isSignedIn) {
-                true -> {
-                    WatchListChip(
-                        titleRes = LR.string.sign_out,
-                        iconRes = IR.drawable.ic_signout,
-                        onClick = viewModel::signOut,
-                    )
-                }
-                false -> {
-                    WatchListChip(
-                        titleRes = LR.string.sign_in,
-                        iconRes = IR.drawable.ic_profile,
-                        onClick = { navigateToRoute(authenticationSubGraph) },
-                    )
-                }
-                null -> { /* Do nothing */ }
-            }
         }
 
         item {
@@ -138,6 +116,14 @@ fun WatchListScreen(
                 titleRes = LR.string.profile_navigation_files,
                 iconRes = PR.drawable.ic_file,
                 onClick = { navigateToRoute(FilesScreen.route) }
+            )
+        }
+
+        item {
+            WatchListChip(
+                titleRes = LR.string.settings,
+                iconRes = IR.drawable.ic_profile_settings,
+                onClick = { navigateToRoute(SettingsScreen.route) }
             )
         }
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ChipScreenHeaders.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ChipScreenHeaders.kt
@@ -1,0 +1,38 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui.component
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
+
+@Composable
+fun ChipScreenHeader(@StringRes text: Int, modifier: Modifier = Modifier) {
+    Header(
+        text,
+        modifier.padding(
+            start = 16.dp,
+            end = 16.dp,
+            bottom = 16.dp,
+        )
+    )
+}
+
+@Composable
+fun ChipSectionHeader(@StringRes text: Int, modifier: Modifier = Modifier) {
+    Header(text, modifier.padding(16.dp))
+}
+
+@Composable
+private fun Header(@StringRes text: Int, modifier: Modifier = Modifier) {
+    Text(
+        text = stringResource(text),
+        color = WearColors.FFBDC1C6,
+        style = MaterialTheme.typography.button,
+        modifier = modifier
+    )
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ChipScreenHeaders.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ChipScreenHeaders.kt
@@ -1,10 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui.component
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
@@ -15,16 +17,16 @@ fun ChipScreenHeader(@StringRes text: Int, modifier: Modifier = Modifier) {
     Header(
         text,
         modifier.padding(
-            start = 16.dp,
-            end = 16.dp,
-            bottom = 16.dp,
+            start = horizontalPadding,
+            end = horizontalPadding,
+            bottom = verticalPadding,
         )
     )
 }
 
 @Composable
 fun ChipSectionHeader(@StringRes text: Int, modifier: Modifier = Modifier) {
-    Header(text, modifier.padding(16.dp))
+    Header(text, modifier.padding(vertical = verticalPadding, horizontal = horizontalPadding))
 }
 
 @Composable
@@ -32,7 +34,11 @@ private fun Header(@StringRes text: Int, modifier: Modifier = Modifier) {
     Text(
         text = stringResource(text),
         color = WearColors.FFBDC1C6,
+        textAlign = TextAlign.Center,
         style = MaterialTheme.typography.button,
-        modifier = modifier
+        modifier = modifier.fillMaxWidth()
     )
 }
+
+private val horizontalPadding = 10.dp
+private val verticalPadding = 14.dp

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ObtainConfirmationScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ObtainConfirmationScreen.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.wear.ui.episode
+package au.com.shiftyjelly.pocketcasts.wear.ui.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreen.kt
@@ -21,10 +21,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -41,6 +39,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatPattern
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 import au.com.shiftyjelly.pocketcasts.wear.theme.theme
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.ChipScreenHeader
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import java.util.Date
@@ -66,35 +65,29 @@ fun DownloadsScreen(
 @Composable
 private fun Content(
     columnState: ScalingLazyColumnState,
-    episodes: List<Episode>,
+    episodes: List<Episode>?,
     onItemClick: (Episode) -> Unit,
 ) {
     ScalingLazyColumn(
         columnState = columnState,
     ) {
-        item {
-            Text(
-                text = stringResource(
-                    if (episodes.isEmpty()) {
+        if (episodes != null) {
+            item {
+                ChipScreenHeader(
+                    text = if (episodes.isEmpty()) {
                         LR.string.profile_empty_downloaded
                     } else {
                         LR.string.downloads
-                    }
-                ),
-                textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.button,
-                modifier = Modifier
-                    .padding(horizontal = 10.dp)
-                    .padding(bottom = 12.dp)
-                    .fillMaxWidth(),
-            )
-        }
+                    },
+                )
+            }
 
-        items(episodes) { episode ->
-            Download(
-                episode = episode,
-                onClick = { onItemClick(episode) }
-            )
+            items(episodes) { episode ->
+                Download(
+                    episode = episode,
+                    onClick = { onItemClick(episode) }
+                )
+            }
         }
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreenViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreenViewModel.kt
@@ -16,5 +16,5 @@ class DownloadsScreenViewModel @Inject constructor(
 
     val stateFlow = episodeManager.observeDownloadEpisodes()
         .asFlow()
-        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+        .stateIn(viewModelScope, SharingStarted.Lazily, null)
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
@@ -38,6 +38,7 @@ fun EpisodeScreen(
     navigateToUpNextOptions: () -> Unit,
     navigateToConfirmDeleteDownload: () -> Unit,
     navigateToRemoveFromUpNextNotification: () -> Unit,
+    navigateToStreamingConfirmation: () -> Unit,
 ) {
 
     val viewModel = hiltViewModel<EpisodeViewModel>()
@@ -119,9 +120,9 @@ fun EpisodeScreen(
                     backgroundColor = state.tintColor,
                     onClick = {
                         if (state.isPlayingEpisode) {
-                            viewModel.pause()
+                            viewModel.onPauseClicked()
                         } else {
-                            viewModel.play()
+                            viewModel.onPlayClicked(navigateToStreamingConfirmation)
                         }
                     },
                     isPlaying = state.isPlayingEpisode,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingScreen.kt
@@ -34,6 +34,7 @@ fun NowPlayingScreen(
     playerViewModel: NowPlayingViewModel = hiltViewModel(),
     volumeViewModel: PCVolumeViewModel = hiltViewModel(),
     navigateToEpisode: (episodeUuid: String) -> Unit,
+    showStreamingConfirmation: () -> Unit,
 ) {
     Scaffold(
         modifier = modifier.fillMaxSize(),
@@ -64,7 +65,7 @@ fun NowPlayingScreen(
             controlButtons = {
                 if (state is NowPlayingViewModel.State.Loaded) {
                     PodcastControlButtons(
-                        onPlayButtonClick = playerViewModel::onPlayButtonClick,
+                        onPlayButtonClick = { playerViewModel.onPlayButtonClick(showStreamingConfirmation) },
                         onPauseButtonClick = playerViewModel::onPauseButtonClick,
                         playPauseButtonEnabled = true,
                         playing = state.playing,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/StreamingConfirmationScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/StreamingConfirmationScreen.kt
@@ -1,0 +1,28 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui.player
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.ObtainConfirmationScreen
+import au.com.shiftyjelly.pocketcasts.wear.ui.player.StreamingConfirmationScreen.Result
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+object StreamingConfirmationScreen {
+    const val route = "streaming_confirmation"
+    const val resultKey = "${route}_result"
+
+    enum class Result {
+        CONFIRMED,
+        CANCELLED
+    }
+}
+
+@Composable
+fun StreamingConfirmationScreen(
+    onFinished: (Result) -> Unit,
+) {
+    ObtainConfirmationScreen(
+        text = stringResource(LR.string.stream_warning_summary_short),
+        onConfirm = { onFinished(Result.CONFIRMED) },
+        onCancel = { onFinished(Result.CANCELLED) }
+    )
+}


### PR DESCRIPTION
## Description
Add settings screen for watch app and implements a setting to give a warning before streaming an episode.

## Testing Instructions
1. Pair your watch to a phone
2. Go to the settings screen in the watch 
3. Check the UI for the log in button
4. Log into the app
5. Check the UI for the log out button
6. Toggle the metered data warning on
7. Check the UI for the metered data warning on state
8. With the connected phone using a metered connection, try to play an episode on the watch (if playing from the now playing screen, the currently queued episode should play, if from the episode details screen, that episode should get loaded and played).
9. Confirm that you get a metered data warning before playback starts (you will only get this warning the first time you play a particular episode)
10. Switch the phone to an unmetered connection
11. Try to play a _different_ episode and confirm you do not get a metered data warning.
12. From the settings, toggle the metered data warning off
13. Try to play a different episode
14. Confirm that you do not get a metered data warning even if the phone is using metered data

## Screenshots or Screencast 

| Logged in, setting off | Logged out, setting on |
| --- | --- |
| <img width="384" alt="Screenshot 2023-04-01 at 11 14 49 AM" src="https://user-images.githubusercontent.com/4656348/229297757-9fb79a7a-88ec-4ece-a6b8-96595d8de352.png"> | <img width="387" alt="Screenshot 2023-04-01 at 11 12 52 AM" src="https://user-images.githubusercontent.com/4656348/229297760-7503fc46-3970-45e0-9793-cfd357661c48.png"> |


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
