### PR TITLE
Update sign-in event handling for 7.37.1

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -10,7 +10,9 @@ enum class AnalyticsEvent(val key: String) {
 
     /* User lifecycle events */
     USER_SIGNED_IN("user_signed_in"),
+    USER_SIGNED_IN_WATCH_FROM_PHONE("user_signed_in_watch_from_phone"),
     USER_SIGNIN_FAILED("user_signin_failed"),
+    USER_SIGNIN_WATCH_FROM_PHONE_FAILED("user_signin_watch_from_phone_failed"),
     USER_ACCOUNT_DELETED("user_account_deleted"),
     USER_PASSWORD_UPDATED("user_password_updated"),
     USER_EMAIL_UPDATED("user_email_updated"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
@@ -152,7 +152,6 @@ class SyncAccountManager @Inject constructor(
 }
 
 enum class SignInSource(val analyticsValue: String) {
-    AccountAuthenticator("account_manager"),
     SignInViewModel("sign_in_view_model"),
     Onboarding("onboarding"),
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -70,7 +70,8 @@ class SyncManagerImpl @Inject constructor(
     }
 
     companion object {
-        private const val TRACKS_KEY_SIGN_IN_SOURCE = "sign_in_source"
+        private const val TRACKS_KEY_SOURCE_IN_CODE = "source_in_code"
+        private const val TRACKS_KEY_SOURCE = "source"
         private const val TRACKS_KEY_ERROR_CODE = "error_code"
     }
 
@@ -130,7 +131,6 @@ class SyncManagerImpl @Inject constructor(
                 refreshToken = refreshToken,
                 syncServerManager = syncServerManager,
                 signInType = syncAccountManager.getSignInType(account),
-                signInSource = SignInSource.AccountAuthenticator
             )
 
             // update the refresh token as the expiry may have been increased
@@ -173,7 +173,9 @@ class SyncManagerImpl @Inject constructor(
             Timber.e(ex, "Failed to sign in with Pocket Casts")
             exceptionToAuthResult(exception = ex, fallbackMessage = LR.string.error_login_failed)
         }
-        trackSignIn(loginResult, signInSource)
+
+        trackSignIn(loginResult, signInSource, loginIdentity)
+
         return loginResult
     }
 
@@ -385,16 +387,64 @@ class SyncManagerImpl @Inject constructor(
         return LoginResult.Failed(message = message, messageId = messageId)
     }
 
-    private fun trackSignIn(loginResult: LoginResult, signInSource: SignInSource) {
-        val properties = mapOf(TRACKS_KEY_SIGN_IN_SOURCE to signInSource.analyticsValue)
+    private fun trackSignIn(
+        loginResult: LoginResult,
+        signInSource: SignInSource,
+        loginIdentity: LoginIdentity,
+    ) {
+        val source = when (loginIdentity) {
+            LoginIdentity.Google -> "google"
+            LoginIdentity.PocketCasts -> "password"
+        }
         when (loginResult) {
             is LoginResult.Success -> {
-                analyticsTracker.track(AnalyticsEvent.USER_SIGNED_IN, properties)
+                when (signInSource) {
+
+                    SignInSource.WatchPhoneSync -> {
+                        analyticsTracker.track(AnalyticsEvent.USER_SIGNED_IN_WATCH_FROM_PHONE)
+                    }
+
+                    SignInSource.SignInViewModel,
+                    SignInSource.Onboarding -> {
+                        analyticsTracker.track(
+                            event = if (loginResult.result.isNewAccount) {
+                                AnalyticsEvent.USER_ACCOUNT_CREATED
+                            } else {
+                                AnalyticsEvent.USER_SIGNED_IN
+                            },
+                            properties = mapOf(
+                                TRACKS_KEY_SOURCE to source,
+                                TRACKS_KEY_SOURCE_IN_CODE to signInSource.analyticsValue,
+                            )
+                        )
+                    }
+                }
             }
             is LoginResult.Failed -> {
                 val errorCodeValue = loginResult.messageId ?: TracksAnalyticsTracker.INVALID_OR_NULL_VALUE
-                val errorProperties = properties.plus(TRACKS_KEY_ERROR_CODE to errorCodeValue)
-                analyticsTracker.track(AnalyticsEvent.USER_SIGNIN_FAILED, errorProperties)
+                when (signInSource) {
+
+                    SignInSource.WatchPhoneSync -> {
+                        analyticsTracker.track(
+                            AnalyticsEvent.USER_SIGNIN_WATCH_FROM_PHONE_FAILED,
+                            mapOf(
+                                TRACKS_KEY_ERROR_CODE to errorCodeValue,
+                            )
+                        )
+                    }
+
+                    SignInSource.SignInViewModel,
+                    SignInSource.Onboarding -> {
+                        analyticsTracker.track(
+                            AnalyticsEvent.USER_SIGNIN_FAILED,
+                            mapOf(
+                                TRACKS_KEY_SOURCE to source,
+                                TRACKS_KEY_SOURCE_IN_CODE to signInSource.analyticsValue,
+                                TRACKS_KEY_ERROR_CODE to errorCodeValue,
+                            )
+                        )
+                    }
+                }
             }
         }
     }
@@ -402,7 +452,10 @@ class SyncManagerImpl @Inject constructor(
     private fun trackRegister(loginResult: LoginResult) {
         when (loginResult) {
             is LoginResult.Success -> {
-                analyticsTracker.track(AnalyticsEvent.USER_ACCOUNT_CREATED)
+                analyticsTracker.track(
+                    AnalyticsEvent.USER_ACCOUNT_CREATED,
+                    mapOf(TRACKS_KEY_SOURCE to "password") // This method is only used when creating an account with a password
+                )
             }
             is LoginResult.Failed -> {
                 val errorCodeValue = loginResult.messageId ?: TracksAnalyticsTracker.INVALID_OR_NULL_VALUE
@@ -420,22 +473,12 @@ class SyncManagerImpl @Inject constructor(
         email: String,
         refreshToken: RefreshToken,
         syncServerManager: SyncServerManager,
-        signInSource: SignInSource,
         signInType: AccountConstants.SignInType
-    ): LoginTokenResponse {
-        val properties = mapOf(TRACKS_KEY_SIGN_IN_SOURCE to signInSource.analyticsValue)
-        try {
-            val response = when (signInType) {
-                AccountConstants.SignInType.Password -> syncServerManager.login(email = email, password = refreshToken.value)
-                AccountConstants.SignInType.Tokens -> syncServerManager.loginToken(refreshToken = refreshToken)
-            }
-            analyticsTracker.track(AnalyticsEvent.USER_SIGNED_IN, properties)
-            return response
-        } catch (ex: Exception) {
-            analyticsTracker.track(AnalyticsEvent.USER_SIGNIN_FAILED, properties)
-            throw ex
+    ): LoginTokenResponse =
+        when (signInType) {
+            AccountConstants.SignInType.Password -> syncServerManager.login(email = email, password = refreshToken.value)
+            AccountConstants.SignInType.Tokens -> syncServerManager.loginToken(refreshToken = refreshToken)
         }
-    }
 
     private suspend fun <T : Any> getCacheTokenOrLogin(serverCall: suspend (token: AccessToken) -> T): T {
         if (isLoggedIn()) {


### PR DESCRIPTION
> **Warning**
> This PR is bringing some of the analytics changes from https://github.com/Automattic/pocket-casts-android/pull/928 to the 7.37.1 hotfix. I believe these changes are safe for the hotfix because they only update how the analytics are sent, so there is very little risk of any regressions our users would notice. It is certainly not critical that this be included in the hotfix though, so let me know if you have any hesitation about including it.

See https://github.com/Automattic/pocket-casts-android/pull/928 for description and testing steps. That PR has two commits, one of which involved a minor refactoring, which I have not included in this PR in order to minimize the hotfix changes.

The reason I think this is worth including this in the hotfix is because with our SSO changes we now call `downloadTokens` in many circumstances where a user is not signing in, and removing this noise from our analytics will help us identify potential authentication issues.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes