### PR TITLE
Fixing the themes import script

### DIFF
--- a/scripts/themes/README.md
+++ b/scripts/themes/README.md
@@ -1,4 +1,4 @@
-Download the google_credentials.json file from 1Password 'Android Themes script'.
+Download the google_credentials.json file from our secret 'Pocket Casts - Android Themes Script'.
 ```
 ./run.sh
 ```

--- a/scripts/themes/download_themes.rb
+++ b/scripts/themes/download_themes.rb
@@ -1,39 +1,15 @@
 require "google/apis/sheets_v4"
 require "googleauth"
-require "googleauth/stores/file_token_store"
 require "fileutils"
 
-OOB_URI = "urn:ietf:wg:oauth:2.0:oob".freeze
 APPLICATION_NAME = "Google Sheets API Pocket Casts Themes".freeze
 CREDENTIALS_PATH = "google_credentials.json".freeze
-# The file token.yaml stores the user's access and refresh tokens, and is
-# created automatically when the authorization flow completes for the first
-# time.
-TOKEN_PATH = "token.yaml".freeze
 SCOPE = Google::Apis::SheetsV4::AUTH_SPREADSHEETS_READONLY
 
 class String
   def uncapitalize
     self[0, 1].downcase + self[1..-1]
   end
-end
-
-def authorize()
-  client_id = Google::Auth::ClientId.from_file CREDENTIALS_PATH
-  token_store = Google::Auth::Stores::FileTokenStore.new file: TOKEN_PATH
-  authorizer = Google::Auth::UserAuthorizer.new client_id, SCOPE, token_store
-  user_id = "default"
-  credentials = authorizer.get_credentials user_id
-  if credentials.nil?
-    url = authorizer.get_authorization_url base_url: OOB_URI
-    puts "Open the following URL in the browser and enter the " \
-         "resulting code after authorization:\n" + url
-    code = gets
-    credentials = authorizer.get_and_store_credentials_from_code(
-      user_id: user_id, code: code, base_url: OOB_URI
-    )
-  end
-  credentials
 end
 
 def response_to_tokens_map(response)
@@ -108,7 +84,10 @@ def download_themes()
   # Initialize the API
   service = Google::Apis::SheetsV4::SheetsService.new
   service.client_options.application_name = APPLICATION_NAME
-  service.authorization = authorize
+  service.authorization = Google::Auth::ServiceAccountCredentials.make_creds(
+    json_key_io: File.open(CREDENTIALS_PATH),
+    scope: Google::Apis::SheetsV4::AUTH_SPREADSHEETS_READONLY
+  )
 
   # https://docs.google.com/spreadsheets/d/1BZWwQo8ZhTt9jRz5eX6iJqt4r9o6ekWeYi_t8AlNDCM/edit
   spreadsheet_id = "1BZWwQo8ZhTt9jRz5eX6iJqt4r9o6ekWeYi_t8AlNDCM"


### PR DESCRIPTION
## Description

This allows us to import our theme colours from a Google Sheets document again.

## Testing Instructions
1. Copy the google_credentials.json to the folder scripts/themes
2. Open Terminal 
3. cd scripts/themes
4. ./run.sh
5. ✅ Verify the script completes successfully

