### PR TITLE
Fix shownote's timestamp not getting parsed when there's a link

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/views/helper/ShowNotesHelperTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/views/helper/ShowNotesHelperTest.kt
@@ -36,5 +36,30 @@ class ShowNotesHelperTest {
         actual = ShowNotesHelper.convertTimesToLinks("<li><a href=\"https://www.theverge.com/2021/12/21/22848957/lg-dualup-32-inch-4k-ultra-fine-monitors-announced-specs\">LG’s new 16:18 monitor looks like a multitasking powerhouse</a></li>")
         expected = "<li><a href=\"https://www.theverge.com/2021/12/21/22848957/lg-dualup-32-inch-4k-ultra-fine-monitors-announced-specs\">LG’s new 16:18 monitor looks like a multitasking powerhouse</a></li>"
         assertEquals(actual, expected)
+
+        actual = ShowNotesHelper.convertTimesToLinks("<p>Example <a>10:30</a></p>")
+        expected = "<p>Example <a>10:30</a></p>"
+        assertEquals(expected, actual)
+
+        // Replace the timestamp if it is outside the <a> tag - https://github.com/Automattic/pocket-casts-android/issues/814
+        actual = ShowNotesHelper.convertTimesToLinks("<p>Example 00:00 <a href=\"https://example.com\">Link</a></p>")
+        expected = "<p>Example <a href=\"http://localhost/#playerJumpTo=00:00\">00:00</a> <a href=\"https://example.com\">Link</a></p>"
+        assertEquals(expected, actual)
+
+        actual = ShowNotesHelper.convertTimesToLinks("<p>Example 00:00 <a>Link</a></p>")
+        expected = "<p>Example <a href=\"http://localhost/#playerJumpTo=00:00\">00:00</a> <a>Link</a></p>"
+        assertEquals(expected, actual)
+
+        actual = ShowNotesHelper.convertTimesToLinks("<p>Example 00:00 <a href=\"https://example00:80.com\">Link</a></p>")
+        expected = "<p>Example <a href=\"http://localhost/#playerJumpTo=00:00\">00:00</a> <a href=\"https://example00:80.com\">Link</a></p>"
+        assertEquals(expected, actual)
+
+        actual = ShowNotesHelper.convertTimesToLinks("<p>Example 00:00 <a href=\"https://example.com\">10:30</a></p>")
+        expected = "<p>Example <a href=\"http://localhost/#playerJumpTo=00:00\">00:00</a> <a href=\"https://example.com\">10:30</a></p>"
+        assertEquals(expected, actual)
+
+        actual = ShowNotesHelper.convertTimesToLinks("<p>Example 00:00 <a>10:30</a></p>")
+        expected = "<p>Example <a href=\"http://localhost/#playerJumpTo=00:00\">00:00</a> <a>10:30</a></p>"
+        assertEquals(expected, actual)
     }
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ShowNotesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ShowNotesHelper.kt
@@ -15,7 +15,8 @@ object ShowNotesHelper {
 
     // searches for the first closing tag that comes after a potential timeskip and compares it to url closing tag (</a>)
     private fun matchIsInUrl(match: MatchResult, html: String): Boolean {
-        val closingTagRegex = "</\\w+>".toRegex()
-        return closingTagRegex.find(html.substring(match.range.first))?.value == "</a>"
+        // try to find by the <a> tag first (either <a href=...> or <a>)
+        val tagRegex = "<a(?:\\s|>)|</a>".toRegex()
+        return tagRegex.find(html.substring(match.range.first))?.value == "</a>"
     }
 }


### PR DESCRIPTION
## Description
"matchIsInUrl" was returning true even when the timestamp was outside of the URL.

- Fixes #814

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Pass an html like `<p>Example 00:00 <a href="https://example.com">Link</a></p>` to the `convertTimesToLinks` function.
2. It should return `<p>Example <a href="http://localhost/#playerJumpTo=00:00">00:00</a> <a href="https://example.com">Link</a></p>`.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
