### PR TITLE
Add refresh button to watch

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/SettingsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/SettingsScreen.kt
@@ -1,11 +1,19 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui
 
 import android.content.res.Configuration
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -14,6 +22,7 @@ import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.ToggleChip
 import androidx.wear.compose.material.ToggleChipDefaults
+import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -46,6 +55,7 @@ fun SettingsScreen(
         onWarnOnMeteredChanged = { viewModel.setWarnOnMeteredNetwork(it) },
         signInClick = signInClick,
         onSignOutClicked = viewModel::signOut,
+        onRefreshClicked = viewModel::refresh,
     )
 }
 
@@ -56,6 +66,7 @@ private fun Content(
     onWarnOnMeteredChanged: (Boolean) -> Unit,
     signInClick: () -> Unit,
     onSignOutClicked: () -> Unit,
+    onRefreshClicked: () -> Unit,
 ) {
     ScalingLazyColumn(columnState = scrollState) {
 
@@ -73,6 +84,27 @@ private fun Content(
 
         item {
             ChipSectionHeader(LR.string.account)
+        }
+
+        item {
+            val title = stringResource(LR.string.profile_refresh_now)
+            val rotation = RotationAnimation(
+                state = state.refreshState,
+                durationMillis = 800,
+            )
+            WatchListChip(
+                title = title,
+                icon = {
+                    Icon(
+                        painter = painterResource(IR.drawable.ic_retry),
+                        contentDescription = null,
+                        modifier = Modifier.graphicsLayer {
+                            rotationZ = rotation.value
+                        }
+                    )
+                },
+                onClick = onRefreshClicked,
+            )
         }
 
         item {
@@ -96,6 +128,41 @@ private fun Content(
             }
         }
     }
+}
+
+@Composable
+private fun RotationAnimation(state: RefreshState?, durationMillis: Int): Animatable<Float, AnimationVector1D> {
+    val anim = remember { Animatable(0f) }
+    LaunchedEffect(state, anim.isRunning) {
+        if (anim.value == 360f) {
+            anim.snapTo(0f)
+        }
+
+        if (anim.value == 0f && state == RefreshState.Refreshing) {
+
+            // We're at 0 and we're refreshing, so start animating
+
+            anim.animateTo(
+                targetValue = 360f,
+                animationSpec = tween(durationMillis, easing = LinearEasing)
+            )
+        } else if (anim.value != 0f && state != RefreshState.Refreshing) {
+
+            // No longer refreshing but we're not at 0 so continue animating until
+            // we're back at 0 to keep things smooth (i.e., if a second refresh is
+            // later initiated, we won't have a "jump" back to 0)
+
+            val degreesLeft = 360 - anim.value
+            val percentLeft = degreesLeft / 360f
+            val timeLeft = (percentLeft * durationMillis).toInt()
+
+            anim.animateTo(
+                targetValue = 360f,
+                animationSpec = tween(timeLeft, easing = LinearEasing)
+            )
+        }
+    }
+    return anim
 }
 
 @Composable
@@ -145,11 +212,12 @@ private fun SettingsScreenPreview_unchecked() {
                     subscriptionStatus = SubscriptionStatus.Free(),
                 ),
                 showDataWarning = false,
+                refreshState = null,
             ),
             signInClick = {},
             onWarnOnMeteredChanged = {},
-            onSignOutClicked = {}
-
+            onSignOutClicked = {},
+            onRefreshClicked = {},
         )
     }
 }
@@ -170,11 +238,12 @@ private fun SettingsScreenPreview_checked() {
                     subscriptionStatus = SubscriptionStatus.Free(),
                 ),
                 showDataWarning = true,
+                refreshState = null,
             ),
             signInClick = {},
             onWarnOnMeteredChanged = {},
-            onSignOutClicked = {}
-
+            onSignOutClicked = {},
+            onRefreshClicked = {},
         )
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/SettingsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/SettingsViewModel.kt
@@ -1,37 +1,40 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.rx2.asFlow
 import javax.inject.Inject
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val playbackManager: PlaybackManager,
+    private val podcastManager: PodcastManager,
     private val userManager: UserManager,
     private val settings: Settings,
 ) : ViewModel() {
 
     data class State(
+        val refreshState: RefreshState?,
         val signInState: SignInState,
         val showDataWarning: Boolean,
     )
 
     private val _state = MutableStateFlow(
         State(
+            refreshState = null,
             signInState = userManager.getSignInState().blockingFirst(),
             showDataWarning = settings.warnOnMeteredNetwork(),
         )
@@ -46,6 +49,14 @@ class SettingsViewModel @Inject constructor(
                     _state.update { it.copy(signInState = signInState) }
                 }
         }
+
+        viewModelScope.launch {
+            settings.refreshStateObservable
+                .asFlow()
+                .collectLatest { refreshState ->
+                    _state.update { it.copy(refreshState = refreshState) }
+                }
+        }
     }
 
     fun setWarnOnMeteredNetwork(warnOnMeteredNetwork: Boolean) {
@@ -58,5 +69,9 @@ class SettingsViewModel @Inject constructor(
             playbackManager = playbackManager,
             wasInitiatedByUser = true
         )
+    }
+
+    fun refresh() {
+        podcastManager.refreshPodcasts("watch")
     }
 }


### PR DESCRIPTION
## Description
This adds a refresh button to the watch's settings screen. I'm not sure if this is where it will end up, but I wanted to add the functionality since it will help with development.

> **Note**
> This PR builds on https://github.com/Automattic/pocket-casts-android/pull/873, so you may want to review that PR before this one.

## Testing Instructions
1. Log into an account on the watch.
2. Pick one of the podcasts from the Podcasts screen and remember it
3. Log into the same account on another device
4. Unsubscribe from the podcast you picked on step 2
5. Sync the changes to the server from the other device
6. On the watch, tap the "Refresh now" button on the settings screen
7. Observe that the icon animates while the refresh is in progress
8. Once the refresh is complete, observe that the unsubscribed podcast is no longer listed on the watch's podcasts screen.

## Screenshots or Screencast 

https://user-images.githubusercontent.com/4656348/231039716-d629f065-78ae-403c-9997-bca287bb5e89.mov

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews

