### PR TITLE
Use fade instead of ellipsis for email overflow

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/LoggingInScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/LoggingInScreen.kt
@@ -101,29 +101,38 @@ fun LoggingInScreen(
                     // Without this if "xxxx@gmail.com" ran just a bit long, it would get shortened
                     // to "xxx@gmail".
                     softWrap = false,
-                    modifier = Modifier
-                        .drawWithContent {
-                            drawContent()
-
-                            // Use < instead of <= because text that doesn't fit will have a width that is equal
-                            // to the available space
-                            val textFits = size.width < widthPx
-
-                            if (!textFits) {
-                                // Apply a fade out gradient to the end of the text to indicate overflow
-                                drawRect(
-                                    // Add a bit of extra width so the gradient goes to the end of the screen
-                                    size = Size(size.width * 1.2f, size.height),
-                                    brush = Brush.horizontalGradient(
-                                        0.7f to Color.Transparent,
-                                        1.0f to background,
-                                    ),
-                                )
-                            }
-                        }
+                    modifier = Modifier.fadeOutOverflow(
+                        overFlowWidthPx = widthPx.toInt(),
+                        backgroundColor = background
+                    )
                 )
             }
         }
+    }
+}
+
+private fun Modifier.fadeOutOverflow(
+    overFlowWidthPx: Int,
+    backgroundColor: Color,
+) = drawWithContent {
+
+    // draw text first
+    drawContent()
+
+    // Use < instead of <= because text that doesn't fit will have a width that is equal
+    // to the available space
+    val textFits = size.width < overFlowWidthPx
+
+    if (!textFits) {
+        // Apply a gradient over the end of the text that fades in the background color to indicate overflow
+        drawRect(
+            // Add a bit of extra width so the gradient goes to the end of the screen
+            size = Size(size.width * 1.2f, size.height),
+            brush = Brush.horizontalGradient(
+                0.7f to Color.Transparent,
+                1.0f to backgroundColor,
+            ),
+        )
     }
 }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/LoggingInScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/LoggingInScreen.kt
@@ -8,24 +8,29 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -48,7 +53,7 @@ fun LoggingInScreen(
 ) {
 
     val viewModel = hiltViewModel<LoggingInScreenViewModel>()
-    val email = remember { viewModel.getEmail() }
+    val email = viewModel.getEmail()
 
     Column(
         verticalArrangement = Arrangement.Center,
@@ -80,13 +85,44 @@ fun LoggingInScreen(
             style = MaterialTheme.typography.title3
         )
         if (email != null) {
-            Text(
-                text = email,
-                textAlign = TextAlign.Center,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                style = MaterialTheme.typography.body2
-            )
+            BoxWithConstraints(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+            ) {
+
+                val widthPx = with(LocalDensity.current) { maxWidth.toPx() }
+                val background = MaterialTheme.colors.background
+
+                Text(
+                    text = email,
+                    style = MaterialTheme.typography.body2,
+                    // Turn off softWrap to make sure the text doesn't get truncated if it runs long.
+                    // Without this if "xxxx@gmail.com" ran just a bit long, it would get shortened
+                    // to "xxx@gmail".
+                    softWrap = false,
+                    modifier = Modifier
+                        .drawWithContent {
+                            drawContent()
+
+                            // Use < instead of <= because text that doesn't fit will have a width that is equal
+                            // to the available space
+                            val textFits = size.width < widthPx
+
+                            if (!textFits) {
+                                // Apply a fade out gradient to the end of the text to indicate overflow
+                                drawRect(
+                                    // Add a bit of extra width so the gradient goes to the end of the screen
+                                    size = Size(size.width * 1.2f, size.height),
+                                    brush = Brush.horizontalGradient(
+                                        0.7f to Color.Transparent,
+                                        1.0f to background,
+                                    ),
+                                )
+                            }
+                        }
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
The logging in screen on the watch used an ellipsis to indicate overflow before. This updates that to use a gradual fade out only when the email is too long.

I was having some trouble getting this to work right, but I got some great help [in Kotlin's Slack](https://kotlinlang.slack.com/archives/C04TPPEQKEJ/p1682438604723239).

Internal ref: p1682125454156639-slack-C040S9BK7SP

## Testing Instructions
1. While logged in on your phone but not logged into the watch, start the watch app
2. Observe that the "Logging in" screen shows a fade out gradient when the user's email is too long (I manually edited [this line](https://github.com/Automattic/pocket-casts-android/blob/0da3d947fac305fe9c217310e8329fd674be2630/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/LoggingInScreen.kt#L98) to create the email lengths that I needed for testing).

## Screenshots or Screencast 
| Not overflowing | Overflowing |
| --- | --- |
| ![Screenshot 2023-04-26 at 2 19 54 PM](https://user-images.githubusercontent.com/4656348/234671590-fe7a1e65-7968-4535-96d2-df714c4bf488.png) | ![Screenshot 2023-04-26 at 2 22 23 PM](https://user-images.githubusercontent.com/4656348/234671609-ef16e4f7-6b0e-4e36-af3e-a56c97faf9c7.png) |


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [X] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack