### PR TITLE
Added empty podcasts screen in watch app

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -436,6 +436,7 @@
     <string name="podcast_group_unplayed" translatable="false">@string/unplayed</string>
     <string name="podcast_hide_archived">Hide archived</string>
     <string name="podcast_load_error">There was an error loading the podcast.</string>
+    <string name="podcast_loading">Loading your podcasts</string>
     <string name="podcast_next_episode_any_day_now">Next episode any day now</string>
     <string name="podcast_next_episode_today">Next episode today</string>
     <string name="podcast_next_episode_tomorrow">Next episode tomorrow</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -339,6 +339,7 @@
     <string name="podcasts_menu_search_podcasts">Search podcasts</string>
     <string name="podcasts_menu_share_podcasts">Share podcasts</string>
     <string name="podcasts_menu_sort_by">Sort by</string>
+    <string name="podcasts_no_subscriptions">No subscribed podcasts</string>
     <string name="podcasts_plural">%d Podcasts</string>
     <string name="podcasts_share">Share podcasts</string>
     <string name="podcasts_share_0_selected">0 selected</string>
@@ -370,6 +371,7 @@
     <string name="podcasts_sort_by_release_date">Episode release date</string>
     <string name="podcasts_sort_by_title">"Title (A - Z)"</string>
     <string name="podcasts_sort_order">Sort order</string>
