### PR TITLE
Add translations documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ If you happen to find a security vulnerability, please let us know at https://ha
 
 - [Coding Style](docs/coding-style.md) - guidelines and validation and auto-formatting tools
 - [Pull Request Guidelines](docs/pull-request-guidelines.md) - branch naming and how to write good pull requests
+- [Translations](docs/translations.md) - how the app gets translated and how to contribute translations
 
 ## Signing a Release
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,0 +1,13 @@
+# Translations
+
+English string resources are saved in the 
+[localization module's strings.xml file](https://github.com/Automattic/pocket-casts-android/blob/main/modules/services/localization/src/main/res/values/strings.xml).
+Those English strings are then translated into the other languages we support through
+https://translate.wordpress.com/projects/pocket-casts/android/. We update the translations for
+all languages other than English from translate.wordpress.com each time we cut a release.
+
+This means that only English string resources should be edited directly in this repo. All other
+languages will get updated from translate.wordpress.com as [part of our release process](https://github.com/Automattic/pocket-casts-android/blob/b8287a4b97e4c1deac852e861b7ea17583412d3d/fastlane/Fastfile#L203-L209).
+
+If you're interested in helping to translate Pocket Casts you can contribute at translate.wordpress.com.
+This page gives an overview of how to get started: https://translate.wordpress.com/glotpress/.


### PR DESCRIPTION
Adding some documentation about how the app gets translated, so it is clear how to contribute translations.