### PR TITLE
Only sign out user if they have not already been fully signed out

### DIFF
--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -613,4 +613,12 @@ interface Settings {
 
     fun setLastSelectedSubscriptionFrequency(frequency: SubscriptionFrequency)
     fun getLastSelectedSubscriptionFrequency(): SubscriptionFrequency?
+
+    // This boolean should be update to false when a user signs in and should be set to
+    // true once a user signs out and that sign out has been fully handled
+    // by the app. This field helps make sure the app fully handles signing a user
+    // out even if they sign out from outside the app (i.e., from the Android OS's
+    // account management settings).
+    fun setFullySignedOut(boolean: Boolean)
+    fun getFullySignedOut(): Boolean
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -64,6 +64,7 @@ class SettingsImpl @Inject constructor(
         private const val CUSTOM_MEDIA_ACTIONS_VISIBLE_KEY = "CustomMediaActionsVisibleKey"
         private const val LAST_SELECTED_SUBSCRIPTION_TIER_KEY = "LastSelectedSubscriptionTierKey"
         private const val LAST_SELECTED_SUBSCRIPTION_FREQUENCY_KEY = "LastSelectedSubscriptionFrequencyKey"
+        private const val PROCESSED_SIGNOUT_KEY = "ProcessedSignout"
     }
 
     private var languageCode: String? = null
@@ -1402,4 +1403,11 @@ class SettingsImpl @Inject constructor(
         getString(LAST_SELECTED_SUBSCRIPTION_FREQUENCY_KEY)?.let {
             SubscriptionFrequency.valueOf(it)
         }
+
+    override fun setFullySignedOut(boolean: Boolean) {
+        setBoolean(PROCESSED_SIGNOUT_KEY, boolean)
+    }
+
+    override fun getFullySignedOut(): Boolean =
+        getBoolean(PROCESSED_SIGNOUT_KEY, true)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -188,6 +188,9 @@ class SyncManagerImpl @Inject constructor(
         val loginResult = try {
             val response = loginFunction()
             val result = handleTokenResponse(loginIdentity = loginIdentity, response = response)
+
+            settings.setFullySignedOut(false)
+
             LoginResult.Success(result)
         } catch (ex: Exception) {
             Timber.e(ex, "Failed to sign in with Pocket Casts")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -91,29 +91,26 @@ class UserManagerImpl @Inject constructor(
 
     @OptIn(DelicateCoroutinesApi::class)
     override fun signOut(playbackManager: PlaybackManager, wasInitiatedByUser: Boolean) {
-        val hasProcessedSignOut = settings.getFullySignedOut()
-        val wasSignedIn = syncManager.isLoggedIn()
+        if (wasInitiatedByUser || !settings.getFullySignedOut()) {
+            LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Signing out")
+            subscriptionManager.clearCachedStatus()
+            syncManager.signOut {
+                settings.clearPlusPreferences()
+                GlobalScope.launch {
+                    userEpisodeManager.removeCloudStatusFromFiles(playbackManager)
+                }
 
-        LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Signing out")
-        subscriptionManager.clearCachedStatus()
-        syncManager.signOut {
-            settings.clearPlusPreferences()
-            GlobalScope.launch {
-                userEpisodeManager.removeCloudStatusFromFiles(playbackManager)
-            }
-
-            settings.setMarketingOptIn(false)
-            settings.setMarketingOptInNeedsSync(false)
-            settings.setEndOfYearModalHasBeenShown(false)
-            if (wasSignedIn || !hasProcessedSignOut) {
+                settings.setMarketingOptIn(false)
+                settings.setMarketingOptInNeedsSync(false)
+                settings.setEndOfYearModalHasBeenShown(false)
                 analyticsTracker.track(
                     AnalyticsEvent.USER_SIGNED_OUT,
                     mapOf(KEY_USER_INITIATED to wasInitiatedByUser)
                 )
+                analyticsTracker.flush()
+                analyticsTracker.clearAllData()
+                analyticsTracker.refreshMetadata()
             }
-            analyticsTracker.flush()
-            analyticsTracker.clearAllData()
-            analyticsTracker.refreshMetadata()
         }
         settings.setFullySignedOut(true)
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -91,6 +91,7 @@ class UserManagerImpl @Inject constructor(
 
     @OptIn(DelicateCoroutinesApi::class)
     override fun signOut(playbackManager: PlaybackManager, wasInitiatedByUser: Boolean) {
+        val hasProcessedSignOut = settings.getFullySignedOut()
         val wasSignedIn = syncManager.isLoggedIn()
 
         LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Signing out")
@@ -104,7 +105,7 @@ class UserManagerImpl @Inject constructor(
             settings.setMarketingOptIn(false)
             settings.setMarketingOptInNeedsSync(false)
             settings.setEndOfYearModalHasBeenShown(false)
-            if (wasSignedIn) {
+            if (wasSignedIn || !hasProcessedSignOut) {
                 analyticsTracker.track(
                     AnalyticsEvent.USER_SIGNED_OUT,
                     mapOf(KEY_USER_INITIATED to wasInitiatedByUser)
@@ -114,5 +115,6 @@ class UserManagerImpl @Inject constructor(
             analyticsTracker.clearAllData()
             analyticsTracker.refreshMetadata()
         }
+        settings.setFullySignedOut(true)
     }
 }


### PR DESCRIPTION
## Description
Follow-up PR to https://github.com/Automattic/pocket-casts-android/pull/931 implementing @ashiagr 's suggested improvement. 🙇 

I'm taking this a bit further and avoiding all sign out work when the user is already fully signed out unless this signout was manually triggered by the user. In theory, it shouldn't be possible for a fully signed out user to manually trigger a sign out, but I figured I'd leave that in as a safety hatch so if a user did somehow get into a weird state they could still possibly recover by manually triggering a sign out.

Fixes #927

## Testing Instructions
1. Fresh install of the app
2. Start the app
3. ✅  Verify there is no `user_signed_out` event
4. Sign into the app
5. Swipe the app away from recents
6. Restart the app
7.  ✅  Verify there is no `user_signed_out` event
8. Sign out of the app from within the app
9. ✅  Verify there IS a `user_signed_out` event
10. Sign back into the app
11. Swipe the app away from recents
12. Sign out of your Pocket Casts account from the Android OS's settings for managing your accounts
13. ✅ Verify there IS a `user_signed_out` event. I see this event in the logs without even needing to open the app, but I think it's also fine if the event doesn't show up until the app is opened.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes