### PR TITLE
Support scrolling with rotary input on watch list

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -150,7 +150,7 @@ fun WearApp(
                 ScrollToTop.handle(navController, it.scrollableState)
 
                 WatchListScreen(
-                    scrollState = it.columnState,
+                    columnState = it.columnState,
                     navigateToRoute = navController::navigate,
                     toNowPlaying = {
                         coroutineScope.launch {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -149,7 +149,7 @@ fun WearApp(
                 ScrollToTop.handle(navController, it.scrollableState)
 
                 WatchListScreen(
-                    scrollState = it.scrollableState,
+                    scrollState = it.columnState,
                     navigateToRoute = navController::navigate,
                     toNowPlaying = {
                         coroutineScope.launch {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -248,7 +248,7 @@ fun WearApp(
                     onFilterTap = { filterUuid ->
                         navController.navigate(FilterScreen.navigateRoute(filterUuid))
                     },
-                    listState = it.scrollableState,
+                    columnState = it.columnState,
                 )
             }
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -225,7 +225,7 @@ fun WearApp(
                     onEpisodeTap = { episode ->
                         navController.navigate(EpisodeScreenFlow.navigateRoute(episodeUuid = episode.uuid))
                     },
-                    listState = it.scrollableState,
+                    columnState = it.columnState,
                 )
             }
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -270,7 +270,7 @@ fun WearApp(
                     onEpisodeTap = { episode ->
                         navController.navigate(EpisodeScreenFlow.navigateRoute(episodeUuid = episode.uuid))
                     },
-                    listState = it.scrollableState,
+                    columnState = it.columnState,
                 )
             }
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -414,7 +414,7 @@ fun PodcastsScreenContent(
         scrollableScaffoldContext = scrollableScaffoldContext,
     ) {
         PodcastsScreen(
-            listState = scrollableScaffoldContext.scrollableState,
+            columnState = scrollableScaffoldContext.columnState,
             navigateToPodcast = { podcastUuid ->
                 navController.navigate(PodcastScreen.navigateRoute(podcastUuid))
             },

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
@@ -15,14 +15,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
-import androidx.wear.compose.foundation.lazy.ScalingLazyListState
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.EpisodeChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 object UpNextScreen {
@@ -34,7 +34,7 @@ fun UpNextScreen(
     navigateToEpisode: (episodeUuid: String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: UpNextViewModel = hiltViewModel(),
-    listState: ScalingLazyListState,
+    columnState: ScalingLazyColumnState,
 ) {
     val queueState by viewModel.upNextQueue.subscribeAsState(initial = null)
 
@@ -50,7 +50,7 @@ fun UpNextScreen(
                 EmptyQueueState()
             } else {
                 ScalingLazyColumn(
-                    state = listState,
+                    columnState = columnState,
                     modifier = modifier.fillMaxWidth(),
                 ) {
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui
 
-import androidx.compose.foundation.gestures.ScrollableDefaults
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
@@ -11,8 +10,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
-import androidx.wear.compose.foundation.lazy.ScalingLazyListState
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
@@ -20,20 +17,19 @@ import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.downloads.DownloadsScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.filters.FiltersScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcasts.PodcastsScreen
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.profile.R as PR
 
 object WatchListScreen {
     const val route = "watch_list_screen"
-
-    // Key for boolean value in SavedStateHandle that is used to have this screen scroll to the top
-    const val scrollToTop = "scroll_to_top"
 }
 
 @Composable
 fun WatchListScreen(
-    scrollState: ScalingLazyListState,
+    scrollState: ScalingLazyColumnState,
     navigateToRoute: (String) -> Unit,
     toNowPlaying: () -> Unit,
 ) {
@@ -47,8 +43,7 @@ fun WatchListScreen(
     }
 
     ScalingLazyColumn(
-        state = scrollState,
-        flingBehavior = ScrollableDefaults.flingBehavior(),
+        columnState = scrollState,
         modifier = Modifier.fillMaxWidth(),
     ) {
 
@@ -130,7 +125,7 @@ private fun WatchListPreview() {
         WatchListScreen(
             toNowPlaying = {},
             navigateToRoute = {},
-            scrollState = ScalingLazyListState()
+            scrollState = ScalingLazyColumnState()
         )
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/WatchListScreen.kt
@@ -30,7 +30,7 @@ object WatchListScreen {
 
 @Composable
 fun WatchListScreen(
-    scrollState: ScalingLazyColumnState,
+    columnState: ScalingLazyColumnState,
     navigateToRoute: (String) -> Unit,
     toNowPlaying: () -> Unit,
 ) {
@@ -44,7 +44,7 @@ fun WatchListScreen(
     }
 
     ScalingLazyColumn(
-        columnState = scrollState,
+        columnState = columnState,
         modifier = Modifier.fillMaxWidth(),
     ) {
 
@@ -126,7 +126,7 @@ private fun WatchListPreview() {
         WatchListScreen(
             toNowPlaying = {},
             navigateToRoute = {},
-            scrollState = ScalingLazyColumnState()
+            columnState = ScalingLazyColumnState()
         )
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/NowPlayingPager.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/NowPlayingPager.kt
@@ -11,13 +11,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
-import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
 import androidx.wear.compose.material.SwipeToDismissBoxState
 import androidx.wear.compose.material.edgeSwipeToDismiss
 import au.com.shiftyjelly.pocketcasts.wear.ui.UpNextScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.WatchListScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.episode.EpisodeScreenFlow
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.NowPlayingScreen
+import com.google.android.horologist.compose.layout.rememberColumnState
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
 import com.google.android.horologist.compose.navscaffold.ScrollableScaffoldContext
 import com.google.android.horologist.compose.pager.PagerScreen
@@ -108,7 +108,7 @@ fun NowPlayingPager(
                     navigateToEpisode = { episodeUuid ->
                         navController.navigate(EpisodeScreenFlow.navigateRoute(episodeUuid))
                     },
-                    listState = rememberScalingLazyListState(),
+                    columnState = rememberColumnState(),
                 )
             }
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterScreen.kt
@@ -6,14 +6,14 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
-import androidx.wear.compose.foundation.lazy.ScalingLazyListState
 import androidx.wear.compose.foundation.lazy.items
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.EpisodeChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.LoadingScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.filter.FilterViewModel.UiState
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 
 object FilterScreen {
     const val argumentFilterUuid = "filterUuid"
@@ -27,7 +27,7 @@ fun FilterScreen(
     onEpisodeTap: (PodcastEpisode) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: FilterViewModel = hiltViewModel(),
-    listState: ScalingLazyListState,
+    columnState: ScalingLazyColumnState,
 ) {
     val uiState by viewModel.uiState.collectAsState(UiState.Loading)
     when (val state = uiState) {
@@ -35,7 +35,7 @@ fun FilterScreen(
             state = state,
             onEpisodeTap = onEpisodeTap,
             modifier = modifier,
-            listState = listState,
+            listState = columnState,
         )
         is UiState.Loading -> LoadingScreen()
         is UiState.Empty -> Unit
@@ -47,11 +47,11 @@ private fun Content(
     state: UiState.Loaded,
     onEpisodeTap: (PodcastEpisode) -> Unit,
     modifier: Modifier = Modifier,
-    listState: ScalingLazyListState,
+    listState: ScalingLazyColumnState,
 ) {
     ScalingLazyColumn(
         modifier = modifier.fillMaxWidth(),
-        state = listState
+        columnState = listState
     ) {
         item {
             ScreenHeaderChip(state.filter.title)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filters/FiltersScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filters/FiltersScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
-import androidx.wear.compose.foundation.lazy.ScalingLazyListState
 import androidx.wear.compose.foundation.lazy.items
 import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.drawableId
@@ -21,6 +19,8 @@ import au.com.shiftyjelly.pocketcasts.wear.ui.component.LoadingScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.filters.FiltersViewModel.UiState
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 object FiltersScreen {
@@ -32,7 +32,7 @@ fun FiltersScreen(
     onFilterTap: (String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: FiltersViewModel = hiltViewModel(),
-    listState: ScalingLazyListState,
+    columnState: ScalingLazyColumnState,
 ) {
     val uiState by viewModel.uiState.collectAsState()
     when (val state = uiState) { // the state needs to be immutable or the following error will happen 'Smart cast is impossible'
@@ -40,7 +40,7 @@ fun FiltersScreen(
             filters = state.filters,
             onFilterTap = onFilterTap,
             modifier = modifier,
-            listState = listState,
+            columnState = columnState,
         )
         is UiState.Loading -> LoadingScreen()
     }
@@ -51,11 +51,11 @@ private fun Content(
     filters: List<Playlist>,
     onFilterTap: (String) -> Unit,
     modifier: Modifier = Modifier,
-    listState: ScalingLazyListState,
+    columnState: ScalingLazyColumnState,
 ) {
     ScalingLazyColumn(
         modifier = modifier.fillMaxWidth(),
-        state = listState
+        columnState = columnState
     ) {
         item {
             ScreenHeaderChip(LR.string.filters)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
@@ -18,8 +18,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
-import androidx.wear.compose.foundation.lazy.ScalingLazyListState
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
@@ -30,6 +28,8 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.EpisodeChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcast.PodcastViewModel.UiState
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 
 object PodcastScreen {
     const val argument = "podcastUuid"
@@ -44,14 +44,14 @@ fun PodcastScreen(
     onEpisodeTap: (PodcastEpisode) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PodcastViewModel = hiltViewModel(),
-    listState: ScalingLazyListState,
+    columnState: ScalingLazyColumnState,
 ) {
     when (val state = viewModel.uiState) {
         is UiState.Loaded -> Content(
             state = state,
             onEpisodeTap = onEpisodeTap,
             modifier = modifier,
-            listState = listState,
+            columnState = columnState,
         )
 
         UiState.Empty -> Unit // Do Nothing
@@ -63,7 +63,7 @@ private fun Content(
     state: UiState.Loaded,
     onEpisodeTap: (PodcastEpisode) -> Unit,
     modifier: Modifier = Modifier,
-    listState: ScalingLazyListState,
+    columnState: ScalingLazyColumnState,
 ) {
     val podcast = state.podcast ?: return
     Box(modifier = modifier.fillMaxWidth()) {
@@ -75,7 +75,7 @@ private fun Content(
 
         ScalingLazyColumn(
             modifier = modifier.fillMaxWidth(),
-            state = listState,
+            columnState = columnState,
         ) {
             item { Spacer(Modifier.height(4.dp)) }
             item {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
@@ -12,8 +12,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
-import androidx.wear.compose.foundation.lazy.ScalingLazyListState
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
@@ -24,6 +22,8 @@ import au.com.shiftyjelly.pocketcasts.compose.extensions.darker
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -39,7 +39,7 @@ object PodcastsScreen {
 fun PodcastsScreen(
     modifier: Modifier = Modifier,
     viewModel: PodcastsViewModel = hiltViewModel(),
-    listState: ScalingLazyListState,
+    columnState: ScalingLazyColumnState,
     navigateToPodcast: (String) -> Unit,
     navigateToFolder: (String) -> Unit,
 ) {
@@ -47,7 +47,7 @@ fun PodcastsScreen(
 
     ScalingLazyColumn(
         modifier = modifier.fillMaxWidth(),
-        state = listState
+        columnState = columnState
     ) {
         item {
             ScreenHeaderChip(if (uiState.folder == null) stringResource(LR.string.podcasts) else uiState.folder.name)


### PR DESCRIPTION
## Description
This PR is adding [support for the rotary input to scroll the screen](https://github.com/Automattic/pocket-casts-android/issues/1045) on the main watch list screen.

I think we just need to import/use the horologist scrollable component instead of the foundation compose one to get this. I'm only making this change on a single screen in this PR so it can be reviewed before we make the same change to all th other screens. I figured we can do that in a follow-up PR, or by updating this PR, but I wanted to get some eyes on this first before investing the additional time.

## Testing Instructions
1. Go to the main watch list screen
2. Verify that you can scroll the list using the rotary spinner

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
