### PR TITLE
Improving the Automotive buffering and seeking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.40
 -----
 *   Bug Fixes:
+    *   Fixed the buffering and seeking issues with some Automotive manufacturers
+        ([#977](https://github.com/Automattic/pocket-casts-android/pull/977)).
     *   Improved the resolution of the Gravatar image
         ([#973](https://github.com/Automattic/pocket-casts-android/pull/973)).
 

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -31,7 +31,8 @@
         android:supportsRtl="true"
         android:theme="@style/Automotive.ThemeDark"
         android:appCategory="audio"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="true"
+        android:largeHeap="true">
         <activity android:name=".AutomotiveSettingsActivity"
             android:exported="true">
             <intent-filter>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -42,11 +42,11 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
         private val REDUCED_BUFFER_MANUFACTURERS = listOf("mercedes-benz")
         private val USE_REDUCED_BUFFER = REDUCED_BUFFER_MANUFACTURERS.contains(Build.MANUFACTURER.lowercase())
 
-        private val BUFFER_TIME_MIN_MILLIS = if (USE_REDUCED_BUFFER) TimeUnit.MINUTES.toMillis(2).toInt() else TimeUnit.MINUTES.toMillis(15).toInt()
+        private val BUFFER_TIME_MIN_MILLIS = if (USE_REDUCED_BUFFER) TimeUnit.MINUTES.toMillis(2).toInt() else TimeUnit.MINUTES.toMillis(5).toInt()
         private val BUFFER_TIME_MAX_MILLIS = BUFFER_TIME_MIN_MILLIS
 
         // Be careful increasing the size of the back buffer. It can easily lead to OOM errors.
-        private val BACK_BUFFER_TIME_MILLIS = if (USE_REDUCED_BUFFER) TimeUnit.SECONDS.toMillis(30).toInt() else TimeUnit.MINUTES.toMillis(2).toInt()
+        private val BACK_BUFFER_TIME_MILLIS = if (USE_REDUCED_BUFFER) TimeUnit.SECONDS.toMillis(30).toInt() else TimeUnit.MINUTES.toMillis(1).toInt()
     }
 
     private var player: ExoPlayer? = null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -42,7 +42,7 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
         private val REDUCED_BUFFER_MANUFACTURERS = listOf("mercedes-benz")
         private val USE_REDUCED_BUFFER = REDUCED_BUFFER_MANUFACTURERS.contains(Build.MANUFACTURER.lowercase())
 
-        private val BUFFER_TIME_MIN_MILLIS =  if (USE_REDUCED_BUFFER) TimeUnit.MINUTES.toMillis(2).toInt() else TimeUnit.MINUTES.toMillis(15).toInt()
+        private val BUFFER_TIME_MIN_MILLIS = if (USE_REDUCED_BUFFER) TimeUnit.MINUTES.toMillis(2).toInt() else TimeUnit.MINUTES.toMillis(15).toInt()
         private val BUFFER_TIME_MAX_MILLIS = BUFFER_TIME_MIN_MILLIS
 
         // Be careful increasing the size of the back buffer. It can easily lead to OOM errors.

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 
 import android.content.Context
 import android.net.Uri
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.view.SurfaceView
@@ -38,11 +39,14 @@ import java.util.concurrent.TimeUnit
 class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val context: Context, override val onPlayerEvent: (au.com.shiftyjelly.pocketcasts.repositories.playback.Player, PlayerEvent) -> Unit) : LocalPlayer(onPlayerEvent) {
 
     companion object {
-        private val BUFFER_TIME_MIN_MILLIS = TimeUnit.MINUTES.toMillis(15).toInt()
+        private val REDUCED_BUFFER_MANUFACTURERS = listOf("mercedes-benz")
+        private val USE_REDUCED_BUFFER = REDUCED_BUFFER_MANUFACTURERS.contains(Build.MANUFACTURER.lowercase())
+
+        private val BUFFER_TIME_MIN_MILLIS =  if (USE_REDUCED_BUFFER) TimeUnit.MINUTES.toMillis(2).toInt() else TimeUnit.MINUTES.toMillis(15).toInt()
         private val BUFFER_TIME_MAX_MILLIS = BUFFER_TIME_MIN_MILLIS
 
         // Be careful increasing the size of the back buffer. It can easily lead to OOM errors.
-        private val BACK_BUFFER_TIME_MILLIS = TimeUnit.MINUTES.toMillis(2).toInt()
+        private val BACK_BUFFER_TIME_MILLIS = if (USE_REDUCED_BUFFER) TimeUnit.SECONDS.toMillis(30).toInt() else TimeUnit.MINUTES.toMillis(2).toInt()
     }
 
     private var player: ExoPlayer? = null


### PR DESCRIPTION
## Description
With Automotive, we are getting reports of issues with the seeking not working, buffering issues and out-of-memory crashes. A fix for this was to add the `largeHeap` configuration to the Automotive manifest file (already in the app manifest) and reduce the player buffer sizes. This is only with certain manufacturers so I have limited the buffer size for those.

## Testing Instructions
1. Deploy to Automotive
2. ✅ Verify you can play an episode, seek to a new position, and use the skip buttons.
