### PR TITLE
Add wear app to build pipeline

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,4 +1,5 @@
 final VERSION_CODE_DIFFERENCE_BETWEEN_APP_AND_AUTOMOTIVE = 50000
+final VERSION_CODE_DIFFERENCE_BETWEEN_APP_AND_WEAR = 50000 + VERSION_CODE_DIFFERENCE_BETWEEN_APP_AND_AUTOMOTIVE
 
 def secretProperties = loadPropertiesFromFile(file("$rootDir/secret.properties") )
 def versionProperties = loadPropertiesFromFile(file("${rootDir}/version.properties"))
@@ -23,10 +24,13 @@ static def loadPropertiesFromFile(inputFile) {
 // The long term solution is to move the version information out of the `base.gradle` and into the specific
 // app & automotive modules and pass this information to the modules that require it.
 def isAutomotiveBuild = (project.findProperty("IS_AUTOMOTIVE_BUILD") ?: false).toBoolean()
+def isWearBuild = (project.findProperty("IS_WEAR_BUILD") ?: false).toBoolean()
 def getVersionCode = {
     def appVersionCode = versionProperties.getProperty("versionCode", null).toInteger()
     if (isAutomotiveBuild) {
         return appVersionCode + VERSION_CODE_DIFFERENCE_BETWEEN_APP_AND_AUTOMOTIVE
+    } else if (isWearBuild) {
+       return appVersionCode + VERSION_CODE_DIFFERENCE_BETWEEN_APP_AND_WEAR
     }
     return appVersionCode
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,6 +18,8 @@ RELEASE_NOTES_SOURCE_PATH = File.join(PROJECT_ROOT_FOLDER, 'CHANGELOG.md')
 EXTRACTED_RELEASE_NOTES_PATH = File.join(ORIGINALS_METADATA_DIR_PATH, 'release_notes.txt')
 PLAY_STORE_TRACK_AUTOMOTIVE_BETA = "automotive:beta"
 PLAY_STORE_TRACK_AUTOMOTIVE_PRODUCTION = "automotive:production"
+PLAY_STORE_TRACK_WEAR_BETA = "wear:beta"
+PLAY_STORE_TRACK_WEAR_PRODUCTION = "wear:production"
 PLAY_STORE_TRACK_BETA = "beta"
 PLAY_STORE_TRACK_PRODUCTION = "production"
 GLOTPRESS_APP_STRINGS_PROJECT_URL = 'https://translate.wordpress.com/projects/pocket-casts/android/'
@@ -52,7 +54,8 @@ ENV['FL_RELEASE_TOOLKIT_DEFAULT_BRANCH'] = 'main'
 GH_REPOSITORY = "automattic/pocket-casts-android"
 APPS_APP = "app"
 APPS_AUTOMOTIVE = "automotive"
-APPS = [APPS_APP, APPS_AUTOMOTIVE]
+APPS_WEAR = "wear"
+APPS = [APPS_APP, APPS_AUTOMOTIVE, APPS_WEAR]
 
 UPLOAD_TO_PLAY_STORE_JSON_KEY = File.join(PROJECT_ROOT_FOLDER, 'google-upload-credentials.json')
 
@@ -164,6 +167,8 @@ platform :android do
 
         track = if (app == APPS_AUTOMOTIVE)
             is_beta ? PLAY_STORE_TRACK_AUTOMOTIVE_BETA : PLAY_STORE_TRACK_AUTOMOTIVE_PRODUCTION
+        elsif (app == APPS_WEAR)
+            is_beta ? PLAY_STORE_TRACK_WEAR_BETA : PLAY_STORE_TRACK_WEAR_PRODUCTION
         else
             is_beta ? PLAY_STORE_TRACK_BETA : PLAY_STORE_TRACK_PRODUCTION
         end
@@ -214,7 +219,7 @@ platform :android do
   end
 
   # @param [Hash<String>] version The version to create. Expects keys "name" and "code"
-  # @param [String] app The Android app to build (i.e 'app' or 'automotive')
+  # @param [String] app The Android app to build (i.e 'app', 'automotive', or 'wear')
   desc "Builds and bundles the given app"
   lane :build_bundle do | options |
     version = options[:version]
@@ -230,7 +235,8 @@ platform :android do
         task: ":#{app}:bundle",
         build_type: "Release",
         properties: {
-            "IS_AUTOMOTIVE_BUILD" => app == APPS_AUTOMOTIVE
+            "IS_AUTOMOTIVE_BUILD" => app == APPS_AUTOMOTIVE,
+            "IS_WEAR_BUILD" => app == APPS_WEAR
         }
     )
 


### PR DESCRIPTION
## Description
Adding the the wear app to our build pipeline.

For reference, this is [the PR](https://github.com/Automattic/pocket-casts-android/pull/314) adding the automotive build.

## Testing Instructions
I don't know how to test this. Maybe @oguzkocer has some suggestions. Or we just merge it and see what happens when we try to run the release script on Monday, May 29.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews