### PR TITLE
Fix episodes table name in hard-coded query

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
@@ -26,9 +26,6 @@ interface PlaylistManager {
     fun observeEpisodes(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<List<PodcastEpisode>>
 
     fun count(): Int
-    fun countEpisodesNotCompleted(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Int
-    fun countEpisodesDownloading(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Int
-    fun countEpisodesNotDownloaded(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Int
 
     fun createPlaylist(name: String, iconId: Int, draft: Boolean): Playlist
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -497,7 +497,7 @@ class PlaylistManagerImpl @Inject constructor(
 
         val playingEpisode = playbackManager?.getCurrentEpisode()?.uuid
         if (playingEpisode != null && playbackManager.lastLoadedFromPodcastOrPlaylistUuid == playlist.uuid) {
-            where.insert(0, "(episodes.uuid = '$playingEpisode' OR (")
+            where.insert(0, "(podcast_episodes.uuid = '$playingEpisode' OR (")
             where.append("))")
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -502,28 +502,6 @@ class PlaylistManagerImpl @Inject constructor(
         }
     }
 
-    override fun countEpisodesNotCompleted(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Int {
-        return episodeManager.countEpisodesWhere("episodes.archived = 0 AND episodes.playing_status != " + EpisodePlayingStatus.COMPLETED.ordinal + " AND " + buildPlaylistWhere(playlist, null))
-    }
-
-    override fun countEpisodesDownloading(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Int {
-        return episodeManager.countEpisodesWhere(
-            "episodes.archived = 0 AND (episodes.episode_status = " + EpisodeStatusEnum.DOWNLOADING.ordinal + " OR episodes.episode_status = " + EpisodeStatusEnum.QUEUED.ordinal + " OR episodes.episode_status = " + EpisodeStatusEnum.WAITING_FOR_WIFI.ordinal + " OR episodes.episode_status = " + EpisodeStatusEnum.WAITING_FOR_POWER.ordinal + ") AND " + buildPlaylistWhere(
-                playlist,
-                null
-            )
-        )
-    }
-
-    override fun countEpisodesNotDownloaded(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Int {
-        return episodeManager.countEpisodesWhere(
-            "episodes.archived = 0 AND (episodes.episode_status = " + EpisodeStatusEnum.NOT_DOWNLOADED.ordinal + " OR episodes.episode_status = " + EpisodeStatusEnum.DOWNLOAD_FAILED.ordinal + ") AND " + buildPlaylistWhere(
-                playlist,
-                null
-            )
-        )
-    }
-
     private fun markAsNotSynced(playlist: Playlist) {
         playlist.syncStatus = Playlist.SYNC_STATUS_NOT_SYNCED
         playlistDao.updateSyncStatus(Playlist.SYNC_STATUS_NOT_SYNCED, playlist.uuid)


### PR DESCRIPTION
## Description

> **Warning**
> Targets release/7.39.1

This replaces `episodes` table name with `podcast_episodes` in continuation of changes made in PR https://github.com/Automattic/pocket-casts-android/pull/910.

Internal Ref: p1685425150749449/1685113399.023749-slack-C028JAG44VD

I also removed 3 unused methods that referenced `episodes` table name:
`countEpisodesNotCompleted`
`countEpisodesDownloading`
`countEpisodesNotDownloaded`
