### PR TITLE
Send Sentry additional data as tags

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -26,6 +26,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.AppIcon
+import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
+import au.com.shiftyjelly.pocketcasts.utils.SentryHelper.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBufferUncaughtExceptionHandler
@@ -118,6 +120,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
 
         SentryAndroid.init(this) { options ->
             options.dsn = if (settings.getSendCrashReports()) settings.getSentryDsn() else ""
+            options.setTag(SentryHelper.GLOBAL_TAG_APP_PLATFORM, AppPlatform.MOBILE.value)
         }
 
         // Link email to Sentry crash reports only if the user has opted in

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
@@ -18,6 +18,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsTask
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
+import au.com.shiftyjelly.pocketcasts.utils.SentryHelper.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
 import au.com.shiftyjelly.pocketcasts.utils.log.RxJavaUncaughtExceptionHandling
 import com.google.android.gms.common.ConnectionResult
@@ -109,6 +111,7 @@ class AutomotiveApplication : Application(), Configuration.Provider {
     private fun setupSentry() {
         SentryAndroid.init(this) { options ->
             options.dsn = settings.getSentryDsn()
+            options.setTag(SentryHelper.GLOBAL_TAG_APP_PLATFORM, AppPlatform.AUTOMOTIVE.value)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -893,10 +893,8 @@ open class PlaybackManager @Inject constructor(
                 } else {
                     event.message
                 }
-                val isAutomotive = Util.isAutomotive(application)
                 Sentry.withScope { scope ->
                     episode?.uuid?.let { scope.setTag("episodeUuid", it) }
-                    scope.setTag("isAutomotive", isAutomotive.toString())
                     SentryHelper.recordException(
                         message = "Illegal playback state encountered",
                         throwable = event.error ?: IllegalStateException(event.message)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -63,6 +63,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.schedulers.Schedulers
+import io.sentry.Sentry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -893,10 +894,14 @@ open class PlaybackManager @Inject constructor(
                     event.message
                 }
                 val isAutomotive = Util.isAutomotive(application)
-                SentryHelper.recordException(
-                    message = "Illegal playback state encountered for episode uuid ${episode?.uuid}, isAutomotive $isAutomotive}: ",
-                    throwable = event.error ?: IllegalStateException(event.message)
-                )
+                Sentry.withScope { scope ->
+                    episode?.uuid?.let { scope.setTag("episodeUuid", it) }
+                    scope.setTag("isAutomotive", isAutomotive.toString())
+                    SentryHelper.recordException(
+                        message = "Illegal playback state encountered",
+                        throwable = event.error ?: IllegalStateException(event.message)
+                    )
+                }
                 playbackStateRelay.accept(playbackState.copy(state = PlaybackState.State.ERROR, lastErrorMessage = errorMessage, lastChangeFrom = "onPlayerError"))
             }
         }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SentryHelper.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SentryHelper.kt
@@ -6,6 +6,7 @@ import java.util.concurrent.CancellationException
 import javax.net.ssl.SSLException
 
 object SentryHelper {
+    const val GLOBAL_TAG_APP_PLATFORM = "app.platform"
 
     fun recordException(throwable: Throwable) {
         if (shouldIgnoreExceptions(throwable)) {
@@ -43,5 +44,11 @@ object SentryHelper {
                 // ignore producer certificate exceptions
                 throwable is SSLException
             )
+    }
+
+    enum class AppPlatform(val value: String) {
+        MOBILE("mobile"),
+        AUTOMOTIVE("automotive"),
+        WEAR("wear"),
     }
 }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -34,7 +34,8 @@ android {
 
             manifestPlaceholders = [
                     appIcon: "@mipmap/ic_launcher_radioactive",
-                    gitHash: gitHash + (gitDirty ? ("-" + gitDirty) : "")
+                    gitHash: gitHash + (gitDirty ? ("-" + gitDirty) : ""),
+                    sentryDsn: ""
             ]
         }
 
@@ -43,6 +44,11 @@ android {
         }
 
         release {
+            manifestPlaceholders = [
+                    gitHash: "",
+                    sentryDsn: project.pocketcastsSentryDsn
+            ]
+
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -49,8 +49,6 @@ android {
                     sentryDsn: project.pocketcastsSentryDsn
             ]
 
-            minifyEnabled true
-            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 
             if (canSignRelease) {

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -38,6 +38,10 @@
             android:name="pocketcasts_wear_os"
             android:value="true" />
 
+        <meta-data
+            android:name="au.com.shiftyjelly.pocketcasts.sentryDsn"
+            android:value="${sentryDsn}" />
+
         <activity
             android:name=".wear.MainActivity"
             android:exported="true">

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -20,6 +20,7 @@ import au.com.shiftyjelly.pocketcasts.utils.log.RxJavaUncaughtExceptionHandling
 import com.google.firebase.FirebaseApp
 import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.HiltAndroidApp
+import io.sentry.android.core.SentryAndroid
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -43,11 +44,18 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
     override fun onCreate() {
         super.onCreate()
 
+        setupSentry()
         setupLogging()
         setupAnalytics()
         setupApp()
 
         RxJavaUncaughtExceptionHandling.setUp()
+    }
+
+    private fun setupSentry() {
+        SentryAndroid.init(this) { options ->
+            options.dsn = settings.getSentryDsn()
+        }
     }
 
     private fun setupLogging() {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -15,6 +15,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
+import au.com.shiftyjelly.pocketcasts.utils.SentryHelper.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
 import au.com.shiftyjelly.pocketcasts.utils.log.RxJavaUncaughtExceptionHandling
 import com.google.firebase.FirebaseApp
@@ -55,6 +57,7 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
     private fun setupSentry() {
         SentryAndroid.init(this) { options ->
             options.dsn = settings.getSentryDsn()
+            options.setTag(SentryHelper.GLOBAL_TAG_APP_PLATFORM, AppPlatform.WEAR.value)
         }
     }
 


### PR DESCRIPTION
## Description

This sends additional data for an exception "separately" to Sentry using [local scope](https://docs.sentry.io/platforms/python/guides/logging/enriching-events/scopes/#local-scopes). This helps in grouping the exception in Sentry. 
I've used `scope.tags` instead of `scope.extra` as [tags help in searching and grouping](https://docs.sentry.io/platforms/python/guides/logging/enriching-events/tags/?original_referrer=https%3A%2F%2Fduckduckgo.com%2F).

> Tags are key/value string pairs that are both indexed and searchable.


## Screenshots or Screencast 

Events with different episode uuids are grouped together:

<img width="1042" alt="Screenshot 2023-05-31 at 12 19 29 PM" src="https://github.com/Automattic/pocket-casts-android/assets/1405144/5313d0a0-df7a-4009-a1fd-ccc99309db05">

<img width="1404" alt="Screenshot 2023-05-31 at 12 21 27 PM" src="https://github.com/Automattic/pocket-casts-android/assets/1405144/c578c707-8c75-4412-aa7c-207fab36dfb0">


We can filter using tags 

![image](https://github.com/Automattic/pocket-casts-android/assets/1405144/0e1364ef-156e-44e2-a179-84a41a258a12)



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
