### PR TITLE
Tracks for watch

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -45,7 +45,6 @@ import io.sentry.protocol.User
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -76,8 +75,6 @@ class PocketCastsApplication : Application(), Configuration.Provider {
     @Inject lateinit var tracksTracker: TracksAnalyticsTracker
     @Inject lateinit var bumpStatsTracker: AnonymousBumpStatsTracker
     @Inject lateinit var syncManager: SyncManager
-
-    private val applicationScope = MainScope()
 
     override fun onCreate() {
         if (BuildConfig.DEBUG) {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -545,4 +545,13 @@ enum class AnalyticsEvent(val key: String) {
 
     /* Ratings */
     RATING_STARS_TAPPED("rating_stars_tapped"),
+
+    /* Wear Main List Screen */
+    WEAR_MAIN_LIST_SHOWN("wear_main_list_shown"),
+    WEAR_MAIN_LIST_NOW_PLAYING_TAPPED("wear_main_list_now_playing_tapped"),
+    WEAR_MAIN_LIST_PODCASTS_TAPPED("wear_main_list_podcasts_tapped"),
+    WEAR_MAIN_LIST_DOWNLOADS_TAPPED("wear_main_list_downloads_tapped"),
+    WEAR_MAIN_LIST_FILTERS_TAPPED("wear_main_list_filters_tapped"),
+    WEAR_MAIN_LIST_FILES_TAPPED("wear_main_list_files_tapped"),
+    WEAR_MAIN_LIST_SETTINGS_TAPPED("wear_main_list_settings_tapped"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsSource.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsSource.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.analytics
 
 enum class AnalyticsSource(val analyticsValue: String) {
     PODCAST_SCREEN("podcast_screen"),
-    WATCH_PODCAST_SCREEN("watch_podcast_screen"),
     PODCAST_LIST("podcast_list"),
     FILTERS("filters"),
     DISCOVER("discover"),
@@ -14,14 +13,11 @@ enum class AnalyticsSource(val analyticsValue: String) {
     STARRED("starred"),
     LISTENING_HISTORY("listening_history"),
     EPISODE_DETAILS("episode_details"),
-    WATCH_EPISODE_DETAILS("watch_episode_details"),
     MINIPLAYER("miniplayer"),
     PLAYER("player"),
-    WATCH_PLAYER("watch_player"),
     NOTIFICATION("notification"),
     FULL_SCREEN_VIDEO("full_screen_video"),
     UP_NEXT("up_next"),
-    WATCH_UP_NEXT("watch_up_next"),
     MEDIA_BUTTON_BROADCAST_ACTION("media_button_broadcast_action"),
     MEDIA_BUTTON_BROADCAST_SEARCH_ACTION("media_button_broadcast_search_action"),
     PLAYER_BROADCAST_ACTION("player_broadcast_action"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/TracksAnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/TracksAnalyticsTracker.kt
@@ -5,7 +5,9 @@ import android.content.SharedPreferences
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.di.PublicSharedPreferences
+import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.DisplayUtil
+import au.com.shiftyjelly.pocketcasts.utils.Util
 import com.automattic.android.tracks.TracksClient
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.json.JSONObject
@@ -45,6 +47,11 @@ class TracksAnalyticsTracker @Inject constructor(
                 PredefinedEventProperty.PLUS_SUBSCRIPTION_TYPE to subscriptionType,
                 PredefinedEventProperty.PLUS_SUBSCRIPTION_PLATFORM to subscriptionPlatform,
                 PredefinedEventProperty.PLUS_SUBSCRIPTION_FREQUENCY to subscriptionFrequency,
+                PredefinedEventProperty.PLATFORM to when (Util.getAppPlatform(appContext)) {
+                    AppPlatform.Automotive -> "automotive"
+                    AppPlatform.Phone -> "phone"
+                    AppPlatform.WearOs -> "watch"
+                },
             ).mapKeys { it.key.analyticsKey }
         }
 
@@ -112,6 +119,7 @@ class TracksAnalyticsTracker @Inject constructor(
         PLUS_SUBSCRIPTION_TYPE("plus_subscription_type"),
         PLUS_SUBSCRIPTION_PLATFORM("plus_subscription_platform"),
         PLUS_SUBSCRIPTION_FREQUENCY("plus_subscription_frequency"),
+        PLATFORM("platform"),
     }
 
     companion object {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
@@ -160,6 +160,7 @@ sealed class SignInSource {
     sealed class UserInitiated(val analyticsValue: String) : SignInSource() {
         object SignInViewModel : UserInitiated("sign_in_view_model")
         object Onboarding : UserInitiated("onboarding")
+        object Watch : UserInitiated("watch")
     }
     object WatchPhoneSync : SignInSource()
 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/AppPlatform.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/AppPlatform.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.utils
+
+enum class AppPlatform {
+    Automotive,
+    Phone,
+    WearOs,
+}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/Util.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/Util.kt
@@ -14,6 +14,7 @@ import java.util.Locale
 
 object Util {
     private const val MINIMUM_SMALLEST_WIDTH_DP_FOR_TABLET = 570
+    private var appPlatform: AppPlatform? = null
 
     fun isCarUiMode(context: Context): Boolean {
         val uiModeManager = context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
@@ -25,6 +26,18 @@ object Util {
 
     fun isWearOs(context: Context): Boolean =
         appInfoHasBoolean("pocketcasts_wear_os", context)
+
+    // Caching this value since it will always be the same for a given app
+    fun getAppPlatform(context: Context): AppPlatform =
+        appPlatform ?: run {
+            val value = when {
+                isAutomotive(context) -> AppPlatform.Automotive
+                isWearOs(context) -> AppPlatform.WearOs
+                else -> AppPlatform.Phone
+            }
+            appPlatform = value
+            value
+        }
 
     private fun appInfoHasBoolean(key: String, context: Context, default: Boolean = false): Boolean {
         val appInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -5,7 +5,9 @@ import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import au.com.shiftyjelly.pocketcasts.BuildConfig
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.AnonymousBumpStatsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.TracksAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.file.StorageOptions
@@ -42,6 +44,9 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
     @Inject lateinit var settings: Settings
     @Inject lateinit var userManager: UserManager
     @Inject lateinit var workerFactory: HiltWorkerFactory
+
+    @Inject lateinit var tracksTracker: TracksAnalyticsTracker
+    @Inject lateinit var bumpStatsTracker: AnonymousBumpStatsTracker
 
     override fun onCreate() {
         super.onCreate()
@@ -99,6 +104,7 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
     }
 
     private fun setupAnalytics() {
+        AnalyticsTracker.register(tracksTracker, bumpStatsTracker)
         AnalyticsTracker.init(settings)
         FirebaseApp.initializeApp(this)
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.ScalingLazyListState
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
@@ -41,6 +42,10 @@ fun WatchListScreen(
     val state by viewModel.state.collectAsState()
     val upNextState = state.upNextQueue
 
+    CallOnce {
+        viewModel.onShown()
+    }
+
     ScalingLazyColumn(
         state = scrollState,
         flingBehavior = ScrollableDefaults.flingBehavior(),
@@ -54,7 +59,10 @@ fun WatchListScreen(
 
         if (upNextState is UpNextQueue.State.Loaded) {
             item {
-                NowPlayingChip(onClick = toNowPlaying)
+                NowPlayingChip(onClick = {
+                    viewModel.onNowPlayingClicked()
+                    toNowPlaying()
+                })
             }
         }
 
@@ -62,7 +70,10 @@ fun WatchListScreen(
             WatchListChip(
                 title = stringResource(LR.string.podcasts),
                 iconRes = IR.drawable.ic_podcasts,
-                onClick = { navigateToRoute(PodcastsScreen.routeHomeFolder) }
+                onClick = {
+                    viewModel.onPodcastsClicked()
+                    navigateToRoute(PodcastsScreen.routeHomeFolder)
+                }
             )
         }
 
@@ -70,7 +81,10 @@ fun WatchListScreen(
             WatchListChip(
                 title = stringResource(LR.string.downloads),
                 iconRes = IR.drawable.ic_download,
-                onClick = { navigateToRoute(DownloadsScreen.route) }
+                onClick = {
+                    viewModel.onDownloadsClicked()
+                    navigateToRoute(DownloadsScreen.route)
+                }
             )
         }
 
@@ -78,7 +92,10 @@ fun WatchListScreen(
             WatchListChip(
                 title = stringResource(LR.string.filters),
                 iconRes = IR.drawable.ic_filters,
-                onClick = { navigateToRoute(FiltersScreen.route) }
+                onClick = {
+                    viewModel.onFiltersClicked()
+                    navigateToRoute(FiltersScreen.route)
+                }
             )
         }
 
@@ -86,7 +103,10 @@ fun WatchListScreen(
             WatchListChip(
                 title = stringResource(LR.string.profile_navigation_files),
                 iconRes = PR.drawable.ic_file,
-                onClick = { navigateToRoute(FilesScreen.route) }
+                onClick = {
+                    viewModel.onFilesClicked()
+                    navigateToRoute(FilesScreen.route)
+                }
             )
         }
 
@@ -94,7 +114,10 @@ fun WatchListScreen(
             WatchListChip(
                 title = stringResource(LR.string.settings),
                 iconRes = IR.drawable.ic_profile_settings,
-                onClick = { navigateToRoute(SettingsScreen.route) }
+                onClick = {
+                    viewModel.onSettingsClicked()
+                    navigateToRoute(SettingsScreen.route)
+                }
             )
         }
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreenViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreenViewModel.kt
@@ -2,6 +2,8 @@ package au.com.shiftyjelly.pocketcasts.wear.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -18,6 +20,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class WatchListScreenViewModel @Inject constructor(
+    private val analyticsTracker: AnalyticsTrackerWrapper,
     episodeManager: EpisodeManager,
     playbackManager: PlaybackManager,
     podcastManager: PodcastManager,
@@ -43,5 +46,33 @@ class WatchListScreenViewModel @Inject constructor(
                     }
                 }
         }
+    }
+
+    fun onShown() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_MAIN_LIST_SHOWN)
+    }
+
+    fun onNowPlayingClicked() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_MAIN_LIST_NOW_PLAYING_TAPPED)
+    }
+
+    fun onPodcastsClicked() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_MAIN_LIST_PODCASTS_TAPPED)
+    }
+
+    fun onDownloadsClicked() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_MAIN_LIST_DOWNLOADS_TAPPED)
+    }
+
+    fun onFiltersClicked() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_MAIN_LIST_FILTERS_TAPPED)
+    }
+
+    fun onFilesClicked() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_MAIN_LIST_FILES_TAPPED)
+    }
+
+    fun onSettingsClicked() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_MAIN_LIST_SETTINGS_TAPPED)
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleScreenViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleScreenViewModel.kt
@@ -42,7 +42,7 @@ class LoginWithGoogleScreenViewModel @Inject constructor(
         }
 
         account.idToken?.let { idToken ->
-            val loginResult = syncManager.loginWithGoogle(idToken, SignInSource.WatchPhoneSync)
+            val loginResult = syncManager.loginWithGoogle(idToken, SignInSource.UserInitiated.Watch)
             when (loginResult) {
                 is LoginResult.Failed -> {
                     LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Failed to login with Google: ${loginResult.message}")

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -77,7 +77,7 @@ class EpisodeViewModel @Inject constructor(
     private val audioOutputSelectorHelper: AudioOutputSelectorHelper,
 ) : AndroidViewModel(appContext as Application) {
     private var playAttempt: Job? = null
-    private val analyticsSource = AnalyticsSource.WATCH_EPISODE_DETAILS
+    private val analyticsSource = AnalyticsSource.EPISODE_DETAILS
 
     sealed class State {
         data class Loaded(
@@ -364,7 +364,7 @@ class EpisodeViewModel @Inject constructor(
         val state = stateFlow.value as? State.Loaded ?: return
         playbackManager.removeEpisode(
             episodeToRemove = state.episode,
-            source = AnalyticsSource.WATCH_EPISODE_DETAILS
+            source = AnalyticsSource.EPISODE_DETAILS
         )
     }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
@@ -94,15 +94,15 @@ class NowPlayingViewModel @Inject constructor(
     fun onPauseButtonClick() {
         playAttempt?.cancel()
 
-        playbackManager.pause(playbackSource = AnalyticsSource.WATCH_PLAYER)
+        playbackManager.pause(playbackSource = AnalyticsSource.PLAYER)
     }
 
     fun onSeekBackButtonClick() {
-        playbackManager.skipBackward(AnalyticsSource.WATCH_PLAYER)
+        playbackManager.skipBackward(AnalyticsSource.PLAYER)
     }
 
     fun onSeekForwardButtonClick() {
-        playbackManager.skipForward(AnalyticsSource.WATCH_PLAYER)
+        playbackManager.skipForward(AnalyticsSource.PLAYER)
     }
 
     fun onStreamingConfirmationResult(result: StreamingConfirmationScreen.Result) {
@@ -115,6 +115,6 @@ class NowPlayingViewModel @Inject constructor(
     }
 
     private fun play() {
-        playbackManager.playQueue(AnalyticsSource.WATCH_PLAYER)
+        playbackManager.playQueue(AnalyticsSource.PLAYER)
     }
 }


### PR DESCRIPTION
## Description
This turns on Tracks in the watch app (issue https://github.com/Automattic/pocket-casts-android/issues/1007).

In addition, I am adding a global `platform` property to identify if a given event is coming from a watch, phone, or automotive app. I thought this was better than adding duplicate events/sources for everything that happens on the phone as well as the watch. Let me know if you think this isn't the right way to go though.

Lastly, this PR includes a fix for the user signed in events. Before this PR, the `user_signed_in_watch_from_phone` event was sent for all sign-ins on the watch. This updates that so that event is only sent when the user is automatically signed into the watch from the phone. All user-initiated sign-ins on the watch now send the `user_signed_in` event.

This PR does **not** add any new events to the watch app.

## Testing Instructions

1. Check and make sure that events from the watch is firing correctly and has an `platform` property of "watch" for each event. Here are the events I see now working in the watch app (there may be more that I missed):

    1. episode_added_to_up_next
    1. episode_removed_from_up_next
    1. episode_archived
    1. episode_unarchived
    1. episode_download_queued
    1. episode_download_cancelled
    1. episode_download_finished
    1. episode_marked_as_played
    1. episode_marked_as_unplayed
    1. episode_starred
    1. episode_unstarred
    1. playback_play
    1. playback_pause
    1. playback_skip_back
    1. playback_skip_forward
    1. user_signed_in
    1. user_signed_out

2. In addition, make sure these events are getting logged in the Tracks backend. I did this by creating my own unique event that got sent off from a release build, and then looking for that event.

3. Check that the `user_signed_in` event is sent if a user logs in with google or email and that the `user_signed_in_watch_from_phone` event is sent if the user is signed in automatically from the phone.

4. Spot-check a few events on the phone to make sure they have the `platform` property of "phone".

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
