### PR TITLE
Fix crash on season grouping

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PodcastGrouping.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PodcastGrouping.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.Resources
 import androidx.annotation.StringRes
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping.Season.getSeasonGroupId
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 sealed class PodcastGrouping(@StringRes val groupName: Int, val sortFunction: ((PodcastEpisode) -> Int)?) {
@@ -36,7 +37,7 @@ sealed class PodcastGrouping(@StringRes val groupName: Int, val sortFunction: ((
         }
     }
 
-    object Season : PodcastGrouping(LR.string.podcast_group_season, { it.season?.toInt() ?: 0 }) {
+    object Season : PodcastGrouping(LR.string.podcast_group_season, { getSeasonGroupId(it) }) {
         lateinit var groupTitlesList: List<String>
         override fun groupTitles(index: Int, context: Context): String {
             return groupTitlesList.getOrNull(index) ?: context.getString(LR.string.podcast_no_season)
@@ -48,7 +49,7 @@ sealed class PodcastGrouping(@StringRes val groupName: Int, val sortFunction: ((
             list.forEach {
                 val firstEpisode = it.firstOrNull()
                 if (firstEpisode != null) {
-                    if (firstEpisode.season != null) {
+                    if (getSeasonGroupId(firstEpisode) > 0) {
                         titleList.add(resources.getString(LR.string.podcast_season_x, firstEpisode.season ?: 0))
                     } else {
                         titleList.add(resources.getString(LR.string.podcast_no_season))
@@ -61,6 +62,9 @@ sealed class PodcastGrouping(@StringRes val groupName: Int, val sortFunction: ((
             groupTitlesList = titleList.toList()
             return list
         }
+
+        private fun getSeasonGroupId(firstEpisode: PodcastEpisode) =
+            firstEpisode.season?.toInt()?.takeIf { season -> season > 0 } ?: 0
     }
 
     object Starred : PodcastGrouping(LR.string.profile_navigation_starred, { if (it.isStarred) 0 else 1 }) {


### PR DESCRIPTION
## Description
This fixes crash on grouping by season for certain podcasts (e.g. https://pca.st/9NOf)


Fixes #961

## Testing Instructions
1. Subscribe to https://pca.st/9NOf
2. Go to Pocket Casts > Profile > Settings > General > Podcast Episode Grouping, set it to None
3. View the podcast page
4. Now go back to Podcast Episode Grouping and set it to 'Season'
5. Recheck the podcast page, you should not see any crash
6. Scroll to the bottom 
7. You should see a "No season" group with an episode

## Screenshots or Screencast 

<img width=320 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/30c1ecda-ce85-41f8-86fb-ece28440b865"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
