### PR TITLE
Open watch app's Now Playing screen when tapping on episode screen's Play icon

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -35,6 +35,7 @@ import au.com.shiftyjelly.pocketcasts.wear.ui.downloads.DownloadsScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.episode.EpisodeScreenFlow
 import au.com.shiftyjelly.pocketcasts.wear.ui.episode.EpisodeScreenFlow.episodeGraph
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.EffectsScreen
+import au.com.shiftyjelly.pocketcasts.wear.ui.player.NowPlayingScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.PCVolumeScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.StreamingConfirmationScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcast.PodcastScreen
@@ -120,7 +121,7 @@ fun WearApp(
                     navigateToRoute = navController::navigate,
                     toNowPlaying = {
                         coroutineScope.launch {
-                            pagerState.animateScrollToPage(1)
+                            pagerState.animateScrollToPage(NowPlayingScreen.pagerIndex)
                         }
                     },
                 )

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
@@ -49,11 +49,15 @@ fun EpisodeScreen(
     navigateToConfirmDeleteDownload: () -> Unit,
     navigateToRemoveFromUpNextNotification: () -> Unit,
     navigateToStreamingConfirmation: () -> Unit,
+    navigateToNowPlaying: () -> Unit,
 ) {
 
     val viewModel = hiltViewModel<EpisodeViewModel>()
     val state = viewModel.stateFlow.collectAsState().value
     if (state !is EpisodeViewModel.State.Loaded) return
+
+    val showNowPlaying = viewModel.showNowPlaying.collectAsState(false).value
+    if (showNowPlaying) navigateToNowPlaying()
 
     val episode = state.episode
     val podcast = state.podcast

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreenFlow.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreenFlow.kt
@@ -2,8 +2,10 @@ package au.com.shiftyjelly.pocketcasts.wear.ui.episode
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -18,11 +20,13 @@ import androidx.wear.compose.material.SwipeToDismissBoxState
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.NotificationScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.NowPlayingPager
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ObtainConfirmationScreen
+import au.com.shiftyjelly.pocketcasts.wear.ui.player.NowPlayingScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.StreamingConfirmationScreen
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
 import com.google.android.horologist.compose.navscaffold.composable
 import com.google.android.horologist.compose.navscaffold.scrollable
+import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 object EpisodeScreenFlow {
@@ -37,6 +41,7 @@ object EpisodeScreenFlow {
     private const val deleteDownloadNotificationScreen = "deleteDownloadNotificationScreen"
     private const val removeFromUpNextNotificationScreen = "removeFromUpNextNotificationScreen"
 
+    @OptIn(ExperimentalFoundationApi::class)
     fun NavGraphBuilder.episodeGraph(
         navigateToPodcast: (podcastUuid: String) -> Unit,
         navController: NavController,
@@ -71,9 +76,13 @@ object EpisodeScreenFlow {
                         }
                     }
 
+                val pagerState = rememberPagerState()
+                val coroutineScope = rememberCoroutineScope()
+
                 @OptIn(ExperimentalFoundationApi::class)
                 NowPlayingPager(
                     navController = navController,
+                    pagerState = pagerState,
                     swipeToDismissState = swipeToDismissState,
                     scrollableScaffoldContext = it,
                 ) {
@@ -89,6 +98,11 @@ object EpisodeScreenFlow {
                         },
                         navigateToStreamingConfirmation = {
                             navController.navigate(StreamingConfirmationScreen.route)
+                        },
+                        navigateToNowPlaying = {
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(NowPlayingScreen.pagerIndex)
+                            }
                         },
                     )
                 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -36,6 +36,7 @@ import coil.request.SuccessResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -103,6 +104,8 @@ class EpisodeViewModel @Inject constructor(
     )
 
     val stateFlow: StateFlow<State>
+    var showNowPlaying = MutableSharedFlow<Boolean>()
+        private set
 
     init {
         val episodeUuid = savedStateHandle.get<String>(EpisodeScreenFlow.episodeUuidArgument)
@@ -259,6 +262,7 @@ class EpisodeViewModel @Inject constructor(
                 episode = episode,
                 playbackSource = analyticsSource,
             )
+            showNowPlaying.emit(true)
         }
     }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
@@ -104,8 +105,10 @@ class EpisodeViewModel @Inject constructor(
     )
 
     val stateFlow: StateFlow<State>
-    var showNowPlaying = MutableSharedFlow<Boolean>()
-        private set
+
+    // SharedFlow used for one shot operation like navigating to the Now Playing screen
+    private val _showNowPlaying = MutableSharedFlow<Boolean>()
+    val showNowPlaying = _showNowPlaying.asSharedFlow()
 
     init {
         val episodeUuid = savedStateHandle.get<String>(EpisodeScreenFlow.episodeUuidArgument)
@@ -262,7 +265,7 @@ class EpisodeViewModel @Inject constructor(
                 episode = episode,
                 playbackSource = analyticsSource,
             )
-            showNowPlaying.emit(true)
+            _showNowPlaying.emit(true)
         }
     }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingScreen.kt
@@ -42,6 +42,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 object NowPlayingScreen {
     const val route = "now_playing"
+    const val pagerIndex = 1
 }
 
 @OptIn(ExperimentalWearFoundationApi::class)


### PR DESCRIPTION
## Description
This opens watch app's Now Playing screen when tapping on episode screen's Play icon

## Testing Instructions

1. Install the app
2. Login with an account having podcasts
3. Open `Podcasts` -> `Podcast` -> `Episode` screen
4. Tap play on the `Episode` screen
5. ✅ Notice that `Now playing` screen is shown
6.  Comment out lines 243, 245-247 inside `EpisodeViewModel`'s `fun onPlayClicked(showStreamingConfirmation: () -> Unit)` to show the streaming dialog confirmation
7. Reinstall the app and repeat steps 3-4
8. Notice that Streaming confirmation dialog is shown
9. Tap X
10. Notice that Streaming confirmation dialog is dismissed and you're not navigated to the `Now playing` screen
11. Re-tap play on the Episode screen
12. Notice that Streaming confirmation dialog is shown
13. Tap ✔️ 
14. ✅ Notice that `Now playing` screen is shown

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/a1427666-22cc-4712-9aa8-996dbaa89061

https://github.com/Automattic/pocket-casts-android/assets/1405144/a6e243be-5d32-4230-85b7-ebec4d584584

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
