### PR TITLE
Bump horologist

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -92,7 +92,7 @@ project.ext {
 
     // When updating this, check to see if versionComposeWear will be updated as well (and update that variable if appropriate)
     // https://github.com/google/horologist/blob/main/gradle/libs.versions.toml
-    versionHorologist = '0.4.5'
+    versionHorologist = '0.4.6'
 
     versionKotlinCoroutines = '1.6.4'
     versionLifecycle = '2.6.0'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -92,7 +92,7 @@ project.ext {
 
     // When updating this, check to see if versionComposeWear will be updated as well (and update that variable if appropriate)
     // https://github.com/google/horologist/blob/main/gradle/libs.versions.toml
-    versionHorologist = '0.4.2'
+    versionHorologist = '0.4.3'
 
     versionKotlinCoroutines = '1.6.4'
     versionLifecycle = '2.6.0'
@@ -200,7 +200,7 @@ project.ext {
             horologistMedia3Backend: "com.google.android.horologist:horologist-media3-backend:$versionHorologist",
             horologistMediaUi: "com.google.android.horologist:horologist-media-ui:$versionHorologist",
             horologistMediaData: "com.google.android.horologist:horologist-media-data:$versionHorologist",
-            horologistNetworkAwarness: "com.google.android.horologist:horologist-network-awareness:$versionHorologist",
+            horologistNetworkAwarnessOkHttp: "com.google.android.horologist:horologist-network-awareness-okhttp:$versionHorologist",
 
             media3DatasourceOkhttp: "androidx.media3:media3-datasource-okhttp:$versionMedia3",
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -92,7 +92,7 @@ project.ext {
 
     // When updating this, check to see if versionComposeWear will be updated as well (and update that variable if appropriate)
     // https://github.com/google/horologist/blob/main/gradle/libs.versions.toml
-    versionHorologist = '0.4.3'
+    versionHorologist = '0.4.4'
 
     versionKotlinCoroutines = '1.6.4'
     versionLifecycle = '2.6.0'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -92,7 +92,7 @@ project.ext {
 
     // When updating this, check to see if versionComposeWear will be updated as well (and update that variable if appropriate)
     // https://github.com/google/horologist/blob/main/gradle/libs.versions.toml
-    versionHorologist = '0.4.4'
+    versionHorologist = '0.4.5'
 
     versionKotlinCoroutines = '1.6.4'
     versionLifecycle = '2.6.0'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -92,7 +92,7 @@ project.ext {
 
     // When updating this, check to see if versionComposeWear will be updated as well (and update that variable if appropriate)
     // https://github.com/google/horologist/blob/main/gradle/libs.versions.toml
-    versionHorologist = '0.4.6'
+    versionHorologist = '0.4.7'
 
     versionKotlinCoroutines = '1.6.4'
     versionLifecycle = '2.6.0'

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     implementation androidLibs.horologistMedia3Backend
     implementation androidLibs.horologistMediaData
     implementation androidLibs.horologistMediaUi
-    implementation androidLibs.horologistNetworkAwarness
+    implementation androidLibs.horologistNetworkAwarnessOkHttp
 
     implementation androidLibs.media3DatasourceOkhttp
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -94,7 +94,7 @@ fun WearApp(
         scrollable(
             route = WatchListScreen.route,
         ) {
-            val pagerState = rememberPagerState()
+            val pagerState = rememberPagerState { NowPlayingPager.pageCount }
             val coroutineScope = rememberCoroutineScope()
             NowPlayingPager(
                 navController = navController,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/WearNetworkModule.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/WearNetworkModule.kt
@@ -73,6 +73,9 @@ object WearNetworkModule {
         )
 
     @Provides
+    fun provideNetworkLogger(): NetworkStatusLogger = NetworkStatusLogger.Logging
+
+    @Provides
     @Singleton
     @DownloadCallFactory
     fun provideDownloadWearCallFactory(
@@ -81,6 +84,7 @@ object WearNetworkModule {
         networkingRulesEngine: NetworkingRulesEngine,
         @DownloadOkHttpClient phoneCallFactory: OkHttpClient,
         @ForApplicationScope coroutineScope: CoroutineScope,
+        logger: NetworkStatusLogger
     ): Call.Factory {
 
         return NetworkSelectingCallFactory(
@@ -91,6 +95,7 @@ object WearNetworkModule {
             rootClient = phoneCallFactory,
             coroutineScope = coroutineScope,
             timeout = 5.seconds,
+            logger = logger,
         )
     }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/NowPlayingPager.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/NowPlayingPager.kt
@@ -23,6 +23,9 @@ import com.google.android.horologist.compose.navscaffold.ScrollableScaffoldConte
 import com.google.android.horologist.compose.pager.PagerScreen
 import kotlinx.coroutines.launch
 
+object NowPlayingPager {
+    const val pageCount = 3
+}
 /**
  * Pager with three pages:
  *
@@ -33,7 +36,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun NowPlayingPager(
     navController: NavController,
-    pagerState: PagerState = rememberPagerState(),
+    pagerState: PagerState = rememberPagerState { NowPlayingPager.pageCount },
     swipeToDismissState: SwipeToDismissBoxState,
     scrollableScaffoldContext: ScrollableScaffoldContext? = null,
     firstPageContent: @Composable () -> Unit,
@@ -62,7 +65,6 @@ fun NowPlayingPager(
     }
 
     PagerScreen(
-        count = 3,
         state = pagerState,
         modifier = modifier
     ) { page ->

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreenFlow.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreenFlow.kt
@@ -76,7 +76,7 @@ object EpisodeScreenFlow {
                         }
                     }
 
-                val pagerState = rememberPagerState()
+                val pagerState = rememberPagerState { NowPlayingPager.pageCount }
                 val coroutineScope = rememberCoroutineScope()
 
                 @OptIn(ExperimentalFoundationApi::class)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingScreen.kt
@@ -201,9 +201,10 @@ fun NowPlayingSettingsButtons(
     }
 }
 
+@Composable
 private fun Modifier.onVolumeChangeByScroll(
     focusRequester: FocusRequester,
-    onVolumeChangeByScroll: (scrollPixels: Float) -> Unit
+    onVolumeChangeByScroll: (scrollPixels: Float) -> Unit,
 ) =
     onRotaryInputAccumulated(onValueChange = onVolumeChangeByScroll)
         .focusRequester(focusRequester)


### PR DESCRIPTION
## Description

This updates the horologist lib version from `0.4.2` to `0.4.7` ([release notes](https://github.com/google/horologist/releases))
Changes are made just so that the wear app compiles after the version bump. Improvements like using `StandardToggleChip` added in `0.4.7` to handle the largest font scale will be taken up separately. 

## Testing Instructions
1. Notice that the marque text background is improved on the Now Playing screen after bringing in changes from [0.4.3](https://github.com/google/horologist/releases/tag/v0.4.3) in 2299cf7db23c412f961621e3fd90bc5f75810ce2
2. Play with the pager to see if it is not broken after bringing in new pager APIs from version [0.4.6](https://github.com/google/horologist/releases/tag/v0.4.6) in 7993d15a9f8ef42576120df92b15e0953da8246c
3. Smoke test the app to see if anything is not working based on the  ([release notes](https://github.com/google/horologist/releases)).

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
