### PR TITLE
Handle user episodes

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -104,6 +104,29 @@ class AddFileActivity :
             intent.putExtra(EXTRA_EXISTING_EPISODE_UUID, fileUuid)
             return intent
         }
+
+        fun darkThemeColors() = listOf(
+            AddFileColourAdapter.Item.Colour(1, ThemeColor.primaryText02Dark, false),
+            AddFileColourAdapter.Item.Colour(2, ThemeColor.filter01Dark, true),
+            AddFileColourAdapter.Item.Colour(3, ThemeColor.filter05Dark, true),
+            AddFileColourAdapter.Item.Colour(4, ThemeColor.filter04Dark, true),
+            AddFileColourAdapter.Item.Colour(5, ThemeColor.filter03Dark, true),
+            AddFileColourAdapter.Item.Colour(6, ThemeColor.filter02Dark, true),
+            AddFileColourAdapter.Item.Colour(7, ThemeColor.filter06Dark, true),
+            AddFileColourAdapter.Item.Colour(8, ThemeColor.filter07Dark, true),
+        )
+
+        private fun lightThemeColors() = listOf(
+
+            AddFileColourAdapter.Item.Colour(1, ThemeColor.primaryText02Light, false),
+            AddFileColourAdapter.Item.Colour(2, ThemeColor.filter01Light, true),
+            AddFileColourAdapter.Item.Colour(3, ThemeColor.filter05Light, true),
+            AddFileColourAdapter.Item.Colour(4, ThemeColor.filter04Light, true),
+            AddFileColourAdapter.Item.Colour(5, ThemeColor.filter03Light, true),
+            AddFileColourAdapter.Item.Colour(6, ThemeColor.filter02Light, true),
+            AddFileColourAdapter.Item.Colour(7, ThemeColor.filter06Light, true),
+            AddFileColourAdapter.Item.Colour(8, ThemeColor.filter07Light, true),
+        )
     }
 
     override val coroutineContext: CoroutineContext
@@ -325,31 +348,15 @@ class AddFileActivity :
     }
 
     private fun updateColorItems() {
-
-        val colors = mutableListOf<AddFileColourAdapter.Item.Colour>()
-        if (Theme.isDark(this)) {
-            colors.add(AddFileColourAdapter.Item.Colour(1, ThemeColor.primaryText02Dark, false))
-            colors.add(AddFileColourAdapter.Item.Colour(2, ThemeColor.filter01Dark, true))
-            colors.add(AddFileColourAdapter.Item.Colour(3, ThemeColor.filter05Dark, true))
-            colors.add(AddFileColourAdapter.Item.Colour(4, ThemeColor.filter04Dark, true))
-            colors.add(AddFileColourAdapter.Item.Colour(5, ThemeColor.filter03Dark, true))
-            colors.add(AddFileColourAdapter.Item.Colour(6, ThemeColor.filter02Dark, true))
-            colors.add(AddFileColourAdapter.Item.Colour(7, ThemeColor.filter06Dark, true))
-            colors.add(AddFileColourAdapter.Item.Colour(8, ThemeColor.filter07Dark, true))
-        } else {
-            colors.add(AddFileColourAdapter.Item.Colour(1, ThemeColor.primaryText02Light, false))
-            colors.add(AddFileColourAdapter.Item.Colour(2, ThemeColor.filter01Light, true))
-            colors.add(AddFileColourAdapter.Item.Colour(3, ThemeColor.filter05Light, true))
-            colors.add(AddFileColourAdapter.Item.Colour(4, ThemeColor.filter04Light, true))
-            colors.add(AddFileColourAdapter.Item.Colour(5, ThemeColor.filter03Light, true))
-            colors.add(AddFileColourAdapter.Item.Colour(6, ThemeColor.filter02Light, true))
-            colors.add(AddFileColourAdapter.Item.Colour(7, ThemeColor.filter06Light, true))
-            colors.add(AddFileColourAdapter.Item.Colour(8, ThemeColor.filter07Light, true))
-        }
-
         val listItems = mutableListOf<AddFileColourAdapter.Item>()
         listItems.add(AddFileColourAdapter.Item.Image(bitmap))
-        listItems.addAll(colors)
+        listItems.addAll(
+            if (Theme.isDark(this)) {
+                darkThemeColors()
+            } else {
+                lightThemeColors()
+            }
+        )
         colorAdapter.submitList(listItems)
     }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -177,12 +177,17 @@ private fun WearApp() {
             }
         }
 
