### PR TITLE
Add screen to more easily access logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,21 @@
 7.38
 -----
+*   Updates:
+    *   Added ability to view/share app logs from the "Help & feedback" screen
+        ([911](https://github.com/Automattic/pocket-casts-android/pull/911)).
 *   Bug Fixes:
     *   Fixed accessibility content desctiption for episode list
-         ([#890](https://github.com/Automattic/pocket-casts-android/issues/890)).
+        ([#890](https://github.com/Automattic/pocket-casts-android/issues/890)).
     *   Improved the validation of the Automotive skip forward and back time settings
-         ([#890](https://github.com/Automattic/pocket-casts-android/pull/892)).
-    *   Fixed the show notes' timestamps not getting converted to a link if it contained
-         another link ([#814](https://github.com/Automattic/pocket-casts-android/issues/814))
+        ([#890](https://github.com/Automattic/pocket-casts-android/pull/892)).
+    *   Fixed the show notes' timestamps not getting converted to a link if it contained another link 
+        ([#814](https://github.com/Automattic/pocket-casts-android/issues/814)).
+ 
 7.37
 -----
-* New Features:
+*   New Features:
     *   Added capability to sign into Pocket Casts using Google account
-        ([#878](https://github.com/Automattic/pocket-casts-android/pull/878))
+        ([#878](https://github.com/Automattic/pocket-casts-android/pull/878)).
 
 7.35
 -----

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
@@ -103,15 +103,23 @@ class HelpFragment : Fragment(), HasBackstack, Toolbar.OnMenuItemClickListener {
         return view
     }
 
-    override fun onMenuItemClick(item: MenuItem): Boolean {
-        return if (item.itemId == R.id.menu_status_page) {
-            val fragment = StatusFragment()
-            (activity as? FragmentHostListener)?.addFragment(fragment)
-            true
-        } else {
-            false
+    override fun onMenuItemClick(item: MenuItem): Boolean =
+        when (item.itemId) {
+
+            R.id.menu_logs -> {
+                val fragment = LogsFragment()
+                (activity as? FragmentHostListener)?.addFragment(fragment)
+                true
+            }
+
+            R.id.menu_status_page -> {
+                val fragment = StatusFragment()
+                (activity as? FragmentHostListener)?.addFragment(fragment)
+                true
+            }
+
+            else -> false
         }
-    }
 
     override fun onBackPressed(): Boolean {
         webView?.let {
@@ -188,7 +196,12 @@ class HelpFragment : Fragment(), HasBackstack, Toolbar.OnMenuItemClickListener {
 
         viewLifecycleOwner.lifecycleScope.launch {
             try {
-                val intent = support.sendEmail(subject = "Android feedback.", intro = "It's a great app, but it really needs...", context)
+                val intent = support.shareLogs(
+                    subject = "Android feedback.",
+                    intro = "It's a great app, but it really needs...",
+                    emailSupport = true,
+                    context = context,
+                )
                 context.startActivity(intent)
             } catch (e: ActivityNotFoundException) {
                 UiUtil.displayDialogNoEmailApp(context)
@@ -203,7 +216,12 @@ class HelpFragment : Fragment(), HasBackstack, Toolbar.OnMenuItemClickListener {
 
         viewLifecycleOwner.lifecycleScope.launch {
             try {
-                val intent = support.sendEmail(subject = "Android support.", intro = "Hi there, just needed help with something...", context)
+                val intent = support.shareLogs(
+                    subject = "Android support.",
+                    intro = "Hi there, just needed help with something...",
+                    emailSupport = true,
+                    context = context,
+                )
                 context.startActivity(intent)
             } catch (e: ActivityNotFoundException) {
                 UiUtil.displayDialogNoEmailApp(context)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LogsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LogsFragment.kt
@@ -1,0 +1,116 @@
+package au.com.shiftyjelly.pocketcasts.settings
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CopyAll
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
+import au.com.shiftyjelly.pocketcasts.settings.viewmodel.LogsViewModel
+import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@AndroidEntryPoint
+class LogsFragment : BaseFragment() {
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
+        ComposeView(requireContext()).apply {
+            setContent {
+                AppThemeWithBackground(theme.activeTheme) {
+                    LogsPage(
+                        onBackPressed = ::closeFragment
+                    )
+                }
+            }
+        }
+
+    private fun closeFragment() {
+        (activity as? FragmentHostListener)?.closeModal(this)
+    }
+}
+
+@Composable
+private fun LogsPage(
+    onBackPressed: () -> Unit,
+) {
+    val viewModel = hiltViewModel<LogsViewModel>()
+    val state by viewModel.state.collectAsState()
+    val logs = state.logs
+    val clipboardManager = LocalClipboardManager.current
+    val context = LocalContext.current
+
+    Column {
+
+        ThemedTopAppBar(
+            title = stringResource(LR.string.settings_logs),
+            onNavigationClick = onBackPressed,
+            actions = {
+                IconButton(
+                    onClick = {
+                        logs?.let {
+                            clipboardManager.setText(AnnotatedString(it))
+                        }
+                    },
+                    enabled = logs != null
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.CopyAll,
+                        contentDescription = stringResource(LR.string.share)
+                    )
+                }
+
+                IconButton(
+                    onClick = { viewModel.shareLogs(context) },
+                    enabled = logs != null
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Share,
+                        contentDescription = stringResource(LR.string.share)
+                    )
+                }
+            }
+        )
+
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp)
+                .fillMaxWidth()
+        ) {
+
+            if (logs == null) {
+                TextH30(
+                    text = stringResource(LR.string.loading),
+                    modifier = Modifier.padding(vertical = 24.dp)
+                )
+            } else {
+                TextP60(logs)
+            }
+        }
+    }
+}

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/status/StatusViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/status/StatusViewModel.kt
@@ -113,7 +113,12 @@ class StatusViewModel @Inject constructor(
 
         launch {
             try {
-                val intent = support.sendEmail(subject = "Android status report.", intro = "Hi there, just needed help with something...", context)
+                val intent = support.shareLogs(
+                    subject = "Android status report.",
+                    intro = "Hi there, just needed help with something...",
+                    emailSupport = true,
+                    context = context,
+                )
                 context.startActivity(intent)
             } catch (e: ActivityNotFoundException) {
                 UiUtil.displayDialogNoEmailApp(context)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/LogsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/LogsViewModel.kt
@@ -1,0 +1,46 @@
+package au.com.shiftyjelly.pocketcasts.settings.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.repositories.support.Support
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@HiltViewModel
+class LogsViewModel @Inject constructor(
+    private val support: Support,
+) : ViewModel() {
+
+    data class State(
+        val logs: String?,
+    )
+
+    private val _state = MutableStateFlow(State(null))
+    val state = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            val logs = support.getUserDebug(false)
+            _state.update { it.copy(logs = logs) }
+        }
+    }
+
+    fun shareLogs(context: Context) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val intent = support.shareLogs(
+                subject = context.getString(LR.string.settings_logs),
+                intro = "",
+                emailSupport = false,
+                context = context
+            )
+            context.startActivity(intent)
+        }
+    }
+}

--- a/modules/features/settings/src/main/res/menu/menu_help.xml
+++ b/modules/features/settings/src/main/res/menu/menu_help.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item android:id="@+id/menu_logs"
+        android:title="@string/settings_logs"
+        android:icon="@drawable/baseline_view_list_24"
+        app:showAsAction="always" />
     <item android:id="@+id/menu_status_page"
         android:title="@string/settings_status_page"
         android:icon="@drawable/ic_status_page"

--- a/modules/services/images/src/main/res/drawable/baseline_view_list_24.xml
+++ b/modules/services/images/src/main/res/drawable/baseline_view_list_24.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#000000" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M3,14h4v-4H3V14zM3,19h4v-4H3V19zM3,9h4V5H3V9zM8,14h13v-4H8V14zM8,19h13v-4H8V19zM8,5v4h13V5H8z"/>
+</vector>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1261,6 +1261,7 @@
     <string name="settings_notification_default_sound">Default sound</string>
     <string name="settings_import_title">Import subscriptions</string>
     <string name="settings_status_page">Status Page</string>
+    <string name="settings_logs">Logs</string>
     <string name="settings_status_description">Check your connection with important services. This helps diagnose issues with your network, proxies, VPN, ad-blocking and security apps.</string>
     <string name="settings_status_service_internet">Internet Connection</string>
     <string name="settings_status_run">Run now</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -72,7 +72,7 @@ class Support @Inject constructor(
         get() = context.resources.getStringArray(R.array.settings_auto_archive_inactive_values)
 
     @Suppress("DEPRECATION")
-    suspend fun sendEmail(subject: String, intro: String, context: Context): Intent {
+    suspend fun shareLogs(subject: String, intro: String, emailSupport: Boolean, context: Context): Intent {
         val dialog = withContext(Dispatchers.Main) {
             android.app.ProgressDialog.show(context, context.getString(R.string.loading), context.getString(R.string.settings_support_please_wait), true)
         }
@@ -80,7 +80,9 @@ class Support @Inject constructor(
 
         withContext(Dispatchers.IO) {
             intent.type = "text/html"
-            intent.putExtra(Intent.EXTRA_EMAIL, arrayOf("support@pocketcasts.com"))
+            if (emailSupport) {
+                intent.putExtra(Intent.EXTRA_EMAIL, arrayOf("support@pocketcasts.com"))
+            }
             val isPlus = subscriptionManager.getCachedStatus() is SubscriptionStatus.Plus
             intent.putExtra(
                 Intent.EXTRA_SUBJECT,
@@ -135,7 +137,7 @@ class Support @Inject constructor(
     }
 
     @Suppress("DEPRECATION")
-    private suspend fun getUserDebug(html: Boolean): String {
+    suspend fun getUserDebug(html: Boolean): String {
         val output = StringBuilder()
         try {
             val eol = if (html) "<br/>" else "\n"


### PR DESCRIPTION
## Description
This adds a screen to enable the user to more easily access their logs within the app.

> **Note**
> This PR builds on https://github.com/Automattic/pocket-casts-android/pull/910, so you may want to review that one first.

Fixes #833 

## Testing Instructions
1. Go to the Profile tab
2. Tap on the ⚙️ 
3. Tap on "Help & feedback"
4. Tap on the list icon at the top of the screen
5. ✅ Observe that the logs are displayed
6. Tap on the copy icon at the top of the screen
7. ✅  Observe that the logs are copied to the clipboard
8. Tap on the Share icon
9. ✅ Observe that you can share a file with the logs (similar to what happens currently when someone contacts support through the app).

## Screenshots or Screencast 

https://user-images.githubusercontent.com/4656348/234631340-cc39fce0-e5be-44a9-8e4d-9e4ea21d391a.mov

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack
