### PR TITLE
Fix downloading cloud files

### DIFF
--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
@@ -228,7 +228,7 @@ open class SyncServerManager @Inject constructor(
         server.deleteFile(addBearer(token), episode.uuid)
 
     fun getPlaybackUrl(episode: UserEpisode, token: AccessToken): Single<String> =
-        Single.just("${Settings.SERVER_API_URL}/files/url/${episode.uuid}?token=$token")
+        Single.just("${Settings.SERVER_API_URL}/files/url/${episode.uuid}?token=${token.value}")
 
     fun getUserEpisode(uuid: String, token: AccessToken): Single<Response<ServerFile>> =
         server.getFile(addBearer(token), uuid)


### PR DESCRIPTION
3787dbd introduced AccessToken, missed a conversion to token.value

## Description
The latest Android beta can't download cloud files, looking in the debug log the requests being made are:

```
E 21/4 19:03:43 Invalid response returned for episode download. 400  hxxps://api.pocketcasts.com/files/url/62743f70-e11c-11ed-8408-2f2a325ada1f?token=AccessToken(value=eyJ0eX...)
```

when they should be:
```
hxxps://api.pocketcasts.com/files/url/62743f70-e11c-11ed-8408-2f2a325ada1f?token=eyJ0eX...
```

Fixes # <!-- issue number, if applicable -->

## Testing Instructions
Use a Plus account with files uploaded to the cloud but not on the local device, try downloading or streaming, confirm that you're no longer getting HTTP/400 responses

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
