### PR TITLE
Upgrade compose to 1.4.2 to fix keyboard display issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
         ([#814](https://github.com/Automattic/pocket-casts-android/issues/814)).
     *   Prevented crash when signing out of Android Automotive and clearing data while playback is in progress
         ([#919](https://github.com/Automattic/pocket-casts-android/pull/919)).    
+    *   Fixed keyboard not appearing when creating or editing folders.
+        ([#946](https://github.com/Automattic/pocket-casts-android/pull/946)).
 
 7.37
 -----

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -80,7 +80,7 @@ project.ext {
     // Library versions
     versionAccessibilityTestFramework = '4.0.0'
     versionBillingClient = '5.0.0'
-    versionCompose = '1.4.1' // When updating this, also check if versionComposeAccompanist should be updated as well: https://github.com/google/accompanist#compose-versions
+    versionCompose = '1.4.2' // When updating this, also check if versionComposeAccompanist should be updated as well: https://github.com/google/accompanist#compose-versions
     versionComposeAccompanist = '0.30.1'
     versionComposeCompiler = '1.3.0'
     versionComposeWear = '1.2.0-alpha07'


### PR DESCRIPTION
## Description
Fixes #906 where the keyboard would not appear when attempting to create or edit a folder. This made it almost impossible to create folders or edit the names of folders (for example, see [this comment)](https://github.com/Automattic/pocket-casts-android/issues/906#issuecomment-1535608479).

This issue was introduced when we updated compose to `1.4.1` in https://github.com/Automattic/pocket-casts-android/commit/ecf1f89c. The issue appears to be resolved in compose `1.4.2` (likely via [this commit](https://android.googlesource.com/platform/frameworks/support/+/1763fd0e7b7e11e0ac928762c2c6d16f0c049762) addressing [this issue](https://issuetracker.google.com/issues/262140644#comment16)).

> **Warning**
> I have this PR targeting `release/7.38` because I think the inability to use the soft keyboard on the folders screen pretty much breaks a lot of folders functionality for many users. Also, because this is only a single minor version bump for the compose dependencies, I'm hoping that the risk of introducing other issues is small. With that said, I do think there is a risk, so my thinking is that we should probably cut a new beta with this change. Let me know if you disagree with any of this though.

There is a `1.4.3` version of compose out, but I just went with `1.4.2` to minimize the changes and risk of regressions since I think we may want to merge this to our `release/7.38` branch.

## Testing Instructions

1. Log into a Plus account
2. From the Podcasts tab, tap the icon to add a new folder
3. Tap on the text field
4. ✅ Observe that the soft keyboard appears
5. Proceed to create the folder
6. From within the just-created folder, tap the overflow menu's option to edit the folder
7. Tap on the "Name" field
8. ✅ Observe that the soft keyboard appears

In addition, do a bit of smoke-testing of the app's screens that use compose to check for possible regressions.

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/4656348/2c5847a4-474f-4015-b4c5-6728c21e448f

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack
