### PR TITLE
Add LogBuffer output to device logs screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
         ([#960](https://github.com/Automattic/pocket-casts-android/pull/960)).
     *   Fixed crash on grouping by season
         ([#962](https://github.com/Automattic/pocket-casts-android/pull/962)).
+    *   Fixed bug that prevented full logs from being displayed within the app
+        ([#974](https://github.com/Automattic/pocket-casts-android/pull/974)).
 *   Updates
     *   Link users to support forum from within the app
         ([#950](https://github.com/Automattic/pocket-casts-android/pull/950)).

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/LogsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/LogsViewModel.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.repositories.support.Support
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.io.ByteArrayOutputStream
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -27,7 +29,12 @@ class LogsViewModel @Inject constructor(
 
     init {
         viewModelScope.launch(Dispatchers.IO) {
-            val logs = support.getUserDebug(false)
+            val logs = buildString {
+                append(support.getUserDebug(false))
+                val outputStream = ByteArrayOutputStream()
+                LogBuffer.output(outputStream)
+                append(outputStream.toString())
+            }
             _state.update { it.copy(logs = logs) }
         }
     }


### PR DESCRIPTION
## Description
When I initially implemented the device logs screen in https://github.com/Automattic/pocket-casts-android/pull/911, I failed to append the `LogBuffer` logs to the output. This PR fixes that.

Before this fix, the logs would end with the "Episode Issues" and would contain none of the timestamped logs like "I 16/5 17:31:44 App started. 7.38 (9094)".

> **Note**
> I am targeting `release/7.39` with this because it seems like a pretty safe change and it would be good to get this out quickly since it fixes a new feature. I don't think we need to do a hotfix for this because emailing the logs (either from the logs display screen or if the user tries to contact support) will still include the full logs, so there is a workaround. I don't think we need to worry about immediately cutting a new beta with this—it's not urgent imo.

## Testing Instructions
1. Go to "Profile" → ⚙️ → "Help & feedback"
2. Tap on the logs icon at the top fo the screen
3. Verify that the screen includes the LogBuffer logs at the bottom.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
