### PR TITLE
Update/horologist version

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -83,7 +83,7 @@ project.ext {
     versionCompose = '1.4.1' // When updating this, also check if versionComposeAccompanist should be updated as well: https://github.com/google/accompanist#compose-versions
     versionComposeAccompanist = '0.30.1'
     versionComposeCompiler = '1.3.0'
-    versionComposeWear = '1.2.0-alpha05'
+    versionComposeWear = '1.2.0-alpha07'
     versionDagger = '2.41'
     versionEspresso = '3.4.0'
     versionExoplayer = '2.18.2'
@@ -92,7 +92,7 @@ project.ext {
 
     // When updating this, check to see if versionComposeWear will be updated as well (and update that variable if appropriate)
     // https://github.com/google/horologist/blob/main/gradle/libs.versions.toml
-    versionHorologist = '0.3.9'
+    versionHorologist = '0.4.2'
 
     versionKotlinCoroutines = '1.6.4'
     versionLifecycle = '2.6.0'

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -59,13 +59,8 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
         // Allow for widescale experimental APIs in Alpha libraries we build upon
-        freeCompilerArgs += "-opt-in=com.google.android.horologist.media.ExperimentalHorologistMediaApi"
+        freeCompilerArgs += "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi"
-        freeCompilerArgs += "-opt-in=com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi"
-        freeCompilerArgs += "-opt-in=com.google.android.horologist.composables.ExperimentalHorologistComposablesApi"
-        freeCompilerArgs += "-opt-in=com.google.android.horologist.media3.ExperimentalHorologistMedia3BackendApi"
-        freeCompilerArgs += "-opt-in=com.google.android.horologist.networks.ExperimentalHorologistNetworksApi"
-        freeCompilerArgs += "-opt-in=com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi"
         freeCompilerArgs += "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
     }
 }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -61,7 +61,6 @@ android {
         // Allow for widescale experimental APIs in Alpha libraries we build upon
         freeCompilerArgs += "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi"
-        freeCompilerArgs += "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
     }
 }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/ViewModelModule.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/ViewModelModule.kt
@@ -22,6 +22,7 @@ import dagger.hilt.android.scopes.ActivityRetainedScoped
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
@@ -42,6 +43,7 @@ object ViewModelModule {
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Provides
     @ActivityRetainedScoped
     fun mediaController(

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.rememberActiveFocusRequester
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Scaffold
@@ -28,6 +29,7 @@ object NowPlayingScreen {
     const val route = "now_playing"
 }
 
+@OptIn(ExperimentalWearFoundationApi::class)
 @Composable
 fun NowPlayingScreen(
     modifier: Modifier = Modifier,


### PR DESCRIPTION
## Description
Just updating to the latest version of horologist. There's not anything specific we need this for right now, but I had to get it working to test something else and I figured I might as well commit that work because I'm sure we'll be updating horologist some more before release.

While doing this I noticed that we weren't requiring annotations for using any experimental compose apis in the wear module. I think I let that slip in by accident, so I took it out. I'm fine using the experimental compose apis, but I feel better about it if Android Studio yells at me a bit when I do.

## Testing Instructions
I don't think there's any need to do more than give the watch app a _very_ light smoke test.


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews