### PR TITLE
Added validations for email/password wear app

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/SignInViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/SignInViewModel.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.viewmodel
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -10,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
 class SignInViewModel
@@ -33,7 +35,7 @@ class SignInViewModel
         if (errors.isEmpty()) {
             signInState.postValue(SignInState.Empty)
         } else {
-            signInState.value = SignInState.Failure(errors = errors, message = errors.last().message)
+            signInState.value = SignInState.Failure(errors = errors, message = null)
         }
     }
 
@@ -89,10 +91,10 @@ class SignInViewModel
     }
 }
 
-enum class SignInError(val message: String) {
-    INVALID_EMAIL("Please enter a valid email address."),
-    INVALID_PASSWORD("Password must be at least 6 characters long."),
-    SERVER("Internal server error occurred. Please try again later.")
+enum class SignInError(@StringRes val message: Int) {
+    INVALID_EMAIL(LR.string.error_invalid_email_address),
+    INVALID_PASSWORD(LR.string.error_invalid_password_length),
+    SERVER(LR.string.error_server_failed)
 }
 
 sealed class SignInState {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/SignInViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/SignInViewModel.kt
@@ -33,7 +33,7 @@ class SignInViewModel
         if (errors.isEmpty()) {
             signInState.postValue(SignInState.Empty)
         } else {
-            signInState.value = SignInState.Failure(errors = errors, message = null)
+            signInState.value = SignInState.Failure(errors = errors, message = errors.last().message)
         }
     }
 
@@ -89,10 +89,10 @@ class SignInViewModel
     }
 }
 
-enum class SignInError {
-    INVALID_EMAIL,
-    INVALID_PASSWORD,
-    SERVER
+enum class SignInError(val message: String) {
+    INVALID_EMAIL("Please enter a valid email address."),
+    INVALID_PASSWORD("Password must be at least 6 characters long."),
+    SERVER("Internal server error occurred. Please try again later.")
 }
 
 sealed class SignInState {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1363,6 +1363,9 @@
     <string name="error_invalid_email">This email address is invalid</string>
     <string name="error_invalid_password">This password is too short</string>
     <string name="error_incorrect_password">This password is incorrect</string>
+    <string name="error_invalid_email_address">Please enter a valid email address.</string>
+    <string name="error_invalid_password_length">Please enter a password that is at least 6 characters long.</string>
+    <string name="error_server_failed">Internal server error occurred. Please try again later.</string>
     <string name="error_field_required">This field is required</string>
     <string name="error_login_failed">Unable to login to your sync account, sorry. Please try again later.</string>
     <string name="error_search_failed">Search Failed</string>

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithEmailScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithEmailScreen.kt
@@ -54,7 +54,7 @@ fun LoginWithEmailScreen(
                 LaunchedEffect(Unit) {
                     launchRemoteInput(label, launcher)
                 }
-            } else if(password.isNullOrEmpty()) {
+            } else if (password.isNullOrEmpty()) {
                 val label = stringResource(LR.string.enter_password)
                 val launcher = getLauncher {
                     viewModel.updatePassword(it)
@@ -62,7 +62,7 @@ fun LoginWithEmailScreen(
                 LaunchedEffect(Unit) {
                     launchRemoteInput(label, launcher)
                 }
-            }else{
+            } else {
                 viewModel.signIn()
             }
         }
@@ -80,7 +80,11 @@ fun LoginWithEmailScreen(
         is SignInState.Failure -> {
             loading = false
             val currentState = signInState as? SignInState.Failure
-            val message = (currentState?.message ?: currentState?.errors?.last()?.message?.let { stringResource(id = it) }) ?: stringResource(id = LR.string.error_login_failed)
+            val message = currentState?.message
+                ?: stringResource(
+                    currentState?.errors?.last()?.message
+                        ?: LR.string.error_login_failed
+                )
             ErrorScreen(message)
         }
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithEmailScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithEmailScreen.kt
@@ -39,6 +39,7 @@ fun LoginWithEmailScreen(
     val viewModel = hiltViewModel<SignInViewModel>()
     val signInState by viewModel.signInState.observeAsState()
     val email by viewModel.email.observeAsState()
+    val password by viewModel.password.observeAsState()
 
     var loading by remember { mutableStateOf(false) }
 
@@ -53,15 +54,16 @@ fun LoginWithEmailScreen(
                 LaunchedEffect(Unit) {
                     launchRemoteInput(label, launcher)
                 }
-            } else {
+            } else if(password.isNullOrEmpty()) {
                 val label = stringResource(LR.string.enter_password)
                 val launcher = getLauncher {
                     viewModel.updatePassword(it)
-                    viewModel.signIn()
                 }
                 LaunchedEffect(Unit) {
                     launchRemoteInput(label, launcher)
                 }
+            }else{
+                viewModel.signIn()
             }
         }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithEmailScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithEmailScreen.kt
@@ -79,9 +79,8 @@ fun LoginWithEmailScreen(
 
         is SignInState.Failure -> {
             loading = false
-            val message = (signInState as? SignInState.Failure)
-                ?.message
-                ?: stringResource(LR.string.error_login_failed)
+            val currentState = signInState as? SignInState.Failure
+            val message = (currentState?.message ?: currentState?.errors?.last()?.message?.let { stringResource(id = it) }) ?: stringResource(id = LR.string.error_login_failed)
             ErrorScreen(message)
         }
     }


### PR DESCRIPTION
## Description

The validations for email and password were present but the message was not displaying due to some bug in the logic. This PR fixes that logic and allows the Wear app to show error screens for invalid email/password.

Fixes #983 

## Testing Instructions

1. Open the app.
2. Click on Login with email.
3. Observe that whenever you enter invalid email or password less than 6 characters, you get the error message accordingly.

## Screenshots

|                                                               Credentials                                                              |                                                                 Screens                                                                |
|:--------------------------------------------------------------------------------------------------------------------------------------:|:--------------------------------------------------------------------------------------------------------------------------------------:|
| ![Screenshot_20230606_190607](https://github.com/Automattic/pocket-casts-android/assets/89896473/26346e0c-b9e7-46b7-8204-09195ad3571f) | ![Screenshot_20230606_190618](https://github.com/Automattic/pocket-casts-android/assets/89896473/06a4c171-9a57-490d-8e71-c650027f5df5) |
| ![Screenshot_20230606_190707](https://github.com/Automattic/pocket-casts-android/assets/89896473/2b584d7a-a02c-4c1c-9bd9-3f70ed7e9a8c) | ![Screenshot_20230606_190714](https://github.com/Automattic/pocket-casts-android/assets/89896473/e6211bc3-5bf0-4917-8279-2f1ee9504a75) |

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews