### PR TITLE
Enable the ratings feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 7.39
 -----
+*   New Features:
+    *   Added the ability to see ratings for podcasts
+        ([#951](https://github.com/Automattic/pocket-casts-android/pull/951)).
 
 7.38
 -----

--- a/base.gradle
+++ b/base.gradle
@@ -30,7 +30,6 @@ android {
 
         // Feature Flags
         buildConfigField "boolean", "END_OF_YEAR_ENABLED", "false"
-        buildConfigField "boolean", "SHOW_RATINGS", "false"
         buildConfigField "boolean", "ADD_PATRON_ENABLED", "false"
 
         testInstrumentationRunner project.testInstrumentationRunner

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/StarRatingView.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
-import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastRatingsViewModel
@@ -66,7 +66,12 @@ private fun Content(
             stars = state.stars,
             color = MaterialTheme.theme.colors.filter03
         )
-        state.total?.let { TextP50(text = it.abbreviated) }
+        state.total?.let {
+            TextP40(
+                text = it.abbreviated,
+                modifier = Modifier.padding(start = 6.dp)
+            )
+        }
     }
 }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -276,10 +276,8 @@ class PodcastAdapter(
         // expand the podcast description and details if the user hasn't subscribed
         if (this.podcast.uuid != podcast.uuid) {
             headerExpanded = !podcast.isSubscribed
-            if (BuildConfig.SHOW_RATINGS) {
-                ratingsViewModel.loadRatings(podcast.uuid)
-                ratingsViewModel.refreshPodcastRatings(podcast.uuid)
-            }
+            ratingsViewModel.loadRatings(podcast.uuid)
+            ratingsViewModel.refreshPodcastRatings(podcast.uuid)
             onHeaderSummaryToggled(headerExpanded, false)
         }
         this.podcast = podcast

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -32,7 +32,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
-import au.com.shiftyjelly.pocketcasts.podcasts.BuildConfig
 import au.com.shiftyjelly.pocketcasts.podcasts.R
 import au.com.shiftyjelly.pocketcasts.podcasts.databinding.AdapterEpisodeBinding
 import au.com.shiftyjelly.pocketcasts.podcasts.databinding.AdapterEpisodeHeaderBinding

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
@@ -34,24 +34,22 @@ class PodcastRatingsViewModel
     val stateFlow: StateFlow<RatingState> = _stateFlow
 
     fun loadRatings(podcastUuid: String) {
-        if (BuildConfig.SHOW_RATINGS) {
-            viewModelScope.launch {
-                try {
-                    ratingsManager.podcastRatings(podcastUuid)
-                        .stateIn(viewModelScope)
-                        .collect { ratings ->
-                            _stateFlow.update {
-                                RatingState.Loaded(
-                                    podcastUuid = ratings.podcastUuid,
-                                    stars = getStars(ratings.average),
-                                    total = ratings.total
-                                )
-                            }
+        viewModelScope.launch {
+            try {
+                ratingsManager.podcastRatings(podcastUuid)
+                    .stateIn(viewModelScope)
+                    .collect { ratings ->
+                        _stateFlow.update {
+                            RatingState.Loaded(
+                                podcastUuid = ratings.podcastUuid,
+                                stars = getStars(ratings.average),
+                                total = ratings.total
+                            )
                         }
-                } catch (e: IOException) {
-                    Timber.e(e, "Failed to load podcast ratings")
-                    _stateFlow.update { RatingState.Error }
-                }
+                    }
+            } catch (e: IOException) {
+                Timber.e(e, "Failed to load podcast ratings")
+                _stateFlow.update { RatingState.Error }
             }
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
-import au.com.shiftyjelly.pocketcasts.podcasts.BuildConfig
 import au.com.shiftyjelly.pocketcasts.repositories.ratings.RatingsManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope


### PR DESCRIPTION
## Description

Removes the flag to enable showing ratings for podcasts. 


## Testing Instructions
Follow the steps here: https://github.com/Automattic/pocket-casts-android/pull/868

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
