### PR TITLE
Update up-next icon to be 24dp

### DIFF
--- a/modules/services/images/src/main/res/drawable/ic_upnext.xml
+++ b/modules/services/images/src/main/res/drawable/ic_upnext.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="12dp"
-    android:height="12dp"
+    android:width="24dp"
+    android:height="24dp"
     android:viewportWidth="12"
     android:viewportHeight="12">
     <path


### PR DESCRIPTION
## Description
When I [updated the up next icon to be more centered](https://github.com/Automattic/pocket-casts-android/pull/914#issuecomment-1525529334), the svg's width and height were reduced, and I didn't realize this would reduce the icon's size on the podcast settings screen. This increases the size of the new icon to be the same as the old icon.

Reported by a beta user https://pocketcastsbeta.slack.com/archives/C013F9RM6UA/p1683238245603559

> **Warning**
> Because this is a regression from 7.37, I'm targeting the `release/7.38` branch. I don't think we need to release a new beta with this though, and it can just go out with the next beta or the actual prod release.

## Testing Instructions
### 1. Phone
1. Install the phone app
2. Go to a subscribed podcast
3. Tap on the ⚙️ to open the podcasts settings
4. ✅ Verify that the icon by the "Add to Up Next" setting is the proper size

### 2. Watch
1. Install the watch app
2. Make sure you have one episode that is both in the up next queue and downloaded
3. Go to the Downloads screen
4. ✅ Verfiy that the up next icon is applied to that episode's chip and looks correct

## Screenshots or Screencast 

| Phone | Watch |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/4656348/236491998-24f39759-f372-47b4-8880-c79b6cc3c1de.png) | ![image](https://user-images.githubusercontent.com/4656348/236492134-4643eba0-9a22-4aa0-bb79-e05a4f2f5fd7.png) |

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews