### PR TITLE
Direct free users to support forums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 7.39
 -----
 
+*   Updates
+    *   Link users to support forum from within the app
+        ([#950](https://github.com/Automattic/pocket-casts-android/pull/950)).
+
 7.38
 -----
 *   Updates:

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
@@ -38,7 +38,6 @@ import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.rx2.await
 import timber.log.Timber
 import java.util.Locale
 import javax.inject.Inject
@@ -225,14 +224,9 @@ class HelpFragment : Fragment(), HasBackstack, Toolbar.OnMenuItemClickListener {
     }
 
     private fun contactSupport() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            val subscriptionStatus = subscriptionManager.getSubscriptionStatus().await()
-
-            if (subscriptionStatus is SubscriptionStatus.Free) {
-                useForumPopup()
-            } else {
-                sendSupportEmail()
-            }
+        when (subscriptionManager.getCachedStatus()) {
+            null, is SubscriptionStatus.Free -> useForumPopup()
+            is SubscriptionStatus.Plus -> sendSupportEmail()
         }
 
         analyticsTracker.track(AnalyticsEvent.SETTINGS_GET_SUPPORT)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
@@ -14,13 +14,18 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Button
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.repositories.support.Support
 import au.com.shiftyjelly.pocketcasts.settings.status.StatusFragment
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.HelpViewModel
@@ -33,6 +38,7 @@ import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.rx2.await
 import timber.log.Timber
 import java.util.Locale
 import javax.inject.Inject
@@ -42,9 +48,11 @@ import au.com.shiftyjelly.pocketcasts.views.R as VR
 @AndroidEntryPoint
 class HelpFragment : Fragment(), HasBackstack, Toolbar.OnMenuItemClickListener {
 
+    @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
     @Inject lateinit var settings: Settings
-    @Inject lateinit var theme: Theme
+    @Inject lateinit var subscriptionManager: SubscriptionManager
     @Inject lateinit var support: Support
+    @Inject lateinit var theme: Theme
 
     val viewModel by viewModels<HelpViewModel>()
 
@@ -98,7 +106,9 @@ class HelpFragment : Fragment(), HasBackstack, Toolbar.OnMenuItemClickListener {
         loadingView = view.findViewById(VR.id.progress_circle)
         layoutError = view.findViewById(VR.id.layoutLoadingError)
 
-        view.findViewById<Button>(VR.id.btnContactSupport).setOnClickListener { sendSupportEmail() }
+        view.findViewById<Button>(VR.id.btnContactSupport).setOnClickListener {
+            contactSupport()
+        }
 
         return view
     }
@@ -148,7 +158,9 @@ class HelpFragment : Fragment(), HasBackstack, Toolbar.OnMenuItemClickListener {
 
             when {
                 url.lowercase(Locale.ROOT).contains("feedback") -> sendFeedbackEmail()
-                url.startsWith("mailto:support@shiftyjelly.com") || url.startsWith("mailto:support@pocketcasts.com") -> sendSupportEmail()
+                url.startsWith("mailto:support@shiftyjelly.com") || url.startsWith("mailto:support@pocketcasts.com") -> {
+                    contactSupport()
+                }
                 url.startsWith("https://support.pocketcasts.com") -> {
                     if (!url.contains("device=android")) {
                         url += (if (url.contains("?")) "&" else "?") + "device=android"
@@ -208,12 +220,41 @@ class HelpFragment : Fragment(), HasBackstack, Toolbar.OnMenuItemClickListener {
             }
         }
 
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_LEAVE_FEEDBACK)
         FirebaseAnalyticsTracker.userGuideEmailFeedback()
+    }
+
+    private fun contactSupport() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val subscriptionStatus = subscriptionManager.getSubscriptionStatus().await()
+
+            if (subscriptionStatus is SubscriptionStatus.Free) {
+                useForumPopup()
+            } else {
+                sendSupportEmail()
+            }
+        }
+
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_GET_SUPPORT)
+        FirebaseAnalyticsTracker.userGuideEmailSupport()
+    }
+
+    private fun useForumPopup() {
+        val context = context ?: return
+        val forumUrl = "https://forums.pocketcasts.com/"
+        AlertDialog.Builder(context)
+            .setTitle(LR.string.settings_forums)
+            .setMessage(context.getString(LR.string.settings_forums_description, forumUrl))
+            .setPositiveButton(LR.string.settings_take_me_there) { _, _ ->
+                val intent =
+                    Intent(Intent.ACTION_VIEW, Uri.parse(forumUrl))
+                startActivity(intent)
+            }
+            .show()
     }
 
     private fun sendSupportEmail() {
         val context = context ?: return
-
         viewLifecycleOwner.lifecycleScope.launch {
             try {
                 val intent = support.shareLogs(
@@ -227,7 +268,5 @@ class HelpFragment : Fragment(), HasBackstack, Toolbar.OnMenuItemClickListener {
                 UiUtil.displayDialogNoEmailApp(context)
             }
         }
-
-        FirebaseAnalyticsTracker.userGuideEmailSupport()
     }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -479,6 +479,8 @@ enum class AnalyticsEvent(val key: String) {
 
     /* Settings - Help */
     SETTINGS_HELP_SHOWN("settings_help_shown"),
+    SETTINGS_LEAVE_FEEDBACK("settings_leave_feedback"),
+    SETTINGS_GET_SUPPORT("settings_get_support"),
 
     /* Settings - Import - Export */
     SETTINGS_IMPORT_SHOWN("settings_import_shown"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1295,6 +1295,9 @@
     <string name="settings_status_service_hosts_help">The most common cause is that you have an ad-blocker configured on your phone or network. You’ll need to unblock this domain to download podcasts. Please note Pocket Casts doesn’t host or choose where podcasts are hosted, that’s up to the author of the show and is out of our control.</string>
     <string name="settings_status_service_support">Support</string>
     <string name="settings_status_service_support_summary">Access to the support FAQ and contact us.</string>
+    <string name="settings_forums">Pocket Casts Forums</string>
+    <string name="settings_forums_description">Please go to Pocket Casts\' forums (%1$s) where our support team can help you.</string>
+    <string name="settings_take_me_there">Take me there</string>
     <string name="settings_about_share_with_friends">Share with friends</string>
     <string name="settings_about_share_with_friends_message">Hey! Here is a link to download the Pocket Casts app. I\'m really enjoying it and thought you might too. \nhttps://www.pocketcasts.com</string>
     <string name="settings_about_rate_us">Rate us</string>


### PR DESCRIPTION
## Description
Currently when free users contact support they get an auto-response directing them to use our forums. This avoids that back-and-forth by directing free users to use our forums when they reach out to support from within the app.

## Testing Instructions
1. Log into the app
2. Go to the Profile tab
3. Tap on the ⚙️ 
4. Tap on "Help & feedback"
5. Scroll to the bottom of the screen and tap on "Get in touch"
6. Tap on "Get support"
7. ✅ If the account is free, the user should see a pop-up directing them to our support forums. Otherwise, the same share dialog that we used before is provided to allow the user to email us.

## Screenshots or Screencast 


https://github.com/Automattic/pocket-casts-android/assets/4656348/6ec7857d-3a78-4a03-b2c2-627deda20ab0


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
