### PR TITLE
Add Wear OS folders

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -19,8 +19,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
+import androidx.wear.compose.material.SwipeToDismissBoxState
 import androidx.wear.compose.material.rememberSwipeToDismissBoxState
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavHostState
@@ -47,6 +49,7 @@ import au.com.shiftyjelly.pocketcasts.wear.ui.player.StreamingConfirmationScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcast.PodcastScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcasts.PodcastsScreen
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
+import com.google.android.horologist.compose.navscaffold.ScrollableScaffoldContext
 import com.google.android.horologist.compose.navscaffold.WearNavScaffold
 import com.google.android.horologist.compose.navscaffold.composable
 import com.google.android.horologist.compose.navscaffold.scrollable
@@ -173,20 +176,28 @@ fun WearApp(
         }
 
         scrollable(
-            route = PodcastsScreen.route,
+            route = PodcastsScreen.routeHomeFolder,
         ) {
-            NowPlayingPager(
+            PlayerAndPodcastsScreen(
                 navController = navController,
                 swipeToDismissState = swipeToDismissState,
                 scrollableScaffoldContext = it,
-            ) {
-                PodcastsScreen(
-                    listState = it.scrollableState,
-                    navigateToPodcast = { podcastUuid ->
-                        navController.navigate(PodcastScreen.navigateRoute(podcastUuid))
-                    }
-                )
-            }
+            )
+        }
+
+        scrollable(
+            route = PodcastsScreen.routeFolder,
+            arguments = listOf(
+                navArgument(PodcastsScreen.argumentFolderUuid) {
+                    type = NavType.StringType
+                }
+            ),
+        ) {
+            PlayerAndPodcastsScreen(
+                navController = navController,
+                swipeToDismissState = swipeToDismissState,
+                scrollableScaffoldContext = it,
+            )
         }
 
         scrollable(
@@ -230,7 +241,6 @@ fun WearApp(
         }
 
         scrollable(DownloadsScreen.route) {
-
             NowPlayingPager(
                 navController = navController,
                 swipeToDismissState = swipeToDismissState,
@@ -350,6 +360,29 @@ fun WearApp(
     }
 
     previousSubscriptionStatus.value = subscriptionStatus
+}
+
+@Composable
+fun PlayerAndPodcastsScreen(
+    navController: NavHostController,
+    swipeToDismissState: SwipeToDismissBoxState,
+    scrollableScaffoldContext: ScrollableScaffoldContext,
+) {
+    NowPlayingPager(
+        navController = navController,
+        swipeToDismissState = swipeToDismissState,
+        scrollableScaffoldContext = scrollableScaffoldContext,
+    ) {
+        PodcastsScreen(
+            listState = scrollableScaffoldContext.scrollableState,
+            navigateToPodcast = { podcastUuid ->
+                navController.navigate(PodcastScreen.navigateRoute(podcastUuid))
+            },
+            navigateToFolder = { folderUuid ->
+                navController.navigate(PodcastsScreen.navigateRoute(folderUuid))
+            },
+        )
+    }
 }
 
 private fun NavGraphBuilder.loggingInScreens(

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -178,7 +178,7 @@ fun WearApp(
         scrollable(
             route = PodcastsScreen.routeHomeFolder,
         ) {
-            PlayerAndPodcastsScreen(
+            PodcastsScreenContent(
                 navController = navController,
                 swipeToDismissState = swipeToDismissState,
                 scrollableScaffoldContext = it,
@@ -193,7 +193,7 @@ fun WearApp(
                 }
             ),
         ) {
-            PlayerAndPodcastsScreen(
+            PodcastsScreenContent(
                 navController = navController,
                 swipeToDismissState = swipeToDismissState,
                 scrollableScaffoldContext = it,
@@ -363,7 +363,7 @@ fun WearApp(
 }
 
 @Composable
-fun PlayerAndPodcastsScreen(
+fun PodcastsScreenContent(
     navController: NavHostController,
     swipeToDismissState: SwipeToDismissBoxState,
     scrollableScaffoldContext: ScrollableScaffoldContext,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearColors.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearColors.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.wear.theme
 
 import androidx.compose.ui.graphics.Color
+import au.com.shiftyjelly.pocketcasts.compose.ThemeExtraDarkColors
 
 object WearColors {
     val highlight = Color(0xFFF43E37)
@@ -10,4 +11,6 @@ object WearColors {
     val secondaryText = Color(0xFFBDC1C6)
     val upNextIcon = Color(0xFF4BA1D6)
     val downloadedIcon = Color(0xFF54C483)
+
+    fun getFolderColor(id: Int): Color = ThemeExtraDarkColors.getFolderColor(id)
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
@@ -61,7 +61,7 @@ fun WatchListScreen(
             WatchListChip(
                 title = stringResource(LR.string.podcasts),
                 iconRes = IR.drawable.ic_podcasts,
-                onClick = { navigateToRoute(PodcastsScreen.route) }
+                onClick = { navigateToRoute(PodcastsScreen.routeHomeFolder) }
             )
         }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
@@ -3,9 +3,11 @@ package au.com.shiftyjelly.pocketcasts.wear.ui.podcasts
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -20,10 +22,16 @@ import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.extensions.darker
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
+import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
+import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 object PodcastsScreen {
-    const val route = "podcasts_screen"
+    const val argumentFolderUuid = "folderUuid"
+    const val routeFolder = "podcasts/{$argumentFolderUuid}"
+    const val routeHomeFolder = "podcasts"
+
+    fun navigateRoute(folderUuid: String) = "podcasts/$folderUuid"
 }
 
 @Composable
@@ -31,7 +39,8 @@ fun PodcastsScreen(
     modifier: Modifier = Modifier,
     viewModel: PodcastsViewModel = hiltViewModel(),
     listState: ScalingLazyListState,
-    navigateToPodcast: (String) -> Unit
+    navigateToPodcast: (String) -> Unit,
+    navigateToFolder: (String) -> Unit,
 ) {
     val uiState = viewModel.uiState
 
@@ -41,18 +50,47 @@ fun PodcastsScreen(
     ) {
         item {
             Text(
-                text = stringResource(LR.string.podcasts),
+                text = if (uiState.folder == null) stringResource(LR.string.podcasts) else uiState.folder.title,
                 style = MaterialTheme.typography.button,
                 color = MaterialTheme.colors.onSecondary,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
         }
         items(items = uiState.items, key = { item -> item.uuid }) { item ->
-            if (item is FolderItem.Podcast) {
-                PodcastChip(podcast = item, onClick = navigateToPodcast)
+            when (item) {
+                is FolderItem.Podcast -> {
+                    PodcastChip(podcast = item, onClick = navigateToPodcast)
+                }
+                is FolderItem.Folder -> {
+                    FolderChip(folderItem = item, onClick = navigateToFolder)
+                }
             }
         }
     }
+}
+
+@Composable
+private fun FolderChip(
+    folderItem: FolderItem.Folder,
+    onClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val folder = folderItem.folder
+    Chip(
+        onClick = { onClick(folder.uuid) },
+        label = {
+            ChipText(folder.name)
+        },
+        icon = {
+            Icon(
+                painter = painterResource(IR.drawable.ic_folder),
+                contentDescription = null,
+                tint = WearColors.getFolderColor(folder.color),
+                modifier = Modifier.padding(horizontal = 8.dp).size(24.dp)
+            )
+        },
+        modifier = modifier.fillMaxWidth()
+    )
 }
 
 @Composable
@@ -68,13 +106,7 @@ private fun PodcastChip(
             endBackgroundColor = MaterialTheme.colors.surface
         ),
         label = {
-            Text(
-                text = podcast.title,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                style = MaterialTheme.typography.button,
-                color = MaterialTheme.colors.onPrimary
-            )
+            ChipText(podcast.title)
         },
         icon = {
             PodcastImage(
@@ -84,5 +116,16 @@ private fun PodcastChip(
             )
         },
         modifier = modifier.fillMaxWidth()
+    )
+}
+
+@Composable
+private fun ChipText(title: String) {
+    Text(
+        text = title,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+        style = MaterialTheme.typography.button,
+        color = MaterialTheme.colors.onPrimary
     )
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsViewModel.kt
@@ -3,19 +3,24 @@ package au.com.shiftyjelly.pocketcasts.wear.ui.podcasts
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem.Folder
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class PodcastsViewModel @Inject constructor(
-    private val podcastManager: PodcastManager
+    savedStateHandle: SavedStateHandle,
+    private val folderManager: FolderManager,
 ) : ViewModel() {
+
+    private val folderUuid: String = savedStateHandle[PodcastsScreen.argumentFolderUuid] ?: ""
 
     data class UiState(
         val folder: Folder? = null,
@@ -27,9 +32,18 @@ class PodcastsViewModel @Inject constructor(
         private set
 
     init {
-        viewModelScope.launch {
-            val podcasts = podcastManager.findPodcastsOrderByTitle().map { FolderItem.Podcast(it) }
-            uiState = UiState(folder = null, items = podcasts, isSignedInAsPlus = false)
+        viewModelScope.launch(Dispatchers.IO) {
+            val folder: FolderItem.Folder?
+            val items: List<FolderItem>
+            if (folderUuid.isEmpty()) {
+                items = folderManager.getHomeFolder()
+                folder = null
+            } else {
+                val podcasts = folderManager.findFolderPodcastsSorted(folderUuid)
+                items = podcasts.map { FolderItem.Podcast(it) }
+                folder = folderManager.findByUuid(folderUuid)?.let { FolderItem.Folder(folder = it, podcasts = podcasts) }
+            }
+            uiState = UiState(folder = folder, items = items, isSignedInAsPlus = false)
         }
     }
 }


### PR DESCRIPTION
## Description

This adds folders to the podcasts page. It only allows you to view the folders you have created on your mobile or web app in this version, you can't create new ones.

Fixes https://github.com/Automattic/pocket-casts-android/issues/1011

## Testing Instructions
1. On the mobile or web app add some folders to your account and sync.
2. In the wear app check you are signed in with the same user.
3. Tap 'Podcasts'
4. ✅ Verify you can see your folders
5. Tap a folder
6. ✅ Verify you are only viewing the podcasts in that folder
7. Tap a podcast
8. ✅ Verify you are taken to the podcast page
9. Swipe from the left of the screen twice
10. ✅ Verify you are back on the home page

## Screenshots 

https://github.com/Automattic/pocket-casts-android/assets/308331/306c3835-7017-4db2-832a-3b43191d2f00

![Screenshot_20230528_214431](https://github.com/Automattic/pocket-casts-android/assets/308331/65f24c83-b7f6-4a2a-8822-74b3995dc572)

