### PR TITLE
Handle large font sizes in watch app

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -83,7 +83,7 @@ project.ext {
     versionCompose = '1.4.2' // When updating this, also check if versionComposeAccompanist should be updated as well: https://github.com/google/accompanist#compose-versions
     versionComposeAccompanist = '0.30.1'
     versionComposeCompiler = '1.3.0'
-    versionComposeWear = '1.2.0-alpha07'
+    versionComposeWear = '1.2.0-alpha10'
     versionDagger = '2.41'
     versionEspresso = '3.4.0'
     versionMedia3 = '1.0.0'
@@ -92,7 +92,7 @@ project.ext {
 
     // When updating this, check to see if versionComposeWear will be updated as well (and update that variable if appropriate)
     // https://github.com/google/horologist/blob/main/gradle/libs.versions.toml
-    versionHorologist = '0.4.7'
+    versionHorologist = '0.4.8'
 
     versionKotlinCoroutines = '1.6.4'
     versionLifecycle = '2.6.0'

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/SettingsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/SettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -31,6 +32,7 @@ import au.com.shiftyjelly.pocketcasts.wear.theme.theme
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.SectionHeaderChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
+import com.google.android.horologist.base.ui.util.adjustChipHeightToFontScale
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -192,7 +194,9 @@ fun ToggleChip(
             checkedEndBackgroundColor = color.copy(alpha = 0.32f),
             checkedToggleControlColor = color,
         ),
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier
+            .adjustChipHeightToFontScale(LocalConfiguration.current.fontScale)
+            .fillMaxWidth()
     )
 }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/WatchListChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/WatchListChip.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.wear.compose.material.Chip
@@ -14,6 +15,9 @@ import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.wear.theme.theme
+import com.google.android.horologist.base.ui.components.StandardChip
+import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.base.ui.util.adjustChipHeightToFontScale
 
 @Composable
 fun WatchListChip(
@@ -21,17 +25,11 @@ fun WatchListChip(
     @DrawableRes iconRes: Int,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    colors: ChipColors = ChipDefaults.secondaryChipColors(
-        secondaryContentColor = MaterialTheme.theme.colors.primaryText02
-    ),
-    overflow: TextOverflow? = null,
     secondaryLabel: String? = null,
 ) {
     WatchListChip(
         title = title,
         onClick = onClick,
-        colors = colors,
-        overflow = overflow,
         secondaryLabel = secondaryLabel,
         icon = {
             Icon(
@@ -49,31 +47,50 @@ fun WatchListChip(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     icon: (@Composable BoxScope.() -> Unit)? = null,
+    secondaryLabel: String? = null,
+) {
+    StandardChip(
+        label = title,
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        secondaryLabel = secondaryLabel,
+        icon = icon,
+        chipType = StandardChipType.Secondary,
+    )
+}
+
+@Composable
+fun WatchListChip(
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: (@Composable BoxScope.() -> Unit)? = null,
+    secondaryLabel: String? = null,
     colors: ChipColors = ChipDefaults.secondaryChipColors(
         secondaryContentColor = MaterialTheme.theme.colors.primaryText02
     ),
-    overflow: TextOverflow? = null,
-    secondaryLabel: String? = null,
 ) {
     Chip(
-        onClick = onClick,
-        colors = colors,
         label = {
             Text(
                 text = title,
-                maxLines = if (secondaryLabel == null) 2 else 1,
+                style = MaterialTheme.typography.button,
                 overflow = TextOverflow.Ellipsis,
+                maxLines = if (secondaryLabel != null) 1 else 2,
             )
         },
+        onClick = onClick,
+        modifier = modifier
+            .adjustChipHeightToFontScale(LocalConfiguration.current.fontScale),
+        icon = icon,
         secondaryLabel = {
             if (secondaryLabel != null) {
                 Text(
                     text = secondaryLabel,
-                    overflow = overflow ?: TextOverflow.Ellipsis,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
         },
-        icon = icon,
-        modifier = modifier.fillMaxWidth()
+        colors = colors,
     )
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
@@ -4,17 +4,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.ScalingLazyListState
 import androidx.wear.compose.foundation.lazy.items
-import androidx.wear.compose.material.Chip
-import androidx.wear.compose.material.ChipDefaults
-import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
+import com.google.android.horologist.base.ui.components.StandardChip
+import com.google.android.horologist.base.ui.components.StandardChipType
 
 object PodcastsScreen {
     const val route = "podcasts_screen"
@@ -42,13 +40,15 @@ fun PodcastsScreen(
 }
 
 @Composable
-private fun PodcastChip(podcast: FolderItem.Podcast, onClick: (String) -> Unit, modifier: Modifier = Modifier) {
-    Chip(
+private fun PodcastChip(
+    podcast: FolderItem.Podcast,
+    onClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    StandardChip(
+        label = podcast.title,
         onClick = { onClick(podcast.uuid) },
-        colors = ChipDefaults.secondaryChipColors(),
-        label = {
-            Text(podcast.title, maxLines = 1, overflow = TextOverflow.Ellipsis)
-        },
+        chipType = StandardChipType.Secondary,
         icon = {
             PodcastImage(uuid = podcast.uuid, dropShadow = false, modifier = Modifier.size(30.dp))
         },


### PR DESCRIPTION
## Description

This switches to using `StandardChip` to handle large font sizes in watch app.
I also bumped horologist to [0.4.8](https://github.com/google/horologist/releases/tag/v0.4.8) to take the latest changes for `StandardChip` and updated composeWear version to the [corresponding horologist compose wear lib version](https://github.com/google/horologist/blob/f7ec07da11658a2d0846a202803744066391eee3/gradle/libs.versions.toml#L62).

## Testing Instructions

1. Increase the font size on the watch to the largest size
2. Install the app
3. Notice that the app handles the largest font sizes well

## Screenshots or Screencast 

**Now Playing** 

Before | After
----|----
<img width=250 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/75a1bc64-58d4-4f46-bb59-8c79610da794"/> |  <img width=250 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/ab6c7d29-0fad-447c-bc2c-a716cab530da"/>

**Settings Toggle** 

Before | After
----|----
 <img width=250 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/bd572c95-aa86-4d19-8a20-eda3757797a4"/> | ! <img width=250 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/6ea0c630-9dd4-41a9-874d-e58cdc8a07c3"/>


Note: 

- Didn't switch to ToggleSwitch yet as it does not display large text into two lines. Instead, I just adjusted the modifier to handle large font sizes for the toggle chip.
    <img width=250 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/9b7c17a6-3b0d-42b7-8e25-4377869b7e34"/>
- Didn't use `StandardChip` for "Now Playing" as it needs custom background color not supported by `StandardChip` yet.



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
