### PR TITLE
Hide up next icons on up next screen

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
@@ -59,6 +59,7 @@ fun UpNextScreen(
                     items(list) { episode ->
                         EpisodeChip(
                             episode = episode,
+                            useUpNextIcon = false,
                             onClick = {
                                 navigateToEpisode(episode.uuid)
                             },

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
@@ -43,7 +43,11 @@ import au.com.shiftyjelly.pocketcasts.wear.theme.theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
-fun EpisodeChip(episode: BaseEpisode, onClick: () -> Unit) {
+fun EpisodeChip(
+    episode: BaseEpisode,
+    useUpNextIcon: Boolean = true,
+    onClick: () -> Unit,
+) {
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
@@ -85,12 +89,13 @@ fun EpisodeChip(episode: BaseEpisode, onClick: () -> Unit) {
                         .clip(RoundedCornerShape(4.dp)),
                 )
 
-                if (episode.isDownloaded || isInUpNextQueue) {
+                val showUpNextIcon = useUpNextIcon && isInUpNextQueue
+                if (episode.isDownloaded || showUpNextIcon) {
                     Row(
                         horizontalArrangement = spacedBy(4.dp),
                         modifier = Modifier.padding(top = 4.dp)
                     ) {
-                        if (isInUpNextQueue) {
+                        if (showUpNextIcon) {
                             Icon(
                                 painter = painterResource(R.drawable.ic_upnext),
                                 contentDescription = stringResource(LR.string.episode_in_up_next),


### PR DESCRIPTION
## Description
This hides the up next icons on the up next screen on the watch since the icon would be on every episode on that screen. This is also consistent with the phone's behavior.

internal discussion: p1682536583755259-slack-C040S9BK7SP

## Testing Instructions
1. Go to the Up Next screen
2. ✅ Confirm that none of the episodes show the Up Next icon
3. Download one of the episodes in the Up Next queue
4. Go to the Downloads screen
5. ✅  Confirm that the episode you just downloaded is there with both the up-next icon and the downloaded icon.

## Screenshots or Screencast 
| Up Next Screen | Downloads Screen|
| --- | --- |
| ![image](https://user-images.githubusercontent.com/4656348/234959100-60dbcf73-b34e-4fdc-aa7d-b6c19de8a5ab.png) | ![image](https://user-images.githubusercontent.com/4656348/234959166-279c4a49-33fe-4673-93ec-1c0062997f75.png) |

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews