### PR TITLE
Disables the ratings feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@
 
 7.39
 -----
-*   New Features:
-    *   Added the ability to see ratings for podcasts
-        ([#951](https://github.com/Automattic/pocket-casts-android/pull/951)).
 *   Bug Fixes:
     *   Fixed the discover categories sorting so that it is alphabetical in the device language
         ([#942](https://github.com/Automattic/pocket-casts-android/pull/942)).

--- a/base.gradle
+++ b/base.gradle
@@ -30,6 +30,7 @@ android {
 
         // Feature Flags
         buildConfigField "boolean", "END_OF_YEAR_ENABLED", "false"
+        buildConfigField "boolean", "SHOW_RATINGS", "false"
         buildConfigField "boolean", "ADD_PATRON_ENABLED", "false"
 
         testInstrumentationRunner project.testInstrumentationRunner

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -32,6 +32,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
+import au.com.shiftyjelly.pocketcasts.podcasts.BuildConfig
 import au.com.shiftyjelly.pocketcasts.podcasts.R
 import au.com.shiftyjelly.pocketcasts.podcasts.databinding.AdapterEpisodeBinding
 import au.com.shiftyjelly.pocketcasts.podcasts.databinding.AdapterEpisodeHeaderBinding
@@ -275,8 +276,10 @@ class PodcastAdapter(
         // expand the podcast description and details if the user hasn't subscribed
         if (this.podcast.uuid != podcast.uuid) {
             headerExpanded = !podcast.isSubscribed
-            ratingsViewModel.loadRatings(podcast.uuid)
-            ratingsViewModel.refreshPodcastRatings(podcast.uuid)
+            if (BuildConfig.SHOW_RATINGS) {
+                ratingsViewModel.loadRatings(podcast.uuid)
+                ratingsViewModel.refreshPodcastRatings(podcast.uuid)
+            }
             onHeaderSummaryToggled(headerExpanded, false)
         }
         this.podcast = podcast

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.podcasts.BuildConfig
 import au.com.shiftyjelly.pocketcasts.repositories.ratings.RatingsManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
@@ -33,22 +34,24 @@ class PodcastRatingsViewModel
     val stateFlow: StateFlow<RatingState> = _stateFlow
 
     fun loadRatings(podcastUuid: String) {
-        viewModelScope.launch {
-            try {
-                ratingsManager.podcastRatings(podcastUuid)
-                    .stateIn(viewModelScope)
-                    .collect { ratings ->
-                        _stateFlow.update {
-                            RatingState.Loaded(
-                                podcastUuid = ratings.podcastUuid,
-                                stars = getStars(ratings.average),
-                                total = ratings.total
-                            )
+        if (BuildConfig.SHOW_RATINGS) {
+            viewModelScope.launch {
+                try {
+                    ratingsManager.podcastRatings(podcastUuid)
+                        .stateIn(viewModelScope)
+                        .collect { ratings ->
+                            _stateFlow.update {
+                                RatingState.Loaded(
+                                    podcastUuid = ratings.podcastUuid,
+                                    stars = getStars(ratings.average),
+                                    total = ratings.total
+                                )
+                            }
                         }
-                    }
-            } catch (e: IOException) {
-                Timber.e(e, "Failed to load podcast ratings")
-                _stateFlow.update { RatingState.Error }
+                } catch (e: IOException) {
+                    Timber.e(e, "Failed to load podcast ratings")
+                    _stateFlow.update { RatingState.Error }
+                }
             }
         }
     }


### PR DESCRIPTION
## Description
This adds the removed ratings feature flag, and removes it from the 7.39 change log.

## Testing Instructions
1. Launch the app 
2. Go to Discover
3. Tap on podcasts
4. ✅ Verify the ratings do not appear
5. Go to your subscribed podcasts
6. Tap on one
7. Expand the details
8. ✅ Verify the rating does not appear

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
