### PR TITLE
Improve watch app podcast screen UI

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -165,7 +165,7 @@ fun WearApp(
             }
         }
 
-        composable(
+        scrollable(
             route = PodcastScreen.route,
             arguments = listOf(
                 navArgument(PodcastScreen.argument) {
@@ -177,11 +177,13 @@ fun WearApp(
             NowPlayingPager(
                 navController = navController,
                 swipeToDismissState = swipeToDismissState,
+                scrollableScaffoldContext = it
             ) {
                 PodcastScreen(
                     onEpisodeTap = { episode ->
                         navController.navigate(EpisodeScreenFlow.navigateRoute(episodeUuid = episode.uuid))
                     },
+                    listState = it.scrollableState,
                 )
             }
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
@@ -47,6 +47,7 @@ fun EpisodeChip(
     episode: BaseEpisode,
     useUpNextIcon: Boolean = true,
     onClick: () -> Unit,
+    showImage: Boolean = true,
 ) {
     Box(
         contentAlignment = Alignment.Center,
@@ -56,7 +57,7 @@ fun EpisodeChip(
             .clickable { onClick() }
             .padding(horizontal = 10.dp)
             .fillMaxWidth()
-            .height(72.dp)
+            .padding(vertical = 10.dp)
     ) {
 
         val viewModel = hiltViewModel<EpisodeChipViewModel>()
@@ -72,7 +73,7 @@ fun EpisodeChip(
             ?.queue
             ?: emptyList()
         val isInUpNextQueue = upNextQueue.any { it.uuid == episode.uuid }
-
+        val showUpNextIcon = useUpNextIcon && isInUpNextQueue
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.height(IntrinsicSize.Max)
@@ -82,37 +83,18 @@ fun EpisodeChip(
                 verticalArrangement = Arrangement.Center,
             ) {
 
-                EpisodeImage(
-                    episode = episode,
-                    modifier = Modifier
-                        .size(30.dp)
-                        .clip(RoundedCornerShape(4.dp)),
-                )
-
-                val showUpNextIcon = useUpNextIcon && isInUpNextQueue
-                if (episode.isDownloaded || showUpNextIcon) {
-                    Row(
-                        horizontalArrangement = spacedBy(4.dp),
-                        modifier = Modifier.padding(top = 4.dp)
-                    ) {
-                        if (showUpNextIcon) {
-                            Icon(
-                                painter = painterResource(R.drawable.ic_upnext),
-                                contentDescription = stringResource(LR.string.episode_in_up_next),
-                                tint = MaterialTheme.theme.colors.support01,
-                                modifier = Modifier.size(12.dp),
-                            )
-                        }
-
-                        if (episode.isDownloaded) {
-                            Icon(
-                                painter = painterResource(R.drawable.ic_downloaded),
-                                contentDescription = stringResource(LR.string.downloaded),
-                                tint = MaterialTheme.theme.colors.support02,
-                                modifier = Modifier.size(12.dp),
-                            )
-                        }
-                    }
+                if (showImage) {
+                    EpisodeImage(
+                        episode = episode,
+                        modifier = Modifier
+                            .size(30.dp)
+                            .clip(RoundedCornerShape(4.dp)),
+                    )
+                    IconsRow(
+                        showUpNextIcon,
+                        episode,
+                        Modifier.padding(top = 4.dp)
+                    )
                 }
             }
 
@@ -145,12 +127,54 @@ fun EpisodeChip(
                     inProgress = episode.isInProgress,
                     context = LocalContext.current
                 ).text
-                Text(
-                    text = "$shortDate • $timeLeft",
-                    color = MaterialTheme.theme.colors.primaryText02,
-                    style = MaterialTheme.typography.caption2
-                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    if (!showImage) {
+                        IconsRow(
+                            showUpNextIcon,
+                            episode,
+                            modifier = Modifier
+                                .padding(end = if (showUpNextIcon || episode.isDownloaded) 4.dp else 0.dp)
+                        )
+                    }
+                    Text(
+                        text = "$shortDate • $timeLeft",
+                        color = MaterialTheme.theme.colors.primaryText02,
+                        style = MaterialTheme.typography.caption2,
+                    )
+                }
             }
+        }
+    }
+}
+
+@Composable
+private fun IconsRow(
+    showUpNextIcon: Boolean,
+    episode: BaseEpisode,
+    modifier: Modifier,
+) {
+    Row(
+        horizontalArrangement = spacedBy(4.dp),
+        modifier = modifier
+    ) {
+        if (showUpNextIcon) {
+            Icon(
+                painter = painterResource(R.drawable.ic_upnext),
+                contentDescription = stringResource(LR.string.episode_in_up_next),
+                tint = MaterialTheme.theme.colors.support01,
+                modifier = Modifier.size(12.dp),
+            )
+        }
+
+        if (episode.isDownloaded) {
+            Icon(
+                painter = painterResource(R.drawable.ic_downloaded),
+                contentDescription = stringResource(LR.string.downloaded),
+                tint = MaterialTheme.theme.colors.support02,
+                modifier = Modifier.size(12.dp),
+            )
         }
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
@@ -107,6 +107,7 @@ fun EpisodeChip(
                     text = episode.title,
                     lineHeight = 16.sp,
                     overflow = TextOverflow.Ellipsis,
+                    color = MaterialTheme.theme.colors.primaryText01,
                     style = MaterialTheme.typography.button.merge(
                         @Suppress("DEPRECATION")
                         (

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
@@ -105,7 +105,7 @@ fun EpisodeChip(
             ) {
                 Text(
                     text = episode.title,
-                    lineHeight = 14.sp,
+                    lineHeight = 16.sp,
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.typography.button.merge(
                         @Suppress("DEPRECATION")

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.wear.ui.podcast
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -11,6 +10,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
+import androidx.wear.compose.foundation.lazy.ScalingLazyListState
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
@@ -33,12 +33,14 @@ fun PodcastScreen(
     onEpisodeTap: (PodcastEpisode) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PodcastViewModel = hiltViewModel(),
+    listState: ScalingLazyListState,
 ) {
     when (val state = viewModel.uiState) {
         is UiState.Loaded -> Content(
             state = state,
             onEpisodeTap = onEpisodeTap,
             modifier = modifier,
+            listState = listState,
         )
 
         UiState.Empty -> Unit // Do Nothing
@@ -50,14 +52,15 @@ private fun Content(
     state: UiState.Loaded,
     onEpisodeTap: (PodcastEpisode) -> Unit,
     modifier: Modifier = Modifier,
+    listState: ScalingLazyListState,
 ) {
     val podcast = state.podcast ?: return
 
     ScalingLazyColumn(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(vertical = 26.dp),
+        modifier = modifier.fillMaxWidth(),
+        state = listState,
     ) {
+        item { Spacer(Modifier.height(4.dp)) }
         item {
             PodcastImage(
                 uuid = podcast.uuid,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
@@ -18,6 +18,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.wear.theme.theme
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.EpisodeChip
+import au.com.shiftyjelly.pocketcasts.wear.ui.podcast.PodcastViewModel.UiState
 
 object PodcastScreen {
     const val argument = "podcastUuid"
@@ -33,7 +34,24 @@ fun PodcastScreen(
     modifier: Modifier = Modifier,
     viewModel: PodcastViewModel = hiltViewModel(),
 ) {
-    val podcast = viewModel.uiState.podcast ?: return
+    when (val state = viewModel.uiState) {
+        is UiState.Loaded -> Content(
+            state = state,
+            onEpisodeTap = onEpisodeTap,
+            modifier = modifier,
+        )
+
+        UiState.Empty -> Unit // Do Nothing
+    }
+}
+
+@Composable
+private fun Content(
+    state: UiState.Loaded,
+    onEpisodeTap: (PodcastEpisode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val podcast = state.podcast ?: return
 
     ScalingLazyColumn(
         modifier = modifier
@@ -63,7 +81,7 @@ fun PodcastScreen(
                 text = podcast.author
             )
         }
-        items(viewModel.uiState.episodes) { episode ->
+        items(state.episodes) { episode ->
             EpisodeChip(
                 episode = episode,
                 onClick = {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
@@ -1,11 +1,16 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui.podcast
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -15,7 +20,10 @@ import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.wear.theme.theme
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.EpisodeChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcast.PodcastViewModel.UiState
@@ -55,43 +63,74 @@ private fun Content(
     listState: ScalingLazyListState,
 ) {
     val podcast = state.podcast ?: return
+    Box(modifier = modifier.fillMaxWidth()) {
+        PodcastColorBackground(
+            podcast = podcast,
+            theme = state.theme,
+            modifier = modifier
+        )
 
-    ScalingLazyColumn(
-        modifier = modifier.fillMaxWidth(),
-        state = listState,
-    ) {
-        item { Spacer(Modifier.height(4.dp)) }
-        item {
-            PodcastImage(
-                uuid = podcast.uuid,
-                modifier = Modifier.size(PodcastScreen.podcastImageSize)
-            )
-            Spacer(Modifier.height(4.dp))
-        }
-        item {
-            Text(
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Center,
-                color = MaterialTheme.theme.colors.primaryText01,
-                text = podcast.title
-            )
-        }
-        item {
-            Text(
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Center,
-                color = MaterialTheme.theme.colors.primaryText02,
-                text = podcast.author
-            )
-        }
-        items(state.episodes) { episode ->
-            EpisodeChip(
-                episode = episode,
-                onClick = {
-                    onEpisodeTap(episode)
-                },
-                showImage = false,
-            )
+        ScalingLazyColumn(
+            modifier = modifier.fillMaxWidth(),
+            state = listState,
+        ) {
+            item { Spacer(Modifier.height(4.dp)) }
+            item {
+                PodcastImage(
+                    uuid = podcast.uuid,
+                    modifier = Modifier.size(PodcastScreen.podcastImageSize)
+                )
+                Spacer(Modifier.height(4.dp))
+            }
+            item {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.theme.colors.primaryText01,
+                    text = podcast.title
+                )
+            }
+            item {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.theme.colors.primaryText02,
+                    text = podcast.author
+                )
+            }
+            items(state.episodes) { episode ->
+                EpisodeChip(
+                    episode = episode,
+                    onClick = {
+                        onEpisodeTap(episode)
+                    },
+                    showImage = false,
+                )
+            }
         }
     }
+}
+
+@Composable
+private fun PodcastColorBackground(
+    podcast: Podcast,
+    theme: Theme,
+    modifier: Modifier = Modifier,
+) {
+    val localConfig = LocalConfiguration.current
+    val tintColor = podcast.tintColorForDarkBg
+    val color = Color(ThemeColor.podcastIcon02(theme.activeTheme, tintColor))
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height((localConfig.screenHeightDp / 2).dp)
+            .background(
+                Brush.verticalGradient(
+                    listOf(
+                        color.copy(alpha = 0.3f),
+                        Color.Transparent
+                    )
+                )
+            )
+    )
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
@@ -22,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.wear.ui.component.EpisodeChip
 object PodcastScreen {
     const val argument = "podcastUuid"
     const val route = "podcast/{$argument}"
+    val podcastImageSize = 72.dp
 
     fun navigateRoute(podcastUuid: String) = "podcast/$podcastUuid"
 }
@@ -42,7 +43,7 @@ fun PodcastScreen(
         item {
             PodcastImage(
                 uuid = podcast.uuid,
-                modifier = Modifier.size(100.dp)
+                modifier = Modifier.size(PodcastScreen.podcastImageSize)
             )
             Spacer(Modifier.height(4.dp))
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
@@ -2,15 +2,19 @@ package au.com.shiftyjelly.pocketcasts.wear.ui.podcast
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -83,20 +87,33 @@ private fun Content(
                 Spacer(Modifier.height(4.dp))
             }
             item {
-                Text(
-                    modifier = Modifier.fillMaxWidth(),
-                    textAlign = TextAlign.Center,
-                    color = MaterialTheme.theme.colors.primaryText01,
-                    text = podcast.title
-                )
-            }
-            item {
-                Text(
-                    modifier = Modifier.fillMaxWidth(),
-                    textAlign = TextAlign.Center,
-                    color = MaterialTheme.theme.colors.primaryText02,
-                    text = podcast.author
-                )
+                Column {
+                    Text(
+                        modifier = modifier.fillMaxWidth(),
+                        textAlign = TextAlign.Center,
+                        color = MaterialTheme.theme.colors.primaryText01,
+                        text = podcast.title,
+                        style = MaterialTheme.typography.button
+                    )
+                    Text(
+                        modifier = modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp),
+                        textAlign = TextAlign.Center,
+                        color = MaterialTheme.theme.colors.primaryText02,
+                        text = podcast.author,
+                        style = MaterialTheme.typography.body2.merge(
+                            @Suppress("DEPRECATION")
+                            (
+                                TextStyle(
+                                    platformStyle = PlatformTextStyle(
+                                        includeFontPadding = false,
+                                    ),
+                                )
+                                )
+                        )
+                    )
+                }
             }
             items(state.episodes) { episode ->
                 EpisodeChip(

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
@@ -8,18 +8,16 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.items
-import androidx.wear.compose.material.Chip
-import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.wear.theme.theme
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.EpisodeChip
 
 object PodcastScreen {
     const val argument = "podcastUuid"
@@ -69,24 +67,9 @@ fun PodcastScreen(
                 episode = episode,
                 onClick = {
                     onEpisodeTap(episode)
-                }
+                },
+                showImage = false,
             )
         }
     }
-}
-
-@Composable
-private fun EpisodeChip(
-    episode: PodcastEpisode,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Chip(
-        onClick = { onClick() },
-        colors = ChipDefaults.secondaryChipColors(),
-        label = {
-            Text(episode.title, maxLines = 1, overflow = TextOverflow.Ellipsis)
-        },
-        modifier = modifier.fillMaxWidth()
-    )
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastViewModel.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -20,6 +21,7 @@ class PodcastViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val episodeManager: EpisodeManager,
     private val podcastManager: PodcastManager,
+    private val theme: Theme,
 ) : ViewModel() {
 
     private val podcastUuid: String = savedStateHandle[PodcastScreen.argument] ?: ""
@@ -29,6 +31,7 @@ class PodcastViewModel @Inject constructor(
         data class Loaded(
             val podcast: Podcast? = null,
             val episodes: List<PodcastEpisode> = emptyList(),
+            val theme: Theme,
         ) : UiState()
     }
 
@@ -44,6 +47,7 @@ class PodcastViewModel @Inject constructor(
             uiState = UiState.Loaded(
                 podcast = podcast,
                 episodes = episodes,
+                theme = theme,
             )
         }
     }


### PR DESCRIPTION
## Description

This improves watch app podcast screen UI.

## Testing Instructions
1. Install the watch app
2. Login with an account having podcasts
3. Tap on a podcast to open the podcast details page
4. Tap on a podcast episode and download it
5. Go back, tap on another episode, and download + add to play next
6. Go back and notice that
    - Podcast screen UI matches Figma design
    - Time text scrolls away on scrolling 
7. Go to "Up Next" screen or "Downloads" screen
8. Notice that episode chips are rendered properly (podcast screen reuses episode chips used on these screens)

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/5347cc05-a395-4661-b24f-1c26f462a072


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
