### PR TITLE
Only send sign out analytics when user was signed in

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -91,6 +91,8 @@ class UserManagerImpl @Inject constructor(
 
     @OptIn(DelicateCoroutinesApi::class)
     override fun signOut(playbackManager: PlaybackManager, wasInitiatedByUser: Boolean) {
+        val wasSignedIn = syncManager.isLoggedIn()
+
         LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Signing out")
         subscriptionManager.clearCachedStatus()
         syncManager.signOut {
@@ -102,10 +104,12 @@ class UserManagerImpl @Inject constructor(
             settings.setMarketingOptIn(false)
             settings.setMarketingOptInNeedsSync(false)
             settings.setEndOfYearModalHasBeenShown(false)
-            analyticsTracker.track(
-                AnalyticsEvent.USER_SIGNED_OUT,
-                mapOf(KEY_USER_INITIATED to wasInitiatedByUser)
-            )
+            if (wasSignedIn) {
+                analyticsTracker.track(
+                    AnalyticsEvent.USER_SIGNED_OUT,
+                    mapOf(KEY_USER_INITIATED to wasInitiatedByUser)
+                )
+            }
             analyticsTracker.flush()
             analyticsTracker.clearAllData()
             analyticsTracker.refreshMetadata()


### PR DESCRIPTION
> **Warning**
> I am targetting the `release/7.37.1` hotfix because this seems like a completely safe change and it helps our analytics be more useful in identifying possible authentication issues. This is certainly not a critical fix, so just let me know if you think we're better off not including it in the hotfix.

## Description

This improves the situation in #927, but it does not fully fix the issue because although we no longer send the sign-out analytics event every time a logged-out user starts the app, we now can miss sending the sign-out analytics event when the user signs out of their Pocket Casts account from the account management options in the Android OS. I think this is probably not a very common thing for people to do, so this feels like a worthwhile tradeoff, but it would be good to find a better way to handle this in the future that also captures those events (let me know if you have any ideas).

## Testing Instructions
1. Freshly install the app
2. Start the app
3. ✅  Observe that there is not a `user_signed_out` event

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
