### PR TITLE
Use regular icon for launcher by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 *   New Features:
     *   Wear OS app
         ([#1068](https://github.com/Automattic/pocket-casts-android/pull/1068)).
+    * Updates
+        Use regular Pocket Casts app icon by default, and allow pride icon to still be selected.
+        ([#1079](https://github.com/Automattic/pocket-casts-android/pull/1079)).
 
 7.40
 -----

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,7 @@ android {
 
         release {
             manifestPlaceholders = [
-                    appIcon: "@mipmap/ic_launcher_pride_2023",
+                    appIcon: "@mipmap/ic_launcher",
                     gitHash: "",
                     sentryDsn: project.pocketcastsSentryDsn
             ]

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/AppIcon.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/AppIcon.kt
@@ -179,7 +179,7 @@ class AppIcon @Inject constructor(
         );
 
         companion object {
-            fun fromString(value: String, default: AppIconType = PRIDE_2023): AppIconType {
+            fun fromString(value: String, default: AppIconType = DEFAULT): AppIconType {
                 return AppIconType.values().find { it.id == value } ?: default
             }
         }
@@ -194,8 +194,8 @@ class AppIcon @Inject constructor(
     val allAppIconTypes = AppIconType.values()
 
     private fun getAppIconFromPreferences(): AppIconType {
-        val appIconId: String = sharedPreferences.getString(PREFERENCE_APPICON, AppIconType.PRIDE_2023.id) ?: AppIconType.PRIDE_2023.id
-        return AppIconType.fromString(appIconId, AppIconType.PRIDE_2023)
+        val appIconId: String = sharedPreferences.getString(PREFERENCE_APPICON, AppIconType.DEFAULT.id) ?: AppIconType.PRIDE_2023.id
+        return AppIconType.fromString(appIconId, AppIconType.DEFAULT)
     }
 
     private fun setAppIconToPreferences(appIconType: AppIconType) {
@@ -210,7 +210,7 @@ class AppIcon @Inject constructor(
         AppIconType.values().forEach { iconType ->
             val componentName = ComponentName(componentPackage, "$classPath${iconType.aliasName}")
             // If we are using the default icon we just switch every alias off
-            val enabledFlag = if (selectedIconType == iconType && selectedIconType != AppIconType.PRIDE_2023) PackageManager.COMPONENT_ENABLED_STATE_ENABLED else PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+            val enabledFlag = if (selectedIconType == iconType && selectedIconType != AppIconType.DEFAULT) PackageManager.COMPONENT_ENABLED_STATE_ENABLED else PackageManager.COMPONENT_ENABLED_STATE_DISABLED
             context.packageManager.setComponentEnabledSetting(componentName, enabledFlag, PackageManager.DONT_KILL_APP)
         }
     }


### PR DESCRIPTION
## Description
With the end of June coming up, this updates the app to again use the regular Pocket Casts icon by default (follow-up to https://github.com/Automattic/pocket-casts-android/pull/997). The Pride icon may still be selected by a user under `Profile` → ⚙️  → `Appearance`.

> **Note**
> This change is targeting the `release/7.41` release branch. We should update the release notes to include this.

## Testing Instructions
### A. Default icon only
1. Install a release build of the app without the changes in this PR
2. Observe the app icon is the pride icon
3. Install a release build of the app with the changes in this PR
4. Observe the app icon is the default icon
5. Under `Profile` → ⚙️  → `Appearance`, select the Pride icon
6. Observe that the app launcher contains both the default icon and the Pride icon

### B. Selected non-default icon
1. Install a release build of the app without the changes in this PR
2. Under `Profile` → ⚙️  → `Appearance`, select any icon other than the default Pocket Casts icon or the Pride icon
3. Observe that the icon you selected and the Pride icon are in the app launcher
4. Install a release build of the app with the changes in this PR
3. Observe that the icon you selected and the default Pocket Casts icon are in the app launcher. The Pride icon should not be there.

### C. Selected default icon
1. Install a release build of the app without the changes in this PR
2. Under `Profile` → ⚙️  → `Appearance`, select the default Pocket Casts icon or the Pride icon
3. Observe that the default Pocket Casts icon and the Pride icon are in the app launcher
4. Install a release build of the app with the changes in this PR
7. Observe the app launcher now contains two instances of the default Pocket Casts icon
8. Open the app
9. Return to the app launcher and observe that the default Pocket Casts icon is now only there once.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
