### PR TITLE
Add pager to watch app

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -5,25 +5,16 @@ package au.com.shiftyjelly.pocketcasts.wear
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-<<<<<<< HEAD
+import androidx.activity.viewModels
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
-=======
-import androidx.activity.viewModels
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.tooling.preview.Devices
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
->>>>>>> origin/main
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import androidx.wear.compose.material.rememberSwipeToDismissBoxState
@@ -63,39 +54,32 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-<<<<<<< HEAD
-            WearAppTheme(theme.activeTheme) {
-                WearApp()
-            }
-=======
             val state by viewModel.state.collectAsState()
-            WearApp(
-                themeType = theme.activeTheme,
-                signInConfirmationAction = state.signInConfirmationAction,
-                onSignInConfirmationActionHandled = viewModel::onSignInConfirmationActionHandled,
-            )
->>>>>>> origin/main
+            WearAppTheme(theme.activeTheme) {
+                WearApp(
+                    signInConfirmationAction = state.signInConfirmationAction,
+                    onSignInConfirmationActionHandled = viewModel::onSignInConfirmationActionHandled,
+                )
+            }
         }
     }
 }
 
 @Composable
-<<<<<<< HEAD
-private fun WearApp() {
-=======
 fun WearApp(
-    themeType: Theme.ThemeType,
     signInConfirmationAction: SignInConfirmationAction?,
     onSignInConfirmationActionHandled: () -> Unit,
 ) {
-    WearAppTheme(themeType) {
-
-        val navController = rememberSwipeDismissableNavController()
->>>>>>> origin/main
 
     val navController = rememberSwipeDismissableNavController()
     val swipeToDismissState = rememberSwipeToDismissBoxState()
     val navState = rememberSwipeDismissableNavHostState(swipeToDismissState)
+
+    handleSignInConfirmation(
+        signInConfirmationAction = signInConfirmationAction,
+        onSignInConfirmationActionHandled = onSignInConfirmationActionHandled,
+        navController = navController
+    )
 
     WearNavScaffold(
         navController = navController,
@@ -142,77 +126,9 @@ fun WearApp(
         scrollable(
             route = PodcastsScreen.route,
         ) {
-
-<<<<<<< HEAD
             NowPlayingPager(
                 navController = navController,
                 swipeToDismissState = swipeToDismissState,
-=======
-            handleSignInConfirmation(
-                signInConfirmationAction = signInConfirmationAction,
-                onSignInConfirmationActionHandled = onSignInConfirmationActionHandled,
-                navController = navController
-            )
-
-            scrollable(
-                route = WatchListScreen.route,
-                columnStateFactory = ScalingLazyColumnDefaults.belowTimeText()
-            ) {
-                WatchListScreen(navController::navigate, it.scrollableState)
-            }
-
-            composable(NowPlayingScreen.route) {
-                it.timeTextMode = NavScaffoldViewModel.TimeTextMode.Off
-
-                // Listen for results from streaming confirmation screen
-                navController.currentBackStackEntry?.savedStateHandle
-                    ?.getStateFlow<StreamingConfirmationScreen.Result?>(StreamingConfirmationScreen.resultKey, null)
-                    ?.collectAsStateWithLifecycle()?.value?.let { streamingConfirmationResult ->
-                        val viewModel = hiltViewModel<NowPlayingViewModel>()
-                        LaunchedEffect(streamingConfirmationResult) {
-                            viewModel.onStreamingConfirmationResult(streamingConfirmationResult)
-                            // Clear result once consumed
-                            navController.currentBackStackEntry?.savedStateHandle
-                                ?.remove<StreamingConfirmationScreen.Result?>(StreamingConfirmationScreen.resultKey)
-                        }
-                    }
-
-                NowPlayingScreen(
-                    navigateToEpisode = { episodeUuid ->
-                        navController.navigate(EpisodeScreenFlow.navigateRoute(episodeUuid))
-                    },
-                    showStreamingConfirmation = { navController.navigate(StreamingConfirmationScreen.route) },
-                )
-            }
-
-            composable(StreamingConfirmationScreen.route) {
-                it.timeTextMode = NavScaffoldViewModel.TimeTextMode.Off
-
-                StreamingConfirmationScreen(
-                    onFinished = { result ->
-                        navController.previousBackStackEntry?.savedStateHandle?.set(
-                            StreamingConfirmationScreen.resultKey,
-                            result
-                        )
-                        navController.popBackStack()
-                    },
-                )
-            }
-
-            scrollable(
-                route = UpNextScreen.route,
-            ) {
-                UpNextScreen(
-                    navigateToEpisode = { episodeUuid ->
-                        navController.navigate(EpisodeScreenFlow.navigateRoute(episodeUuid))
-                    },
-                    listState = it.scrollableState,
-                )
-            }
-
-            scrollable(
-                route = PodcastsScreen.route,
->>>>>>> origin/main
             ) {
                 PodcastsScreen(
                     listState = it.scrollableState,
@@ -275,26 +191,6 @@ fun WearApp(
                     }
                 )
             }
-<<<<<<< HEAD
-=======
-
-            composable(FilesScreen.route) { FilesScreen() }
-
-            scrollable(SettingsScreen.route) {
-                SettingsScreen(
-                    scrollState = it.columnState,
-                    signInClick = { navController.navigate(authenticationSubGraph) },
-                )
-            }
-
-            authenticationGraph(navController)
-
-            composable(LoggingInScreen.route) {
-                LoggingInScreen(
-                    onClose = { navController.popBackStack() },
-                )
-            }
->>>>>>> origin/main
         }
 
         composable(FilesScreen.route) {
@@ -314,6 +210,12 @@ fun WearApp(
         }
 
         authenticationGraph(navController)
+
+        composable(LoggingInScreen.route) {
+            LoggingInScreen(
+                onClose = { navController.popBackStack() },
+            )
+        }
     }
 }
 
@@ -348,15 +250,8 @@ private fun handleSignInConfirmation(
 @Preview(device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
 @Composable
 fun DefaultPreview() {
-<<<<<<< HEAD
-    WearAppTheme(Theme.ThemeType.DARK) {
-        WearApp()
-    }
-=======
     WearApp(
-        themeType = Theme.ThemeType.DARK,
         signInConfirmationAction = null,
         onSignInConfirmationActionHandled = {},
     )
->>>>>>> origin/main
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalFoundationApi::class)
+
 package au.com.shiftyjelly.pocketcasts.wear
 
 import android.os.Bundle
@@ -10,7 +12,6 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -20,8 +21,6 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
-import androidx.wear.compose.material.SwipeToDismissBoxState
-import androidx.wear.compose.material.edgeSwipeToDismiss
 import androidx.wear.compose.material.rememberSwipeToDismissBoxState
 import androidx.wear.compose.navigation.SwipeDismissableNavHostState
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
@@ -43,7 +42,6 @@ import au.com.shiftyjelly.pocketcasts.wear.ui.player.NowPlayingViewModel
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.StreamingConfirmationScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcast.PodcastScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcasts.PodcastsScreen
-import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
 import com.google.android.horologist.compose.navscaffold.WearNavScaffold
 import com.google.android.horologist.compose.navscaffold.composable
@@ -68,7 +66,6 @@ class MainActivity : ComponentActivity() {
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun WearApp(themeType: Theme.ThemeType) {
     WearAppTheme(themeType) {
@@ -77,33 +74,31 @@ fun WearApp(themeType: Theme.ThemeType) {
 
         val swipeDismissState = rememberSwipeToDismissBoxState()
         val navState = rememberSwipeDismissableNavHostState(swipeDismissState)
-        val pagerState = rememberPagerState()
-        val coroutineScope = rememberCoroutineScope()
+//        val pagerState = rememberPagerState()
+//        val coroutineScope = rememberCoroutineScope()
 
-        NowPlayingPager(
+//        NowPlayingPager(
+//            navController = navController,
+// //            swipeToDismissState = swipeDismissState,
+//            pagerState = pagerState,
+//        ) {
+        ListPage(
             navController = navController,
-//            swipeToDismissState = swipeDismissState,
-            pagerState = pagerState,
-        ) {
-            ListPage(
-                navController = navController,
-                state = navState,
-                toNowPlaying = {
-                    coroutineScope.launch {
-                        pagerState.animateScrollToPage(1)
-                    }
-                },
-            )
-        }
+            state = navState,
+//                toNowPlaying = {
+//                    coroutineScope.launch {
+//                        pagerState.animateScrollToPage(1)
+//                    }
+//                },
+        )
+//        }
     }
 }
 
 @Composable
-@OptIn(ExperimentalFoundationApi::class)
 private fun NowPlayingPager(
     navController: NavController,
-//    swipeToDismissState: SwipeToDismissBoxState,
-    pagerState: PagerState,
+    pagerState: PagerState = rememberPagerState(),
     content: @Composable () -> Unit,
 ) {
     PagerScreen(
@@ -155,7 +150,7 @@ private fun NowPlayingPager(
 private fun ListPage(
     navController: NavHostController,
     state: SwipeDismissableNavHostState,
-    toNowPlaying: () -> Unit,
+//    toNowPlaying: () -> Unit,
 ) {
     WearNavScaffold(
         navController = navController,
@@ -166,11 +161,22 @@ private fun ListPage(
         scrollable(
             route = WatchListScreen.route,
         ) {
-            WatchListScreen(
-                scrollState = it.scrollableState,
-                navigateToRoute = navController::navigate,
-                toNowPlaying = toNowPlaying,
-            )
+            val pagerState = rememberPagerState()
+            val coroutineScope = rememberCoroutineScope()
+            NowPlayingPager(
+                navController = navController,
+                pagerState = pagerState,
+            ) {
+                WatchListScreen(
+                    scrollState = it.scrollableState,
+                    navigateToRoute = navController::navigate,
+                    toNowPlaying = {
+                        coroutineScope.launch {
+                            pagerState.animateScrollToPage(1)
+                        }
+                    },
+                )
+            }
         }
 
         composable(StreamingConfirmationScreen.route) {
@@ -191,13 +197,14 @@ private fun ListPage(
             route = PodcastsScreen.route,
         ) {
 
-            it.scrollableState
-            PodcastsScreen(
-                listState = it.scrollableState,
-                navigateToPodcast = { podcastUuid ->
-                    navController.navigate(PodcastScreen.navigateRoute(podcastUuid))
-                }
-            )
+            NowPlayingPager(navController) {
+                PodcastsScreen(
+                    listState = it.scrollableState,
+                    navigateToPodcast = { podcastUuid ->
+                        navController.navigate(PodcastScreen.navigateRoute(podcastUuid))
+                    }
+                )
+            }
         }
 
         composable(

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -260,7 +260,6 @@ fun NowPlayingPager(
                     navigateToEpisode = { episodeUuid ->
                         coroutineScope.launch {
                             navController.navigate(EpisodeScreenFlow.navigateRoute(episodeUuid))
-                            pagerState.scrollToPage(0)
                         }
                     },
                     showStreamingConfirmation = { navController.navigate(StreamingConfirmationScreen.route) },

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/WearMainActivityViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/WearMainActivityViewModel.kt
@@ -104,8 +104,7 @@ class WearMainActivityViewModel @Inject constructor(
     }
 
     /**
-     * This should be invoked when the UI it has handled showing or hiding the sign in
-     * confirmation.
+     * This should be invoked when the UI has handled showing or hiding the sign in confirmation.
      */
     fun onSignInConfirmationActionHandled() {
         _state.update { it.copy(signInConfirmationAction = null) }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesScreen.kt
@@ -1,5 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -15,10 +18,21 @@ object FilesScreen {
 
 @Composable
 fun FilesScreen() {
-    Text(
-        modifier = Modifier.fillMaxWidth(),
-        textAlign = TextAlign.Center,
-        color = MaterialTheme.colors.primary,
-        text = stringResource(LR.string.profile_navigation_files)
-    )
+    Column(
+        verticalArrangement = Arrangement.Center,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colors.primary,
+            text = stringResource(LR.string.profile_navigation_files)
+        )
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colors.primary.copy(alpha = 0.5f),
+            text = "placeholder screen"
+        )
+    }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FiltersScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FiltersScreen.kt
@@ -1,5 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -15,10 +18,21 @@ object FiltersScreen {
 
 @Composable
 fun FiltersScreen() {
-    Text(
-        modifier = Modifier.fillMaxWidth(),
-        textAlign = TextAlign.Center,
-        color = MaterialTheme.colors.primary,
-        text = stringResource(LR.string.filters)
-    )
+    Column(
+        verticalArrangement = Arrangement.Center,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colors.primary,
+            text = stringResource(LR.string.filters)
+        )
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colors.primary.copy(alpha = 0.5f),
+            text = "placeholder screen"
+        )
+    }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
@@ -1,43 +1,30 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.gestures.ScrollableDefaults
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
+import au.com.shiftyjelly.pocketcasts.wear.ui.player.NowPlayingScreen
+
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.ScalingLazyListState
-import androidx.wear.compose.material.Chip
-import androidx.wear.compose.material.ChipDefaults
-import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
-import au.com.shiftyjelly.pocketcasts.wear.theme.theme
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.downloads.DownloadsScreen
-import au.com.shiftyjelly.pocketcasts.wear.ui.player.NowPlayingScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcasts.PodcastsScreen
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -49,17 +36,18 @@ object WatchListScreen {
 
 @Composable
 fun WatchListScreen(
-    navigateToRoute: (String) -> Unit,
     scrollState: ScalingLazyListState,
+    navigateToRoute: (String) -> Unit,
+    toNowPlaying: () -> Unit,
 ) {
 
     val viewModel = hiltViewModel<WatchListScreenViewModel>()
     val state by viewModel.state.collectAsState()
-
     val upNextState = state.upNextQueue
 
     ScalingLazyColumn(
         state = scrollState,
+        flingBehavior = ScrollableDefaults.flingBehavior(),
         modifier = Modifier.fillMaxWidth(),
     ) {
 
@@ -70,9 +58,7 @@ fun WatchListScreen(
 
         if (upNextState is UpNextQueue.State.Loaded) {
             item {
-                NowPlayingChip(
-                    onClick = { navigateToRoute(NowPlayingScreen.route) },
-                )
+                NowPlayingChip(onClick = toNowPlaying)
             }
         }
 
@@ -81,14 +67,6 @@ fun WatchListScreen(
                 title = stringResource(LR.string.podcasts),
                 iconRes = IR.drawable.ic_podcasts,
                 onClick = { navigateToRoute(PodcastsScreen.route) }
-            )
-        }
-
-        item {
-            val num = (upNextState as? UpNextQueue.State.Loaded)?.queue?.size ?: 0
-            UpNextChip(
-                navigateToRoute = navigateToRoute,
-                numInUpNext = num
             )
         }
 
@@ -126,58 +104,6 @@ fun WatchListScreen(
     }
 }
 
-@Composable
-private fun UpNextChip(navigateToRoute: (String) -> Unit, numInUpNext: Int) {
-    val title = stringResource(LR.string.up_next)
-    Chip(
-        onClick = { navigateToRoute(UpNextScreen.route) },
-        colors = ChipDefaults.secondaryChipColors(),
-        border = ChipDefaults.chipBorder(),
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxHeight()
-        ) {
-            Box(
-                modifier = Modifier.wrapContentSize(align = Alignment.Center),
-                content = {
-                    Icon(
-                        painter = painterResource(IR.drawable.ic_upnext),
-                        contentDescription = title
-                    )
-                }
-            )
-
-            Text(
-                text = title,
-                modifier = Modifier.padding(horizontal = 6.dp)
-            )
-
-            Spacer(modifier = Modifier.weight(1f))
-
-            // Only show number in queue if queue isn't empty
-            if (numInUpNext != 0) {
-                Box(
-                    contentAlignment = Alignment.Center,
-                    modifier = Modifier
-                        .padding(vertical = 8.dp)
-                        .clip(CircleShape)
-                        .background(MaterialTheme.theme.colors.primaryIcon02Active)
-                ) {
-                    val num = if (numInUpNext < 100) numInUpNext.toString() else "99+"
-                    Text(
-                        text = num,
-                        textAlign = TextAlign.Center,
-                        color = MaterialTheme.theme.colors.primaryUi01,
-                        modifier = Modifier.padding(horizontal = 6.dp)
-                    )
-                }
-            }
-        }
-    }
-}
-
 @Preview(device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
 @Composable
 private fun WatchListPreview(
@@ -185,6 +111,7 @@ private fun WatchListPreview(
 ) {
     WearAppTheme(themeType) {
         WatchListScreen(
+            toNowPlaying = {},
             navigateToRoute = {},
             scrollState = ScalingLazyListState()
         )

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
@@ -6,19 +6,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import au.com.shiftyjelly.pocketcasts.wear.ui.player.NowPlayingScreen
-
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.ScalingLazyListState
-import androidx.wear.compose.material.MaterialTheme
-import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/NowPlayingPager.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/NowPlayingPager.kt
@@ -7,11 +7,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
 import androidx.wear.compose.material.SwipeToDismissBoxState
@@ -20,8 +17,6 @@ import au.com.shiftyjelly.pocketcasts.wear.ui.UpNextScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.WatchListScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.episode.EpisodeScreenFlow
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.NowPlayingScreen
-import au.com.shiftyjelly.pocketcasts.wear.ui.player.NowPlayingViewModel
-import au.com.shiftyjelly.pocketcasts.wear.ui.player.StreamingConfirmationScreen
 import com.google.android.horologist.compose.pager.PagerScreen
 import kotlinx.coroutines.launch
 
@@ -63,27 +58,6 @@ fun NowPlayingPager(
 
             1 -> Column {
 
-                // FIXME move this to inside Now Playing Screen???
-
-                // Listen for results from streaming confirmation screen
-                navController.currentBackStackEntry?.savedStateHandle
-                    ?.getStateFlow<StreamingConfirmationScreen.Result?>(
-                        StreamingConfirmationScreen.resultKey,
-                        null
-                    )
-                    ?.collectAsStateWithLifecycle()?.value?.let { streamingConfirmationResult ->
-
-                        val viewModel = hiltViewModel<NowPlayingViewModel>()
-                        LaunchedEffect(streamingConfirmationResult) {
-                            viewModel.onStreamingConfirmationResult(streamingConfirmationResult)
-                            // Clear result once consumed
-                            navController.currentBackStackEntry?.savedStateHandle
-                                ?.remove<StreamingConfirmationScreen.Result?>(
-                                    StreamingConfirmationScreen.resultKey
-                                )
-                        }
-                    }
-
                 val coroutineScope = rememberCoroutineScope()
 
                 NowPlayingScreen(
@@ -109,7 +83,7 @@ fun NowPlayingPager(
                             }
                         }
                     },
-                    showStreamingConfirmation = { navController.navigate(StreamingConfirmationScreen.route) },
+                    navController = navController,
                 )
             }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/NowPlayingPager.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/NowPlayingPager.kt
@@ -1,0 +1,127 @@
+@file:OptIn(ExperimentalFoundationApi::class)
+
+package au.com.shiftyjelly.pocketcasts.wear.ui.component
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
+import androidx.wear.compose.material.SwipeToDismissBoxState
+import androidx.wear.compose.material.edgeSwipeToDismiss
+import au.com.shiftyjelly.pocketcasts.wear.ui.UpNextScreen
+import au.com.shiftyjelly.pocketcasts.wear.ui.WatchListScreen
+import au.com.shiftyjelly.pocketcasts.wear.ui.episode.EpisodeScreenFlow
+import au.com.shiftyjelly.pocketcasts.wear.ui.player.NowPlayingScreen
+import au.com.shiftyjelly.pocketcasts.wear.ui.player.NowPlayingViewModel
+import au.com.shiftyjelly.pocketcasts.wear.ui.player.StreamingConfirmationScreen
+import com.google.android.horologist.compose.pager.PagerScreen
+import kotlinx.coroutines.launch
+
+/**
+ * Pager with three pages:
+ *
+ * 1. [firstPageContent] (passed in as a composable argument)
+ * 2. [NowPlayingScreen]
+ * 3. [UpNextScreen]
+ */
+@Composable
+fun NowPlayingPager(
+    navController: NavController,
+    pagerState: PagerState = rememberPagerState(),
+    swipeToDismissState: SwipeToDismissBoxState,
+    firstPageContent: @Composable () -> Unit,
+) {
+
+    // Don't allow swipe to dismiss on first screen (because there is no where to swipe back to--instead
+    // just let the app close) or when the pager is not on the initial page (because we want to avoid
+    // swipe to dismiss from the, for example, Now Playing screen, taking the user back to another
+    // Now Playing screen.
+    val isOnFirstScreen = navController.currentDestination?.route == WatchListScreen.route
+    val allowSwipeToDismiss = !isOnFirstScreen && pagerState.currentPage == 0
+    val modifier = if (allowSwipeToDismiss) {
+        Modifier.edgeSwipeToDismiss(swipeToDismissState)
+    } else {
+        Modifier
+    }
+
+    PagerScreen(
+        count = 3,
+        state = pagerState,
+        modifier = modifier
+    ) { page ->
+        when (page) {
+
+            0 -> firstPageContent()
+
+            1 -> Column {
+
+                // FIXME move this to inside Now Playing Screen???
+
+                // Listen for results from streaming confirmation screen
+                navController.currentBackStackEntry?.savedStateHandle
+                    ?.getStateFlow<StreamingConfirmationScreen.Result?>(
+                        StreamingConfirmationScreen.resultKey,
+                        null
+                    )
+                    ?.collectAsStateWithLifecycle()?.value?.let { streamingConfirmationResult ->
+
+                        val viewModel = hiltViewModel<NowPlayingViewModel>()
+                        LaunchedEffect(streamingConfirmationResult) {
+                            viewModel.onStreamingConfirmationResult(streamingConfirmationResult)
+                            // Clear result once consumed
+                            navController.currentBackStackEntry?.savedStateHandle
+                                ?.remove<StreamingConfirmationScreen.Result?>(
+                                    StreamingConfirmationScreen.resultKey
+                                )
+                        }
+                    }
+
+                val coroutineScope = rememberCoroutineScope()
+
+                NowPlayingScreen(
+                    navigateToEpisode = { episodeUuid ->
+                        coroutineScope.launch {
+
+                            val alreadyOnEpisodeScreen =
+                                navController.currentDestination?.route == EpisodeScreenFlow.episodeScreen
+                            val alreadyOnCorrectEpisode by lazy {
+                                navController
+                                    .currentBackStackEntry
+                                    ?.arguments
+                                    ?.getString(EpisodeScreenFlow.episodeUuidArgument)
+                                    ?.let { currentScreenEpisodeUuid ->
+                                        episodeUuid == currentScreenEpisodeUuid
+                                    } ?: false
+                            }
+                            if (alreadyOnEpisodeScreen && alreadyOnCorrectEpisode) {
+                                // Already on the correct episode screen, so just switch back to that page
+                                pagerState.animateScrollToPage(0)
+                            } else {
+                                navController.navigate(EpisodeScreenFlow.navigateRoute(episodeUuid))
+                            }
+                        }
+                    },
+                    showStreamingConfirmation = { navController.navigate(StreamingConfirmationScreen.route) },
+                )
+            }
+
+            2 -> Column {
+                val scrollableState = rememberScalingLazyListState()
+                UpNextScreen(
+                    navigateToEpisode = { episodeUuid ->
+                        navController.navigate(EpisodeScreenFlow.navigateRoute(episodeUuid))
+                    },
+                    listState = scrollableState,
+                )
+            }
+        }
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui.episode
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -84,7 +85,11 @@ fun EpisodeScreen(
                 color = WearColors.FFDADCE0,
                 lineHeight = headingLineHeight,
                 textAlign = TextAlign.Center,
-                modifier = Modifier.padding(horizontal = 8.dp)
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .clickable {
+                        navigateToPodcast(podcast.uuid)
+                    }
             )
         }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreenFlow.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreenFlow.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui.episode
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -13,6 +14,8 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.navigation
 import androidx.navigation.navArgument
+import androidx.wear.compose.material.SwipeToDismissBoxState
+import au.com.shiftyjelly.pocketcasts.wear.NowPlayingPager
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ObtainConfirmationScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.StreamingConfirmationScreen
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
@@ -36,6 +39,7 @@ object EpisodeScreenFlow {
     fun NavGraphBuilder.episodeGraph(
         navigateToPodcast: (podcastUuid: String) -> Unit,
         navController: NavController,
+        swipeToDismissState: SwipeToDismissBoxState,
     ) {
         navigation(
             route = this@EpisodeScreenFlow.route,
@@ -66,14 +70,26 @@ object EpisodeScreenFlow {
                         }
                     }
 
-                EpisodeScreen(
-                    columnState = it.columnState,
-                    navigateToPodcast = navigateToPodcast,
-                    navigateToUpNextOptions = { navController.navigate(upNextOptionsScreen) },
-                    navigateToConfirmDeleteDownload = { navController.navigate(deleteDownloadConfirmationScreen) },
-                    navigateToRemoveFromUpNextNotification = { navController.navigate(removeFromUpNextNotificationScreen) },
-                    navigateToStreamingConfirmation = { navController.navigate(StreamingConfirmationScreen.route) },
-                )
+                @OptIn(ExperimentalFoundationApi::class)
+                NowPlayingPager(
+                    navController = navController,
+                    swipeToDismissState = swipeToDismissState,
+                ) {
+                    EpisodeScreen(
+                        columnState = it.columnState,
+                        navigateToPodcast = navigateToPodcast,
+                        navigateToUpNextOptions = { navController.navigate(upNextOptionsScreen) },
+                        navigateToConfirmDeleteDownload = {
+                            navController.navigate(deleteDownloadConfirmationScreen)
+                        },
+                        navigateToRemoveFromUpNextNotification = {
+                            navController.navigate(removeFromUpNextNotificationScreen)
+                        },
+                        navigateToStreamingConfirmation = {
+                            navController.navigate(StreamingConfirmationScreen.route)
+                        },
+                    )
+                }
             }
 
             scrollable(upNextOptionsScreen) {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreenFlow.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreenFlow.kt
@@ -15,7 +15,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.navigation
 import androidx.navigation.navArgument
 import androidx.wear.compose.material.SwipeToDismissBoxState
-import au.com.shiftyjelly.pocketcasts.wear.NowPlayingPager
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.NowPlayingPager
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ObtainConfirmationScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.StreamingConfirmationScreen
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
@@ -30,7 +30,7 @@ object EpisodeScreenFlow {
     fun navigateRoute(episodeUuid: String) = "episode/$episodeUuid"
 
     // Routes
-    private const val episodeScreen = "episodeScreen"
+    const val episodeScreen = "episodeScreen"
     private const val upNextOptionsScreen = "upNextOptionsScreen"
     private const val deleteDownloadConfirmationScreen = "deleteDownloadConfirmationScreen"
     private const val deleteDownloadNotificationScreen = "deleteDownloadNotificationScreen"


### PR DESCRIPTION
## Description
This adds a three screen pager to the watch app. The first page will be the current page. The second page will always be the now playing screen. The third page will always be the Up Next screen.

I initially wanted to create a `Pager` at the top level and have navigation within the first page, but it looks like that [isn't really possible currently](https://github.com/google/horologist/issues/1181).

## Testing Instructions

Verify that the pager works as expected and is present on the screens you would expect. Transient notification-style screens and the Settings screen are the only ones that should not have the pager. Also check that back navigation works as expected (i.e., swiping back and swiping to exit the app).

Note that you should only be able to swipe back to the previous screen if you are on the `0` page of the pager. I did this to avoid having users tap on the episode title in the Now Playing screen, swipe to the Now Playing screen again from the episode screen, and then having swipe to dismiss take them from one Now Playing screen to their previous (identical) Now Playing screen on the previous pager.

Lastly, this PR includes a somewhat-unrelated change: Tapping on the podcast name on the episode details screen should now take you to the podcast screen. (internal discussion: p1682360221894429/1682357294.725699-slack-C040S9BK7SP)

## Screenshots or Screencast 

https://user-images.githubusercontent.com/4656348/234282129-936e12c1-e1fd-41d9-9d31-559cdb1c02b7.mov

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews