### PR TITLE
Move downloads chip above filters on watch list

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
@@ -92,17 +92,17 @@ fun WatchListScreen(
 
         item {
             WatchListChip(
-                title = stringResource(LR.string.filters),
-                iconRes = IR.drawable.ic_filters,
-                onClick = { navigateToRoute(FiltersScreen.route) }
+                title = stringResource(LR.string.downloads),
+                iconRes = IR.drawable.ic_download,
+                onClick = { navigateToRoute(DownloadsScreen.route) }
             )
         }
 
         item {
             WatchListChip(
-                title = stringResource(LR.string.downloads),
-                iconRes = IR.drawable.ic_download,
-                onClick = { navigateToRoute(DownloadsScreen.route) }
+                title = stringResource(LR.string.filters),
+                iconRes = IR.drawable.ic_filters,
+                onClick = { navigateToRoute(FiltersScreen.route) }
             )
         }
 


### PR DESCRIPTION
## Description
Moving downloads to be above filters on the watch list. Note that Up Next is still in this list for the time being because the pager has not been created yet. 

Internal ref: pdeCcb-2Bu-p2

## Testing Instructions
1. Start up the watch app.
2. Verify that Downloads is between the "Up Next" and "Filters" chips.

![Screenshot 2023-04-23 at 5 57 10 AM](https://user-images.githubusercontent.com/4656348/233832919-e931d835-f92e-4bd1-bc09-47231e2c0f54.png)

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews