### PR TITLE
Avoiding crashing on RxJava errors in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
         ([#960](https://github.com/Automattic/pocket-casts-android/pull/960)).
     *   Fixed crash on grouping by season
         ([#962](https://github.com/Automattic/pocket-casts-android/pull/962)).
+    *   Fixed crash that could occur when signing out of the app
+        ([#971](https://github.com/Automattic/pocket-casts-android/pull/971)).
 *   Updates
     *   Link users to support forum from within the app
         ([#950](https://github.com/Automattic/pocket-casts-android/pull/950)).

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -29,6 +29,7 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.AppIcon
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBufferUncaughtExceptionHandler
+import au.com.shiftyjelly.pocketcasts.utils.log.RxJavaUncaughtExceptionHandling
 import coil.Coil
 import coil.ImageLoader
 import com.google.firebase.FirebaseApp
@@ -100,6 +101,8 @@ class PocketCastsApplication : Application(), Configuration.Provider {
         setupLogging()
         setupAnalytics()
         setupApp()
+
+        RxJavaUncaughtExceptionHandling.setUp()
     }
 
     private fun setupAnalytics() {

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
@@ -19,6 +19,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsTask
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
+import au.com.shiftyjelly.pocketcasts.utils.log.RxJavaUncaughtExceptionHandling
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.firebase.analytics.FirebaseAnalytics
@@ -53,6 +54,8 @@ class AutomotiveApplication : Application(), Configuration.Provider {
         setupAnalytics()
         setupAutomotiveDefaults()
         setupApp()
+
+        RxJavaUncaughtExceptionHandling.setUp()
     }
 
     override fun getWorkManagerConfiguration(): Configuration {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBuffer.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBuffer.kt
@@ -17,6 +17,7 @@ object LogBuffer {
     const val TAG_PLAYBACK = "Playback"
     const val TAG_CRASH = "Crash"
     const val TAG_BACKGROUND_TASKS = "BgTask"
+    const val TAG_RX_JAVA_DEFAULT_ERROR_HANDLER = "RxJavaDefaultErrorHandler"
     const val TAG_SUBSCRIPTIONS = "Subscriptions"
     const val TAG_INVALID_STATE = "InvalidState"
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/RxJavaUncaughtExceptionHandling.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/RxJavaUncaughtExceptionHandling.kt
@@ -1,0 +1,32 @@
+package au.com.shiftyjelly.pocketcasts.utils.log
+
+import au.com.shiftyjelly.pocketcasts.helper.BuildConfig
+import io.reactivex.plugins.RxJavaPlugins
+import io.sentry.Sentry
+
+// Wrapper that indicates this exception is only thrown in debug builds.
+// We still want to try to fix any of these that occur, but they won't
+// crash the app in release builds.
+class DebugOnlyException(t: Throwable) :
+    Throwable("Exception that is only thrown in debug builds.", t)
+
+object RxJavaUncaughtExceptionHandling {
+    fun setUp() {
+
+        // RxJava's default error handler crashes the app on any uncaught exception. Allow
+        // that on debug builds, but swallow the error in release builds.
+        // See https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling
+        RxJavaPlugins.setErrorHandler { exception ->
+            if (BuildConfig.DEBUG) {
+                throw DebugOnlyException(exception)
+            } else {
+                Sentry.captureException(exception)
+                LogBuffer.e(
+                    tag = LogBuffer.TAG_RX_JAVA_DEFAULT_ERROR_HANDLER,
+                    throwable = exception,
+                    message = "RxJava default error handler caught an exception"
+                )
+            }
+        }
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -16,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
+import au.com.shiftyjelly.pocketcasts.utils.log.RxJavaUncaughtExceptionHandling
 import com.google.firebase.FirebaseApp
 import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.HiltAndroidApp
@@ -45,6 +46,8 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
         setupLogging()
         setupAnalytics()
         setupApp()
+
+        RxJavaUncaughtExceptionHandling.setUp()
     }
 
     private fun setupLogging() {


### PR DESCRIPTION
## TLDR

This updates the app so that in release builds, when there are uncaught errors in RxJava streams, we log the error but no longer crash the app. On debug builds, however, the current default behavior of crashing the app remains.

## But Why?

I was digging into [this crash](https://github.com/Automattic/pocket-casts-android/issues/958) on the watch app, and it appears to be a fairly tricky race condition. In particular, the problem seems to happen if while the server call is being made inside a `Single.fromCallable` [here](https://github.com/Automattic/pocket-casts-android/blob/5049b0109fa90c0074d5428a77ca990041cf39e8/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt#L521-L524) the downstream disposes of the `Single` source. When that happens any `Throwable` that is thrown [bypasses any error handling in the stream and instead goes straight to RxJava's global error handler](https://github.com/ReactiveX/RxJava/blob/06e52db5356c7cda93480e5019959ff5c651938e/src/main/java/io/reactivex/rxjava3/core/Single.java#L965-L969) which, [on Android, crashes the app](https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling:~:text=However%2C%20Android%20is%20more%20strict%20and%20terminates%20the%20application%20in%20such%20uncaught%20exception%20cases.).


The best solution would be to find and fix the race condition, but it appears to be quite tricky, and I'm not sure how much time we want to devote to improving our RxJava handling since our long-term goal is to remove RxJava from the app. For that reason, I thought that this might be a "good enough" solution.

I feel conflicted about this, so let me know if you think this isn't a good idea. The reasons I decided to propose this is that we're planning to eventually remove RxJava anyway and, as long as we're still receiving these exceptions in Sentry, I don't see why we would want the app to crash in production. If you have any other ideas for how to handle this, though, definitely let me know.

The reason I applied this change to all 3 of our apps is that:
1. It is possible for the crash to happen on the phone and automotive apps (although it appears _much_ less likely)
2. Applying it to all 3 apps makes development easier because we have consistent behavior on all the apps.

## Testing Instructions

### A. Debug build
1. Install a debug build
2. Attempt to recreate https://github.com/Automattic/pocket-casts-android/issues/958, and observe that it still crashes. Alternatively, apply [this patch](https://gist.github.com/mchowning/3f567e4754bd67f5acb5e466e48479a4), and the crash will happen pretty consistently on both the watch and phone apps.

### B. Release build
1. Install a release build
2. Observe that you cannot crash the app by attempting to recreate https://github.com/Automattic/pocket-casts-android/issues/958 or applying [the patch](https://gist.github.com/mchowning/3f567e4754bd67f5acb5e466e48479a4), but the exception does show up in Sentry [like this](https://a8c.sentry.io/issues/4114268937/events/7eee9cc683b644c4855c6f42c430a99f/).

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes