### PR TITLE
Display errors on episode screen in watch app

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
@@ -40,6 +40,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatPattern
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
+import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -144,6 +145,26 @@ fun EpisodeChip(
                         color = MaterialTheme.colors.onSecondary,
                         style = MaterialTheme.typography.caption2,
                     )
+                }
+                episode.playErrorDetails?.let {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            painter = painterResource(IR.drawable.ic_alert_small),
+                            contentDescription = stringResource(LR.string.podcast_episode_playback_error),
+                            modifier = Modifier.size(14.dp),
+                            tint = MaterialTheme.colors.onSecondary,
+                        )
+                        Text(
+                            text = it,
+                            overflow = TextOverflow.Ellipsis,
+                            maxLines = 1,
+                            color = MaterialTheme.colors.onSecondary,
+                            style = MaterialTheme.typography.caption3,
+                            modifier = Modifier.padding(start = 5.dp)
+                        )
+                    }
                 }
             }
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
@@ -1,8 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui.episode
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -11,12 +13,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight.Companion.W700
 import androidx.compose.ui.text.style.TextAlign
@@ -25,6 +29,7 @@ import androidx.compose.ui.unit.sp
 import androidx.core.text.parseAsHtml
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
@@ -167,6 +172,12 @@ fun EpisodeScreen(
             }
         }
 
+        state.errorData?.let {
+            item {
+                EpisodeErrorDetails(it)
+            }
+        }
+
         item {
             EpisodeDateTimeText(
                 episode = episode,
@@ -281,6 +292,46 @@ private fun EpisodeListChip(episodeScreenItem: EpisodeScreenItem) {
             .padding(bottom = 4.dp)
             .fillMaxWidth()
     )
+}
+
+@Composable
+private fun EpisodeErrorDetails(
+    errorData: EpisodeViewModel.State.Loaded.ErrorData,
+) {
+    val padding = 8.dp
+    Row(
+        modifier = Modifier
+            .padding(start = padding, end = padding, bottom = padding)
+            .background(
+                color = MaterialTheme.colors.secondary,
+                shape = RoundedCornerShape(10.dp)
+            ),
+    ) {
+        Box(modifier = Modifier.padding(start = padding, top = 10.dp)) {
+            Icon(
+                painter = painterResource(errorData.errorIconRes),
+                contentDescription = null,
+                modifier = Modifier.size(16.dp)
+            )
+        }
+
+        Column {
+            Text(
+                text = stringResource(errorData.errorTitleRes),
+                color = MaterialTheme.colors.onSecondary,
+                style = MaterialTheme.typography.caption2,
+                modifier = Modifier.padding(padding)
+            )
+            errorData.errorDescription?.let {
+                Text(
+                    text = it,
+                    color = MaterialTheme.colors.onSecondary,
+                    style = MaterialTheme.typography.caption3,
+                    modifier = Modifier.padding(start = padding, end = padding, bottom = padding)
+                )
+            }
+        }
+    }
 }
 
 private data class EpisodeScreenItem(

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
@@ -315,21 +315,20 @@ private fun EpisodeErrorDetails(
             )
         }
 
-        Column {
+        if (errorData.errorDescription == null) {
             Text(
                 text = stringResource(errorData.errorTitleRes),
                 color = MaterialTheme.colors.onSecondary,
                 style = MaterialTheme.typography.caption2,
                 modifier = Modifier.padding(padding)
             )
-            errorData.errorDescription?.let {
-                Text(
-                    text = it,
-                    color = MaterialTheme.colors.onSecondary,
-                    style = MaterialTheme.typography.caption3,
-                    modifier = Modifier.padding(start = padding, end = padding, bottom = padding)
-                )
-            }
+        } else {
+            Text(
+                text = errorData.errorDescription,
+                color = MaterialTheme.colors.onSecondary,
+                style = MaterialTheme.typography.caption3,
+                modifier = Modifier.padding(padding)
+            )
         }
     }
 }


### PR DESCRIPTION
## Description

This displays episode (playback/download) errors on the episode details screen.

Task #1026

## Testing Instructions

1. Disable the internet on your watch device
2. Launch that app and go to the episode screen
3. Tap on the play icon (you're navigated to the Now Playing screen)
4. Wait for a while
5. ✅ Notice that the play icon switches to pause icon
6. Slide to the previous page in the pager to get back to the Episode screen
7. ✅ Notice that you see playback error message
8. Tap on download icon
9. ✅ Notice that the error is cleared
10. Wait for a while
11. ✅ Notice that you see a download error message and the download icon changes to retry icon

## Screenshots or Screencast 

Playback | Download 
--- | ---
![image](https://github.com/Automattic/pocket-casts-android/assets/1405144/d2b4cd69-e163-40e4-9fd1-54b4040775b1) | ![image](https://github.com/Automattic/pocket-casts-android/assets/1405144/ae113b5a-fb5b-4a62-9cb8-2af0988f9bcf)

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
