### PR TITLE
Fix for keyboard popup on episode preview close. Check if searchterm …

### DIFF
--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -173,8 +173,10 @@ class SearchFragment : BaseFragment() {
         searchView.imeOptions = searchView.imeOptions or EditorInfo.IME_ACTION_SEARCH or EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_FLAG_NO_FULLSCREEN
         searchView.setIconifiedByDefault(false)
         // seems like a more reliable focus using a post
-        searchView.post {
-            searchView.showKeyboard()
+        if(viewModel.state.value.searchTerm.isEmpty()) {
+            searchView.post {
+                searchView.showKeyboard()
+            }
         }
         searchView.setOnCloseListener {
             UiUtil.hideKeyboard(searchView)

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -173,7 +173,7 @@ class SearchFragment : BaseFragment() {
         searchView.imeOptions = searchView.imeOptions or EditorInfo.IME_ACTION_SEARCH or EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_FLAG_NO_FULLSCREEN
         searchView.setIconifiedByDefault(false)
         // seems like a more reliable focus using a post
-        if(viewModel.state.value.searchTerm.isEmpty()) {
+        if (viewModel.state.value.searchTerm.isEmpty()) {
             searchView.post {
                 searchView.showKeyboard()
             }


### PR DESCRIPTION
…value is empty to determine hide/show keyboard.

## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Created fix for Issue #862.  Able to go back to search results without triggering keyboard to open.  Only files changed : SearchFragment.

Fixes # <!-- issue number, if applicable -->
Issue #862 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
