### PR TITLE
Update compose version

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -80,8 +80,8 @@ project.ext {
     // Library versions
     versionAccessibilityTestFramework = '4.0.0'
     versionBillingClient = '5.0.0'
-    versionCompose = '1.2.1' // When updating this, also check if versionComposeAccompanist should be updated as well: https://github.com/google/accompanist#compose-versions
-    versionComposeAccompanist = '0.25.1'
+    versionCompose = '1.4.1' // When updating this, also check if versionComposeAccompanist should be updated as well: https://github.com/google/accompanist#compose-versions
+    versionComposeAccompanist = '0.30.1'
     versionComposeCompiler = '1.3.0'
     versionComposeWear = '1.2.0-alpha05'
     versionDagger = '2.41'


### PR DESCRIPTION
## Description

This updates compose version from `1.2.1 `to the latest stable version `1.4.1`.

This is mainly done to access `Compose Pager` added in [Compose Foundation Version 1.4.0-alpha03](https://developer.android.com/jetpack/androidx/releases/compose-foundation#1.4.0-alpha03).


## Testing Instructions
- Randomly smoke test new screens built using Compose
- Go through release notes to see if anything is a breaking change
[Version 1.3](https://developer.android.com/jetpack/androidx/releases/compose-animation#version_13_2)
[Version 1.4](https://developer.android.com/jetpack/androidx/releases/compose-animation#version_14_2)