### PR TITLE
Add tracks for sign in screens on watch

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -554,4 +554,10 @@ enum class AnalyticsEvent(val key: String) {
     WEAR_MAIN_LIST_FILTERS_TAPPED("wear_main_list_filters_tapped"),
     WEAR_MAIN_LIST_FILES_TAPPED("wear_main_list_files_tapped"),
     WEAR_MAIN_LIST_SETTINGS_TAPPED("wear_main_list_settings_tapped"),
+
+    /* Wear Sign In */
+    WEAR_SIGNIN_SHOWN("wear_signin_shown"),
+    WEAR_SIGNIN_GOOGLE_TAPPED("wear_signin_google_tapped"),
+    WEAR_SIGNIN_PHONE_TAPPED("wear_signin_phone_tapped"),
+    WEAR_SIGNIN_EMAIL_TAPPED("wear_signin_email_tapped"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -556,6 +556,7 @@ enum class AnalyticsEvent(val key: String) {
     WEAR_MAIN_LIST_SETTINGS_TAPPED("wear_main_list_settings_tapped"),
 
     /* Wear Sign In */
+    WEAR_REQUIRE_PLUS_SHOWN("wear_require_plus_shown"),
     WEAR_SIGNIN_SHOWN("wear_signin_shown"),
     WEAR_SIGNIN_GOOGLE_TAPPED("wear_signin_google_tapped"),
     WEAR_SIGNIN_PHONE_TAPPED("wear_signin_phone_tapped"),

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginScreen.kt
@@ -8,7 +8,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.material.MaterialTheme
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
@@ -23,6 +25,13 @@ fun LoginScreen(
     onLoginWithPhoneClick: () -> Unit,
     onLoginWithEmailClick: () -> Unit,
 ) {
+
+    val viewModel = hiltViewModel<LoginViewModel>()
+
+    CallOnce {
+        viewModel.onShown()
+    }
+
     ScalingLazyColumn(
         columnState = columnState,
     ) {
@@ -53,7 +62,10 @@ fun LoginScreen(
                 labelId = LR.string.log_in_with_google,
                 chipType = StandardChipType.Secondary,
                 icon = IR.drawable.google_g_white,
-                onClick = onLoginWithGoogleClick,
+                onClick = {
+                    viewModel.onGoogleLoginClicked()
+                    onLoginWithGoogleClick()
+                },
             )
         }
 
@@ -62,7 +74,10 @@ fun LoginScreen(
                 labelId = LR.string.log_in_on_phone,
                 chipType = StandardChipType.Secondary,
                 icon = IR.drawable.baseline_phone_android_24,
-                onClick = onLoginWithPhoneClick,
+                onClick = {
+                    viewModel.onPhoneLoginClicked()
+                    onLoginWithPhoneClick()
+                },
             )
         }
 
@@ -71,7 +86,10 @@ fun LoginScreen(
                 labelId = LR.string.log_in_with_email,
                 chipType = StandardChipType.Secondary,
                 icon = IR.drawable.ic_email_white_24dp,
-                onClick = onLoginWithEmailClick,
+                onClick = {
+                    viewModel.onEmailLoginClicked()
+                    onLoginWithEmailClick()
+                },
             )
         }
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginViewModel.kt
@@ -1,0 +1,29 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui.authentication
+
+import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    private val analyticsTracker: AnalyticsTrackerWrapper
+) : ViewModel() {
+
+    fun onShown() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_SIGNIN_SHOWN)
+    }
+
+    fun onGoogleLoginClicked() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_SIGNIN_GOOGLE_TAPPED)
+    }
+
+    fun onPhoneLoginClicked() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_SIGNIN_PHONE_TAPPED)
+    }
+
+    fun onEmailLoginClicked() {
+        analyticsTracker.track(AnalyticsEvent.WEAR_SIGNIN_EMAIL_TAPPED)
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/RequirePlusScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/RequirePlusScreen.kt
@@ -14,9 +14,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.account.onboarding.components.SubscriptionBadge
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.UpgradeFeatureCard
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
@@ -33,6 +35,12 @@ fun RequirePlusScreen(
     columnState: ScalingLazyColumnState,
     onContinueToLogin: () -> Unit,
 ) {
+
+    val viewModel = hiltViewModel<RequirePlusViewModel>()
+
+    CallOnce {
+        viewModel.onShown()
+    }
 
     ScalingLazyColumn(
         columnState = columnState,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/RequirePlusViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/RequirePlusViewModel.kt
@@ -1,0 +1,17 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui.authentication
+
+import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class RequirePlusViewModel @Inject constructor(
+    private val analytTracker: AnalyticsTrackerWrapper
+) : ViewModel() {
+
+    fun onShown() {
+        analytTracker.track(AnalyticsEvent.WEAR_REQUIRE_PLUS_SHOWN)
+    }
+}


### PR DESCRIPTION
## Description
This adds tracks for the require plus screen and the login screen on the watch (relevant issue: https://github.com/Automattic/pocket-casts-android/issues/1007).

## Testing Instructions
1. Install the watch app (make sure you're not logged into PC on a connected phone)
2. ✅  Observe that when the require plus screen is shown the `wear_require_plus_shown` event is tracked
3. Proceed to the login screen
4. ✅ Observe that the `wear_signin_shown` event is tracked
5. Tap on each of the signin options and observe that the following events are tracked when appropriate:
    - `wear_signin_google_tapped`
    - `wear_signin_phone_tapped`
    - `wear_signin_email_tapped`

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`