### PR TITLE
Only rebind discover views when there are changes

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -92,7 +92,7 @@ internal class DiscoverAdapter(
     val staticServerManager: StaticServerManagerImpl,
     val listener: Listener,
     val theme: Theme,
-    val loadPodcastList: (String) -> Flowable<PodcastList>,
+    loadPodcastList: (String) -> Flowable<PodcastList>,
     val loadCarouselSponsoredPodcastList: (List<SponsoredPodcast>) -> Flowable<List<CarouselSponsoredPodcast>>,
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) : ListAdapter<Any, RecyclerView.ViewHolder>(DiscoverRowDiffCallback()) {
@@ -106,6 +106,10 @@ internal class DiscoverAdapter(
         fun onSearchClicked()
     }
 
+    val loadPodcastList = { s: String ->
+        loadPodcastList(s)
+            .distinctUntilChanged()
+    }
     var onChangeRegion: (() -> Unit)? = null
 
     init {


### PR DESCRIPTION
## Description
This filters the podcast lists used for the discover views so that the list is resent only when changes occur. This avoids rebinding the views unnecessarily and appears to significantly improve the situation reported in https://github.com/Automattic/pocket-casts-android/issues/359  where we were sending off too many `discover_list_impression` events.

"Example 1" in that issue is _not_ entirely fixed by the change in this PR because we still send off an extra `discover_list_impression` event for the specific list episode item that is being played. We don't send off any events for any other of the list items though, so even that example is significantly improved.

## Testing Instructions

In addition to the specific tests below, also do some smoke testing of the Discover feed. In particular, try subscribing to some podcasts and playing episodes from the discover feed and make sure the UI updates appropriately.

### 1. Subscribing/Unsubscribing from featured podcast
1. Open one of the featured podcasts from the discover screen
2. Tap the subscribe button
3. ✅  Observe that no `discover_list_impression` events are sent
4. Unsubscribe from the podcast
5. ✅  Observe that no `discover_list_impression` events are sent

### 2. Playing/Pausing an episode
1. Go to the discover screen
2. Observe some `discover_list_impression` events are sent
3. Go to the Podcasts tab (or any tab other than the Discover tab)
4. Tap play on the miniplayer
5. ✅ Observe that no `discover_list_impression` events are sent
6. Tap pause on the miniplayer
7. ✅ Observe that no `discover_list_impression` events are sent

## Screenshots or Screencast

https://user-images.githubusercontent.com/4656348/236903060-05d16e74-2c01-410d-ab6d-2147a887ed09.mov

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`