### PR TITLE
Update podcast_episodes table name in hardcoded queries

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -289,7 +289,7 @@ abstract class EpisodeDao {
     abstract fun updatePlayedUpToIfChanged(playedUpTo: Double, playedUpToMin: Double, playedUpToMax: Double, modified: Long, uuid: String)
 
     fun countWhere(queryAfterWhere: String, appDatabase: AppDatabase): Int {
-        val result = QueryHelper.firstRowArray("SELECT count(*) FROM episodes JOIN podcasts ON episodes.podcast_id = podcasts.uuid WHERE podcasts.subscribed = 1 AND $queryAfterWhere", null, appDatabase) ?: return 0
+        val result = QueryHelper.firstRowArray("SELECT count(*) FROM podcast_episodes JOIN podcasts ON podcast_episodes.podcast_id = podcasts.uuid WHERE podcasts.subscribed = 1 AND $queryAfterWhere", null, appDatabase) ?: return 0
         val firstResult = result[0] ?: return 0
         return Integer.parseInt(firstResult)
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -177,14 +177,14 @@ class EpisodeManagerImpl @Inject constructor(
     }
 
     override fun findEpisodesWhere(queryAfterWhere: String): List<PodcastEpisode> {
-        return episodeDao.findEpisodes(SimpleSQLiteQuery("SELECT episodes.* FROM episodes JOIN podcasts ON episodes.podcast_id = podcasts.uuid WHERE podcasts.subscribed = 1 AND $queryAfterWhere"))
+        return episodeDao.findEpisodes(SimpleSQLiteQuery("SELECT podcast_episodes.* FROM podcast_episodes JOIN podcasts ON podcast_episodes.podcast_id = podcasts.uuid WHERE podcasts.subscribed = 1 AND $queryAfterWhere"))
     }
 
     override fun observeEpisodeCount(queryAfterWhere: String): Flowable<Int> {
         return appDatabase.podcastDao().observeUnsubscribedUuid()
             .switchMap {
                 val podcastList = it.joinToString(separator = "', '", prefix = "podcast_id NOT IN ('", postfix = "')")
-                val query = "SELECT COUNT(*) FROM episodes WHERE $podcastList AND $queryAfterWhere"
+                val query = "SELECT COUNT(*) FROM podcast_episodes WHERE $podcastList AND $queryAfterWhere"
                 return@switchMap Flowable.just(query)
             }
             .switchMap {
@@ -196,7 +196,7 @@ class EpisodeManagerImpl @Inject constructor(
         return appDatabase.podcastDao().observeUnsubscribedUuid()
             .switchMap {
                 val podcastList = it.joinToString(separator = "', '", prefix = "podcast_id NOT IN ('", postfix = "')")
-                val query = "SELECT episodes.* FROM episodes WHERE $podcastList AND $queryAfterWhere"
+                val query = "SELECT podcast_episodes.* FROM podcast_episodes WHERE $podcastList AND $queryAfterWhere"
                 return@switchMap Flowable.just(query)
             }
             .switchMap {


### PR DESCRIPTION
## Description
When I [updated the table name from `episodes` to `podcast episodes`](https://github.com/Automattic/pocket-casts-android/pull/895), I didn't think to check for hardcoded queries. Turns out I should have. This fixes those.

One place this showed up was that the app would include some database errors in the logs when creating the logs file for support.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews