### PR TITLE
Update wear logging in spinner

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/LoggingInScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/LoggingInScreen.kt
@@ -82,7 +82,7 @@ private fun Content(
             .fillMaxSize()
     ) {
         val placeholder = @Composable {
-            LoadingSpinner(Modifier.size(48.dp))
+            LoadingSpinner(Modifier.size(36.dp))
         }
 
         val profileModifier = Modifier

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithEmailScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithEmailScreen.kt
@@ -100,7 +100,7 @@ private fun Loading() {
         contentAlignment = Alignment.Center,
         modifier = Modifier.fillMaxSize(),
     ) {
-        LoadingSpinner(Modifier.size(48.dp))
+        LoadingSpinner(Modifier.size(36.dp))
     }
 }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/LoadingSpinner.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/LoadingSpinner.kt
@@ -1,39 +1,19 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui.component
 
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.res.painterResource
-import androidx.wear.compose.material.Icon
-import au.com.shiftyjelly.pocketcasts.images.R as IR
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.CircularProgressIndicator
+import androidx.wear.compose.material.MaterialTheme
 
 @Composable
 fun LoadingSpinner(
     modifier: Modifier = Modifier,
 ) {
-    val infiniteTransition = rememberInfiniteTransition()
-    val rotation by infiniteTransition.animateFloat(
-        initialValue = 0f,
-        targetValue = 360f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(1000, easing = LinearEasing),
-            repeatMode = RepeatMode.Restart
-        )
-    )
-
-    Icon(
-        painter = painterResource(IR.drawable.ic_retry),
-        contentDescription = null,
+    CircularProgressIndicator(
+        indicatorColor = MaterialTheme.colors.onPrimary.copy(alpha = 0.9f),
+        trackColor = MaterialTheme.colors.onBackground.copy(alpha = 0.1f),
+        strokeWidth = 5.dp,
         modifier = modifier
-            .graphicsLayer {
-                rotationZ = rotation
-            }
     )
 }


### PR DESCRIPTION
## Description
This updates the logging in spinner to use the standard material spinner instead of the rotating arrow from the refresh button.

internal discussion: p1686302267124569/1686229326.882529-slack-C040S9BK7SP

## Testing Instructions
1. Fresh install of the app
2. If you're using an emulator, make sure and slow down the network connection so you have time to enjoy the amazing new spinner
3. Log in using either google or email
4. When there is not an avatar image to display, observe that the placeholder spinner is the standard material spinner

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/4656348/5ac6243d-78e3-41d9-9210-167e3f642064

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
 
#### I have tested any UI changes...
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack