### PR TITLE
Add privacy settings for watch

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/PrivacyFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/PrivacyFragment.kt
@@ -62,7 +62,7 @@ class PrivacyFragment : BaseFragment() {
                             viewModel.updateAnalyticsSetting(it)
                         },
                         onCrashReportsClick = {
-                            viewModel.updateCrashReportsSetting(context, it)
+                            viewModel.updateCrashReportsSetting(it)
                         },
                         onLinkAccountClick = {
                             viewModel.updateLinkAccountSetting(it)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/PrivacyViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/PrivacyViewModel.kt
@@ -1,15 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.settings.privacy
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.sentry.Sentry
-import io.sentry.android.core.SentryAndroid
-import io.sentry.protocol.User
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -17,9 +12,10 @@ import javax.inject.Inject
 
 @HiltViewModel
 class PrivacyViewModel @Inject constructor(
-    private val settings: Settings,
+    settings: Settings,
     private val syncManager: SyncManager,
-    private val analyticsTracker: AnalyticsTrackerWrapper,
+    analyticsTracker: AnalyticsTrackerWrapper,
+    private val userAnalyticsSettings: UserAnalyticsSettings,
 ) : ViewModel() {
 
     var isFragmentChangingConfigurations: Boolean = false
@@ -39,39 +35,23 @@ class PrivacyViewModel @Inject constructor(
             analytics = analyticsTracker.getSendUsageStats(),
             crashReports = settings.getSendCrashReports(),
             linkAccount = settings.getLinkCrashReportsToUser(),
-            getUserEmail = { getUserEmail() }
+            getUserEmail = { syncManager.getEmail() }
         )
     )
     val uiState: StateFlow<UiState> = mutableUiState.asStateFlow()
 
     fun updateAnalyticsSetting(on: Boolean) {
-        if (on) {
-            analyticsTracker.setSendUsageStats(true)
-            analyticsTracker.track(AnalyticsEvent.ANALYTICS_OPT_IN)
-        } else {
-            analyticsTracker.track(AnalyticsEvent.ANALYTICS_OPT_OUT)
-            analyticsTracker.setSendUsageStats(false)
-        }
+        userAnalyticsSettings.updateAnalyticsSetting(on)
         mutableUiState.value = (mutableUiState.value as UiState.Loaded).copy(analytics = on)
     }
 
-    fun updateCrashReportsSetting(context: Context, on: Boolean) {
-        if (on) {
-            SentryAndroid.init(context) { it.dsn = settings.getSentryDsn() }
-        } else {
-            SentryAndroid.init(context) { it.dsn = "" }
-        }
-        settings.setSendCrashReports(on)
+    fun updateCrashReportsSetting(on: Boolean) {
+        userAnalyticsSettings.updateCrashReportsSetting(on)
         mutableUiState.value = (mutableUiState.value as UiState.Loaded).copy(crashReports = on)
     }
 
     fun updateLinkAccountSetting(on: Boolean) {
-        val user = if (on) User().apply { email = getUserEmail() } else null
-        Sentry.setUser(user)
-
-        settings.setLinkCrashReportsToUser(on)
+        userAnalyticsSettings.updateLinkAccountSetting(on)
         mutableUiState.value = (mutableUiState.value as UiState.Loaded).copy(linkAccount = on)
     }
-
-    private fun getUserEmail() = syncManager.getEmail()
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
@@ -1,0 +1,46 @@
+package au.com.shiftyjelly.pocketcasts.settings.privacy
+
+import android.content.Context
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.sentry.Sentry
+import io.sentry.android.core.SentryAndroid
+import io.sentry.protocol.User
+import javax.inject.Inject
+
+class UserAnalyticsSettings @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val settings: Settings,
+    private val syncManager: SyncManager,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+) {
+
+    fun updateAnalyticsSetting(enabled: Boolean) {
+        if (enabled) {
+            analyticsTracker.setSendUsageStats(true)
+            analyticsTracker.track(AnalyticsEvent.ANALYTICS_OPT_IN)
+        } else {
+            analyticsTracker.track(AnalyticsEvent.ANALYTICS_OPT_OUT)
+            analyticsTracker.setSendUsageStats(false)
+        }
+    }
+
+    fun updateCrashReportsSetting(enabled: Boolean) {
+        if (enabled) {
+            SentryAndroid.init(context) { it.dsn = settings.getSentryDsn() }
+        } else {
+            SentryAndroid.init(context) { it.dsn = "" }
+        }
+        settings.setSendCrashReports(enabled)
+    }
+
+    fun updateLinkAccountSetting(enabled: Boolean) {
+        val user = if (enabled) User().apply { email = syncManager.getEmail() } else null
+        Sentry.setUser(user)
+
+        settings.setLinkCrashReportsToUser(enabled)
+    }
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1334,6 +1334,7 @@
     <string name="settings_privacy_crash">Crash reports</string>
     <string name="settings_privacy_crash_summary">Allow us to collect crash reports.</string>
     <string name="settings_privacy_crash_link">Link your account to crashes</string>
+    <string name="settings_privacy_crash_link_short">Link your account</string>
     <string name="settings_privacy_crash_link_summary">Allow us to link your Pocket Casts account to crash reports.</string>
 
     <string name="settings_advanced_sync_on_metered">Sync on Metered Networks</string>

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -115,6 +115,7 @@ dependencies {
     implementation project(':modules:features:account')
     implementation project(':modules:features:podcasts')
     implementation project(':modules:features:profile')
+    implementation project(':modules:features:settings')
 }
 
 task useGoogleServicesDebugFile {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -32,7 +32,6 @@ import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 import au.com.shiftyjelly.pocketcasts.wear.ui.FilesScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.LoggingInScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.ScrollToTop
-import au.com.shiftyjelly.pocketcasts.wear.ui.SettingsScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.WatchListScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.authentication.RequirePlusScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.authentication.authenticationNavGraph
@@ -49,6 +48,8 @@ import au.com.shiftyjelly.pocketcasts.wear.ui.player.PCVolumeScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.StreamingConfirmationScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcast.PodcastScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcasts.PodcastsScreen
+import au.com.shiftyjelly.pocketcasts.wear.ui.settings.PrivacySettingsScreen
+import au.com.shiftyjelly.pocketcasts.wear.ui.settings.SettingsScreen
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
 import com.google.android.horologist.compose.navscaffold.ScrollableScaffoldContext
 import com.google.android.horologist.compose.navscaffold.WearNavScaffold
@@ -308,7 +309,12 @@ fun WearApp(
             SettingsScreen(
                 scrollState = it.columnState,
                 signInClick = { navController.navigate(authenticationSubGraph) },
+                navigateToPrivacySettings = { navController.navigate(PrivacySettingsScreen.route) },
             )
+        }
+
+        scrollable(PrivacySettingsScreen.route) {
+            PrivacySettingsScreen(scrollState = it.columnState)
         }
 
         val popToStartDestination: () -> Unit = {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -61,7 +61,7 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
 
     private fun setupSentry() {
         SentryAndroid.init(this) { options ->
-            options.dsn = settings.getSentryDsn()
+            options.dsn = if (settings.getSendCrashReports()) settings.getSentryDsn() else ""
             options.setTag(SentryHelper.GLOBAL_TAG_APP_PLATFORM, AppPlatform.WEAR.value)
         }
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -76,6 +76,9 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
                 Sentry.setUser(user)
             }
         }
+
+        // Setup the Firebase, the documentation says this isn't needed but in production we sometimes get the following error "FirebaseApp is not initialized in this process au.com.shiftyjelly.pocketcasts. Make sure to call FirebaseApp.initializeApp(Context) first."
+        FirebaseApp.initializeApp(this)
     }
 
     private fun setupLogging() {
@@ -118,7 +121,7 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
     private fun setupAnalytics() {
         AnalyticsTracker.register(tracksTracker, bumpStatsTracker)
         AnalyticsTracker.init(settings)
-        FirebaseApp.initializeApp(this)
+        AnalyticsTracker.refreshMetadata()
     }
 
     override fun getWorkManagerConfiguration(): Configuration {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
@@ -19,6 +19,7 @@ import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.downloads.DownloadsScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.filters.FiltersScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcasts.PodcastsScreen
+import au.com.shiftyjelly.pocketcasts.wear.ui.settings.SettingsScreen
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.profile.R as PR

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/WatchListChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/WatchListChip.kt
@@ -3,11 +3,13 @@ package au.com.shiftyjelly.pocketcasts.wear.ui.component
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipColors
 import androidx.wear.compose.material.ChipDefaults
@@ -34,6 +36,7 @@ fun WatchListChip(
             Icon(
                 painter = painterResource(iconRes),
                 contentDescription = title,
+                modifier = Modifier.size(24.dp)
             )
         },
         modifier = modifier,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsScreen.kt
@@ -33,8 +33,8 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.wear.ui.ToggleChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
+import au.com.shiftyjelly.pocketcasts.wear.ui.settings.ToggleChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.belowTimeTextPreview

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/PrivacySettingsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/PrivacySettingsScreen.kt
@@ -8,10 +8,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
+import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
@@ -27,7 +30,23 @@ fun PrivacySettingsScreen(
 ) {
     val viewModel = hiltViewModel<PrivacySettingsViewModel>()
     val state by viewModel.state.collectAsState()
+    Content(
+        scrollState = scrollState,
+        state = state,
+        onAnalyticsChanged = viewModel::onAnalyticsChanged,
+        onCrashReportingChanged = viewModel::onCrashReportingChanged,
+        onLinkCrashReportsToUserChanged = viewModel::onLinkCrashReportsToUserChanged,
+    )
+}
 
+@Composable
+private fun Content(
+    scrollState: ScalingLazyColumnState,
+    state: PrivacySettingsViewModel.State,
+    onAnalyticsChanged: (Boolean) -> Unit,
+    onCrashReportingChanged: (Boolean) -> Unit,
+    onLinkCrashReportsToUserChanged: (Boolean) -> Unit,
+) {
     ScalingLazyColumn(columnState = scrollState) {
 
         item {
@@ -43,7 +62,7 @@ fun PrivacySettingsScreen(
             ToggleChip(
                 label = analyticsLabel,
                 checked = state.sendAnalytics,
-                onCheckedChanged = viewModel::onAnalyticsChanged,
+                onCheckedChanged = onAnalyticsChanged,
             )
         }
 
@@ -56,7 +75,7 @@ fun PrivacySettingsScreen(
             ToggleChip(
                 label = analyticsLabel,
                 checked = state.sendCrashReports,
-                onCheckedChanged = viewModel::onCrashReportingChanged,
+                onCheckedChanged = onCrashReportingChanged,
             )
         }
 
@@ -69,7 +88,7 @@ fun PrivacySettingsScreen(
             ToggleChip(
                 label = analyticsLabel,
                 checked = state.linkCrashReportsToUser,
-                onCheckedChanged = viewModel::onLinkCrashReportsToUserChanged,
+                onCheckedChanged = onLinkCrashReportsToUserChanged,
             )
         }
 
@@ -88,4 +107,22 @@ private fun DescriptionText(@StringRes text: Int) {
         textAlign = TextAlign.Center,
         modifier = Modifier.padding(8.dp)
     )
+}
+
+@Composable
+@Preview(device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+private fun Preview() {
+    WearAppTheme {
+        Content(
+            scrollState = ScalingLazyColumnState(),
+            state = PrivacySettingsViewModel.State(
+                sendAnalytics = true,
+                sendCrashReports = true,
+                linkCrashReportsToUser = false,
+            ),
+            onAnalyticsChanged = {},
+            onCrashReportingChanged = {},
+            onLinkCrashReportsToUserChanged = {},
+        )
+    }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/PrivacySettingsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/PrivacySettingsScreen.kt
@@ -1,0 +1,91 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui.settings
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+object PrivacySettingsScreen {
+    const val route = "analytics_settings_screen"
+}
+
+@Composable
+fun PrivacySettingsScreen(
+    scrollState: ScalingLazyColumnState,
+) {
+    val viewModel = hiltViewModel<PrivacySettingsViewModel>()
+    val state by viewModel.state.collectAsState()
+
+    ScalingLazyColumn(columnState = scrollState) {
+
+        item {
+            ScreenHeaderChip(LR.string.settings_privacy_analytics)
+        }
+
+        item {
+            DescriptionText(LR.string.settings_privacy_summary)
+        }
+
+        item {
+            val analyticsLabel = stringResource(LR.string.settings_privacy_analytics)
+            ToggleChip(
+                label = analyticsLabel,
+                checked = state.sendAnalytics,
+                onCheckedChanged = viewModel::onAnalyticsChanged,
+            )
+        }
+
+        item {
+            DescriptionText(LR.string.settings_privacy_analytics_summary)
+        }
+
+        item {
+            val analyticsLabel = stringResource(LR.string.settings_privacy_crash)
+            ToggleChip(
+                label = analyticsLabel,
+                checked = state.sendCrashReports,
+                onCheckedChanged = viewModel::onCrashReportingChanged,
+            )
+        }
+
+        item {
+            DescriptionText(LR.string.settings_privacy_crash_summary)
+        }
+
+        item {
+            val analyticsLabel = stringResource(LR.string.settings_privacy_crash_link_short)
+            ToggleChip(
+                label = analyticsLabel,
+                checked = state.linkCrashReportsToUser,
+                onCheckedChanged = viewModel::onLinkCrashReportsToUserChanged,
+            )
+        }
+
+        item {
+            DescriptionText(LR.string.settings_privacy_crash_link_summary)
+        }
+    }
+}
+
+@Composable
+private fun DescriptionText(@StringRes text: Int) {
+    Text(
+        text = stringResource(text),
+        style = MaterialTheme.typography.caption3,
+        color = MaterialTheme.colors.onSecondary,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(8.dp)
+    )
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/PrivacySettingsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/PrivacySettingsViewModel.kt
@@ -1,0 +1,47 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui.settings
+
+import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.settings.privacy.UserAnalyticsSettings
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class PrivacySettingsViewModel @Inject constructor(
+    private val userAnalyticsSettings: UserAnalyticsSettings,
+    settings: Settings,
+) : ViewModel() {
+
+    data class State(
+        val sendAnalytics: Boolean,
+        val sendCrashReports: Boolean,
+        val linkCrashReportsToUser: Boolean,
+    )
+
+    private val _state = MutableStateFlow(
+        State(
+            sendAnalytics = settings.getSendUsageStats(),
+            sendCrashReports = settings.getSendCrashReports(),
+            linkCrashReportsToUser = settings.getLinkCrashReportsToUser(),
+        )
+    )
+    val state = _state.asStateFlow()
+
+    fun onAnalyticsChanged(enabled: Boolean) {
+        userAnalyticsSettings.updateAnalyticsSetting(enabled)
+        _state.update { it.copy(sendAnalytics = enabled) }
+    }
+
+    fun onCrashReportingChanged(enabled: Boolean) {
+        userAnalyticsSettings.updateCrashReportsSetting(enabled)
+        _state.update { it.copy(sendCrashReports = enabled) }
+    }
+
+    fun onLinkCrashReportsToUserChanged(enabled: Boolean) {
+        userAnalyticsSettings.updateLinkAccountSetting(enabled)
+        _state.update { it.copy(linkCrashReportsToUser = enabled) }
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsScreen.kt
@@ -5,8 +5,6 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -93,26 +91,24 @@ private fun Content(
             )
         }
 
+        val backgroundRefreshStringRes =
+            if (state.refreshInBackground) LR.string.settings_storage_background_refresh_on else LR.string.settings_storage_background_refresh_off
         item {
-            Column {
-                val stringRes =
-                    if (state.refreshInBackground) LR.string.settings_storage_background_refresh_on else LR.string.settings_storage_background_refresh_off
-                ToggleChip(
-                    label = stringResource(LR.string.settings_storage_background_refresh),
-                    checked = state.refreshInBackground,
-                    onCheckedChanged = onRefreshInBackgroundChanged,
-                )
-                Box(
-                    modifier = Modifier.padding(8.dp)
-                ) {
-                    Text(
-                        text = stringResource(stringRes),
-                        style = MaterialTheme.typography.caption3,
-                        color = MaterialTheme.colors.onSecondary,
-                        textAlign = TextAlign.Center,
-                    )
-                }
-            }
+            ToggleChip(
+                label = stringResource(LR.string.settings_storage_background_refresh),
+                checked = state.refreshInBackground,
+                onCheckedChanged = onRefreshInBackgroundChanged,
+            )
+        }
+
+        item {
+            Text(
+                text = stringResource(backgroundRefreshStringRes),
+                style = MaterialTheme.typography.caption3,
+                color = MaterialTheme.colors.onSecondary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(8.dp)
+            )
         }
 
         item {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsScreen.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.wear.ui
+package au.com.shiftyjelly.pocketcasts.wear.ui.settings
 
 import android.content.res.Configuration
 import androidx.compose.animation.core.Animatable
@@ -40,6 +40,7 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import au.com.shiftyjelly.pocketcasts.settings.R as SR
 
 object SettingsScreen {
     const val route = "settings_screen"
@@ -49,6 +50,7 @@ object SettingsScreen {
 fun SettingsScreen(
     scrollState: ScalingLazyColumnState,
     signInClick: () -> Unit,
+    navigateToPrivacySettings: () -> Unit,
 ) {
 
     val viewModel = hiltViewModel<SettingsViewModel>()
@@ -62,6 +64,7 @@ fun SettingsScreen(
         signInClick = signInClick,
         onSignOutClicked = viewModel::signOut,
         onRefreshClicked = viewModel::refresh,
+        onPrivacyClicked = navigateToPrivacySettings,
     )
 }
 
@@ -74,6 +77,7 @@ private fun Content(
     signInClick: () -> Unit,
     onSignOutClicked: () -> Unit,
     onRefreshClicked: () -> Unit,
+    onPrivacyClicked: () -> Unit,
 ) {
     ScalingLazyColumn(columnState = scrollState) {
 
@@ -133,6 +137,14 @@ private fun Content(
                     )
                 },
                 onClick = onRefreshClicked,
+            )
+        }
+
+        item {
+            WatchListChip(
+                title = stringResource(LR.string.settings_privacy_analytics),
+                iconRes = SR.drawable.whatsnew_privacy,
+                onClick = onPrivacyClicked,
             )
         }
 
@@ -252,6 +264,7 @@ private fun SettingsScreenPreview_unchecked() {
             onRefreshInBackgroundChanged = {},
             onSignOutClicked = {},
             onRefreshClicked = {},
+            onPrivacyClicked = {},
         )
     }
 }
@@ -280,6 +293,7 @@ private fun SettingsScreenPreview_checked() {
             onRefreshInBackgroundChanged = {},
             onSignOutClicked = {},
             onRefreshClicked = {},
+            onPrivacyClicked = {},
         )
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsViewModel.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.wear.ui
+package au.com.shiftyjelly.pocketcasts.wear.ui.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope


### PR DESCRIPTION
## Description
This adds user privacy options for the watch (issue https://github.com/Automattic/pocket-casts-android/issues/1007). For now I'm just going with the same settings we have on the phone.

## Testing Instructions

The privacy settings are available under `Settings` → `Privacy`. 
- Verify that the default settings have "Analytics" and "Crash Reports" toggled on, with "Link your account" toggled off
- Verify that Tracks are only sent off if "Analytics" is toggled on
- Verify that crash reports are only sent off if "Crash reports" is toggled on
- Verify that the crash reports only includes the users email address if "Link your account" is toggled on

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/4656348/d965a1e6-d09d-4974-b7ee-1018200114cd

#### Crash report
| Account unlinked | Account linked |
| --- | --- |
| ![image](https://github.com/Automattic/pocket-casts-android/assets/4656348/604343a8-ef21-4e58-901e-9a952c8ad786) | ![image](https://github.com/Automattic/pocket-casts-android/assets/4656348/320ac30a-dbf7-4103-a36d-eba154cae9dd) |

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
