### PR TITLE
Update watch's Up Next UI

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -185,7 +185,7 @@ class PlayerViewModel @Inject constructor(
     val playingEpisodeLive: LiveData<Pair<BaseEpisode, Int>> =
         listDataRx.map { Pair(it.podcastHeader.episodeUuid, it.podcastHeader.backgroundColor) }
             .distinctUntilChanged()
-            .switchMap { pair -> episodeManager.observeEpisodeByUuid(pair.first).map { Pair(it, pair.second) } }
+            .switchMap { pair -> episodeManager.observeEpisodeByUuidRx(pair.first).map { Pair(it, pair.second) } }
             .toLiveData()
 
     private val shelfObservable = settings.shelfItemsObservable.map { list ->
@@ -250,7 +250,7 @@ class PlayerViewModel @Inject constructor(
     val effectsObservable: Flowable<PodcastEffectsPair> = playbackStateObservable
         .toFlowable(BackpressureStrategy.LATEST)
         .map { it.episodeUuid }
-        .switchMap { episodeManager.observeEpisodeByUuid(it) }
+        .switchMap { episodeManager.observeEpisodeByUuidRx(it) }
         .switchMap {
             if (it is PodcastEpisode) {
                 podcastManager.observePodcastByUuid(it.podcastUuid)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
@@ -46,7 +46,7 @@ class CloudBottomSheetViewModel @Inject constructor(
     fun setup(uuid: String) {
         val isPlayingFlowable = playbackManager.playbackStateRelay.filter { it.episodeUuid == uuid }.map { it.isPlaying }.startWith(false).toFlowable(BackpressureStrategy.LATEST)
         val inUpNextFlowable = playbackManager.upNextQueue.changesObservable.containsUuid(uuid).toFlowable(BackpressureStrategy.LATEST)
-        val episodeFlowable = userEpisodeManager.observeEpisode(uuid)
+        val episodeFlowable = userEpisodeManager.observeEpisodeRx(uuid)
         val combined = Flowables.combineLatest(episodeFlowable, inUpNextFlowable, isPlayingFlowable) { episode, inUpNext, isPlaying ->
             BottomSheetState(episode, inUpNext, isPlaying)
         }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/EpisodeImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/EpisodeImage.kt
@@ -1,0 +1,30 @@
+package au.com.shiftyjelly.pocketcasts.compose.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+
+@Composable
+fun EpisodeImage(
+    episode: BaseEpisode,
+    modifier: Modifier = Modifier,
+) {
+    when (episode) {
+        is PodcastEpisode -> {
+            PodcastImage(
+                uuid = episode.podcastUuid,
+                dropShadow = false,
+                modifier = modifier,
+            )
+        }
+        is UserEpisode -> {
+            UserEpisodeImage(
+                episode = episode,
+                contentDescription = null,
+                modifier = modifier,
+            )
+        }
+    }
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/UserEpisodeImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/UserEpisodeImage.kt
@@ -1,0 +1,29 @@
+package au.com.shiftyjelly.pocketcasts.compose.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.extensions.getUrlForArtwork
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+
+@Composable
+fun UserEpisodeImage(
+    episode: UserEpisode,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    placeholder: Int = IR.drawable.ic_uploadedfile,
+) {
+    AsyncImage(
+        model = ImageRequest.Builder(LocalContext.current)
+            .data(episode.getUrlForArtwork(themeIsDark = true, thumbnail = true))
+            .crossfade(true)
+            .build(),
+        contentDescription = contentDescription,
+        placeholder = painterResource(placeholder),
+        modifier = modifier,
+    )
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -281,6 +281,7 @@
     <string name="player_up_next_clear_queue_button">Clear Up Next</string>
     <string name="player_up_next_empty">Nothing in Up Next</string>
     <string name="player_up_next_empty_desc">You can queue episodes to play next by swiping right on episode rows, or tapping the icon on an episode card.</string>
+    <string name="player_up_next_empty_desc_watch">You can queue episodes to play next in the episode details screen.</string>
     <string name="player_up_next_move_to_bottom">Move to bottom</string>
     <string name="player_up_next_move_to_top">Move to top</string>
     <string name="player_up_next_select">Select</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/UserEpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/UserEpisodeDao.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.UserEpisodeServerStatus
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Maybe
+import kotlinx.coroutines.flow.Flow
 import java.util.Date
 
 @Dao
@@ -63,7 +64,10 @@ abstract class UserEpisodeDao {
     abstract fun observeDownloadingUserEpisodes(): Flowable<List<UserEpisode>>
 
     @Query("SELECT * FROM user_episodes WHERE uuid = :uuid")
-    abstract fun observeEpisode(uuid: String): Flowable<UserEpisode>
+    abstract fun observeEpisodeRx(uuid: String): Flowable<UserEpisode>
+
+    @Query("SELECT * FROM user_episodes WHERE uuid = :uuid")
+    abstract fun observeEpisode(uuid: String): Flow<UserEpisode>
 
     @Query("SELECT * FROM user_episodes WHERE uuid = :uuid")
     abstract fun findEpisodeByUuidRx(uuid: String): Maybe<UserEpisode>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
@@ -5,7 +5,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import java.util.Date
 import java.util.UUID
 
-interface BaseEpisode {
+sealed interface BaseEpisode {
     companion object {
         /**
          * Used to reduce the changes sent out by the media session.

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -279,7 +279,7 @@ class MediaSessionManager(
             .observeOn(Schedulers.io())
             .switchMap { state ->
                 val episodeSource =
-                    if (state.isEmpty) Observable.just(Optional.empty()) else episodeManager.observeEpisodeByUuid(state.episodeUuid).distinctUntilChanged(BaseEpisode.isMediaSessionEqual).map { Optional.of(it) }.toObservable()
+                    if (state.isEmpty) Observable.just(Optional.empty()) else episodeManager.observeEpisodeByUuidRx(state.episodeUuid).distinctUntilChanged(BaseEpisode.isMediaSessionEqual).map { Optional.of(it) }.toObservable()
                 Observables.combineLatest(Observable.just(state), episodeSource)
             }
             // ignore events until seeking has finished or the progress won't stay where the user requested

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1405,7 +1405,7 @@ open class PlaybackManager @Inject constructor(
                         .asFlowable()
                         .cast(BaseEpisode::class.java)
                 } else if (episode is UserEpisode) {
-                    userEpisodeManager.observeEpisode(episode.uuid).cast(BaseEpisode::class.java)
+                    userEpisodeManager.observeEpisodeRx(episode.uuid).cast(BaseEpisode::class.java)
                 } else {
                     null
                 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
@@ -72,12 +72,12 @@ interface UpNextQueue {
             if (state is State.Loaded) {
                 if (state.podcast != null) {
                     // If we have a podcast we need to observe its effects state as well to ensure it updates when the global override changes
-                    episodeManager.observeEpisodeByUuid(state.episode.uuid)
+                    episodeManager.observeEpisodeByUuidRx(state.episode.uuid)
                         .combineLatest(podcastManager.observePodcastByUuid(state.podcast.uuid).distinctUntilChanged { t1, t2 -> t1.isUsingEffects == t2.isUsingEffects })
                         .map { State.Loaded(it.first, it.second, state.queue) }
                         .toObservable()
                 } else {
-                    episodeManager.observeEpisodeByUuid(state.episode.uuid)
+                    episodeManager.observeEpisodeByUuidRx(state.episode.uuid)
                         .map { State.Loaded(it, state.podcast, state.queue) }
                         .toObservable()
                 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -27,7 +27,8 @@ interface EpisodeManager {
     fun findByUuid(uuid: String): PodcastEpisode?
     fun findByUuidRx(uuid: String): Maybe<PodcastEpisode>
     fun observeByUuid(uuid: String): Flow<PodcastEpisode>
-    fun observeEpisodeByUuid(uuid: String): Flowable<BaseEpisode>
+    fun observeEpisodeByUuidRx(uuid: String): Flowable<BaseEpisode>
+    fun observeEpisodeByUuid(uuid: String): Flow<BaseEpisode>
     fun findFirstBySearchQuery(query: String): PodcastEpisode?
 
     fun findAll(rowParser: (PodcastEpisode) -> Boolean)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -43,6 +43,7 @@ import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.await
 import kotlinx.coroutines.rx2.awaitSingleOrNull
@@ -67,7 +68,8 @@ interface UserEpisodeManager {
     suspend fun deleteAll(episodes: List<UserEpisode>, playbackManager: PlaybackManager)
     fun observeUserEpisodes(): Flowable<List<UserEpisode>>
     suspend fun findUserEpisodes(): List<UserEpisode>
-    fun observeEpisode(uuid: String): Flowable<UserEpisode>
+    fun observeEpisodeRx(uuid: String): Flowable<UserEpisode>
+    fun observeEpisode(uuid: String): Flow<UserEpisode>
     fun findEpisodeByUuidRx(uuid: String): Maybe<UserEpisode>
     suspend fun findEpisodeByUuid(uuid: String): UserEpisode?
     fun uploadToServer(userEpisode: UserEpisode, waitForWifi: Boolean)
@@ -228,7 +230,11 @@ class UserEpisodeManagerImpl @Inject constructor(
         return userEpisodeDao.observeDownloadingUserEpisodes()
     }
 
-    override fun observeEpisode(uuid: String): Flowable<UserEpisode> {
+    override fun observeEpisodeRx(uuid: String): Flowable<UserEpisode> {
+        return userEpisodeDao.observeEpisodeRx(uuid)
+    }
+
+    override fun observeEpisode(uuid: String): Flow<UserEpisode> {
         return userEpisodeDao.observeEpisode(uuid)
     }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -76,6 +76,7 @@ private fun WearApp() {
                 navController = navController,
                 pagerState = pagerState,
                 swipeToDismissState = swipeToDismissState,
+                scrollableScaffoldContext = it,
             ) {
                 WatchListScreen(
                     scrollState = it.scrollableState,
@@ -110,6 +111,7 @@ private fun WearApp() {
             NowPlayingPager(
                 navController = navController,
                 swipeToDismissState = swipeToDismissState,
+                scrollableScaffoldContext = it,
             ) {
                 PodcastsScreen(
                     listState = it.scrollableState,
@@ -163,6 +165,7 @@ private fun WearApp() {
             NowPlayingPager(
                 navController = navController,
                 swipeToDismissState = swipeToDismissState,
+                scrollableScaffoldContext = it,
             ) {
                 DownloadsScreen(
                     columnState = it.columnState,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/SettingsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/SettingsScreen.kt
@@ -28,8 +28,8 @@ import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 import au.com.shiftyjelly.pocketcasts.wear.theme.theme
-import au.com.shiftyjelly.pocketcasts.wear.ui.component.ChipScreenHeader
-import au.com.shiftyjelly.pocketcasts.wear.ui.component.ChipSectionHeader
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.SectionHeaderChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
@@ -71,7 +71,7 @@ private fun Content(
     ScalingLazyColumn(columnState = scrollState) {
 
         item {
-            ChipScreenHeader(LR.string.settings)
+            ScreenHeaderChip(LR.string.settings)
         }
 
         item {
@@ -83,7 +83,7 @@ private fun Content(
         }
 
         item {
-            ChipSectionHeader(LR.string.account)
+            SectionHeaderChip(LR.string.account)
         }
 
         item {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
@@ -42,44 +42,51 @@ fun UpNextScreen(
 
         null -> { /* Show nothing while loading */ }
 
-        UpNextQueue.State.Empty -> {
-            Column(
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.fillMaxSize()
-            ) {
-                Text(
-                    text = stringResource(LR.string.player_up_next_empty),
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.title3,
-                )
-                Spacer(Modifier.height(8.dp))
-                Text(
-                    text = stringResource(LR.string.player_up_next_empty_desc_watch),
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.body2,
-                )
-            }
-        }
+        UpNextQueue.State.Empty -> EmptyQueueState()
 
         is UpNextQueue.State.Loaded -> {
             val list = (queueState as UpNextQueue.State.Loaded).queue
-            ScalingLazyColumn(
-                state = listState,
-                modifier = modifier.fillMaxWidth(),
-            ) {
+            if (list.isEmpty()) {
+                EmptyQueueState()
+            } else {
+                ScalingLazyColumn(
+                    state = listState,
+                    modifier = modifier.fillMaxWidth(),
+                ) {
 
-                item { ScreenHeaderChip(LR.string.up_next) }
+                    item { ScreenHeaderChip(LR.string.up_next) }
 
-                items(list) { episode ->
-                    EpisodeChip(
-                        episode = episode,
-                        onClick = {
-                            navigateToEpisode(episode.uuid)
-                        },
-                    )
+                    items(list) { episode ->
+                        EpisodeChip(
+                            episode = episode,
+                            onClick = {
+                                navigateToEpisode(episode.uuid)
+                            },
+                        )
+                    }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun EmptyQueueState() {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Text(
+            text = stringResource(LR.string.player_up_next_empty),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.title3,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = stringResource(LR.string.player_up_next_empty_desc_watch),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.body2,
+        )
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
@@ -1,11 +1,19 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rxjava2.subscribeAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -14,9 +22,11 @@ import androidx.wear.compose.foundation.lazy.ScalingLazyListState
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 object UpNextScreen {
     const val route = "up_next_screen"
@@ -33,9 +43,27 @@ fun UpNextScreen(
 
     when (queueState) {
 
-        UpNextQueue.State.Empty -> {}
+        null -> { /* Show nothing while loading */ }
 
-        null -> {}
+        UpNextQueue.State.Empty -> {
+            Column(
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                Text(
+                    text = stringResource(LR.string.player_up_next_empty),
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.title3,
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = stringResource(LR.string.player_up_next_empty_desc_watch),
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.body2,
+                )
+            }
+        }
 
         is UpNextQueue.State.Loaded -> {
             val list = (queueState as UpNextQueue.State.Loaded).queue

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rxjava2.subscribeAsState
@@ -14,18 +13,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.ScalingLazyListState
 import androidx.wear.compose.foundation.lazy.items
-import androidx.wear.compose.material.Chip
-import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.EpisodeChip
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 object UpNextScreen {
@@ -68,26 +65,18 @@ fun UpNextScreen(
         is UpNextQueue.State.Loaded -> {
             val list = (queueState as UpNextQueue.State.Loaded).queue
             ScalingLazyColumn(
-                modifier = modifier.fillMaxWidth(),
                 state = listState,
+                modifier = modifier.fillMaxWidth(),
             ) {
+
+                item { ScreenHeaderChip(LR.string.up_next) }
+
                 items(list) { episode ->
-                    Chip(
+                    EpisodeChip(
+                        episode = episode,
                         onClick = {
                             navigateToEpisode(episode.uuid)
                         },
-                        colors = ChipDefaults.secondaryChipColors(),
-                        label = {
-                            Text(episode.title, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                        },
-                        icon = {
-                            PodcastImage(
-                                uuid = episode.uuid,
-                                dropShadow = false,
-                                modifier = Modifier.size(30.dp)
-                            )
-                        },
-                        modifier = modifier.fillMaxWidth()
                     )
                 }
             }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ChipScreenHeaders.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ChipScreenHeaders.kt
@@ -14,7 +14,7 @@ import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
 
 @Composable
-fun ChipScreenHeader(
+fun ScreenHeaderChip(
     @StringRes text: Int,
     textColor: Color? = null,
     modifier: Modifier = Modifier,
@@ -31,7 +31,7 @@ fun ChipScreenHeader(
 }
 
 @Composable
-fun ChipSectionHeader(@StringRes text: Int, modifier: Modifier = Modifier) {
+fun SectionHeaderChip(@StringRes text: Int, modifier: Modifier = Modifier) {
     Header(
         text = text,
         modifier = modifier.padding(vertical = verticalPadding, horizontal = horizontalPadding)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -23,6 +25,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
@@ -45,6 +48,15 @@ fun EpisodeChip(episode: BaseEpisode, onClick: () -> Unit) {
             .fillMaxWidth()
             .height(72.dp)
     ) {
+
+        val viewModel = hiltViewModel<EpisodeChipViewModel>()
+
+        // Make sure the episode is always up-to-date
+        @Suppress("NAME_SHADOWING")
+        val episode by viewModel
+            .observeByUuid(episode)
+            .collectAsState(episode)
+
         Row {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
@@ -26,13 +26,10 @@ import androidx.compose.ui.unit.sp
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
-import au.com.shiftyjelly.pocketcasts.compose.components.UserEpisodeImage
+import au.com.shiftyjelly.pocketcasts.compose.components.EpisodeImage
 import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatPattern
 import au.com.shiftyjelly.pocketcasts.wear.theme.theme
 
@@ -53,26 +50,12 @@ fun EpisodeChip(episode: BaseEpisode, onClick: () -> Unit) {
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
 
-                val modifier = Modifier
-                    .size(30.dp)
-                    .clip(RoundedCornerShape(4.dp))
-
-                when (episode) {
-                    is PodcastEpisode -> {
-                        PodcastImage(
-                            uuid = episode.podcastUuid,
-                            dropShadow = false,
-                            modifier = modifier,
-                        )
-                    }
-                    is UserEpisode -> {
-                        UserEpisodeImage(
-                            episode = episode,
-                            contentDescription = null,
-                            modifier = modifier,
-                        )
-                    }
-                }
+                EpisodeImage(
+                    episode = episode,
+                    modifier = Modifier
+                        .size(30.dp)
+                        .clip(RoundedCornerShape(4.dp)),
+                )
 
                 if (episode.isDownloaded) {
                     Spacer(Modifier.height(4.dp))

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
@@ -27,6 +27,7 @@ import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.UserEpisodeImage
 import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
@@ -51,25 +52,37 @@ fun EpisodeChip(episode: BaseEpisode, onClick: () -> Unit) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
+
+                val modifier = Modifier
+                    .size(30.dp)
+                    .clip(RoundedCornerShape(4.dp))
+
                 when (episode) {
                     is PodcastEpisode -> {
                         PodcastImage(
                             uuid = episode.podcastUuid,
                             dropShadow = false,
-                            modifier = Modifier.size(30.dp),
+                            modifier = modifier,
                         )
                     }
                     is UserEpisode -> {
-                        // TODO
+                        UserEpisodeImage(
+                            episode = episode,
+                            contentDescription = null,
+                            modifier = modifier,
+                        )
                     }
                 }
-                Spacer(Modifier.height(4.dp))
-                Icon(
-                    painter = painterResource(R.drawable.ic_downloaded),
-                    contentDescription = null,
-                    tint = MaterialTheme.theme.colors.support02,
-                    modifier = Modifier.size(12.dp),
-                )
+
+                if (episode.isDownloaded) {
+                    Spacer(Modifier.height(4.dp))
+                    Icon(
+                        painter = painterResource(R.drawable.ic_downloaded),
+                        contentDescription = null,
+                        tint = MaterialTheme.theme.colors.support02,
+                        modifier = Modifier.size(12.dp),
+                    )
+                }
             }
 
             Spacer(Modifier.width(6.dp))

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
@@ -1,0 +1,112 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.images.R
+import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatPattern
+import au.com.shiftyjelly.pocketcasts.wear.theme.theme
+
+@Composable
+fun EpisodeChip(episode: BaseEpisode, onClick: () -> Unit) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .clip(RoundedCornerShape(24.dp))
+            .background(MaterialTheme.colors.surface)
+            .clickable { onClick() }
+            .padding(horizontal = 10.dp)
+            .fillMaxWidth()
+            .height(72.dp)
+    ) {
+        Row {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                when (episode) {
+                    is PodcastEpisode -> {
+                        PodcastImage(
+                            uuid = episode.podcastUuid,
+                            dropShadow = false,
+                            modifier = Modifier.size(30.dp),
+                        )
+                    }
+                    is UserEpisode -> {
+                        // TODO
+                    }
+                }
+                Spacer(Modifier.height(4.dp))
+                Icon(
+                    painter = painterResource(R.drawable.ic_downloaded),
+                    contentDescription = null,
+                    tint = MaterialTheme.theme.colors.support02,
+                    modifier = Modifier.size(12.dp),
+                )
+            }
+
+            Spacer(Modifier.width(6.dp))
+
+            Column(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    text = episode.title,
+                    lineHeight = 14.sp,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.button.merge(
+                        @Suppress("DEPRECATION")
+                        (
+                            TextStyle(
+                                platformStyle = PlatformTextStyle(
+                                    // So we can align the top of the text as closely as possible to the image
+                                    includeFontPadding = false,
+                                ),
+                            )
+                            )
+                    ),
+                    maxLines = 2,
+                )
+                val shortDate = episode.publishedDate.toLocalizedFormatPattern("dd MMM")
+                val timeLeft = TimeHelper.getTimeLeft(
+                    currentTimeMs = episode.playedUpToMs,
+                    durationMs = episode.durationMs.toLong(),
+                    inProgress = episode.isInProgress,
+                    context = LocalContext.current
+                ).text
+                Text(
+                    text = "$shortDate • $timeLeft",
+                    color = MaterialTheme.theme.colors.primaryText02,
+                    style = MaterialTheme.typography.caption2
+                )
+            }
+        }
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
@@ -55,7 +55,7 @@ fun EpisodeChip(episode: BaseEpisode, onClick: () -> Unit) {
         @Suppress("NAME_SHADOWING")
         val episode by viewModel
             .observeByUuid(episode)
-            .collectAsState(episode)
+            .collectAsState()
 
         Row {
             Column(

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChipViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChipViewModel.kt
@@ -1,15 +1,22 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui.component
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 @HiltViewModel
 class EpisodeChipViewModel @Inject constructor(
     private val episodeManager: EpisodeManager,
 ) : ViewModel() {
-    fun observeByUuid(episode: BaseEpisode) =
-        episodeManager.observeByUuid(episode.uuid)
+
+    fun observeByUuid(episode: BaseEpisode): StateFlow<BaseEpisode> =
+        episodeManager
+            .observeEpisodeByUuid(episode.uuid)
+            .stateIn(viewModelScope, SharingStarted.Eagerly, episode)
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChipViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChipViewModel.kt
@@ -1,0 +1,15 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui.component
+
+import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class EpisodeChipViewModel @Inject constructor(
+    private val episodeManager: EpisodeManager,
+) : ViewModel() {
+    fun observeByUuid(episode: BaseEpisode) =
+        episodeManager.observeByUuid(episode.uuid)
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/NowPlayingPager.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/NowPlayingPager.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
@@ -17,6 +18,8 @@ import au.com.shiftyjelly.pocketcasts.wear.ui.UpNextScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.WatchListScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.episode.EpisodeScreenFlow
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.NowPlayingScreen
+import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
+import com.google.android.horologist.compose.navscaffold.ScrollableScaffoldContext
 import com.google.android.horologist.compose.pager.PagerScreen
 import kotlinx.coroutines.launch
 
@@ -32,8 +35,11 @@ fun NowPlayingPager(
     navController: NavController,
     pagerState: PagerState = rememberPagerState(),
     swipeToDismissState: SwipeToDismissBoxState,
+    scrollableScaffoldContext: ScrollableScaffoldContext? = null,
     firstPageContent: @Composable () -> Unit,
 ) {
+
+    val defaultTimeTextMode = remember { scrollableScaffoldContext?.timeTextMode }
 
     // Don't allow swipe to dismiss on first screen (because there is no where to swipe back to--instead
     // just let the app close) or when the pager is not on the initial page (because we want to avoid
@@ -45,6 +51,14 @@ fun NowPlayingPager(
         Modifier.edgeSwipeToDismiss(swipeToDismissState)
     } else {
         Modifier
+    }
+
+    if (defaultTimeTextMode != null) {
+        scrollableScaffoldContext?.timeTextMode = if (pagerState.currentPage == 0) {
+            defaultTimeTextMode
+        } else {
+            NavScaffoldViewModel.TimeTextMode.Off
+        }
     }
 
     PagerScreen(
@@ -88,12 +102,11 @@ fun NowPlayingPager(
             }
 
             2 -> Column {
-                val scrollableState = rememberScalingLazyListState()
                 UpNextScreen(
                     navigateToEpisode = { episodeUuid ->
                         navController.navigate(EpisodeScreenFlow.navigateRoute(episodeUuid))
                     },
-                    listState = scrollableState,
+                    listState = rememberScalingLazyListState(),
                 )
             }
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreen.kt
@@ -1,49 +1,20 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui.downloads
 
 import android.content.res.Configuration
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.PlatformTextStyle
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.items
-import androidx.wear.compose.material.Icon
-import androidx.wear.compose.material.MaterialTheme
-import androidx.wear.compose.material.Text
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
-import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatPattern
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
-import au.com.shiftyjelly.pocketcasts.wear.theme.theme
-import au.com.shiftyjelly.pocketcasts.wear.ui.component.ChipScreenHeader
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.EpisodeChip
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import java.util.Date
-import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 object DownloadsScreen {
@@ -73,7 +44,7 @@ private fun Content(
     ) {
         if (episodes != null) {
             item {
-                ChipScreenHeader(
+                ScreenHeaderChip(
                     text = if (episodes.isEmpty()) {
                         LR.string.profile_empty_downloaded
                     } else {
@@ -83,76 +54,9 @@ private fun Content(
             }
 
             items(episodes) { episode ->
-                Download(
+                EpisodeChip(
                     episode = episode,
                     onClick = { onItemClick(episode) }
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun Download(episode: PodcastEpisode, onClick: () -> Unit) {
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier
-            .clip(RoundedCornerShape(24.dp))
-            .background(MaterialTheme.colors.surface)
-            .clickable { onClick() }
-            .padding(horizontal = 10.dp)
-            .fillMaxWidth()
-            .height(72.dp)
-    ) {
-        Row {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                PodcastImage(
-                    uuid = episode.podcastUuid,
-                    dropShadow = false,
-                    modifier = Modifier.size(30.dp),
-                )
-                Spacer(Modifier.height(4.dp))
-                Icon(
-                    painter = painterResource(IR.drawable.ic_downloaded),
-                    contentDescription = null,
-                    tint = MaterialTheme.theme.colors.support02,
-                    modifier = Modifier.size(12.dp),
-                )
-            }
-
-            Spacer(Modifier.width(6.dp))
-
-            Column(
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(
-                    text = episode.title,
-                    lineHeight = 14.sp,
-                    overflow = TextOverflow.Ellipsis,
-                    style = MaterialTheme.typography.button.merge(
-                        @Suppress("DEPRECATION")
-                        TextStyle(
-                            platformStyle = PlatformTextStyle(
-                                // So we can align the top of the text as closely as possible to the image
-                                includeFontPadding = false,
-                            ),
-                        )
-                    ),
-                    maxLines = 2,
-                )
-                val shortDate = episode.publishedDate.toLocalizedFormatPattern("dd MMM")
-                val timeLeft = TimeHelper.getTimeLeft(
-                    currentTimeMs = episode.playedUpToMs,
-                    durationMs = episode.durationMs.toLong(),
-                    inProgress = episode.isInProgress,
-                    context = LocalContext.current
-                ).text
-                Text(
-                    text = "$shortDate • $timeLeft",
-                    color = MaterialTheme.theme.colors.primaryText02,
-                    style = MaterialTheme.typography.caption2
                 )
             }
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreenFlow.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreenFlow.kt
@@ -74,6 +74,7 @@ object EpisodeScreenFlow {
                 NowPlayingPager(
                     navController = navController,
                     swipeToDismissState = swipeToDismissState,
+                    scrollableScaffoldContext = it,
                 ) {
                     EpisodeScreen(
                         columnState = it.columnState,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/UpNextOptionsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/UpNextOptionsScreen.kt
@@ -12,7 +12,7 @@ import androidx.lifecycle.ViewModelStoreOwner
 import androidx.wear.compose.foundation.lazy.items
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
-import au.com.shiftyjelly.pocketcasts.wear.ui.component.ChipScreenHeader
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
@@ -44,7 +44,7 @@ private fun Content(
         modifier = Modifier.padding(horizontal = 16.dp)
     ) {
         item {
-            ChipScreenHeader(
+            ScreenHeaderChip(
                 text = LR.string.add_to_up_next_question,
                 textColor = Color.White,
             )


### PR DESCRIPTION
## Description
This PR updates the styling of the Up Next screen on the watch.

One trickiness I ran into here was that it does not seem possible to use horologist's scrollable components on multiple pages of a pager when the pager is inside a single navigation context (more info [here](https://github.com/google/horologist/issues/1181#issuecomment-1522555773)). I'm working around that by just hiding the time text from the Up Next screen and using a scrollable composable from foundation there. That way the time text can still be shown on the pager's "main" screen.

> **Note**
> This PR builds on https://github.com/Automattic/pocket-casts-android/pull/908, so you may want to review that first.

## Testing Instructions
1. Load up the app while logged into an account with episodes in the Up Next queue
2. Swipe to the third page in the pager from any screen where the pager is available
3. Tap on one of the episodes in the up next queue that isn't downloaded
4. From the Episode screen download the episode
5. Return to the up next screen and observe that once the download is complete the download icon is displayed on the episode chip.

Also check that the artwork from user-uploaded files are displayed properly in the Up Next queue. Don't tap on a user-downloaded epsiosde in the queue though, that is crashing currently and I will address that in a separate PR.

Also check the Up Next queue UI when there are no items in the queue.

## Screenshots or Screencast 

https://user-images.githubusercontent.com/4656348/234433386-12332aea-1cdc-4f70-af88-669fa0837982.mov


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews