### PR TITLE
Advanced settings screen updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 7.38
 -----
+*   Updates:
+    *   Added Advanced Settings section for experimental settings
+        ([#885](https://github.com/Automattic/pocket-casts-android/pull/885/)).
+    *   Added setting to disable sync on metered networks
+        ([#885](https://github.com/Automattic/pocket-casts-android/pull/885/)).
 *   Bug Fixes:
     *   Fixed accessibility content desctiption for episode list
          ([#890](https://github.com/Automattic/pocket-casts-android/issues/890)).

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AdvancedSettingsPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AdvancedSettingsPage.kt
@@ -2,9 +2,11 @@ package au.com.shiftyjelly.pocketcasts.settings
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -19,12 +21,20 @@ import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRow
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRowToggle
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingSection
+import au.com.shiftyjelly.pocketcasts.compose.components.SettingsSection
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.AdvancedSettingsViewModel
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import java.util.*
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
+/**
+ * The advanced settings page is for settings that we are not sure many users will need, or that we are
+ * worried might create a worse user experience for most users. Basically, this is a place where we can
+ * add settings without complicating things for the typical user.
+ */
 @Composable
 fun AdvancedSettingsPage(
     viewModel: AdvancedSettingsViewModel,
@@ -61,7 +71,15 @@ fun AdvancedSettingsView(
                 .fillMaxHeight()
                 .verticalScroll(rememberScrollState())
         ) {
-            SettingSection(heading = stringResource(LR.string.settings_storage_section_heading_mobile_data)) {
+            TextP50(
+                text = stringResource(LR.string.settings_description_advanced),
+                color = MaterialTheme.theme.colors.primaryText02,
+                modifier = Modifier.padding(SettingsSection.horizontalPadding)
+            )
+            SettingSection(
+                heading = stringResource(LR.string.settings_storage_section_heading_mobile_data),
+                indent = false,
+            ) {
                 SyncOnMeteredRow(state.backgroundSyncOnMeteredState)
             }
         }
@@ -77,10 +95,12 @@ private fun SyncOnMeteredRow(
         primaryText = stringResource(LR.string.settings_advanced_sync_on_metered),
         secondaryText = stringResource(LR.string.settings_advanced_sync_on_metered_summary),
         toggle = SettingRowToggle.Switch(state.isChecked, state.isEnabled),
+        indent = false,
         modifier = modifier.toggleable(
             value = state.isChecked,
-            role = Role.Switch
-        ) { state.onCheckedChange(it) }
+            role = Role.Switch,
+            onValueChange = { state.onCheckedChange(it) }
+        ),
     )
 }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragmentPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragmentPage.kt
@@ -75,9 +75,9 @@ fun SettingsFragmentPage(
             AutoAddToUpNextRow(onClick = { openFragment(AutoAddSettingsFragment()) })
             HelpAndFeedbackRow(onClick = { openFragment(HelpFragment()) })
             ImportAndExportOpmlRow(onClick = { openFragment(ExportSettingsFragment()) })
+            AdvancedRow(onClick = { openFragment(AdvancedSettingsFragment()) })
             PrivacyRow(onClick = { openFragment(PrivacyFragment()) })
             AboutRow(onClick = { openFragment(AboutFragment()) })
-            AdvancedRow(onClick = { openFragment(AdvancedSettingsFragment()) })
         }
     }
 }

--- a/modules/features/settings/src/main/res/layout/fragment_media_notification_controls.xml
+++ b/modules/features/settings/src/main/res/layout/fragment_media_notification_controls.xml
@@ -34,7 +34,7 @@
             android:clipChildren="false"
             android:clipToPadding="false"
             android:paddingTop="4dp"
-            android:paddingStart="8dp"
+            android:paddingStart="16dp"
             android:paddingBottom="32dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Settings.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Settings.kt
@@ -29,14 +29,19 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.components.SettingsSection.horizontalPadding
+import au.com.shiftyjelly.pocketcasts.compose.components.SettingsSection.indentedStartPadding
+import au.com.shiftyjelly.pocketcasts.compose.components.SettingsSection.verticalPadding
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 
-private val startPadding = 72.dp
-private val endPadding = 24.dp
-private val verticalPadding = 12.dp
+object SettingsSection {
+    val horizontalPadding = 24.dp
+    val indentedStartPadding = horizontalPadding + 48.dp
+    val verticalPadding = 12.dp
+}
 
 sealed class SettingRowToggle {
     data class Checkbox(val checked: Boolean, val enabled: Boolean = true) : SettingRowToggle()
@@ -48,22 +53,20 @@ sealed class SettingRowToggle {
 fun SettingSection(
     modifier: Modifier = Modifier,
     heading: String? = null,
-    content: @Composable () -> Unit = {}
+    indent: Boolean = true,
+    content: @Composable () -> Unit = {},
 ) {
     Column(modifier = modifier) {
         Column(
-            modifier = Modifier.padding(
-                top = verticalPadding,
-                bottom = verticalPadding,
-            )
+            modifier = Modifier.padding(vertical = verticalPadding)
         ) {
             if (heading != null) {
                 TextH40(
                     text = heading,
                     color = MaterialTheme.theme.colors.primaryInteractive01,
                     modifier = Modifier.padding(
-                        start = startPadding,
-                        end = endPadding,
+                        start = if (indent) indentedStartPadding else horizontalPadding,
+                        end = horizontalPadding,
                         top = verticalPadding,
                         bottom = verticalPadding
                     )
@@ -124,14 +127,14 @@ fun SettingRow(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
             .padding(
-                end = endPadding,
+                end = horizontalPadding,
                 top = verticalPadding,
                 bottom = verticalPadding
             )
     ) {
         Box(
             contentAlignment = Alignment.Center,
-            modifier = Modifier.width(if (indent || icon != null) startPadding else 16.dp)
+            modifier = Modifier.width(if (indent || icon != null) indentedStartPadding else horizontalPadding)
         ) {
             GradientIcon(icon)
         }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1157,6 +1157,7 @@
     <string name="settings_title">Title</string>
     <string name="settings_title_about">About</string>
     <string name="settings_title_advanced">Advanced</string>
+    <string name="settings_description_advanced">These settings are experimental. We recommend that most users not change these from their default values.</string>
     <string name="settings_title_appearance">Appearance</string>
     <string name="settings_title_auto_add_to_up_next">Auto add to Up Next</string>
     <string name="settings_title_auto_archive" translatable="false">@string/auto_archive</string>
@@ -1310,7 +1311,7 @@
     <string name="settings_privacy_crash_link_summary">Allow us to link your Pocket Casts account to crash reports.</string>
 
     <string name="settings_advanced_sync_on_metered">Sync on Metered Networks</string>
-    <string name="settings_advanced_sync_on_metered_summary">Permits automatic background synchronization on metered networks. This is enabled by default and has no effect if background refresh is turned off.</string>
+    <string name="settings_advanced_sync_on_metered_summary">Permits automatic background sync on metered networks. This is enabled by default and has no effect if background refresh is turned off.</string>
     <string name="whats_new_folders_title_7_20" translatable="false">@string/folders</string>
     <string name="whats_new_folders_7_20">If you love podcasts half as much as we do, you probably have a lot of them. If you\'re a Pocket Casts Plus subscriber, you can now sort these into folders and file them into neat groups.\n\nThanks to your support, your Home Screen has never looked better!</string>
     <string name="whats_new_grid_title_7_20">Home Grid Syncing</string>


### PR DESCRIPTION
## Description
* Adds changelog entries for https://github.com/Automattic/pocket-casts-android/issues/858
* Adds a bit of descriptive text to the top of the Advanced settings. My thinking is that we want to caution users a bit about playing with these settings since they can create a worse user experience.
* Removes the indent from the advanced settings to be more like the privacy screen. I think we want to move away from using that on screens like this where we're not using that indented space for any icons. (The privacy settings screen also doesn't have the indent).
* Moves Advanced settings to be above About and Privacy on the Settings screen

## Testing Instructions
* Make sure that the padding on the "General" → "Media notification controls" screen still looks good.
* Check the that the Advanced settings screen looks good.
* Check that the text on the top of the Advanced settings screen sounds right.
* Confirm that the new position for Advanced settings in the settings list (i.e., it's not on the bottom anymore) makes sense.

## Screenshots or Screencast 

![image](https://user-images.githubusercontent.com/4656348/234663277-d55bb484-d513-4b6f-b2dc-ac9ef7b16ead.png)

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack
