### PR TITLE
Rename upgrade screens

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -10,7 +10,7 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.import.OnboardingImport
 import au.com.shiftyjelly.pocketcasts.account.onboarding.import.OnboardingImportFlow.importFlowGraph
 import au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations.OnboardingRecommendationsFlow
 import au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations.OnboardingRecommendationsFlow.onboardingRecommendationsFlowGraph
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusUpgradeFlow
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeFlow
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
@@ -173,7 +173,7 @@ fun OnboardingFlowComposable(
                     OnboardingUpgradeSource.RECOMMENDATIONS -> true
                 }
 
-                OnboardingPlusUpgradeFlow(
+                OnboardingUpgradeFlow(
                     flow = flow,
                     source = upgradeSource,
                     isLoggedIn = signInState.isSignedIn,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingWelcomePage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingWelcomePage.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.R
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusHelper
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingWelcomeState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingWelcomeViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -317,7 +317,7 @@ private fun NewsletterSwitch(
 
 @Composable
 private fun PlusPersonCheckmark() {
-    PersonCheckmark(OnboardingPlusHelper.plusGradientBrush)
+    PersonCheckmark(OnboardingUpgradeHelper.plusGradientBrush)
 }
 
 @Composable

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
@@ -35,11 +35,11 @@ import androidx.compose.ui.unit.dp
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.hilt.navigation.compose.hiltViewModel
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusHelper.PlusOutlinedRowButton
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusHelper.PlusRowButton
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusHelper.UnselectedPlusOutlinedRowButton
-import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusBottomSheetState
-import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusBottomSheetViewModel
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.PlusOutlinedRowButton
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.PlusRowButton
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.UnselectedPlusOutlinedRowButton
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetState
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetViewModel
 import au.com.shiftyjelly.pocketcasts.compose.bottomsheet.Pill
 import au.com.shiftyjelly.pocketcasts.compose.components.Clickable
 import au.com.shiftyjelly.pocketcasts.compose.components.ClickableTextHelper
@@ -52,7 +52,7 @@ import java.util.Locale
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
-fun OnboardingPlusBottomSheet(
+fun OnboardingUpgradeBottomSheet(
     onClickSubscribe: () -> Unit,
 ) {
 
@@ -60,9 +60,9 @@ fun OnboardingPlusBottomSheet(
     // This is keeps it closed while on this screen.
     KeepKeyboardClosed()
 
-    val viewModel = hiltViewModel<OnboardingPlusBottomSheetViewModel>()
+    val viewModel = hiltViewModel<OnboardingUpgradeBottomSheetViewModel>()
     val state = viewModel.state.collectAsState().value
-    val subscriptions = (state as? OnboardingPlusBottomSheetState.Loaded)?.subscriptions
+    val subscriptions = (state as? OnboardingUpgradeBottomSheetState.Loaded)?.subscriptions
         ?: emptyList()
 
     val resources = LocalContext.current.resources
@@ -85,7 +85,7 @@ fun OnboardingPlusBottomSheet(
             color = Color.White
         )
 
-        if (state is OnboardingPlusBottomSheetState.Loaded) {
+        if (state is OnboardingUpgradeBottomSheetState.Loaded) {
             Spacer(Modifier.height(16.dp))
 
             // Using LazyColumn instead of Column to avoid issue where unselected button that was not

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -49,10 +49,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusHelper.IconRow
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusHelper.PlusOutlinedRowButton
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusHelper.PlusRowButton
-import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusFeaturesViewModel
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.IconRow
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.PlusOutlinedRowButton
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.PlusRowButton
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesViewModel
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
@@ -68,7 +68,7 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
-internal fun OnboardingPlusFeaturesPage(
+internal fun OnboardingUpgradeFeaturesPage(
     flow: OnboardingFlow,
     source: OnboardingUpgradeSource,
     onUpgradePressed: () -> Unit,
@@ -77,7 +77,7 @@ internal fun OnboardingPlusFeaturesPage(
     canUpgrade: Boolean
 ) {
 
-    val viewModel = hiltViewModel<OnboardingPlusFeaturesViewModel>()
+    val viewModel = hiltViewModel<OnboardingUpgradeFeaturesViewModel>()
     val state by viewModel.state.collectAsState()
 
     @Suppress("NAME_SHADOWING")
@@ -109,10 +109,10 @@ internal fun OnboardingPlusFeaturesPage(
     BoxWithConstraints(
         Modifier
             .fillMaxHeight()
-            .background(OnboardingPlusHelper.backgroundColor)
+            .background(OnboardingUpgradeHelper.backgroundColor)
     ) {
 
-        OnboardingPlusHelper.PlusBackground(Modifier.verticalScroll(scrollState)) {
+        OnboardingUpgradeHelper.PlusBackground(Modifier.verticalScroll(scrollState)) {
             Column(
                 Modifier
                     .windowInsetsPadding(WindowInsets.statusBars)
@@ -189,7 +189,7 @@ private fun setStatusBarBackground(scrollState: ScrollState) {
     )
 
     val statusBarBackground = if (scrimAlpha > 0) {
-        OnboardingPlusHelper.backgroundColor.copy(alpha = scrimAlpha)
+        OnboardingUpgradeHelper.backgroundColor.copy(alpha = scrimAlpha)
     } else {
         Color.Transparent
     }
@@ -358,8 +358,8 @@ private tailrec suspend fun autoScroll(
 
 @Preview
 @Composable
-private fun OnboardingPlusFeaturesPreview() {
-    OnboardingPlusFeaturesPage(
+private fun OnboardingUpgradeFeaturesPreview() {
+    OnboardingUpgradeFeaturesPage(
         flow = OnboardingFlow.InitialOnboarding,
         source = OnboardingUpgradeSource.RECOMMENDATIONS,
         onBackPressed = {},

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -17,11 +17,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusHelper.PlusOutlinedRowButton
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusHelper.UnselectedPlusOutlinedRowButton
-import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusBottomSheetState
-import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusBottomSheetViewModel
-import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusFeaturesViewModel
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.PlusOutlinedRowButton
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.UnselectedPlusOutlinedRowButton
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetState
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetViewModel
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesViewModel
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
@@ -30,7 +30,7 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun OnboardingPlusUpgradeFlow(
+fun OnboardingUpgradeFlow(
     flow: OnboardingFlow,
     source: OnboardingUpgradeSource,
     isLoggedIn: Boolean,
@@ -39,10 +39,10 @@ fun OnboardingPlusUpgradeFlow(
     onProceed: () -> Unit,
 ) {
 
-    val bottomSheetViewModel = hiltViewModel<OnboardingPlusBottomSheetViewModel>()
-    val mainSheetViewModel = hiltViewModel<OnboardingPlusFeaturesViewModel>()
+    val bottomSheetViewModel = hiltViewModel<OnboardingUpgradeBottomSheetViewModel>()
+    val mainSheetViewModel = hiltViewModel<OnboardingUpgradeFeaturesViewModel>()
     val state = bottomSheetViewModel.state.collectAsState().value
-    val hasSubscriptions = state is OnboardingPlusBottomSheetState.Loaded && state.subscriptions.isNotEmpty()
+    val hasSubscriptions = state is OnboardingUpgradeBottomSheetState.Loaded && state.subscriptions.isNotEmpty()
 
     val coroutineScope = rememberCoroutineScope()
 
@@ -97,7 +97,7 @@ fun OnboardingPlusUpgradeFlow(
         scrimColor = Color.Black.copy(alpha = 0.5f),
         sheetShape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
         content = {
-            OnboardingPlusFeaturesPage(
+            OnboardingUpgradeFeaturesPage(
                 flow = flow,
                 source = source,
                 onUpgradePressed = {
@@ -113,7 +113,7 @@ fun OnboardingPlusUpgradeFlow(
             )
         },
         sheetContent = {
-            OnboardingPlusBottomSheet(
+            OnboardingUpgradeBottomSheet(
                 onClickSubscribe = {
                     if (activity != null) {
                         bottomSheetViewModel.onClickSubscribe(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
@@ -44,7 +44,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.extensions.brush
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 
-object OnboardingPlusHelper {
+object OnboardingUpgradeHelper {
     val plusGradientBrush = Brush.horizontalGradient(
         0f to Color(0xFFFED745),
         1f to Color(0xFFFEB525),
@@ -300,7 +300,7 @@ object OnboardingPlusHelper {
     fun IconRow(modifier: Modifier = Modifier) {
         Row(modifier) {
             Icon(
-                painter = painterResource(au.com.shiftyjelly.pocketcasts.account.R.drawable.pocket_casts_white),
+                painter = painterResource(R.drawable.pocket_casts_white),
                 contentDescription = null,
                 tint = Color.White,
             )
@@ -308,7 +308,7 @@ object OnboardingPlusHelper {
             Spacer(Modifier.width(8.dp))
 
             Icon(
-                painter = painterResource(au.com.shiftyjelly.pocketcasts.account.R.drawable.plus_bw),
+                painter = painterResource(R.drawable.plus_bw),
                 contentDescription = null,
                 tint = Color.White,
             )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -21,20 +21,20 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingPlusHelper.IconRow
-import au.com.shiftyjelly.pocketcasts.account.viewmodel.ProfilePlusUpgradeBannerViewModel
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.IconRow
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.ProfileUpgradeBannerViewModel
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH60
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
-fun ProfilePlusUpgradeBanner(
+fun ProfileUpgradeBanner(
     onClick: () -> Unit
 ) {
-    val state by hiltViewModel<ProfilePlusUpgradeBannerViewModel>()
+    val state by hiltViewModel<ProfileUpgradeBannerViewModel>()
         .state
         .collectAsState()
 
-    OnboardingPlusHelper.PlusBackground {
+    OnboardingUpgradeHelper.PlusBackground {
         Column(Modifier.padding(horizontal = 16.dp)) {
             Spacer(Modifier.height(24.dp))
             IconRow()
@@ -47,7 +47,7 @@ fun ProfilePlusUpgradeBanner(
 
             state.numPeriodFree?.let { numPeriodFree ->
                 Spacer(Modifier.height(16.dp))
-                OnboardingPlusHelper.TopText(topText = numPeriodFree)
+                OnboardingUpgradeHelper.TopText(topText = numPeriodFree)
             }
 
             Spacer(Modifier.height(20.dp))
@@ -67,7 +67,7 @@ fun ProfilePlusUpgradeBanner(
             }
 
             Spacer(Modifier.height(30.dp))
-            OnboardingPlusHelper.PlusRowButton(
+            OnboardingUpgradeHelper.PlusRowButton(
                 text = stringResource(LR.string.profile_upgrade_to_plus),
                 onClick = onClick,
             )
@@ -101,8 +101,8 @@ private fun FeatureItemComposable(
 
 @Preview
 @Composable
-private fun ProfilePlusUpgradeBannerPreview() {
-    ProfilePlusUpgradeBanner(
+private fun ProfileUpgradeBannerPreview() {
+    ProfileUpgradeBanner(
         onClick = { }
     )
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
@@ -3,9 +3,9 @@ package au.com.shiftyjelly.pocketcasts.account.viewmodel
 import android.app.Activity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusBottomSheetState.Loaded
-import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusBottomSheetState.Loading
-import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingPlusBottomSheetState.NoSubscriptions
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetState.Loaded
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetState.Loading
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetState.NoSubscriptions
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
@@ -29,13 +29,13 @@ import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
-class OnboardingPlusBottomSheetViewModel @Inject constructor(
+class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
     private val subscriptionManager: SubscriptionManager,
     private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow<OnboardingPlusBottomSheetState>(Loading)
-    val state: StateFlow<OnboardingPlusBottomSheetState> = _state
+    private val _state = MutableStateFlow<OnboardingUpgradeBottomSheetState>(Loading)
+    val state: StateFlow<OnboardingUpgradeBottomSheetState> = _state
         .map {
             // If selected subscription has trialPricingPhase, update mostRecentlySelectedTrialPhase
             (it as? Loaded)?.selectedSubscription?.trialPricingPhase?.let { trialPhase ->
@@ -131,7 +131,7 @@ class OnboardingPlusBottomSheetViewModel @Inject constructor(
         }
     }
 
-    private fun stateFromList(subscriptions: List<Subscription>): OnboardingPlusBottomSheetState {
+    private fun stateFromList(subscriptions: List<Subscription>): OnboardingUpgradeBottomSheetState {
         val defaultSelected = subscriptionManager.getDefaultSubscription(subscriptions)
         return if (defaultSelected == null) {
             NoSubscriptions
@@ -164,9 +164,9 @@ class OnboardingPlusBottomSheetViewModel @Inject constructor(
     }
 }
 
-sealed class OnboardingPlusBottomSheetState {
-    object Loading : OnboardingPlusBottomSheetState()
-    object NoSubscriptions : OnboardingPlusBottomSheetState()
+sealed class OnboardingUpgradeBottomSheetState {
+    object Loading : OnboardingUpgradeBottomSheetState()
+    object NoSubscriptions : OnboardingUpgradeBottomSheetState()
     data class Loaded constructor(
         val subscriptions: List<Subscription>, // This list should never be empty
         val selectedSubscription: Subscription,
@@ -174,7 +174,7 @@ sealed class OnboardingPlusBottomSheetState {
         // it animates out of view after a subscription without a trial phase is selected
         val mostRecentlySelectedTrialPhase: TrialSubscriptionPricingPhase? = null,
         val purchaseFailed: Boolean = false
-    ) : OnboardingPlusBottomSheetState() {
+    ) : OnboardingUpgradeBottomSheetState() {
         val showTrialInfo = selectedSubscription.trialPricingPhase != null
 
         init {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -14,24 +14,24 @@ import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
 @HiltViewModel
-class OnboardingPlusFeaturesViewModel @Inject constructor(
+class OnboardingUpgradeFeaturesViewModel @Inject constructor(
     app: Application,
     private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : AndroidViewModel(app) {
 
-    private val _state: MutableStateFlow<OnboardingPlusFeaturesState>
-    val state: StateFlow<OnboardingPlusFeaturesState>
+    private val _state: MutableStateFlow<OnboardingUpgradeFeaturesState>
+    val state: StateFlow<OnboardingUpgradeFeaturesState>
 
     init {
         val accessibiltyManager = getApplication<Application>().getSystemService(Context.ACCESSIBILITY_SERVICE)
             as? AccessibilityManager
 
         val isTouchExplorationEnabled = accessibiltyManager?.isTouchExplorationEnabled ?: false
-        _state = MutableStateFlow(OnboardingPlusFeaturesState(isTouchExplorationEnabled))
+        _state = MutableStateFlow(OnboardingUpgradeFeaturesState(isTouchExplorationEnabled))
         state = _state
 
         accessibiltyManager?.addTouchExplorationStateChangeListener { enabled ->
-            _state.value = OnboardingPlusFeaturesState(enabled)
+            _state.value = OnboardingUpgradeFeaturesState(enabled)
         }
     }
 
@@ -57,6 +57,6 @@ class OnboardingPlusFeaturesViewModel @Inject constructor(
     }
 }
 
-data class OnboardingPlusFeaturesState(private val isTouchExplorationEnabled: Boolean) {
+data class OnboardingUpgradeFeaturesState(private val isTouchExplorationEnabled: Boolean) {
     val scrollAutomatically = !isTouchExplorationEnabled
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
@@ -15,7 +15,7 @@ import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
-class ProfilePlusUpgradeBannerViewModel @Inject constructor(
+class ProfileUpgradeBannerViewModel @Inject constructor(
     subscriptionManager: SubscriptionManager,
     app: Application,
 ) : AndroidViewModel(app) {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -15,7 +15,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.account.ChangeEmailFragment
 import au.com.shiftyjelly.pocketcasts.account.ChangePwdFragment
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.ProfilePlusUpgradeBanner
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.ProfileUpgradeBanner
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
@@ -119,7 +119,7 @@ class AccountDetailsFragment : BaseFragment() {
                 setContent {
                     AppTheme(theme.activeTheme) {
                         if (subscription != null && (signInState.isSignedInAsFree || giftExpiring)) {
-                            ProfilePlusUpgradeBanner(
+                            ProfileUpgradeBanner(
                                 onClick = {
                                     val source = OnboardingUpgradeSource.PROFILE
                                     val onboardingFlow = OnboardingFlow.PlusAccountUpgrade(source)


### PR DESCRIPTION
## Description
This renames upgrade screens to remove an explicit plan name like "Plus" in their names. Since the change impacts 10+ classes, I extracted these simple changes to a separate branch. 

## Testing Instructions
Since this does not include any user-facing changes, just make sure that CI is green.

## Merge Instructions
- Since it is built upon `update/compose-version` branch, make sure it is merged before merging this branch to `main`.
