### PR TITLE
Improving the Wear OS podcasts page

### DIFF
--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Color.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Color.kt
@@ -1,0 +1,8 @@
+package au.com.shiftyjelly.pocketcasts.compose.extensions
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.core.graphics.ColorUtils
+
+fun Color.darker(factor: Float = 1f) =
+    Color(ColorUtils.blendARGB(this.toArgb(), Color.Black.toArgb(), factor))

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -46,12 +46,9 @@ import com.google.android.horologist.compose.navscaffold.composable
 import com.google.android.horologist.compose.navscaffold.scrollable
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-
-    @Inject lateinit var theme: Theme
 
     private val viewModel: WearMainActivityViewModel by viewModels()
 
@@ -59,7 +56,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             val state by viewModel.state.collectAsState()
-            WearAppTheme(theme.activeTheme) {
+            WearAppTheme(Theme.ThemeType.EXTRA_DARK) {
                 WearApp(
                     signInConfirmationAction = state.signInConfirmationAction,
                     onSignInConfirmationActionHandled = viewModel::onSignInConfirmationActionHandled,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearAppTheme.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearAppTheme.kt
@@ -3,6 +3,8 @@ package au.com.shiftyjelly.pocketcasts.wear.theme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
 import androidx.wear.compose.material.Colors
 import androidx.wear.compose.material.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.compose.LocalColors
@@ -19,11 +21,51 @@ fun WearAppTheme(
     val colors = themeTypeToColors(themeType)
     val isLight = !themeType.darkTheme
     val theme = PocketCastsTheme(colors = colors, isLight = isLight)
+    val typography = MaterialTheme.typography
 
     CompositionLocalProvider(LocalColors provides theme) {
         // Using the wear.compose.material theme here
         // instead of the regular compose.material theme we use in the phone app
         MaterialTheme(
+            typography = typography.copy(
+                display1 = typography.display1,
+                display2 = typography.display2,
+                display3 = typography.display3,
+                title1 = typography.title1,
+                title2 = typography.title2.copy(
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 16.sp,
+                    lineHeight = 20.sp,
+                    letterSpacing = 0.2.sp
+                ),
+                title3 = typography.title3.copy(
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 14.sp,
+                    lineHeight = 18.sp,
+                    letterSpacing = 0.sp
+                ),
+                body1 = typography.body1.copy(
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 14.sp,
+                    lineHeight = 18.sp,
+                    letterSpacing = 0.sp
+                ),
+                body2 = typography.body2.copy(
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 12.sp,
+                    lineHeight = 16.sp,
+                    letterSpacing = 0.sp
+                ),
+                button = typography.button.copy(
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 14.sp,
+                    lineHeight = 18.sp,
+                    letterSpacing = 0.sp
+                ),
+                caption1 = typography.caption1,
+                caption2 = typography.caption2,
+                caption3 = typography.caption3
+            ),
             colors = buildWearMaterialColors(colors),
             content = content
         )

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearAppTheme.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearAppTheme.kt
@@ -1,94 +1,82 @@
 package au.com.shiftyjelly.pocketcasts.wear.theme
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import androidx.wear.compose.material.Colors
 import androidx.wear.compose.material.MaterialTheme
-import au.com.shiftyjelly.pocketcasts.compose.LocalColors
-import au.com.shiftyjelly.pocketcasts.compose.PocketCastsTheme
-import au.com.shiftyjelly.pocketcasts.compose.ThemeColors
-import au.com.shiftyjelly.pocketcasts.compose.themeTypeToColors
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 
 @Composable
 fun WearAppTheme(
-    themeType: Theme.ThemeType,
     content: @Composable () -> Unit
 ) {
-    val colors = themeTypeToColors(themeType)
-    val isLight = !themeType.darkTheme
-    val theme = PocketCastsTheme(colors = colors, isLight = isLight)
     val typography = MaterialTheme.typography
 
-    CompositionLocalProvider(LocalColors provides theme) {
-        // Using the wear.compose.material theme here
-        // instead of the regular compose.material theme we use in the phone app
-        MaterialTheme(
-            typography = typography.copy(
-                display1 = typography.display1,
-                display2 = typography.display2,
-                display3 = typography.display3,
-                title1 = typography.title1,
-                title2 = typography.title2.copy(
-                    fontWeight = FontWeight.Medium,
-                    fontSize = 16.sp,
-                    lineHeight = 20.sp,
-                    letterSpacing = 0.2.sp
-                ),
-                title3 = typography.title3.copy(
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 14.sp,
-                    lineHeight = 18.sp,
-                    letterSpacing = 0.sp
-                ),
-                body1 = typography.body1.copy(
-                    fontWeight = FontWeight.Normal,
-                    fontSize = 14.sp,
-                    lineHeight = 18.sp,
-                    letterSpacing = 0.sp
-                ),
-                body2 = typography.body2.copy(
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 12.sp,
-                    lineHeight = 16.sp,
-                    letterSpacing = 0.sp
-                ),
-                button = typography.button.copy(
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 14.sp,
-                    lineHeight = 18.sp,
-                    letterSpacing = 0.sp
-                ),
-                caption1 = typography.caption1,
-                caption2 = typography.caption2,
-                caption3 = typography.caption3
+    // Using the wear.compose.material theme here
+    // instead of the regular compose.material theme we use in the phone app
+    MaterialTheme(
+        typography = typography.copy(
+            display1 = typography.display1,
+            display2 = typography.display2,
+            display3 = typography.display3,
+            title1 = typography.title1,
+            title2 = typography.title2.copy(
+                fontWeight = FontWeight.Medium,
+                fontSize = 16.sp,
+                lineHeight = 20.sp,
+                letterSpacing = 0.2.sp
             ),
-            colors = buildWearMaterialColors(colors),
-            content = content
-        )
-    }
-}
-
-private fun buildWearMaterialColors(colors: ThemeColors): Colors {
-    return Colors(
-        primary = colors.primaryText01,
-        primaryVariant = colors.primaryText01,
-        secondary = colors.primaryText02,
-        secondaryVariant = colors.primaryText02,
-        background = colors.primaryUi04,
-        surface = colors.primaryUi01,
-        error = colors.support05,
-        onPrimary = colors.primaryInteractive02,
-        onSecondary = colors.primaryInteractive02,
-        onBackground = colors.secondaryIcon02,
-        onSurface = colors.primaryText01,
-        onError = colors.secondaryIcon01,
+            title3 = typography.title3.copy(
+                fontWeight = FontWeight.Bold,
+                fontSize = 14.sp,
+                lineHeight = 18.sp,
+                letterSpacing = 0.sp
+            ),
+            body1 = typography.body1.copy(
+                fontWeight = FontWeight.Normal,
+                fontSize = 14.sp,
+                lineHeight = 18.sp,
+                letterSpacing = 0.sp
+            ),
+            body2 = typography.body2.copy(
+                fontWeight = FontWeight.Bold,
+                fontSize = 12.sp,
+                lineHeight = 16.sp,
+                letterSpacing = 0.sp
+            ),
+            button = typography.button.copy(
+                fontWeight = FontWeight.Bold,
+                fontSize = 14.sp,
+                lineHeight = 18.sp,
+                letterSpacing = 0.sp
+            ),
+            caption1 = typography.caption1,
+            caption2 = typography.caption2,
+            caption3 = typography.caption3
+        ),
+        colors = buildWearMaterialColors(),
+        content = content
     )
 }
-val MaterialTheme.theme: PocketCastsTheme
-    @Composable
-    @ReadOnlyComposable
-    get() = LocalColors.current
+
+private fun buildWearMaterialColors(): Colors {
+    val backgroundColor = Color.Black
+    val surfaceColor = WearColors.surface
+    val primaryTextColor = WearColors.primaryText
+    val secondaryTextColor = WearColors.secondaryText
+    return Colors(
+        primary = surfaceColor,
+        primaryVariant = surfaceColor,
+        secondary = surfaceColor,
+        secondaryVariant = surfaceColor,
+        background = backgroundColor,
+        surface = surfaceColor,
+        error = WearColors.highlight,
+        onPrimary = primaryTextColor,
+        onSecondary = secondaryTextColor,
+        onBackground = primaryTextColor,
+        onSurface = primaryTextColor,
+        onError = primaryTextColor,
+    )
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearColors.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearColors.kt
@@ -3,8 +3,11 @@ package au.com.shiftyjelly.pocketcasts.wear.theme
 import androidx.compose.ui.graphics.Color
 
 object WearColors {
-    val FF202124 = Color(0xFF202124)
-    val FFA1E7B0 = Color(0xFFA1E7B0)
-    val FFBDC1C6 = Color(0xFFBDC1C6)
-    val FFDADCE0 = Color(0xFFDADCE0)
+    val highlight = Color(0xFFF43E37)
+    val success = Color(0xFFA1E7B0)
+    val surface = Color(0xFF202124)
+    val primaryText = Color.White
+    val secondaryText = Color(0xFFBDC1C6)
+    val upNextIcon = Color(0xFF4BA1D6)
+    val downloadedIcon = Color(0xFF54C483)
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesScreen.kt
@@ -67,6 +67,7 @@ private fun EmptyState() {
         Text(
             text = stringResource(LR.string.profile_cloud_no_files_uploaded),
             textAlign = TextAlign.Center,
+            color = MaterialTheme.colors.onPrimary,
             style = MaterialTheme.typography.title3,
         )
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FiltersScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FiltersScreen.kt
@@ -25,7 +25,8 @@ fun FiltersScreen() {
         Text(
             modifier = Modifier.fillMaxWidth(),
             textAlign = TextAlign.Center,
-            color = MaterialTheme.colors.primary,
+            color = MaterialTheme.colors.onPrimary,
+            style = MaterialTheme.typography.body1,
             text = stringResource(LR.string.filters)
         )
         Text(

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/LoggingInScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/LoggingInScreen.kt
@@ -31,7 +31,6 @@ import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.compose.images.GravatarProfileImage
 import au.com.shiftyjelly.pocketcasts.compose.images.ProfileImage
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.LoadingSpinner
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -117,7 +116,8 @@ private fun Content(
             Text(
                 text = stringResource(LR.string.profile_logging_in),
                 textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.title3
+                color = MaterialTheme.colors.onPrimary,
+                style = MaterialTheme.typography.title2
             )
         }
 
@@ -134,7 +134,8 @@ private fun Content(
                 if (email != null) {
                     Text(
                         text = email,
-                        style = MaterialTheme.typography.body2,
+                        color = MaterialTheme.colors.onPrimary,
+                        style = MaterialTheme.typography.body1,
                         // Turn off softWrap to make sure the text doesn't get truncated if it runs long.
                         // Without this if "xxxx@gmail.com" ran just a bit long, it would get shortened
                         // to "xxx@gmail".
@@ -178,7 +179,7 @@ private fun Modifier.fadeOutOverflow(
 @Preview
 @Composable
 private fun LoggingInScreenPreview() {
-    WearAppTheme(Theme.ThemeType.DARK) {
+    WearAppTheme {
         LoggingInScreen(
             onClose = {}
         )

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/NowPlayingChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/NowPlayingChip.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.painter.Painter
@@ -27,9 +26,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.ui.images.PodcastImageLoaderThemed
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
-import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
 import coil.compose.rememberAsyncImagePainter
 import com.airbnb.lottie.compose.LottieAnimation
@@ -109,8 +106,8 @@ private fun Content(
             } else {
                 SolidColor(MaterialTheme.colors.surface)
             },
-            contentColor = Color.White,
-            secondaryContentColor = WearColors.FFDADCE0,
+            contentColor = MaterialTheme.colors.onPrimary,
+            secondaryContentColor = MaterialTheme.colors.onSecondary,
         ),
         onClick = onClick,
         modifier = Modifier.fillMaxWidth() // This is needed for the backgroundImagePainter to work
@@ -148,7 +145,7 @@ private fun PlayIcon() {
 )
 @Composable
 private fun Preview() {
-    WearAppTheme(Theme.ThemeType.DARK) {
+    WearAppTheme {
         Content(
             podcast = Podcast(
                 uuid = "b643cb50-2c52-013b-ef7a-0acc26574db2",

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/SettingsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/SettingsScreen.kt
@@ -26,9 +26,7 @@ import androidx.wear.compose.material.ToggleChipDefaults
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
-import au.com.shiftyjelly.pocketcasts.wear.theme.theme
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.SectionHeaderChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
@@ -173,13 +171,14 @@ fun ToggleChip(
     checked: Boolean,
     onCheckedChanged: (Boolean) -> Unit,
 ) {
-    val color = MaterialTheme.theme.colors.support05
+    val color = MaterialTheme.colors.error
     ToggleChip(
         checked = checked,
         onCheckedChange = { onCheckedChanged(it) },
         label = {
             Text(
                 text = label,
+                color = MaterialTheme.colors.onPrimary,
                 style = MaterialTheme.typography.button,
             )
         },
@@ -207,7 +206,7 @@ fun ToggleChip(
 )
 @Composable
 private fun SettingsScreenPreview_unchecked() {
-    WearAppTheme(Theme.ThemeType.DARK) {
+    WearAppTheme {
         Content(
             scrollState = ScalingLazyColumnState(),
             state = SettingsViewModel.State(
@@ -233,7 +232,7 @@ private fun SettingsScreenPreview_unchecked() {
 )
 @Composable
 private fun SettingsScreenPreview_checked() {
-    WearAppTheme(Theme.ThemeType.DARK) {
+    WearAppTheme {
         Content(
             scrollState = ScalingLazyColumnState(),
             state = SettingsViewModel.State(

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
@@ -81,13 +81,15 @@ private fun EmptyQueueState() {
         Text(
             text = stringResource(LR.string.player_up_next_empty),
             textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.title3,
+            color = MaterialTheme.colors.onPrimary,
+            style = MaterialTheme.typography.title2,
         )
         Spacer(Modifier.height(8.dp))
         Text(
             text = stringResource(LR.string.player_up_next_empty_desc_watch),
             textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.body2,
+            color = MaterialTheme.colors.onPrimary,
+            style = MaterialTheme.typography.body1,
         )
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
@@ -10,13 +10,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.ScalingLazyListState
-import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.downloads.DownloadsScreen
@@ -104,10 +101,8 @@ fun WatchListScreen(
 
 @Preview(device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
 @Composable
-private fun WatchListPreview(
-    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
-) {
-    WearAppTheme(themeType) {
+private fun WatchListPreview() {
+    WearAppTheme {
         WatchListScreen(
             toNowPlaying = {},
             navigateToRoute = {},

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -30,18 +29,18 @@ fun LoginScreen(
         item {
             Text(
                 text = stringResource(LR.string.log_in),
-                style = MaterialTheme.typography.title3,
                 textAlign = TextAlign.Center,
-                color = Color.White,
+                color = MaterialTheme.colors.onPrimary,
+                style = MaterialTheme.typography.title2,
             )
         }
 
         item {
             Text(
                 text = stringResource(LR.string.log_in_subtitle),
-                style = MaterialTheme.typography.body2,
                 textAlign = TextAlign.Center,
-                color = Color.White,
+                color = MaterialTheme.colors.onPrimary,
+                style = MaterialTheme.typography.body1,
             )
         }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ChipScreenHeaders.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ChipScreenHeaders.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
-import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
 
 @Composable
 fun ScreenHeaderChip(
@@ -46,7 +45,7 @@ private fun Header(
 ) {
     Text(
         text = stringResource(text),
-        color = textColor ?: WearColors.FFBDC1C6,
+        color = textColor ?: MaterialTheme.colors.onSecondary,
         textAlign = TextAlign.Center,
         style = MaterialTheme.typography.button,
         modifier = modifier.fillMaxWidth()

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
@@ -39,7 +39,7 @@ import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatPattern
-import au.com.shiftyjelly.pocketcasts.wear.theme.theme
+import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -107,7 +107,7 @@ fun EpisodeChip(
                     text = episode.title,
                     lineHeight = 16.sp,
                     overflow = TextOverflow.Ellipsis,
-                    color = MaterialTheme.theme.colors.primaryText01,
+                    color = MaterialTheme.colors.onPrimary,
                     style = MaterialTheme.typography.button.merge(
                         @Suppress("DEPRECATION")
                         (
@@ -141,7 +141,7 @@ fun EpisodeChip(
                     }
                     Text(
                         text = "$shortDate • $timeLeft",
-                        color = MaterialTheme.theme.colors.primaryText02,
+                        color = MaterialTheme.colors.onSecondary,
                         style = MaterialTheme.typography.caption2,
                     )
                 }
@@ -164,7 +164,7 @@ private fun IconsRow(
             Icon(
                 painter = painterResource(R.drawable.ic_upnext),
                 contentDescription = stringResource(LR.string.episode_in_up_next),
-                tint = MaterialTheme.theme.colors.support01,
+                tint = WearColors.upNextIcon,
                 modifier = Modifier.size(12.dp),
             )
         }
@@ -173,7 +173,7 @@ private fun IconsRow(
             Icon(
                 painter = painterResource(R.drawable.ic_downloaded),
                 contentDescription = stringResource(LR.string.downloaded),
-                tint = MaterialTheme.theme.colors.support02,
+                tint = WearColors.downloadedIcon,
                 modifier = Modifier.size(12.dp),
             )
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ErrorScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ErrorScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 
 @Composable
@@ -62,7 +61,7 @@ fun ErrorScreen(
 @Preview
 @Composable
 private fun NotificationScreenPreview() {
-    WearAppTheme(Theme.ThemeType.DARK) {
+    WearAppTheme {
         ErrorScreen("There was a problem")
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/NotificationScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/NotificationScreen.kt
@@ -17,8 +17,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
 import kotlinx.coroutines.delay
@@ -34,7 +34,7 @@ fun NotificationScreen(
     icon: @Composable () -> Unit = {
         Icon(
             painter = painterResource(IR.drawable.ic_check_black_24dp),
-            tint = WearColors.FFA1E7B0,
+            tint = WearColors.success,
             contentDescription = null,
             modifier = Modifier.size(52.dp)
         )
@@ -61,6 +61,7 @@ fun NotificationScreen(
         TextH30(
             text = text,
             textAlign = TextAlign.Center,
+            color = MaterialTheme.colors.onPrimary,
         )
     }
 }
@@ -68,7 +69,7 @@ fun NotificationScreen(
 @Preview
 @Composable
 private fun NotificationScreenPreview() {
-    WearAppTheme(Theme.ThemeType.DARK) {
+    WearAppTheme {
         NotificationScreen(
             text = "Done",
             onClose = {}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ObtainConfirmationScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/ObtainConfirmationScreen.kt
@@ -22,8 +22,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
-import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -40,6 +40,7 @@ fun ObtainConfirmationScreen(
         TextH30(
             text = text,
             textAlign = TextAlign.Center,
+            color = MaterialTheme.colors.onPrimary,
             modifier = Modifier
                 .padding(horizontal = 16.dp)
                 .fillMaxWidth()
@@ -57,7 +58,7 @@ fun ObtainConfirmationScreen(
                 Box(
                     contentAlignment = Alignment.Center,
                     modifier = Modifier
-                        .background(color = WearColors.FF202124)
+                        .background(color = MaterialTheme.colors.surface)
                         .clip(CircleShape)
                         .fillMaxSize()
                 ) {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/WatchListChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/WatchListChip.kt
@@ -14,7 +14,6 @@ import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
-import au.com.shiftyjelly.pocketcasts.wear.theme.theme
 import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.base.ui.util.adjustChipHeightToFontScale
@@ -67,7 +66,7 @@ fun WatchListChip(
     icon: (@Composable BoxScope.() -> Unit)? = null,
     secondaryLabel: String? = null,
     colors: ChipColors = ChipDefaults.secondaryChipColors(
-        secondaryContentColor = MaterialTheme.theme.colors.primaryText02
+        secondaryContentColor = MaterialTheme.colors.onPrimary
     ),
 ) {
     Chip(
@@ -75,6 +74,7 @@ fun WatchListChip(
             Text(
                 text = title,
                 style = MaterialTheme.typography.button,
+                color = MaterialTheme.colors.onPrimary,
                 overflow = TextOverflow.Ellipsis,
                 maxLines = if (secondaryLabel != null) 1 else 2,
             )
@@ -87,6 +87,7 @@ fun WatchListChip(
             if (secondaryLabel != null) {
                 Text(
                     text = secondaryLabel,
+                    color = MaterialTheme.colors.onSecondary,
                     overflow = TextOverflow.Ellipsis,
                 )
             }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.items
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.EpisodeChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
@@ -70,7 +69,7 @@ private fun Content(
 )
 @Composable
 private fun DownloadsScreenPreview() {
-    WearAppTheme(Theme.ThemeType.DARK) {
+    WearAppTheme {
         Content(
             columnState = ScalingLazyColumnState(),
             onItemClick = {},

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/DownloadButton.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/DownloadButton.kt
@@ -16,7 +16,6 @@ import androidx.wear.compose.material.CircularProgressIndicator
 import androidx.wear.compose.material.Icon
 import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.DownloadButtonState
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 
 @Composable
@@ -70,7 +69,7 @@ fun DownloadButton(
 @Preview
 @Composable
 private fun DownloadingPreview() {
-    WearAppTheme(Theme.ThemeType.DARK) {
+    WearAppTheme {
         Column {
             listOf(
                 DownloadButtonState.NotDownloaded("3 MB"),

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeDateTimeText.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeDateTimeText.kt
@@ -6,10 +6,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
-import au.com.shiftyjelly.pocketcasts.compose.components.TextC70
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatPattern
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
@@ -47,15 +47,23 @@ private fun LayoutContent(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
     ) {
-        TextC70("$shortDate • $timeLeft")
-        TextC70(downloadSize)
+        Text(
+            text = "$shortDate • $timeLeft",
+            style = MaterialTheme.typography.body2,
+            color = MaterialTheme.colors.onPrimary
+        )
+        Text(
+            text = downloadSize,
+            style = MaterialTheme.typography.body2,
+            color = MaterialTheme.colors.onPrimary
+        )
     }
 }
 
 @Preview
 @Composable
 private fun Preview() {
-    WearAppTheme(Theme.ThemeType.DARK) {
+    WearAppTheme {
         LayoutContent(
             shortDate = "06 Dec",
             timeLeft = "25m left",

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
@@ -26,13 +26,13 @@ import androidx.core.text.parseAsHtml
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.DownloadButtonState
 import au.com.shiftyjelly.pocketcasts.utils.Util
-import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ExpandableText
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
@@ -71,12 +71,14 @@ fun EpisodeScreen(
 
         val headingLineHeight = 14.sp
         item {
-            TextP50(
+            Text(
                 text = episode.title,
                 maxLines = 2,
                 fontWeight = W700,
                 lineHeight = headingLineHeight,
                 textAlign = TextAlign.Center,
+                color = MaterialTheme.colors.onPrimary,
+                style = MaterialTheme.typography.title3,
                 modifier = Modifier.padding(horizontal = 8.dp)
             )
         }
@@ -86,7 +88,8 @@ fun EpisodeScreen(
                 TextP50(
                     text = podcast.title,
                     maxLines = 1,
-                    color = WearColors.FFDADCE0,
+                    color = MaterialTheme.colors.onSecondary,
+                    style = MaterialTheme.typography.body1,
                     lineHeight = headingLineHeight,
                     textAlign = TextAlign.Center,
                     modifier = Modifier

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/PlayButton.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/PlayButton.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.images.R
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 
 @Composable
@@ -51,7 +50,7 @@ fun PlayButton(
 @Preview
 @Composable
 private fun Preview() {
-    WearAppTheme(Theme.ThemeType.DARK) {
+    WearAppTheme {
         Column {
             PlayButton(
                 isPlaying = true,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/QueueButton.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/QueueButton.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Icon
 import au.com.shiftyjelly.pocketcasts.images.R
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 
 @Composable
@@ -36,7 +35,7 @@ fun QueueButton(inUpNext: Boolean, tint: Color, onClick: () -> Unit) {
 @Preview
 @Composable
 private fun Preview() {
-    WearAppTheme(Theme.ThemeType.DARK) {
+    WearAppTheme {
         Column {
             QueueButton(
                 inUpNext = true,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/UpNextOptionsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/UpNextOptionsScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.wear.compose.foundation.lazy.items
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
@@ -66,7 +65,7 @@ private fun Content(
 @Preview
 @Composable
 private fun Preview() {
-    WearAppTheme(Theme.ThemeType.DARK) {
+    WearAppTheme {
         Content(
             columnState = ScalingLazyColumnState(),
             upNextOptions = listOf(

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsScreen.kt
@@ -33,7 +33,6 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.wear.theme.theme
 import au.com.shiftyjelly.pocketcasts.wear.ui.ToggleChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
@@ -168,7 +167,10 @@ private fun SpeedChip(
                             contentDescription = stringResource(LR.string.player_effects_speed_up),
                         )
                     }
-                    TextH30(text = String.format("%.1fx", state.playbackEffects.playbackSpeed))
+                    TextH30(
+                        text = String.format("%.1fx", state.playbackEffects.playbackSpeed),
+                        color = MaterialTheme.colors.onPrimary,
+                    )
                     IconButton(onClick = onPlusClicked) {
                         Icon(
                             painter = painterResource(IR.drawable.plus_simple),
@@ -203,6 +205,7 @@ fun TrimSilenceSlider(
             TextH50(
                 text = stringResource(id = LR.string.player_effects_trim_silence),
                 fontWeight = FontWeight.W700,
+                color = MaterialTheme.colors.onPrimary,
                 modifier = Modifier.padding(start = 8.dp)
             )
         }
@@ -226,7 +229,7 @@ fun TrimSilenceSlider(
             steps = 2,
             segmented = true,
             colors = InlineSliderDefaults.colors(
-                selectedBarColor = MaterialTheme.theme.colors.support05
+                selectedBarColor = MaterialTheme.colors.onSurface
             )
         )
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
@@ -28,7 +28,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
-import au.com.shiftyjelly.pocketcasts.wear.theme.theme
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.EpisodeChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcast.PodcastViewModel.UiState
 
@@ -91,7 +90,7 @@ private fun Content(
                     Text(
                         modifier = modifier.fillMaxWidth(),
                         textAlign = TextAlign.Center,
-                        color = MaterialTheme.theme.colors.primaryText01,
+                        color = MaterialTheme.colors.onPrimary,
                         text = podcast.title,
                         style = MaterialTheme.typography.button
                     )
@@ -100,7 +99,7 @@ private fun Content(
                             .fillMaxWidth()
                             .padding(bottom = 8.dp),
                         textAlign = TextAlign.Center,
-                        color = MaterialTheme.theme.colors.primaryText02,
+                        color = MaterialTheme.colors.onSecondary,
                         text = podcast.author,
                         style = MaterialTheme.typography.body2.merge(
                             @Suppress("DEPRECATION")

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
@@ -7,10 +7,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.ScalingLazyListState
@@ -22,7 +20,6 @@ import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.extensions.darker
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
-import au.com.shiftyjelly.pocketcasts.wear.theme.theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 object PodcastsScreen {
@@ -45,8 +42,8 @@ fun PodcastsScreen(
         item {
             Text(
                 text = stringResource(LR.string.podcasts),
-                style = MaterialTheme.typography.title2,
-                color = MaterialTheme.theme.colors.primaryText01,
+                style = MaterialTheme.typography.button,
+                color = MaterialTheme.colors.onSecondary,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
         }
@@ -74,11 +71,9 @@ private fun PodcastChip(
             Text(
                 text = podcast.title,
                 maxLines = 2,
-                fontSize = 14.sp,
-                lineHeight = 16.sp,
-                fontWeight = FontWeight.Bold,
                 overflow = TextOverflow.Ellipsis,
-                color = Color.White
+                style = MaterialTheme.typography.button,
+                color = MaterialTheme.colors.onPrimary
             )
         },
         icon = {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
@@ -40,14 +40,14 @@ fun PodcastsScreen(
 
     ScalingLazyColumn(
         modifier = modifier.fillMaxWidth(),
-        state = listState,
+        state = listState
     ) {
         item {
             Text(
                 text = stringResource(LR.string.podcasts),
                 style = MaterialTheme.typography.title2,
                 color = MaterialTheme.theme.colors.primaryText01,
-                modifier = Modifier.padding(bottom = 24.dp)
+                modifier = Modifier.padding(bottom = 16.dp)
             )
         }
         items(items = uiState.items, key = { item -> item.uuid }) { item ->

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
@@ -1,20 +1,29 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui.podcasts
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.ScalingLazyListState
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.extensions.darker
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
+import au.com.shiftyjelly.pocketcasts.wear.theme.theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 object PodcastsScreen {
     const val route = "podcasts_screen"
@@ -33,7 +42,15 @@ fun PodcastsScreen(
         modifier = modifier.fillMaxWidth(),
         state = listState,
     ) {
-        items(uiState.items) { item ->
+        item {
+            Text(
+                text = stringResource(LR.string.podcasts),
+                style = MaterialTheme.typography.title2,
+                color = MaterialTheme.theme.colors.primaryText01,
+                modifier = Modifier.padding(bottom = 24.dp)
+            )
+        }
+        items(items = uiState.items, key = { item -> item.uuid }) { item ->
             if (item is FolderItem.Podcast) {
                 PodcastChip(podcast = item, onClick = navigateToPodcast)
             }
@@ -45,12 +62,27 @@ fun PodcastsScreen(
 private fun PodcastChip(podcast: FolderItem.Podcast, onClick: (String) -> Unit, modifier: Modifier = Modifier) {
     Chip(
         onClick = { onClick(podcast.uuid) },
-        colors = ChipDefaults.secondaryChipColors(),
+        colors = ChipDefaults.gradientBackgroundChipColors(
+            startBackgroundColor = Color(podcast.podcast.tintColorForDarkBg).darker(0.5f),
+            endBackgroundColor = MaterialTheme.colors.surface
+        ),
         label = {
-            Text(podcast.title, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Text(
+                text = podcast.title,
+                maxLines = 2,
+                fontSize = 14.sp,
+                lineHeight = 16.sp,
+                fontWeight = FontWeight.Bold,
+                overflow = TextOverflow.Ellipsis,
+                color = Color.White
+            )
         },
         icon = {
-            PodcastImage(uuid = podcast.uuid, dropShadow = false, modifier = Modifier.size(30.dp))
+            PodcastImage(
+                uuid = podcast.uuid,
+                dropShadow = false,
+                modifier = Modifier.size(32.dp)
+            )
         },
         modifier = modifier.fillMaxWidth()
     )


### PR DESCRIPTION
## Description

This change improves the podcasts page in the following ways.

- Adds a podcast color gradient to the chip.
- Adds a page header. 

It also includes:

- Changing to the extra dark theme. This fixes the issue that you can see Pixel watch bezel if the background isn't black.
- Changing the theme typography to match the design.

## Testing Instructions
1. Tap "Podcasts"
2. ✅  Scroll down the list and verify the tint colours look fine.

## Screenshots
![Screenshot_20230524_203452](https://github.com/Automattic/pocket-casts-android/assets/308331/b3887e35-3e7f-465c-8fa3-2ff0dba5f495)
