### PR TITLE
Add about screen for watch

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -193,6 +193,7 @@ project.ext {
             wearComposeNavigation: "androidx.wear.compose:compose-navigation:$versionComposeWear",
             wearPlayServices: "com.google.android.gms:play-services-wearable:18.0.0",
             wearInput: 'androidx.wear:wear-input:1.2.0-alpha02',
+            wearRemoteInteractions: 'androidx.wear:wear-remote-interactions:1.0.0',
 
             horologistAudioUi: "com.google.android.horologist:horologist-audio-ui:$versionHorologist",
             horologistAuthData: "com.google.android.horologist:horologist-auth-data:$versionHorologist",

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1328,6 +1328,8 @@
     <string name="settings_about_privacy_policy">Privacy policy</string>
     <string name="settings_about_acknowledgements">Acknowledgements</string>
     <string name="settings_about_website">Website</string>
+    <string name="settings_about_terms_of_service_available_at">Our Terms of service are available at %s</string>
+    <string name="settings_about_privacy_policy_available_at">Our Privacy policy is available at %s</string>
     <string name="settings_privacy_summary">Allowing us to collect analytics and crash reports helps us build a better app. We understand if you would prefer not to share this information.</string>
     <string name="settings_privacy_analytics">Analytics</string>
     <string name="settings_privacy_analytics_summary">Allow us to collect analytics.</string>
@@ -1336,6 +1338,8 @@
     <string name="settings_privacy_crash_link">Link your account to crashes</string>
     <string name="settings_privacy_crash_link_short">Link your account</string>
     <string name="settings_privacy_crash_link_summary">Allow us to link your Pocket Casts account to crash reports.</string>
+    <string name="settings_open_on_phone">Open on phone</string>
+    <string name="settings_could_not_open_on_phone">Unable to open on phone</string>
 
     <string name="settings_advanced_sync_on_metered">Sync on Metered Networks</string>
     <string name="settings_advanced_sync_on_metered_summary">Permits automatic background sync on metered networks. This is enabled by default and has no effect if background refresh is turned off.</string>

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -75,6 +75,7 @@ sentry {
 
 dependencies {
     implementation androidLibs.wearInput
+    implementation androidLibs.wearRemoteInteractions
 
     // General Compose dependencies
     implementation androidLibs.composeActivity

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -50,6 +50,7 @@ import au.com.shiftyjelly.pocketcasts.wear.ui.podcast.PodcastScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcasts.PodcastsScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.settings.PrivacySettingsScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.settings.SettingsScreen
+import au.com.shiftyjelly.pocketcasts.wear.ui.settings.WearAboutScreen
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
 import com.google.android.horologist.compose.navscaffold.ScrollableScaffoldContext
 import com.google.android.horologist.compose.navscaffold.WearNavScaffold
@@ -310,11 +311,16 @@ fun WearApp(
                 scrollState = it.columnState,
                 signInClick = { navController.navigate(authenticationSubGraph) },
                 navigateToPrivacySettings = { navController.navigate(PrivacySettingsScreen.route) },
+                navigateToAbout = { navController.navigate(WearAboutScreen.route) }
             )
         }
 
         scrollable(PrivacySettingsScreen.route) {
             PrivacySettingsScreen(scrollState = it.columnState)
+        }
+
+        scrollable(WearAboutScreen.route) {
+            WearAboutScreen(columnState = it.columnState)
         }
 
         val popToStartDestination: () -> Unit = {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -50,7 +50,9 @@ import au.com.shiftyjelly.pocketcasts.wear.ui.podcast.PodcastScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcasts.PodcastsScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.settings.PrivacySettingsScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.settings.SettingsScreen
+import au.com.shiftyjelly.pocketcasts.wear.ui.settings.UrlScreenRoutes
 import au.com.shiftyjelly.pocketcasts.wear.ui.settings.WearAboutScreen
+import au.com.shiftyjelly.pocketcasts.wear.ui.settings.settingsUrlScreens
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
 import com.google.android.horologist.compose.navscaffold.ScrollableScaffoldContext
 import com.google.android.horologist.compose.navscaffold.WearNavScaffold
@@ -320,8 +322,14 @@ fun WearApp(
         }
 
         scrollable(WearAboutScreen.route) {
-            WearAboutScreen(columnState = it.columnState)
+            WearAboutScreen(
+                columnState = it.columnState,
+                onTermsOfServiceClick = { navController.navigate(UrlScreenRoutes.termsOfService) },
+                onPrivacyClick = { navController.navigate(UrlScreenRoutes.privacy) }
+            )
         }
+
+        settingsUrlScreens()
 
         val popToStartDestination: () -> Unit = {
             when (startDestination) {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsScreen.kt
@@ -49,6 +49,7 @@ fun SettingsScreen(
     scrollState: ScalingLazyColumnState,
     signInClick: () -> Unit,
     navigateToPrivacySettings: () -> Unit,
+    navigateToAbout: () -> Unit,
 ) {
 
     val viewModel = hiltViewModel<SettingsViewModel>()
@@ -63,6 +64,7 @@ fun SettingsScreen(
         onSignOutClicked = viewModel::signOut,
         onRefreshClicked = viewModel::refresh,
         onPrivacyClicked = navigateToPrivacySettings,
+        onAboutClicked = navigateToAbout,
     )
 }
 
@@ -76,6 +78,7 @@ private fun Content(
     onSignOutClicked: () -> Unit,
     onRefreshClicked: () -> Unit,
     onPrivacyClicked: () -> Unit,
+    onAboutClicked: () -> Unit,
 ) {
     ScalingLazyColumn(columnState = scrollState) {
 
@@ -163,6 +166,14 @@ private fun Content(
                     )
                 }
             }
+        }
+
+        item {
+            WatchListChip(
+                title = stringResource(LR.string.settings_title_about),
+                iconRes = SR.drawable.settings_about,
+                onClick = onAboutClicked
+            )
         }
     }
 }
@@ -261,6 +272,7 @@ private fun SettingsScreenPreview_unchecked() {
             onSignOutClicked = {},
             onRefreshClicked = {},
             onPrivacyClicked = {},
+            onAboutClicked = {},
         )
     }
 }
@@ -290,6 +302,7 @@ private fun SettingsScreenPreview_checked() {
             onSignOutClicked = {},
             onRefreshClicked = {},
             onPrivacyClicked = {},
+            onAboutClicked = {},
         )
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/UrlScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/UrlScreen.kt
@@ -1,0 +1,103 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui.settings
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.navigation.NavGraphBuilder
+import androidx.wear.compose.material.Text
+import androidx.wear.remote.interactions.RemoteActivityHelper
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.navscaffold.scrollable
+import kotlinx.coroutines.guava.await
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.util.concurrent.Executors
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+object UrlScreenRoutes {
+    const val termsOfService = "url_screen_terms_of_service"
+    const val privacy = "url_screen_privacy_policy"
+}
+
+fun NavGraphBuilder.settingsUrlScreens() {
+    scrollable(UrlScreenRoutes.termsOfService) {
+        UrlScreen(
+            title = stringResource(LR.string.settings_about_terms_of_serivce),
+            message = stringResource(LR.string.settings_about_terms_of_service_available_at, Settings.INFO_TOS_URL),
+            url = Settings.INFO_TOS_URL,
+            columnState = it.columnState,
+        )
+    }
+
+    scrollable(UrlScreenRoutes.privacy) {
+        UrlScreen(
+            title = stringResource(id = LR.string.settings_about_privacy_policy),
+            message = stringResource(LR.string.settings_about_privacy_policy_available_at, Settings.INFO_PRIVACY_URL),
+            url = Settings.INFO_PRIVACY_URL,
+            columnState = it.columnState,
+        )
+    }
+}
+
+@Composable
+fun UrlScreen(
+    title: String,
+    message: String,
+    url: String,
+    columnState: ScalingLazyColumnState,
+) {
+
+    val coroutineScope = rememberCoroutineScope()
+
+    ScalingLazyColumn(
+        columnState = columnState,
+    ) {
+        item {
+            ScreenHeaderChip(text = title)
+        }
+
+        item {
+            Text(
+                text = message,
+                textAlign = TextAlign.Center,
+            )
+        }
+
+        item {
+            val context = LocalContext.current
+            WatchListChip(
+                title = stringResource(LR.string.settings_open_on_phone),
+                onClick = {
+                    coroutineScope.launch {
+                        openUrlOnPhone(url, context)
+                    }
+                }
+            )
+        }
+    }
+}
+
+private suspend fun openUrlOnPhone(url: String, context: Context) {
+    try {
+        val intent = Intent(Intent.ACTION_VIEW)
+            .addCategory(Intent.CATEGORY_BROWSABLE)
+            .setData(Uri.parse(url))
+        RemoteActivityHelper(context, Executors.newSingleThreadExecutor())
+            .startRemoteActivity(intent)
+            .await()
+    } catch (e: Exception) {
+        Timber.i("UrlScreen failed to open url $url on phone")
+        Toast.makeText(context, LR.string.settings_could_not_open_on_phone, Toast.LENGTH_SHORT)
+            .show()
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/WearAboutScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/WearAboutScreen.kt
@@ -1,0 +1,67 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui.settings
+
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import au.com.shiftyjelly.pocketcasts.BuildConfig
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+object WearAboutScreen {
+    const val route = "wear_about_screen"
+}
+
+@Composable
+fun WearAboutScreen(columnState: ScalingLazyColumnState) {
+    ScalingLazyColumn(
+        columnState = columnState,
+    ) {
+        item {
+            Image(
+                painter = painterResource(IR.drawable.about_logo_pocketcasts),
+                contentDescription = stringResource(LR.string.settings_app_icon),
+            )
+        }
+
+        item {
+            Text(
+                text = stringResource(LR.string.settings_version, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE.toString()),
+                style = MaterialTheme.typography.body1,
+                color = MaterialTheme.colors.onSecondary,
+                textAlign = TextAlign.Center,
+            )
+        }
+
+        // share
+        // website
+        // instagram
+        // twitter
+
+//        item {
+//            WatchListChip(
+//                title = stringResource(LR.string.settings_about_terms_of_serivce),
+//                onClick = { TODO() }
+//            )
+//        }
+//
+//        item {
+//            WatchListChip(
+//                title = stringResource(LR.string.settings_about_privacy_policy),
+//                onClick = { TODO() }
+//            )
+//        }
+//
+//        item {
+//            WatchListChip(
+//                title = stringResource(LR.string.settings_about_acknowledgements),
+//                onClick = { TODO() }
+//            )
+//        }
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/WearAboutScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/WearAboutScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.BuildConfig
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -18,7 +19,12 @@ object WearAboutScreen {
 }
 
 @Composable
-fun WearAboutScreen(columnState: ScalingLazyColumnState) {
+fun WearAboutScreen(
+    columnState: ScalingLazyColumnState,
+    onTermsOfServiceClick: () -> Unit,
+    onPrivacyClick: () -> Unit,
+) {
+
     ScalingLazyColumn(
         columnState = columnState,
     ) {
@@ -38,30 +44,18 @@ fun WearAboutScreen(columnState: ScalingLazyColumnState) {
             )
         }
 
-        // share
-        // website
-        // instagram
-        // twitter
+        item {
+            WatchListChip(
+                title = stringResource(LR.string.settings_about_terms_of_serivce),
+                onClick = onTermsOfServiceClick
+            )
+        }
 
-//        item {
-//            WatchListChip(
-//                title = stringResource(LR.string.settings_about_terms_of_serivce),
-//                onClick = { TODO() }
-//            )
-//        }
-//
-//        item {
-//            WatchListChip(
-//                title = stringResource(LR.string.settings_about_privacy_policy),
-//                onClick = { TODO() }
-//            )
-//        }
-//
-//        item {
-//            WatchListChip(
-//                title = stringResource(LR.string.settings_about_acknowledgements),
-//                onClick = { TODO() }
-//            )
-//        }
+        item {
+            WatchListChip(
+                title = stringResource(LR.string.settings_about_privacy_policy),
+                onClick = onPrivacyClick
+            )
+        }
     }
 }


### PR DESCRIPTION
## Description
This is an initial implementation of an about screen for the watch app.

This PR makes progress on, but does not complete, #1070.

## Testing Instructions
1. On the watch, go to Settings
8. Observe there is an about chip at the bottom of the screen
9. Tap on that chip and observe an about screen is loaded
10. Observe that the correct version number is displayed.
11. Tap on either "Terms of service" or "Privacy policy"
12. Observe that a screen is opened which directs the user to the relevant URL and has a button to open that URL on the phone
13. Tap on the button to open the URL on the phone and observe that (a) if a phone is connected to the watch the URL is opened on the phone or (b) if a phone is not connected to the watch a toast message appears after 5 seconds or so advising that it could not open the URL on the phone.

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/4656348/b86dc52f-e99d-4e12-8be0-0c43c9d3de37

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X]  I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
