### PR TITLE
Patron: Update account details header

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/SubscriptionBadge.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/SubscriptionBadge.kt
@@ -27,7 +27,7 @@ private val iconSizeInDp = 14.dp
 private val pillCornerRadiusInDp = 800.dp
 
 @Composable
-fun SubscriptionTierPill(
+fun SubscriptionBadge(
     @DrawableRes iconRes: Int,
     @StringRes shortNameRes: Int,
     modifier: Modifier = Modifier,
@@ -68,8 +68,8 @@ fun SubscriptionTierPill(
 
 @Preview
 @Composable
-private fun SubscriptionTierPillPreview() {
-    SubscriptionTierPill(
+private fun SubscriptionBadgePreview() {
+    SubscriptionBadge(
         iconRes = R.drawable.ic_patron,
         shortNameRes = LR.string.pocket_casts_patron_short,
         backgroundColor = Color.Black,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/SubscriptionTierPill.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/SubscriptionTierPill.kt
@@ -20,8 +20,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
-import au.com.shiftyjelly.pocketcasts.images.R as IR
-import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import au.com.shiftyjelly.pocketcasts.images.R
 
 private val iconSizeInDp = 14.dp
 private val pillCornerRadiusInDp = 800.dp
@@ -40,6 +39,7 @@ fun SubscriptionTierPill(
     Card(
         shape = RoundedCornerShape(pillCornerRadiusInDp),
         backgroundColor = backgroundColor ?: bgColor,
+        modifier = modifier,
     ) {
         Row(
             modifier = Modifier
@@ -50,7 +50,7 @@ fun SubscriptionTierPill(
             Icon(
                 painter = painterResource(iconRes),
                 contentDescription = null,
-                modifier = modifier
+                modifier = Modifier
                     .size(iconSizeInDp)
                     .background(bgColor),
                 tint = iconColor,
@@ -69,7 +69,8 @@ fun SubscriptionTierPill(
 @Composable
 private fun SubscriptionTierPillPreview() {
     SubscriptionTierPill(
-        iconRes = IR.drawable.ic_patron,
-        shortNameRes = LR.string.pocket_casts_patron_short,
+        iconRes = R.drawable.ic_patron,
+        shortNameRes = au.com.shiftyjelly.pocketcasts.localization.R.string.pocket_casts_patron_short,
+        backgroundColor = Color.Black,
     )
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/SubscriptionTierPill.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/SubscriptionTierPill.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.images.R
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private val iconSizeInDp = 14.dp
 private val pillCornerRadiusInDp = 800.dp
@@ -70,7 +71,7 @@ fun SubscriptionTierPill(
 private fun SubscriptionTierPillPreview() {
     SubscriptionTierPill(
         iconRes = R.drawable.ic_patron,
-        shortNameRes = au.com.shiftyjelly.pocketcasts.localization.R.string.pocket_casts_patron_short,
+        shortNameRes = LR.string.pocket_casts_patron_short,
         backgroundColor = Color.Black,
     )
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -65,7 +65,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import au.com.shiftyjelly.pocketcasts.account.onboarding.components.SubscriptionTierPill
+import au.com.shiftyjelly.pocketcasts.account.onboarding.components.SubscriptionBadge
 import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradeFeatureItem
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.IconRow
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.OutlinedRowButton
@@ -339,7 +339,7 @@ private fun FeatureCard(
                     .padding(bottom = 12.dp),
                 contentAlignment = Alignment.TopStart
             ) {
-                SubscriptionTierPill(
+                SubscriptionBadge(
                     iconRes = card.iconRes,
                     shortNameRes = card.shortNameRes,
                     backgroundColor = Color.Black,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import au.com.shiftyjelly.pocketcasts.account.onboarding.components.SubscriptionTierPill
+import au.com.shiftyjelly.pocketcasts.account.onboarding.components.SubscriptionBadge
 import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradeFeatureItem
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.IconRow
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.ProfileUpgradeBannerViewModel
@@ -121,7 +121,7 @@ private fun FeatureCard(
                 .fillMaxWidth()
                 .padding(bottom = 12.dp),
         ) {
-            SubscriptionTierPill(
+            SubscriptionBadge(
                 iconRes = card.iconRes,
                 shortNameRes = card.shortNameRes,
             )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -125,7 +124,6 @@ private fun FeatureCard(
             SubscriptionTierPill(
                 iconRes = card.iconRes,
                 shortNameRes = card.shortNameRes,
-                modifier = Modifier.background(Color.Black)
             )
 
             AmountView(button.subscription)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -126,8 +126,9 @@ class AccountDetailsFragment : BaseFragment() {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
                 setContent {
                     AppTheme(theme.activeTheme) {
-                        if (subscription != null && (signInState.isSignedInAsFree || giftExpiring)) {
-                            binding.dividerView15?.isVisible = BuildConfig.ADD_PATRON_ENABLED
+                        val showUpgradeBanner = subscription != null && (signInState.isSignedInAsFree || giftExpiring)
+                        binding.dividerView15?.isVisible = showUpgradeBanner && BuildConfig.ADD_PATRON_ENABLED
+                        if (showUpgradeBanner) {
                             ProfileUpgradeBanner(
                                 onClick = {
                                     val source = OnboardingUpgradeSource.PROFILE

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/UserView.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/UserView.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.widget.ConstraintLayout
 import au.com.shiftyjelly.pocketcasts.account.ProfileCircleView
-import au.com.shiftyjelly.pocketcasts.account.onboarding.components.SubscriptionTierPill
+import au.com.shiftyjelly.pocketcasts.account.onboarding.components.SubscriptionBadge
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralDaysMonthsOrYears
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralSecondsMinutesHoursDaysOrYears
@@ -54,7 +54,7 @@ open class UserView @JvmOverloads constructor(
     val lblSignInStatus: TextView?
     val imgProfilePicture: ProfileCircleView
     val btnAccount: Button?
-    private val subscriptionTierPill: ComposeView?
+    private val subscriptionBadge: ComposeView?
     private val isDarkTheme: Boolean
         get() = Theme.isDark(context)
 
@@ -64,14 +64,14 @@ open class UserView @JvmOverloads constructor(
         lblSignInStatus = findViewById(R.id.lblSignInStatus)
         imgProfilePicture = findViewById(R.id.imgProfilePicture)
         btnAccount = findViewById(R.id.btnAccount)
-        subscriptionTierPill = findViewById(R.id.subscriptionTierPill)
+        subscriptionBadge = findViewById(R.id.subscriptionBadge)
         setBackgroundResource(R.drawable.background_user_view)
     }
 
     open fun update(signInState: SignInState?) {
         updateProfileImageAndDaysRemaining(signInState)
         updateEmail(signInState)
-        updateSubscriptionTierPill(signInState)
+        updateSubscriptionBadge(signInState)
         updateAccountButton(signInState)
     }
 
@@ -152,8 +152,8 @@ open class UserView @JvmOverloads constructor(
         }
     }
 
-    private fun updateSubscriptionTierPill(signInState: SignInState?) {
-        subscriptionTierPill?.apply {
+    private fun updateSubscriptionBadge(signInState: SignInState?) {
+        subscriptionBadge?.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 AppTheme(if (isDarkTheme) Theme.ThemeType.DARK else Theme.ThemeType.LIGHT) {
@@ -161,7 +161,7 @@ open class UserView @JvmOverloads constructor(
                         val isExpandedUserView = this@UserView is ExpandedUserView
                         val modifier = Modifier.padding(top = 16.dp)
                         if (signInState.isSignedInAsPatron) {
-                            SubscriptionTierPill(
+                            SubscriptionBadge(
                                 iconRes = IR.drawable.ic_patron,
                                 shortNameRes = LR.string.pocket_casts_patron_short,
                                 iconColor = if (!isExpandedUserView) Color.White else Color.Unspecified,
@@ -170,7 +170,7 @@ open class UserView @JvmOverloads constructor(
                                 modifier = if (isExpandedUserView) modifier else Modifier,
                             )
                         } else if (signInState.isSignedInAsPlus) {
-                            SubscriptionTierPill(
+                            SubscriptionBadge(
                                 iconRes = IR.drawable.ic_plus,
                                 shortNameRes = LR.string.pocket_casts_plus_short,
                                 iconColor = colorResource(UR.color.plus_gold),

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/UserView.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/UserView.kt
@@ -169,12 +169,12 @@ open class UserView @JvmOverloads constructor(
                                 textColor = if (!isExpandedUserView) colorResource(UR.color.patron_purple_light) else null,
                                 modifier = if (isExpandedUserView) modifier else Modifier,
                             )
-                        } else if (signInState.isSignedInAsPlus) {
+                        } else if (signInState.isSignedInAsPlus && isExpandedUserView) {
                             SubscriptionBadge(
                                 iconRes = IR.drawable.ic_plus,
                                 shortNameRes = LR.string.pocket_casts_plus_short,
                                 iconColor = colorResource(UR.color.plus_gold),
-                                modifier = if (isExpandedUserView) modifier else Modifier,
+                                modifier = modifier,
                             )
                         }
                     }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/UserView.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/UserView.kt
@@ -208,7 +208,7 @@ class ExpandedUserView @JvmOverloads constructor(
         val status = (signInState as? SignInState.SignedIn)?.subscriptionStatus ?: return
         when (status) {
             is SubscriptionStatus.Free -> {
-                lblPaymentStatus.text = ""
+                lblPaymentStatus.text = context.getString(LR.string.profile_free_account)
                 lblSignInStatus?.text = ""
             }
             is SubscriptionStatus.Plus -> {

--- a/modules/features/profile/src/main/res/layout-car/view_expanded_user.xml
+++ b/modules/features/profile/src/main/res/layout-car/view_expanded_user.xml
@@ -29,16 +29,14 @@
         app:layout_constraintTop_toBottomOf="@+id/imgProfilePicture"
         tools:text="Setup Account" />
 
-    <TextView
-        android:id="@+id/lblAccountType"
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/subscriptionTierPill"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.Car.Display3"
-        android:textColor="?attr/primary_text_02"
+        android:layout_marginTop="16dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/lblUserEmail"
-        tools:text="Pocket Casts Plus" />
+        app:layout_constraintTop_toBottomOf="@id/lblUserEmail" />
 
     <TextView
         android:id="@+id/lblPaymentStatus"
@@ -49,7 +47,7 @@
         android:textAppearance="@style/TextAppearance.Car.Body3"
         android:textColor="?attr/primary_text_02"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/lblAccountType"
+        app:layout_constraintTop_toBottomOf="@+id/subscriptionTierPill"
         tools:text="Next payment:" />
 
     <TextView
@@ -61,7 +59,7 @@
         android:textAppearance="@style/TextAppearance.Car.Body3"
         android:textColor="?attr/primary_text_02"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/lblAccountType"
+        app:layout_constraintTop_toBottomOf="@+id/subscriptionTierPill"
         tools:text="Not signed in" />
 
 

--- a/modules/features/profile/src/main/res/layout-car/view_expanded_user.xml
+++ b/modules/features/profile/src/main/res/layout-car/view_expanded_user.xml
@@ -30,7 +30,7 @@
         tools:text="Setup Account" />
 
     <androidx.compose.ui.platform.ComposeView
-        android:id="@+id/subscriptionTierPill"
+        android:id="@+id/subscriptionBadge"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
@@ -47,7 +47,7 @@
         android:textAppearance="@style/TextAppearance.Car.Body3"
         android:textColor="?attr/primary_text_02"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/subscriptionTierPill"
+        app:layout_constraintTop_toBottomOf="@+id/subscriptionBadge"
         tools:text="Next payment:" />
 
     <TextView
@@ -59,7 +59,7 @@
         android:textAppearance="@style/TextAppearance.Car.Body3"
         android:textColor="?attr/primary_text_02"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/subscriptionTierPill"
+        app:layout_constraintTop_toBottomOf="@+id/subscriptionBadge"
         tools:text="Not signed in" />
 
 

--- a/modules/features/profile/src/main/res/layout-land-car/view_user.xml
+++ b/modules/features/profile/src/main/res/layout-land-car/view_user.xml
@@ -19,7 +19,7 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.compose.ui.platform.ComposeView
-        android:id="@+id/subscriptionTierPill"
+        android:id="@+id/subscriptionBadge"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
@@ -37,7 +37,7 @@
         android:textAppearance="@style/H70"
         android:textAlignment="center"
         android:textColor="?attr/primary_text_01"
-        app:layout_constraintTop_toBottomOf="@id/subscriptionTierPill"
+        app:layout_constraintTop_toBottomOf="@id/subscriptionBadge"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         tools:text="xxx@gmail.com" />

--- a/modules/features/profile/src/main/res/layout-land-car/view_user.xml
+++ b/modules/features/profile/src/main/res/layout-land-car/view_user.xml
@@ -9,8 +9,8 @@
 
     <au.com.shiftyjelly.pocketcasts.account.ProfileCircleView
         android:id="@+id/imgProfilePicture"
-        android:layout_width="@dimen/profile_picture_size_new"
-        android:layout_height="@dimen/profile_picture_size_new"
+        android:layout_width="@dimen/profile_picture_size"
+        android:layout_height="@dimen/profile_picture_size"
         android:layout_marginTop="16dp"
         android:importantForAccessibility="no"
         app:layout_constraintEnd_toEndOf="parent"

--- a/modules/features/profile/src/main/res/layout-land/view_user.xml
+++ b/modules/features/profile/src/main/res/layout-land/view_user.xml
@@ -20,7 +20,7 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.compose.ui.platform.ComposeView
-        android:id="@+id/subscriptionTierPill"
+        android:id="@+id/subscriptionBadge"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"

--- a/modules/features/profile/src/main/res/layout-land/view_user.xml
+++ b/modules/features/profile/src/main/res/layout-land/view_user.xml
@@ -9,8 +9,8 @@
 
     <au.com.shiftyjelly.pocketcasts.account.ProfileCircleView
         android:id="@+id/imgProfilePicture"
-        android:layout_width="@dimen/profile_picture_size_new"
-        android:layout_height="@dimen/profile_picture_size_new"
+        android:layout_width="@dimen/profile_picture_size"
+        android:layout_height="@dimen/profile_picture_size"
         android:layout_marginTop="8dp"
         android:layout_marginBottom="8dp"
         android:importantForAccessibility="no"

--- a/modules/features/profile/src/main/res/layout/fragment_account_details.xml
+++ b/modules/features/profile/src/main/res/layout/fragment_account_details.xml
@@ -589,12 +589,13 @@
                 android:id="@+id/dividerView15"
                 android:layout_width="0dp"
                 android:layout_height="@dimen/divider_height"
+                android:layout_marginTop="6dp"
                 android:background="?attr/primary_ui_05"
                 android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintBottom_toBottomOf="@+id/userView" />
+                app:layout_constraintTop_toBottomOf="@+id/userView" />
 
             <androidx.compose.ui.platform.ComposeView
                 android:id="@+id/userUpgradeComposeView"

--- a/modules/features/profile/src/main/res/layout/view_expanded_user.xml
+++ b/modules/features/profile/src/main/res/layout/view_expanded_user.xml
@@ -4,10 +4,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/mainLayout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:background="?attr/primary_ui_02"
     android:paddingBottom="8dp"
-    tools:layout_height="200dp">
+    tools:layout_height="wrap_content">
 
     <au.com.shiftyjelly.pocketcasts.account.ProfileCircleView
         android:id="@+id/imgProfilePicture"
@@ -30,16 +30,13 @@
         app:layout_constraintTop_toBottomOf="@+id/imgProfilePicture"
         tools:text="Setup Account" />
 
-    <TextView
-        android:id="@+id/lblAccountType"
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/subscriptionTierPill"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/H40"
-        android:textColor="?attr/primary_text_02"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/lblUserEmail"
-        tools:text="Pocket Casts Plus" />
+        app:layout_constraintTop_toBottomOf="@id/lblUserEmail" />
 
     <TextView
         android:id="@+id/lblPaymentStatus"
@@ -53,7 +50,7 @@
         android:gravity="start"
         app:layout_constraintEnd_toStartOf="@id/lblSignInStatus"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/lblAccountType"
+        app:layout_constraintTop_toBottomOf="@+id/subscriptionTierPill"
         app:layout_constraintBottom_toBottomOf="parent"
         tools:text="Next payment:" />
 
@@ -68,7 +65,7 @@
         android:textColor="?attr/primary_text_01"
         android:gravity="end"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/lblAccountType"
+        app:layout_constraintTop_toBottomOf="@+id/subscriptionTierPill"
         app:layout_constraintStart_toEndOf="@id/lblPaymentStatus"
         app:layout_constraintBottom_toBottomOf="parent"
         tools:text="Not signed in" />

--- a/modules/features/profile/src/main/res/layout/view_expanded_user.xml
+++ b/modules/features/profile/src/main/res/layout/view_expanded_user.xml
@@ -11,8 +11,8 @@
 
     <au.com.shiftyjelly.pocketcasts.account.ProfileCircleView
         android:id="@+id/imgProfilePicture"
-        android:layout_width="56dp"
-        android:layout_height="56dp"
+        android:layout_width="@dimen/account_details_picture_size"
+        android:layout_height="@dimen/account_details_picture_size"
         android:layout_marginTop="32dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/modules/features/profile/src/main/res/layout/view_expanded_user.xml
+++ b/modules/features/profile/src/main/res/layout/view_expanded_user.xml
@@ -31,7 +31,7 @@
         tools:text="Setup Account" />
 
     <androidx.compose.ui.platform.ComposeView
-        android:id="@+id/subscriptionTierPill"
+        android:id="@+id/subscriptionBadge"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
@@ -50,7 +50,7 @@
         android:gravity="start"
         app:layout_constraintEnd_toStartOf="@id/lblSignInStatus"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/subscriptionTierPill"
+        app:layout_constraintTop_toBottomOf="@+id/subscriptionBadge"
         app:layout_constraintBottom_toBottomOf="parent"
         tools:text="Next payment:" />
 
@@ -65,7 +65,7 @@
         android:textColor="?attr/primary_text_01"
         android:gravity="end"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/subscriptionTierPill"
+        app:layout_constraintTop_toBottomOf="@+id/subscriptionBadge"
         app:layout_constraintStart_toEndOf="@id/lblPaymentStatus"
         app:layout_constraintBottom_toBottomOf="parent"
         tools:text="Not signed in" />

--- a/modules/features/profile/src/main/res/layout/view_user.xml
+++ b/modules/features/profile/src/main/res/layout/view_user.xml
@@ -9,8 +9,8 @@
 
     <au.com.shiftyjelly.pocketcasts.account.ProfileCircleView
         android:id="@+id/imgProfilePicture"
-        android:layout_width="@dimen/profile_picture_size_new"
-        android:layout_height="@dimen/profile_picture_size_new"
+        android:layout_width="@dimen/profile_picture_size"
+        android:layout_height="@dimen/profile_picture_size"
         android:importantForAccessibility="no"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintDimensionRatio="W,1:1"

--- a/modules/features/profile/src/main/res/layout/view_user.xml
+++ b/modules/features/profile/src/main/res/layout/view_user.xml
@@ -18,7 +18,7 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.compose.ui.platform.ComposeView
-        android:id="@+id/subscriptionTierPill"
+        android:id="@+id/subscriptionBadge"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
@@ -36,7 +36,7 @@
         android:textAppearance="@style/H70"
         android:textAlignment="center"
         android:textColor="?attr/primary_text_01"
-        app:layout_constraintTop_toBottomOf="@id/subscriptionTierPill"
+        app:layout_constraintTop_toBottomOf="@id/subscriptionBadge"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         tools:text="xxx@gmail.com" />

--- a/modules/features/profile/src/main/res/values/dimens.xml
+++ b/modules/features/profile/src/main/res/values/dimens.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="profile_picture_size_old">48dp</dimen>
-    <dimen name="profile_picture_size_new">104dp</dimen>
+    <dimen name="profile_picture_size">104dp</dimen>
+    <dimen name="account_details_picture_size">64dp</dimen>
 </resources>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.models.to
 
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
 import au.com.shiftyjelly.pocketcasts.utils.DateUtil
 import java.util.Date
 
@@ -17,7 +18,10 @@ sealed class SignInState {
         get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Free
 
     val isSignedInAsPlus: Boolean
-        get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus
+        get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && this.subscriptionStatus.type == SubscriptionType.PLUS
+
+    val isSignedInAsPatron: Boolean
+        get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && this.subscriptionStatus.type == SubscriptionType.PATRON
 
     val isSignedInAsPlusPaid: Boolean
         get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && paidSubscriptionPlatforms.contains(this.subscriptionStatus.platform)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.models.to
 
+import au.com.shiftyjelly.pocketcasts.model.BuildConfig
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
 import au.com.shiftyjelly.pocketcasts.utils.DateUtil
@@ -21,7 +22,7 @@ sealed class SignInState {
         get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && this.subscriptionStatus.type == SubscriptionType.PLUS
 
     val isSignedInAsPatron: Boolean
-        get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && this.subscriptionStatus.type == SubscriptionType.PATRON
+        get() = BuildConfig.ADD_PATRON_ENABLED && this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && this.subscriptionStatus.type == SubscriptionType.PATRON
 
     val isSignedInAsPlusPaid: Boolean
         get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && paidSubscriptionPlatforms.contains(this.subscriptionStatus.platform)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
@@ -26,9 +26,6 @@ sealed class SignInState {
     val isSignedInAsPlusPaid: Boolean
         get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && paidSubscriptionPlatforms.contains(this.subscriptionStatus.platform)
 
-    val isSignedInAsPlusGifted: Boolean
-        get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && this.subscriptionStatus.platform == SubscriptionPlatform.GIFT && this.subscriptionStatus.giftDays != 0
-
     val isLifetimePlus: Boolean
         get() = this is SignedIn && this.subscriptionStatus.isLifetimePlus
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionType.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionType.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.models.type
 
 enum class SubscriptionType(val label: String) {
     NONE("none"),
-    PLUS("plus");
+    PLUS("plus"),
+    PATRON("patron");
     override fun toString() = label
 }


### PR DESCRIPTION
## Description

This updates "Account Details" screen profile header to include a subscription badge.

## Testing Instructions

#### Free account

1. Enable feature flag for Patron
2. Install release build
3. Login with an account without any plan 
4. Go to Profile -> Account screen 
5. Notice there's no subscription badge

#### Plus - Gift 

1. Logout 
2. Login with an account with a Plus - Gift account
3. Go to Profile -> Account screen 
4. Notice there's a Plus subscription badge

#### Plus - Subscription

1. Logout 
3. Login with a license test account with a Plus - Gift expiring account
4. Go to Profile -> Account screen 
5. Notice there's a Plus subscription badge
6. Buy Plus plan using upgrade banner
7. Notice there's a Plus subscription badge after the plan is bought

#### Patron  - Subscription

I tested it by setting `isSignedInAsPatron` to true in `SignInState`
```
val isSignedInAsPatron: Boolean
        get() = true
```
You can skip testing this part until the API is functional to support Patron.

## Screenshots or Screencast 
![out](https://github.com/Automattic/pocket-casts-android/assets/1405144/845c86c0-e7ed-4e29-b5ee-528fffaba58f)

## Checklist
- If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
