### PR TITLE
Remove bufferedPercentage and handleCurrentPositionMs methods

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -98,8 +98,6 @@ class CastPlayer(
     override fun isPlaying(): Boolean =
         isMediaLoaded && (remoteMediaClient?.isPlaying ?: false)
 
-    override suspend fun bufferedPercentage(): Int = 0
-
     override suspend fun durationMs(): Int? = episode?.durationMs
 
     override suspend fun isBuffering(): Boolean =

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LocalPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LocalPlayer.kt
@@ -45,7 +45,6 @@ abstract class LocalPlayer(
     abstract fun handleSeekToTimeMs(positionMs: Int)
     abstract fun handleIsBuffering(): Boolean
     abstract fun handleIsPrepared(): Boolean
-    abstract fun handleCurrentPositionMs(): Int
 
     override suspend fun load(currentPositionMs: Int) {
         withContext(Dispatchers.Main) {
@@ -74,19 +73,19 @@ abstract class LocalPlayer(
     override fun pause() {
         if (isPlaying) {
             handlePause()
-            positionMs = handleCurrentPositionMs()
+            positionMs = currentPosition.toInt()
         }
         onPlayerEvent(this@LocalPlayer, PlayerEvent.PlayerPaused)
     }
 
     override fun stop() {
-        positionMs = handleCurrentPositionMs()
+        positionMs = currentPosition.toInt()
         handleStop()
     }
 
     override suspend fun getCurrentPositionMs(): Int {
         return withContext(Dispatchers.Main) {
-            handleCurrentPositionMs()
+            currentPosition.toInt()
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsPlayer.kt
@@ -20,7 +20,6 @@ interface PocketCastsPlayer : Player {
     suspend fun seekToTimeMs(positionMs: Int)
     suspend fun isBuffering(): Boolean
     suspend fun durationMs(): Int?
-    suspend fun bufferedPercentage(): Int
     fun supportsTrimSilence(): Boolean
     fun supportsVolumeBoost(): Boolean
     fun supportsVideo(): Boolean

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -45,12 +45,6 @@ class SimplePlayer(
     @Volatile
     private var prepared = false
 
-    override suspend fun bufferedPercentage(): Int {
-        return withContext(Dispatchers.Main) {
-            player.bufferedPercentage
-        }
-    }
-
     override suspend fun durationMs(): Int? {
         return withContext(Dispatchers.Main) {
             val duration = player.duration

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -54,8 +54,6 @@ class SimplePlayer(
 
     override fun isPlaying(): Boolean = player.playWhenReady
 
-    override fun handleCurrentPositionMs(): Int = player.currentPosition.toInt()
-
     override fun handlePrepare() {
         if (prepared) {
             return


### PR DESCRIPTION
## Description
Just trying to simplify a bit more by relying directly on the `Player` interface. Again, there's more that could be done here, but I want to keep these PRs small.

## Testing Instructions
Play a podcast and skip around a bit in the episode.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews