### PR TITLE
Add splash screen to watch app

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@android:style/Theme.DeviceDefault">
+        android:theme="@style/SplashTheme">
 
         <uses-library
             android:name="com.google.android.wearable"
@@ -40,8 +40,7 @@
 
         <activity
             android:name=".wear.MainActivity"
-            android:exported="true"
-            android:theme="@android:style/Theme.DeviceDefault">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -57,6 +57,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setTheme(android.R.style.Theme_DeviceDefault)
         setContent {
             val state by viewModel.state.collectAsState()
             WearAppTheme(theme.activeTheme) {

--- a/wear/src/main/res/drawable/splash_background.xml
+++ b/wear/src/main/res/drawable/splash_background.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/black"/>
+        </shape>
+    </item>
+    <item
+        android:width="48dp"
+        android:height="48dp"
+        android:gravity="center"
+        android:drawable="@mipmap/ic_launcher"/>
+</layer-list>

--- a/wear/src/main/res/values/styles.xml
+++ b/wear/src/main/res/values/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="SplashTheme" parent="@android:style/Theme.DeviceDefault">
+        <item name="android:windowBackground">@drawable/splash_background</item>
+    </style>
+</resources>


### PR DESCRIPTION
## Description
This adds splash screen to watch app

## Testing Instructions
1. Fresh install the app
2. Notice that splash screen is shown :)

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/e677838d-dd33-4885-8b30-f27c861d6de6

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
