### PR TITLE
Patron: Account Details - Add Upgrade to Patron

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -104,7 +104,8 @@ private fun Content(
                 onDismiss = {
                     when (flow) {
                         // This should never happen. If the user isn't logged in they should be in the AccountUpgradeNeedsLogin flow
-                        is OnboardingFlow.PlusAccountUpgrade -> throw IllegalStateException("PlusAccountUpgrade flow tried to present LoginOrSignupPage")
+                        is OnboardingFlow.PlusAccountUpgrade,
+                        is OnboardingFlow.PatronAccountUpgrade -> throw IllegalStateException("Account upgrade flow tried to present LoginOrSignupPage")
 
                         OnboardingFlow.PlusAccountUpgradeNeedsLogin,
                         is OnboardingFlow.PlusUpsell -> {
@@ -148,6 +149,7 @@ private fun Content(
                         OnboardingFlow.LoggedOut -> exitOnboarding()
 
                         is OnboardingFlow.PlusAccountUpgrade,
+                        is OnboardingFlow.PatronAccountUpgrade,
                         OnboardingFlow.PlusAccountUpgradeNeedsLogin,
                         is OnboardingFlow.PlusUpsell -> navController.navigate(
                             OnboardingNavRoute.PlusUpgrade.routeWithSource(OnboardingUpgradeSource.LOGIN)
@@ -195,7 +197,8 @@ private fun Content(
                 OnboardingUpgradeSource.FOLDERS,
                 OnboardingUpgradeSource.LOGIN,
                 OnboardingUpgradeSource.PLUS_DETAILS,
-                OnboardingUpgradeSource.PROFILE -> false
+                OnboardingUpgradeSource.PROFILE,
+                OnboardingUpgradeSource.ACCOUNT_DETAILS -> false
 
                 OnboardingUpgradeSource.RECOMMENDATIONS -> true
             }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -49,6 +49,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 fun ProfileUpgradeBanner(
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val viewModel = hiltViewModel<ProfileUpgradeBannerViewModel>()
     val state by viewModel.state.collectAsState()
@@ -61,7 +62,8 @@ fun ProfileUpgradeBanner(
                 onClick = onClick,
                 onFeatureCardChanged = {
                     viewModel.onFeatureCardChanged(loadedState.featureCardsState.featureCards[it])
-                }
+                },
+                modifier = modifier,
             )
         }
 
@@ -80,7 +82,8 @@ fun ProfileUpgradeBanner(
 fun ProfileUpgradeBannerView(
     state: State.Loaded,
     onFeatureCardChanged: (Int) -> Unit,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val featureCardsState = state.featureCardsState
     HorizontalPagerWrapper(
@@ -89,6 +92,7 @@ fun ProfileUpgradeBannerView(
         onPageChanged = onFeatureCardChanged,
         showPageIndicator = featureCardsState.showPageIndicator,
         pageIndicatorColor = MaterialTheme.theme.colors.primaryText01,
+        modifier = modifier,
     ) { index, pagerHeight ->
         val currentTier = featureCardsState.featureCards[index].subscriptionTier
         FeatureCard(

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -10,7 +10,10 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.unit.dp
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.account.ChangeEmailFragment
@@ -130,7 +133,8 @@ class AccountDetailsFragment : BaseFragment() {
                                     val source = OnboardingUpgradeSource.PROFILE
                                     val onboardingFlow = OnboardingFlow.PlusAccountUpgrade(source)
                                     OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
-                                }
+                                },
+                                modifier = Modifier.padding(top = 16.dp)
                             )
                         }
                     }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -116,6 +116,8 @@ class AccountDetailsFragment : BaseFragment() {
 
             binding.cancelViewGroup?.isVisible = signInState.isSignedInAsPlusPaid
             binding.btnCancelSub?.isVisible = signInState.isSignedInAsPlusPaid
+            // TODO: Patron - hide if upgraded to patron
+            binding.upgradeAccountGroup?.isVisible = signInState.isSignedInAsPlus && BuildConfig.ADD_PATRON_ENABLED
 
             binding.userUpgradeComposeView?.apply {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
@@ -160,6 +162,12 @@ class AccountDetailsFragment : BaseFragment() {
         binding.btnChangePwd?.setOnClickListener {
             val fragment = ChangePwdFragment.newInstance()
             (this.activity as FragmentHostListener).addFragment(fragment)
+        }
+
+        binding.btnUpgradeAccount?.setOnClickListener {
+            val source = OnboardingUpgradeSource.ACCOUNT_DETAILS
+            val onboardingFlow = OnboardingFlow.PatronAccountUpgrade(source)
+            OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
         }
 
         binding.btnCancelSub?.setOnClickListener {

--- a/modules/features/profile/src/main/res/layout/fragment_account_details.xml
+++ b/modules/features/profile/src/main/res/layout/fragment_account_details.xml
@@ -137,13 +137,65 @@
                 app:constraint_referenced_ids="dividerView,imgMail,lblChangeEmail,btnChangeEmail,dividerView2,imgPassword,lblChangePassword,btnChangePwd" />
 
             <View
+                android:id="@+id/dividerViewUpgradeAccount"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/divider_height"
+                android:background="?attr/primary_ui_05"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/btnChangePwd" />
+
+            <ImageView
+                android:id="@+id/imgUpgradeAccount"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginStart="16dp"
+                app:tint="@color/patron_purple"
+                app:layout_constraintBottom_toBottomOf="@id/btnUpgradeAccount"
+                app:layout_constraintStart_toStartOf="@id/btnUpgradeAccount"
+                app:layout_constraintTop_toTopOf="@id/btnUpgradeAccount"
+                app:srcCompat="@drawable/ic_patron" />
+
+            <TextView
+                android:id="@+id/lblUpgradeAccount"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:text="@string/profile_upgrade_to_patron"
+                android:textAppearance="@style/H40"
+                android:textColor="@color/patron_purple"
+                android:importantForAccessibility="no"
+                app:layout_constraintBottom_toBottomOf="@+id/btnUpgradeAccount"
+                app:layout_constraintStart_toEndOf="@id/imgUpgradeAccount"
+                app:layout_constraintTop_toTopOf="@+id/btnUpgradeAccount" />
+
+            <View
+                android:id="@+id/btnUpgradeAccount"
+                android:layout_width="0dp"
+                android:layout_height="64dp"
+                android:background="?attr/selectableItemBackground"
+                android:paddingTop="16dp"
+                android:paddingBottom="16dp"
+                android:contentDescription="@string/profile_change_password"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/btnChangePwd" />
+
+            <androidx.constraintlayout.widget.Group
+                android:id="@+id/upgradeAccountGroup"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:constraint_referenced_ids="dividerViewUpgradeAccount,imgUpgradeAccount,lblUpgradeAccount,btnUpgradeAccount" />
+
+            <View
                 android:id="@+id/dividerView3"
                 android:layout_width="0dp"
                 android:layout_height="@dimen/divider_height"
                 android:background="?attr/primary_ui_05"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/btnChangePwd" />
+                app:layout_constraintTop_toBottomOf="@+id/btnUpgradeAccount" />
 
             <ImageView
                 android:id="@+id/imgSub"
@@ -183,7 +235,7 @@
                 android:contentDescription="@string/profile_cancel_subscription"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/btnChangePwd" />
+                app:layout_constraintTop_toBottomOf="@+id/btnUpgradeAccount" />
 
             <View
                 android:id="@+id/dividerView4"

--- a/modules/features/profile/src/main/res/layout/fragment_account_details.xml
+++ b/modules/features/profile/src/main/res/layout/fragment_account_details.xml
@@ -590,7 +590,6 @@
                 android:layout_width="0dp"
                 android:layout_height="@dimen/divider_height"
                 android:background="?attr/primary_ui_05"
-                android:layout_marginBottom="20dp"
                 android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"
@@ -603,7 +602,7 @@
                 android:layout_height="wrap_content"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/userView" />
+                app:layout_constraintTop_toBottomOf="@+id/dividerView15" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingFlow.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingFlow.kt
@@ -10,6 +10,7 @@ sealed class OnboardingFlow(val analyticsValue: String) : Parcelable {
     @Parcelize class PlusAccountUpgrade(override val source: OnboardingUpgradeSource) : PlusFlow, OnboardingFlow("plus_account_upgrade")
     @Parcelize object PlusAccountUpgradeNeedsLogin : OnboardingFlow("plus_account_upgrade_needs_login")
     @Parcelize class PlusUpsell(override val source: OnboardingUpgradeSource) : PlusFlow, OnboardingFlow("plus_upsell")
+    @Parcelize class PatronAccountUpgrade(override val source: OnboardingUpgradeSource) : PlusFlow, OnboardingFlow("patron_account_upgrade")
 
     sealed interface PlusFlow {
         val source: OnboardingUpgradeSource

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
@@ -7,5 +7,6 @@ enum class OnboardingUpgradeSource(val analyticsValue: String) {
     LOGIN("login"),
     PLUS_DETAILS("plus_details"),
     PROFILE("profile"),
+    ACCOUNT_DETAILS("account_details"),
     RECOMMENDATIONS("recommendations"),
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
@@ -38,6 +38,7 @@ fun HorizontalPagerWrapper(
     pageCount: Int,
     initialPage: Int,
     onPageChanged: (Int) -> Unit,
+    modifier: Modifier = Modifier,
     showPageIndicator: Boolean = true,
     pageIndicatorColor: Color = Color.White,
     pageSize: PageSize = PageSize.Fixed(LocalConfiguration.current.screenWidthDp.dp - 1.dp), // With full page width, height is not adjusted properly
@@ -53,7 +54,7 @@ fun HorizontalPagerWrapper(
     }
 
     var pagerHeight by remember { mutableStateOf(0) }
-    Column {
+    Column(modifier = modifier) {
         HorizontalPager(
             pageCount = pageCount,
             state = pagerState,

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -910,6 +910,7 @@
     <string name="profile_updates_ended">Updates ended: %s</string>
     <string name="profile_updates_ends">Updates end: %s</string>
     <string name="profile_upgrade_to_plus">Upgrade to Plus</string>
+    <string name="profile_upgrade_to_patron">Upgrade to Patron</string>
     <string name="profile_web_player">Web Player</string>
     <string name="profile_welcome_to_free">Welcome to Pocket Casts!</string>
     <string name="profile_welcome_to_plus">Welcome to Pocket Casts Plus!</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -62,10 +62,11 @@ sealed interface Subscription {
     enum class SubscriptionTier { PLUS, PATRON, UNKNOWN }
 
     companion object {
-        const val PATRON_PRODUCT_BASE = "com.pocketcasts.patron"
         const val PLUS_PRODUCT_BASE = "com.pocketcasts.plus"
         const val PLUS_MONTHLY_PRODUCT_ID = "$PLUS_PRODUCT_BASE.monthly"
         const val PLUS_YEARLY_PRODUCT_ID = "$PLUS_PRODUCT_BASE.yearly"
+        const val PATRON_MONTHLY_PRODUCT_ID = "com.pocketcasts.monthly.patron"
+        const val PATRON_YEARLY_PRODUCT_ID = "com.pocketcasts.yearly.patron"
 
         fun fromProductDetails(productDetails: ProductDetails, isFreeTrialEligible: Boolean): Subscription? =
             SubscriptionMapper.map(productDetails, isFreeTrialEligible)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
@@ -1,7 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.models.type
 
-import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_PRODUCT_BASE
-import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_PRODUCT_BASE
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_MONTHLY_PRODUCT_ID
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_YEARLY_PRODUCT_ID
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_MONTHLY_PRODUCT_ID
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_YEARLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.android.billingclient.api.ProductDetails
@@ -120,9 +122,9 @@ object SubscriptionMapper {
             null
         }
 
-    fun mapProductIdToTier(productId: String) = when {
-        productId.startsWith(PLUS_PRODUCT_BASE) -> SubscriptionTier.PLUS
-        productId.startsWith(PATRON_PRODUCT_BASE) -> SubscriptionTier.PATRON
+    fun mapProductIdToTier(productId: String) = when (productId) {
+        in listOf(PLUS_MONTHLY_PRODUCT_ID, PLUS_YEARLY_PRODUCT_ID) -> SubscriptionTier.PLUS
+        in listOf(PATRON_MONTHLY_PRODUCT_ID, PATRON_YEARLY_PRODUCT_ID) -> SubscriptionTier.PATRON
         else -> SubscriptionTier.UNKNOWN
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_MONTHLY_PRODUCT_ID
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_YEARLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_MONTHLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_PRODUCT_BASE
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_YEARLY_PRODUCT_ID
@@ -13,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.BuildConfig
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionPurchaseRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionResponse
@@ -158,7 +161,22 @@ class SubscriptionManagerImpl @Inject constructor(
                     .setProductId(PLUS_YEARLY_PRODUCT_ID)
                     .setProductType(BillingClient.ProductType.SUBS)
                     .build(),
-            )
+            ).apply {
+                if (BuildConfig.ADD_PATRON_ENABLED) {
+                    add(
+                        QueryProductDetailsParams.Product.newBuilder()
+                            .setProductId(PATRON_MONTHLY_PRODUCT_ID)
+                            .setProductType(BillingClient.ProductType.SUBS)
+                            .build(),
+                    )
+                    add(
+                        QueryProductDetailsParams.Product.newBuilder()
+                            .setProductId(PATRON_YEARLY_PRODUCT_ID)
+                            .setProductType(BillingClient.ProductType.SUBS)
+                            .build(),
+                    )
+                }
+            }
 
         val params = QueryProductDetailsParams.newBuilder()
             .setProductList(productList)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -292,6 +292,7 @@ class SubscriptionManagerImpl @Inject constructor(
             .build()
 
         billingClient.queryPurchaseHistoryAsync(queryPurchaseHistoryParams) { _, purchases ->
+            // TODO: Patron - Update free trial eligibility for Patron
             if (purchases?.any { it.products.toString().contains(PLUS_PRODUCT_BASE) } == true) {
                 updateFreeTrialEligible(false)
             }


### PR DESCRIPTION
## Description

This adds "Upgrade to Patron" row in the Account Details screen.

## Testing Instructions

1. Enable feature flag for Patron
2. Fresh install release build
3. Sign in with an in-app billing licence test account without having any plan
4. Go to `Profile` -> `Account`
5. Upgrade to `Plus` plan
6. Once subscribed to `Plus`, notice that "Upgrade to Patron" row is visible
7. Tap on the "Upgrade to Patron"
8. Notice that upgrade screen for only Patron plan features is shown 


## Screenshots or Screencast 
<img height=400 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/e4bdf874-13fb-4389-ae95-2b7a42859ad5"/>


## Checklist
- If this is a user-facing change, I have added an entry in CHANGELOG.md
- I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
