### PR TITLE
Fixing Automotive playback state

### DIFF
--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -6,9 +6,6 @@
         android:name="android.hardware.type.automotive"
         android:required="true" />
     <uses-feature
-        android:name="android.software.car.templates_host"
-        android:required="true" />
-    <uses-feature
         android:name="android.hardware.wifi"
         android:required="false" />
     <uses-feature

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -307,6 +307,7 @@
     <string name="player_skipped_last">Skipped the last %d seconds</string>
     <string name="player_started_from">Starting podcast from %d seconds</string>
     <string name="player_open_full_size_player">Activate to open full size player</string>
+    <string name="player_play_failed_check_internet">Could not load podcast. Please check your internet connection and try again.</string>
 
     <!-- Podcasts -->
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -279,12 +279,18 @@ class MediaSessionManager(
     }
 
     private fun observePlaybackState() {
-        val ignoreStates = listOf(
-            // ignore the current position update because the media session progress the time without it and it causes the position to jump when seeking
-            "updateCurrentPosition",
+        val ignoreStates = mutableListOf(
             // ignore buffer position because it isn't displayed in the media session
             "updateBufferPosition"
         )
+
+        val isAutomotive = Util.isAutomotive(context)
+        // listen to the playback progress every second on Automotive as it can get out of sync
+        if (!isAutomotive) {
+            // ignore the playback progress updates as the media session can calculate this without being sent it every second
+            ignoreStates.add("updateCurrentPosition")
+        }
+
         var previousEpisode: BaseEpisode? = null
 
         playbackManager.playbackStateRelay

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -305,7 +305,8 @@ class MediaSessionManager(
             }
             // ignore events until seeking has finished or the progress won't stay where the user requested
             .doOnNext {
-                if (it.first.lastChangeFrom == "onSeekComplete" || it.first.isPaused) {
+                val changeFrom = it.first.lastChangeFrom
+                if (changeFrom == "onSeekComplete" || changeFrom == "updateCurrentPosition" || it.first.isPaused) {
                     seeking = false
                 }
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -889,7 +889,7 @@ open class PlaybackManager @Inject constructor(
         withContext(Dispatchers.Main) {
             playbackStateRelay.blockingFirst().let { playbackState ->
                 val errorMessage = if (event.error?.cause is HttpDataSource.HttpDataSourceException) {
-                    "Could not load podcast. Please check your internet connection and try again."
+                    application.getString(LR.string.player_play_failed_check_internet)
                 } else {
                     event.message
                 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -153,7 +153,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
     fun isForegroundService(): Boolean {
         val manager = baseContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
         for (service in manager.getRunningServices(Int.MAX_VALUE)) {
-            if (PlaybackService::class.java.name == service.service.className) {
+            if (this::class.java.name == service.service.className) {
                 return service.foreground
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -216,11 +216,13 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
             }
 
             override fun onPlaybackStateChanged(playbackState: Int) {
-                if (playbackState == Player.STATE_ENDED) {
-                    onCompletion()
-                } else if (playbackState == Player.STATE_READY) {
-                    onBufferingStateChanged()
-                    onDurationAvailable()
+                when (playbackState) {
+                    Player.STATE_READY -> {
+                        onBufferingStateChanged()
+                        onDurationAvailable()
+                    }
+                    Player.STATE_BUFFERING -> onBufferingStateChanged()
+                    Player.STATE_ENDED -> onCompletion()
                 }
             }
 


### PR DESCRIPTION
## Description

### Issue 1

When playing audio in Automotive the following error is in the logs:

```
isServiceRunningInForeground found no matching service
```

The issue is that the playback service with Automotive is AutoPlaybackService and not PlaybackService. The AutoPlaybackService extends the PlaybackService so changing the condition to `this` stops the error message.

### Issue 2

The Automotive player is having trouble indicating the correct playback state. For example if you tap on the seek bar sometimes it won't show it is buffering and the playback time with continue to change without any audio playback. I believe there is a few issues happening but the main one is that we have a `seeking` flag to stop events when we think the user is seeking, the issue is that this blocks the event that says playback in buffering. There is also another issue that the switchMap doesn't give us all the events, only the latest, so we can't rely on getting all the events from `lastChangeFrom`.

## Issue 3

The error message "Could not load podcast. Please check your internet connection" isn't translated so I have added it to the strings file.

<img  width="500" src="https://github.com/Automattic/pocket-casts-android/assets/308331/1970eb1b-d5bc-4105-aba3-753b15103776" />

## Issue 4

We received an email asking why we include the feature flag `<uses-feature android:name="android.software.car.templates_host"android:required="true"/>`. I can't find any documentation on this and removing it doesn't affect the app. So I have removed it for now.

## Testing Instructions

### Test the error fix
1. Install the Automotive app
2. Play an episode
3. ✅  Verify the error message "isServiceRunningInForeground found no matching service" is no longer in the logs
4. Install the mobile app
5. Play an episode
3. ✅  Verify the error message "isServiceRunningInForeground found no matching service" is not in the logs

### Test the seek bar
1. Open the Automotive app 
2. Play an episode
3. Open the full screen player
4. Tap a new position on the seek bar 
5. ✅ Verify audio starts playing from the new position and that the buffering animation is shown.
6. Repeat this process a few times