### PR TITLE
Fix wear media notifications

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -199,7 +199,13 @@ class MediaSessionManager(
             .setActions(getSupportedActions(playbackState))
             .setExtras(bundleOf(EXTRA_TRANSIENT to playbackState.transientLoss))
 
-        addCustomActions(stateBuilder, currentEpisode, playbackState)
+        // Do not add custom actions on Wear OS because there is a bug in Wear 3.5 that causes
+        // this to make the Wear OS media notification stop working. This bug was fixed
+        // internally by the Wear OS team in June 2023. Once that fix is released we should be
+        // able to remove this guard.
+        if (!Util.isWearOs(context)) {
+            addCustomActions(stateBuilder, currentEpisode, playbackState)
+        }
 
         return stateBuilder.build()
     }


### PR DESCRIPTION
## Description
This fixes the watch app so that the system's media controls reflect our app's playback state. The fix for this is to not add custom media actions in the watch app. The reason we need to do this is because of a bug in Wear OS 3.5. This has been fixed by Google and will be released at some point in the future.

Fixes https://github.com/Automattic/pocket-casts-android/issues/1050

Thanks to @kul3r4, @yschimke, and the wear os team for their figuring this out. 🙇 

## Testing Instructions
1. Fesh install of the watch app on a physical device
2. Begin playing an episode
3. Go to the watch's home screen and wait a few seconds for the media notification to appear (it takes at least 5 seconds or so in my testing)
4. Tap on the media notification
5. Verify that you're taken back to our app
6. Open the OS's "Media Controls" app
7. Verify that the Media Controls reflect the episode our app is playing
8. Verify that tapping pause stops playback. There is a fair bit of delay here for the UI to respond to the button tap. I also see quite a bit of delay in the Media Controls when the Youtube Music app is playing, so I don't think most of this delay is due to our app.
9. Verify that tapping play resumes the podcast.

## Screenshots or Screencast 

![Screenshot 2023-06-09 at 3 25 15 PM](https://github.com/Automattic/pocket-casts-android/assets/4656348/794d8e55-057f-4ec6-ba08-f81d1983eb63)

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`