### PR TITLE
Patron: Update account screen's upgrade banner

### DIFF
--- a/modules/features/account/src/main/AndroidManifest.xml
+++ b/modules/features/account/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     <application>
         <activity
             android:name="au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivity"
-            android:windowSoftInputMode="adjustResize" />
+            android:windowSoftInputMode="adjustResize"
+            android:theme="@style/Theme.Transparent"/>
     </application>
 </manifest>

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
@@ -26,8 +26,6 @@ class OnboardingActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        theme.setupThemeForConfig(this, resources.configuration)
-
         // Make content edge-to-edge
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
@@ -46,6 +44,10 @@ class OnboardingActivity : AppCompatActivity() {
                     }
                 } ?: throw IllegalStateException("Analytics flow not set")
 
+                if (shouldSetupTheme(onboardingFlow)) {
+                    theme.setupThemeForConfig(this, resources.configuration)
+                }
+
                 OnboardingFlowComposable(
                     theme = theme.activeTheme,
                     flow = onboardingFlow,
@@ -57,6 +59,11 @@ class OnboardingActivity : AppCompatActivity() {
         }
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        theme.setupThemeForConfig(this, resources.configuration)
+    }
+
     private fun finishWithResult(result: OnboardingFinish) {
         setResult(
             Activity.RESULT_OK,
@@ -66,6 +73,9 @@ class OnboardingActivity : AppCompatActivity() {
         )
         finish()
     }
+
+    private fun shouldSetupTheme(onboardingFlow: OnboardingFlow) =
+        (onboardingFlow !is OnboardingFlow.PlusAccountUpgrade)
 
     companion object {
         fun newInstance(context: Context, onboardingFlow: OnboardingFlow) =

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -64,7 +64,7 @@ private fun Content(
 
         // Cannot use OnboardingNavRoute.PlusUpgrade.routeWithSource here, it is set as a defaultValue in the PlusUpgrade composable,
         // see https://stackoverflow.com/a/70410872/1910286
-        is OnboardingFlow.PlusAccountUpgrade, // FIXME this should just open the purchase modal
+        is OnboardingFlow.PlusAccountUpgrade,
         is OnboardingFlow.PlusFlow -> OnboardingNavRoute.PlusUpgrade.route
     }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/SubscriptionTierPill.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/SubscriptionTierPill.kt
@@ -2,12 +2,14 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding.components
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -18,7 +20,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
-import au.com.shiftyjelly.pocketcasts.images.R
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private val iconSizeInDp = 14.dp
 private val pillCornerRadiusInDp = 800.dp
@@ -29,11 +32,14 @@ fun SubscriptionTierPill(
     @StringRes shortNameRes: Int,
     modifier: Modifier = Modifier,
     iconColor: Color = Color.Unspecified,
-    backgroundColor: Color = Color.Black,
+    backgroundColor: Color? = null,
+    textColor: Color? = null,
 ) {
+    val isLight = MaterialTheme.colors.isLight
+    val bgColor = backgroundColor ?: if (isLight) Color.Black else Color.White
     Card(
         shape = RoundedCornerShape(pillCornerRadiusInDp),
-        backgroundColor = backgroundColor,
+        backgroundColor = backgroundColor ?: bgColor,
     ) {
         Row(
             modifier = Modifier
@@ -46,12 +52,14 @@ fun SubscriptionTierPill(
                 contentDescription = null,
                 modifier = modifier
                     .size(iconSizeInDp)
-                    .padding(end = 4.dp),
+                    .background(bgColor),
                 tint = iconColor,
             )
             TextH50(
                 text = stringResource(shortNameRes),
-                color = Color.White,
+                color = textColor ?: if (isLight) Color.White else Color.Black,
+                modifier = Modifier
+                    .padding(start = 4.dp),
             )
         }
     }
@@ -61,8 +69,7 @@ fun SubscriptionTierPill(
 @Composable
 private fun SubscriptionTierPillPreview() {
     SubscriptionTierPill(
-        iconRes = R.drawable.ic_patron,
-        shortNameRes = au.com.shiftyjelly.pocketcasts.localization.R.string.pocket_casts_patron_short,
-        backgroundColor = Color.Black,
+        iconRes = IR.drawable.ic_patron,
+        shortNameRes = LR.string.pocket_casts_patron_short,
     )
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeFeatureItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeFeatureItem.kt
@@ -1,0 +1,48 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.UpgradeFeatureItem
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
+
+@Composable
+fun UpgradeFeatureItem(
+    item: UpgradeFeatureItem,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Black,
+) {
+    Row(
+        modifier = modifier
+            .semantics(mergeDescendants = true) {}
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        Icon(
+            painter = painterResource(item.image),
+            contentDescription = null,
+            tint = color,
+            modifier = modifier
+                .size(20.dp)
+                .padding(2.dp),
+        )
+        Spacer(Modifier.width(16.dp))
+        TextH50(
+            text = stringResource(item.title),
+            color = color,
+        )
+    }
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
@@ -123,6 +123,7 @@ fun OnboardingUpgradeBottomSheet(
                                 OutlinedRowButton(
                                     text = text,
                                     topText = topText,
+                                    subscriptionTier = subscriptionTier,
                                     brush = subscriptionTier.toOutlinedButtonBrush(),
                                     onClick = { viewModel.updateSelectedSubscription(subscription) },
                                     interactionSource = interactionSource,
@@ -132,6 +133,7 @@ fun OnboardingUpgradeBottomSheet(
                                 UnselectedOutlinedRowButton(
                                     text = text,
                                     topText = topText,
+                                    subscriptionTier = subscriptionTier,
                                     onClick = { viewModel.updateSelectedSubscription(subscription) },
                                     interactionSource = interactionSource,
                                 )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -80,7 +80,6 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgra
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.UpgradeButton
-import au.com.shiftyjelly.pocketcasts.account.viewmodel.UpgradeFeatureCard
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
@@ -150,7 +149,7 @@ internal fun OnboardingUpgradeFeaturesPage(
                 onBackPressed = onBackPressed,
                 onNotNowPressed = onNotNowPressed,
                 onSubscriptionFrequencyChanged = { viewModel.onSubscriptionFrequencyChanged(it) },
-                onFeatureCardChanged = { viewModel.onFeatureCardChanged(loadedState.featureCards[it]) },
+                onFeatureCardChanged = { viewModel.onFeatureCardChanged(loadedState.featureCardsState.featureCards[it]) },
                 onClickSubscribe = onClickSubscribe,
                 canUpgrade = canUpgrade,
             )
@@ -306,7 +305,7 @@ fun FeatureCards(
     onFeatureCardChanged: (Int) -> Unit,
 ) {
     val pagerState =
-        rememberPagerState(initialPage = state.featureCards.indexOf(state.currentFeatureCard))
+        rememberPagerState(initialPage = state.featureCardsState.featureCards.indexOf(state.currentFeatureCard))
     LaunchedEffect(pagerState) {
         snapshotFlow { pagerState.currentPage }.collect { index ->
             onFeatureCardChanged(index)
@@ -315,7 +314,7 @@ fun FeatureCards(
 
     var pagerHeight by remember { mutableStateOf(0) }
     HorizontalPager(
-        pageCount = state.featureCards.size,
+        pageCount = state.featureCardsState.featureCards.size,
         state = pagerState,
         pageSize = PageSize.Fixed(LocalConfiguration.current.screenWidthDp.dp - 64.dp),
         contentPadding = PaddingValues(horizontal = 32.dp),
@@ -341,7 +340,7 @@ fun FeatureCards(
                 }
         ) {
             FeatureCard(
-                card = state.featureCards[index],
+                card = state.featureCardsState.featureCards[index],
                 modifier = if (pagerHeight > 0) {
                     Modifier.height(pagerHeight.pxToDp(LocalContext.current).dp)
                 } else Modifier
@@ -349,7 +348,7 @@ fun FeatureCards(
         }
     }
 
-    if (state.showPageIndicator) {
+    if (state.featureCardsState.showPageIndicator) {
         Row(
             Modifier
                 .height(40.dp)
@@ -357,7 +356,7 @@ fun FeatureCards(
                 .padding(top = 16.dp),
             horizontalArrangement = Arrangement.Center,
         ) {
-            repeat(state.featureCards.size) { iteration ->
+            repeat(state.featureCardsState.featureCards.size) { iteration ->
                 val color =
                     if (pagerState.currentPage == iteration) Color.White else Color.White.copy(alpha = 0.5f)
                 Box(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
@@ -66,7 +67,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.onboarding.components.SubscriptionTierPill
 import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradeFeatureItem
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.IconRow
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.PlusOutlinedRowButton
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.OutlinedRowButton
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.PlusRowButton
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.UpgradeRowButton
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
@@ -382,8 +383,8 @@ private fun UpgradeButton(
             UpgradeRowButton(
                 primaryText = primaryText,
                 secondaryText = secondaryText,
-                backgroundColor = button.backgroundColor,
-                textColor = button.textColor,
+                backgroundColor = colorResource(button.backgroundColorRes),
+                textColor = colorResource(button.textColorRes),
                 onClick = onClickSubscribe,
                 modifier = Modifier
                     .padding(horizontal = 20.dp, vertical = 24.dp)
@@ -466,9 +467,10 @@ private fun OldUpgradeLayout(
 
                 Spacer(Modifier.height(16.dp))
 
-                PlusOutlinedRowButton(
+                OutlinedRowButton(
                     text = stringResource(LR.string.not_now),
                     onClick = onNotNowPressed,
+                    brush = OnboardingUpgradeHelper.plusGradientBrush,
                     modifier = Modifier.padding(horizontal = 24.dp),
                 )
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -71,7 +71,6 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgra
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.UpgradeRowButton
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesViewModel
-import au.com.shiftyjelly.pocketcasts.account.viewmodel.UpgradeButton
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -85,6 +85,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
@@ -474,6 +475,7 @@ private fun OldUpgradeLayout(
                     onClick = onNotNowPressed,
                     brush = OnboardingUpgradeHelper.plusGradientBrush,
                     modifier = Modifier.padding(horizontal = 24.dp),
+                    subscriptionTier = SubscriptionTier.PLUS
                 )
 
                 Spacer(Modifier.height(16.dp))

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.onboarding.components.SubscriptionTierPill
+import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradeFeatureItem
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.IconRow
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.PlusOutlinedRowButton
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.PlusRowButton
@@ -79,7 +80,6 @@ import au.com.shiftyjelly.pocketcasts.compose.components.StyledToggle
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
@@ -339,13 +339,14 @@ private fun FeatureCard(
                 SubscriptionTierPill(
                     iconRes = card.iconRes,
                     shortNameRes = card.shortNameRes,
-                    modifier = Modifier.background(Color.Black)
+                    backgroundColor = Color.Black,
+                    textColor = Color.White,
                 )
             }
 
             Column {
                 card.featureItems.forEach {
-                    FeatureItem(it)
+                    UpgradeFeatureItem(it)
                 }
                 Spacer(modifier = Modifier.weight(1f))
                 OnboardingUpgradeHelper.PrivacyPolicy(
@@ -355,34 +356,6 @@ private fun FeatureCard(
                 )
             }
         }
-    }
-}
-
-@Composable
-private fun FeatureItem(
-    content: UpgradeFeatureItem,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier = modifier
-            .semantics(mergeDescendants = true) {}
-            .fillMaxWidth()
-            .padding(vertical = 8.dp),
-        verticalAlignment = Alignment.Top,
-    ) {
-        Icon(
-            painter = painterResource(content.image),
-            contentDescription = null,
-            tint = Color.Black,
-            modifier = modifier
-                .size(20.dp)
-                .padding(2.dp),
-        )
-        Spacer(Modifier.width(16.dp))
-        TextH50(
-            text = stringResource(content.title),
-            color = Color.Black,
-        )
     }
 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -38,6 +38,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Card
 import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -82,6 +83,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
+import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
@@ -636,7 +638,7 @@ fun NoSubscriptionsLayout(
         ) {
             NavigationIconButton(
                 onNavigationClick = onBackPressed,
-                iconColor = Color.White,
+                iconColor = MaterialTheme.theme.colors.primaryText01,
                 modifier = Modifier
                     .height(48.dp)
                     .width(48.dp)
@@ -644,7 +646,7 @@ fun NoSubscriptionsLayout(
             if (showNotNow) {
                 TextH30(
                     text = stringResource(LR.string.not_now),
-                    color = Color.White,
+                    color = MaterialTheme.theme.colors.primaryText01,
                     modifier = Modifier
                         .padding(horizontal = 24.dp)
                         .clickable { onNotNowPressed() },

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -23,6 +23,7 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgra
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesViewModel
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
@@ -174,22 +175,26 @@ private fun OutlinedButtonPreview() {
             text = "one this is way too long | | | | | | | | | | |",
             brush = OnboardingUpgradeHelper.plusGradientBrush,
             selectedCheckMark = true,
+            subscriptionTier = Subscription.SubscriptionTier.PLUS,
             onClick = {},
         )
         OutlinedRowButton(
             text = "two",
             topText = "woohoo!",
             brush = OnboardingUpgradeHelper.plusGradientBrush,
+            subscriptionTier = Subscription.SubscriptionTier.PLUS,
             selectedCheckMark = true,
             onClick = {},
         )
         UnselectedOutlinedRowButton(
             text = "three",
+            subscriptionTier = Subscription.SubscriptionTier.PLUS,
             onClick = {},
         )
         UnselectedOutlinedRowButton(
             text = "four this is also way too long | | | | | | |",
             topText = "woohoo!",
+            subscriptionTier = Subscription.SubscriptionTier.PLUS,
             onClick = {},
         )
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -90,6 +90,10 @@ fun OnboardingUpgradeFlow(
                 // Don't fire event when initially loading the screen and both current and target are "Hidden"
                 if (sheetState.currentValue == ModalBottomSheetValue.Expanded) {
                     bottomSheetViewModel.onSelectPaymentFrequencyDismissed(flow)
+                    if (flow is OnboardingFlow.PlusAccountUpgrade) {
+                        mainSheetViewModel.onDismiss(flow, source)
+                        onBackPressed()
+                    }
                 }
             }
             ModalBottomSheetValue.Expanded -> bottomSheetViewModel.onSelectPaymentFrequencyShown(flow)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -112,35 +112,37 @@ fun OnboardingUpgradeFlow(
         scrimColor = Color.Black.copy(alpha = 0.5f),
         sheetShape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
         content = {
-            OnboardingUpgradeFeaturesPage(
-                flow = flow,
-                source = source,
-                onUpgradePressed = {
-                    if (isLoggedIn) {
-                        coroutineScope.launch { sheetState.show() }
-                    } else {
-                        onNeedLogin()
-                    }
-                },
-                onNotNowPressed = onProceed,
-                onBackPressed = onBackPressed,
-                onClickSubscribe = {
-                    if (activity != null) {
+            if (source != OnboardingUpgradeSource.PROFILE) {
+                OnboardingUpgradeFeaturesPage(
+                    flow = flow,
+                    source = source,
+                    onUpgradePressed = {
                         if (isLoggedIn) {
-                            mainSheetViewModel.onClickSubscribe(
-                                activity = activity,
-                                flow = flow,
-                                onComplete = onProceed,
-                            )
+                            coroutineScope.launch { sheetState.show() }
                         } else {
                             onNeedLogin()
                         }
-                    } else {
-                        LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, NULL_ACTIVITY_ERROR)
-                    }
-                },
-                canUpgrade = hasSubscriptions,
-            )
+                    },
+                    onNotNowPressed = onProceed,
+                    onBackPressed = onBackPressed,
+                    onClickSubscribe = {
+                        if (activity != null) {
+                            if (isLoggedIn) {
+                                mainSheetViewModel.onClickSubscribe(
+                                    activity = activity,
+                                    flow = flow,
+                                    onComplete = onProceed,
+                                )
+                            } else {
+                                onNeedLogin()
+                            }
+                        } else {
+                            LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, NULL_ACTIVITY_ERROR)
+                        }
+                    },
+                    canUpgrade = hasSubscriptions,
+                )
+            }
         },
         sheetContent = {
             OnboardingUpgradeBottomSheet(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -18,8 +18,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.BuildConfig
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.PlusOutlinedRowButton
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.UnselectedPlusOutlinedRowButton
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.OutlinedRowButton
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.UnselectedOutlinedRowButton
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesViewModel
@@ -170,22 +170,24 @@ fun OnboardingUpgradeFlow(
 @Composable
 private fun OutlinedButtonPreview() {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        PlusOutlinedRowButton(
+        OutlinedRowButton(
             text = "one this is way too long | | | | | | | | | | |",
+            brush = OnboardingUpgradeHelper.plusGradientBrush,
             selectedCheckMark = true,
             onClick = {},
         )
-        PlusOutlinedRowButton(
+        OutlinedRowButton(
             text = "two",
             topText = "woohoo!",
+            brush = OnboardingUpgradeHelper.plusGradientBrush,
             selectedCheckMark = true,
             onClick = {},
         )
-        UnselectedPlusOutlinedRowButton(
+        UnselectedOutlinedRowButton(
             text = "three",
             onClick = {},
         )
-        UnselectedPlusOutlinedRowButton(
+        UnselectedOutlinedRowButton(
             text = "four this is also way too long | | | | | | |",
             topText = "woohoo!",
             onClick = {},

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -112,7 +112,7 @@ fun OnboardingUpgradeFlow(
         scrimColor = Color.Black.copy(alpha = 0.5f),
         sheetShape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
         content = {
-            if (source != OnboardingUpgradeSource.PROFILE) {
+            if (flow !is OnboardingFlow.PlusAccountUpgrade) {
                 OnboardingUpgradeFeaturesPage(
                     flow = flow,
                     source = source,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
@@ -63,13 +63,18 @@ object OnboardingUpgradeHelper {
         0f to Color(0xFFFED745),
         1f to Color(0xFFFEB525),
     )
+    val patronGradientBrush = Brush.horizontalGradient(
+        0f to Color(0xFFAFA2fA),
+        1f to Color(0xFFAFA2fA),
+    )
+
     private val unselectedColor = Color(0xFF666666)
 
     @Composable
     fun UpgradeRowButton(
         primaryText: String,
-        backgroundColor: Long,
-        textColor: Long,
+        backgroundColor: Color,
+        textColor: Color,
         onClick: () -> Unit,
         modifier: Modifier = Modifier,
         fontWeight: FontWeight = FontWeight.W600,
@@ -80,7 +85,7 @@ object OnboardingUpgradeHelper {
             shape = RoundedCornerShape(12.dp),
             modifier = modifier.fillMaxWidth(),
             colors = ButtonDefaults.buttonColors(
-                backgroundColor = Color(backgroundColor),
+                backgroundColor = backgroundColor,
             ),
         ) {
             Column(
@@ -88,7 +93,7 @@ object OnboardingUpgradeHelper {
             ) {
                 AutoResizeText(
                     text = primaryText,
-                    color = Color(textColor),
+                    color = textColor,
                     maxFontSize = 18.sp,
                     lineHeight = 21.sp,
                     fontWeight = fontWeight,
@@ -99,7 +104,7 @@ object OnboardingUpgradeHelper {
                     TextP60(
                         text = it,
                         textAlign = TextAlign.Center,
-                        color = Color(textColor),
+                        color = textColor,
                         modifier = Modifier.padding(top = 4.dp)
                     )
                 }
@@ -141,8 +146,9 @@ object OnboardingUpgradeHelper {
     }
 
     @Composable
-    fun PlusOutlinedRowButton(
+    fun OutlinedRowButton(
         text: String,
+        brush: Brush,
         onClick: () -> Unit,
         modifier: Modifier = Modifier,
         topText: String? = null,
@@ -156,7 +162,7 @@ object OnboardingUpgradeHelper {
             Button(
                 onClick = onClick,
                 shape = RoundedCornerShape(12.dp),
-                border = BorderStroke(2.dp, plusGradientBrush),
+                border = BorderStroke(2.dp, brush),
                 elevation = null,
                 interactionSource = interactionSource,
                 colors = ButtonDefaults.outlinedButtonColors(backgroundColor = Color.Transparent),
@@ -170,16 +176,16 @@ object OnboardingUpgradeHelper {
                         text = text,
                         textAlign = TextAlign.Center,
                         modifier = Modifier
+                            .brush(brush)
                             .padding(vertical = 6.dp, horizontal = 24.dp)
                             .align(Alignment.Center)
-                            .brush(plusGradientBrush)
                     )
                     if (selectedCheckMark) {
                         Icon(
                             painter = painterResource(IR.drawable.plus_check),
                             contentDescription = null,
                             modifier = Modifier
-                                .brush(plusGradientBrush)
+                                .brush(brush)
                                 .align(Alignment.CenterEnd)
                                 .width(24.dp)
                         )
@@ -198,7 +204,7 @@ object OnboardingUpgradeHelper {
     }
 
     @Composable
-    fun UnselectedPlusOutlinedRowButton(
+    fun UnselectedOutlinedRowButton(
         text: String,
         onClick: () -> Unit,
         modifier: Modifier = Modifier,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
@@ -53,7 +53,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.ClickableTextHelper
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.extensions.brush
-import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -152,6 +152,7 @@ object OnboardingUpgradeHelper {
         onClick: () -> Unit,
         modifier: Modifier = Modifier,
         topText: String? = null,
+        subscriptionTier: SubscriptionTier,
         selectedCheckMark: Boolean = false,
         interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     ) {
@@ -197,6 +198,7 @@ object OnboardingUpgradeHelper {
                 ConstrainedTopText(
                     buttonRef = buttonRef,
                     topText = it,
+                    subscriptionTier = subscriptionTier,
                     isSelected = true
                 )
             }
@@ -209,6 +211,7 @@ object OnboardingUpgradeHelper {
         onClick: () -> Unit,
         modifier: Modifier = Modifier,
         topText: String? = null,
+        subscriptionTier: SubscriptionTier,
         interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     ) {
         ConstraintLayout(modifier) {
@@ -239,7 +242,8 @@ object OnboardingUpgradeHelper {
                 ConstrainedTopText(
                     buttonRef = buttonRef,
                     topText = it,
-                    isSelected = false
+                    isSelected = false,
+                    subscriptionTier = subscriptionTier,
                 )
             }
         }
@@ -248,13 +252,24 @@ object OnboardingUpgradeHelper {
     @Composable
     fun TopText(
         topText: String,
+        subscriptionTier: SubscriptionTier,
         modifier: Modifier = Modifier,
         selected: Boolean = true,
     ) {
+        val brush = when (subscriptionTier) {
+            SubscriptionTier.PLUS -> plusGradientBrush
+            SubscriptionTier.PATRON -> patronGradientBrush
+            SubscriptionTier.UNKNOWN -> throw IllegalStateException("Unknown subscription tier")
+        }
+        val textColor = when (subscriptionTier) {
+            SubscriptionTier.PLUS -> Color.Black
+            SubscriptionTier.PATRON -> Color.White
+            SubscriptionTier.UNKNOWN -> throw IllegalStateException("Unknown subscription tier")
+        }
         Box(
             modifier = if (selected) {
                 modifier.background(
-                    brush = plusGradientBrush,
+                    brush = brush,
                     shape = RoundedCornerShape(4.dp)
                 )
             } else {
@@ -266,7 +281,7 @@ object OnboardingUpgradeHelper {
         ) {
             TextP60(
                 text = topText,
-                color = Color.Black,
+                color = textColor,
                 textAlign = TextAlign.Center,
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier.padding(
@@ -281,6 +296,7 @@ object OnboardingUpgradeHelper {
     private fun ConstraintLayoutScope.ConstrainedTopText(
         buttonRef: ConstrainedLayoutReference,
         topText: String,
+        subscriptionTier: SubscriptionTier,
         isSelected: Boolean,
     ) {
         val topTextRef = createRef()
@@ -293,6 +309,7 @@ object OnboardingUpgradeHelper {
             }
         TopText(
             topText = topText,
+            subscriptionTier = subscriptionTier,
             selected = isSelected,
             modifier = topTextModifier
         )
@@ -318,16 +335,16 @@ object OnboardingUpgradeHelper {
     @Composable
     fun UpgradeBackground(
         modifier: Modifier = Modifier,
-        tier: Subscription.SubscriptionTier,
+        tier: SubscriptionTier,
         @DrawableRes backgroundGlowsRes: Int,
         content: @Composable () -> Unit,
     ) {
         Box(modifier) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 when (tier) {
-                    Subscription.SubscriptionTier.PLUS -> PlusBlurredCanvasBackground()
-                    Subscription.SubscriptionTier.PATRON -> PatronBlurredCanvasBackground()
-                    Subscription.SubscriptionTier.UNKNOWN -> throw IllegalStateException("Unknown tier")
+                    SubscriptionTier.PLUS -> PlusBlurredCanvasBackground()
+                    SubscriptionTier.PATRON -> PatronBlurredCanvasBackground()
+                    SubscriptionTier.UNKNOWN -> throw IllegalStateException("Unknown tier")
                 }
             } else {
                 ImageBackground(backgroundGlowsRes)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
@@ -72,6 +72,7 @@ object OnboardingUpgradeHelper {
         textColor: Long,
         onClick: () -> Unit,
         modifier: Modifier = Modifier,
+        fontWeight: FontWeight = FontWeight.W600,
         secondaryText: String? = null,
     ) {
         Button(
@@ -90,7 +91,7 @@ object OnboardingUpgradeHelper {
                     color = Color(textColor),
                     maxFontSize = 18.sp,
                     lineHeight = 21.sp,
-                    fontWeight = FontWeight.W600,
+                    fontWeight = fontWeight,
                     maxLines = 1,
                     textAlign = TextAlign.Center,
                 )
@@ -142,11 +143,11 @@ object OnboardingUpgradeHelper {
     @Composable
     fun PlusOutlinedRowButton(
         text: String,
-        topText: String? = null,
         onClick: () -> Unit,
+        modifier: Modifier = Modifier,
+        topText: String? = null,
         selectedCheckMark: Boolean = false,
         interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-        modifier: Modifier = Modifier,
     ) {
 
         ConstraintLayout(modifier) {
@@ -199,10 +200,10 @@ object OnboardingUpgradeHelper {
     @Composable
     fun UnselectedPlusOutlinedRowButton(
         text: String,
-        topText: String? = null,
         onClick: () -> Unit,
-        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
         modifier: Modifier = Modifier,
+        topText: String? = null,
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     ) {
         ConstraintLayout(modifier) {
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -1,6 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,26 +12,33 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import au.com.shiftyjelly.pocketcasts.account.onboarding.components.SubscriptionTierPill
+import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradeFeatureItem
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.IconRow
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.ProfileUpgradeBannerViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.ProfileUpgradeBannerViewModel.State
+import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalPagerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH60
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun ProfileUpgradeBanner(
-    onClick: () -> Unit
+    onClick: () -> Unit,
 ) {
     val state by hiltViewModel<ProfileUpgradeBannerViewModel>()
         .state
@@ -39,6 +48,8 @@ fun ProfileUpgradeBanner(
             ProfileUpgradeBannerView(
                 state = state as State.Loaded,
                 onClick = onClick,
+                onFeatureCardChanged = {
+                }
             )
 
         is State.OldLoaded ->
@@ -51,17 +62,67 @@ fun ProfileUpgradeBanner(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ProfileUpgradeBannerView(
     state: State.Loaded,
+    onFeatureCardChanged: (Int) -> Unit,
     onClick: () -> Unit
 ) {
+    val featureCardsState = state.featureCardsState
+    HorizontalPagerWrapper(
+        pageCount = featureCardsState.featureCards.size,
+        initialPage = featureCardsState.featureCards.indexOf(featureCardsState.currentFeatureCard),
+        onPageChanged = onFeatureCardChanged,
+        showPageIndicator = featureCardsState.showPageIndicator,
+        pageIndicatorColor = MaterialTheme.theme.colors.primaryText01,
+    ) { index, pagerHeight ->
+        FeatureCard(
+            card = featureCardsState.featureCards[index],
+            onClick = onClick,
+            modifier = if (pagerHeight > 0) {
+                Modifier.height(pagerHeight.pxToDp(LocalContext.current).dp)
+            } else Modifier
+        )
+    }
+}
+
+@Composable
+private fun FeatureCard(
+    card: UpgradeFeatureCard,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.padding(horizontal = 16.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 12.dp),
+            contentAlignment = Alignment.TopStart
+        ) {
+            SubscriptionTierPill(
+                iconRes = card.iconRes,
+                shortNameRes = card.shortNameRes,
+            )
+        }
+
+        Column {
+            card.featureItems.forEach {
+                UpgradeFeatureItem(
+                    item = it,
+                    color = MaterialTheme.theme.colors.primaryText01,
+                )
+            }
+        }
+    }
 }
 
 @Composable
 fun ProfileOldUpgradeBannerView(
     state: State.OldLoaded,
-    onClick: () -> Unit
+    onClick: () -> Unit,
 ) {
     OnboardingUpgradeHelper.OldPlusBackground {
         Column(Modifier.padding(horizontal = 16.dp)) {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.IconRow
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.ProfileUpgradeBannerViewModel
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.ProfileUpgradeBannerViewModel.State
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH60
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -33,7 +34,35 @@ fun ProfileUpgradeBanner(
     val state by hiltViewModel<ProfileUpgradeBannerViewModel>()
         .state
         .collectAsState()
+    when (state) {
+        is State.Loaded ->
+            ProfileUpgradeBannerView(
+                state = state as State.Loaded,
+                onClick = onClick,
+            )
 
+        is State.OldLoaded ->
+            ProfileOldUpgradeBannerView(
+                state = state as State.OldLoaded,
+                onClick = onClick,
+            )
+
+        is State.Empty -> Unit // Do nothing
+    }
+}
+
+@Composable
+fun ProfileUpgradeBannerView(
+    state: State.Loaded,
+    onClick: () -> Unit
+) {
+}
+
+@Composable
+fun ProfileOldUpgradeBannerView(
+    state: State.OldLoaded,
+    onClick: () -> Unit
+) {
     OnboardingUpgradeHelper.OldPlusBackground {
         Column(Modifier.padding(horizontal = 16.dp)) {
             Spacer(Modifier.height(24.dp))

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -42,17 +42,20 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 fun ProfileUpgradeBanner(
     onClick: () -> Unit,
 ) {
-    val state by hiltViewModel<ProfileUpgradeBannerViewModel>()
-        .state
-        .collectAsState()
+    val viewModel = hiltViewModel<ProfileUpgradeBannerViewModel>()
+    val state by viewModel.state.collectAsState()
+
     when (state) {
-        is State.Loaded ->
+        is State.Loaded -> {
+            val loadedState = state as State.Loaded
             ProfileUpgradeBannerView(
-                state = state as State.Loaded,
+                state = loadedState,
                 onClick = onClick,
                 onFeatureCardChanged = {
+                    viewModel.onFeatureCardChanged(loadedState.featureCardsState.featureCards[it])
                 }
             )
+        }
 
         is State.OldLoaded ->
             ProfileOldUpgradeBannerView(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -41,6 +41,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalPagerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH60
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import java.util.Locale
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -70,7 +71,7 @@ fun ProfileUpgradeBanner(
                 onClick = onClick,
             )
 
-        is State.Empty -> Unit // Do nothing
+        is State.Loading -> Unit // Do nothing
     }
 }
 
@@ -193,7 +194,10 @@ fun ProfileOldUpgradeBannerView(
 
             state.numPeriodFree?.let { numPeriodFree ->
                 Spacer(Modifier.height(16.dp))
-                OnboardingUpgradeHelper.TopText(topText = numPeriodFree)
+                OnboardingUpgradeHelper.TopText(
+                    topText = numPeriodFree,
+                    subscriptionTier = SubscriptionTier.PLUS,
+                )
             }
 
             Spacer(Modifier.height(20.dp))

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -22,6 +23,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -72,13 +74,15 @@ fun ProfileUpgradeBannerView(
     val featureCardsState = state.featureCardsState
     HorizontalPagerWrapper(
         pageCount = featureCardsState.featureCards.size,
-        initialPage = featureCardsState.featureCards.indexOf(featureCardsState.currentFeatureCard),
+        initialPage = featureCardsState.featureCards.indexOf(state.featureCardsState.currentFeatureCard),
         onPageChanged = onFeatureCardChanged,
         showPageIndicator = featureCardsState.showPageIndicator,
         pageIndicatorColor = MaterialTheme.theme.colors.primaryText01,
     ) { index, pagerHeight ->
+        val currentTier = featureCardsState.featureCards[index].subscriptionTier
         FeatureCard(
             card = featureCardsState.featureCards[index],
+            button = requireNotNull(state.upgradeButtons.find { it.subscription.tier == currentTier }),
             onClick = onClick,
             modifier = if (pagerHeight > 0) {
                 Modifier.height(pagerHeight.pxToDp(LocalContext.current).dp)
@@ -90,6 +94,7 @@ fun ProfileUpgradeBannerView(
 @Composable
 private fun FeatureCard(
     card: UpgradeFeatureCard,
+    button: UpgradeButton,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -115,6 +120,21 @@ private fun FeatureCard(
                     color = MaterialTheme.theme.colors.primaryText01,
                 )
             }
+
+            Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.height(8.dp))
+
+            val primaryText = stringResource(LR.string.upgrade_to, stringResource(button.shortNameRes))
+            OnboardingUpgradeHelper.UpgradeRowButton(
+                primaryText = primaryText,
+                backgroundColor = button.backgroundColor,
+                fontWeight = FontWeight.W500,
+                textColor = button.textColor,
+                onClick = onClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 48.dp),
+            )
         }
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -244,12 +243,4 @@ private fun FeatureItemComposable(
             color = Color.White,
         )
     }
-}
-
-@Preview
-@Composable
-private fun ProfileUpgradeBannerPreview() {
-    ProfileUpgradeBanner(
-        onClick = { }
-    )
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -130,9 +131,9 @@ private fun FeatureCard(
             val primaryText = stringResource(LR.string.upgrade_to, stringResource(button.shortNameRes))
             OnboardingUpgradeHelper.UpgradeRowButton(
                 primaryText = primaryText,
-                backgroundColor = button.backgroundColor,
+                backgroundColor = colorResource(button.backgroundColorRes),
                 fontWeight = FontWeight.W500,
-                textColor = button.textColor,
+                textColor = colorResource(button.textColorRes),
                 onClick = onClick,
                 modifier = Modifier
                     .fillMaxWidth()

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -24,9 +25,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.onboarding.components.SubscriptionTierPill
 import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradeFeatureItem
@@ -36,7 +41,9 @@ import au.com.shiftyjelly.pocketcasts.account.viewmodel.ProfileUpgradeBannerView
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalPagerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH60
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
+import java.util.Locale
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -105,16 +112,19 @@ private fun FeatureCard(
     Column(
         modifier = modifier.padding(horizontal = 16.dp)
     ) {
-        Box(
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 12.dp),
-            contentAlignment = Alignment.TopStart
         ) {
             SubscriptionTierPill(
                 iconRes = card.iconRes,
                 shortNameRes = card.shortNameRes,
+                modifier = Modifier.background(Color.Black)
             )
+
+            AmountView(button.subscription)
         }
 
         Column {
@@ -124,23 +134,46 @@ private fun FeatureCard(
                     color = MaterialTheme.theme.colors.primaryText01,
                 )
             }
-
-            Spacer(modifier = Modifier.weight(1f))
-            Spacer(modifier = Modifier.height(8.dp))
-
-            val primaryText = stringResource(LR.string.upgrade_to, stringResource(button.shortNameRes))
-            OnboardingUpgradeHelper.UpgradeRowButton(
-                primaryText = primaryText,
-                backgroundColor = colorResource(button.backgroundColorRes),
-                fontWeight = FontWeight.W500,
-                textColor = colorResource(button.textColorRes),
-                onClick = onClick,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(min = 48.dp),
-            )
         }
+
+        Spacer(modifier = Modifier.weight(1f))
+        Spacer(modifier = Modifier.height(8.dp))
+
+        val primaryText = stringResource(LR.string.upgrade_to, stringResource(button.shortNameRes))
+        OnboardingUpgradeHelper.UpgradeRowButton(
+            primaryText = primaryText,
+            backgroundColor = colorResource(button.backgroundColorRes),
+            fontWeight = FontWeight.W500,
+            textColor = colorResource(button.textColorRes),
+            onClick = onClick,
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 48.dp),
+        )
     }
+}
+
+@Composable
+private fun AmountView(
+    subscription: Subscription,
+) {
+    Text(
+        fontSize = 22.sp,
+        lineHeight = 30.sp,
+        color = MaterialTheme.theme.colors.primaryText01,
+        text = buildAnnotatedString {
+            withStyle(style = SpanStyle(fontWeight = FontWeight.W700)) {
+                append("${subscription.recurringPricingPhase.formattedPrice} ")
+            }
+
+            withStyle(style = SpanStyle(fontWeight = FontWeight.W400)) {
+                append(
+                    stringResource(subscription.recurringPricingPhase.perPeriod)
+                        .lowercase(Locale.getDefault())
+                )
+            }
+        }
+    )
 }
 
 @Composable

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeButton.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeButton.kt
@@ -1,0 +1,36 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
+
+import androidx.annotation.StringRes
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+sealed class UpgradeButton(
+    @StringRes val shortNameRes: Int,
+    val backgroundColor: Long,
+    val textColor: Long,
+    open val subscription: Subscription,
+) {
+    data class Plus(
+        override val subscription: Subscription,
+    ) : UpgradeButton(
+        shortNameRes = LR.string.pocket_casts_plus_short,
+        backgroundColor = 0xFFFFD846,
+        textColor = 0xFF000000,
+        subscription = subscription,
+    )
+
+    data class Patron(
+        override val subscription: Subscription,
+    ) : UpgradeButton(
+        shortNameRes = LR.string.pocket_casts_patron_short,
+        backgroundColor = 0xFF6046F5,
+        textColor = 0xFFFFFFFF,
+        subscription = subscription,
+    )
+}
+
+fun Subscription.toUpgradeButton() = when (this.tier) {
+    Subscription.SubscriptionTier.PLUS -> UpgradeButton.Plus(this)
+    Subscription.SubscriptionTier.PATRON -> UpgradeButton.Patron(this)
+    Subscription.SubscriptionTier.UNKNOWN -> throw IllegalStateException("Unknown subscription tier")
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeButton.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeButton.kt
@@ -1,21 +1,23 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
+import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 sealed class UpgradeButton(
     @StringRes val shortNameRes: Int,
-    val backgroundColor: Long,
-    val textColor: Long,
+    @ColorRes val backgroundColorRes: Int,
+    @ColorRes val textColorRes: Int,
     open val subscription: Subscription,
 ) {
     data class Plus(
         override val subscription: Subscription,
     ) : UpgradeButton(
         shortNameRes = LR.string.pocket_casts_plus_short,
-        backgroundColor = 0xFFFFD846,
-        textColor = 0xFF000000,
+        backgroundColorRes = UR.color.plus_gold,
+        textColorRes = UR.color.black,
         subscription = subscription,
     )
 
@@ -23,8 +25,8 @@ sealed class UpgradeButton(
         override val subscription: Subscription,
     ) : UpgradeButton(
         shortNameRes = LR.string.pocket_casts_patron_short,
-        backgroundColor = 0xFF6046F5,
-        textColor = 0xFFFFFFFF,
+        backgroundColorRes = UR.color.patron_purple,
+        textColorRes = UR.color.white,
         subscription = subscription,
     )
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
@@ -1,0 +1,52 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import au.com.shiftyjelly.pocketcasts.account.R
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+enum class UpgradeFeatureCard(
+    @StringRes val titleRes: Int,
+    @StringRes val shortNameRes: Int,
+    @DrawableRes val backgroundGlowsRes: Int,
+    @DrawableRes val iconRes: Int,
+    val featureItems: List<UpgradeFeatureItem>,
+    val subscriptionTier: SubscriptionTier,
+) {
+    PLUS(
+        titleRes = LR.string.onboarding_plus_features_title,
+        shortNameRes = LR.string.pocket_casts_plus_short,
+        backgroundGlowsRes = R.drawable.upgrade_background_plus_glows,
+        iconRes = IR.drawable.ic_plus,
+        featureItems = PlusUpgradeFeatureItem.values().toList(),
+        subscriptionTier = SubscriptionTier.PLUS,
+    ),
+    PATRON(
+        titleRes = LR.string.onboarding_patron_features_title,
+        shortNameRes = LR.string.pocket_casts_patron_short,
+        backgroundGlowsRes = R.drawable.upgrade_background_patron_glows,
+        iconRes = IR.drawable.ic_patron,
+        featureItems = PatronUpgradeFeatureItem.values().toList(),
+        subscriptionTier = SubscriptionTier.PATRON,
+    )
+}
+
+data class FeatureCardsState(
+    val subscriptions: List<Subscription>,
+    val currentFeatureCard: UpgradeFeatureCard,
+) {
+    val featureCards = SubscriptionTier.values().toList()
+        .filter { tier -> tier != SubscriptionTier.UNKNOWN && tier in subscriptions.map { it.tier } }
+        .map { it.toUpgradeFeatureCard() }
+
+    val showPageIndicator = featureCards.size > 1
+}
+
+fun SubscriptionTier.toUpgradeFeatureCard() = when (this) {
+    SubscriptionTier.PLUS -> UpgradeFeatureCard.PLUS
+    SubscriptionTier.PATRON -> UpgradeFeatureCard.PATRON
+    SubscriptionTier.UNKNOWN -> throw IllegalStateException("Unknown subscription tier")
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
@@ -142,6 +142,7 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
         val lastSelectedTier = settings.getLastSelectedSubscriptionTier().takeIf { source in listOf(OnboardingUpgradeSource.LOGIN, OnboardingUpgradeSource.PROFILE) }
         val lastSelectedFrequency = settings.getLastSelectedSubscriptionFrequency().takeIf { source in listOf(OnboardingUpgradeSource.LOGIN, OnboardingUpgradeSource.PROFILE) }
 
+        val fromProfile = source == OnboardingUpgradeSource.PROFILE
         val defaultSelected = subscriptionManager.getDefaultSubscription(
             subscriptions = subscriptions,
             tier = lastSelectedTier,
@@ -151,7 +152,7 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
             NoSubscriptions
         } else {
             Loaded(
-                subscriptions = subscriptions,
+                subscriptions = if (fromProfile) subscriptions.filter { it.tier == defaultSelected.tier } else subscriptions,
                 selectedSubscription = defaultSelected,
                 purchaseFailed = false,
             )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.toUpgradeButton
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetState.Loaded
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetState.Loading
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetState.NoSubscriptions
@@ -191,7 +192,7 @@ sealed class OnboardingUpgradeBottomSheetState {
         val purchaseFailed: Boolean = false
     ) : OnboardingUpgradeBottomSheetState() {
         val showTrialInfo = selectedSubscription.trialPricingPhase != null
-
+        val upgradeButton = selectedSubscription.toUpgradeButton()
         init {
             if (subscriptions.isEmpty()) {
                 LogBuffer.e(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -86,8 +86,8 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
     private fun updateState(
         subscriptions: List<Subscription>,
     ) {
-        val lastSelectedTier = settings.getLastSelectedSubscriptionTier().takeIf { source == OnboardingUpgradeSource.LOGIN }
-        val lastSelectedFrequency = settings.getLastSelectedSubscriptionFrequency().takeIf { source == OnboardingUpgradeSource.LOGIN }
+        val lastSelectedTier = settings.getLastSelectedSubscriptionTier().takeIf { source in listOf(OnboardingUpgradeSource.LOGIN, OnboardingUpgradeSource.PROFILE) }
+        val lastSelectedFrequency = settings.getLastSelectedSubscriptionFrequency().takeIf { source in listOf(OnboardingUpgradeSource.LOGIN, OnboardingUpgradeSource.PROFILE) }
 
         val selectedSubscription = subscriptionManager.getDefaultSubscription(
             subscriptions = subscriptions,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -4,15 +4,13 @@ import android.app.Activity
 import android.app.Application
 import android.content.Context
 import android.view.accessibility.AccessibilityManager
-import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import au.com.shiftyjelly.pocketcasts.account.R
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.PatronUpgradeFeatureItem
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.PlusUpgradeFeatureItem
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.UpgradeFeatureItem
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.FeatureCardsState
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.UpgradeFeatureCard
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.toUpgradeFeatureCard
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.type.RecurringSubscriptionPricingPhase
@@ -38,7 +36,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
 import timber.log.Timber
 import javax.inject.Inject
-import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
@@ -106,7 +103,10 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
             val currentFeatureCard = currentTier.toUpgradeFeatureCard()
             _state.update {
                 OnboardingUpgradeFeaturesState.Loaded(
-                    subscriptions = subscriptions,
+                    featureCardsState = FeatureCardsState(
+                        subscriptions = subscriptions,
+                        currentFeatureCard = currentFeatureCard,
+                    ),
                     currentSubscription = selectedSubscription,
                     currentFeatureCard = currentFeatureCard,
                     currentSubscriptionFrequency = currentSubscriptionFrequency,
@@ -138,7 +138,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
         (_state.value as? OnboardingUpgradeFeaturesState.Loaded)?.let { loadedState ->
             val currentSubscription = subscriptionManager
                 .getDefaultSubscription(
-                    subscriptions = loadedState.subscriptions,
+                    subscriptions = loadedState.featureCardsState.subscriptions,
                     tier = loadedState.currentFeatureCard.subscriptionTier,
                     frequency = frequency
                 )
@@ -158,7 +158,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
         (_state.value as? OnboardingUpgradeFeaturesState.Loaded)?.let { loadedState ->
             val currentSubscription = subscriptionManager
                 .getDefaultSubscription(
-                    subscriptions = loadedState.subscriptions,
+                    subscriptions = loadedState.featureCardsState.subscriptions,
                     tier = upgradeFeatureCard.subscriptionTier,
                     frequency = loadedState.currentSubscriptionFrequency
                 )
@@ -183,7 +183,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
             _state.update { loadedState.copy(purchaseFailed = false) }
             val currentSubscription = subscriptionManager
                 .getDefaultSubscription(
-                    subscriptions = loadedState.subscriptions,
+                    subscriptions = loadedState.featureCardsState.subscriptions,
                     tier = loadedState.currentFeatureCard.subscriptionTier,
                     frequency = loadedState.currentSubscriptionFrequency
                 )
@@ -254,29 +254,18 @@ sealed class OnboardingUpgradeFeaturesState {
     }
 
     data class Loaded(
-        val subscriptions: List<Subscription>,
         val currentFeatureCard: UpgradeFeatureCard,
+        val featureCardsState: FeatureCardsState,
         val currentSubscriptionFrequency: SubscriptionFrequency,
         val currentSubscription: Subscription,
         val purchaseFailed: Boolean = false,
         val showNotNow: Boolean,
     ) : OnboardingUpgradeFeaturesState() {
-
-        val featureCards = SubscriptionTier.values().toList()
-            .filter { tier -> tier != SubscriptionTier.UNKNOWN && tier in subscriptions.map { it.tier } }
-            .map { it.toUpgradeFeatureCard() }
         val subscriptionFrequencies =
             listOf(SubscriptionFrequency.YEARLY, SubscriptionFrequency.MONTHLY)
         val currentUpgradeButton: UpgradeButton
             get() = currentSubscription.toUpgradeButton()
-        val showPageIndicator = featureCards.size > 1
     }
-}
-
-private fun SubscriptionTier.toUpgradeFeatureCard() = when (this) {
-    SubscriptionTier.PLUS -> UpgradeFeatureCard.PLUS
-    SubscriptionTier.PATRON -> UpgradeFeatureCard.PATRON
-    SubscriptionTier.UNKNOWN -> throw IllegalStateException("Unknown subscription tier")
 }
 
 private fun Subscription.toUpgradeButton() = when (this.tier) {
@@ -288,32 +277,6 @@ private fun Subscription.toUpgradeButton() = when (this.tier) {
 private fun RecurringSubscriptionPricingPhase.toSubscriptionFrequency() = when (this) {
     is SubscriptionPricingPhase.Months -> SubscriptionFrequency.MONTHLY
     is SubscriptionPricingPhase.Years -> SubscriptionFrequency.YEARLY
-}
-
-enum class UpgradeFeatureCard(
-    @StringRes val titleRes: Int,
-    @StringRes val shortNameRes: Int,
-    @DrawableRes val backgroundGlowsRes: Int,
-    @DrawableRes val iconRes: Int,
-    val featureItems: List<UpgradeFeatureItem>,
-    val subscriptionTier: SubscriptionTier,
-) {
-    PLUS(
-        titleRes = LR.string.onboarding_plus_features_title,
-        shortNameRes = LR.string.pocket_casts_plus_short,
-        backgroundGlowsRes = R.drawable.upgrade_background_plus_glows,
-        iconRes = IR.drawable.ic_plus,
-        featureItems = PlusUpgradeFeatureItem.values().toList(),
-        subscriptionTier = SubscriptionTier.PLUS,
-    ),
-    PATRON(
-        titleRes = LR.string.onboarding_patron_features_title,
-        shortNameRes = LR.string.pocket_casts_patron_short,
-        backgroundGlowsRes = R.drawable.upgrade_background_patron_glows,
-        iconRes = IR.drawable.ic_patron,
-        featureItems = PatronUpgradeFeatureItem.values().toList(),
-        subscriptionTier = SubscriptionTier.PATRON,
-    )
 }
 
 sealed class UpgradeButton(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -4,18 +4,18 @@ import android.app.Activity
 import android.app.Application
 import android.content.Context
 import android.view.accessibility.AccessibilityManager
-import androidx.annotation.StringRes
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.FeatureCardsState
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.UpgradeButton
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.UpgradeFeatureCard
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.toUpgradeButton
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.toUpgradeFeatureCard
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.type.RecurringSubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
-import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPricingPhase
@@ -36,7 +36,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
 import timber.log.Timber
 import javax.inject.Inject
-import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
 class OnboardingUpgradeFeaturesViewModel @Inject constructor(
@@ -268,38 +267,7 @@ sealed class OnboardingUpgradeFeaturesState {
     }
 }
 
-private fun Subscription.toUpgradeButton() = when (this.tier) {
-    SubscriptionTier.PLUS -> UpgradeButton.Plus(this)
-    SubscriptionTier.PATRON -> UpgradeButton.Patron(this)
-    SubscriptionTier.UNKNOWN -> throw IllegalStateException("Unknown subscription tier")
-}
-
 private fun RecurringSubscriptionPricingPhase.toSubscriptionFrequency() = when (this) {
     is SubscriptionPricingPhase.Months -> SubscriptionFrequency.MONTHLY
     is SubscriptionPricingPhase.Years -> SubscriptionFrequency.YEARLY
-}
-
-sealed class UpgradeButton(
-    @StringRes val shortNameRes: Int,
-    val backgroundColor: Long,
-    val textColor: Long,
-    open val subscription: Subscription,
-) {
-    data class Plus(
-        override val subscription: Subscription,
-    ) : UpgradeButton(
-        shortNameRes = LR.string.pocket_casts_plus_short,
-        backgroundColor = 0xFFFFD846,
-        textColor = 0xFF000000,
-        subscription = subscription,
-    )
-
-    data class Patron(
-        override val subscription: Subscription,
-    ) : UpgradeButton(
-        shortNameRes = LR.string.pocket_casts_patron_short,
-        backgroundColor = 0xFF6046F5,
-        textColor = 0xFFFFFFFF,
-        subscription = subscription,
-    )
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
@@ -3,7 +3,11 @@ package au.com.shiftyjelly.pocketcasts.account.viewmodel
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.account.BuildConfig
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.FeatureCardsState
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.toUpgradeFeatureCard
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -20,13 +24,22 @@ class ProfileUpgradeBannerViewModel @Inject constructor(
     app: Application,
 ) : AndroidViewModel(app) {
 
-    data class State(val numPeriodFree: String?) {
-        companion object {
-            val EMPTY = State(null)
-        }
+    sealed class State(
+        open val numPeriodFree: String?
+    ) {
+        data class Loaded(
+            override val numPeriodFree: String?,
+            val featureCardsState: FeatureCardsState,
+        ) : State(numPeriodFree)
+
+        data class OldLoaded(
+            override val numPeriodFree: String?
+        ) : State(numPeriodFree)
+
+        object Empty : State(null)
     }
 
-    private val _state = MutableStateFlow(State.EMPTY)
+    private val _state: MutableStateFlow<State> = MutableStateFlow(State.Empty)
     val state = _state as StateFlow<State>
 
     init {
@@ -46,10 +59,25 @@ class ProfileUpgradeBannerViewModel @Inject constructor(
                                 )
                             } ?: emptyList()
                         val defaultSubscription = subscriptionManager.getDefaultSubscription(subscriptions)
-                        if (defaultSubscription is Subscription.WithTrial) {
-                            val numPeriodFree = defaultSubscription.trialPricingPhase.numPeriodFreeTrial(getApplication<Application>().resources)
-                            _state.value = state.value.copy(
-                                numPeriodFree = numPeriodFree.uppercase(Locale.getDefault())
+                        val numPeriodFree = if (defaultSubscription is Subscription.WithTrial) {
+                            defaultSubscription.trialPricingPhase.numPeriodFreeTrial(getApplication<Application>().resources)
+                        } else {
+                            null
+                        }
+                        if (BuildConfig.ADD_PATRON_ENABLED) {
+                            defaultSubscription?.let {
+                                val currentTier = SubscriptionMapper.mapProductIdToTier(defaultSubscription.productDetails.productId)
+                                _state.value = State.Loaded(
+                                    numPeriodFree = numPeriodFree?.uppercase(Locale.getDefault()),
+                                    featureCardsState = FeatureCardsState(
+                                        subscriptions = subscriptions,
+                                        currentFeatureCard = currentTier.toUpgradeFeatureCard()
+                                    )
+                                )
+                            }
+                        } else {
+                            _state.value = State.OldLoaded(
+                                numPeriodFree = numPeriodFree?.uppercase(Locale.getDefault())
                             )
                         }
                     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
@@ -88,7 +88,7 @@ class ProfileUpgradeBannerViewModel @Inject constructor(
                                         subscriptions = subscriptions,
                                         currentFeatureCard = currentTier.toUpgradeFeatureCard()
                                     ),
-                                    upgradeButtons = upgradeButtons,
+                                    upgradeButtons = upgradeButtons
                                 )
                             }
                         } else {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
@@ -6,11 +6,13 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.account.BuildConfig
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.FeatureCardsState
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.UpgradeButton
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.UpgradeFeatureCard
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.toUpgradeButton
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.toUpgradeFeatureCard
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -23,7 +25,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class ProfileUpgradeBannerViewModel @Inject constructor(
-    subscriptionManager: SubscriptionManager,
+    private val subscriptionManager: SubscriptionManager,
+    private val settings: Settings,
     app: Application,
 ) : AndroidViewModel(app) {
 
@@ -95,6 +98,13 @@ class ProfileUpgradeBannerViewModel @Inject constructor(
                         }
                     }
             }
+        }
+    }
+
+    fun onFeatureCardChanged(upgradeFeatureCard: UpgradeFeatureCard) {
+        (_state.value as? State.Loaded)?.let {
+            settings.setLastSelectedSubscriptionFrequency(SubscriptionFrequency.YEARLY)
+            settings.setLastSelectedSubscriptionTier(upgradeFeatureCard.subscriptionTier)
         }
     }
 }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -122,6 +122,7 @@ class AccountDetailsFragment : BaseFragment() {
                 setContent {
                     AppTheme(theme.activeTheme) {
                         if (subscription != null && (signInState.isSignedInAsFree || giftExpiring)) {
+                            binding.dividerView15?.isVisible = BuildConfig.ADD_PATRON_ENABLED
                             ProfileUpgradeBanner(
                                 onClick = {
                                     val source = OnboardingUpgradeSource.PROFILE

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/UserView.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/UserView.kt
@@ -157,6 +157,7 @@ open class UserView @JvmOverloads constructor(
                         shortNameRes = LR.string.pocket_casts_patron_short,
                         iconColor = Color.White,
                         backgroundColor = colorResource(UR.color.patron_purple),
+                        textColor = colorResource(UR.color.patron_purple_light),
                     )
                 }
             }

--- a/modules/features/profile/src/main/res/layout/fragment_account_details.xml
+++ b/modules/features/profile/src/main/res/layout/fragment_account_details.xml
@@ -533,6 +533,18 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
+            <View
+                android:id="@+id/dividerView15"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/divider_height"
+                android:background="?attr/primary_ui_05"
+                android:layout_marginBottom="20dp"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintBottom_toBottomOf="@+id/userView" />
+
             <androidx.compose.ui.platform.ComposeView
                 android:id="@+id/userUpgradeComposeView"
                 android:layout_width="match_parent"

--- a/modules/features/profile/src/main/res/values/color.xml
+++ b/modules/features/profile/src/main/res/values/color.xml
@@ -3,4 +3,5 @@
     <color name="plus_gold_dark">#feb525</color>
     <color name="plus_gold_light">#fed745</color>
     <color name="patron_purple">#6046f5</color>
+    <color name="patron_purple_light">#e4e0fd</color>
 </resources>

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
@@ -1,0 +1,124 @@
+package au.com.shiftyjelly.pocketcasts.compose.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PageSize
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+
+/* This wrapper class allows the pager to adjust its height based on the tallest page. */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun HorizontalPagerWrapper(
+    pageCount: Int,
+    initialPage: Int,
+    onPageChanged: (Int) -> Unit,
+    showPageIndicator: Boolean = true,
+    pageIndicatorColor: Color = Color.White,
+    pageSize: PageSize = PageSize.Fixed(LocalConfiguration.current.screenWidthDp.dp - 1.dp), // With full page width, height is not adjusted properly
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    content: @Composable (Int, Int) -> Unit = { _, _ -> },
+) {
+    val pagerState = rememberPagerState(initialPage = initialPage)
+
+    LaunchedEffect(pagerState) {
+        snapshotFlow { pagerState.currentPage }.collect { index ->
+            onPageChanged(index)
+        }
+    }
+
+    var pagerHeight by remember { mutableStateOf(0) }
+    Column {
+        HorizontalPager(
+            pageCount = pageCount,
+            state = pagerState,
+            pageSize = pageSize,
+            contentPadding = contentPadding,
+        ) { index ->
+            var pageHeight by remember { mutableStateOf(0) }
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .layout { measurable, constraints ->
+                        /* https://github.com/google/accompanist/issues/1050#issuecomment-1097483476 */
+                        val placeable = measurable.measure(constraints)
+                        pageHeight = placeable.height
+                        /* Restrict page height to the pager height */
+                        layout(constraints.maxWidth, pagerHeight) {
+                            placeable.placeRelative(0, 0)
+                        }
+                    }
+                    .onGloballyPositioned {
+                        /* Update pager height to the tallest page */
+                        if (pageHeight > pagerHeight) {
+                            pagerHeight = pageHeight
+                        }
+                    }
+            ) {
+                content(index, pagerHeight)
+            }
+        }
+
+        if (showPageIndicator) {
+            PageIndicator(
+                pageCount = pageCount,
+                pagerState = pagerState,
+                color = pageIndicatorColor,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun PageIndicator(
+    pageCount: Int,
+    pagerState: PagerState,
+    modifier: Modifier = Modifier,
+    color: Color = Color.White,
+) {
+    Row(
+        Modifier
+            .height(40.dp)
+            .fillMaxWidth()
+            .padding(top = 16.dp),
+        horizontalArrangement = Arrangement.Center,
+    ) {
+        repeat(pageCount) { iteration ->
+            val circleColor =
+                if (pagerState.currentPage == iteration) color else color.copy(alpha = 0.5f)
+            Box(
+                modifier = modifier
+                    .padding(4.dp)
+                    .clip(CircleShape)
+                    .background(circleColor)
+                    .size(8.dp)
+            )
+        }
+    }
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -82,6 +82,7 @@
     <string name="stream">Stream</string>
     <string name="subscribe">Subscribe</string>
     <string name="subscribe_to">Subscribe to %s</string>
+    <string name="upgrade_to">Upgrade to %s</string>
     <string name="unarchive_all">Unarchive all</string>
     <string name="unplayed">Unplayed</string>
     <string name="unsubscribe">Unsubscribe</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1561,6 +1561,7 @@
     <string name="onboarding_patron_feature_profile_badge_title">Supporters profile badge</string>
     <string name="onboarding_patron_feature_special_icons_title">Special Pocket Casts app icons</string>
     <string name="onboarding_patron_feature_gratitude_title" translatable="false">@string/onboarding_plus_feature_gratitude_title</string>
+    <string name="onboarding_patron_subscribe">Subscribe to Pocket&#160;Casts Patron</string>
     <string name="onboarding_plus_features_title" translatable="false">@string/onboarding_upgrade_everything_you_love_about_pocket_casts_plus</string>
     <string name="onboarding_plus_feature_desktop_apps_title">Desktop Apps</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Listen in more places with our Windows, macOS, and Web apps.</string>
@@ -1576,6 +1577,7 @@
     <string name="onboarding_plus_privacy_policy">Privacy Policy</string>
     <string name="onboarding_plus_terms_and_conditions">Terms and Conditions</string>
     <string name="onboarding_plus_start_free_trial_and_subscribe">Start free trial &amp; subscribe</string>
+    <string name="onboarding_plus_subscribe">Subscribe to Pocket&#160;Casts Plus</string>
     <string name="onboarding_plus_recurring_after_free_trial">Recurring payments will begin after your %s</string>
     <string name="onboarding_plus_can_be_canceled_at_any_time">Can be canceled at any time.</string>
     <string name="onboarding_welcome_get_you_listening">Welcome, now let\'s get you listening!</string>

--- a/modules/services/ui/src/main/res/values/colors.xml
+++ b/modules/services/ui/src/main/res/values/colors.xml
@@ -22,9 +22,11 @@
     <color name="podcast_header_background">#1E1F1E</color>
 
     <!-- Plan colors -->
+    <color name="plus_gold">#ffD846</color>
     <color name="plus_gold_dark">#feb525</color>
     <color name="plus_gold_light">#fed745</color>
     <color name="patron_purple">#6046f5</color>
+    <color name="patron_purple_light">#afa2fa</color>
 
     <!-- Material components -->
     <color name="mtrl_textinput_default_box_stroke_color" tools:override="true">#884f4f4f</color>

--- a/modules/services/ui/src/main/res/values/themes.xml
+++ b/modules/services/ui/src/main/res/values/themes.xml
@@ -1868,4 +1868,16 @@
         <item name="android:textColor">#b3ffffff</item>
     </style>
 
+    <style name="Theme.Transparent" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:background">@android:color/transparent</item>
+        <item name="background">@android:color/transparent</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:colorBackgroundCacheHint">@null</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowAnimationStyle">@null</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>x
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
## Description

This updates account screen's upgrade banner and displays only the modal (without the full-screen features screen behind it) when the upgrade button is tapped from this banner.


Large PR size is due to
- I extracted certain components such as the pager and feature card enum from the `OnboardingUpgradeFeaturesPage` to allow for reuse in the account screen upgrade banner. 
- Most of the changes made to the `OnboardingFlowComposable` class involved reindenting the code (~200 lines).

## Testing Instructions

Prerequisite: Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/11343238/upgrade-testing-patch-with-patron.patch) 

#### Test.1 - Feature Flag off

0. Turn off Patron feature flag
1. Fresh install the app
2. Go to `Profile` screen
3. Sign in with an account "without Plus"
4. Go to `Accounts` screen
5. ✅ Notice that the old upgrade view is shown
6. Click on the upgrade button
7. ✅ Notice that the pricing bottom sheet modal is shown without the full-screen features page behind it
8. Tap outside the modal
9. ✅ Notice that the pricing bottom sheet modal is dismissed
10. Click on the upgrade button again
11. Tap the device's back button or perform a back swipe gesture
12. ✅ Notice that the pricing bottom sheet modal is dismissed

#### Test.2 - Feature Flag on 

0. Turn on Patron feature flag
1. Reinstall the app 
2. Go to `Profile` ->  `Accounts` screen
3. ✅ Notice that the new upgrade view is shown
4. Click on the upgrade button
5. ✅ Notice that the pricing bottom sheet modal is shown for the default plan for Plus
6. Dismiss the pricing modal
7. Switch to the next page
8. ✅ Notice that the default plan for Patron is shown
9. Click on the upgrade button
10. ✅ Notice that the pricing bottom sheet modal is shown for the default plan for Patron (**)
11. Dimiss it and go to Podcasts tab
12. Tap on the locked folder icon
13. ✅ Notice that the default Plus plan is shown

** Patron test product is a placeholder one, you won't see any yearly test plan for it
** Do not test buying any plan, that entire flow will be tested in a separate PR

## Screenshots or Screencast 

https://user-images.githubusercontent.com/1405144/236820201-19c001ae-6987-4213-b159-1de0bd9b0f20.mp4


## Checklist
- If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
