### PR TITLE
Stop playback before signing out if clearing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
         ([#890](https://github.com/Automattic/pocket-casts-android/pull/892)).
     *   Fixed the show notes' timestamps not getting converted to a link if it contained another link 
         ([#814](https://github.com/Automattic/pocket-casts-android/issues/814)).
- 
+    *   Prevented crash when signing out of Android Automotive and clearing data while playback is in progress
+        ([#919](https://github.com/Automattic/pocket-casts-android/pull/919)).    
+
 7.37
 -----
 *   New Features:

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.account.ChangeEmailFragment
 import au.com.shiftyjelly.pocketcasts.account.ChangePwdFragment
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.ProfileUpgradeBanner
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
@@ -282,8 +283,17 @@ class AccountDetailsFragment : BaseFragment() {
         // Sign out first to make sure no data changes get synced
         userManager.signOut(playbackManager, wasInitiatedByUser = true)
 
-        // Block while clearing data so that we don't return to the app until the users data has been cleared
+        // Need to stop playback before we start clearing data
+        playbackManager.removeEpisode(
+            episodeToRemove = playbackManager.getCurrentEpisode(),
+            // Unknown is fine here because we don't send analytics when the user did not initiate the action
+            source = AnalyticsSource.UNKNOWN,
+            userInitiated = false,
+        )
+
+        // Block while clearing data so that users cannot interact with the until we're done clearing data
         runBlocking(Dispatchers.IO) {
+
             upNextQueue.removeAllIncludingChanges()
 
             playlistManager.resetDb()


### PR DESCRIPTION
## Description
This fixes a crash that occurred on Android Automotive when signing out and clearing data while playback was in progress.

Fixes #916 

## Testing Instructions
See https://github.com/Automattic/pocket-casts-android/issues/916

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
