### PR TITLE
Download smaller images on the watch

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImage.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImage.kt
@@ -1,6 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.repositories.images
 
+import android.content.Context
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.utils.Util
 
 object PodcastImage {
 
@@ -31,7 +33,9 @@ object PodcastImage {
         return String.format(STATIC_ARTWORK_JPG_URL, Settings.SERVER_STATIC_URL, size, uuid)
     }
 
-    fun getLargeArtworkUrl(uuid: String): String {
-        return getArtworkUrl(960, uuid)
+    fun getLargeArtworkUrl(uuid: String, context: Context): String {
+        // The watch's smaller screen does not need such large images
+        val size = if (Util.isWearOs(context)) 480 else 960
+        return getArtworkUrl(size, uuid)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
@@ -84,7 +84,11 @@ open class PodcastImageLoader(
 
     fun loadCoil(podcastUuid: String?, size: Int? = null, placeholder: Boolean = true, onComplete: () -> Unit = {}): ImageRequest.Builder {
         if (podcastUuid == null) return loadNoPodcastCoil()
-        val url = if (size != null) PodcastImage.getArtworkUrl(size = size, uuid = podcastUuid) else PodcastImage.getLargeArtworkUrl(uuid = podcastUuid)
+        val url = if (size != null) {
+            PodcastImage.getArtworkUrl(size = size, uuid = podcastUuid)
+        } else {
+            PodcastImage.getLargeArtworkUrl(uuid = podcastUuid, context = context)
+        }
 
         val placeholderDrawable = if (placeholder) placeholderResId() else 0
         var builder = ImageRequest.Builder(context)
@@ -184,7 +188,7 @@ open class PodcastImageLoader(
 
     private fun cacheSubscribedArtworkRequest(podcast: Podcast): ImageRequest {
         return ImageRequest.Builder(context)
-            .data(PodcastImage.getLargeArtworkUrl(podcast.uuid))
+            .data(PodcastImage.getLargeArtworkUrl(uuid = podcast.uuid, context = context))
             .memoryCachePolicy(CachePolicy.DISABLED)
             .build()
     }


### PR DESCRIPTION
## Description
Instead of downloading 960 pixel images like we do on the phone, let's just download 480 pixel images on the watch. This will reduce the watch's data usage and improve [the initial login and sync time](https://github.com/Automattic/pocket-casts-android/issues/1047). Thanks for the suggestion @geekygecko . 🙇 

## Testing Instructions
1. Log into a fresh install of the app
2. Use the network inspector to verify that 480 pixel images are being instead of 960 pixel images
3. Check the UI in the app to make sure the images still look good. I believe the larges image we display in the watch app is the podcast artwork we display at the top of the screen for a particular podcast.

## Screenshots or Screencast 

![image](https://github.com/Automattic/pocket-casts-android/assets/4656348/67166794-500a-4f57-9e79-dea5742f788e)

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes