### PR TITLE
Adding tracks for the watch's main list screen

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -545,4 +545,13 @@ enum class AnalyticsEvent(val key: String) {
 
     /* Ratings */
     RATING_STARS_TAPPED("rating_stars_tapped"),
+
+    /* Wear Main List Screen */
+    WEAR_MAIN_LIST_SHOWN("wear_main_list_shown"),
+    WEAR_MAIN_LIST_NOW_PLAYING_TAPPED("wear_main_list_now_playing_tapped"),
+    WEAR_MAIN_LIST_PODCASTS_TAPPED("wear_main_list_podcasts_tapped"),
+    WEAR_MAIN_LIST_DOWNLOADS_TAPPED("wear_main_list_downloads_tapped"),
+    WEAR_MAIN_LIST_FILTERS_TAPPED("wear_main_list_filters_tapped"),
+    WEAR_MAIN_LIST_FILES_TAPPED("wear_main_list_files_tapped"),
+    WEAR_MAIN_LIST_SETTINGS_TAPPED("wear_main_list_settings_tapped"),
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.ScalingLazyListState
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
@@ -41,6 +42,10 @@ fun WatchListScreen(
     val state by viewModel.state.collectAsState()
     val upNextState = state.upNextQueue
 
+    CallOnce {
+        viewModel.onShown()
+    }
+
     ScalingLazyColumn(
         state = scrollState,
         flingBehavior = ScrollableDefaults.flingBehavior(),
@@ -54,7 +59,10 @@ fun WatchListScreen(
 
         if (upNextState is UpNextQueue.State.Loaded) {
             item {
-                NowPlayingChip(onClick = toNowPlaying)
+                NowPlayingChip(onClick = {
+                    viewModel.onNowPlayingClicked()
+                    toNowPlaying()
+                })
             }
         }
 
@@ -62,7 +70,10 @@ fun WatchListScreen(
             WatchListChip(
                 title = stringResource(LR.string.podcasts),
                 iconRes = IR.drawable.ic_podcasts,
-                onClick = { navigateToRoute(PodcastsScreen.routeHomeFolder) }
+                onClick = {
+                    viewModel.onPodcastsClicked()
+                    navigateToRoute(PodcastsScreen.routeHomeFolder)
+                }
             )
         }
 
@@ -70,7 +81,10 @@ fun WatchListScreen(
             WatchListChip(
                 title = stringResource(LR.string.downloads),
                 iconRes = IR.drawable.ic_download,
-                onClick = { navigateToRoute(DownloadsScreen.route) }
+                onClick = {
+                    viewModel.onDownloadsClicked()
+                    navigateToRoute(DownloadsScreen.route)
+                }
             )
         }
 
@@ -78,7 +92,10 @@ fun WatchListScreen(
             WatchListChip(
                 title = stringResource(LR.string.filters),
                 iconRes = IR.drawable.ic_filters,
-                onClick = { navigateToRoute(FiltersScreen.route) }
+                onClick = {
+                    viewModel.onFiltersClicked()
+                    navigateToRoute(FiltersScreen.route)
+                }
             )
         }
 
@@ -86,7 +103,10 @@ fun WatchListScreen(
             WatchListChip(
                 title = stringResource(LR.string.profile_navigation_files),
                 iconRes = PR.drawable.ic_file,
-                onClick = { navigateToRoute(FilesScreen.route) }
+                onClick = {
+                    viewModel.onFilesClicked()
+                    navigateToRoute(FilesScreen.route)
+                }
             )
         }
 
@@ -94,7 +114,10 @@ fun WatchListScreen(
             WatchListChip(
                 title = stringResource(LR.string.settings),
                 iconRes = IR.drawable.ic_profile_settings,
-                onClick = { navigateToRoute(SettingsScreen.route) }
+                onClick = {
+                    viewModel.onSettingsClicked()
+                    navigateToRoute(SettingsScreen.route)
+                }
             )
         }
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreenViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreenViewModel.kt
@@ -2,6 +2,8 @@ package au.com.shiftyjelly.pocketcasts.wear.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -18,6 +20,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class WatchListScreenViewModel @Inject constructor(
+    private val analyticsTracker: AnalyticsTrackerWrapper,
     episodeManager: EpisodeManager,
     playbackManager: PlaybackManager,
     podcastManager: PodcastManager,
@@ -43,5 +46,33 @@ class WatchListScreenViewModel @Inject constructor(
                     }
                 }
         }
+    }
+
+    fun onShown() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_MAIN_LIST_SHOWN)
+    }
+
+    fun onNowPlayingClicked() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_MAIN_LIST_NOW_PLAYING_TAPPED)
+    }
+
+    fun onPodcastsClicked() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_MAIN_LIST_PODCASTS_TAPPED)
+    }
+
+    fun onDownloadsClicked() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_MAIN_LIST_DOWNLOADS_TAPPED)
+    }
+
+    fun onFiltersClicked() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_MAIN_LIST_FILTERS_TAPPED)
+    }
+
+    fun onFilesClicked() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_MAIN_LIST_FILES_TAPPED)
+    }
+
+    fun onSettingsClicked() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_MAIN_LIST_SETTINGS_TAPPED)
     }
 }


### PR DESCRIPTION
## Description
This PR adds tracks to the main list screen on the watch (issue https://github.com/Automattic/pocket-casts-android/issues/1007).

## Testing Instructions
1. Install the watch app and log in so that you are brought to the main list screen
2. ✅ Observe that the `wear_main_list_shown` event is sent
3. Tap on each of the buttons on the main list screen
4. ✅ Observe that for each button the appropriate `wear_main_list_[button]_tapped` event is sent.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews