### PR TITLE
Add header to add to up next screen on watch

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
 
     <string name="account">Account</string>
     <string name="add_to_up_next">Add to Up Next</string>
+    <string name="add_to_up_next_question">Add to up next?</string>
     <string name="archive">Archive</string>
     <string name="unarchive">Unarchive</string>
     <string name="archive_episode">Archive episode</string>

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ChipScreenHeaders.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ChipScreenHeaders.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -13,10 +14,15 @@ import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
 
 @Composable
-fun ChipScreenHeader(@StringRes text: Int, modifier: Modifier = Modifier) {
+fun ChipScreenHeader(
+    @StringRes text: Int,
+    textColor: Color? = null,
+    modifier: Modifier = Modifier,
+) {
     Header(
-        text,
-        modifier.padding(
+        text = text,
+        textColor = textColor,
+        modifier = modifier.padding(
             start = horizontalPadding,
             end = horizontalPadding,
             bottom = verticalPadding,
@@ -26,14 +32,21 @@ fun ChipScreenHeader(@StringRes text: Int, modifier: Modifier = Modifier) {
 
 @Composable
 fun ChipSectionHeader(@StringRes text: Int, modifier: Modifier = Modifier) {
-    Header(text, modifier.padding(vertical = verticalPadding, horizontal = horizontalPadding))
+    Header(
+        text = text,
+        modifier = modifier.padding(vertical = verticalPadding, horizontal = horizontalPadding)
+    )
 }
 
 @Composable
-private fun Header(@StringRes text: Int, modifier: Modifier = Modifier) {
+private fun Header(
+    @StringRes text: Int,
+    textColor: Color? = null,
+    modifier: Modifier = Modifier,
+) {
     Text(
         text = stringResource(text),
-        color = WearColors.FFBDC1C6,
+        color = textColor ?: WearColors.FFBDC1C6,
         textAlign = TextAlign.Center,
         style = MaterialTheme.typography.button,
         modifier = modifier.fillMaxWidth()

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreenFlow.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreenFlow.kt
@@ -76,12 +76,13 @@ object EpisodeScreenFlow {
                 )
             }
 
-            composable(upNextOptionsScreen) {
+            scrollable(upNextOptionsScreen) {
                 it.viewModel.timeTextMode = NavScaffoldViewModel.TimeTextMode.Off
                 val episodeScreenBackStackEntry = remember(it.backStackEntry) {
                     navController.getBackStackEntry(episodeScreen)
                 }
                 UpNextOptionsScreen(
+                    columnState = it.columnState,
                     episodeScreenViewModelStoreOwner = episodeScreenBackStackEntry, // Reuse view model from EpisodeScreen
                     onComplete = { navController.popBackStack() },
                 )

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/UpNextOptionsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/UpNextOptionsScreen.kt
@@ -1,59 +1,63 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui.episode
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModelStoreOwner
+import androidx.wear.compose.foundation.lazy.items
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.ChipScreenHeader
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun UpNextOptionsScreen(
+    columnState: ScalingLazyColumnState,
     episodeScreenViewModelStoreOwner: ViewModelStoreOwner,
-    onComplete: () -> Unit
+    onComplete: () -> Unit,
 ) {
     val viewModel = hiltViewModel<EpisodeViewModel>(episodeScreenViewModelStoreOwner)
     Content(
+        columnState = columnState,
         upNextOptions = viewModel.upNextOptions,
         onComplete = onComplete
     )
 }
 
 @Composable
-private fun Content(upNextOptions: List<EpisodeViewModel.UpNextOption>, onComplete: () -> Unit) {
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier.fillMaxSize()
+private fun Content(
+    columnState: ScalingLazyColumnState,
+    upNextOptions: List<EpisodeViewModel.UpNextOption>,
+    onComplete: () -> Unit,
+) {
+    ScalingLazyColumn(
+        columnState = columnState,
+        modifier = Modifier.padding(horizontal = 16.dp)
     ) {
-        Column(
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-            modifier = Modifier
-                .width(IntrinsicSize.Max)
-                .padding(horizontal = 16.dp)
-        ) {
-            upNextOptions.forEach { upNextOption ->
-                WatchListChip(
-                    titleRes = upNextOption.titleRes,
-                    iconRes = upNextOption.iconRes,
-                    onClick = {
-                        upNextOption.onClick()
-                        onComplete()
-                    },
-                )
-            }
+        item {
+            ChipScreenHeader(
+                text = LR.string.add_to_up_next_question,
+                textColor = Color.White,
+            )
+        }
+
+        items(upNextOptions) { upNextOption ->
+            WatchListChip(
+                titleRes = upNextOption.titleRes,
+                iconRes = upNextOption.iconRes,
+                onClick = {
+                    upNextOption.onClick()
+                    onComplete()
+                },
+            )
         }
     }
 }
@@ -63,7 +67,7 @@ private fun Content(upNextOptions: List<EpisodeViewModel.UpNextOption>, onComple
 private fun Preview() {
     WearAppTheme(Theme.ThemeType.DARK) {
         Content(
-            onComplete = {},
+            columnState = ScalingLazyColumnState(),
             upNextOptions = listOf(
                 EpisodeViewModel.UpNextOption(
                     iconRes = IR.drawable.ic_upnext_playnext,
@@ -75,7 +79,8 @@ private fun Preview() {
                     titleRes = LR.string.play_last,
                     onClick = {},
                 ),
-            )
+            ),
+            onComplete = {},
         )
     }
 }


### PR DESCRIPTION
## Description
Adds a header with "Add to up next?" to the add to up next screen on the watch to match the Figma designs. In addition, I've made that screen scrollable since there is now more content.

The icons on this screen are different from Figma. I think these are the appropriate icons for "adding" to the up next queue (as opposed to moving something within the up next queue), so I've left them as-is. I've left a question for Adam though confirming whether that is ok, and if they need to be changed I'll do that in a separate PR.

## Testing Instructions
1. Ensure that you have at least 1 episode in your Up Next queue
2. Go to the episode details screen for an episode that is not in your Up Next queue
3. Tap the add to up next button
4. Observe that you get the below screen with the "Add to up next?" header. There are no functionality changes, so no specific testing is needed apart from checking that the screen looks fine.

## Screenshots or Screencast 

![image](https://user-images.githubusercontent.com/4656348/230521253-4df2a7b8-d951-45a4-b11f-2bf3c339a1ba.png)


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews