### PR TITLE
Improve the resolution of the Gravatar image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.40
 -----
-
+*   Bug Fixes:
+    *   Improved the resolution of the Gravatar image
+        ([#973](https://github.com/Automattic/pocket-casts-android/pull/973)).
 
 7.39
 -----

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/Gravatar.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/Gravatar.kt
@@ -6,10 +6,11 @@ object Gravatar {
 
     /**
      * d=404: display no image if there is not one associated with the requested email hash
+     * s=400: size of the image
      * https://en.gravatar.com/site/implement/images/
      */
     fun getUrl(email: String): String? =
         email.md5Hex()?.let { md5Email ->
-            "https://www.gravatar.com/avatar/$md5Email?d=404"
+            "https://www.gravatar.com/avatar/$md5Email?d=404&s=400"
         }
 }


### PR DESCRIPTION
## Description
The default image size for a Gravatar image is 80px. This increases it to 400px. The sizes I could find it being used were 104dp, 100dp, 64dp, and 56dp so I thought 400px would be big enough.
https://en.gravatar.com/site/implement/images/

Fixes https://github.com/Automattic/pocket-casts-android/issues/968

## Testing Instructions
1. Tap on the Profile tab
2. Sign in if you aren't already
3. ✅  Verify the quality of the Gravatar image

## Screenshots 

| Before | After |
| --- | --- |
| ![Screenshot_20230517-211941](https://github.com/Automattic/pocket-casts-android/assets/308331/c591269b-98d9-408f-8628-f50e2b0670dd) | ![Screenshot_20230517-212229](https://github.com/Automattic/pocket-casts-android/assets/308331/84e492a1-5ded-40c2-b3ca-3d293a464f2c) |
