### PR TITLE
Patron: Introduce tiers and remove pricing modal on upgrade screen

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
@@ -60,6 +60,8 @@ fun OnboardingUpgradeBottomSheet(
     val state = viewModel.state.collectAsState().value
     val subscriptions = (state as? OnboardingUpgradeBottomSheetState.Loaded)?.subscriptions
         ?: emptyList()
+    val selectedSubscription = (state as? OnboardingUpgradeBottomSheetState.Loaded)?.selectedSubscription
+    val selectedTier = selectedSubscription?.tier
 
     val resources = LocalContext.current.resources
 
@@ -89,43 +91,44 @@ fun OnboardingUpgradeBottomSheet(
             Column(
                 verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                subscriptions.forEach { subscription ->
+                (selectedTier?.let { subscriptions.filter { it.tier == selectedTier } } ?: subscriptions)
+                    .forEach { subscription ->
 
-                    // Have to remember the interaction source here instead of inside the RowButtons
-                    // because otherwise the interaction sources get misapplied to the wrong button
-                    // as the user changes selections.
-                    val interactionSource = remember(subscription) { MutableInteractionSource() }
+                        // Have to remember the interaction source here instead of inside the RowButtons
+                        // because otherwise the interaction sources get misapplied to the wrong button
+                        // as the user changes selections.
+                        val interactionSource = remember(subscription) { MutableInteractionSource() }
 
-                    val text = subscription.recurringPricingPhase.pricePerPeriod(resources)
-                    val topText = subscription
-                        .trialPricingPhase
-                        ?.numPeriodFreeTrial(resources)
-                        ?.uppercase(Locale.getDefault())
+                        val text = subscription.recurringPricingPhase.pricePerPeriod(resources)
+                        val topText = subscription
+                            .trialPricingPhase
+                            ?.numPeriodFreeTrial(resources)
+                            ?.uppercase(Locale.getDefault())
 
-                    Column {
+                        Column {
 
-                        if (topText == null) {
-                            Spacer(Modifier.height(8.dp))
-                        }
+                            if (topText == null) {
+                                Spacer(Modifier.height(8.dp))
+                            }
 
-                        if (subscription == state.selectedSubscription) {
-                            PlusOutlinedRowButton(
-                                text = text,
-                                topText = topText,
-                                onClick = { viewModel.updateSelectedSubscription(subscription) },
-                                interactionSource = interactionSource,
-                                selectedCheckMark = true,
-                            )
-                        } else {
-                            UnselectedPlusOutlinedRowButton(
-                                text = text,
-                                topText = topText,
-                                onClick = { viewModel.updateSelectedSubscription(subscription) },
-                                interactionSource = interactionSource,
-                            )
+                            if (subscription == state.selectedSubscription) {
+                                PlusOutlinedRowButton(
+                                    text = text,
+                                    topText = topText,
+                                    onClick = { viewModel.updateSelectedSubscription(subscription) },
+                                    interactionSource = interactionSource,
+                                    selectedCheckMark = true,
+                                )
+                            } else {
+                                UnselectedPlusOutlinedRowButton(
+                                    text = text,
+                                    topText = topText,
+                                    onClick = { viewModel.updateSelectedSubscription(subscription) },
+                                    interactionSource = interactionSource,
+                                )
+                            }
                         }
                     }
-                }
             }
 
             val descriptionText = state.selectedSubscription.trialPricingPhase.let { trialPhase ->

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -41,12 +40,9 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgra
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetViewModel
 import au.com.shiftyjelly.pocketcasts.compose.bottomsheet.Pill
-import au.com.shiftyjelly.pocketcasts.compose.components.Clickable
-import au.com.shiftyjelly.pocketcasts.compose.components.ClickableTextHelper
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.models.type.TrialSubscriptionPricingPhase
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import java.util.Locale
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -193,32 +189,9 @@ fun OnboardingUpgradeBottomSheet(
 
         Spacer(Modifier.height(16.dp))
 
-        val privacyPolicyText = stringResource(LR.string.onboarding_plus_privacy_policy)
-        val termsAndConditionsText = stringResource(LR.string.onboarding_plus_terms_and_conditions)
-        val text = stringResource(
-            LR.string.onboarding_plus_continuing_agrees_to,
-            privacyPolicyText,
-            termsAndConditionsText
-        )
-        val uriHandler = LocalUriHandler.current
-        ClickableTextHelper(
-            text = text,
+        OnboardingUpgradeHelper.PrivacyPolicy(
             color = Color.White,
             textAlign = TextAlign.Center,
-            clickables = listOf(
-                Clickable(
-                    text = privacyPolicyText,
-                    onClick = {
-                        uriHandler.openUri(Settings.INFO_PRIVACY_URL)
-                    }
-                ),
-                Clickable(
-                    text = termsAndConditionsText,
-                    onClick = {
-                        uriHandler.openUri(Settings.INFO_TOS_URL)
-                    }
-                ),
-            )
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -81,11 +81,9 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
-import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
@@ -152,7 +150,6 @@ internal fun OnboardingUpgradeFeaturesPage(
                     onFeatureCardChanged = { viewModel.onFeatureCardChanged(loadedState.featureCards[it]) },
                     onUpgradePressed = onUpgradePressed,
                     canUpgrade = canUpgrade,
-                    upgradePrice = { subscriptionTier: SubscriptionTier -> viewModel.getUpgradePrice(subscriptions, subscriptionTier) },
                 )
             }
             is OnboardingUpgradeFeaturesState.OldLoaded -> {
@@ -181,7 +178,6 @@ private fun BoxWithConstraintsScope.UpgradeLayout(
     onFeatureCardChanged: (Int) -> Unit,
     onUpgradePressed: () -> Unit,
     canUpgrade: Boolean,
-    upgradePrice: (SubscriptionTier) -> String,
 ) {
     OnboardingUpgradeHelper.UpgradeBackground(
         modifier = Modifier.verticalScroll(scrollState),
@@ -257,7 +253,6 @@ private fun BoxWithConstraintsScope.UpgradeLayout(
                     onFeatureCardChanged = onFeatureCardChanged,
                     onUpgradePressed = onUpgradePressed,
                     canUpgrade = canUpgrade,
-                    upgradePrice = upgradePrice,
                 )
             }
 
@@ -273,7 +268,6 @@ fun FeatureCards(
     onFeatureCardChanged: (Int) -> Unit,
     onUpgradePressed: () -> Unit,
     canUpgrade: Boolean,
-    upgradePrice: (SubscriptionTier) -> String,
 ) {
     val pagerState = rememberPagerState()
 
@@ -290,11 +284,9 @@ fun FeatureCards(
         contentPadding = PaddingValues(horizontal = 32.dp),
     ) { index ->
         FeatureCard(
-            subscriptionFrequency = state.currentSubscriptionFrequency,
             card = state.featureCards[index],
             onUpgradePressed = onUpgradePressed,
             canUpgrade = canUpgrade,
-            upgradePrice = upgradePrice,
         )
     }
 
@@ -320,14 +312,11 @@ fun FeatureCards(
     }
 }
 
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun FeatureCard(
-    subscriptionFrequency: SubscriptionFrequency,
     card: UpgradeFeatureCard,
     onUpgradePressed: () -> Unit,
     canUpgrade: Boolean,
-    upgradePrice: (SubscriptionTier) -> String,
     modifier: Modifier = Modifier,
 ) {
     Card(
@@ -349,46 +338,6 @@ fun FeatureCard(
             ) {
                 FeaturePill(card.iconRes, card.shortNameRes)
             }
-
-            Row(
-                modifier = modifier
-                    .padding(bottom = 8.dp),
-                verticalAlignment = Alignment.Bottom,
-            ) {
-                AnimatedContent(
-                    targetState = upgradePrice(card.subscriptionTier),
-                    label = "price"
-                ) { price ->
-                    TextH10(
-                        text = price,
-                        color = Color.Black,
-                        modifier = modifier.padding(end = 8.dp)
-                    )
-                }
-
-                TextH30(
-                    text = stringResource(
-                        id = when (subscriptionFrequency) {
-                            SubscriptionFrequency.YEARLY -> LR.string.slash_year
-                            SubscriptionFrequency.MONTHLY -> LR.string.slash_month
-                            SubscriptionFrequency.NONE -> throw IllegalStateException("Unknown subscription frequency: $subscriptionFrequency")
-                        }
-                    ),
-                    color = Color.Black,
-                    modifier = modifier
-                        .alpha(.6f)
-                        .padding(bottom = 6.dp)
-                )
-            }
-
-            TextH70(
-                text = stringResource(id = card.descriptionRes),
-                color = Color.Black,
-                textAlign = TextAlign.Start,
-                modifier = modifier
-                    .padding(bottom = 8.dp)
-                    .alpha(.6f)
-            )
 
             Column(
                 modifier = modifier.padding(bottom = 18.dp)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -85,7 +85,6 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
-import au.com.shiftyjelly.pocketcasts.preferences.BuildConfig
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
@@ -141,32 +140,31 @@ internal fun OnboardingUpgradeFeaturesPage(
         when (state) {
             is OnboardingUpgradeFeaturesState.Loading -> Unit // Do Nothing
             is OnboardingUpgradeFeaturesState.Loaded -> {
-                val loadedState = state as OnboardingUpgradeFeaturesState.Loaded
-                if (BuildConfig.ADD_PATRON_ENABLED) {
-                    UpgradeLayout(
-                        state = loadedState,
-                        scrollState = scrollState,
-                        onBackPressed = onBackPressed,
-                        onNotNowPressed = onNotNowPressed,
-                        onSubscriptionFrequencyChanged = { viewModel.onSubscriptionFrequencyChanged(it) },
-                        onFeatureCardChanged = { viewModel.onFeatureCardChanged(it) },
-                        onUpgradePressed = onUpgradePressed,
-                        canUpgrade = canUpgrade,
-                        upgradePrice = { productId: String -> viewModel.getUpgradePrice(subscriptions, productId) },
-                    )
-                } else {
-                    OldUpgradeLayout(
-                        state = loadedState,
-                        scrollState = scrollState,
-                        onBackPressed = onBackPressed,
-                        onUpgradePressed = onUpgradePressed,
-                        onNotNowPressed = onNotNowPressed,
-                        canUpgrade = canUpgrade,
-                    )
-                }
+                UpgradeLayout(
+                    state = state as OnboardingUpgradeFeaturesState.Loaded,
+                    scrollState = scrollState,
+                    onBackPressed = onBackPressed,
+                    onNotNowPressed = onNotNowPressed,
+                    onSubscriptionFrequencyChanged = { viewModel.onSubscriptionFrequencyChanged(it) },
+                    onFeatureCardChanged = { viewModel.onFeatureCardChanged(it) },
+                    onUpgradePressed = onUpgradePressed,
+                    canUpgrade = canUpgrade,
+                    upgradePrice = { productId: String -> viewModel.getUpgradePrice(subscriptions, productId) },
+                )
+            }
+            is OnboardingUpgradeFeaturesState.OldLoaded -> {
+                OldUpgradeLayout(
+                    state = state as OnboardingUpgradeFeaturesState.OldLoaded,
+                    scrollState = scrollState,
+                    onBackPressed = onBackPressed,
+                    onUpgradePressed = onUpgradePressed,
+                    onNotNowPressed = onNotNowPressed,
+                    canUpgrade = canUpgrade,
+                )
             }
         }
     }
+    viewModel.start(subscriptions)
 }
 
 @OptIn(ExperimentalAnimationApi::class)
@@ -471,7 +469,7 @@ private fun FeatureItem(
 
 @Composable
 private fun BoxWithConstraintsScope.OldUpgradeLayout(
-    state: OnboardingUpgradeFeaturesState.Loaded,
+    state: OnboardingUpgradeFeaturesState.OldLoaded,
     scrollState: ScrollState,
     onBackPressed: () -> Unit,
     onUpgradePressed: () -> Unit,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -101,7 +101,6 @@ internal fun OnboardingUpgradeFeaturesPage(
     onNotNowPressed: () -> Unit,
     onBackPressed: () -> Unit,
     canUpgrade: Boolean,
-    subscriptions: List<Subscription>,
 ) {
 
     val viewModel = hiltViewModel<OnboardingUpgradeFeaturesViewModel>()
@@ -165,7 +164,6 @@ internal fun OnboardingUpgradeFeaturesPage(
             }
         }
     }
-    viewModel.start(subscriptions)
 }
 
 @OptIn(ExperimentalAnimationApi::class)
@@ -672,6 +670,5 @@ private fun OnboardingUpgradeFeaturesPreview() {
         onUpgradePressed = {},
         onNotNowPressed = {},
         canUpgrade = true,
-        subscriptions = emptyList()
     )
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -84,6 +84,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
@@ -149,7 +150,7 @@ internal fun OnboardingUpgradeFeaturesPage(
                     onFeatureCardChanged = { viewModel.onFeatureCardChanged(it) },
                     onUpgradePressed = onUpgradePressed,
                     canUpgrade = canUpgrade,
-                    upgradePrice = { productId: String -> viewModel.getUpgradePrice(subscriptions, productId) },
+                    upgradePrice = { subscriptionTier: SubscriptionTier -> viewModel.getUpgradePrice(subscriptions, subscriptionTier) },
                 )
             }
             is OnboardingUpgradeFeaturesState.OldLoaded -> {
@@ -178,7 +179,7 @@ private fun BoxWithConstraintsScope.UpgradeLayout(
     onFeatureCardChanged: (Int) -> Unit,
     onUpgradePressed: () -> Unit,
     canUpgrade: Boolean,
-    upgradePrice: (String) -> String,
+    upgradePrice: (SubscriptionTier) -> String,
 ) {
     OnboardingUpgradeHelper.UpgradeBackground(
         modifier = Modifier.verticalScroll(scrollState),
@@ -270,7 +271,7 @@ fun FeatureCards(
     onFeatureCardChanged: (Int) -> Unit,
     onUpgradePressed: () -> Unit,
     canUpgrade: Boolean,
-    upgradePrice: (String) -> String,
+    upgradePrice: (SubscriptionTier) -> String,
 ) {
     val pagerState = rememberPagerState()
 
@@ -324,7 +325,7 @@ fun FeatureCard(
     card: UpgradeFeatureCard,
     onUpgradePressed: () -> Unit,
     canUpgrade: Boolean,
-    upgradePrice: (String) -> String,
+    upgradePrice: (SubscriptionTier) -> String,
     modifier: Modifier = Modifier,
 ) {
     Card(
@@ -353,7 +354,7 @@ fun FeatureCard(
                 verticalAlignment = Alignment.Bottom,
             ) {
                 AnimatedContent(
-                    targetState = upgradePrice(card.productIdPrefix),
+                    targetState = upgradePrice(card.subscriptionTier),
                     label = "price"
                 ) { price ->
                     TextH10(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -141,13 +141,14 @@ internal fun OnboardingUpgradeFeaturesPage(
         when (state) {
             is OnboardingUpgradeFeaturesState.Loading -> Unit // Do Nothing
             is OnboardingUpgradeFeaturesState.Loaded -> {
+                val loadedState = state as OnboardingUpgradeFeaturesState.Loaded
                 UpgradeLayout(
-                    state = state as OnboardingUpgradeFeaturesState.Loaded,
+                    state = loadedState,
                     scrollState = scrollState,
                     onBackPressed = onBackPressed,
                     onNotNowPressed = onNotNowPressed,
                     onSubscriptionFrequencyChanged = { viewModel.onSubscriptionFrequencyChanged(it) },
-                    onFeatureCardChanged = { viewModel.onFeatureCardChanged(it) },
+                    onFeatureCardChanged = { viewModel.onFeatureCardChanged(loadedState.featureCards[it]) },
                     onUpgradePressed = onUpgradePressed,
                     canUpgrade = canUpgrade,
                     upgradePrice = { subscriptionTier: SubscriptionTier -> viewModel.getUpgradePrice(subscriptions, subscriptionTier) },

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -163,6 +163,12 @@ internal fun OnboardingUpgradeFeaturesPage(
                     canUpgrade = canUpgrade,
                 )
             }
+            is OnboardingUpgradeFeaturesState.NoSubscriptions -> {
+                NoSubscriptionsLayout(
+                    onBackPressed = onBackPressed,
+                    onNotNowPressed = onNotNowPressed,
+                )
+            }
         }
     }
 }
@@ -642,6 +648,53 @@ private fun OldFeatureItem(
             color = Color.White,
             modifier = Modifier.alpha(0.72f),
         )
+    }
+}
+
+@Composable
+fun BoxWithConstraintsScope.NoSubscriptionsLayout(
+    onBackPressed: () -> Unit,
+    onNotNowPressed: () -> Unit,
+) {
+    Column(
+        Modifier
+            .windowInsetsPadding(WindowInsets.statusBars)
+            .windowInsetsPadding(WindowInsets.navigationBars)
+            .heightIn(min = this.calculateMinimumHeightWithInsets())
+            .fillMaxWidth()
+    ) {
+
+        Spacer(Modifier.height(8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            NavigationIconButton(
+                onNavigationClick = onBackPressed,
+                iconColor = Color.White,
+                modifier = Modifier
+                    .height(48.dp)
+                    .width(48.dp)
+            )
+            TextH30(
+                text = stringResource(LR.string.not_now),
+                color = Color.White,
+                modifier = Modifier
+                    .padding(horizontal = 24.dp)
+                    .clickable { onNotNowPressed() },
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            TextH30(
+                text = stringResource(id = LR.string.onboarding_upgrade_no_subscriptions_found)
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
     }
 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -138,27 +138,33 @@ internal fun OnboardingUpgradeFeaturesPage(
             .fillMaxHeight()
             .background(OnboardingUpgradeHelper.backgroundColor)
     ) {
-        if (BuildConfig.ADD_PATRON_ENABLED) {
-            UpgradeLayout(
-                state = state,
-                scrollState = scrollState,
-                onBackPressed = onBackPressed,
-                onNotNowPressed = onNotNowPressed,
-                onSubscriptionFrequencyChanged = { viewModel.onSubscriptionFrequencyChanged(it) },
-                onFeatureCardChanged = { viewModel.onFeatureCardChanged(it) },
-                onUpgradePressed = onUpgradePressed,
-                canUpgrade = canUpgrade,
-                upgradePrice = { productId: String -> viewModel.getUpgradePrice(subscriptions, productId) },
-            )
-        } else {
-            OldUpgradeLayout(
-                state = state,
-                scrollState = scrollState,
-                onBackPressed = onBackPressed,
-                onUpgradePressed = onUpgradePressed,
-                onNotNowPressed = onNotNowPressed,
-                canUpgrade = canUpgrade,
-            )
+        when (state) {
+            is OnboardingUpgradeFeaturesState.Loading -> Unit // Do Nothing
+            is OnboardingUpgradeFeaturesState.Loaded -> {
+                val loadedState = state as OnboardingUpgradeFeaturesState.Loaded
+                if (BuildConfig.ADD_PATRON_ENABLED) {
+                    UpgradeLayout(
+                        state = loadedState,
+                        scrollState = scrollState,
+                        onBackPressed = onBackPressed,
+                        onNotNowPressed = onNotNowPressed,
+                        onSubscriptionFrequencyChanged = { viewModel.onSubscriptionFrequencyChanged(it) },
+                        onFeatureCardChanged = { viewModel.onFeatureCardChanged(it) },
+                        onUpgradePressed = onUpgradePressed,
+                        canUpgrade = canUpgrade,
+                        upgradePrice = { productId: String -> viewModel.getUpgradePrice(subscriptions, productId) },
+                    )
+                } else {
+                    OldUpgradeLayout(
+                        state = loadedState,
+                        scrollState = scrollState,
+                        onBackPressed = onBackPressed,
+                        onUpgradePressed = onUpgradePressed,
+                        onNotNowPressed = onNotNowPressed,
+                        canUpgrade = canUpgrade,
+                    )
+                }
+            }
         }
     }
 }
@@ -166,7 +172,7 @@ internal fun OnboardingUpgradeFeaturesPage(
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
 private fun BoxWithConstraintsScope.UpgradeLayout(
-    state: OnboardingUpgradeFeaturesState,
+    state: OnboardingUpgradeFeaturesState.Loaded,
     scrollState: ScrollState,
     onBackPressed: () -> Unit,
     onNotNowPressed: () -> Unit,
@@ -262,7 +268,7 @@ private fun BoxWithConstraintsScope.UpgradeLayout(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun FeatureCards(
-    state: OnboardingUpgradeFeaturesState,
+    state: OnboardingUpgradeFeaturesState.Loaded,
     onFeatureCardChanged: (Int) -> Unit,
     onUpgradePressed: () -> Unit,
     canUpgrade: Boolean,
@@ -465,7 +471,7 @@ private fun FeatureItem(
 
 @Composable
 private fun BoxWithConstraintsScope.OldUpgradeLayout(
-    state: OnboardingUpgradeFeaturesState,
+    state: OnboardingUpgradeFeaturesState.Loaded,
     scrollState: ScrollState,
     onBackPressed: () -> Unit,
     onUpgradePressed: () -> Unit,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -97,9 +97,10 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 internal fun OnboardingUpgradeFeaturesPage(
     flow: OnboardingFlow,
     source: OnboardingUpgradeSource,
-    onUpgradePressed: () -> Unit,
-    onNotNowPressed: () -> Unit,
     onBackPressed: () -> Unit,
+    onClickSubscribe: () -> Unit,
+    onNotNowPressed: () -> Unit,
+    onUpgradePressed: () -> Unit,
     canUpgrade: Boolean,
 ) {
 
@@ -148,7 +149,7 @@ internal fun OnboardingUpgradeFeaturesPage(
                     onNotNowPressed = onNotNowPressed,
                     onSubscriptionFrequencyChanged = { viewModel.onSubscriptionFrequencyChanged(it) },
                     onFeatureCardChanged = { viewModel.onFeatureCardChanged(loadedState.featureCards[it]) },
-                    onUpgradePressed = onUpgradePressed,
+                    onClickSubscribe = onClickSubscribe,
                     canUpgrade = canUpgrade,
                 )
             }
@@ -175,7 +176,7 @@ private fun BoxWithConstraintsScope.UpgradeLayout(
     onNotNowPressed: () -> Unit,
     onSubscriptionFrequencyChanged: (SubscriptionFrequency) -> Unit,
     onFeatureCardChanged: (Int) -> Unit,
-    onUpgradePressed: () -> Unit,
+    onClickSubscribe: () -> Unit,
     canUpgrade: Boolean,
 ) {
     OnboardingUpgradeHelper.UpgradeBackground(
@@ -250,7 +251,7 @@ private fun BoxWithConstraintsScope.UpgradeLayout(
                 FeatureCards(
                     state = state,
                     onFeatureCardChanged = onFeatureCardChanged,
-                    onUpgradePressed = onUpgradePressed,
+                    onClickSubscribe = onClickSubscribe,
                     canUpgrade = canUpgrade,
                 )
             }
@@ -265,7 +266,7 @@ private fun BoxWithConstraintsScope.UpgradeLayout(
 fun FeatureCards(
     state: OnboardingUpgradeFeaturesState.Loaded,
     onFeatureCardChanged: (Int) -> Unit,
-    onUpgradePressed: () -> Unit,
+    onClickSubscribe: () -> Unit,
     canUpgrade: Boolean,
 ) {
     val resources = LocalContext.current.resources
@@ -326,7 +327,7 @@ fun FeatureCards(
             secondaryText = secondaryText,
             backgroundColor = button.backgroundColor,
             textColor = button.textColor,
-            onClick = onUpgradePressed,
+            onClick = onClickSubscribe,
             modifier = Modifier
                 .padding(horizontal = 20.dp, vertical = 24.dp)
                 .fillMaxWidth(),
@@ -667,8 +668,9 @@ private fun OnboardingUpgradeFeaturesPreview() {
         flow = OnboardingFlow.InitialOnboarding,
         source = OnboardingUpgradeSource.RECOMMENDATIONS,
         onBackPressed = {},
-        onUpgradePressed = {},
+        onClickSubscribe = {},
         onNotNowPressed = {},
+        onUpgradePressed = {},
         canUpgrade = true,
     )
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -165,6 +165,7 @@ internal fun OnboardingUpgradeFeaturesPage(
             }
             is OnboardingUpgradeFeaturesState.NoSubscriptions -> {
                 NoSubscriptionsLayout(
+                    showNotNow = (state as OnboardingUpgradeFeaturesState.NoSubscriptions).showNotNow,
                     onBackPressed = onBackPressed,
                     onNotNowPressed = onNotNowPressed,
                 )
@@ -211,13 +212,15 @@ private fun BoxWithConstraintsScope.UpgradeLayout(
                         .height(48.dp)
                         .width(48.dp)
                 )
-                TextH30(
-                    text = stringResource(LR.string.not_now),
-                    color = Color.White,
-                    modifier = Modifier
-                        .padding(horizontal = 24.dp)
-                        .clickable { onNotNowPressed() },
-                )
+                if (state.showNotNow) {
+                    TextH30(
+                        text = stringResource(LR.string.not_now),
+                        color = Color.White,
+                        modifier = Modifier
+                            .padding(horizontal = 24.dp)
+                            .clickable { onNotNowPressed() },
+                    )
+                }
             }
 
             Spacer(Modifier.weight(1f))
@@ -656,6 +659,7 @@ private fun OldFeatureItem(
 fun BoxWithConstraintsScope.NoSubscriptionsLayout(
     onBackPressed: () -> Unit,
     onNotNowPressed: () -> Unit,
+    showNotNow: Boolean,
 ) {
     Column(
         Modifier
@@ -678,13 +682,15 @@ fun BoxWithConstraintsScope.NoSubscriptionsLayout(
                     .height(48.dp)
                     .width(48.dp)
             )
-            TextH30(
-                text = stringResource(LR.string.not_now),
-                color = Color.White,
-                modifier = Modifier
-                    .padding(horizontal = 24.dp)
-                    .clickable { onNotNowPressed() },
-            )
+            if (showNotNow) {
+                TextH30(
+                    text = stringResource(LR.string.not_now),
+                    color = Color.White,
+                    modifier = Modifier
+                        .padding(horizontal = 24.dp)
+                        .clickable { onNotNowPressed() },
+                )
+            }
         }
         Spacer(modifier = Modifier.weight(1f))
         Box(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -240,8 +240,9 @@ private fun BoxWithConstraintsScope.UpgradeLayout(
                     contentAlignment = Alignment.Center
                 ) {
                     StyledToggle(
-                        state.subscriptionFrequencies
+                        items = state.subscriptionFrequencies
                             .map { stringResource(id = it.localisedLabelRes) },
+                        defaultSelectedItemIndex = state.subscriptionFrequencies.indexOf(state.currentSubscriptionFrequency),
                     ) {
                         val selectedFrequency = state.subscriptionFrequencies[it]
                         onSubscriptionFrequencyChanged(selectedFrequency)
@@ -270,8 +271,7 @@ fun FeatureCards(
     canUpgrade: Boolean,
 ) {
     val resources = LocalContext.current.resources
-    val pagerState = rememberPagerState()
-
+    val pagerState = rememberPagerState(initialPage = state.featureCards.indexOf(state.currentFeatureCard))
     LaunchedEffect(pagerState) {
         snapshotFlow { pagerState.currentPage }.collect { index ->
             onFeatureCardChanged(index)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -295,24 +295,25 @@ fun FeatureCards(
         )
     }
 
-    // Page indicator
-    Row(
-        Modifier
-            .height(40.dp)
-            .fillMaxWidth()
-            .padding(top = 24.dp),
-        horizontalArrangement = Arrangement.Center,
-    ) {
-        repeat(state.featureCards.size) { iteration ->
-            val color =
-                if (pagerState.currentPage == iteration) Color.White else Color.White.copy(alpha = 0.5f)
-            Box(
-                modifier = Modifier
-                    .padding(4.dp)
-                    .clip(CircleShape)
-                    .background(color)
-                    .size(8.dp)
-            )
+    if (state.showPageIndicator) {
+        Row(
+            Modifier
+                .height(40.dp)
+                .fillMaxWidth()
+                .padding(top = 24.dp),
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            repeat(state.featureCards.size) { iteration ->
+                val color =
+                    if (pagerState.currentPage == iteration) Color.White else Color.White.copy(alpha = 0.5f)
+                Box(
+                    modifier = Modifier
+                        .padding(4.dp)
+                        .clip(CircleShape)
+                        .background(color)
+                        .size(8.dp)
+                )
+            }
         }
     }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.IconRow
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.PlusOutlinedRowButton
@@ -395,6 +396,11 @@ fun FeatureCard(
                 card.featureItems.forEach {
                     FeatureItem(it)
                 }
+                OnboardingUpgradeHelper.PrivacyPolicy(
+                    color = Color(0xA3000000).copy(alpha = .8f),
+                    textAlign = TextAlign.Start,
+                    lineHeight = 18.sp
+                )
             }
 
             if (canUpgrade) {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -377,7 +377,7 @@ fun FeatureCard(
                     FeatureItem(it)
                 }
                 OnboardingUpgradeHelper.PrivacyPolicy(
-                    color = Color(0xA3000000).copy(alpha = .8f),
+                    color = Color.Black.copy(alpha = .5f),
                     textAlign = TextAlign.Start,
                     lineHeight = 18.sp
                 )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -110,11 +110,6 @@ fun OnboardingUpgradeFlow(
                 onNotNowPressed = onProceed,
                 onBackPressed = onBackPressed,
                 canUpgrade = hasSubscriptions,
-                subscriptions = if (hasSubscriptions) {
-                    (state as OnboardingUpgradeBottomSheetState.Loaded).subscriptions
-                } else {
-                    emptyList()
-                },
             )
         },
         sheetContent = {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -112,11 +112,15 @@ fun OnboardingUpgradeFlow(
                 onBackPressed = onBackPressed,
                 onClickSubscribe = {
                     if (activity != null) {
-                        mainSheetViewModel.onClickSubscribe(
-                            activity = activity,
-                            flow = flow,
-                            onComplete = onProceed,
-                        )
+                        if (isLoggedIn) {
+                            mainSheetViewModel.onClickSubscribe(
+                                activity = activity,
+                                flow = flow,
+                                onComplete = onProceed,
+                            )
+                        } else {
+                            onNeedLogin()
+                        }
                     } else {
                         LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, NULL_ACTIVITY_ERROR)
                     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -28,6 +28,7 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import kotlinx.coroutines.launch
 
+private const val NULL_ACTIVITY_ERROR = "Activity is null when attempting subscription"
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun OnboardingUpgradeFlow(
@@ -109,6 +110,17 @@ fun OnboardingUpgradeFlow(
                 },
                 onNotNowPressed = onProceed,
                 onBackPressed = onBackPressed,
+                onClickSubscribe = {
+                    if (activity != null) {
+                        mainSheetViewModel.onClickSubscribe(
+                            activity = activity,
+                            flow = flow,
+                            onComplete = onProceed,
+                        )
+                    } else {
+                        LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, NULL_ACTIVITY_ERROR)
+                    }
+                },
                 canUpgrade = hasSubscriptions,
             )
         },
@@ -122,10 +134,7 @@ fun OnboardingUpgradeFlow(
                             onComplete = onProceed,
                         )
                     } else {
-                        LogBuffer.e(
-                            LogBuffer.TAG_SUBSCRIPTIONS,
-                            "Activity is null when attempting subscription"
-                        )
+                        LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, NULL_ACTIVITY_ERROR)
                     }
                 }
             )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
@@ -34,18 +34,24 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstrainedLayoutReference
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.ConstraintLayoutScope
 import au.com.shiftyjelly.pocketcasts.account.R
+import au.com.shiftyjelly.pocketcasts.compose.components.Clickable
+import au.com.shiftyjelly.pocketcasts.compose.components.ClickableTextHelper
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.extensions.brush
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -420,5 +426,43 @@ object OnboardingUpgradeHelper {
                 tint = Color.White,
             )
         }
+    }
+
+    @Composable
+    fun PrivacyPolicy(
+        color: Color,
+        textAlign: TextAlign,
+        modifier: Modifier = Modifier,
+        lineHeight: TextUnit = 16.sp,
+    ) {
+        val privacyPolicyText = stringResource(LR.string.onboarding_plus_privacy_policy)
+        val termsAndConditionsText = stringResource(LR.string.onboarding_plus_terms_and_conditions)
+        val text = stringResource(
+            LR.string.onboarding_plus_continuing_agrees_to,
+            privacyPolicyText,
+            termsAndConditionsText
+        )
+        val uriHandler = LocalUriHandler.current
+        ClickableTextHelper(
+            text = text,
+            color = color,
+            lineHeight = lineHeight,
+            textAlign = textAlign,
+            clickables = listOf(
+                Clickable(
+                    text = privacyPolicyText,
+                    onClick = {
+                        uriHandler.openUri(Settings.INFO_PRIVACY_URL)
+                    }
+                ),
+                Clickable(
+                    text = termsAndConditionsText,
+                    onClick = {
+                        uriHandler.openUri(Settings.INFO_TOS_URL)
+                    }
+                ),
+            ),
+            modifier = modifier,
+        )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -64,11 +65,12 @@ object OnboardingUpgradeHelper {
 
     @Composable
     fun UpgradeRowButton(
-        text: String,
+        primaryText: String,
         backgroundColor: Long,
         textColor: Long,
         onClick: () -> Unit,
         modifier: Modifier = Modifier,
+        secondaryText: String? = null,
     ) {
         Button(
             onClick = onClick,
@@ -78,10 +80,21 @@ object OnboardingUpgradeHelper {
                 backgroundColor = Color(backgroundColor),
             ),
         ) {
-            TextH30(
-                text = text,
-                color = Color(textColor),
-            )
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                TextH30(
+                    text = primaryText,
+                    color = Color(textColor),
+                )
+                secondaryText?.let { subTitle ->
+                    TextP60(
+                        text = subTitle,
+                        color = Color(textColor),
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+            }
         }
     }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -13,12 +13,12 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.UpgradeFeatureI
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_PRODUCT_BASE
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_PRODUCT_BASE
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.repositories.BuildConfig
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
-import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager.Companion.PATRON_PRODUCT_BASE
-import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager.Companion.PLUS_PRODUCT_BASE
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -129,24 +129,6 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
         }
     }
 
-    fun getUpgradePrice(
-        subscriptions: List<Subscription>,
-        subscriptionTier: SubscriptionTier,
-    ): String {
-        val loadedState = _state.value as? OnboardingUpgradeFeaturesState.Loaded
-        return loadedState?.let {
-            subscriptions
-                .find {
-                    if (loadedState.currentSubscriptionFrequency == SubscriptionFrequency.MONTHLY) {
-                        it.recurringPricingPhase is SubscriptionPricingPhase.Months
-                    } else {
-                        it.recurringPricingPhase is SubscriptionPricingPhase.Years
-                    } && SubscriptionMapper.mapProductIdToTier(it.productDetails.productId) == subscriptionTier
-                }
-                ?.recurringPricingPhase?.formattedPrice
-        } ?: ""
-    }
-
     companion object {
         private fun analyticsProps(flow: OnboardingFlow, source: OnboardingUpgradeSource) =
             mapOf("flow" to flow.analyticsValue, "source" to source.analyticsValue)
@@ -189,7 +171,6 @@ private fun RecurringSubscriptionPricingPhase.toSubscriptionFrequency() = when (
 enum class UpgradeFeatureCard(
     @StringRes val titleRes: Int,
     @StringRes val shortNameRes: Int,
-    @StringRes val descriptionRes: Int,
     @DrawableRes val backgroundGlowsRes: Int,
     @DrawableRes val iconRes: Int,
     val buttonBackgroundColor: Long,
@@ -200,7 +181,6 @@ enum class UpgradeFeatureCard(
     PLUS(
         titleRes = LR.string.onboarding_plus_features_title,
         shortNameRes = LR.string.pocket_casts_plus_short,
-        descriptionRes = LR.string.onboarding_plus_features_description,
         backgroundGlowsRes = R.drawable.upgrade_background_plus_glows,
         iconRes = IR.drawable.ic_plus,
         buttonBackgroundColor = 0xFFFFD846,
@@ -211,7 +191,6 @@ enum class UpgradeFeatureCard(
     PATRON(
         titleRes = LR.string.onboarding_patron_features_title,
         shortNameRes = LR.string.pocket_casts_patron_short,
-        descriptionRes = LR.string.onboarding_patron_features_description,
         backgroundGlowsRes = R.drawable.upgrade_background_patron_glows,
         iconRes = IR.drawable.ic_patron,
         buttonBackgroundColor = 0xFF6046F5,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -96,9 +96,9 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
         }
     }
 
-    fun onFeatureCardChanged(index: Int) {
+    fun onFeatureCardChanged(upgradeFeatureCard: UpgradeFeatureCard) {
         (_state.value as? OnboardingUpgradeFeaturesState.Loaded)?.let { loadedState ->
-            _state.update { loadedState.copy(currentFeatureCard = UpgradeFeatureCard.values()[index]) }
+            _state.update { loadedState.copy(currentFeatureCard = upgradeFeatureCard) }
         }
     }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -259,11 +259,14 @@ sealed class OnboardingUpgradeFeaturesState {
         val purchaseFailed: Boolean = false,
     ) : OnboardingUpgradeFeaturesState() {
 
-        val featureCards = UpgradeFeatureCard.values().toList()
+        val featureCards = SubscriptionTier.values().toList()
+            .filter { tier -> tier != SubscriptionTier.UNKNOWN && tier in subscriptions.map { it.tier } }
+            .map { it.toUpgradeFeatureCard() }
         val subscriptionFrequencies =
             listOf(SubscriptionFrequency.YEARLY, SubscriptionFrequency.MONTHLY)
         val currentUpgradeButton: UpgradeButton
             get() = currentSubscription.toUpgradeButton()
+        val showPageIndicator = featureCards.size > 1
     }
 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -111,7 +111,9 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
                     currentSubscriptionFrequency = currentSubscriptionFrequency
                 )
             }
-        } ?: Timber.e("No subscriptions found")
+        } ?: _state.update { // In ideal world, we should never get here
+            OnboardingUpgradeFeaturesState.NoSubscriptions
+        }
     }
 
     fun onShown(flow: OnboardingFlow, source: OnboardingUpgradeSource) {
@@ -240,6 +242,8 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
 
 sealed class OnboardingUpgradeFeaturesState {
     object Loading : OnboardingUpgradeFeaturesState()
+
+    object NoSubscriptions : OnboardingUpgradeFeaturesState()
 
     data class OldLoaded(
         private val isTouchExplorationEnabled: Boolean,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -66,6 +66,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
             val currentFeatureCard = defaultTier.toUpgradeFeatureCard()
             _state.update {
                 OnboardingUpgradeFeaturesState.Loaded(
+                    subscriptions = subscriptions,
                     currentSubscription = defaultSelected,
                     currentFeatureCard = currentFeatureCard,
                     currentSubscriptionFrequency = currentSubscriptionFrequency
@@ -92,13 +93,39 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
 
     fun onSubscriptionFrequencyChanged(frequency: SubscriptionFrequency) {
         (_state.value as? OnboardingUpgradeFeaturesState.Loaded)?.let { loadedState ->
-            _state.update { loadedState.copy(currentSubscriptionFrequency = frequency) }
+            val currentSubscription = subscriptionManager
+                .getSubscriptionByTierAndFrequency(
+                    subscriptions = loadedState.subscriptions,
+                    tier = loadedState.currentFeatureCard.subscriptionTier,
+                    frequency = frequency
+                )
+            currentSubscription?.let {
+                _state.update {
+                    loadedState.copy(
+                        currentSubscription = currentSubscription,
+                        currentSubscriptionFrequency = frequency
+                    )
+                }
+            }
         }
     }
 
     fun onFeatureCardChanged(upgradeFeatureCard: UpgradeFeatureCard) {
         (_state.value as? OnboardingUpgradeFeaturesState.Loaded)?.let { loadedState ->
-            _state.update { loadedState.copy(currentFeatureCard = upgradeFeatureCard) }
+            val currentSubscription = subscriptionManager
+                .getSubscriptionByTierAndFrequency(
+                    subscriptions = loadedState.subscriptions,
+                    tier = upgradeFeatureCard.subscriptionTier,
+                    frequency = loadedState.currentSubscriptionFrequency
+                )
+            currentSubscription?.let {
+                _state.update {
+                    loadedState.copy(
+                        currentSubscription = currentSubscription,
+                        currentFeatureCard = upgradeFeatureCard
+                    )
+                }
+            }
         }
     }
 
@@ -136,6 +163,7 @@ sealed class OnboardingUpgradeFeaturesState {
     }
 
     data class Loaded(
+        val subscriptions: List<Subscription>,
         val currentFeatureCard: UpgradeFeatureCard = UpgradeFeatureCard.PLUS,
         val currentSubscriptionFrequency: SubscriptionFrequency = SubscriptionFrequency.YEARLY,
         val currentSubscription: Subscription,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -149,17 +149,26 @@ sealed class OnboardingUpgradeFeaturesState {
         val currentFeatureCard: UpgradeFeatureCard = UpgradeFeatureCard.PLUS,
         val currentSubscriptionFrequency: SubscriptionFrequency = SubscriptionFrequency.YEARLY,
         val currentSubscription: Subscription,
+
     ) : OnboardingUpgradeFeaturesState() {
 
         val featureCards = UpgradeFeatureCard.values().toList()
         val subscriptionFrequencies =
             listOf(SubscriptionFrequency.YEARLY, SubscriptionFrequency.MONTHLY)
+        val currentUpgradeButton: UpgradeButton
+            get() = currentSubscription.toUpgradeButton()
     }
 }
 
 private fun SubscriptionTier.toUpgradeFeatureCard() = when (this) {
     SubscriptionTier.PLUS -> UpgradeFeatureCard.PLUS
     SubscriptionTier.PATRON -> UpgradeFeatureCard.PATRON
+    SubscriptionTier.UNKNOWN -> throw IllegalStateException("Unknown subscription tier")
+}
+
+private fun Subscription.toUpgradeButton() = when (this.tier) {
+    SubscriptionTier.PLUS -> UpgradeButton.Plus(this)
+    SubscriptionTier.PATRON -> UpgradeButton.Patron(this)
     SubscriptionTier.UNKNOWN -> throw IllegalStateException("Unknown subscription tier")
 }
 
@@ -173,8 +182,6 @@ enum class UpgradeFeatureCard(
     @StringRes val shortNameRes: Int,
     @DrawableRes val backgroundGlowsRes: Int,
     @DrawableRes val iconRes: Int,
-    val buttonBackgroundColor: Long,
-    val buttonTextColor: Long,
     val featureItems: List<UpgradeFeatureItem>,
     val subscriptionTier: SubscriptionTier,
 ) {
@@ -183,8 +190,6 @@ enum class UpgradeFeatureCard(
         shortNameRes = LR.string.pocket_casts_plus_short,
         backgroundGlowsRes = R.drawable.upgrade_background_plus_glows,
         iconRes = IR.drawable.ic_plus,
-        buttonBackgroundColor = 0xFFFFD846,
-        buttonTextColor = 0xFF000000,
         featureItems = PlusUpgradeFeatureItem.values().toList(),
         subscriptionTier = SubscriptionTier.PLUS,
     ),
@@ -193,9 +198,32 @@ enum class UpgradeFeatureCard(
         shortNameRes = LR.string.pocket_casts_patron_short,
         backgroundGlowsRes = R.drawable.upgrade_background_patron_glows,
         iconRes = IR.drawable.ic_patron,
-        buttonBackgroundColor = 0xFF6046F5,
-        buttonTextColor = 0xFFFFFFFF,
         featureItems = PatronUpgradeFeatureItem.values().toList(),
         subscriptionTier = SubscriptionTier.PATRON,
+    )
+}
+
+sealed class UpgradeButton(
+    @StringRes val shortNameRes: Int,
+    val backgroundColor: Long,
+    val textColor: Long,
+    open val subscription: Subscription,
+) {
+    data class Plus(
+        override val subscription: Subscription,
+    ) : UpgradeButton(
+        shortNameRes = LR.string.pocket_casts_plus_short,
+        backgroundColor = 0xFFFFD846,
+        textColor = 0xFF000000,
+        subscription = subscription,
+    )
+
+    data class Patron(
+        override val subscription: Subscription,
+    ) : UpgradeButton(
+        shortNameRes = LR.string.pocket_casts_patron_short,
+        backgroundColor = 0xFF6046F5,
+        textColor = 0xFFFFFFFF,
+        subscription = subscription,
     )
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -84,7 +84,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
     private fun updateState(
         subscriptions: List<Subscription>,
     ) {
-        val defaultSelected = subscriptionManager.getDefaultSubscription(subscriptions) // TODO: Patron or Plus?
+        val defaultSelected = subscriptionManager.getDefaultSubscription(subscriptions)
         defaultSelected?.let {
             val currentSubscriptionFrequency = defaultSelected.recurringPricingPhase.toSubscriptionFrequency()
             val defaultTier = SubscriptionMapper.mapProductIdToTier(defaultSelected.productDetails.productId)
@@ -119,7 +119,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
     fun onSubscriptionFrequencyChanged(frequency: SubscriptionFrequency) {
         (_state.value as? OnboardingUpgradeFeaturesState.Loaded)?.let { loadedState ->
             val currentSubscription = subscriptionManager
-                .getSubscriptionByTierAndFrequency(
+                .getDefaultSubscription(
                     subscriptions = loadedState.subscriptions,
                     tier = loadedState.currentFeatureCard.subscriptionTier,
                     frequency = frequency
@@ -138,7 +138,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
     fun onFeatureCardChanged(upgradeFeatureCard: UpgradeFeatureCard) {
         (_state.value as? OnboardingUpgradeFeaturesState.Loaded)?.let { loadedState ->
             val currentSubscription = subscriptionManager
-                .getSubscriptionByTierAndFrequency(
+                .getDefaultSubscription(
                     subscriptions = loadedState.subscriptions,
                     tier = upgradeFeatureCard.subscriptionTier,
                     frequency = loadedState.currentSubscriptionFrequency
@@ -162,7 +162,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
         (state.value as? OnboardingUpgradeFeaturesState.Loaded)?.let { loadedState ->
             _state.update { loadedState.copy(purchaseFailed = false) }
             val currentSubscription = subscriptionManager
-                .getSubscriptionByTierAndFrequency(
+                .getDefaultSubscription(
                     subscriptions = loadedState.subscriptions,
                     tier = loadedState.currentFeatureCard.subscriptionTier,
                     frequency = loadedState.currentSubscriptionFrequency
@@ -233,8 +233,8 @@ sealed class OnboardingUpgradeFeaturesState {
 
     data class Loaded(
         val subscriptions: List<Subscription>,
-        val currentFeatureCard: UpgradeFeatureCard = UpgradeFeatureCard.PLUS,
-        val currentSubscriptionFrequency: SubscriptionFrequency = SubscriptionFrequency.YEARLY,
+        val currentFeatureCard: UpgradeFeatureCard,
+        val currentSubscriptionFrequency: SubscriptionFrequency,
         val currentSubscription: Subscription,
         val purchaseFailed: Boolean = false,
     ) : OnboardingUpgradeFeaturesState() {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -99,6 +99,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
             frequency = lastSelectedFrequency
         )
 
+        val showNotNow = source == OnboardingUpgradeSource.RECOMMENDATIONS
         selectedSubscription?.let {
             val currentSubscriptionFrequency = selectedSubscription.recurringPricingPhase.toSubscriptionFrequency()
             val currentTier = SubscriptionMapper.mapProductIdToTier(selectedSubscription.productDetails.productId)
@@ -108,11 +109,12 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
                     subscriptions = subscriptions,
                     currentSubscription = selectedSubscription,
                     currentFeatureCard = currentFeatureCard,
-                    currentSubscriptionFrequency = currentSubscriptionFrequency
+                    currentSubscriptionFrequency = currentSubscriptionFrequency,
+                    showNotNow = showNotNow
                 )
             }
         } ?: _state.update { // In ideal world, we should never get here
-            OnboardingUpgradeFeaturesState.NoSubscriptions
+            OnboardingUpgradeFeaturesState.NoSubscriptions(showNotNow)
         }
     }
 
@@ -243,7 +245,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
 sealed class OnboardingUpgradeFeaturesState {
     object Loading : OnboardingUpgradeFeaturesState()
 
-    object NoSubscriptions : OnboardingUpgradeFeaturesState()
+    data class NoSubscriptions(val showNotNow: Boolean) : OnboardingUpgradeFeaturesState()
 
     data class OldLoaded(
         private val isTouchExplorationEnabled: Boolean,
@@ -257,6 +259,7 @@ sealed class OnboardingUpgradeFeaturesState {
         val currentSubscriptionFrequency: SubscriptionFrequency,
         val currentSubscription: Subscription,
         val purchaseFailed: Boolean = false,
+        val showNotNow: Boolean,
     ) : OnboardingUpgradeFeaturesState() {
 
         val featureCards = SubscriptionTier.values().toList()

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ClickableTextHelper.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ClickableTextHelper.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -32,6 +33,7 @@ fun ClickableTextHelper(
     text: String,
     clickables: List<Clickable>,
     color: Color = MaterialTheme.theme.colors.primaryText01,
+    lineHeight: TextUnit,
     textAlign: TextAlign = TextAlign.Start,
     modifier: Modifier = Modifier,
 ) {
@@ -108,7 +110,7 @@ fun ClickableTextHelper(
         text = annotatedString,
         style = TextStyle(
             color = color,
-            lineHeight = 16.sp,
+            lineHeight = lineHeight,
             fontSize = 14.sp,
             fontWeight = FontWeight.Normal,
             textAlign = textAlign,

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -80,6 +80,7 @@
     <string name="stop_downloading">Stop downloading</string>
     <string name="stream">Stream</string>
     <string name="subscribe">Subscribe</string>
+    <string name="subscribe_to">Subscribe to %s</string>
     <string name="unarchive_all">Unarchive all</string>
     <string name="unplayed">Unplayed</string>
     <string name="unsubscribe">Unsubscribe</string>
@@ -956,6 +957,12 @@
     <string name="plus_day">day</string>
     <string name="plus_yearly">Yearly</string>
     <string name="plus_monthly">Monthly</string>
+
+    <!-- Trial -->
+
+    <string name="trial_start">Start my free trial</string>
+    <string name="trial_then_per_month">Try %1$s, then %2$s per month</string>
+    <string name="trial_then_per_year">Try %1$s, then %2$s per year</string>
 
     <!-- Settings -->
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1543,6 +1543,7 @@
     <string name="onboarding_recommendations_more">More %s</string>
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">Everything you love about Pocket&#160;Casts, plus more</string>
     <string name="onboarding_upgrade_exclusive_features_and_options">Get access to exclusive features and customization options</string>
+    <string name="onboarding_upgrade_no_subscriptions_found">No subscriptions found.</string>
     <string name="onboarding_upgrade_unlock_all_features">Unlock all features</string>
     <string name="onboarding_patron_features_title">Believe in what we\’re doing and want to show your support?</string>
     <string name="onboarding_patron_feature_everything_in_plus_title">Everything in Plus</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -69,8 +69,6 @@
     <string name="sign_out">Sign out</string>
     <string name="skip_back">Skip back</string>
     <string name="skip_forward">Skip forward</string>
-    <string name="slash_year">/year</string>
-    <string name="slash_month">/month</string>
     <string name="sort_by">Sort by</string>
     <string name="star">Star</string>
     <string name="star_episode">Star episode</string>
@@ -1540,14 +1538,12 @@
     <string name="onboarding_upgrade_exclusive_features_and_options">Get access to exclusive features and customization options</string>
     <string name="onboarding_upgrade_unlock_all_features">Unlock all features</string>
     <string name="onboarding_patron_features_title">Believe in what we\’re doing and want to show your support?</string>
-    <string name="onboarding_patron_features_description">Become a Pocket Casts Patron and help us continue to deliver the best podcasting experience available.</string>
     <string name="onboarding_patron_feature_everything_in_plus_title">Everything in Plus</string>
     <string name="onboarding_patron_feature_cloud_storage_title">50GB Cloud Storage</string>
     <string name="onboarding_patron_feature_profile_badge_title">Supporters profile badge</string>
     <string name="onboarding_patron_feature_special_icons_title">Special Pocket Casts app icons</string>
     <string name="onboarding_patron_feature_gratitude_title" translatable="false">@string/onboarding_plus_feature_gratitude_title</string>
     <string name="onboarding_plus_features_title" translatable="false">@string/onboarding_upgrade_everything_you_love_about_pocket_casts_plus</string>
-    <string name="onboarding_plus_features_description">Take your podcasting experience to the next level with exclusive access to features and customization options.</string>
     <string name="onboarding_plus_feature_desktop_apps_title">Desktop Apps</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Listen in more places with our Windows, macOS, and Web apps.</string>
     <string name="onboarding_plus_feature_folders_title">Folders</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -44,6 +44,11 @@ sealed interface Subscription {
     }
 
     companion object {
+        const val PATRON_PRODUCT_BASE = "com.pocketcasts.patron"
+        const val PLUS_PRODUCT_BASE = "com.pocketcasts.plus"
+        const val PLUS_MONTHLY_PRODUCT_ID = "$PLUS_PRODUCT_BASE.monthly"
+        const val PLUS_YEARLY_PRODUCT_ID = "$PLUS_PRODUCT_BASE.yearly"
+
         fun fromProductDetails(productDetails: ProductDetails, isFreeTrialEligible: Boolean): Subscription? =
             SubscriptionMapper.map(productDetails, isFreeTrialEligible)
     }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -14,6 +14,7 @@ sealed interface Subscription {
         get() = productDetails.title.split(" (").first()
 
     fun numFreeThenPricePerPeriod(res: Resources): String?
+    fun tryFreeThenPricePerPeriod(res: Resources): String?
 
     // Simple subscriptions do not have a trial phase
     class Simple(
@@ -24,6 +25,7 @@ sealed interface Subscription {
     ) : Subscription {
         override val trialPricingPhase = null
         override fun numFreeThenPricePerPeriod(res: Resources): String? = null
+        override fun tryFreeThenPricePerPeriod(res: Resources): String? = null
     }
 
     class WithTrial(
@@ -37,6 +39,17 @@ sealed interface Subscription {
             val stringRes = when (recurringPricingPhase) {
                 is SubscriptionPricingPhase.Years -> R.string.plus_trial_then_slash_year
                 is SubscriptionPricingPhase.Months -> R.string.plus_trial_then_slash_month
+            }
+            return res.getString(
+                stringRes,
+                trialPricingPhase.periodValuePlural(res),
+                recurringPricingPhase.formattedPrice
+            )
+        }
+        override fun tryFreeThenPricePerPeriod(res: Resources): String {
+            val stringRes = when (recurringPricingPhase) {
+                is SubscriptionPricingPhase.Years -> R.string.trial_then_per_year
+                is SubscriptionPricingPhase.Months -> R.string.trial_then_per_month
             }
             return res.getString(
                 stringRes,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -5,6 +5,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R
 import com.android.billingclient.api.ProductDetails
 
 sealed interface Subscription {
+    val tier: SubscriptionTier
     val recurringPricingPhase: RecurringSubscriptionPricingPhase
     val trialPricingPhase: TrialSubscriptionPricingPhase?
     val productDetails: ProductDetails
@@ -16,6 +17,7 @@ sealed interface Subscription {
 
     // Simple subscriptions do not have a trial phase
     class Simple(
+        override val tier: SubscriptionTier,
         override val recurringPricingPhase: RecurringSubscriptionPricingPhase,
         override val productDetails: ProductDetails,
         override val offerToken: String
@@ -25,6 +27,7 @@ sealed interface Subscription {
     }
 
     class WithTrial(
+        override val tier: SubscriptionTier,
         override val recurringPricingPhase: RecurringSubscriptionPricingPhase,
         override val trialPricingPhase: TrialSubscriptionPricingPhase, // override to not be nullable
         override val productDetails: ProductDetails,
@@ -42,6 +45,8 @@ sealed interface Subscription {
             )
         }
     }
+
+    enum class SubscriptionTier { PLUS, PATRON, UNKNOWN }
 
     companion object {
         const val PATRON_PRODUCT_BASE = "com.pocketcasts.patron"

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
@@ -1,5 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.models.type
 
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_PRODUCT_BASE
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_PRODUCT_BASE
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.android.billingclient.api.ProductDetails
 import java.time.Period
@@ -32,12 +35,14 @@ object SubscriptionMapper {
                 val trialPricingPhase = relevantSubscriptionOfferDetails.trialSubscriptionPricingPhase
                 if (trialPricingPhase == null) {
                     Subscription.Simple(
+                        tier = mapProductIdToTier(productDetails.productId),
                         recurringPricingPhase = recurringPricingPhase,
                         productDetails = productDetails,
                         offerToken = relevantSubscriptionOfferDetails.offerToken
                     )
                 } else {
                     Subscription.WithTrial(
+                        tier = mapProductIdToTier(productDetails.productId),
                         recurringPricingPhase = recurringPricingPhase,
                         trialPricingPhase = trialPricingPhase,
                         productDetails = productDetails,
@@ -114,4 +119,10 @@ object SubscriptionMapper {
             )
             null
         }
+
+    fun mapProductIdToTier(productId: String) = when {
+        productId.startsWith(PLUS_PRODUCT_BASE) -> SubscriptionTier.PLUS
+        productId.startsWith(PATRON_PRODUCT_BASE) -> SubscriptionTier.PATRON
+        else -> SubscriptionTier.UNKNOWN
+    }
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -10,6 +10,8 @@ import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import io.reactivex.Observable
@@ -605,4 +607,10 @@ interface Settings {
 
     fun isNotificationsDisabledMessageShown(): Boolean
     fun setNotificationsDisabledMessageShown(value: Boolean)
+
+    fun setLastSelectedSubscriptionTier(tier: Subscription.SubscriptionTier)
+    fun getLastSelectedSubscriptionTier(): Subscription.SubscriptionTier?
+
+    fun setLastSelectedSubscriptionFrequency(frequency: SubscriptionFrequency)
+    fun getLastSelectedSubscriptionFrequency(): SubscriptionFrequency?
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -16,6 +16,8 @@ import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.DEFAULT_MAX_AUTO_ADD_LIMIT
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.NOTIFICATIONS_DISABLED_MESSAGE_SHOWN
@@ -60,6 +62,8 @@ class SettingsImpl @Inject constructor(
         private const val END_OF_YEAR_MODAL_HAS_BEEN_SHOWN_KEY = "EndOfYearModalHasBeenShownKey"
         private const val DONE_INITIAL_ONBOARDING_KEY = "CompletedOnboardingKey"
         private const val CUSTOM_MEDIA_ACTIONS_VISIBLE_KEY = "CustomMediaActionsVisibleKey"
+        private const val LAST_SELECTED_SUBSCRIPTION_TIER_KEY = "LastSelectedSubscriptionTierKey"
+        private const val LAST_SELECTED_SUBSCRIPTION_FREQUENCY_KEY = "LastSelectedSubscriptionFrequencyKey"
     }
 
     private var languageCode: String? = null
@@ -1380,4 +1384,22 @@ class SettingsImpl @Inject constructor(
     override fun setNotificationsDisabledMessageShown(value: Boolean) {
         setBoolean(NOTIFICATIONS_DISABLED_MESSAGE_SHOWN, value)
     }
+
+    override fun setLastSelectedSubscriptionTier(tier: Subscription.SubscriptionTier) {
+        setString(LAST_SELECTED_SUBSCRIPTION_TIER_KEY, tier.name)
+    }
+
+    override fun getLastSelectedSubscriptionTier() =
+        getString(LAST_SELECTED_SUBSCRIPTION_TIER_KEY)?.let {
+            Subscription.SubscriptionTier.valueOf(it)
+        }
+
+    override fun setLastSelectedSubscriptionFrequency(frequency: SubscriptionFrequency) {
+        setString(LAST_SELECTED_SUBSCRIPTION_FREQUENCY_KEY, frequency.name)
+    }
+
+    override fun getLastSelectedSubscriptionFrequency() =
+        getString(LAST_SELECTED_SUBSCRIPTION_FREQUENCY_KEY)?.let {
+            SubscriptionFrequency.valueOf(it)
+        }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -14,13 +14,6 @@ import io.reactivex.Single
 
 interface SubscriptionManager {
 
-    companion object {
-        const val PATRON_PRODUCT_BASE = "com.pocketcasts.patron"
-        const val PLUS_PRODUCT_BASE = "com.pocketcasts.plus"
-        const val PLUS_MONTHLY_PRODUCT_ID = "$PLUS_PRODUCT_BASE.monthly"
-        const val PLUS_YEARLY_PRODUCT_ID = "$PLUS_PRODUCT_BASE.yearly"
-    }
-
     fun signOut()
     fun observeSubscriptionChangeEvents(): Flowable<SubscriptionChangedEvent>
     fun observeProductDetails(): Flowable<ProductDetailsState>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -34,10 +34,9 @@ interface SubscriptionManager {
     fun clearCachedStatus()
     fun isFreeTrialEligible(): Boolean
     fun updateFreeTrialEligible(eligible: Boolean)
-    fun getDefaultSubscription(subscriptions: List<Subscription>): Subscription?
-    fun getSubscriptionByTierAndFrequency(
+    fun getDefaultSubscription(
         subscriptions: List<Subscription>,
-        tier: Subscription.SubscriptionTier,
-        frequency: SubscriptionFrequency,
+        tier: Subscription.SubscriptionTier? = null,
+        frequency: SubscriptionFrequency? = null,
     ): Subscription?
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.ProductDetails
@@ -34,4 +35,9 @@ interface SubscriptionManager {
     fun isFreeTrialEligible(): Boolean
     fun updateFreeTrialEligible(eligible: Boolean)
     fun getDefaultSubscription(subscriptions: List<Subscription>): Subscription?
+    fun getSubscriptionByTierAndFrequency(
+        subscriptions: List<Subscription>,
+        tier: Subscription.SubscriptionTier,
+        frequency: SubscriptionFrequency,
+    ): Subscription?
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -17,8 +17,8 @@ interface SubscriptionManager {
     companion object {
         const val PATRON_PRODUCT_BASE = "com.pocketcasts.patron"
         const val PLUS_PRODUCT_BASE = "com.pocketcasts.plus"
-        const val MONTHLY_PRODUCT_ID = "$PLUS_PRODUCT_BASE.monthly"
-        const val YEARLY_PRODUCT_ID = "$PLUS_PRODUCT_BASE.yearly"
+        const val PLUS_MONTHLY_PRODUCT_ID = "$PLUS_PRODUCT_BASE.monthly"
+        const val PLUS_YEARLY_PRODUCT_ID = "$PLUS_PRODUCT_BASE.yearly"
     }
 
     fun signOut()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -336,29 +336,22 @@ class SubscriptionManagerImpl @Inject constructor(
         freeTrialEligible = eligible
     }
 
-    override fun getDefaultSubscription(subscriptions: List<Subscription>): Subscription? {
-        val trialsIfPresent = subscriptions
-            .filterIsInstance<Subscription.WithTrial>()
-            .ifEmpty { subscriptions }
-
-        return trialsIfPresent.find {
-            it.recurringPricingPhase is SubscriptionPricingPhase.Months
-        } ?: trialsIfPresent.firstOrNull() // if no monthly subscriptions, just display the first
-    }
-
-    override fun getSubscriptionByTierAndFrequency(
+    override fun getDefaultSubscription(
         subscriptions: List<Subscription>,
-        tier: Subscription.SubscriptionTier,
-        frequency: SubscriptionFrequency,
+        tier: Subscription.SubscriptionTier?,
+        frequency: SubscriptionFrequency?,
     ): Subscription? {
-        val tierSubscriptions = subscriptions.filter { it.tier == tier }
+        val subscriptionTier = tier ?: Subscription.SubscriptionTier.PLUS
+        val subscriptionFrequency = frequency ?: SubscriptionFrequency.YEARLY
+
+        val tierSubscriptions = subscriptions.filter { it.tier == subscriptionTier }
         val trialsIfPresent = tierSubscriptions
             .filterIsInstance<Subscription.WithTrial>()
 
         return trialsIfPresent.find {
             it.recurringPricingPhase is SubscriptionPricingPhase.Months // trial is available for monthly only
         } ?: tierSubscriptions.firstOrNull {
-            when (frequency) {
+            when (subscriptionFrequency) {
                 SubscriptionFrequency.MONTHLY -> it.recurringPricingPhase is SubscriptionPricingPhase.Months
                 SubscriptionFrequency.YEARLY -> it.recurringPricingPhase is SubscriptionPricingPhase.Years
                 SubscriptionFrequency.NONE -> throw IllegalStateException("Unknown subscription frequency found")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -10,9 +10,9 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager.Companion.MONTHLY_PRODUCT_ID
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager.Companion.PLUS_MONTHLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager.Companion.PLUS_PRODUCT_BASE
-import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager.Companion.YEARLY_PRODUCT_ID
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager.Companion.PLUS_YEARLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionPurchaseRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionResponse
@@ -151,11 +151,11 @@ class SubscriptionManagerImpl @Inject constructor(
         val productList =
             mutableListOf(
                 QueryProductDetailsParams.Product.newBuilder()
-                    .setProductId(MONTHLY_PRODUCT_ID)
+                    .setProductId(PLUS_MONTHLY_PRODUCT_ID)
                     .setProductType(BillingClient.ProductType.SUBS)
                     .build(),
                 QueryProductDetailsParams.Product.newBuilder()
-                    .setProductId(YEARLY_PRODUCT_ID)
+                    .setProductId(PLUS_YEARLY_PRODUCT_ID)
                     .setProductType(BillingClient.ProductType.SUBS)
                     .build(),
             )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -5,14 +5,14 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_MONTHLY_PRODUCT_ID
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_PRODUCT_BASE
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_YEARLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager.Companion.PLUS_MONTHLY_PRODUCT_ID
-import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager.Companion.PLUS_PRODUCT_BASE
-import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager.Companion.PLUS_YEARLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionPurchaseRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionResponse


### PR DESCRIPTION
## Description

This introduces upgrade tiers (see this comment on tiers: pdeCcb-2fL-p2#comment-1902) and updates the new upgrade screen to display prices right away, allowing the purchase without the need to show the modal.

## Testing Instructions

P.S. Skip any UI-related feedback, they'll be covered in a future PR

#### Test.1 Displays featured cards filtered by available subscriptions
1. Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/11343183/upgrade-testing-patch.patch)
2. Run the app being logged out
3. Subscribe to any podcast
4. Go to Podcasts
5. Tap the folder icon
6. ✅ You should see the upgrade screen that displays only the Plus tier plans
7. Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/11343238/upgrade-testing-patch-with-patron.patch) to add new tier
8. ✅ You should see the upgrade screen that displays two features cards, one for each tier


#### Test.2 Display prices right away, allowing the purchase without the need to show the modal
1. Continue from above
2. Toggle between the yearly/ monthly frequencies
3. ✅ Notice that pricing on the upgrade button changes right away without the need to show the pricing modal **

** Note this comment: pdeCcb-2fL-p2#comment-1997 on Patron yearly base plan. You will not see yearly pricing for this plan right now.

#### Test.3 Tier, frequency saved after returning from login
1. Continue from above, select non-default tier and frequency
2. Tap on upgrade button 
3. ✅ Notice that you see the login screen
4. Complete the login flow
5. ✅ Notice that you still see the last selected tier, frequency, and upgrade button

#### Test.4 Test subscription purchase success and failure
1. Continue from above (same patch)
2. Switch to release build variant (you'll need to configure gradle.properties for the release key) and install the build
3. Go to Podcasts tab
6. Tap the folder icon
7. Complete purchase flow for a Plus plan (do not test purchasing a Patron plan)
8. ✅ Notice that purchase is successful and the folder icon on the Podcasts tab changes to the plus folder
9. Wait for the test subscription to end or cancel it
10. Restart the flow and configure the test card to always fail
11. ✅ Notice that the failure message is shown within the Google-provided modal. I'm not showing any custom alerts, let me know if you think I should

<img width=200 src="https://user-images.githubusercontent.com/1405144/234862135-5eab0e08-b2fd-4a1e-bf33-b4ab97e3c3dd.png"/>

#### Test.5 Feature flag disabled
1. Disable the feature flag
2. Retrigger the same upgrade flow 
3. Notice that you see the previous upgrade screen and upgrading from it displays "only" the Plus tier plans in a modal
4. Tap on a plan and complete the purchase flow with the test card to always pass
5. ✅ Notice that the purchase is successful and is not impacted by upgrade screen changes

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack