### PR TITLE
Fixed Japanese show played setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 *   New Features:
     *   Added the ability to see ratings for podcasts
         ([#951](https://github.com/Automattic/pocket-casts-android/pull/951)).
+*   Bug Fixes:
+    *   Fixed Japanese translations for the 'Show played episodes' setting in Automotive.
+        ([#890](https://github.com/Automattic/pocket-casts-android/issues/955)).
 
 7.38
 -----

--- a/modules/services/localization/src/main/res/values-ja/strings.xml
+++ b/modules/services/localization/src/main/res/values-ja/strings.xml
@@ -239,8 +239,8 @@ Language: ja_JP
     <string name="end_of_year_launch_modal_summary">人気のポッドキャスト、カテゴリー、視聴統計などを確認します。 友達と共有したり、お気に入りのクリエイターにエールを送ったりしましょう。</string>
     <string name="end_of_year_launch_modal_title">ポッドキャストで振り返る1年</string>
     <string name="settings_app_icon_halloween">ハロウィーン</string>
-    <string name="settings_show_played_summary">Episodes that you have finished playing will still be displayed</string>
-    <string name="settings_show_played">Show played episodes</string>
+    <string name="settings_show_played_summary">プレイを終了したエピソードは、引き続き表示されます。</string>
+    <string name="settings_show_played">「再生されたエピソードを表示」</string>
     <string name="settings_privacy_crash_link_summary">クラッシュレポートへの Pocket Casts アカウントのリンクを許可します。 </string>
     <string name="settings_privacy_crash_link">アカウントをクラッシュにリンク</string>
     <string name="settings_privacy_crash_summary">クラッシュレポートの収集を許可します。</string>


### PR DESCRIPTION
## Description
The accepted translations for the show played setting in Android Automotive had been changed to English. This has been fixed. We normally add the translations as part of the release process but I wanted to know which version this was in and include it in the change log.

## Testing Instructions
1. Deploy the Automotive version
2. Go to Settings
3. Tap 'System'
4. Tap 'Languages & input'
5. Tap 'Languages'
6. Change it to 
<img width="112" alt="Screenshot 2023-05-12 at 7 53 30 am" src="https://github.com/Automattic/pocket-casts-android/assets/308331/ed047703-fad9-411a-8a06-ed650f1c2997">

7. Open Pocket Casts
8. Tap settings and scroll down
9. ✅ Verify there is no English

## Screenshots 
![unnamed (4)](https://github.com/Automattic/pocket-casts-android/assets/308331/8cc5e47d-1158-4f65-bce0-32076e495d5d)

| Before | After |
| --- | --- |
| ![Screenshot_20230512_075358](https://github.com/Automattic/pocket-casts-android/assets/308331/c6cd9c08-03b2-4259-8b01-739f3b57fcd5) | ![Screenshot_20230512_080900](https://github.com/Automattic/pocket-casts-android/assets/308331/57322591-11de-498b-8a91-815029818c90) |
