### PR TITLE
Add google sign in to the automotive app

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountFragment.kt
@@ -5,6 +5,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.unit.sp
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.activityViewModels
@@ -12,11 +14,13 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.findNavController
 import au.com.shiftyjelly.pocketcasts.account.databinding.FragmentAccountBinding
+import au.com.shiftyjelly.pocketcasts.account.onboarding.components.ContinueWithGoogleButton
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.AccountFragmentViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.CreateAccountViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeTintedDrawable
 import au.com.shiftyjelly.pocketcasts.utils.Util
@@ -24,6 +28,7 @@ import au.com.shiftyjelly.pocketcasts.utils.observeOnce
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import au.com.shiftyjelly.pocketcasts.cartheme.R as CR
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
@@ -85,6 +90,19 @@ class AccountFragment : BaseFragment() {
             analyticsTracker.track(AnalyticsEvent.SETUP_ACCOUNT_DISMISSED, ACCOUNT_SOURCE)
             FirebaseAnalyticsTracker.closeAccountMissingClicked()
             activity?.finish()
+        }
+
+        binding.btnContinueWithGoogle?.apply {
+            setContent {
+                AppThemeWithBackground(theme.activeTheme) {
+                    ContinueWithGoogleButton(
+                        flow = null,
+                        fontSize = dimensionResource(CR.dimen.car_body2_size).value.sp,
+                        includePadding = false,
+                        onComplete = { activity?.finish() }
+                    )
+                }
+            }
         }
 
         binding.btnCreate.setOnClickListener {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/ContinueWithGoogleButton.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/ContinueWithGoogleButton.kt
@@ -1,0 +1,94 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.components
+
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.GoogleSignInButtonViewModel
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.GoogleSignInState
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+/**
+ * Let the user sign into Pocket Casts with their Google account.
+ * The One Tap for Android library is used. Sign in doesn't work when no Google accounts are set up on the device. In this case, fallback to the legacy Google Sign-In for Android.
+ */
+@Composable
+fun ContinueWithGoogleButton(
+    flow: OnboardingFlow?,
+    fontSize: TextUnit? = null,
+    includePadding: Boolean = true,
+    onComplete: (GoogleSignInState) -> Unit,
+) {
+
+    val viewModel = hiltViewModel<GoogleSignInButtonViewModel>()
+    val context = LocalContext.current
+
+    val showContinueWithGoogleButton = GoogleSignInButtonViewModel.showContinueWithGoogleButton(context)
+    if (!showContinueWithGoogleButton) return
+
+    val errorMessage = stringResource(LR.string.onboarding_continue_with_google_error)
+
+    val showError = {
+        Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
+    }
+
+    // request legacy Google Sign-In and process the result
+    val googleLegacySignInLauncher = rememberLauncherForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
+        viewModel.onGoogleLegacySignInResult(
+            result = result,
+            onSuccess = onComplete,
+            onError = showError
+        )
+    }
+
+    // request Google One Tap Sign-In and process the result
+    val googleOneTapSignInLauncher = rememberLauncherForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
+        viewModel.onGoogleOneTapSignInResult(
+            result = result,
+            onSuccess = onComplete,
+            onError = {
+                viewModel.startGoogleLegacySignIn(
+                    onSuccess = { request -> googleLegacySignInLauncher.launch(request) },
+                    onError = showError
+                )
+            }
+        )
+    }
+
+    val onSignInClick = {
+        viewModel.startGoogleOneTapSignIn(
+            flow = flow,
+            onSuccess = { request -> googleOneTapSignInLauncher.launch(request) },
+            onError = {
+                viewModel.startGoogleLegacySignIn(
+                    onSuccess = { request -> googleLegacySignInLauncher.launch(request) },
+                    onError = showError
+                )
+            }
+        )
+    }
+
+    RowOutlinedButton(
+        text = stringResource(LR.string.onboarding_continue_with_google),
+        leadingIcon = painterResource(IR.drawable.google_g),
+        tintIcon = false,
+        border = BorderStroke(2.dp, MaterialTheme.theme.colors.primaryInteractive03),
+        fontSize = fontSize,
+        includePadding = includePadding,
+        colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.theme.colors.primaryText01),
+        onClick = onSignInClick
+    )
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/GoogleSignInButtonViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/GoogleSignInButtonViewModel.kt
@@ -1,0 +1,197 @@
+package au.com.shiftyjelly.pocketcasts.account.viewmodel
+
+import android.content.Context
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.IntentSenderRequest
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SignInSource
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
+import au.com.shiftyjelly.pocketcasts.utils.Util
+import au.com.shiftyjelly.pocketcasts.utils.extensions.isGooglePlayServicesAvailableSuccess
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import com.google.android.gms.auth.api.identity.BeginSignInRequest
+import com.google.android.gms.auth.api.identity.GetSignInIntentRequest
+import com.google.android.gms.auth.api.identity.Identity
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.gms.common.api.ApiException
+import com.google.android.gms.common.api.CommonStatusCodes
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import timber.log.Timber
+import java.lang.IllegalArgumentException
+import javax.inject.Inject
+
+@HiltViewModel
+class GoogleSignInButtonViewModel @Inject constructor(
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    @ApplicationContext private val context: Context,
+    private val podcastManager: PodcastManager,
+    private val syncManager: SyncManager,
+) : ViewModel() {
+
+    companion object {
+        fun showContinueWithGoogleButton(context: Context) =
+            Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID.isNotEmpty() &&
+                GoogleApiAvailability.getInstance().isGooglePlayServicesAvailableSuccess(context)
+    }
+
+    /**
+     * Try to sign in with Google One Tap.
+     * It's common for the One Tap to fail so then try the legacy Google Sign-In.
+     */
+    fun startGoogleOneTapSignIn(
+        flow: OnboardingFlow?,
+        onSuccess: (IntentSenderRequest) -> Unit,
+        onError: suspend () -> Unit,
+    ) {
+        if (flow != null) {
+            analyticsTracker.track(
+                AnalyticsEvent.SETUP_ACCOUNT_BUTTON_TAPPED,
+                mapOf(
+                    OnboardingLoginOrSignUpViewModel.Companion.AnalyticsProp.flow(flow),
+                    OnboardingLoginOrSignUpViewModel.Companion.AnalyticsProp.ButtonTapped.continueWithGoogle,
+                )
+            )
+        } else if (!Util.isAutomotive(context)) {
+            throw IllegalArgumentException("OnboardingFlow must be provided for non-automotive devices")
+        }
+
+        viewModelScope.launch {
+            try {
+                val beginSignInRequest = BeginSignInRequest.GoogleIdTokenRequestOptions.builder()
+                    .setSupported(true)
+                    // use the Google Cloud credentials OAuth Server Client ID, not the Android Client ID.
+                    .setServerClientId(Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID)
+                    // don't just show accounts previously used to sign in.
+                    .setFilterByAuthorizedAccounts(false)
+                    .build()
+                val signInRequest = BeginSignInRequest.builder()
+                    .setGoogleIdTokenRequestOptions(beginSignInRequest)
+                    .build()
+                val result = Identity.getSignInClient(context).beginSignIn(signInRequest).await()
+                val intentRequest = IntentSenderRequest.Builder(result.pendingIntent).build()
+                onSuccess(intentRequest)
+            } catch (e: Exception) {
+                LogBuffer.e(LogBuffer.TAG_CRASH, e, "Unable to sign in with Google One Tap")
+                onError()
+            }
+        }
+    }
+
+    /**
+     * Try to sign in with the legacy Google Sign-In.
+     */
+    fun startGoogleLegacySignIn(
+        onSuccess: (IntentSenderRequest) -> Unit,
+        onError: () -> Unit,
+    ) {
+        viewModelScope.launch {
+            try {
+                Timber.i("Using legacy Google Sign-In")
+                val lastSignedInAccount = GoogleSignIn.getLastSignedInAccount(context)
+                val idToken = lastSignedInAccount?.idToken
+                val email = lastSignedInAccount?.email
+                if (idToken == null || email == null) {
+                    val request = GetSignInIntentRequest.builder().setServerClientId(Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID).build()
+                    val signInIntent = Identity.getSignInClient(context).getSignInIntent(request).await()
+                    val intentSenderRequest = IntentSenderRequest.Builder(signInIntent.intentSender).build()
+                    onSuccess(intentSenderRequest)
+                } else {
+                    signInWithGoogleToken(
+                        idToken = idToken,
+                        onSuccess = {},
+                        onError = onError
+                    )
+                }
+            } catch (ex: Exception) {
+                LogBuffer.e(LogBuffer.TAG_CRASH, ex, "Unable to sign in with legacy Google Sign-In")
+                onError()
+            }
+        }
+    }
+
+    /**
+     * Handle the response from the Google One Tap intent to sign in.
+     */
+    fun onGoogleOneTapSignInResult(
+        result: ActivityResult,
+        onSuccess: (GoogleSignInState) -> Unit,
+        onError: suspend () -> Unit,
+    ) {
+        viewModelScope.launch {
+            try {
+                onGoogleSignInResult(
+                    result = result,
+                    onSuccess = onSuccess,
+                    onError = {
+                        onError()
+                    }
+                )
+            } catch (e: Exception) {
+                if (e is ApiException && e.statusCode == CommonStatusCodes.CANCELED) {
+                    // user declined to sign in
+                    return@launch
+                }
+                LogBuffer.e(LogBuffer.TAG_CRASH, e, "Unable to get sign in credentials from Google One Tap result.")
+                onError()
+            }
+        }
+    }
+
+    /**
+     * Handle the response from the legacy Google Sign-In intent.
+     */
+    fun onGoogleLegacySignInResult(result: ActivityResult, onSuccess: (GoogleSignInState) -> Unit, onError: () -> Unit) {
+        viewModelScope.launch {
+            try {
+                onGoogleSignInResult(
+                    result = result,
+                    onSuccess = onSuccess,
+                    onError = onError
+                )
+            } catch (e: Exception) {
+                LogBuffer.e(
+                    LogBuffer.TAG_CRASH,
+                    e,
+                    "Unable to get sign in credentials from legacy Google Sign-In result."
+                )
+                onError()
+            }
+        }
+    }
+
+    private suspend fun onGoogleSignInResult(
+        result: ActivityResult,
+        onSuccess: (GoogleSignInState) -> Unit,
+        onError: suspend () -> Unit
+    ) {
+        val credential = Identity.getSignInClient(context).getSignInCredentialFromIntent(result.data)
+        val idToken = credential.googleIdToken ?: throw Exception("Unable to sign in because no token was returned.")
+        signInWithGoogleToken(idToken = idToken, onSuccess = onSuccess, onError = onError)
+    }
+
+    private suspend fun signInWithGoogleToken(
+        idToken: String,
+        onSuccess: (GoogleSignInState) -> Unit,
+        onError: suspend () -> Unit
+    ) =
+        when (val authResult = syncManager.loginWithGoogle(idToken = idToken, signInSource = SignInSource.Onboarding)) {
+            is LoginResult.Success -> {
+                podcastManager.refreshPodcastsAfterSignIn()
+                onSuccess(GoogleSignInState(isNewAccount = authResult.result.isNewAccount))
+            }
+            is LoginResult.Failed -> {
+                onError()
+            }
+        }
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLoginOrSignUpViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLoginOrSignUpViewModel.kt
@@ -2,8 +2,6 @@ package au.com.shiftyjelly.pocketcasts.account.viewmodel
 
 import android.app.Application
 import android.content.Context
-import androidx.activity.result.ActivityResult
-import androidx.activity.result.IntentSenderRequest
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
@@ -11,25 +9,13 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
-import au.com.shiftyjelly.pocketcasts.repositories.sync.SignInSource
-import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isGooglePlayServicesAvailableSuccess
-import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
-import com.google.android.gms.auth.api.identity.BeginSignInRequest
-import com.google.android.gms.auth.api.identity.GetSignInIntentRequest
-import com.google.android.gms.auth.api.identity.Identity
-import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.common.GoogleApiAvailability
-import com.google.android.gms.common.api.ApiException
-import com.google.android.gms.common.api.CommonStatusCodes
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
-import timber.log.Timber
 import javax.inject.Inject
 
 data class GoogleSignInState(val isNewAccount: Boolean)
@@ -39,7 +25,6 @@ class OnboardingLoginOrSignUpViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     @ApplicationContext context: Context,
     private val podcastManager: PodcastManager,
-    private val syncManager: SyncManager,
 ) : AndroidViewModel(context as Application) {
 
     val showContinueWithGoogleButton =
@@ -48,121 +33,10 @@ class OnboardingLoginOrSignUpViewModel @Inject constructor(
 
     val randomPodcasts = mutableListOf<Podcast>()
 
-    private val context: Context
-        get() = getApplication()
-
     init {
         viewModelScope.launch(Dispatchers.IO) {
             randomPodcasts.clear()
             randomPodcasts.addAll(podcastManager.findRandomPodcasts(limit = 6))
-        }
-    }
-
-    /**
-     * Try to sign in with Google One Tap.
-     * It's common for the One Tap to fail so then try the legacy Google Sign-In.
-     */
-    fun startGoogleOneTapSignIn(
-        flow: OnboardingFlow,
-        onSuccess: (IntentSenderRequest) -> Unit,
-        onError: suspend () -> Unit,
-    ) {
-        analyticsTracker.track(
-            AnalyticsEvent.SETUP_ACCOUNT_BUTTON_TAPPED,
-            mapOf(AnalyticsProp.flow(flow), AnalyticsProp.ButtonTapped.continueWithGoogle)
-        )
-        viewModelScope.launch {
-            try {
-                val beginSignInRequest = BeginSignInRequest.GoogleIdTokenRequestOptions.builder()
-                    .setSupported(true)
-                    // use the Google Cloud credentials OAuth Server Client ID, not the Android Client ID.
-                    .setServerClientId(Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID)
-                    // don't just show accounts previously used to sign in.
-                    .setFilterByAuthorizedAccounts(false)
-                    .build()
-                val signInRequest = BeginSignInRequest.builder()
-                    .setGoogleIdTokenRequestOptions(beginSignInRequest)
-                    .build()
-                val result = Identity.getSignInClient(context).beginSignIn(signInRequest).await()
-                val intentRequest = IntentSenderRequest.Builder(result.pendingIntent).build()
-                onSuccess(intentRequest)
-            } catch (e: Exception) {
-                LogBuffer.e(LogBuffer.TAG_CRASH, e, "Unable to sign in with Google One Tap")
-                onError()
-            }
-        }
-    }
-
-    /**
-     * Try to sign in with the legacy Google Sign-In.
-     */
-    suspend fun startGoogleLegacySignIn(onSuccess: (IntentSenderRequest) -> Unit, onError: () -> Unit) {
-        try {
-            Timber.i("Using legacy Google Sign-In")
-            val lastSignedInAccount = GoogleSignIn.getLastSignedInAccount(context)
-            val idToken = lastSignedInAccount?.idToken
-            val email = lastSignedInAccount?.email
-            if (idToken == null || email == null) {
-                val request = GetSignInIntentRequest.builder().setServerClientId(Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID).build()
-                val signInIntent = Identity.getSignInClient(context).getSignInIntent(request).await()
-                val intentSenderRequest = IntentSenderRequest.Builder(signInIntent.intentSender).build()
-                onSuccess(intentSenderRequest)
-            } else {
-                signInWithGoogleToken(
-                    idToken = idToken,
-                    onSuccess = {},
-                    onError = onError
-                )
-            }
-        } catch (ex: Exception) {
-            LogBuffer.e(LogBuffer.TAG_CRASH, ex, "Unable to sign in with legacy Google Sign-In")
-            onError()
-        }
-    }
-
-    /**
-     * Handle the response from the Google One Tap intent to sign in.
-     */
-    fun onGoogleOneTapSignInResult(
-        result: ActivityResult,
-        onSuccess: (GoogleSignInState) -> Unit,
-        onError: suspend () -> Unit,
-    ) {
-        viewModelScope.launch {
-            try {
-                onGoogleSignInResult(
-                    result = result,
-                    onSuccess = onSuccess,
-                    onError = {
-                        onError()
-                    }
-                )
-            } catch (e: Exception) {
-                if (e is ApiException && e.statusCode == CommonStatusCodes.CANCELED) {
-                    // user declined to sign in
-                    return@launch
-                }
-                LogBuffer.e(LogBuffer.TAG_CRASH, e, "Unable to get sign in credentials from Google One Tap result.")
-                onError()
-            }
-        }
-    }
-
-    /**
-     * Handle the response from the legacy Google Sign-In intent.
-     */
-    fun onGoogleLegacySignInResult(result: ActivityResult, onSuccess: (GoogleSignInState) -> Unit, onError: () -> Unit) {
-        viewModelScope.launch {
-            try {
-                onGoogleSignInResult(
-                    result = result,
-                    onSuccess = onSuccess,
-                    onError = onError
-                )
-            } catch (e: Exception) {
-                LogBuffer.e(LogBuffer.TAG_CRASH, e, "Unable to get sign in credentials from legacy Google Sign-In result.")
-                onError()
-            }
         }
     }
 
@@ -194,25 +68,8 @@ class OnboardingLoginOrSignUpViewModel @Inject constructor(
         )
     }
 
-    private suspend fun onGoogleSignInResult(result: ActivityResult, onSuccess: (GoogleSignInState) -> Unit, onError: suspend () -> Unit) {
-        val credential = Identity.getSignInClient(context).getSignInCredentialFromIntent(result.data)
-        val idToken = credential.googleIdToken ?: throw Exception("Unable to sign in because no token was returned.")
-        signInWithGoogleToken(idToken = idToken, onSuccess = onSuccess, onError = onError)
-    }
-
-    private suspend fun signInWithGoogleToken(idToken: String, onSuccess: (GoogleSignInState) -> Unit, onError: suspend () -> Unit) =
-        when (val authResult = syncManager.loginWithGoogle(idToken = idToken, signInSource = SignInSource.Onboarding)) {
-            is LoginResult.Success -> {
-                podcastManager.refreshPodcastsAfterSignIn()
-                onSuccess(GoogleSignInState(isNewAccount = authResult.result.isNewAccount))
-            }
-            is LoginResult.Failed -> {
-                onError()
-            }
-        }
-
     companion object {
-        private object AnalyticsProp {
+        object AnalyticsProp {
             fun flow(flow: OnboardingFlow) = "flow" to flow.analyticsValue
             object ButtonTapped {
                 private const val button = "button"

--- a/modules/features/account/src/main/res/layout-car/fragment_account.xml
+++ b/modules/features/account/src/main/res/layout-car/fragment_account.xml
@@ -63,13 +63,24 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:src="@drawable/ic_create_new_account" />
 
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/btnContinueWithGoogle"
+                android:layout_width="592dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/car_create_account_btn_top_margin"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/lblSaveYourPodcasts" />
+
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnCreate"
                 style="@style/MaterialButtonStyle"
                 android:layout_width="592dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
-                android:layout_marginTop="@dimen/car_create_account_btn_top_margin"
+                android:layout_marginTop="@dimen/car_sign_in_btn_top_margin"
                 android:layout_marginEnd="16dp"
                 android:fontFamily="sans-serif-medium"
                 android:letterSpacing="0.02"
@@ -81,7 +92,7 @@
                 app:cornerRadius="8dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/lblSaveYourPodcasts" />
+                app:layout_constraintTop_toBottomOf="@id/btnContinueWithGoogle" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnSignIn"

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowOutlinedButton.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowOutlinedButton.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
@@ -46,6 +47,7 @@ fun RowOutlinedButton(
     border: BorderStroke? = outlinedBorder,
     colors: ButtonColors = ButtonDefaults.outlinedButtonColors(),
     textIcon: Painter? = null,
+    fontSize: TextUnit? = null,
     leadingIcon: Painter? = null,
     tintIcon: Boolean = true,
     onClick: () -> Unit,
@@ -82,6 +84,7 @@ fun RowOutlinedButton(
                         text = text,
                         color = colors.contentColor(enabled = true).value,
                         textAlign = TextAlign.Center,
+                        fontSize = fontSize,
                         modifier = Modifier.padding(6.dp)
                     )
                 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
@@ -84,13 +84,14 @@ fun TextH30(
     fontWeight: FontWeight? = null,
     maxLines: Int = Int.MAX_VALUE,
     disableScale: Boolean = false,
-    fontSize: TextUnit = 18.sp,
+    fontSize: TextUnit? = null,
     lineHeight: TextUnit = 21.sp,
 ) {
+    val fontSizeUpdated = fontSize ?: 18.sp
     Text(
         text = text,
         color = color,
-        fontSize = if (disableScale) fontSize.value.nonScaledSp else fontSize,
+        fontSize = if (disableScale) fontSizeUpdated.value.nonScaledSp else fontSizeUpdated,
         lineHeight = if (disableScale) lineHeight.value.nonScaledSp else lineHeight.value.sp,
         textAlign = textAlign,
         fontWeight = fontWeight ?: FontWeight.W600,


### PR DESCRIPTION
## Description
This adds the ability to sign in with google to the automotive app.

> **Warning**
> This PR is targeting the `release/7.37` branch because I think we need to roll SSO out at the same time everywhere as much as we can. Let me know if you feel differently.

## Testing Instructions

### 1. Automotive device already connected to a Google Account
1. Go to the sign in screen (⚙️  → "Set Up Account")
2. Observe there is now a "Continue with Google" button
3. Tap "Continue with Google" and select a Google account

### 2. When the automotive device is not already connected to a Google account
1. Go to the sign in screen (⚙️  → "Set Up Account")
2. Observe there is now a "Continue with Google" button
3. Either sign in to a google account on the device or on an Android phone (I didn't see how to test with a connected Android phone using the emulator, maybe you can test that @geekygecko ? )

## Issue when not already connected to a google account

I am seeing an issue when the automotive device is not already signed into a Google account. The OS has you sign into a Google account, but when it returns to the app and shows the OS pop-up screen to select an account it does not show the just-signed-into google account. Closing that pop-up and tapping Continue with Google again fixes the issue though.

Here is a video of that issue.

https://user-images.githubusercontent.com/4656348/232623179-8c114176-f8b7-497c-bb29-5bbbb8db11cc.mov

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews