### PR TITLE
Replace ExoPlayer with equivalent Media3 dependencies

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -63,7 +63,7 @@
 -dontwarn com.google.android.gms.measurement.**
 
 # chrome cast
--keep class com.google.android.exoplayer2.ext.cast.DefaultCastOptionsProvider { *; }
+-keep class androidx.media3.cast.DefaultCastOptionsProvider { *; }
 -keep class androidx.mediarouter.app.MediaRouteActionProvider { *; }
 -keep class au.com.shiftyjelly.pocketcasts.CastOptionsProvider { *; }
 

--- a/base.gradle
+++ b/base.gradle
@@ -211,11 +211,6 @@ dependencies {
     implementation libs.kotlinCoroutinesPlayServices
     implementation libs.kotlinCoroutinesRx
     implementation libs.deviceNames
-    implementation libs.exoplayerCore
-    implementation libs.exoplayerUi
-    implementation libs.exoplayerMediaSession
-    implementation libs.exoplayerCast
-    implementation libs.exoplayerHls
     implementation libs.glide
     implementation libs.glideOkHttp
     implementation libs.coil
@@ -246,6 +241,12 @@ dependencies {
     implementation libs.sentry
     implementation libs.sentryFragment
     implementation libs.sentryTimber
+    implementation libs.media3Cast
+    implementation libs.media3Datasource
+    implementation libs.media3Exoplayer
+    implementation libs.media3ExoplayerHls
+    implementation libs.media3Extractor
+    implementation libs.media3Ui
 
     kapt libs.moshiKotlinCompile
     kapt libs.glideCompile

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -86,7 +86,7 @@ project.ext {
     versionComposeWear = '1.2.0-alpha07'
     versionDagger = '2.41'
     versionEspresso = '3.4.0'
-    versionExoplayer = '2.18.5'
+    versionMedia3 = '1.0.0'
     versionGlide = '4.13.2'
     versionHilt = '2.43.2'
 
@@ -96,7 +96,6 @@ project.ext {
 
     versionKotlinCoroutines = '1.6.4'
     versionLifecycle = '2.6.0'
-    versionMedia3 = '1.0.0-beta03'
     versionMoshi = '1.13.0'
     versionNavigation = '2.5.1'
     versionPaging = '3.1.1'
@@ -222,12 +221,13 @@ project.ext {
             timber: "com.jakewharton.timber:timber:5.0.1",
             // Android device names for debug email - https://bintray.com/bintray/jcenter/com.jaredrummler%3Aandroid-device-names
             deviceNames: "com.jaredrummler:android-device-names:2.1.0",
-            // ExoPlayer, replacement for MediaPlayer from Google
-            exoplayerCore: "com.google.android.exoplayer:exoplayer-core:$versionExoplayer",
-            exoplayerUi: "com.google.android.exoplayer:exoplayer-ui:$versionExoplayer",
-            exoplayerMediaSession: "com.google.android.exoplayer:extension-mediasession:$versionExoplayer",
-            exoplayerCast: "com.google.android.exoplayer:extension-cast:$versionExoplayer",
-            exoplayerHls: "com.google.android.exoplayer:exoplayer-hls:$versionExoplayer",
+            // Media3
+            media3Cast: "androidx.media3:media3-cast:$versionMedia3",
+            media3Datasource: "androidx.media3:media3-datasource:$versionMedia3",
+            media3Exoplayer: "androidx.media3:media3-exoplayer:$versionMedia3",
+            media3ExoplayerHls: "androidx.media3:media3-exoplayer-hls:$versionMedia3",
+            media3Extractor: "androidx.media3:media3-extractor:$versionMedia3",
+            media3Ui: "androidx.media3:media3-ui:$versionMedia3",
             // Material Dialog - https://github.com/afollestad/material-dialogs
             materialDialog: "com.afollestad.material-dialogs:core:3.3.0",
             // Glide (image loading) - https://github.com/bumptech/glide
@@ -278,6 +278,7 @@ project.ext {
             sentryTimber: 'io.sentry:sentry-android-timber',
             // AboutLibraries - https://github.com/mikepenz/AboutLibraries
             aboutLibrariesCore: 'com.mikepenz:aboutlibraries-core:10.5.0',
-            aboutLibrariesCompose: 'com.mikepenz:aboutlibraries-compose:10.5.0'
+            aboutLibrariesCompose: 'com.mikepenz:aboutlibraries-compose:10.5.0',
+
     ]
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -86,7 +86,7 @@ project.ext {
     versionComposeWear = '1.2.0-alpha07'
     versionDagger = '2.41'
     versionEspresso = '3.4.0'
-    versionExoplayer = '2.18.2'
+    versionExoplayer = '2.18.5'
     versionGlide = '4.13.2'
     versionHilt = '2.43.2'
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoView.kt
@@ -5,12 +5,12 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.SurfaceHolder
 import android.view.SurfaceView
-import android.view.View
 import android.widget.FrameLayout
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.ui.AspectRatioFrameLayout
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.SimplePlayer
-import com.google.android.exoplayer2.ui.AspectRatioFrameLayout
 
 class VideoView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : FrameLayout(context, attrs, defStyleAttr), SurfaceHolder.Callback, SimplePlayer.VideoChangedListener {
 
@@ -22,6 +22,7 @@ class VideoView @JvmOverloads constructor(context: Context, attrs: AttributeSet?
         }
 
     private val view = LayoutInflater.from(context).inflate(R.layout.video_view, this, true)
+    @UnstableApi
     private val aspectRatioLayout = view.findViewById<AspectRatioFrameLayout>(R.id.aspectRatioLayout).apply {
         setAspectRatio(1.78f)
     }
@@ -35,7 +36,7 @@ class VideoView @JvmOverloads constructor(context: Context, attrs: AttributeSet?
 
     override fun setVisibility(visibility: Int) {
         super.setVisibility(visibility)
-        if (visibility == View.GONE) {
+        if (visibility == GONE) {
             isSurfaceSet = false
             (playbackManager?.player as? SimplePlayer)?.setDisplay(null)
         }
@@ -63,6 +64,7 @@ class VideoView @JvmOverloads constructor(context: Context, attrs: AttributeSet?
         }
     }
 
+    @UnstableApi
     override fun videoSizeChanged(width: Int, height: Int, pixelWidthHeightRatio: Float) {
         val videoAspectRatio = if (height == 0 || width == 0) 1f else width * pixelWidthHeightRatio / height
         aspectRatioLayout.setAspectRatio(videoAspectRatio)

--- a/modules/features/player/src/main/res/layout/fragment_video.xml
+++ b/modules/features/player/src/main/res/layout/fragment_video.xml
@@ -14,7 +14,7 @@
         android:layout_height="match_parent"
         android:background="#000000">
 
-        <com.google.android.exoplayer2.ui.PlayerView
+        <androidx.media3.ui.PlayerView
             android:id="@+id/videoView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/modules/features/player/src/main/res/layout/video_view.xml
+++ b/modules/features/player/src/main/res/layout/video_view.xml
@@ -1,13 +1,12 @@
 <androidx.cardview.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="center"
     app:cardCornerRadius="8dp">
 
-    <com.google.android.exoplayer2.ui.AspectRatioFrameLayout
+    <androidx.media3.ui.AspectRatioFrameLayout
         android:id="@+id/aspectRatioLayout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -19,6 +18,6 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
 
-    </com.google.android.exoplayer2.ui.AspectRatioFrameLayout>
+    </androidx.media3.ui.AspectRatioFrameLayout>
 
 </androidx.cardview.widget.CardView>

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -23,6 +23,17 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.view.isVisible
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.Tracks
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.media3.extractor.mp3.Mp3Extractor
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivity
@@ -51,16 +62,6 @@ import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import coil.imageLoader
 import coil.request.ImageRequest
 import coil.target.Target
-import com.google.android.exoplayer2.DefaultLoadControl
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.Tracks
-import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory
-import com.google.android.exoplayer2.extractor.mp3.Mp3Extractor
-import com.google.android.exoplayer2.source.ProgressiveMediaSource
-import com.google.android.exoplayer2.upstream.DefaultDataSource
-import com.google.android.exoplayer2.upstream.DefaultHttpDataSource
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -162,6 +163,7 @@ class AddFileActivity :
         binding.upgradeLayout.root.isVisible = readOnly && !settings.getUpgradeClosedAddFile() && !loading
     }
 
+    @UnstableApi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         theme.setupThemeForConfig(this, resources.configuration)
@@ -292,6 +294,7 @@ class AddFileActivity :
         startActivity(OnboardingActivity.newInstance(this, onboardingFlow))
     }
 
+    @UnstableApi
     @Suppress("NAME_SHADOWING")
     private fun setupForNewFile(fileUri: Uri?) {
         val fileUri = fileUri ?: return
@@ -369,6 +372,7 @@ class AddFileActivity :
         binding.btnImage.text = getString(LR.string.profile_files_add_custom_image)
     }
 
+    @UnstableApi
     @Suppress("DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
@@ -667,6 +671,7 @@ class AddFileActivity :
         startActivityForResult(Intent.createChooser(intent, "Select Picture"), ACTION_PICK_IMAGE)
     }
 
+    @UnstableApi
     private fun preparePlayer(uri: Uri) {
         val loadControl = DefaultLoadControl.Builder().setBufferDurationsMs(0, 0, 0, 0).build()
         val player = ExoPlayer.Builder(this).setLoadControl(loadControl).build()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/extensions/MediaMetadataCompatExt.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/extensions/MediaMetadataCompatExt.kt
@@ -20,10 +20,11 @@ import android.graphics.Bitmap
 import android.net.Uri
 import android.support.v4.media.MediaDescriptionCompat
 import android.support.v4.media.MediaMetadataCompat
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.source.ConcatenatingMediaSource
-import com.google.android.exoplayer2.source.ProgressiveMediaSource
-import com.google.android.exoplayer2.upstream.DataSource
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.exoplayer.source.ConcatenatingMediaSource
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
 
 /**
  * Useful extensions for [MediaMetadataCompat].
@@ -231,6 +232,7 @@ inline val MediaMetadataCompat.fullDescription
  *
  * For convenience, place the [MediaDescriptionCompat] into the tag so it can be retrieved later.
  */
+@UnstableApi
 fun MediaMetadataCompat.toMediaSource(dataSourceFactory: DataSource.Factory) =
     ProgressiveMediaSource.Factory(dataSourceFactory)
         .createMediaSource(
@@ -245,6 +247,7 @@ fun MediaMetadataCompat.toMediaSource(dataSourceFactory: DataSource.Factory) =
  * Extension method for building a [ConcatenatingMediaSource] given a [List]
  * of [MediaMetadataCompat] objects.
  */
+@UnstableApi
 fun List<MediaMetadataCompat>.toMediaSource(
     dataSourceFactory: DataSource.Factory
 ): ConcatenatingMediaSource {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeFileMetadata.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeFileMetadata.kt
@@ -3,14 +3,15 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import androidx.media3.common.Tracks
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.extractor.metadata.id3.ApicFrame
+import androidx.media3.extractor.metadata.id3.ChapterFrame
+import androidx.media3.extractor.metadata.id3.TextInformationFrame
+import androidx.media3.extractor.metadata.id3.UrlLinkFrame
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.models.to.Chapters
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import com.google.android.exoplayer2.Tracks
-import com.google.android.exoplayer2.metadata.id3.ApicFrame
-import com.google.android.exoplayer2.metadata.id3.ChapterFrame
-import com.google.android.exoplayer2.metadata.id3.TextInformationFrame
-import com.google.android.exoplayer2.metadata.id3.UrlLinkFrame
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import timber.log.Timber
 import java.io.BufferedOutputStream
@@ -36,10 +37,12 @@ class EpisodeFileMetadata(val filenamePrefix: String? = null) {
     var embeddedTitle: String? = null
     var embeddedLength: Long? = null
 
+    @UnstableApi
     fun read(tracks: Tracks?, settings: Settings, context: Context) {
         return read(tracks, settings.getUseEmbeddedArtwork(), context)
     }
 
+    @UnstableApi
     fun read(tracks: Tracks?, loadArtwork: Boolean, context: Context) {
         val newChapters = mutableListOf<Chapter>()
         embeddedArtworkPath = null
@@ -82,6 +85,7 @@ class EpisodeFileMetadata(val filenamePrefix: String? = null) {
         }
     }
 
+    @UnstableApi
     private fun convertFrameToChapter(frame: ChapterFrame?, chapterIndex: Int, context: Context): Chapter? {
         if (frame == null || frame.startTimeMs < 0) {
             return null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeFileMetadata.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeFileMetadata.kt
@@ -64,9 +64,9 @@ class EpisodeFileMetadata(val filenamePrefix: String? = null) {
                                 this.embeddedArtworkPath = filePath
                             }
                         } else if (frame is TextInformationFrame && TAG_TITLE == frame.id) {
-                            this.embeddedTitle = frame.value
+                            this.embeddedTitle = frame.values.firstOrNull()
                         } else if (frame is TextInformationFrame && TAG_LENGTH == frame.id) {
-                            this.embeddedLength = frame.value.toLongOrNull()
+                            this.embeddedLength = frame.values.firstOrNull()?.toLongOrNull()
                         }
                     }
                 }
@@ -94,7 +94,7 @@ class EpisodeFileMetadata(val filenamePrefix: String? = null) {
             val subFrame = frame.getSubFrame(i)
             if (subFrame is TextInformationFrame) {
                 if ("TIT2" == subFrame.id) {
-                    title = subFrame.value
+                    title = subFrame.values.firstOrNull() ?: ""
                 }
             } else if (subFrame is UrlLinkFrame) {
                 url = subFrame.url

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -11,6 +11,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.toLiveData
+import androidx.media3.datasource.HttpDataSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
@@ -50,7 +51,6 @@ import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isPositive
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
-import com.google.android.exoplayer2.upstream.HttpDataSource
 import com.jakewharton.rxrelay2.BehaviorRelay
 import com.jakewharton.rxrelay2.Relay
 import dagger.hilt.android.qualifiers.ApplicationContext

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerEvent.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerEvent.kt
@@ -1,6 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
-import com.google.android.exoplayer2.PlaybackException
+import androidx.media3.common.PlaybackException
 
 /**
  * A event on Player

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyAudioProcessorChain.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyAudioProcessorChain.kt
@@ -1,13 +1,16 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
+import androidx.annotation.OptIn
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.AudioProcessorChain
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.audio.SonicAudioProcessor
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
-import com.google.android.exoplayer2.PlaybackParameters
-import com.google.android.exoplayer2.audio.AudioProcessor
-import com.google.android.exoplayer2.audio.AudioProcessorChain
-import com.google.android.exoplayer2.audio.SonicAudioProcessor
 import timber.log.Timber
 
-internal class ShiftyAudioProcessorChain(private val customAudio: ShiftyCustomAudio) :
+@OptIn(UnstableApi::class)
+class ShiftyAudioProcessorChain(private val customAudio: ShiftyCustomAudio) :
     AudioProcessorChain {
     private val lowProcessor = ShiftyTrimSilenceProcessor(
         this::onSkippedFrames,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyAudioRendererV2.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyAudioRendererV2.kt
@@ -3,17 +3,24 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 import android.content.Context
 import android.media.MediaCodec
 import android.os.Handler
-import com.google.android.exoplayer2.ExoPlaybackException
-import com.google.android.exoplayer2.Format
-import com.google.android.exoplayer2.PlaybackParameters
-import com.google.android.exoplayer2.audio.AudioRendererEventListener
-import com.google.android.exoplayer2.audio.AudioSink
-import com.google.android.exoplayer2.audio.MediaCodecAudioRenderer
-import com.google.android.exoplayer2.mediacodec.MediaCodecAdapter
-import com.google.android.exoplayer2.mediacodec.MediaCodecSelector
-import com.google.android.exoplayer2.util.MediaClock
+import androidx.annotation.OptIn
+import androidx.media3.common.Format
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlaybackException
+import androidx.media3.exoplayer.MediaClock
+import androidx.media3.exoplayer.audio.AudioRendererEventListener
+import androidx.media3.exoplayer.audio.AudioSink
+import androidx.media3.exoplayer.audio.MediaCodecAudioRenderer
+import androidx.media3.exoplayer.mediacodec.MediaCodecAdapter
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import java.nio.ByteBuffer
 
+/**
+ * An [AudioProcessor] that skips silence in the input stream. Input and output are 16-bit
+ * PCM.
+ */
+@OptIn(UnstableApi::class)
 class ShiftyAudioRendererV2(
     val customAudio: ShiftyCustomAudio,
     context: Context,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyRenderersFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyRenderersFactory.kt
@@ -2,16 +2,23 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 
 import android.content.Context
 import android.os.Handler
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.DefaultRenderersFactory
+import androidx.media3.exoplayer.Renderer
+import androidx.media3.exoplayer.audio.AudioCapabilities
+import androidx.media3.exoplayer.audio.AudioRendererEventListener
+import androidx.media3.exoplayer.audio.AudioSink
+import androidx.media3.exoplayer.audio.DefaultAudioSink
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
-import com.google.android.exoplayer2.DefaultRenderersFactory
-import com.google.android.exoplayer2.Renderer
-import com.google.android.exoplayer2.audio.AudioCapabilities
-import com.google.android.exoplayer2.audio.AudioRendererEventListener
-import com.google.android.exoplayer2.audio.AudioSink
-import com.google.android.exoplayer2.audio.DefaultAudioSink
-import com.google.android.exoplayer2.mediacodec.MediaCodecSelector
 
+/**
+ * An [AudioProcessor] that skips silence in the input stream. Input and output are 16-bit
+ * PCM.
+ */
+@OptIn(UnstableApi::class)
 class ShiftyRenderersFactory(context: Context?, statsManager: StatsManager, private var boostVolume: Boolean) : DefaultRenderersFactory(context!!) {
     private var playbackSpeed = 0f
     private var internalRenderer: ShiftyAudioRendererV2? = null
@@ -53,7 +60,7 @@ class ShiftyRenderersFactory(context: Context?, statsManager: StatsManager, priv
         audioSink: AudioSink,
         eventHandler: Handler,
         eventListener: AudioRendererEventListener,
-        out: ArrayList<Renderer>
+        out: ArrayList<Renderer>,
     ) {
         this.audioSink = audioSink
         internalRenderer = ShiftyAudioRendererV2(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyTrimSilenceProcessor.java
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyTrimSilenceProcessor.java
@@ -2,11 +2,13 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback;
 
 import androidx.annotation.IntDef;
 
-import com.google.android.exoplayer2.C;
-import com.google.android.exoplayer2.audio.AudioProcessor;
-import com.google.android.exoplayer2.audio.BaseAudioProcessor;
-import com.google.android.exoplayer2.util.Assertions;
-import com.google.android.exoplayer2.util.Util;
+import androidx.annotation.OptIn;
+import androidx.media3.common.C;
+import androidx.media3.common.audio.AudioProcessor;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.exoplayer.audio.BaseAudioProcessor;
+import androidx.media3.common.util.Assertions;
+import androidx.media3.common.util.Util;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -19,6 +21,7 @@ import static java.lang.Math.min;
  * An {@link AudioProcessor} that skips silence in the input stream. Input and output are 16-bit
  * PCM.
  */
+@OptIn(markerClass = UnstableApi.class)
 public final class ShiftyTrimSilenceProcessor extends BaseAudioProcessor {
 
     /**

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -6,27 +6,29 @@ import android.os.Handler
 import android.os.Looper
 import android.view.SurfaceView
 import android.widget.Toast
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Player
+import androidx.media3.common.Tracks
+import androidx.media3.common.VideoSize
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.hls.HlsMediaSource
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
+import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.media3.extractor.mp3.Mp3Extractor
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
-import com.google.android.exoplayer2.C
-import com.google.android.exoplayer2.DefaultLoadControl
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.PlaybackException
-import com.google.android.exoplayer2.PlaybackParameters
-import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.Tracks
-import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory
-import com.google.android.exoplayer2.extractor.mp3.Mp3Extractor
-import com.google.android.exoplayer2.source.ProgressiveMediaSource
-import com.google.android.exoplayer2.source.hls.HlsMediaSource
-import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
-import com.google.android.exoplayer2.upstream.DefaultDataSource
-import com.google.android.exoplayer2.upstream.DefaultHttpDataSource
-import com.google.android.exoplayer2.video.VideoSize
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -166,6 +168,7 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
 
     override fun setPodcast(podcast: Podcast?) {}
 
+    @OptIn(UnstableApi::class)
     private fun prepare() {
         val trackSelector = DefaultTrackSelector(context)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import android.content.Context
 import androidx.lifecycle.LiveData
+import androidx.media3.exoplayer.source.UnrecognizedInputFormatException
 import androidx.paging.PagedList
 import androidx.sqlite.db.SimpleSQLiteQuery
 import androidx.work.Constraints
@@ -38,7 +39,6 @@ import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.utils.days
 import au.com.shiftyjelly.pocketcasts.utils.extensions.anyMessageContains
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
-import com.google.android.exoplayer2.source.UnrecognizedInputFormatException
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.Completable
 import io.reactivex.Flowable


### PR DESCRIPTION
Parent https://github.com/Automattic/pocket-casts-android/issues/887

## Description

This replaces `ExoPlayer` dependencies with equivalent `Media3` ones that now include `ExoPlayer`.
 
[Media3 1.0.0](https://github.com/androidx/media/blob/release/RELEASENOTES.md#100-2023-03-22) corresponds to the [ExoPlayer 2.18.5 release](https://github.com/google/ExoPlayer/releases/tag/r2.18.5). In 2ca9d942c39b6744a016d3b43114b04e116946ba, I upgraded `ExoPlayer` to the latest version r2.18.5 before migrating it to `Media3`.

## Testing Instructions

- Clean Project in Android Studio
- Install and smoke test the app, I tested 
   - streaming audio-only episode
   - playing downloaded episode
   - chrome casting an episode
   - playing an episode with video (e.g. from Ted Talks HD)
   - changing audio effects like playback speed, volume boost
   - playing an episode on Automotive, Wear

(feel free to randomly test any of these or anything else that you might think can be a breaking change) 

> **Warning**

Note that, APIs intended for more advanced use cases are marked as unstable in `media3`. To avoid lint errors, classes that use these APIs are annotated with "UnstableApi":
```
AddFileActivity
EpisodeFileMetadata
MediaMetadataCompatExt
ShiftyAudioProcessorChain
ShiftyAudioRendererV2
ShiftyRenderersFactory
ShiftyTrimSilenceProcessor
SimplePlayer
VideoView
```

Even with the annotation, they are reliable for production use as [described](https://medium.com/google-exoplayer/jetpack-media3-1-0-0-beta01-whats-new-2367a712f112) by `google-exoplayer` editor:
> Just because part of an API is marked as unstable doesn’t mean that the API is unreliable or that you shouldn’t use it — it’s just a way of informing you that it might change in the future.

## Merging Instructions
- Make sure that release `7.37` is cut-out before merging this PR to give us some more time to test the changes. 