### PR TITLE
Make sure app has correct `SignInType` after upgrading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 7.38
 -----
 
+7.37.1
+-----
+* Bug Fixes:
+    *    Fixed an issue that could cause users to be repeatedly logged out of the app.
+         ([#930](https://github.com/Automattic/pocket-casts-android/pull/930)).
 
 7.37
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
@@ -115,8 +115,15 @@ class SyncAccountManager @Inject constructor(
             AccountConstants.SIGN_IN_TYPE_KEY to AccountConstants.SignInType.Tokens.value,
             AccountConstants.LOGIN_IDENTITY to loginIdentity.value
         )
-        accountManager.addAccountExplicitly(account, refreshToken.value, userData)
+        val accountAdded = accountManager.addAccountExplicitly(account, refreshToken.value, userData)
         accountManager.setAuthToken(account, AccountConstants.TOKEN_TYPE, accessToken.value)
+
+        // When the account was already added, set the sign in type to Tokens because the account
+        // does not seem to get updated with this from the userData in the addAccountExplicitly call
+        if (!accountAdded) {
+            LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Account already added, setting sign in type to Tokens")
+            accountManager.setUserData(account, AccountConstants.SIGN_IN_TYPE_KEY, AccountConstants.SignInType.Tokens.value)
+        }
     }
 
     fun signOut() {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
@@ -135,6 +135,7 @@ class SyncAccountManager @Inject constructor(
     fun setRefreshToken(refreshToken: RefreshToken) {
         val account = getAccount() ?: return
         accountManager.setPassword(account, refreshToken.value)
+        accountManager.setUserData(account, AccountConstants.SIGN_IN_TYPE_KEY, AccountConstants.SignInType.Tokens.value)
     }
 
     fun setAccessToken(accessToken: AccessToken) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -124,12 +124,12 @@ class SyncManagerImpl @Inject constructor(
     private suspend fun fetchAccessToken(account: Account): AccessToken? {
         val refreshToken = syncAccountManager.getRefreshToken(account) ?: return null
         return try {
-            Timber.d("Refreshing the access token")
+            val signInType = syncAccountManager.getSignInType(account)
+            LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Fetching the access token, SignInType: $signInType")
             val tokenResponse = downloadTokens(
                 email = account.name,
                 refreshToken = refreshToken,
-                syncServerManager = syncServerManager,
-                signInType = syncAccountManager.getSignInType(account),
+                signInType = signInType,
                 signInSource = SignInSource.AccountAuthenticator
             )
 
@@ -419,9 +419,8 @@ class SyncManagerImpl @Inject constructor(
     private suspend fun downloadTokens(
         email: String,
         refreshToken: RefreshToken,
-        syncServerManager: SyncServerManager,
         signInSource: SignInSource,
-        signInType: AccountConstants.SignInType
+        signInType: AccountConstants.SignInType,
     ): LoginTokenResponse {
         val properties = mapOf(TRACKS_KEY_SIGN_IN_SOURCE to signInSource.analyticsValue)
         try {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -498,7 +498,7 @@ class SyncManagerImpl @Inject constructor(
 
     private suspend fun refreshTokenSuspend(): AccessToken {
         syncAccountManager.invalidateAccessToken()
-        return syncAccountManager.getAccessToken() ?: throw Exception("Failed to get refresh token")
+        return syncAccountManager.getAccessToken() ?: throw Exception("Failed to get access token")
     }
 
     private fun isHttpUnauthorized(throwable: Throwable?): Boolean {


### PR DESCRIPTION
> **Warning**
> I think this PR merits a hotfix, so I have it targeting a new hotfix branch: `release/7.37.1`.

## Description
This avoids scenarios where users migrating from a password `SignInType` to the token `SIgnInType` can get stuck in a bad state where the app will always fail to retrieve an updated access token because the app still thought the user was using a password `SignInType` so it would try to use the stored token as a password, which would fail. This causes the app to present notifications saying the user has been signed out, but the app still indicates the user is signed in apart from this error (and all the API calls would fail).

![image](https://user-images.githubusercontent.com/4656348/236315989-75a2f68f-7bf6-4f92-9290-d51a30708945.png)

This PR essentially has two fixes for this issue...

1. d13c31b55feaf9fa12dba8bf0ce1a787c8b94283 makes it so that when a user signs in after getting one of these errors, the `SignInType` is updated appropriately. Before, the `SignInType` would not get updated because when we called `addAccountExplicitly(...)` the account already existed. In other words, this makes it so that even if a user gets one of these errors, the issue will be resolved when they sign in.
2. db1fb965340d0654a6ba8d8bc9f3b3a1714da227 avoids the issue arising in the first place by making sure that any time we store a refresh token instead of a password, we update the `SignInType` to be `Tokens`.

This PR also includes some minor improvements to our logging in this area.

## Testing Instructions
### 1. Test that logging in clears the error
1. Install a debugProd build from the `7.36` tag
2. Log into the app
4. Install a debugProd build from the `release/7.37.1` branch, applying [this patch](https://gist.github.com/mchowning/0d4edda7247b536a5abccd20357cebb0) to make the issue easy to recreate.
5. Tap refresh from the "Profile" tab
6. Observe a sign-in error notification is presented
7. Tap on the sign-in error notification and sign into the same account you signed into on the 7.36 build
8. Observe a new sign-in error notification is presented
9. Install a debugProd build from the first commit in this PR (d13c31b55feaf9fa12dba8bf0ce1a787c8b94283) applying [this patch](https://gist.github.com/mchowning/0d4edda7247b536a5abccd20357cebb0). The reason for using this commit is because it will still allow the error to occur (the fix that avoids the error entirely is db1fb965340d0654a6ba8d8bc9f3b3a1714da227) and allow you to test that signing in will now fix the error.
10. Install that build
11. Tap refresh from the "Profile" tab
12. Observe there is a sign-in error notification
13. Tap on the error notification and sign into the app using the same account you signed into on the 7.36 build
14. ✅ Observe there is no sign-in error notification and that you can refresh the app from the "Profile" tab without any issues

### 2.  Test that error is avoided entirely
1. Install a debugProd build from the `7.36` tag
2. Log into the app
3. Install a debugProd build from this PR applying [this patch (https://gist.github.com/mchowning/0d4edda7247b536a5abccd20357cebb0).
4. Start the app and perform a refresh.
5. ✅ Observe there are no error notifications

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
