### PR TITLE
Fix custom skip buttons not appearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
         ([#960](https://github.com/Automattic/pocket-casts-android/pull/960)).
     *   Fixed crash on grouping by season
         ([#962](https://github.com/Automattic/pocket-casts-android/pull/962)).
+    *   Fixed the skip buttons not appearing in the remote player views
+        ([#976](https://github.com/Automattic/pocket-casts-android/pull/976)).
 *   Updates
     *   Link users to support forum from within the app
         ([#950](https://github.com/Automattic/pocket-casts-android/pull/950)).

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -70,7 +70,7 @@ class MediaSessionManager(
         // ACTION_SKIP_TO_NEXT then the skip buttons on the lock screen are disabled. We work around this
         // by hiding our custom buttons on Samsung phones. It means the buttons in Android Auto aren't our
         // custom skip buttons, but it all still works.
-        private val MANUFACTURERS_TO_HIDE_CUSTOM_SKIP_BUTTONS = listOf("samsung", "mercedes-benz", "google")
+        private val MANUFACTURERS_TO_HIDE_CUSTOM_SKIP_BUTTONS = listOf("samsung", "mercedes-benz")
 
         fun calculateSearchQueryOptions(query: String): List<String> {
             val options = mutableListOf<String>()


### PR DESCRIPTION
## Description
This change fixes the issue that the media session isn't using our custom skip buttons.

## Testing Instructions
1. Play an episode
2. Swipe down the notification shade
3. ✅ Verify that our custom skip buttons are used in the notification player view, not the next / previous track buttons.

## Screenshots 
| Before | After |
| --- | --- |
| ![Screenshot_20230518_104156](https://github.com/Automattic/pocket-casts-android/assets/308331/31fceaf3-6ba4-4956-9496-ab86e47e7b4d) | ![Screenshot_20230518_104429](https://github.com/Automattic/pocket-casts-android/assets/308331/75a639cc-a836-4a0a-94b0-a86f616ea07d) |