### PR TITLE
translation fix

### DIFF
--- a/modules/services/localization/src/main/res/values-ru/strings.xml
+++ b/modules/services/localization/src/main/res/values-ru/strings.xml
@@ -1224,7 +1224,7 @@ Language: ru
     <string name="podcast_archive_played">Это стоит делать только в том случае, если вы больше не хотите их видеть.</string>
     <string name="podcast_archive_all_played">Архивировать все прослушанные</string>
     <string name="podcast_archive_all">Архивировать все</string>
-    <string name="podcasts_unarchive">Из&amp;nbsp;архива</string>
+    <string name="podcasts_unarchive">Из архива</string>
     <string name="podcasts_time_to_add_some_podcasts_summary">Вы можете добавить подкасты с помощью поиска выше, а если вы ищете немного вдохновения, попробуйте вкладку «Поиск».</string>
     <string name="podcasts_time_to_add_some_podcasts">Пора добавить подкасты!</string>
     <string name="podcasts_sort_order">Порядок сортировки</string>


### PR DESCRIPTION
## Description
removing html tags from `<string name="podcasts_unarchive">`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Switch the interface to russian lang-->
<!-- 2. Tap on the Profile tab -->
<!-- 3. Tap on a Listen History -->
<!-- 4. Tap on podcast -->

## Screenshots or Screencast 
![Screenshots](https://i.imgur.com/TeQ2jED.jpg)

## Checklist
- [-] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [-] I have considered whether it makes sense to add tests for my changes
- [+] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [-] Any jetpack compose components I added or changed are covered by compose previews
