### PR TITLE
Fix automotive sentry meta data name

### DIFF
--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -83,7 +83,7 @@
             android:name="pocketcasts_automotive"
             android:value="true" />
         <meta-data
-            android:name="io.sentry.dsn"
+            android:name="au.com.shiftyjelly.pocketcasts.sentryDsn"
             android:value="${sentryDsn}" />
     </application>
 


### PR DESCRIPTION
## Description
This fixes automotive app sentry meta data name. 

> **Warning**
> Targets release/7.36

## Testing Instructions
I tested that the exceptions are caught in Sentry for automotive using this key ([example](https://a8c.sentry.io/share/issue/fab8a515de964f2289b3bd7e3b984062/)). 