### PR TITLE
Refresh podcasts on app open in watch app

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -82,6 +82,11 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.refreshPodcasts()
+    }
 }
 
 @Composable

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/WearMainActivityViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/WearMainActivityViewModel.kt
@@ -100,7 +100,7 @@ class WearMainActivityViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             delay(REFRESH_START_DELAY) // delay the refresh to allow the UI to load
             try {
-                podcastManager.refreshPodcastsIfRequired(fromLog = "open app")
+                podcastManager.refreshPodcastsIfRequired(fromLog = "watch - open app")
             } catch (e: Exception) {
                 Timber.e(e)
             }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/WearMainActivityViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/WearMainActivityViewModel.kt
@@ -13,11 +13,14 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import com.google.android.horologist.auth.data.tokenshare.TokenBundleRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -91,5 +94,20 @@ class WearMainActivityViewModel @Inject constructor(
 
     fun signOut() {
         userManager.signOut(playbackManager, wasInitiatedByUser = false)
+    }
+
+    fun refreshPodcasts() {
+        viewModelScope.launch(Dispatchers.IO) {
+            delay(REFRESH_START_DELAY) // delay the refresh to allow the UI to load
+            try {
+                podcastManager.refreshPodcastsIfRequired(fromLog = "open app")
+            } catch (e: Exception) {
+                Timber.e(e)
+            }
+        }
+    }
+
+    companion object {
+        private const val REFRESH_START_DELAY = 1000L
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/SettingsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/SettingsViewModel.kt
@@ -72,6 +72,6 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun refresh() {
-        podcastManager.refreshPodcasts("watch")
+        podcastManager.refreshPodcasts("watch - settings")
     }
 }


### PR DESCRIPTION
## Description
This refreshes podcasts on app open in the watch app.

Task https://github.com/Automattic/pocket-casts-android/issues/1008

## Testing Instructions

#### Test.1 Check that refresh occurs on app open only when threshold refresh time is passed

1. Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/11634464/Reduce_refresh_time.patch) to reduce threshold time to refresh on app open to 5 secs
2. Install the app on watch with wifi debugging enabled
3. Login with a plus account having podcasts
4. Search `BgTask: RefreshPodcastsTask` in logs 
5. ✅ Notice that you see `BgTask: RefreshPodcastsTask - runNow - Start` in logs
6. Go to the recent apps
7. Tap and open Pocket Casts app before 5 secs
8.  ✅ Notice that you do not see `BgTask: RefreshPodcastsTask - runNow - Start`  in logs 
9. Go to the recent apps again
10. Tap and open Pocket Casts app after 5 secs
11.  ✅ Notice that you do not see `BgTask: RefreshPodcastsTask - runNow - Start`  in logs 

#### Test.2 Check that podcasts are refreshed on app open

1. Subscribe to a podcast using web player or android app and sync with server
2. Open the watch app
3. Notice that you see the subscribed podcast in the podcasts list


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
