### PR TITLE
Use radioactive icons for debug builds on wear and automotive apps

### DIFF
--- a/automotive/build.gradle
+++ b/automotive/build.gradle
@@ -25,6 +25,7 @@ android {
             applicationIdSuffix '.debug'
 
             manifestPlaceholders = [
+                    appIcon: "@mipmap/ic_launcher_radioactive",
                     sentryDsn: ""
             ]
         }
@@ -36,6 +37,7 @@ android {
 
         release {
             manifestPlaceholders = [
+                    appIcon: "@mipmap/ic_launcher",
                     gitHash: "",
                     sentryDsn: project.pocketcastsSentryDsn
             ]

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
     <application
         android:name=".AutomotiveApplication"
         android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
+        android:icon="${appIcon}"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Automotive.ThemeDark"

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -45,6 +45,7 @@ android {
 
         release {
             manifestPlaceholders = [
+                    appIcon: "@mipmap/ic_launcher",
                     gitHash: "",
                     sentryDsn: project.pocketcastsSentryDsn
             ]

--- a/wear/src/debug/res/values/titles.xml
+++ b/wear/src/debug/res/values/titles.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Pocket Debug</string>
+</resources>

--- a/wear/src/debugProd/res/values/titles.xml
+++ b/wear/src/debugProd/res/values/titles.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Pocket Debug</string>
+</resources>

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
     <application
         android:name=".wear.PocketCastsWearApplication"
         android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
+        android:icon="${appIcon}"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/SplashTheme">


### PR DESCRIPTION
## Description
This uses the radioactive icon by default for debug builds of the automotive and wear apps like we do for the phone app currently. In addition, this uses the "Pocket Debug" app name for the debug builds like the phone app does. It's so much easier to differentiate the apps on your device during development with these changes.

## Testing Instructions
1. Verify that debug builds of the wear and automotive apps have the green radioactive icon by default.
2. Verify that release builds of the wear and automotive apps still have the regular icon by default

## Screenshots or Screencast 

![image](https://github.com/Automattic/pocket-casts-android/assets/4656348/63ba4dd9-58dc-4325-a3dc-bf7c885409be)

![image](https://github.com/Automattic/pocket-casts-android/assets/4656348/cdaa370a-4ffb-435a-a728-801c6c99fa71)

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes