### PR TITLE
Add expandable show notes to watch episode screen

### DIFF
--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerShowNotesManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerShowNotesManager.kt
@@ -17,6 +17,8 @@ import timber.log.Timber
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 @Singleton
 class ServerShowNotesManager @Inject constructor(@ShowNotesCache private val httpShowNotesCache: OkHttpClient) {
@@ -62,6 +64,26 @@ class ServerShowNotesManager @Inject constructor(@ShowNotesCache private val htt
             }
         )
     }
+
+    suspend fun loadShowNotes(episodeUuid: String): String? =
+        suspendCoroutine { cont ->
+            loadShowNotes(
+                episodeUuid,
+                object : CachedServerCallback<String> {
+                    override fun cachedDataFound(data: String) {
+                        cont.resume(data)
+                    }
+
+                    override fun networkDataFound(data: String) {
+                        cont.resume(data)
+                    }
+
+                    override fun notFound() {
+                        cont.resume(null)
+                    }
+                }
+            )
+        }
 
     private fun buildUrl(episodeUuid: String): String {
         return Settings.SERVER_CACHE_URL + "/mobile/episode/show_notes/" + episodeUuid

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/Flow.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/Flow.kt
@@ -1,0 +1,29 @@
+package au.com.shiftyjelly.pocketcasts.utils.extensions
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Because sometimes 5 just isn't enough.
+ * See https://stackoverflow.com/a/73130632/1910286
+ */
+inline fun <T1, T2, T3, T4, T5, T6, R> combine6(
+    flow: Flow<T1>,
+    flow2: Flow<T2>,
+    flow3: Flow<T3>,
+    flow4: Flow<T4>,
+    flow5: Flow<T5>,
+    flow6: Flow<T6>,
+    crossinline transform: suspend (T1, T2, T3, T4, T5, T6) -> R
+): Flow<R> {
+    return kotlinx.coroutines.flow.combine(flow, flow2, flow3, flow4, flow5, flow6) { args: Array<*> ->
+        @Suppress("UNCHECKED_CAST")
+        transform(
+            args[0] as T1,
+            args[1] as T2,
+            args[2] as T3,
+            args[3] as T4,
+            args[4] as T5,
+            args[5] as T6,
+        )
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ExpandableText.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ExpandableText.kt
@@ -1,0 +1,82 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.wear.compose.material.LocalTextStyle
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+
+@Composable
+fun ExpandableText(
+    modifier: Modifier = Modifier,
+    textModifier: Modifier = Modifier,
+    style: TextStyle = LocalTextStyle.current,
+    fontStyle: FontStyle? = null,
+    text: String,
+    collapsedMaxLine: Int = 3,
+    textAlign: TextAlign? = null,
+    onClick: (isExpanded: Boolean) -> Unit = {},
+) {
+
+    var isExpanded by remember { mutableStateOf(false) }
+    var hasOverflow by remember { mutableStateOf(false) }
+    var lastCharIndex by remember { mutableStateOf(0) }
+    val showCollapsedState by remember { derivedStateOf { hasOverflow && !isExpanded } }
+
+    Box(
+        modifier = Modifier
+            .height(IntrinsicSize.Min)
+            .clickable(enabled = hasOverflow) {
+                isExpanded = !isExpanded
+                onClick(isExpanded)
+            }
+            .then(modifier)
+    ) {
+        Text(
+            modifier = textModifier.fillMaxWidth(),
+            text = if (showCollapsedState) {
+                text.substring(startIndex = 0, endIndex = lastCharIndex)
+            } else {
+                text
+            },
+            maxLines = if (isExpanded) Int.MAX_VALUE else collapsedMaxLine,
+            fontStyle = fontStyle,
+            onTextLayout = { textLayoutResult ->
+                if (textLayoutResult.hasVisualOverflow && !isExpanded) {
+                    hasOverflow = true
+                    lastCharIndex = textLayoutResult.getLineEnd(collapsedMaxLine - 1)
+                }
+            },
+            style = style,
+            textAlign = textAlign
+        )
+
+        if (showCollapsedState) {
+            val gradientBrush = Brush.verticalGradient(
+                listOf(Color.Transparent, MaterialTheme.colors.background)
+            )
+            Box(
+                Modifier
+                    .background(gradientBrush)
+                    .fillMaxSize()
+            )
+        }
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
@@ -2,13 +2,19 @@ package au.com.shiftyjelly.pocketcasts.wear.ui.episode
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -17,17 +23,21 @@ import androidx.compose.ui.text.font.FontWeight.Companion.W700
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.text.parseAsHtml
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.material.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.DownloadButtonState
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.ExpandableText
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -148,6 +158,40 @@ fun EpisodeScreen(
                     .fillMaxWidth()
                     .padding(bottom = 12.dp)
             )
+        }
+
+        item {
+            if (state.showNotes != null) {
+                val coroutineScope = rememberCoroutineScope()
+                Column {
+                    ExpandableText(
+                        text = state.showNotes.parseAsHtml().toString(),
+                        style = MaterialTheme.typography.caption2,
+                        textAlign = TextAlign.Center,
+                        onClick = { isExpanded ->
+                            if (!isExpanded) {
+                                val thisItemIndex = 4
+                                val visibleIndices = columnState.state.layoutInfo.visibleItemsInfo.map { it.index }
+                                val isPreviousItemVisible = visibleIndices.any { it == thisItemIndex - 1 }
+
+                                // If the previous item is not visible, scroll to this item to ensure that the top of
+                                // the show notes is still visible after collapsing is complete. Otherwise, it is
+                                // possible for collapsing the show notes to cause all of the content on the screen
+                                // to change, leaving the user confused about what happened and where they have ended up.
+                                if (!isPreviousItemVisible) {
+                                    coroutineScope.launch {
+                                        columnState.state.animateScrollToItem(thisItemIndex)
+                                    }
+                                }
+                            }
+                        },
+                        modifier = Modifier
+                            .padding(horizontal = 5.dp)
+                            .fillMaxWidth()
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
+            }
         }
 
         val episodeIsMarkedPlayed = episode.playingStatus == EpisodePlayingStatus.COMPLETED

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -18,8 +18,10 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextPosition
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.servers.ServerShowNotesManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
+import au.com.shiftyjelly.pocketcasts.utils.extensions.combine6
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.StreamingConfirmationScreen
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -27,6 +29,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
@@ -44,6 +47,7 @@ class EpisodeViewModel @Inject constructor(
     private val episodeManager: EpisodeManager,
     private val playbackManager: PlaybackManager,
     private val podcastManager: PodcastManager,
+    private val showNotesManager: ServerShowNotesManager,
     theme: Theme,
 ) : ViewModel() {
 
@@ -57,6 +61,7 @@ class EpisodeViewModel @Inject constructor(
             val inUpNext: Boolean,
             val tintColor: Color,
             val downloadProgress: Float? = null,
+            val showNotes: String? = null,
         ) : State()
 
         object Empty : State()
@@ -98,7 +103,6 @@ class EpisodeViewModel @Inject constructor(
         val isPlayingEpisodeFlow = playbackManager.playbackStateRelay.asFlow()
             .filter { it.episodeUuid == episodeUuid }
             .map { it.isPlaying }
-            .onStart { emit(false) }
 
         val inUpNextFlow = playbackManager.upNextQueue.changesObservable.asFlow()
 
@@ -113,17 +117,21 @@ class EpisodeViewModel @Inject constructor(
                 episode.uuid == downloadProgressUpdate.episodeUuid
             }.map { (_, downloadProgressUpdate) ->
                 downloadProgressUpdate.downloadProgress
-            }.onStart<Float?> {
-                emit(null)
             }
 
-            combine(
+            val showNotesFlow = flow {
+                emit(showNotesManager.loadShowNotes(episodeUuid))
+            }
+
+            combine6(
                 episodeFlow,
                 podcastFlow,
-                isPlayingEpisodeFlow,
+                // Emitting a value "onStart" for the flows that don't need to block the UI
+                isPlayingEpisodeFlow.onStart { emit(false) },
                 inUpNextFlow,
-                downloadProgressFlow
-            ) { episode, podcast, isPlayingEpisode, upNext, downloadProgress ->
+                downloadProgressFlow.onStart<Float?> { emit(null) },
+                showNotesFlow.onStart { emit(null) }
+            ) { episode, podcast, isPlayingEpisode, upNext, downloadProgress, showNotes ->
                 if (podcast != null) {
                     val podcastTint = podcast.getTintColor(theme.isDarkTheme)
 
@@ -142,6 +150,7 @@ class EpisodeViewModel @Inject constructor(
                         downloadProgress = downloadProgress,
                         inUpNext = inUpNext,
                         tintColor = tintColor,
+                        showNotes = showNotes,
                     )
                 } else {
                     State.Empty


### PR DESCRIPTION
## Description
Adds an expandable section for the show notes to the episode details screen on the watch.

This is converting the HTML show notes into plain text. This seemed like the best way to deal with this for now since web views are not supported on Wear OS. This does mean that links and other HTML elements are basically not rendered, but I think this implementation is better than nothing and it's something we can address later if it proves to be a problem (I'm skeptical that many will be doing much reading of long show notes on their watch, but maybe I'm wrong).

## Testing Instructions
1. Go to the episode details screen
2. Scroll down and observe that the show notes displays at most three lines and (assuming there is more than 3 lines), there is a gradient fading out the text toward the bottom
3. Tap on the show notes
4. Observe the notes expand
5. Tap on the show notes again
6. Observe that the notes collapse. If you had scrolled down quite a ways in the show notes, when collapsing them the list should scroll to ensure that the collapsed scroll notes are still visible (as opposed to the scroll position remaining at the bottom of the list). I have noticed that sometimes there is a bit of a jump with this on my emulator, but it doesn't seem to occur on my physical device.

## Screenshots or Screencast 

[device-2023-04-06-174133.webm](https://user-images.githubusercontent.com/4656348/230499245-3ec9e3f9-f241-4e46-989a-5d7cb6ea9aef.webm)

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews