### PR TITLE
Opt-in to UnstableApis instead of creating UnstableApis

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -264,7 +264,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
     }
 
     companion object {
-        @UnstableApi
+        @androidx.annotation.OptIn(UnstableApi::class)
         val playbackService = PlaybackService::class.java
     }
 }

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
@@ -48,7 +48,7 @@ const val PROFILE_FILES = "__PROFILE_FILES__"
 const val PROFILE_STARRED = "__PROFILE_STARRED__"
 const val PROFILE_LISTENING_HISTORY = "__LISTENING_HISTORY__"
 
-@UnstableApi
+@androidx.annotation.OptIn(UnstableApi::class)
 @SuppressLint("LogNotTimber")
 @AndroidEntryPoint
 open class AutoPlaybackService : PlaybackService() {

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
@@ -122,7 +122,7 @@ class AutomotiveApplication : Application(), Configuration.Provider {
     }
 
     companion object {
-        @UnstableApi
+        @androidx.annotation.OptIn(UnstableApi::class)
         val playbackService = AutoPlaybackService::class.java
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
@@ -11,7 +11,6 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.media3.common.util.UnstableApi
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentVideoBinding
 import au.com.shiftyjelly.pocketcasts.player.view.PlayerSeekBar
@@ -157,7 +156,6 @@ class VideoFragment : Fragment(), PlayerSeekBar.OnUserSeekListener {
     override fun onSeekPositionChanging(progress: Int) {
     }
 
-    @UnstableApi
     override fun onSeekPositionChangeStop(progress: Int, seekComplete: () -> Unit) {
         viewModel.seekToMs(progress)
         playbackManager.trackPlaybackSeek(progress, AnalyticsSource.FULL_SCREEN_VIDEO)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoView.kt
@@ -22,7 +22,7 @@ class VideoView @JvmOverloads constructor(context: Context, attrs: AttributeSet?
         }
 
     private val view = LayoutInflater.from(context).inflate(R.layout.video_view, this, true)
-    @UnstableApi
+    @androidx.annotation.OptIn(UnstableApi::class)
     private val aspectRatioLayout = view.findViewById<AspectRatioFrameLayout>(R.id.aspectRatioLayout).apply {
         setAspectRatio(1.78f)
     }
@@ -64,7 +64,7 @@ class VideoView @JvmOverloads constructor(context: Context, attrs: AttributeSet?
         }
     }
 
-    @UnstableApi
+    @androidx.annotation.OptIn(UnstableApi::class)
     override fun videoSizeChanged(width: Int, height: Int, pixelWidthHeightRatio: Float) {
         val videoAspectRatio = if (height == 0 || width == 0) 1f else width * pixelWidthHeightRatio / height
         aspectRatioLayout.setAspectRatio(videoAspectRatio)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -163,7 +163,6 @@ class AddFileActivity :
         binding.upgradeLayout.root.isVisible = readOnly && !settings.getUpgradeClosedAddFile() && !loading
     }
 
-    @UnstableApi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         theme.setupThemeForConfig(this, resources.configuration)
@@ -294,7 +293,6 @@ class AddFileActivity :
         startActivity(OnboardingActivity.newInstance(this, onboardingFlow))
     }
 
-    @UnstableApi
     @Suppress("NAME_SHADOWING")
     private fun setupForNewFile(fileUri: Uri?) {
         val fileUri = fileUri ?: return
@@ -372,7 +370,6 @@ class AddFileActivity :
         binding.btnImage.text = getString(LR.string.profile_files_add_custom_image)
     }
 
-    @UnstableApi
     @Suppress("DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
@@ -671,7 +668,7 @@ class AddFileActivity :
         startActivityForResult(Intent.createChooser(intent, "Select Picture"), ACTION_PICK_IMAGE)
     }
 
-    @UnstableApi
+    @androidx.annotation.OptIn(UnstableApi::class)
     private fun preparePlayer(uri: Uri) {
         val loadControl = DefaultLoadControl.Builder().setBufferDurationsMs(0, 0, 0, 0).build()
         val player = ExoPlayer.Builder(this).setLoadControl(loadControl).build()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/extensions/MediaMetadataCompatExt.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/extensions/MediaMetadataCompatExt.kt
@@ -232,7 +232,7 @@ inline val MediaMetadataCompat.fullDescription
  *
  * For convenience, place the [MediaDescriptionCompat] into the tag so it can be retrieved later.
  */
-@UnstableApi
+@androidx.annotation.OptIn(UnstableApi::class)
 fun MediaMetadataCompat.toMediaSource(dataSourceFactory: DataSource.Factory) =
     ProgressiveMediaSource.Factory(dataSourceFactory)
         .createMediaSource(
@@ -247,11 +247,10 @@ fun MediaMetadataCompat.toMediaSource(dataSourceFactory: DataSource.Factory) =
  * Extension method for building a [ConcatenatingMediaSource] given a [List]
  * of [MediaMetadataCompat] objects.
  */
-@UnstableApi
+@androidx.annotation.OptIn(UnstableApi::class)
 fun List<MediaMetadataCompat>.toMediaSource(
     dataSourceFactory: DataSource.Factory
 ): ConcatenatingMediaSource {
-
     val concatenatingMediaSource = ConcatenatingMediaSource()
     forEach {
         concatenatingMediaSource.addMediaSource(it.toMediaSource(dataSourceFactory))

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeFileMetadata.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeFileMetadata.kt
@@ -20,6 +20,7 @@ import java.io.FileOutputStream
 import java.io.IOException
 import java.util.Collections
 
+@androidx.annotation.OptIn(UnstableApi::class)
 class EpisodeFileMetadata(val filenamePrefix: String? = null) {
 
     companion object {
@@ -37,12 +38,10 @@ class EpisodeFileMetadata(val filenamePrefix: String? = null) {
     var embeddedTitle: String? = null
     var embeddedLength: Long? = null
 
-    @UnstableApi
     fun read(tracks: Tracks?, settings: Settings, context: Context) {
         return read(tracks, settings.getUseEmbeddedArtwork(), context)
     }
 
-    @UnstableApi
     fun read(tracks: Tracks?, loadArtwork: Boolean, context: Context) {
         val newChapters = mutableListOf<Chapter>()
         embeddedArtworkPath = null
@@ -85,7 +84,6 @@ class EpisodeFileMetadata(val filenamePrefix: String? = null) {
         }
     }
 
-    @UnstableApi
     private fun convertFrameToChapter(frame: ChapterFrame?, chapterIndex: Int, context: Context): Chapter? {
         if (frame == null || frame.startTimeMs < 0) {
             return null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -107,7 +107,7 @@ const val CONTENT_STYLE_GRID_ITEM_HINT_VALUE = 2
 private const val EPISODE_LIMIT = 100
 private const val NUM_SUGGESTED_ITEMS = 8
 
-@UnstableApi
+@androidx.annotation.OptIn(UnstableApi::class)
 @AndroidEntryPoint
 open class PlaybackService : MediaLibraryService(), CoroutineScope {
     inner class LocalBinder : Binder() {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactoryImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactoryImpl.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 
 import android.content.Context
 import androidx.media3.common.Player
-import androidx.media3.common.util.UnstableApi
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -25,7 +24,6 @@ class PlayerFactoryImpl @Inject constructor(
         )
     }
 
-    @UnstableApi
     override fun createSimplePlayer(
         onPlayerEvent: (PocketCastsPlayer, PlayerEvent) -> Unit,
         player: Player,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -12,7 +12,6 @@ import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.Tracks
 import androidx.media3.common.VideoSize
-import androidx.media3.common.util.UnstableApi
 import au.com.shiftyjelly.pocketcasts.models.entity.Playable
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
@@ -23,7 +22,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
-@UnstableApi
 class SimplePlayer(
     val settings: Settings,
     val statsManager: StatsManager,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/AutoConverter.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/AutoConverter.kt
@@ -64,7 +64,7 @@ data class AutoMediaId(
     }
 }
 
-@UnstableApi
+@androidx.annotation.OptIn(UnstableApi::class)
 object AutoConverter {
 
     private const val THUMBNAIL_IMAGE_SIZE = 200

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -100,7 +100,7 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
     }
 
     companion object {
-        @UnstableApi
+        @androidx.annotation.OptIn(UnstableApi::class)
         val playbackService = PlaybackService::class.java
     }
 }


### PR DESCRIPTION
## Description
When using `@UnstableApi` when we use an unstable api, anything that uses the annotated method/class will now also get a lint warning. For that reason, I think we should switch to using the not-at-all-pleasant-to-type-or-remember `@androidx.annotation.OptIn(UnstableApi::class)`. Using that does not create lint warnings for callers of the annotated class/method. That's why I was actually able to remove a number of annotations entirely in this PR.

Alternatively, we could just add a rule to ignore this lint warning throughout the project. I'm not at all strongly opposed to that, but since I didn't feel strongly I figured I'd keep the lint check so we're at least aware when we use an unstable API in a new place. Like I said, I don't feel strongly though, so if you'd rather ignore the rule entirely just let me know and I'll make that change.

## Testing Instructions
If CI is happy then we should be good.