### PR TITLE
Prevent playback on watch speakers 

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/ConfigModule.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/ConfigModule.kt
@@ -5,6 +5,8 @@ import android.os.Build
 import android.os.Vibrator
 import au.com.shiftyjelly.pocketcasts.wear.ui.AppConfig
 import com.google.android.horologist.audio.SystemAudioRepository
+import com.google.android.horologist.media3.audio.AudioOutputSelector
+import com.google.android.horologist.media3.audio.BluetoothSettingsOutputSelector
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -23,6 +25,13 @@ object ConfigModule {
     @Singleton
     @Provides
     fun appConfig(): AppConfig = AppConfig()
+
+    @Singleton
+    @Provides
+    fun audioOutputSelector(
+        systemAudioRepository: SystemAudioRepository
+    ): AudioOutputSelector =
+        BluetoothSettingsOutputSelector(systemAudioRepository)
 
     @Singleton
     @Provides

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/WearAppModule.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/WearAppModule.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.wear.di
 
 import android.content.Context
 import android.net.ConnectivityManager
+import com.google.android.horologist.media3.rules.PlaybackRules
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -24,7 +25,17 @@ object WearAppModule {
 
     @Provides
     fun connectivityManager(
-        @ApplicationContext application: Context
+        @ApplicationContext application: Context,
     ): ConnectivityManager =
         application.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    @Singleton
+    @Provides
+    fun playbackRules(
+        @IsEmulator isEmulator: Boolean,
+    ): PlaybackRules = if (isEmulator) {
+        PlaybackRules.SpeakerAllowed
+    } else {
+        PlaybackRules.Normal
+    }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/AudioOutputSelectorHelper.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/AudioOutputSelectorHelper.kt
@@ -1,0 +1,36 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui.player
+
+import com.google.android.horologist.audio.SystemAudioRepository
+import com.google.android.horologist.media3.audio.AudioOutputSelector
+import com.google.android.horologist.media3.rules.PlaybackRules
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AudioOutputSelectorHelper @Inject constructor(
+    private val audioOutputRepository: SystemAudioRepository,
+    private val audioOutputSelector: AudioOutputSelector,
+    private val playbackRules: PlaybackRules,
+) {
+    suspend fun attemptPlay(play: () -> Unit) {
+        val currentAudioOutput = audioOutputRepository.audioOutput.value
+
+        val canPlayWithCurrentOutput = playbackRules.canPlayWithOutput(currentAudioOutput)
+
+        if (canPlayWithCurrentOutput) {
+            play()
+        } else {
+            val newAudioOutput = audioOutputSelector.selectNewOutput(currentAudioOutput)
+
+            val canPlayWithNewOutput =
+                newAudioOutput != null && playbackRules.canPlayWithOutput(newAudioOutput)
+
+            if (canPlayWithNewOutput) {
+                play()
+            } else {
+                Timber.e("Cannot play audio on output $newAudioOutput")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/Automattic/pocket-casts-android/issues/1013
 
## Description
This prevents playback on watch speakers. 


## Testing Instructions
1. Make sure that Bluetooth speaker is not connected to watch
2. Launch the app and login with a Plus account having podcasts
3. Select Podcasts -> select a Podcast -> select an Episode
4. Tap play on the selected episode
5. ✅ Notice that a screen is shown to select a Bluetooth device
6. Connect to a Bluetooth speaker
7. ✅ Notice that the episode starts playing 
8. Navigate to the Now Playing screen
9. Tap on the volume button
10. On the volume screen, deselect the Bluetooth speaker
11. ✅ Notice that the player pauses
12. Go back to the Now Playing screen
13. Tap on the play icon
14. ✅ Notice that a screen is shown to select a Bluetooth device

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/56560017-ffdd-4b1f-b5d6-2fb45b1e991d

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
