### PR TITLE
Update sign_in and create_account events

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/account/SyncAccountTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/account/SyncAccountTest.kt
@@ -96,7 +96,7 @@ internal class SyncAccountTest {
             syncManager.loginWithEmailAndPassword(
                 email = "support+signin@pocketcasts.com",
                 password = "password_signin",
-                signInSource = SignInSource.Onboarding
+                signInSource = SignInSource.UserInitiated.Onboarding
             )
         }
         assert(result is LoginResult.Success)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/GoogleSignInButtonViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/GoogleSignInButtonViewModel.kt
@@ -185,7 +185,7 @@ class GoogleSignInButtonViewModel @Inject constructor(
         onSuccess: (GoogleSignInState) -> Unit,
         onError: suspend () -> Unit
     ) =
-        when (val authResult = syncManager.loginWithGoogle(idToken = idToken, signInSource = SignInSource.Onboarding)) {
+        when (val authResult = syncManager.loginWithGoogle(idToken = idToken, signInSource = SignInSource.UserInitiated.Onboarding)) {
             is LoginResult.Success -> {
                 podcastManager.refreshPodcastsAfterSignIn()
                 onSuccess(GoogleSignInState(isNewAccount = authResult.result.isNewAccount))

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
@@ -62,7 +62,7 @@ class OnboardingLogInViewModel @Inject constructor(
             val result = syncManager.loginWithEmailAndPassword(
                 email = state.email,
                 password = state.password,
-                signInSource = SignInSource.Onboarding
+                signInSource = SignInSource.UserInitiated.Onboarding
             )
             when (result) {
                 is LoginResult.Success -> {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/SignInViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/SignInViewModel.kt
@@ -72,7 +72,7 @@ class SignInViewModel
             val result = syncManager.loginWithEmailAndPassword(
                 email = emailString,
                 password = pwdString,
-                signInSource = SignInSource.SignInViewModel
+                signInSource = SignInSource.UserInitiated.SignInViewModel
             )
             when (result) {
                 is LoginResult.Success -> {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -10,7 +10,9 @@ enum class AnalyticsEvent(val key: String) {
 
     /* User lifecycle events */
     USER_SIGNED_IN("user_signed_in"),
+    USER_SIGNED_IN_WATCH_FROM_PHONE("user_signed_in_watch_from_phone"),
     USER_SIGNIN_FAILED("user_signin_failed"),
+    USER_SIGNIN_WATCH_FROM_PHONE_FAILED("user_signin_watch_from_phone_failed"),
     USER_ACCOUNT_DELETED("user_account_deleted"),
     USER_PASSWORD_UPDATED("user_password_updated"),
     USER_EMAIL_UPDATED("user_email_updated"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
@@ -149,7 +149,6 @@ class SyncAccountManager @Inject constructor(
 }
 
 enum class SignInSource(val analyticsValue: String) {
-    AccountAuthenticator("account_manager"),
     SignInViewModel("sign_in_view_model"),
     Onboarding("onboarding"),
     WatchPhoneSync("watch_phone_sync"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
@@ -148,8 +148,10 @@ class SyncAccountManager @Inject constructor(
     }
 }
 
-enum class SignInSource(val analyticsValue: String) {
-    SignInViewModel("sign_in_view_model"),
-    Onboarding("onboarding"),
-    WatchPhoneSync("watch_phone_sync"),
+sealed class SignInSource {
+    sealed class UserInitiated(val analyticsValue: String) : SignInSource() {
+        object SignInViewModel : UserInitiated("sign_in_view_model")
+        object Onboarding : UserInitiated("onboarding")
+    }
+    object WatchPhoneSync : SignInSource()
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -420,12 +420,10 @@ class SyncManagerImpl @Inject constructor(
             is LoginResult.Success -> {
                 when (signInSource) {
 
-                    SignInSource.WatchPhoneSync -> {
+                    SignInSource.WatchPhoneSync ->
                         analyticsTracker.track(AnalyticsEvent.USER_SIGNED_IN_WATCH_FROM_PHONE)
-                    }
 
-                    SignInSource.SignInViewModel,
-                    SignInSource.Onboarding -> {
+                    is SignInSource.UserInitiated ->
                         analyticsTracker.track(
                             event = if (loginResult.result.isNewAccount) {
                                 AnalyticsEvent.USER_ACCOUNT_CREATED
@@ -437,24 +435,21 @@ class SyncManagerImpl @Inject constructor(
                                 TRACKS_KEY_SOURCE_IN_CODE to signInSource.analyticsValue,
                             )
                         )
-                    }
                 }
             }
             is LoginResult.Failed -> {
                 val errorCodeValue = loginResult.messageId ?: TracksAnalyticsTracker.INVALID_OR_NULL_VALUE
                 when (signInSource) {
 
-                    SignInSource.WatchPhoneSync -> {
+                    SignInSource.WatchPhoneSync ->
                         analyticsTracker.track(
                             AnalyticsEvent.USER_SIGNIN_WATCH_FROM_PHONE_FAILED,
                             mapOf(
                                 TRACKS_KEY_ERROR_CODE to errorCodeValue,
                             )
                         )
-                    }
 
-                    SignInSource.SignInViewModel,
-                    SignInSource.Onboarding -> {
+                    is SignInSource.UserInitiated ->
                         analyticsTracker.track(
                             AnalyticsEvent.USER_SIGNIN_FAILED,
                             mapOf(
@@ -463,7 +458,6 @@ class SyncManagerImpl @Inject constructor(
                                 TRACKS_KEY_ERROR_CODE to errorCodeValue,
                             )
                         )
-                    }
                 }
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -70,7 +70,8 @@ class SyncManagerImpl @Inject constructor(
     }
 
     companion object {
-        private const val TRACKS_KEY_SIGN_IN_SOURCE = "sign_in_source"
+        private const val TRACKS_KEY_SOURCE_IN_CODE = "source_in_code"
+        private const val TRACKS_KEY_SOURCE = "source"
         private const val TRACKS_KEY_ERROR_CODE = "error_code"
     }
 
@@ -136,7 +137,6 @@ class SyncManagerImpl @Inject constructor(
                 refreshToken = refreshToken,
                 syncServerManager = syncServerManager,
                 signInType = syncAccountManager.getSignInType(account),
-                signInSource = SignInSource.AccountAuthenticator
             )
 
             // update the refresh token as the expiry may have been increased
@@ -193,7 +193,9 @@ class SyncManagerImpl @Inject constructor(
             Timber.e(ex, "Failed to sign in with Pocket Casts")
             exceptionToAuthResult(exception = ex, fallbackMessage = LR.string.error_login_failed)
         }
-        trackSignIn(loginResult, signInSource)
+
+        trackSignIn(loginResult, signInSource, loginIdentity)
+
         return loginResult
     }
 
@@ -405,16 +407,64 @@ class SyncManagerImpl @Inject constructor(
         return LoginResult.Failed(message = message, messageId = messageId)
     }
 
-    private fun trackSignIn(loginResult: LoginResult, signInSource: SignInSource) {
-        val properties = mapOf(TRACKS_KEY_SIGN_IN_SOURCE to signInSource.analyticsValue)
+    private fun trackSignIn(
+        loginResult: LoginResult,
+        signInSource: SignInSource,
+        loginIdentity: LoginIdentity,
+    ) {
+        val source = when (loginIdentity) {
+            LoginIdentity.Google -> "google"
+            LoginIdentity.PocketCasts -> "password"
+        }
         when (loginResult) {
             is LoginResult.Success -> {
-                analyticsTracker.track(AnalyticsEvent.USER_SIGNED_IN, properties)
+                when (signInSource) {
+
+                    SignInSource.WatchPhoneSync -> {
+                        analyticsTracker.track(AnalyticsEvent.USER_SIGNED_IN_WATCH_FROM_PHONE)
+                    }
+
+                    SignInSource.SignInViewModel,
+                    SignInSource.Onboarding -> {
+                        analyticsTracker.track(
+                            event = if (loginResult.result.isNewAccount) {
+                                AnalyticsEvent.USER_ACCOUNT_CREATED
+                            } else {
+                                AnalyticsEvent.USER_SIGNED_IN
+                            },
+                            properties = mapOf(
+                                TRACKS_KEY_SOURCE to source,
+                                TRACKS_KEY_SOURCE_IN_CODE to signInSource.analyticsValue,
+                            )
+                        )
+                    }
+                }
             }
             is LoginResult.Failed -> {
                 val errorCodeValue = loginResult.messageId ?: TracksAnalyticsTracker.INVALID_OR_NULL_VALUE
-                val errorProperties = properties.plus(TRACKS_KEY_ERROR_CODE to errorCodeValue)
-                analyticsTracker.track(AnalyticsEvent.USER_SIGNIN_FAILED, errorProperties)
+                when (signInSource) {
+
+                    SignInSource.WatchPhoneSync -> {
+                        analyticsTracker.track(
+                            AnalyticsEvent.USER_SIGNIN_WATCH_FROM_PHONE_FAILED,
+                            mapOf(
+                                TRACKS_KEY_ERROR_CODE to errorCodeValue,
+                            )
+                        )
+                    }
+
+                    SignInSource.SignInViewModel,
+                    SignInSource.Onboarding -> {
+                        analyticsTracker.track(
+                            AnalyticsEvent.USER_SIGNIN_FAILED,
+                            mapOf(
+                                TRACKS_KEY_SOURCE to source,
+                                TRACKS_KEY_SOURCE_IN_CODE to signInSource.analyticsValue,
+                                TRACKS_KEY_ERROR_CODE to errorCodeValue,
+                            )
+                        )
+                    }
+                }
             }
         }
     }
@@ -422,7 +472,10 @@ class SyncManagerImpl @Inject constructor(
     private fun trackRegister(loginResult: LoginResult) {
         when (loginResult) {
             is LoginResult.Success -> {
-                analyticsTracker.track(AnalyticsEvent.USER_ACCOUNT_CREATED)
+                analyticsTracker.track(
+                    AnalyticsEvent.USER_ACCOUNT_CREATED,
+                    mapOf(TRACKS_KEY_SOURCE to "password") // This method is only used when creating an account with a password
+                )
             }
             is LoginResult.Failed -> {
                 val errorCodeValue = loginResult.messageId ?: TracksAnalyticsTracker.INVALID_OR_NULL_VALUE
@@ -440,22 +493,12 @@ class SyncManagerImpl @Inject constructor(
         email: String,
         refreshToken: RefreshToken,
         syncServerManager: SyncServerManager,
-        signInSource: SignInSource,
         signInType: AccountConstants.SignInType
-    ): LoginTokenResponse {
-        val properties = mapOf(TRACKS_KEY_SIGN_IN_SOURCE to signInSource.analyticsValue)
-        try {
-            val response = when (signInType) {
-                AccountConstants.SignInType.Password -> syncServerManager.login(email = email, password = refreshToken.value)
-                AccountConstants.SignInType.Tokens -> syncServerManager.loginToken(refreshToken = refreshToken)
-            }
-            analyticsTracker.track(AnalyticsEvent.USER_SIGNED_IN, properties)
-            return response
-        } catch (ex: Exception) {
-            analyticsTracker.track(AnalyticsEvent.USER_SIGNIN_FAILED, properties)
-            throw ex
+    ): LoginTokenResponse =
+        when (signInType) {
+            AccountConstants.SignInType.Password -> syncServerManager.login(email = email, password = refreshToken.value)
+            AccountConstants.SignInType.Tokens -> syncServerManager.loginToken(refreshToken = refreshToken)
         }
-    }
 
     private suspend fun <T : Any> getCacheTokenOrLogin(serverCall: suspend (token: AccessToken) -> T): T {
         if (isLoggedIn()) {


### PR DESCRIPTION
## Description
This updates the sign-in and create-account events. I think that the SSO changes caused these to stop working the way they should.

## Testing Instructions

### 1. Create account with SSO
1. Fresh install of the app
2. Create an account using SSO
3. Observe the `user_account_created` event
4. Sign out
5. Sign in using SSO
6. Observe the `user_signed_in` event

### 2. Create account with email/pass
1. Delete the account you created in the previous test
2. Create an account using that email, but with a password instead of using SSO
3. Observe the `user_account_created` event
4. Sign out
5. Sign in using email/pass
6. Observe the `user_signed_in` event
7. Sign out
8. Sign in using SSO
9. Observe the `user_signed_in` event

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
