### PR TITLE
Hide custom skip buttons for an Automotive manufacturer

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -66,6 +66,8 @@ class MediaSessionManager(
     companion object {
         const val EXTRA_TRANSIENT = "pocketcasts_transient_loss"
 
+        private val MANUFACTURERS_TO_HIDE_CUSTOM_SKIP_BUTTONS = listOf("samsung", "mercedes-benz")
+
         fun calculateSearchQueryOptions(query: String): List<String> {
             val options = mutableListOf<String>()
             options.add(query)
@@ -787,7 +789,7 @@ class MediaSessionManager(
     // there's an issue on Samsung phones that if you don't say you support ACTION_SKIP_TO_PREVIOUS and ACTION_SKIP_TO_NEXT then the skip buttons on the lock screen are disabled.
     // we work around this by hiding our custom buttons on Samsung phones. It means the buttons in Android Auto aren't our custom skip buttons, but it all still works.
     private fun shouldHideCustomSkipButtons(): Boolean {
-        return Build.MANUFACTURER.lowercase() == "samsung"
+        return MANUFACTURERS_TO_HIDE_CUSTOM_SKIP_BUTTONS.contains(Build.MANUFACTURER.lowercase())
     }
 }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -66,7 +66,11 @@ class MediaSessionManager(
     companion object {
         const val EXTRA_TRANSIENT = "pocketcasts_transient_loss"
 
-        private val MANUFACTURERS_TO_HIDE_CUSTOM_SKIP_BUTTONS = listOf("samsung", "mercedes-benz")
+        // there's an issue on Samsung phones that if you don't say you support ACTION_SKIP_TO_PREVIOUS and
+        // ACTION_SKIP_TO_NEXT then the skip buttons on the lock screen are disabled. We work around this
+        // by hiding our custom buttons on Samsung phones. It means the buttons in Android Auto aren't our
+        // custom skip buttons, but it all still works.
+        private val MANUFACTURERS_TO_HIDE_CUSTOM_SKIP_BUTTONS = listOf("samsung", "mercedes-benz", "google")
 
         fun calculateSearchQueryOptions(query: String): List<String> {
             val options = mutableListOf<String>()
@@ -786,8 +790,6 @@ class MediaSessionManager(
         playbackManager.playNow(episode = latestEpisode, playbackSource = playbackSource)
     }
 
-    // there's an issue on Samsung phones that if you don't say you support ACTION_SKIP_TO_PREVIOUS and ACTION_SKIP_TO_NEXT then the skip buttons on the lock screen are disabled.
-    // we work around this by hiding our custom buttons on Samsung phones. It means the buttons in Android Auto aren't our custom skip buttons, but it all still works.
     private fun shouldHideCustomSkipButtons(): Boolean {
         return MANUFACTURERS_TO_HIDE_CUSTOM_SKIP_BUTTONS.contains(Build.MANUFACTURER.lowercase())
     }


### PR DESCRIPTION
## Description
After testing, a manufacturer using our Automotive build needs us to hide our custom skip buttons and instead say we respond to the playback events `ACTION_SKIP_TO_PREVIOUS` and `ACTION_SKIP_TO_NEXT`.

## Testing Instructions
1. Add "google" to the list of manufacturers `MANUFACTURERS_TO_HIDE_CUSTOM_SKIP_BUTTONS`
2. Deploy to the Google automotive emulator
3. Play an episode
4. ✅ Verify the skip buttons don't appear