### PR TITLE
Upgrade Gradle tools to 7.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     // Gradle Plugins
     dependencies {
         // Android - https://developer.android.com/studio/releases/gradle-plugin
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         // Google Services - https://developers.google.com/android/guides/google-services-plugin
         classpath "com.google.gms:google-services:4.3.14"
         // Kotlin

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -11,6 +11,7 @@ apply plugin: 'com.google.gms.google-services'
 apply from: "../base.gradle"
 
 android {
+    namespace 'au.com.shiftyjelly.pocketcasts'
 
     defaultConfig {
         minSdk project.minSdkVersionWear

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="au.com.shiftyjelly.pocketcasts">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.BLUETOOTH"/>


### PR DESCRIPTION
## Description

I got an error deploying a debug build to Wear OS and upgrading the Gradle tools fixed it for me. I tried to upgrade to 8.0.2 but it was erroring so I thought I would leave that for a future PR.

```
E  java.lang.NoSuchFieldError: No instance field delegate of type Landroid/database/sqlite/SQLiteStatement; in class Landroidx/sqlite/db/framework/FrameworkSQLiteStatement; or its superclasses (declaration of 'androidx.sqlite.db.framework.FrameworkSQLiteStatement' appears in /data/app/~~fFjdLX1TbF6d9sqPi609OQ==/au.com.shiftyjelly.pocketcasts.debug-9JfEpQW9bnvJ98MqSMTmmg==/base.apk!classes17.dex)
E  	at androidx.sqlite.db.framework.FrameworkSQLiteStatement.executeUpdateDelete(Unknown Source:0)
E  	at androidx.work.impl.model.WorkSpecDao_Impl.markWorkSpecScheduled(WorkSpecDao_Impl.java:343)
E  	at androidx.work.impl.background.systemjob.SystemJobScheduler.reconcileJobs(SystemJobScheduler.java:336)
```

## Testing Instructions
1. Install the app
2. ✅ Verify it installs successfully