-        composable(FilesScreen.route) {
+        scrollable(FilesScreen.route) {
             NowPlayingPager(
                 navController = navController,
                 swipeToDismissState = swipeToDismissState,
             ) {
-                FilesScreen()
+                FilesScreen(
+                    columnState = it.columnState,
+                    navigateToEpisode = { episodeUuid ->
+                        navController.navigate(EpisodeScreenFlow.navigateRoute(episodeUuid))
+                    },
+                )
             }
         }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesScreen.kt
@@ -3,13 +3,20 @@ package au.com.shiftyjelly.pocketcasts.wear.ui
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.EpisodeChip
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 object FilesScreen {
@@ -17,22 +24,50 @@ object FilesScreen {
 }
 
 @Composable
-fun FilesScreen() {
+fun FilesScreen(
+    columnState: ScalingLazyColumnState,
+    navigateToEpisode: (episodeUuid: String) -> Unit,
+) {
+
+    val viewModel = hiltViewModel<FilesViewModel>()
+    val userEpisodesState = viewModel.userEpisodes.collectAsState(null)
+    val userEpisodes = userEpisodesState.value
+
+    when {
+        // Show nothing while screen is loading
+        userEpisodes == null -> return
+
+        userEpisodes.isEmpty() -> EmptyState()
+
+        else -> {
+            ScalingLazyColumn(
+                columnState = columnState
+            ) {
+
+                item { ScreenHeaderChip(LR.string.profile_navigation_files) }
+
+                items(userEpisodes) { episode ->
+                    EpisodeChip(
+                        episode = episode,
+                        onClick = { navigateToEpisode(episode.uuid) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyState() {
     Column(
         verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier.fillMaxSize()
     ) {
         Text(
-            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(LR.string.profile_cloud_no_files_uploaded),
             textAlign = TextAlign.Center,
-            color = MaterialTheme.colors.primary,
-            text = stringResource(LR.string.profile_navigation_files)
-        )
-        Text(
-            modifier = Modifier.fillMaxWidth(),
-            textAlign = TextAlign.Center,
-            color = MaterialTheme.colors.primary.copy(alpha = 0.5f),
-            text = "placeholder screen"
+            style = MaterialTheme.typography.title3,
         )
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesViewModel.kt
@@ -1,0 +1,19 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui
+
+import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.reactive.asFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class FilesViewModel @Inject constructor(
+    settings: Settings,
+    userEpisodeManager: UserEpisodeManager,
+) : ViewModel() {
+
+    val userEpisodes = userEpisodeManager
+        .observeUserEpisodesSorted(settings.getCloudSortOrder())
+        .asFlow()
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeDateTimeText.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeDateTimeText.kt
@@ -8,14 +8,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import au.com.shiftyjelly.pocketcasts.compose.components.TextC70
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
-import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatPattern
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 
 @Composable
-fun EpisodeDateTimeText(episode: PodcastEpisode, modifier: Modifier = Modifier) {
+fun EpisodeDateTimeText(episode: BaseEpisode, modifier: Modifier = Modifier) {
     val context = LocalContext.current
     val shortDate = episode.publishedDate.toLocalizedFormatPattern("dd MMM")
     val timeLeft = TimeHelper.getTimeLeft(

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
@@ -13,9 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -29,6 +27,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.DownloadButtonState
@@ -78,19 +77,21 @@ fun EpisodeScreen(
             )
         }
 
-        item {
-            TextP50(
-                text = podcast.title,
-                maxLines = 1,
-                color = WearColors.FFDADCE0,
-                lineHeight = headingLineHeight,
-                textAlign = TextAlign.Center,
-                modifier = Modifier
-                    .padding(horizontal = 8.dp)
-                    .clickable {
-                        navigateToPodcast(podcast.uuid)
-                    }
-            )
+        if (podcast != null) {
+            item {
+                TextP50(
+                    text = podcast.title,
+                    maxLines = 1,
+                    color = WearColors.FFDADCE0,
+                    lineHeight = headingLineHeight,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .padding(horizontal = 8.dp)
+                        .clickable {
+                            navigateToPodcast(podcast.uuid)
+                        }
+                )
+            }
         }
 
         item {
@@ -103,8 +104,11 @@ fun EpisodeScreen(
             ) {
                 val downloadSize = Util.formattedBytes(episode.sizeInBytes, context)
                     .replace("-", stringResource(LR.string.podcasts_download_download))
+
+                val tintColor = state.tintColor ?: MaterialTheme.colors.primary
+
                 DownloadButton(
-                    tint = state.tintColor,
+                    tint = tintColor,
                     onClick = {
                         if (episode.isDownloaded) {
                             navigateToConfirmDeleteDownload()
@@ -132,7 +136,7 @@ fun EpisodeScreen(
                 )
 
                 PlayButton(
-                    backgroundColor = state.tintColor,
+                    backgroundColor = tintColor,
                     onClick = {
                         if (state.isPlayingEpisode) {
                             viewModel.onPauseClicked()
@@ -145,7 +149,7 @@ fun EpisodeScreen(
 
                 QueueButton(
                     inUpNext = state.inUpNext,
-                    tint = state.tintColor,
+                    tint = tintColor,
                     onClick = {
                         viewModel.onUpNextClicked(
                             onRemoveFromUpNext = navigateToRemoveFromUpNextNotification,
@@ -202,32 +206,36 @@ fun EpisodeScreen(
         val episodeIsMarkedPlayed = episode.playingStatus == EpisodePlayingStatus.COMPLETED
         items(
             listOf(
-                EpisodeScreenItem(
-                    title = if (episode.isArchived) {
-                        LR.string.podcasts_unarchive
-                    } else {
-                        LR.string.archive
-                    },
-                    iconRes = if (episode.isArchived) {
-                        IR.drawable.ic_unarchive
-                    } else {
-                        IR.drawable.ic_archive
-                    },
-                    onClick = viewModel::onArchiveClicked,
-                ),
-                EpisodeScreenItem(
-                    title = if (episode.isStarred) {
-                        LR.string.unstar
-                    } else {
-                        LR.string.star
-                    },
-                    iconRes = if (episode.isStarred) {
-                        IR.drawable.ic_star_filled
-                    } else {
-                        IR.drawable.ic_star
-                    },
-                    onClick = viewModel::onStarClicked,
-                ),
+                if (episode is PodcastEpisode) {
+                    EpisodeScreenItem(
+                        title = if (episode.isArchived) {
+                            LR.string.podcasts_unarchive
+                        } else {
+                            LR.string.archive
+                        },
+                        iconRes = if (episode.isArchived) {
+                            IR.drawable.ic_unarchive
+                        } else {
+                            IR.drawable.ic_archive
+                        },
+                        onClick = viewModel::onArchiveClicked,
+                    )
+                } else null,
+                if (episode is PodcastEpisode) {
+                    EpisodeScreenItem(
+                        title = if (episode.isStarred) {
+                            LR.string.unstar
+                        } else {
+                            LR.string.star
+                        },
+                        iconRes = if (episode.isStarred) {
+                            IR.drawable.ic_star_filled
+                        } else {
+                            IR.drawable.ic_star
+                        },
+                        onClick = viewModel::onStarClicked,
+                    )
+                } else null,
                 EpisodeScreenItem(
                     title = if (episodeIsMarkedPlayed) {
                         LR.string.mark_unplayed
@@ -241,12 +249,15 @@ fun EpisodeScreen(
                     },
                     onClick = viewModel::onMarkAsPlayedClicked,
                 ),
-                EpisodeScreenItem(
-                    title = LR.string.go_to_podcast,
-                    iconRes = IR.drawable.ic_goto_32,
-                    onClick = { navigateToPodcast(podcast.uuid) },
-                ),
+                if (podcast != null) {
+                    EpisodeScreenItem(
+                        title = LR.string.go_to_podcast,
+                        iconRes = IR.drawable.ic_goto_32,
+                        onClick = { navigateToPodcast(podcast.uuid) },
+                    )
+                } else null,
             )
+                .filterNotNull()
         ) {
             EpisodeListChip(it)
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -41,7 +41,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
@@ -137,10 +136,9 @@ class EpisodeViewModel @Inject constructor(
                 downloadProgressUpdate.downloadProgress
             }
 
-            val showNotesFlow = flow {
-                // FIXME don't load show notes for user episodes
-                emit(showNotesManager.loadShowNotes(episodeUuid))
-            }
+            val showNotesFlow = episodeFlow
+                .filterIsInstance<PodcastEpisode>() // user episodes don't have show notes
+                .map { showNotesManager.loadShowNotes(it.uuid) }
 
             combine6(
                 episodeFlow,


### PR DESCRIPTION
## Description
This updates the watch app to handle user episodes. The first part of that is to update the `EpisodeScreen` so it can handle user episodes. The second part is implementing the FIles screeen.

> **Note**
> This PR builds on https://github.com/Automattic/pocket-casts-android/pull/909.

## Testing Instructions

### Empty File Screen State
1. Open the app with an account that does not have any user episodes
2. Tap on files
3. Observe the UI informs you that you have no files

### Non-Empty FIle Screen State
1. Open the app with an account that has some files uploaded to the cloud
2. Tap on files
3. Observe the UI lists all your files
4. Tap on one of the files to open the episode screen
5. Confirm the UI of the episode screen looks fine (note that files only have the "Mark played" button and there are no show notes for user episodes). 
6. Observe that the episode screen controls are tinted based on the appropriate "color" for the episode. For podcast episodes, this comes back from our server (this logic should be unchanged in this PR). For user episodes, if the user has set a color for the episode, that color is used; if the user has set custom artwork for the episode, we're using the [palette api](https://developer.android.com/develop/ui/views/graphics/palette-colors) to extract a light vibrant color from the artwork.
7. Tap the download button to download the episode
8. Tap the play button to play the episode

## Screenshots or Screencast 

| No Files | Files list | Episode screen for file |
| --- | --- | --- |
| ![Screenshot 2023-04-26 at 5 17 06 PM](https://user-images.githubusercontent.com/4656348/234708223-28574fb8-c07d-4e4a-af45-ab4d9194782a.png) | ![Screenshot 2023-04-26 at 5 17 34 PM](https://user-images.githubusercontent.com/4656348/234708242-2688543a-8228-4850-ac3c-d48ee3400ba8.png) | ![Screenshot 2023-04-26 at 5 34 43 PM](https://user-images.githubusercontent.com/4656348/234708248-614a8e5f-29e0-451c-b50b-f3ac3a70d5c3.png) |

## Checklist

- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews