### PR TITLE
Remove AD_ID permission from wear app

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
     <uses-permission android:name="com.android.vending.BILLING" />
     <uses-permission android:name="com.android.vending.CHECK_LICENSE"/>
 
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
+
     <uses-feature android:name="android.hardware.type.watch" />
 
     <application


### PR DESCRIPTION
## Description
We haven't removed the AD_ID permission from the wear app like we have the other apps. This is removing that so Google doesn't require an advertising id declaration from us.

## Testing Instructions
1. Build a release apk
2. Inspect the merged AndroidManifiest.xml file in the resulting apk and verify that it does not include `    <uses-permission android:name="com.google.android.gms.permission.AD_ID" />`.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`