### PR TITLE
Remove SSO feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 7.37
 -----
-
-
-7.36
------
-
+* New Features:
+    *   Added capability to sign into Pocket Casts using Google account
+        ([#878](https://github.com/Automattic/pocket-casts-android/pull/878))
 
 7.35
 -----

--- a/base.gradle
+++ b/base.gradle
@@ -30,7 +30,6 @@ android {
 
         // Feature Flags
         buildConfigField "boolean", "END_OF_YEAR_ENABLED", "false"
-        buildConfigField "boolean", "SINGLE_SIGN_ON_ENABLED", "false"
 
         testInstrumentationRunner project.testInstrumentationRunner
         testApplicationId "au.com.shiftyjelly.pocketcasts.test" + project.name.replace("-", "_")

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLoginOrSignUpViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLoginOrSignUpViewModel.kt
@@ -6,7 +6,6 @@ import androidx.activity.result.ActivityResult
 import androidx.activity.result.IntentSenderRequest
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import au.com.shiftyjelly.pocketcasts.account.BuildConfig
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -44,8 +43,7 @@ class OnboardingLoginOrSignUpViewModel @Inject constructor(
 ) : AndroidViewModel(context as Application) {
 
     val showContinueWithGoogleButton =
-        BuildConfig.SINGLE_SIGN_ON_ENABLED &&
-            Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID.isNotEmpty() &&
+        Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID.isNotEmpty() &&
             GoogleApiAvailability.getInstance().isGooglePlayServicesAvailableSuccess(context)
 
     val randomPodcasts = mutableListOf<Podcast>()


### PR DESCRIPTION
## Description
This follows up on https://github.com/Automattic/pocket-casts-android/pull/712 and removes the SSO feature flag. I figure we just should go ahead and remove it now because we probably won't need it again and it will be easy to add back if for some reason we do need it again.

I also added a changelog entry for SSO.

## Testing Instructions
Go to the app's login screen and verify that the "Continue with Google" option is available

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews