### PR TITLE
Stop the Automotive set skip settings accepting a blank value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Bug Fixes:
     *   Fixed accessibility content desctiption for episode list
          ([#890](https://github.com/Automattic/pocket-casts-android/issues/890)).
+    *   Improved the validation of the Automotive skip forward and back time settings
+         ([#890](https://github.com/Automattic/pocket-casts-android/pull/892)).
 
 7.37
 -----

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -317,7 +317,6 @@ interface Settings {
     fun getSkipForwardInMs(): Long
     fun getSkipBackwardInSecs(): Int
     fun getSkipBackwardInMs(): Long
-    fun updateSkipValues()
 
     fun getLastScreenOpened(): String?
     fun setLastScreenOpened(screenId: String)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -208,11 +208,6 @@ class SettingsImpl @Inject constructor(
         setBoolean(Settings.PREFERENCE_SKIP_BACK_NEEDS_SYNC, value)
     }
 
-    override fun updateSkipValues() {
-        skipBackwardInSecsObservable.accept(getSkipBackwardInSecs())
-        skipForwardInSecsObservable.accept(getSkipForwardInSecs())
-    }
-
     override fun getMarketingOptIn(): Boolean {
         return getBoolean(Settings.PREFERENCE_MARKETING_OPT_IN, false)
     }


### PR DESCRIPTION
## Description
It is possible to set the Automotive skip foward and back times to an empty string. This doesn't break the skip buttons as it will use the defaults but in the UI when you open the settings it remains blank. This change improves the input validation and doesn't accept the blank value. 

## Testing Instructions

1. Tap on the settings icon
2. Tap the "Skip forward time" setting
3. Remove the numbers so the field is blank
4. Tap ok
5. Tap the "Skip forward time" setting
6. ✅ Verify the value is not blank  
<hr>

7. Tap the "Skip back time" setting
8. Remove the numbers so the field is blank
9. Tap ok
10. Tap the "Skip back time" setting
11. ✅ Verify the value is not blank
<hr>

12. Tap the "Skip forward time" setting
13. Change the skip time to another value
14. Tap ok
15. ✅ Verify the forward time setting summary value has changed
<hr>

16. Tap the "Skip back time" setting
17. Change the skip time to another value
18. Tap ok
19. ✅ Verify the back time setting summary value has changed
<hr>

20. Tap the back button
21. Play an episode
22. ✅ Verify the change to the skip times has worked and the episode skips the correct amount of time

## Screenshots or Screencast 

https://user-images.githubusercontent.com/308331/232970468-ef42fdaa-6104-43e6-b1b0-76997b2cd345.mov

