### PR TITLE
On Automotive add the option to clear your data before logging in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 7.40
 -----
+*   Updates:
+    *   Automotive now has the option to clear your data before logging in
+        ([#978](https://github.com/Automattic/pocket-casts-android/pull/978)).
 *   Bug Fixes:
     *   Improved the resolution of the Gravatar image
         ([#973](https://github.com/Automattic/pocket-casts-android/pull/973)).

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsFragment.kt
@@ -21,7 +21,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
-import au.com.shiftyjelly.pocketcasts.utils.Util
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -89,7 +88,7 @@ class AutomotiveSettingsFragment : Fragment(), CoroutineScope {
         // ask the user if they want to clear their data before they sign in
         if (isAccountUsed()) {
             val context = context ?: return
-            val themedContext = if (Util.isAutomotive(context)) ContextThemeWrapper(context, CR.style.Theme_Car_NoActionBar) else context
+            val themedContext = ContextThemeWrapper(context, CR.style.Theme_Car_NoActionBar)
             val builder = AlertDialog.Builder(themedContext)
             builder.setTitle(getString(LR.string.profile_clear_data_question))
                 .setMessage(getString(LR.string.profile_clear_data_would_you_also_like_question))
@@ -102,7 +101,7 @@ class AutomotiveSettingsFragment : Fragment(), CoroutineScope {
                         folderManager = folderManager,
                         searchHistoryManager = searchHistoryManager,
                         episodeManager = episodeManager,
-                        wasInitiatedByUser = true
+                        wasInitiatedByUser = false
                     )
                     openSignInActivity()
                 }

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsFragment.kt
@@ -2,23 +2,51 @@ package au.com.shiftyjelly.pocketcasts
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.account.AccountActivity
 import au.com.shiftyjelly.pocketcasts.databinding.FragmentAutomotiveSettingsBinding
 import au.com.shiftyjelly.pocketcasts.profile.AccountDetailsFragment
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.utils.Util
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
+import au.com.shiftyjelly.pocketcasts.cartheme.R as CR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @AndroidEntryPoint
-class AutomotiveSettingsFragment : Fragment() {
+class AutomotiveSettingsFragment : Fragment(), CoroutineScope {
     @Inject lateinit var userManager: UserManager
+    @Inject lateinit var syncManager: SyncManager
+    @Inject lateinit var podcastManager: PodcastManager
+    @Inject lateinit var episodeManager: EpisodeManager
+    @Inject lateinit var folderManager: FolderManager
+    @Inject lateinit var playlistManager: PlaylistManager
+    @Inject lateinit var searchHistoryManager: SearchHistoryManager
+    @Inject lateinit var playbackManager: PlaybackManager
+    @Inject lateinit var upNextQueue: UpNextQueue
 
     private lateinit var binding: FragmentAutomotiveSettingsBinding
+
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.Main
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentAutomotiveSettingsBinding.inflate(inflater, container, false)
@@ -49,15 +77,55 @@ class AutomotiveSettingsFragment : Fragment() {
 
     private fun onProfileAccountButtonClicked(loggedIn: Boolean) {
         if (loggedIn) {
-            val fragment = AccountDetailsFragment.newInstance()
-            (activity as? AutomotiveSettingsActivity)?.addFragment(fragment)
+            openSettingsFragment()
         } else {
-            signIn()
+            launch {
+                signIn()
+            }
         }
     }
 
-    fun signIn() {
-        val loginIntent = Intent(activity, AccountActivity::class.java)
-        startActivity(loginIntent)
+    private suspend fun signIn() {
+        // ask the user if they want to clear their data before they sign in
+        if (isAccountUsed()) {
+            val context = context ?: return
+            val themedContext = if (Util.isAutomotive(context)) ContextThemeWrapper(context, CR.style.Theme_Car_NoActionBar) else context
+            val builder = AlertDialog.Builder(themedContext)
+            builder.setTitle(getString(LR.string.profile_clear_data_question))
+                .setMessage(getString(LR.string.profile_clear_data_would_you_also_like_question))
+                .setPositiveButton(getString(LR.string.sign_in)) { _, _ -> openSignInActivity() }
+                .setNegativeButton(getString(LR.string.profile_clear_data)) { _, _ ->
+                    userManager.signOutAndClearData(
+                        playbackManager = playbackManager,
+                        upNextQueue = upNextQueue,
+                        playlistManager = playlistManager,
+                        folderManager = folderManager,
+                        searchHistoryManager = searchHistoryManager,
+                        episodeManager = episodeManager,
+                        wasInitiatedByUser = true
+                    )
+                    openSignInActivity()
+                }
+                .show()
+        } else {
+            openSignInActivity()
+        }
+    }
+
+    private fun openSettingsFragment() {
+        val fragment = AccountDetailsFragment.newInstance()
+        (activity as? AutomotiveSettingsActivity)?.addFragment(fragment)
+    }
+
+    private fun openSignInActivity() {
+        val intent = Intent(activity, AccountActivity::class.java)
+        startActivity(intent)
+    }
+
+    private suspend fun isAccountUsed(): Boolean {
+        return syncManager.isLoggedIn() ||
+            !upNextQueue.isEmpty ||
+            podcastManager.countSubscribed() > 0 ||
+            episodeManager.countEpisodes() > 0
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -225,7 +225,7 @@ abstract class EpisodeDao {
     abstract fun markPlaybackHistorySynced()
 
     @Query("SELECT COUNT(*) FROM podcast_episodes")
-    abstract fun count(): Int
+    abstract suspend fun count(): Int
 
     @Query("SELECT COUNT(*) FROM podcast_episodes WHERE uuid = :uuid")
     abstract fun countByUuid(uuid: String): Int

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -216,7 +216,7 @@ abstract class PodcastDao {
     abstract fun countByUuid(uuid: String): Int
 
     @Query("SELECT COUNT(*) FROM podcasts WHERE subscribed = 1")
-    abstract fun countSubscribed(): Int
+    abstract suspend fun countSubscribed(): Int
 
     @Query("SELECT COUNT(*) FROM podcasts WHERE subscribed = 1 AND uuid = :uuid")
     abstract fun countSubscribedByUuid(uuid: String): Int

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
@@ -68,6 +68,7 @@ interface UpNextQueue {
      * when certain metadata changes
      */
     fun getChangesObservableWithLiveCurrentEpisode(episodeManager: EpisodeManager, podcastManager: PodcastManager): Observable<State> {
+        // the debounce prevents too many events being generated and just returns the latest
         return changesObservable.debounce(100, TimeUnit.MILLISECONDS).switchMap { state ->
             if (state is State.Loaded) {
                 if (state.podcast != null) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
@@ -75,11 +75,13 @@ interface UpNextQueue {
                     // If we have a podcast we need to observe its effects state as well to ensure it updates when the global override changes
                     episodeManager.observeEpisodeByUuidRx(state.episode.uuid)
                         .combineLatest(podcastManager.observePodcastByUuid(state.podcast.uuid).distinctUntilChanged { t1, t2 -> t1.isUsingEffects == t2.isUsingEffects })
-                        .map { State.Loaded(it.first, it.second, state.queue) }
+                        .map<State> { State.Loaded(it.first, it.second, state.queue) }
+                        .onErrorReturn { State.Empty }
                         .toObservable()
                 } else {
                     episodeManager.observeEpisodeByUuidRx(state.episode.uuid)
-                        .map { State.Loaded(it, state.podcast, state.queue) }
+                        .map<State> { State.Loaded(it, state.podcast, state.queue) }
+                        .onErrorReturn { State.Empty }
                         .toObservable()
                 }
             } else {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -120,7 +120,7 @@ interface EpisodeManager {
     fun deleteDownloadedEpisodeFiles()
 
     /** Utility methods  */
-    fun countEpisodes(): Int
+    suspend fun countEpisodes(): Int
     fun countEpisodesWhere(queryAfterWhere: String): Int
     fun downloadMissingEpisode(episodeUuid: String, podcastUuid: String, skeletonEpisode: PodcastEpisode, podcastManager: PodcastManager, downloadMetaData: Boolean): Maybe<BaseEpisode>
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -587,7 +587,7 @@ class EpisodeManagerImpl @Inject constructor(
         cleanUpDownloadFiles(episode)
     }
 
-    override fun countEpisodes(): Int {
+    override suspend fun countEpisodes(): Int {
         return episodeDao.count()
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -116,7 +116,7 @@ interface PodcastManager {
 
     /** Utility methods  */
     fun countPodcasts(): Int
-    fun countSubscribed(): Int
+    suspend fun countSubscribed(): Int
     fun countSubscribedRx(): Single<Int>
     fun observeCountSubscribed(): Flowable<Int>
     fun countDownloadStatus(downloadStatus: Int): Int

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -500,7 +500,7 @@ class PodcastManagerImpl @Inject constructor(
         return podcastDao.count()
     }
 
-    override fun countSubscribed(): Int {
+    override suspend fun countSubscribed(): Int {
         return podcastDao.countSubscribed()
     }
 
@@ -739,17 +739,6 @@ class PodcastManagerImpl @Inject constructor(
             sortPosition = sortPosition,
             addedDate = addedDate
         )
-    }
-
-    /**
-     * Will return true if all the podcasts are have auto download turned on.
-     */
-    private fun isAutoDownloadingAllPodcasts(): Boolean {
-        return if (countPodcasts() == 0) false else podcastDao.countDownloadStatus(Podcast.AUTO_DOWNLOAD_NEW_EPISODES) == podcastDao.countSubscribed()
-    }
-
-    private fun isNotificationsForAllPodcasts(): Boolean {
-        return if (countPodcasts() == 0) false else podcastDao.countNotificationsOn() == podcastDao.countSubscribed()
     }
 
     override suspend fun updatePodcastPositions(podcasts: List<Podcast>) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -150,7 +150,7 @@ class UserManagerImpl @Inject constructor(
             userInitiated = false,
         )
 
-        // Block while clearing data so that users cannot interact with the until we're done clearing data
+        // Block while clearing data so that users cannot interact with the app until we're done clearing data
         runBlocking(Dispatchers.IO) {
 
             upNextQueue.removeAllIncludingChanges()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -4,13 +4,19 @@ import android.accounts.AccountManager
 import android.accounts.OnAccountsUpdateListener
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
@@ -19,16 +25,21 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import io.reactivex.Single
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
 
 interface UserManager {
     fun beginMonitoringAccountManager(playbackManager: PlaybackManager)
     fun getSignInState(): Flowable<SignInState>
     fun signOut(playbackManager: PlaybackManager, wasInitiatedByUser: Boolean)
+    fun signOutAndClearData(playbackManager: PlaybackManager, upNextQueue: UpNextQueue, playlistManager: PlaylistManager, folderManager: FolderManager, searchHistoryManager: SearchHistoryManager, episodeManager: EpisodeManager, wasInitiatedByUser: Boolean,)
 }
 
 class UserManagerImpl @Inject constructor(
@@ -39,11 +50,14 @@ class UserManagerImpl @Inject constructor(
     val podcastManager: PodcastManager,
     val userEpisodeManager: UserEpisodeManager,
     private val analyticsTracker: AnalyticsTrackerWrapper
-) : UserManager {
+) : UserManager, CoroutineScope {
 
     companion object {
         private const val KEY_USER_INITIATED = "user_initiated"
     }
+
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.Default
 
     override fun beginMonitoringAccountManager(playbackManager: PlaybackManager) {
         val accountListener = OnAccountsUpdateListener {
@@ -114,5 +128,43 @@ class UserManagerImpl @Inject constructor(
             }
         }
         settings.setFullySignedOut(true)
+    }
+
+    override fun signOutAndClearData(
+        playbackManager: PlaybackManager,
+        upNextQueue: UpNextQueue,
+        playlistManager: PlaylistManager,
+        folderManager: FolderManager,
+        searchHistoryManager: SearchHistoryManager,
+        episodeManager: EpisodeManager,
+        wasInitiatedByUser: Boolean,
+    ) {
+        // Sign out first to make sure no data changes get synced
+        signOut(playbackManager, wasInitiatedByUser = true)
+
+        // Need to stop playback before we start clearing data
+        playbackManager.removeEpisode(
+            episodeToRemove = playbackManager.getCurrentEpisode(),
+            // Unknown is fine here because we don't send analytics when the user did not initiate the action
+            source = AnalyticsSource.UNKNOWN,
+            userInitiated = false,
+        )
+
+        // Block while clearing data so that users cannot interact with the until we're done clearing data
+        runBlocking(Dispatchers.IO) {
+
+            upNextQueue.removeAllIncludingChanges()
+
+            playlistManager.resetDb()
+            folderManager.deleteAll()
+            searchHistoryManager.clearAll()
+
+            podcastManager.deleteAllPodcasts()
+
+            userEpisodeManager.findUserEpisodes().forEach {
+                userEpisodeManager.delete(it, playbackManager)
+            }
+            episodeManager.deleteAll()
+        }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -140,7 +140,7 @@ class UserManagerImpl @Inject constructor(
         wasInitiatedByUser: Boolean,
     ) {
         // Sign out first to make sure no data changes get synced
-        signOut(playbackManager, wasInitiatedByUser = true)
+        signOut(playbackManager = playbackManager, wasInitiatedByUser = wasInitiatedByUser)
 
         // Need to stop playback before we start clearing data
         playbackManager.removeEpisode(
@@ -162,7 +162,7 @@ class UserManagerImpl @Inject constructor(
             podcastManager.deleteAllPodcasts()
 
             userEpisodeManager.findUserEpisodes().forEach {
-                userEpisodeManager.delete(it, playbackManager)
+                userEpisodeManager.delete(episode = it, playbackManager = playbackManager)
             }
             episodeManager.deleteAll()
         }


### PR DESCRIPTION
## Description
For the Automotive app, we have been asked if we can add the option to clear your data before you can log in or create an account. If you have an Up Next, any podcasts or episodes then it will ask you, otherwise the dialog won't be shown to you.

## Testing Instructions
1. Deploy the Automotive version
2. Tap on the Discover tab
3. Tap a podcast
4. Tap on an episode to play it
5. Close the full screen player with the arrow at the top left
6. Tap the settings cog
7. Tap 'Set up account'
8. ✅ Verify a dialog is shown asking if you want to clear your data
9. Tap 'Clear data'
10. Tap close and back to get back to the app
11. ✅ Verify the mini player has closed
12. Tap the settings cog
13. Tap 'Set up account'
14. ✅ Verify it goes straight to the "Sign in or create account" page and doesn't show the dialog

## Screenshots
![Screenshot_20230518_170246](https://github.com/Automattic/pocket-casts-android/assets/308331/ae268f44-096c-4450-a69b-2dc98bbd63f3)