+    <string name="podcasts_subscribe_on_phone">Subscribe to podcasts on your phone and they\'ll appear here.</string>
     <string name="podcasts_time_to_add_some_podcasts">Time to add some Podcasts!</string>
     <string name="podcasts_time_to_add_some_podcasts_summary">You can add podcasts by searching above or if you are looking for some inspiration try the Discover tab.</string>
     <string name="podcasts_empty_folder">Your folder is empty</string>

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
@@ -1,15 +1,20 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui.podcasts
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -20,8 +25,6 @@ import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
-import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.extensions.darker
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
@@ -47,42 +50,49 @@ fun PodcastsScreen(
     navigateToPodcast: (String) -> Unit,
     navigateToFolder: (String) -> Unit,
 ) {
-    val uiState = viewModel.uiState
 
-    ScalingLazyColumn(
-        modifier = modifier.fillMaxWidth(),
-        columnState = columnState
-    ) {
-        item {
-            ScreenHeaderChip(if (uiState.folder == null) stringResource(LR.string.podcasts) else uiState.folder.name)
-        }
-        if (uiState.items.isNotEmpty()) {
-            items(items = uiState.items, key = { item -> item.uuid }) { item ->
-                when (item) {
-                    is FolderItem.Podcast -> {
-                        PodcastChip(podcast = item, onClick = navigateToPodcast)
-                    }
-
-                    is FolderItem.Folder -> {
-                        FolderChip(folderItem = item, onClick = navigateToFolder)
-                    }
-                }
-            }
-        } else {
-            item {
-                TextH30(
-                    text = stringResource(id = LR.string.podcasts_no_subscriptions),
-                    textAlign = TextAlign.Center,
-                    color = MaterialTheme.colors.onPrimary
-                )
-            }
-            item {
-                TextP40(
-                    text = stringResource(id = LR.string.podcasts_subscribe_on_phone),
+    when (val uiState = viewModel.uiState) {
+        is PodcastsViewModel.UiState.Empty -> {
+            Column(
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                Text(
+                    text = stringResource(LR.string.podcasts_no_subscriptions),
                     textAlign = TextAlign.Center,
                     color = MaterialTheme.colors.onPrimary,
-                    fontWeight = FontWeight.W400
+                    style = MaterialTheme.typography.title2,
                 )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = stringResource(LR.string.podcasts_subscribe_on_phone),
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colors.onPrimary,
+                    style = MaterialTheme.typography.body1,
+                )
+            }
+        }
+
+        is PodcastsViewModel.UiState.Loaded -> {
+            ScalingLazyColumn(
+                modifier = modifier.fillMaxWidth(),
+                columnState = columnState
+            ) {
+                item {
+                    ScreenHeaderChip(if (uiState.folder == null) stringResource(LR.string.podcasts) else uiState.folder.name)
+                }
+                items(items = uiState.items, key = { item -> item.uuid }) { item ->
+                    when (item) {
+                        is FolderItem.Podcast -> {
+                            PodcastChip(podcast = item, onClick = navigateToPodcast)
+                        }
+
+                        is FolderItem.Folder -> {
+                            FolderChip(folderItem = item, onClick = navigateToFolder)
+                        }
+                    }
+                }
             }
         }
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -18,6 +20,8 @@ import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.extensions.darker
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
@@ -52,14 +56,24 @@ fun PodcastsScreen(
         item {
             ScreenHeaderChip(if (uiState.folder == null) stringResource(LR.string.podcasts) else uiState.folder.name)
         }
-        items(items = uiState.items, key = { item -> item.uuid }) { item ->
-            when (item) {
-                is FolderItem.Podcast -> {
-                    PodcastChip(podcast = item, onClick = navigateToPodcast)
+        if (uiState.items.isNotEmpty()) {
+            items(items = uiState.items, key = { item -> item.uuid }) { item ->
+                when (item) {
+                    is FolderItem.Podcast -> {
+                        PodcastChip(podcast = item, onClick = navigateToPodcast)
+                    }
+
+                    is FolderItem.Folder -> {
+                        FolderChip(folderItem = item, onClick = navigateToFolder)
+                    }
                 }
-                is FolderItem.Folder -> {
-                    FolderChip(folderItem = item, onClick = navigateToFolder)
-                }
+            }
+        } else {
+            item {
+                TextH30(text = "No subscribed podcasts", textAlign = TextAlign.Center, color = Color.White)
+            }
+            item {
+                TextP40(text = "Subscribe to podcasts on your phone and they'll appear here.", textAlign = TextAlign.Center, color = Color.White, fontWeight = FontWeight.W400)
             }
         }
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -28,6 +29,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.extensions.darker
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.LoadingSpinner
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
@@ -50,8 +52,7 @@ fun PodcastsScreen(
     navigateToPodcast: (String) -> Unit,
     navigateToFolder: (String) -> Unit,
 ) {
-
-    when (val uiState = viewModel.uiState) {
+    when (val uiState = viewModel.uiState.collectAsState().value) {
         is PodcastsViewModel.UiState.Empty -> {
             Column(
                 verticalArrangement = Arrangement.Center,
@@ -93,6 +94,23 @@ fun PodcastsScreen(
                         }
                     }
                 }
+            }
+        }
+
+        is PodcastsViewModel.UiState.Loading -> {
+            Column(
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                LoadingSpinner()
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = stringResource(LR.string.podcast_loading),
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colors.onPrimary,
+                    style = MaterialTheme.typography.body1,
+                )
             }
         }
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
@@ -70,10 +70,19 @@ fun PodcastsScreen(
             }
         } else {
             item {
-                TextH30(text = "No subscribed podcasts", textAlign = TextAlign.Center, color = Color.White)
+                TextH30(
+                    text = stringResource(id = LR.string.podcasts_no_subscriptions),
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colors.onPrimary
+                )
             }
             item {
-                TextP40(text = "Subscribe to podcasts on your phone and they'll appear here.", textAlign = TextAlign.Center, color = Color.White, fontWeight = FontWeight.W400)
+                TextP40(
+                    text = stringResource(id = LR.string.podcasts_subscribe_on_phone),
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colors.onPrimary,
+                    fontWeight = FontWeight.W400
+                )
             }
         }
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsViewModel.kt
@@ -1,8 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui.podcasts
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -11,6 +8,8 @@ import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -24,14 +23,15 @@ class PodcastsViewModel @Inject constructor(
 
     sealed class UiState {
         object Empty : UiState()
+        object Loading : UiState()
         data class Loaded(
             val folder: Folder? = null,
             val items: List<FolderItem> = emptyList()
         ) : UiState()
     }
 
-    var uiState by mutableStateOf<UiState>(UiState.Empty)
-        private set
+    private val _uiState = MutableStateFlow<UiState>(UiState.Loading)
+    val uiState: StateFlow<UiState> = _uiState
 
     init {
         viewModelScope.launch(Dispatchers.IO) {
@@ -45,8 +45,10 @@ class PodcastsViewModel @Inject constructor(
                 items = podcasts.map { FolderItem.Podcast(it) }
                 folder = folderManager.findByUuid(folderUuid)
             }
-            if (items.isNotEmpty()) {
-                uiState = UiState.Loaded(folder = folder, items = items)
+            _uiState.value = if (items.isNotEmpty()) {
+                UiState.Loaded(folder = folder, items = items)
+            } else {
+                UiState.Empty
             }
         }
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsViewModel.kt
@@ -22,12 +22,15 @@ class PodcastsViewModel @Inject constructor(
 
     private val folderUuid: String = savedStateHandle[PodcastsScreen.argumentFolderUuid] ?: ""
 
-    data class UiState(
-        val folder: Folder? = null,
-        val items: List<FolderItem> = emptyList()
-    )
+    sealed class UiState {
+        object Empty : UiState()
+        data class Loaded(
+            val folder: Folder? = null,
+            val items: List<FolderItem> = emptyList()
+        ) : UiState()
+    }
 
-    var uiState by mutableStateOf(UiState())
+    var uiState by mutableStateOf<UiState>(UiState.Empty)
         private set
 
     init {
@@ -42,7 +45,9 @@ class PodcastsViewModel @Inject constructor(
                 items = podcasts.map { FolderItem.Podcast(it) }
                 folder = folderManager.findByUuid(folderUuid)
             }
-            uiState = UiState(folder = folder, items = items)
+            if (items.isNotEmpty()) {
+                uiState = UiState.Loaded(folder = folder, items = items)
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

This PR adds a message screen for wear app when the user isn't subscribed to any podcasts, showing message to subscribe to podcasts on their phone.

Fixes #1076

## Testing Instructions
1. Login to the wear app.
2. Click on podcasts.
3. ✅ Verify the subscribe screen is shown when the user doesn't have any subscribed podcasts, telling them to subscribe to podcast on phone
4. ✅ Verify that the previous flow when the user does have subscribed podcast(s) works.

## Screenshots or Screencast 
<img src="https://github.com/Automattic/pocket-casts-android/assets/89896473/41c571ed-67dd-4494-84b1-0fe1975bed5d" width="40%" height="40%">

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with the device set to have a large display and font size
