### PR TITLE
Hide Now Playing chip if nothing is playing

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
@@ -68,10 +68,12 @@ fun WatchListScreen(
             Spacer(Modifier)
         }
 
-        item {
-            NowPlayingChip(
-                onClick = { navigateToRoute(NowPlayingScreen.route) },
-            )
+        if (upNextState is UpNextQueue.State.Loaded) {
+            item {
+                NowPlayingChip(
+                    onClick = { navigateToRoute(NowPlayingScreen.route) },
+                )
+            }
         }
 
         item {


### PR DESCRIPTION
## Description
This hides the Now Playing chip if there is nothing playing.

Internal ref: pdeCcb-2Bu-p2

## Testing Instructions
1. Do a clean install of the watch app
2. Observe there is no "Now Playing" chip at the top of the watch's main list
3. Log into an account with an episode queued to play
4. Observe that the "Now Playing" chip is visible at the top of the watch's main list screen

| No episode queued | Episode queued |
| --- | --- |
| ![Screenshot 2023-04-23 at 6 11 39 AM](https://user-images.githubusercontent.com/4656348/233833656-820681f6-bae9-4a9a-b1b6-54512690456b.png) | ![Screenshot 2023-04-23 at 6 11 13 AM](https://user-images.githubusercontent.com/4656348/233833628-8267bd6d-42aa-4b4a-9c56-b025a706860c.png) |

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews