### PR TITLE
Remove bufferedUpToMs method

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -98,8 +98,6 @@ class CastPlayer(
     override fun isPlaying(): Boolean =
         isMediaLoaded && (remoteMediaClient?.isPlaying ?: false)
 
-    override suspend fun bufferedUpToMs(): Int = 0
-
     override suspend fun bufferedPercentage(): Int = 0
 
     override suspend fun durationMs(): Int? = episode?.durationMs

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsPlayer.kt
@@ -20,7 +20,6 @@ interface PocketCastsPlayer : Player {
     suspend fun seekToTimeMs(positionMs: Int)
     suspend fun isBuffering(): Boolean
     suspend fun durationMs(): Int?
-    suspend fun bufferedUpToMs(): Int
     suspend fun bufferedPercentage(): Int
     fun supportsTrimSilence(): Boolean
     fun supportsVolumeBoost(): Boolean

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -47,12 +47,6 @@ class SimplePlayer(
     @Volatile
     private var prepared = false
 
-    override suspend fun bufferedUpToMs(): Int {
-        return withContext(Dispatchers.Main) {
-            player.bufferedPosition.toInt()
-        }
-    }
-
     override suspend fun bufferedPercentage(): Int {
         return withContext(Dispatchers.Main) {
             player.bufferedPercentage


### PR DESCRIPTION
## Description
The `PocketCastsPlayer::bufferedUpToMs` method is basically just exposing the `Player::getBufferedPosition` method. Since `PocketCastsPlayer` now implements `Player`, I think we can drop that method. There are other methods that we can do this with, but I limited it to just the one method for this PR so you can see what it looks like without too much noise and let me know if you're on board with moving in this direction.

The benefits of this change are that it removes some code, and gives us a more consistent interface since the `PocketCastsPlayer` would only have one method (via `Player`) for obtaining the bufferedMs position.

The negative of this change is that our implementation of `PocketCastsPlayer::bufferedUpToMs` took care of making sure it was executed on the main thread. We lose that by relying on the (non-suspending) `Player::getBufferedPosition` method. Personally, I think this is ok because essentially the `PlaybackManager` is already our gateway to playback commands and it will just now be the point that is responsible for ensuring that calls to the player are made on the correct thread (and it can do it once for all the `PocketCastsPlayer` implementations instead of each implementation having to handle it separately). In an ideal world I would personally prefer to have the `Player` take care of that itself, but since we can't change that I think having the `PlaybackManager` handle it makes sense.

An alternative approach would be to no longer expose the `Player` interface from `PocketCastsPlayer` and to wrap all the `Player` methods we need in `PocketCastsPlayer`. This doesn't seem like an awful idea, but it will lead to a lot of code most likely and I'm not sure that the benefits of having the `Player` instead of the `PlaybackManager` manage the proper threading for its calls is worth it.

What do you think? If you like this direction, I'll do a follow-up PR removing some more of the now duplicate (imo) `PocketCastsPlayer` methods.

## Testing Instructions
1. Load up a podcast episode and jump to some different positions in the episode.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews

