### PR TITLE
Improve error message during login when no network is present

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingCreateAccountPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingCreateAccountPage.kt
@@ -122,9 +122,17 @@ internal fun OnboardingCreateAccountPage(
                     .padding(bottom = 16.dp)
             )
 
-            state.serverErrorMessage?.let {
+            if (state.showNetworkError) {
                 TextP40(
-                    text = it,
+                    text = stringResource(LR.string.log_in_no_network),
+                    color = MaterialTheme.theme.colors.support05,
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .padding(bottom = 16.dp)
+                )
+            } else if (state.serverErrorMessage != null) {
+                TextP40(
+                    text = state.serverErrorMessage!!,
                     color = MaterialTheme.theme.colors.support05,
                     modifier = Modifier
                         .padding(horizontal = 16.dp)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingCreateAccountPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingCreateAccountPage.kt
@@ -122,17 +122,9 @@ internal fun OnboardingCreateAccountPage(
                     .padding(bottom = 16.dp)
             )
 
-            if (state.showNetworkError) {
+            state.errorMessage?.let { errorMessage ->
                 TextP40(
-                    text = stringResource(LR.string.log_in_no_network),
-                    color = MaterialTheme.theme.colors.support05,
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .padding(bottom = 16.dp)
-                )
-            } else if (state.serverErrorMessage != null) {
-                TextP40(
-                    text = state.serverErrorMessage!!,
+                    text = errorMessage,
                     color = MaterialTheme.theme.colors.support05,
                     modifier = Modifier
                         .padding(horizontal = 16.dp)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
@@ -113,13 +113,13 @@ internal fun OnboardingLoginPage(
                 modifier = Modifier.padding(16.dp),
             )
 
-            if(state.showNetworkError){
+            if (state.showNetworkError) {
                 TextP40(
                     text = stringResource(id = LR.string.log_in_no_network),
                     color = MaterialTheme.theme.colors.support05,
                     modifier = Modifier.padding(horizontal = 16.dp)
                 )
-            }else if(state.serverErrorMessage != null){
+            } else if (state.serverErrorMessage != null) {
                 TextP40(
                     text = state.serverErrorMessage!!,
                     color = MaterialTheme.theme.colors.support05,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -41,7 +40,6 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -58,9 +56,6 @@ internal fun OnboardingLoginPage(
 
     val viewModel = hiltViewModel<OnboardingLogInViewModel>()
     val state by viewModel.state.collectAsState()
-    val context = LocalContext.current
-
-    val networkErrorMessage = stringResource(id = LR.string.log_in_no_network)
 
     CallOnce {
         viewModel.onShown()
@@ -111,21 +106,22 @@ internal fun OnboardingLoginPage(
                 showEmailError = state.showEmailError,
                 showPasswordError = state.showPasswordError,
                 enabled = state.enableSubmissionFields,
-                onDone = {
-                    viewModel.updateServerErrorMessage(
-                        if (Network.isConnected(context)) null else networkErrorMessage
-                    )
-                    viewModel.logIn(onLoginComplete)
-                },
+                onDone = { viewModel.logIn(onLoginComplete) },
                 onUpdateEmail = viewModel::updateEmail,
                 onUpdatePassword = viewModel::updatePassword,
                 isCreatingAccount = false,
                 modifier = Modifier.padding(16.dp),
             )
 
-            state.serverErrorMessage?.let {
+            if(state.showNetworkError){
                 TextP40(
-                    text = it,
+                    text = stringResource(id = LR.string.log_in_no_network),
+                    color = MaterialTheme.theme.colors.support05,
+                    modifier = Modifier.padding(horizontal = 16.dp)
+                )
+            }else if(state.serverErrorMessage != null){
+                TextP40(
+                    text = state.serverErrorMessage!!,
                     color = MaterialTheme.theme.colors.support05,
                     modifier = Modifier.padding(horizontal = 16.dp)
                 )
@@ -150,12 +146,7 @@ internal fun OnboardingLoginPage(
             RowButton(
                 text = stringResource(LR.string.onboarding_log_in),
                 enabled = state.enableSubmissionFields,
-                onClick = {
-                    viewModel.updateServerErrorMessage(
-                        if (Network.isConnected(context)) null else networkErrorMessage
-                    )
-                    viewModel.logIn(onLoginComplete)
-                },
+                onClick = { viewModel.logIn(onLoginComplete) },
             )
         }
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -40,6 +41,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -56,6 +58,9 @@ internal fun OnboardingLoginPage(
 
     val viewModel = hiltViewModel<OnboardingLogInViewModel>()
     val state by viewModel.state.collectAsState()
+    val context = LocalContext.current
+
+    val networkErrorMessage = stringResource(id = LR.string.log_in_no_network)
 
     CallOnce {
         viewModel.onShown()
@@ -106,7 +111,12 @@ internal fun OnboardingLoginPage(
                 showEmailError = state.showEmailError,
                 showPasswordError = state.showPasswordError,
                 enabled = state.enableSubmissionFields,
-                onDone = { viewModel.logIn(onLoginComplete) },
+                onDone = {
+                    viewModel.updateServerErrorMessage(
+                        if (Network.isConnected(context)) null else networkErrorMessage
+                    )
+                    viewModel.logIn(onLoginComplete)
+                },
                 onUpdateEmail = viewModel::updateEmail,
                 onUpdatePassword = viewModel::updatePassword,
                 isCreatingAccount = false,
@@ -140,7 +150,12 @@ internal fun OnboardingLoginPage(
             RowButton(
                 text = stringResource(LR.string.onboarding_log_in),
                 enabled = state.enableSubmissionFields,
-                onClick = { viewModel.logIn(onLoginComplete) },
+                onClick = {
+                    viewModel.updateServerErrorMessage(
+                        if (Network.isConnected(context)) null else networkErrorMessage
+                    )
+                    viewModel.logIn(onLoginComplete)
+                },
             )
         }
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
@@ -113,15 +113,9 @@ internal fun OnboardingLoginPage(
                 modifier = Modifier.padding(16.dp),
             )
 
-            if (state.showNetworkError) {
+            state.errorMessage?.let { errorMessage ->
                 TextP40(
-                    text = stringResource(id = LR.string.log_in_no_network),
-                    color = MaterialTheme.theme.colors.support05,
-                    modifier = Modifier.padding(horizontal = 16.dp)
-                )
-            } else if (state.serverErrorMessage != null) {
-                TextP40(
-                    text = state.serverErrorMessage!!,
+                    text = errorMessage,
                     color = MaterialTheme.theme.colors.support05,
                     modifier = Modifier.padding(horizontal = 16.dp)
                 )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/ContinueWithGoogleButton.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/ContinueWithGoogleButton.kt
@@ -18,6 +18,7 @@ import au.com.shiftyjelly.pocketcasts.account.viewmodel.GoogleSignInState
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
+import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -39,7 +40,11 @@ fun ContinueWithGoogleButton(
     val showContinueWithGoogleButton = GoogleSignInButtonViewModel.showContinueWithGoogleButton(context)
     if (!showContinueWithGoogleButton) return
 
-    val errorMessage = stringResource(LR.string.onboarding_continue_with_google_error)
+    val errorMessage = if (!Network.isConnected(context)) {
+        stringResource(LR.string.log_in_no_network)
+    } else {
+        stringResource(LR.string.onboarding_continue_with_google_error)
+    }
 
     val showError = {
         Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingCreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingCreateAccountViewModel.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
 class OnboardingCreateAccountViewModel @Inject constructor(
@@ -34,7 +35,9 @@ class OnboardingCreateAccountViewModel @Inject constructor(
         get() = Dispatchers.Default
 
     private val _stateFlow = MutableStateFlow(
-        OnboardingCreateAccountState()
+        OnboardingCreateAccountState(
+            noNetworkErrorMessage = getApplication<Application>().getString(LR.string.log_in_no_network)
+        )
     )
     val stateFlow: StateFlow<OnboardingCreateAccountState> = _stateFlow
 
@@ -100,16 +103,24 @@ data class OnboardingCreateAccountState(
     val email: String = "",
     val password: String = "",
     val serverErrorMessage: String? = null,
+    private val noNetworkErrorMessage: String,
     private val hasAttemptedLogIn: Boolean = false,
     private val isCallInProgress: Boolean = false,
-    private val isNetworkAvailable: Boolean = true
+    private val isNetworkAvailable: Boolean = true,
 ) {
     val isEmailValid = AccountViewModel.isEmailValid(email)
     val isPasswordValid = AccountViewModel.isPasswordValid(password)
 
     val showEmailError = hasAttemptedLogIn && !isEmailValid
     val showPasswordError = hasAttemptedLogIn && !isPasswordValid
-    val showNetworkError = hasAttemptedLogIn && !isNetworkAvailable
+
+    val errorMessage: String? = if (!hasAttemptedLogIn) {
+        null
+    } else if (!isNetworkAvailable) {
+        noNetworkErrorMessage
+    } else {
+        serverErrorMessage
+    }
 
     val enableSubmissionFields = !isCallInProgress
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingCreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingCreateAccountViewModel.kt
@@ -61,7 +61,7 @@ class OnboardingCreateAccountViewModel @Inject constructor(
         _stateFlow.update { it.copy(hasAttemptedLogIn = true, isNetworkAvailable = Network.isConnected(getApplication())) }
 
         val state = stateFlow.value
-        if (!state.isEmailValid || !state.isPasswordValid) {
+        if (!state.isEmailValid || !state.isPasswordValid || !state.isNetworkAvailable) {
             return
         }
 
@@ -106,7 +106,7 @@ data class OnboardingCreateAccountState(
     private val noNetworkErrorMessage: String,
     private val hasAttemptedLogIn: Boolean = false,
     private val isCallInProgress: Boolean = false,
-    private val isNetworkAvailable: Boolean = true,
+    val isNetworkAvailable: Boolean = true,
 ) {
     val isEmailValid = AccountViewModel.isEmailValid(email)
     val isPasswordValid = AccountViewModel.isPasswordValid(password)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
 class OnboardingLogInViewModel @Inject constructor(
@@ -35,7 +36,11 @@ class OnboardingLogInViewModel @Inject constructor(
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
 
-    private val _state = MutableStateFlow(LogInState())
+    private val _state = MutableStateFlow(
+        LogInState(
+            noNetworkErrorMessage = getApplication<Application>().getString(LR.string.log_in_no_network)
+        )
+    )
     val state: StateFlow<LogInState> = _state
 
     fun updateEmail(email: String) {
@@ -99,17 +104,25 @@ class OnboardingLogInViewModel @Inject constructor(
 data class LogInState(
     val email: String = "",
     val password: String = "",
-    val serverErrorMessage: String? = null,
+    private val noNetworkErrorMessage: String,
+    private val serverErrorMessage: String? = null,
     private val isCallInProgress: Boolean = false,
     private val hasAttemptedLogIn: Boolean = false,
-    private val isNetworkAvailable: Boolean = true
+    private val isNetworkAvailable: Boolean = true,
 ) {
     val isEmailValid = AccountViewModel.isEmailValid(email)
     val isPasswordValid = AccountViewModel.isPasswordValid(password)
 
     val showEmailError = hasAttemptedLogIn && !isEmailValid
     val showPasswordError = hasAttemptedLogIn && !isPasswordValid
-    val showNetworkError = hasAttemptedLogIn && !isNetworkAvailable
+
+    val errorMessage: String? = if (!hasAttemptedLogIn) {
+        null
+    } else if (!isNetworkAvailable) {
+        noNetworkErrorMessage
+    } else {
+        serverErrorMessage
+    }
 
     val enableSubmissionFields = !isCallInProgress
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
@@ -55,7 +55,7 @@ class OnboardingLogInViewModel @Inject constructor(
         _state.update { it.copy(hasAttemptedLogIn = true, isNetworkAvailable = Network.isConnected(getApplication())) }
 
         val state = state.value
-        if (!state.isEmailValid || !state.isPasswordValid || state.serverErrorMessage != null) {
+        if (!state.isEmailValid || !state.isPasswordValid) {
             return
         }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
@@ -55,7 +55,7 @@ class OnboardingLogInViewModel @Inject constructor(
         _state.update { it.copy(hasAttemptedLogIn = true, isNetworkAvailable = Network.isConnected(getApplication())) }
 
         val state = state.value
-        if (!state.isEmailValid || !state.isPasswordValid) {
+        if (!state.isEmailValid || !state.isPasswordValid || !state.isNetworkAvailable) {
             return
         }
 
@@ -108,7 +108,7 @@ data class LogInState(
     private val serverErrorMessage: String? = null,
     private val isCallInProgress: Boolean = false,
     private val hasAttemptedLogIn: Boolean = false,
-    private val isNetworkAvailable: Boolean = true,
+    val isNetworkAvailable: Boolean = true,
 ) {
     val isEmailValid = AccountViewModel.isEmailValid(email)
     val isPasswordValid = AccountViewModel.isPasswordValid(password)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
@@ -41,11 +41,15 @@ class OnboardingLogInViewModel @Inject constructor(
         _state.update { it.copy(password = password) }
     }
 
+    fun updateServerErrorMessage(message: String?) {
+        _state.update { it.copy(serverErrorMessage = message) }
+    }
+
     fun logIn(onSuccessfulLogin: () -> Unit) {
         _state.update { it.copy(hasAttemptedLogIn = true) }
 
         val state = state.value
-        if (!state.isEmailValid || !state.isPasswordValid) {
+        if (!state.isEmailValid || !state.isPasswordValid || state.serverErrorMessage != null) {
             return
         }
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1552,6 +1552,7 @@
     <string name="onboarding_sign_up">Sign up</string>
     <string name="onboarding_continue_with_google">Continue with Google</string>
     <string name="onboarding_continue_with_google_error">Unable to launch Google sign in.</string>
+    <string name="log_in_no_network">No network connection detected. Please try again later.</string>
     <string name="log_in_with_google">Log in with Google</string>
     <string name="log_in_on_phone">Log in on phone</string>
     <string name="log_in_with_email">Log in with email</string>

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithEmailScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithEmailScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -27,6 +28,7 @@ import androidx.wear.input.RemoteInputIntentHelper
 import androidx.wear.input.wearableExtender
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.SignInState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.SignInViewModel
+import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ErrorScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.LoadingSpinner
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -39,6 +41,7 @@ fun LoginWithEmailScreen(
     val viewModel = hiltViewModel<SignInViewModel>()
     val signInState by viewModel.signInState.observeAsState()
     val email by viewModel.email.observeAsState()
+    val context = LocalContext.current
 
     var loading by remember { mutableStateOf(false) }
 
@@ -77,9 +80,13 @@ fun LoginWithEmailScreen(
 
         is SignInState.Failure -> {
             loading = false
-            val message = (signInState as? SignInState.Failure)
-                ?.message
-                ?: stringResource(LR.string.error_login_failed)
+            val message = if (!Network.isConnected(context)) {
+                stringResource(LR.string.log_in_no_network)
+            } else {
+                (signInState as? SignInState.Failure)
+                    ?.message
+                    ?: stringResource(LR.string.error_login_failed)
+            }
             ErrorScreen(message)
         }
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleScreen.kt
@@ -3,12 +3,17 @@ package au.com.shiftyjelly.pocketcasts.wear.ui.authentication
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
+import au.com.shiftyjelly.pocketcasts.utils.Network
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.ErrorScreen
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.android.horologist.auth.composables.screens.AuthErrorScreen
 import com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreen
 import timber.log.Timber
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun LoginWithGoogleScreen(
@@ -17,6 +22,7 @@ fun LoginWithGoogleScreen(
 ) {
     val viewModel = hiltViewModel<LoginWithGoogleScreenViewModel>()
     val state by viewModel.state.collectAsState()
+    val context = LocalContext.current
 
     CallOnce {
         // Allow the user to sign in with a different account
@@ -29,7 +35,13 @@ fun LoginWithGoogleScreen(
             Timber.i("Google sign in cancelled")
             onAuthCanceled()
         },
-        failedContent = { AuthErrorScreen() },
+        failedContent = {
+            if(!Network.isConnected(context)){
+                ErrorScreen(stringResource(LR.string.log_in_no_network))
+            }else {
+                AuthErrorScreen()
+            }
+        },
         content = {
             signInSuccessScreen(state.googleSignInAccount)
         },

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleScreen.kt
@@ -10,10 +10,10 @@ import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ErrorScreen
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
-import com.google.android.horologist.auth.composables.screens.AuthErrorScreen
 import com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreen
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import com.google.android.horologist.auth.composables.R as HR
 
 @Composable
 fun LoginWithGoogleScreen(
@@ -36,11 +36,12 @@ fun LoginWithGoogleScreen(
             onAuthCanceled()
         },
         failedContent = {
-            if(!Network.isConnected(context)){
-                ErrorScreen(stringResource(LR.string.log_in_no_network))
-            }else {
-                AuthErrorScreen()
+            val message = if (Network.isConnected(context)) {
+                HR.string.horologist_auth_error_message
+            } else {
+                LR.string.log_in_no_network
             }
+            ErrorScreen(stringResource(message))
         },
         content = {
             signInSuccessScreen(state.googleSignInAccount)


### PR DESCRIPTION
## Description

When there is no network connection available, the app used to display a generic message.

In the case of email, the message is "Unable to login to your sync account, sorry. Please try again later". In the case of google sign in, the message is "Unable to launch Google sign in."

This PR just modifies that message to a more specific message "No network connection detected. Please try again later.".

Fixes #1027 

## Testing Instructions

1. Open the app
2. Turn on Airplane Mode
3. Attempt to Sign in using either google or email.
4. Observe that a specific message telling that no network connection detected is displayed.

## Screenshots

![Screenshot_20230606_125011](https://github.com/Automattic/pocket-casts-android/assets/89896473/0c29a8e0-caff-438e-b3f0-7d9321d8d1bd)
