### PR TITLE
Update media3 player + migrate local player instantiation to PlaybackService

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.os.Environment
 import android.os.StrictMode
 import androidx.hilt.work.HiltWorkerFactory
+import androidx.media3.common.util.UnstableApi
 import androidx.work.Configuration
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.AnonymousBumpStatsTracker
@@ -17,6 +18,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.file.StorageOptions
 import au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsJob
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackService
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -154,7 +156,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
             Coil.setImageLoader(coilImageLoader)
 
             withContext(Dispatchers.Default) {
-                playbackManager.setup()
+                playbackManager.setup(playbackService)
                 downloadManager.setup(episodeManager, podcastManager, playlistManager, playbackManager)
 
                 val isRestoreFromBackup = settings.isRestoreFromBackup()
@@ -259,5 +261,10 @@ class PocketCastsApplication : Application(), Configuration.Provider {
                 }
             }
         }
+    }
+
+    companion object {
+        @UnstableApi
+        val playbackService = PlaybackService::class.java
     }
 }

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
@@ -6,6 +6,7 @@ import android.app.UiModeManager
 import android.util.Log
 import androidx.core.content.getSystemService
 import androidx.hilt.work.HiltWorkerFactory
+import androidx.media3.common.util.UnstableApi
 import androidx.work.Configuration
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
@@ -70,7 +71,7 @@ class AutomotiveApplication : Application(), Configuration.Provider {
             FirebaseAnalyticsTracker.setup(FirebaseAnalytics.getInstance(this@AutomotiveApplication), settings)
 
             withContext(Dispatchers.Default) {
-                playbackManager.setup()
+                playbackManager.setup(playbackService)
                 downloadManager.setup(episodeManager, podcastManager, playlistManager, playbackManager)
                 RefreshPodcastsTask.runNow(this@AutomotiveApplication)
             }
@@ -118,5 +119,10 @@ class AutomotiveApplication : Application(), Configuration.Provider {
 
     private fun setupAnalytics() {
         AnalyticsTracker.init(settings)
+    }
+
+    companion object {
+        @UnstableApi
+        val playbackService = AutoPlaybackService::class.java
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
@@ -11,13 +11,13 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.media3.common.util.UnstableApi
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentVideoBinding
 import au.com.shiftyjelly.pocketcasts.player.view.PlayerSeekBar
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.VideoViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playback.SimplePlayer
 import au.com.shiftyjelly.pocketcasts.views.extensions.hide
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import com.airbnb.lottie.LottieAnimationView
@@ -83,7 +83,7 @@ class VideoFragment : Fragment(), PlayerSeekBar.OnUserSeekListener {
         }
 
         viewModel.playbackState.observe(viewLifecycleOwner) {
-            val newPlayer = (playbackManager.pocketCastsPlayer as? SimplePlayer)?.exoPlayer
+            val newPlayer = playbackManager.pocketCastsPlayer
 
             // setPlayer returns straight away if the player is the same so calling this too much doesn't matter.
             // This ensures while the full screen player is visible, the surface isn't set from somewhere else causing
@@ -157,6 +157,7 @@ class VideoFragment : Fragment(), PlayerSeekBar.OnUserSeekListener {
     override fun onSeekPositionChanging(progress: Int) {
     }
 
+    @UnstableApi
     override fun onSeekPositionChangeStop(progress: Int, seekComplete: () -> Unit) {
         viewModel.seekToMs(progress)
         playbackManager.trackPlaybackSeek(progress, AnalyticsSource.FULL_SCREEN_VIDEO)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -62,9 +62,6 @@ class CastPlayer(
 
     override var episodeLocation: EpisodeLocation? = null
 
-    override val url: String?
-        get() = (episodeLocation as? EpisodeLocation.Stream)?.uri
-
     override val isRemote: Boolean
         get() = true
 
@@ -74,10 +71,12 @@ class CastPlayer(
     override val name: String
         get() = "Cast"
 
-    override val episodeUuid: String?
-        get() = episode?.uuid
-
-    override val filePath: String? = null
+    override var playable: Playable? = null
+        set(value) {
+            field = value
+            localEpisodeUuid = value?.uuid
+            buildCustomData()
+        }
 
     private val isConnected: Boolean
         get() {
@@ -206,17 +205,6 @@ class CastPlayer(
         this.podcast = podcast
     }
 
-    override fun setEpisode(episode: Playable) {
-        this.episode = episode
-        this.episodeLocation =
-            EpisodeLocation.Stream(
-                episode.downloadUrl
-            )
-
-        localEpisodeUuid = episode.uuid
-        buildCustomData()
-    }
-
     private fun addRemoteMediaListener() {
         if (remoteListenerAdded) {
             return
@@ -322,7 +310,7 @@ class CastPlayer(
         // Convert the remote playback states to media playback states.
         when (status) {
             MediaStatus.PLAYER_STATE_IDLE -> if (idleReason == MediaStatus.IDLE_REASON_FINISHED) {
-                onPlayerEvent(this, PlayerEvent.Completion(episodeUuid))
+                onPlayerEvent(this, PlayerEvent.Completion(playable?.uuid))
             }
             MediaStatus.PLAYER_STATE_BUFFERING, MediaStatus.PLAYER_STATE_LOADING -> {
                 state = PlaybackStateCompat.STATE_BUFFERING

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.support.v4.media.session.PlaybackStateCompat
 import android.text.TextUtils
+import androidx.media3.common.Player
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -26,7 +27,11 @@ import org.json.JSONException
 import org.json.JSONObject
 import timber.log.Timber
 
-class CastPlayer(val context: Context, override val onPlayerEvent: (PocketCastsPlayer, PlayerEvent) -> Unit) : PocketCastsPlayer {
+class CastPlayer(
+    val context: Context,
+    override val onPlayerEvent: (PocketCastsPlayer, PlayerEvent) -> Unit,
+    player: Player,
+) : PocketCastsPlayer, Player by player {
 
     private var customData: JSONObject? = null
     private var podcast: Podcast? = null
@@ -93,27 +98,17 @@ class CastPlayer(val context: Context, override val onPlayerEvent: (PocketCastsP
         }
     }
 
-    override suspend fun isPlaying(): Boolean {
-        return withContext(Dispatchers.Main) {
-            isMediaLoaded && (remoteMediaClient?.isPlaying ?: false)
-        }
-    }
+    override fun isPlaying(): Boolean =
+        isMediaLoaded && (remoteMediaClient?.isPlaying ?: false)
 
-    override suspend fun bufferedUpToMs(): Int {
-        return 0
-    }
+    override suspend fun bufferedUpToMs(): Int = 0
 
-    override suspend fun bufferedPercentage(): Int {
-        return 0
-    }
+    override suspend fun bufferedPercentage(): Int = 0
 
-    override suspend fun durationMs(): Int? {
-        return episode?.durationMs
-    }
+    override suspend fun durationMs(): Int? = episode?.durationMs
 
-    override suspend fun isBuffering(): Boolean {
-        return state == PlaybackStateCompat.STATE_BUFFERING
-    }
+    override suspend fun isBuffering(): Boolean =
+        state == PlaybackStateCompat.STATE_BUFFERING
 
     override suspend fun getCurrentPositionMs(): Int {
         return withContext(Dispatchers.Main) {
@@ -131,8 +126,7 @@ class CastPlayer(val context: Context, override val onPlayerEvent: (PocketCastsP
         }
     }
 
-    override suspend fun load(currentPositionMs: Int) {
-    }
+    override suspend fun load(currentPositionMs: Int) {}
 
     override suspend fun play(currentPositionMs: Int) {
         withContext(Dispatchers.Main) {
@@ -143,33 +137,23 @@ class CastPlayer(val context: Context, override val onPlayerEvent: (PocketCastsP
         }
     }
 
-    override suspend fun pause() {
-        withContext(Dispatchers.Main) {
-            if (isMediaLoaded) {
-                remoteMediaClient?.pause()
-            }
+    override fun pause() {
+        if (isMediaLoaded) {
+            remoteMediaClient?.pause()
         }
     }
 
-    override suspend fun stop() {
-        withContext(Dispatchers.Main) {
-            state = PlaybackStateCompat.STATE_STOPPED
-            remoteListenerAdded = false
-            remoteMediaClient?.unregisterCallback(remoteMediaClientListener)
-        }
+    override fun stop() {
+        state = PlaybackStateCompat.STATE_STOPPED
+        remoteListenerAdded = false
+        remoteMediaClient?.unregisterCallback(remoteMediaClientListener)
     }
 
-    override fun supportsTrimSilence(): Boolean {
-        return false
-    }
+    override fun supportsTrimSilence(): Boolean = false
 
-    override fun supportsVolumeBoost(): Boolean {
-        return false
-    }
+    override fun supportsVolumeBoost(): Boolean = false
 
-    override fun supportsVideo(): Boolean {
-        return true
-    }
+    override fun supportsVideo(): Boolean = true
 
     override suspend fun seekToTimeMs(positionMs: Int) {
         withContext(Dispatchers.Main) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -60,8 +60,6 @@ class CastPlayer(
             TextUtils.equals(localEpisodeUuid, remoteEpisodeUuid) &&
             state != PlaybackStateCompat.STATE_NONE && state != PlaybackStateCompat.STATE_STOPPED
 
-    override var episodeLocation: EpisodeLocation? = null
-
     override val isRemote: Boolean
         get() = true
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FocusManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FocusManager.kt
@@ -9,7 +9,6 @@ import androidx.media.AudioFocusRequestCompat
 import androidx.media.AudioManagerCompat
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
-import timber.log.Timber
 
 /**
  * Manages the focus of the player by tracking audio focus and audio noisy events.
@@ -114,7 +113,7 @@ open class FocusManager(private val settings: Settings, context: Context?) : Aud
 
     override fun onAudioFocusChange(focusChange: Int) {
         // map to our own focus status
-        if (focusChange == AudioManager.AUDIOFOCUS_GAIN ||
+        /*if (focusChange == AudioManager.AUDIOFOCUS_GAIN ||
             focusChange == AudioManager.AUDIOFOCUS_GAIN_TRANSIENT ||
             focusChange == AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK ||
             focusChange == AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE
@@ -147,7 +146,7 @@ open class FocusManager(private val settings: Settings, context: Context?) : Aud
             focusChangeListener?.onFocusRequestFailed()
         } else {
             Timber.w("onAudioFocusChange: Ignoring unsupported focusChange: %d", focusChange)
-        }
+        }*/
     }
 
     fun canDuck(): Boolean {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LocalPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LocalPlayer.kt
@@ -1,19 +1,24 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
 import android.os.SystemClock
+import androidx.media3.common.Player
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlin.math.abs
 
 /**
  * Manages audio focus with local media player.
  */
-abstract class LocalPlayer(override val onPlayerEvent: (PocketCastsPlayer, PlayerEvent) -> Unit) : PocketCastsPlayer {
+abstract class LocalPlayer(
+    override val onPlayerEvent: (PocketCastsPlayer, PlayerEvent) -> Unit,
+    player: Player,
+) : PocketCastsPlayer, Player by player {
 
     companion object {
-        // The volume we set the media player to seekToTimeMswhen we lose audio focus, but are allowed to reduce the volume instead of stopping playback.
+        // The volume we set the media player to seekToTimeMs when we lose audio focus, but are allowed to reduce the volume instead of stopping playback.
         const val VOLUME_DUCK = 1.0f // We don't actually duck the volume
         // The volume we set the media player when we have audio focus.
         const val VOLUME_NORMAL = 1.0f
@@ -78,21 +83,17 @@ abstract class LocalPlayer(override val onPlayerEvent: (PocketCastsPlayer, Playe
         }
     }
 
-    override suspend fun pause() {
-        withContext(Dispatchers.Main) {
-            if (isPlaying()) {
-                handlePause()
-                positionMs = handleCurrentPositionMs()
-            }
-            onPlayerEvent(this@LocalPlayer, PlayerEvent.PlayerPaused)
+    override fun pause() {
+        if (isPlaying) {
+            handlePause()
+            positionMs = handleCurrentPositionMs()
         }
+        onPlayerEvent(this@LocalPlayer, PlayerEvent.PlayerPaused)
     }
 
-    override suspend fun stop() {
-        withContext(Dispatchers.Main) {
-            positionMs = handleCurrentPositionMs()
-            handleStop()
-        }
+    override fun stop() {
+        positionMs = handleCurrentPositionMs()
+        handleStop()
     }
 
     override suspend fun getCurrentPositionMs(): Int {
@@ -106,16 +107,16 @@ abstract class LocalPlayer(override val onPlayerEvent: (PocketCastsPlayer, Playe
     }
 
     private suspend fun playIfAllowed() {
-        setVolume(VOLUME_NORMAL)
+        volume = VOLUME_NORMAL
 
         // already playing?
-        if (isPlaying()) {
+        if (isPlaying) {
             onPlayerEvent(this, PlayerEvent.PlayerPlaying)
         } else {
-            // check the player is seeked to the correct position
+            // check the player seeks to the correct position
             val playerPositionMs = getCurrentPositionMs()
             // check if the player is where it's meant to be, allow for a 2 second variance
-            if (Math.abs(positionMs - playerPositionMs) > 2000) {
+            if (abs(positionMs - playerPositionMs) > 2000) {
                 onSeekStart(positionMs)
                 handleSeekToTimeMs(positionMs)
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LocalPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LocalPlayer.kt
@@ -29,10 +29,6 @@ abstract class LocalPlayer(
     private var seekingToPositionMs: Int = 0
     private var seekRetryAllowed: Boolean = false
 
-    protected var isHLS: Boolean = false
-
-    override var episodeLocation: EpisodeLocation? = null
-
     override val isRemote: Boolean
         get() = false
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -544,7 +544,7 @@ open class PlaybackManager @Inject constructor(
 
         cancelUpdateTimer()
 
-        launch {
+        launch(Dispatchers.Main) {
             pocketCastsPlayer?.pause()
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -37,7 +37,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper.removeEpisodeFromQueue
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
-import au.com.shiftyjelly.pocketcasts.repositories.playback.LocalPlayer.Companion.VOLUME_DUCK
 import au.com.shiftyjelly.pocketcasts.repositories.playback.LocalPlayer.Companion.VOLUME_NORMAL
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
@@ -1241,7 +1240,7 @@ open class PlaybackManager @Inject constructor(
     }
 
     override fun onFocusLoss(mayDuck: Boolean, transientLoss: Boolean) {
-        val player = pocketCastsPlayer
+        /*val player = pocketCastsPlayer
         if (player == null || player.isRemote) {
             return
         }
@@ -1260,22 +1259,22 @@ open class PlaybackManager @Inject constructor(
         // check if we need to reduce the volume
         if (focusManager.canDuck()) {
             player.setVolume(VOLUME_DUCK)
-        }
+        }*/
     }
 
     override fun onFocusRequestFailed() {
-        LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Could not get audio focus, stopping")
-        stopAsync(isAudioFocusFailed = true)
+//        LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Could not get audio focus, stopping")
+//        stopAsync(isAudioFocusFailed = true)
     }
 
     override fun onAudioBecomingNoisy() {
-        val player = pocketCastsPlayer
-        if (player == null || player.isRemote) {
-            return
-        }
-        LogBuffer.i(LogBuffer.TAG_PLAYBACK, "System fired 'Audio Becoming Noisy' event, pausing playback.")
-        pause(playbackSource = AnalyticsSource.AUTO_PAUSE)
-        focusWasPlaying = null
+//        val player = pocketCastsPlayer
+//        if (player == null || player.isRemote) {
+//            return
+//        }
+//        LogBuffer.i(LogBuffer.TAG_PLAYBACK, "System fired 'Audio Becoming Noisy' event, pausing playback.")
+//        pause(playbackSource = AnalyticsSource.AUTO_PAUSE)
+//        focusWasPlaying = null
     }
 
     /** PRIVATE METHODS  */

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -137,7 +137,7 @@ open class PlaybackService : MediaLibraryService(), CoroutineScope {
     open var librarySessionCallback: MediaLibrarySession.Callback = CustomMediaLibrarySessionCallback()
 
     private lateinit var mediaLibrarySession: MediaLibrarySession
-    private lateinit var player: ExoPlayer
+    private lateinit var localPlayer: ExoPlayer
 
     private var mediaControllerCallback: MediaControllerCallback? = null
     lateinit var notificationManager: PlayerNotificationManager
@@ -167,9 +167,9 @@ open class PlaybackService : MediaLibraryService(), CoroutineScope {
     }
 
     private fun initializeSessionAndPlayer() {
-        player = createExoPlayer()
+        localPlayer = createExoPlayer()
 
-        val mediaSessionBuilder = MediaLibrarySession.Builder(this, player, librarySessionCallback)
+        val mediaSessionBuilder = MediaLibrarySession.Builder(this, localPlayer, librarySessionCallback)
         if (!Util.isAutomotive(this)) { // We can't start activities on automotive
             mediaSessionBuilder.setSessionActivity(this.getLaunchActivityPendingIntent())
         }
@@ -235,6 +235,8 @@ open class PlaybackService : MediaLibraryService(), CoroutineScope {
 
     override fun onDestroy() {
         super.onDestroy()
+        mediaLibrarySession.release()
+        localPlayer.release()
 
         disposables.clear()
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactory.kt
@@ -1,7 +1,16 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
+import androidx.media3.common.Player
+
 interface PlayerFactory {
 
-    fun createCastPlayer(onPlayerEvent: (PocketCastsPlayer, PlayerEvent) -> Unit): PocketCastsPlayer
-    fun createSimplePlayer(onPlayerEvent: (PocketCastsPlayer, PlayerEvent) -> Unit): PocketCastsPlayer
+    fun createSimplePlayer(
+        onPlayerEvent: (PocketCastsPlayer, PlayerEvent) -> Unit,
+        player: Player,
+    ): PocketCastsPlayer
+
+    fun createCastPlayer(
+        onPlayerEvent: (PocketCastsPlayer, PlayerEvent) -> Unit,
+        player: Player,
+    ): PocketCastsPlayer
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactoryImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactoryImpl.kt
@@ -1,6 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
 import android.content.Context
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -12,14 +14,28 @@ class PlayerFactoryImpl @Inject constructor(
     @ApplicationContext private val context: Context
 ) : PlayerFactory {
 
-    override fun createCastPlayer(onPlayerEvent: (PocketCastsPlayer, PlayerEvent) -> Unit): PocketCastsPlayer {
+    override fun createCastPlayer(
+        onPlayerEvent: (PocketCastsPlayer, PlayerEvent) -> Unit,
+        player: Player,
+    ): PocketCastsPlayer {
         return CastPlayer(
-            context,
-            onPlayerEvent
+            context = context,
+            onPlayerEvent = onPlayerEvent,
+            player = player,
         )
     }
 
-    override fun createSimplePlayer(onPlayerEvent: (PocketCastsPlayer, PlayerEvent) -> Unit): PocketCastsPlayer {
-        return SimplePlayer(settings, statsManager, context, onPlayerEvent)
+    @UnstableApi
+    override fun createSimplePlayer(
+        onPlayerEvent: (PocketCastsPlayer, PlayerEvent) -> Unit,
+        player: Player,
+    ): PocketCastsPlayer {
+        return SimplePlayer(
+            settings = settings,
+            statsManager = statsManager,
+            context = context,
+            onPlayerEvent = onPlayerEvent,
+            player = player,
+        )
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsPlayer.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
+import androidx.media3.common.Player
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
@@ -9,7 +10,7 @@ sealed class EpisodeLocation {
     data class Downloaded(val filePath: String?) : EpisodeLocation()
 }
 
-interface PocketCastsPlayer {
+interface PocketCastsPlayer : Player {
     var isPip: Boolean
     val isRemote: Boolean
     val isStreaming: Boolean
@@ -23,11 +24,8 @@ interface PocketCastsPlayer {
     suspend fun load(currentPositionMs: Int)
     suspend fun getCurrentPositionMs(): Int
     suspend fun play(currentPositionMs: Int)
-    suspend fun pause()
-    suspend fun stop()
     suspend fun setPlaybackEffects(playbackEffects: PlaybackEffects)
     suspend fun seekToTimeMs(positionMs: Int)
-    suspend fun isPlaying(): Boolean
     suspend fun isBuffering(): Boolean
     suspend fun durationMs(): Int?
     suspend fun bufferedUpToMs(): Int
@@ -35,7 +33,6 @@ interface PocketCastsPlayer {
     fun supportsTrimSilence(): Boolean
     fun supportsVolumeBoost(): Boolean
     fun supportsVideo(): Boolean
-    fun setVolume(volume: Float)
     fun setPodcast(podcast: Podcast?)
     fun setEpisode(episode: Playable)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsPlayer.kt
@@ -15,9 +15,7 @@ interface PocketCastsPlayer : Player {
     val isRemote: Boolean
     val isStreaming: Boolean
     var episodeLocation: EpisodeLocation?
-    val filePath: String?
-    val url: String?
-    val episodeUuid: String?
+    var playable: Playable?
     val name: String
     val onPlayerEvent: (PocketCastsPlayer, PlayerEvent) -> Unit
 
@@ -34,5 +32,4 @@ interface PocketCastsPlayer : Player {
     fun supportsVolumeBoost(): Boolean
     fun supportsVideo(): Boolean
     fun setPodcast(podcast: Podcast?)
-    fun setEpisode(episode: Playable)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsPlayer.kt
@@ -5,16 +5,10 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 
-sealed class EpisodeLocation {
-    data class Stream(val uri: String?) : EpisodeLocation()
-    data class Downloaded(val filePath: String?) : EpisodeLocation()
-}
-
 interface PocketCastsPlayer : Player {
     var isPip: Boolean
     val isRemote: Boolean
     val isStreaming: Boolean
-    var episodeLocation: EpisodeLocation?
     var playable: Playable?
     val name: String
     val onPlayerEvent: (PocketCastsPlayer, PlayerEvent) -> Unit

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -23,6 +23,7 @@ import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.mp3.Mp3Extractor
+import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -60,6 +61,8 @@ class SimplePlayer(
     override var isPip: Boolean = false
 
     private var videoChangedListener: VideoChangedListener? = null
+
+    override var playable: Playable? = null
 
     @Volatile
     private var prepared = false
@@ -184,7 +187,7 @@ class SimplePlayer(
         setPlayerEffects()
         player.addListener(object : Player.Listener {
             override fun onTracksChanged(tracks: Tracks) {
-                val episodeMetadata = EpisodeFileMetadata(filenamePrefix = episodeUuid)
+                val episodeMetadata = EpisodeFileMetadata(filenamePrefix = playable?.uuid)
                 episodeMetadata.read(tracks, settings, context)
                 onMetadataAvailable(episodeMetadata)
             }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.wear
 
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
+import androidx.media3.common.util.UnstableApi
 import androidx.work.Configuration
 import au.com.shiftyjelly.pocketcasts.BuildConfig
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
@@ -11,6 +12,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.file.StorageOptions
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackService
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -63,7 +65,7 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
             notificationHelper.setupNotificationChannels()
 
             withContext(Dispatchers.Default) {
-                playbackManager.setup()
+                playbackManager.setup(playbackService)
                 downloadManager.setup(episodeManager, podcastManager, playlistManager, playbackManager)
 
                 val storageChoice = settings.getStorageChoice()
@@ -95,5 +97,10 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
             .setExecutor(Executors.newFixedThreadPool(3))
             .setJobSchedulerJobIdRange(1000, 20000)
             .build()
+    }
+
+    companion object {
+        @UnstableApi
+        val playbackService = PlaybackService::class.java
     }
 }


### PR DESCRIPTION
Parent https://github.com/Automattic/pocket-casts-android/issues/887

## Description

This PR migrates
- Existing `LocalPlayer` and `CastPlayer` to implement media3 common `Player` interface.
- Local player (`ExoPlayer`) instantiation to `PlaybackService` so that it can be set on the media3 library session.

** Switching to media3 `CastPlayer` in the session will be taken up in a future PR.

## Testing Instructions
- CI is green
- Media can be played
