### PR TITLE
Fix the listening stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
         ([#942](https://github.com/Automattic/pocket-casts-android/pull/942)).
     *   Fixed Japanese translations for the 'Show played episodes' setting in Automotive.
         ([#890](https://github.com/Automattic/pocket-casts-android/issues/955)).
+    *   Fixed the listening stats.
+        ([#960](https://github.com/Automattic/pocket-casts-android/pull/960)).
 *   Updates
     *   Link users to support forum from within the app
         ([#950](https://github.com/Automattic/pocket-casts-android/pull/950)).

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerManager.kt
@@ -195,14 +195,6 @@ open class ServerManager @Inject constructor(
             .add("scope", "mobile")
     }
 
-    private fun postToSyncServer(servicePath: String, email: String?, password: String?, parameters: Parameters?, async: Boolean, postCallback: PostCallback): Call? {
-        val params = parameters ?: Parameters()
-        params.add("email", email)
-        password?.let { params.add("password", it) }
-        addDeviceParameters(params)
-        return post(Settings.SERVER_API_URL, servicePath, params, async, postCallback)
-    }
-
     private fun postToMainServer(servicePath: String, parameters: Parameters?, async: Boolean, postCallback: PostCallback): Call? {
         val parametersOrEmpty = parameters ?: Parameters()
         addDeviceParameters(parametersOrEmpty)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.servers.sync
 
+import android.os.Build
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -33,6 +34,7 @@ import okhttp3.RequestBody.Companion.asRequestBody
 import retrofit2.Response
 import retrofit2.Retrofit
 import java.io.File
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -111,13 +113,14 @@ open class SyncServerManager @Inject constructor(
         server.namedSettings(addBearer(token), request)
 
     fun syncUpdate(email: String, data: String, lastModified: String, token: AccessToken): Single<SyncUpdateResponse> {
-        val fields = mapOf(
+        val fields = mutableMapOf(
             "email" to email,
             "token" to token.value,
             "data" to data,
             "device_utc_time_ms" to System.currentTimeMillis().toString(),
             "last_modified" to lastModified
         )
+        addDeviceFields(fields)
         return server.syncUpdate(fields)
     }
 
@@ -257,5 +260,18 @@ open class SyncServerManager @Inject constructor(
 
     private fun addBearer(token: AccessToken): String {
         return "Bearer ${token.value}"
+    }
+
+    private fun addDeviceFields(fields: MutableMap<String, String>) {
+        with(fields) {
+            put("device", settings.getUniqueDeviceId())
+            put("v", Settings.PARSER_VERSION)
+            put("av", settings.getVersion())
+            put("ac", settings.getVersionCode().toString())
+            put("dt", "2")
+            put("c", Locale.getDefault().country)
+            put("l", Locale.getDefault().language)
+            put("m", Build.MODEL)
+        }
     }
 }


### PR DESCRIPTION
## Description
The device user listening stats require a device id to keep track of the listening stats on different devices. As part of the Google single sign-on change, I removed this. 🤦‍♂️ This change puts it back. 

## Testing Instructions
1. Open the Android Studio panel called 'App Inspection'
2. Tap the 'Network Inspector' tab
3. In the app go to the Profile tab and tap 'Refresh Now'
4. In the 'Network Inspector' find the 'https://api.pocketcasts.net/sync/update' call
5. ✅  Verify the request contains the device parameter with a value

## Screenshot
<img width="1707" alt="Screenshot 2023-05-15 at 3 31 05 pm" src="https://github.com/Automattic/pocket-casts-android/assets/308331/6c2395da-e533-4752-bb97-26b5ae212e71">
