### PR TITLE
Retrieve show notes from JSON cache

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
@@ -52,7 +52,7 @@ class PodcastManagerTest {
 
         val application = context
         val podcastCacheServer = mock<PodcastCacheServerManager> {
-            on { getPodcast(uuid, 0, 3, 1500) } doReturn Single.just(Podcast(uuid))
+            on { getPodcast(uuid) } doReturn Single.just(Podcast(uuid))
         }
         val staticServerManager = mock<StaticServerManager> {
             on { getColorsSingle(uuid) } doReturn Single.just(Optional.empty())

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -413,6 +413,8 @@ class EpisodeFragment : BaseDialogFragment() {
                 val showNotes = showNotesState.showNotes
                 formattedNotes = showNotesFormatter.format(showNotes) ?: showNotes
                 loadShowNotes(formattedNotes ?: "")
+            } else if (showNotesState is ShowNotesState.Error || showNotesState is ShowNotesState.NotFound) {
+                loadShowNotes("")
             }
         }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -409,13 +409,19 @@ class EpisodeFragment : BaseDialogFragment() {
         )
 
         viewModel.showNotesState.observe(viewLifecycleOwner) { showNotesState ->
-            if (showNotesState is ShowNotesState.Loaded) {
-                val showNotes = showNotesState.showNotes
-                formattedNotes = showNotesFormatter.format(showNotes) ?: showNotes
-                loadShowNotes(formattedNotes ?: "")
-            } else if (showNotesState is ShowNotesState.Error || showNotesState is ShowNotesState.NotFound) {
-                formattedNotes = ""
-                loadShowNotes("")
+            when (showNotesState) {
+                is ShowNotesState.Loaded -> {
+                    val showNotes = showNotesState.showNotes
+                    formattedNotes = showNotesFormatter.format(showNotes) ?: showNotes
+                    loadShowNotes(formattedNotes ?: "")
+                }
+                is ShowNotesState.Error, is ShowNotesState.NotFound -> {
+                    formattedNotes = ""
+                    loadShowNotes("")
+                }
+                is ShowNotesState.Loading -> {
+                    // Do nothing as the starting state is loading
+                }
             }
         }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -38,6 +38,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImageLoader
 import au.com.shiftyjelly.pocketcasts.repositories.images.into
 import au.com.shiftyjelly.pocketcasts.servers.ServerManager
+import au.com.shiftyjelly.pocketcasts.servers.shownotes.ShowNotesState
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
@@ -407,10 +408,12 @@ class EpisodeFragment : BaseDialogFragment() {
             }
         )
 
-        // Ideally this would all be contained in the viewmodel state observable but webview flickers when updating
-        viewModel.showNotes.observe(viewLifecycleOwner) { showNotes ->
-            formattedNotes = showNotesFormatter.format(showNotes) ?: showNotes
-            loadShowNotes(formattedNotes ?: "")
+        viewModel.showNotesState.observe(viewLifecycleOwner) { showNotesState ->
+            if (showNotesState is ShowNotesState.Loaded) {
+                val showNotes = showNotesState.showNotes
+                formattedNotes = showNotesFormatter.format(showNotes) ?: showNotes
+                loadShowNotes(formattedNotes ?: "")
+            }
         }
 
         binding?.btnArchive?.let { button ->

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -414,6 +414,7 @@ class EpisodeFragment : BaseDialogFragment() {
                 formattedNotes = showNotesFormatter.format(showNotes) ?: showNotes
                 loadShowNotes(formattedNotes ?: "")
             } else if (showNotesState is ShowNotesState.Error || showNotesState is ShowNotesState.NotFound) {
+                formattedNotes = ""
                 loadShowNotes("")
             }
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlowable
-import timber.log.Timber
 import java.util.Date
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -117,7 +116,6 @@ class EpisodeFragmentViewModel @Inject constructor(
                     zipper
                 )
             }
-            .doOnNext { Timber.i("PHILIP Episode state $it") }
             .doOnNext { if (it is EpisodeFragmentState.Loaded) { episode = it.episode } }
             .onErrorReturn { EpisodeFragmentState.Error(it) }
             .observeOn(AndroidSchedulers.mainThread())

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -50,7 +50,6 @@ interface Settings {
         const val WHATS_NEW_VERSION_CODE = 7566
 
         const val DEFAULT_MAX_AUTO_ADD_LIMIT = 100
-        const val LIMIT_MAX_PODCAST_EPISODES = 1500
         const val MAX_DOWNLOAD = 100
 
         const val PARSER_VERSION = "1.7"

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateShowNotesTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateShowNotesTask.kt
@@ -7,6 +7,7 @@ import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.servers.ServerShowNotesManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import timber.log.Timber
 
 @HiltWorker
 class UpdateShowNotesTask @AssistedInject constructor(
@@ -19,7 +20,7 @@ class UpdateShowNotesTask @AssistedInject constructor(
         const val INPUT_EPISODE_UUID = "episode_uuid"
     }
 
-    private val podcastUuid = inputData.getString(INPUT_EPISODE_UUID)!!
+    private val podcastUuid = inputData.getString(INPUT_PODCAST_UUID)!!
     private val episodeUuid = inputData.getString(INPUT_EPISODE_UUID)!!
 
     override suspend fun doWork(): Result {
@@ -27,6 +28,7 @@ class UpdateShowNotesTask @AssistedInject constructor(
             showNotesManager.downloadShowNotes(podcastUuid = podcastUuid, episodeUuid = episodeUuid)
             Result.success()
         } catch (e: Exception) {
+            Timber.e(e)
             Result.failure()
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateShowNotesTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateShowNotesTask.kt
@@ -1,24 +1,30 @@
 package au.com.shiftyjelly.pocketcasts.repositories.download.task
 
 import android.content.Context
-import androidx.work.Worker
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.servers.ServerShowNotesManager
-import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
-import okhttp3.OkHttpClient
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
 
-class UpdateShowNotesTask(val context: Context, val params: WorkerParameters) : Worker(context, params) {
+@HiltWorker
+class UpdateShowNotesTask @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters,
+    private val showNotesManager: ServerShowNotesManager
+) : CoroutineWorker(context, params) {
     companion object {
+        const val INPUT_PODCAST_UUID = "podcast_uuid"
         const val INPUT_EPISODE_UUID = "episode_uuid"
     }
 
-    private val httpClient: OkHttpClient = ServersModule.getShowNotesClient(context)
-    private val episodeUUID = inputData.getString(INPUT_EPISODE_UUID)!!
+    private val podcastUuid = inputData.getString(INPUT_EPISODE_UUID)!!
+    private val episodeUuid = inputData.getString(INPUT_EPISODE_UUID)!!
 
-    override fun doWork(): Result {
+    override suspend fun doWork(): Result {
         return try {
-            val serverShowNotes = ServerShowNotesManager(httpClient)
-            serverShowNotes.cacheShowNotes(episodeUUID).onErrorComplete().blockingAwait()
+            showNotesManager.downloadShowNotes(podcastUuid = podcastUuid, episodeUuid = episodeUuid)
             Result.success()
         } catch (e: Exception) {
             Result.failure()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -201,7 +201,7 @@ class PodcastManagerImpl @Inject constructor(
     override fun refreshPodcastInBackground(existingPodcast: Podcast, playbackManager: PlaybackManager) {
         launch {
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Refreshing podcast ${existingPodcast.uuid}")
-            val updatedPodcast = cacheServerManager.getPodcastResponse(existingPodcast.uuid, episodeLimit = Settings.LIMIT_MAX_PODCAST_EPISODES)
+            val updatedPodcast = cacheServerManager.getPodcastResponse(existingPodcast.uuid)
                 .map {
                     val responsePodcast = it.body()?.toPodcast()
                     if (it.wasCached()) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -156,7 +156,7 @@ class SubscribeManager @Inject constructor(
 
     private fun downloadPodcast(podcastUuid: String): Single<Podcast> {
         // download the podcast
-        val serverPodcastObservable = podcastCacheServerManager.getPodcast(podcastUuid, episodeLimit = Settings.LIMIT_MAX_PODCAST_EPISODES)
+        val serverPodcastObservable = podcastCacheServerManager.getPodcast(podcastUuid)
             .subscribeOn(Schedulers.io())
             .doOnSuccess { Timber.i("Downloaded episodes success podcast $podcastUuid") }
         // download the colors

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerShowNotesManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerShowNotesManager.kt
@@ -1,30 +1,17 @@
 package au.com.shiftyjelly.pocketcasts.servers
 
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.servers.di.ShowNotesCache
-import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesResponse
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
 import au.com.shiftyjelly.pocketcasts.servers.shownotes.ShowNotesState
-import au.com.shiftyjelly.pocketcasts.utils.extensions.await
-import com.squareup.moshi.Moshi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import okhttp3.CacheControl
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.Response
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class ServerShowNotesManager @Inject constructor(
-    @ShowNotesCache private val showNotesHttpClient: OkHttpClient,
-    private val moshi: Moshi
+    private val podcastCacheServerManager: PodcastCacheServerManager
 ) {
-
-    companion object {
-        const val URL = "${Settings.SERVER_CACHE_URL}/mobile/show_notes/full/%s"
-    }
 
     /**
      * Check the cache for show notes then download them if not found or update the cache.
@@ -86,40 +73,13 @@ class ServerShowNotesManager @Inject constructor(
         return if (downloadException != null) ShowNotesState.Error(downloadException) else ShowNotesState.NotFound
     }
 
-    private fun buildUrl(podcastUuid: String): String {
-        return URL.format(podcastUuid)
-    }
-
-    private fun findShowNotesInCache(podcastUuid: String, episodeUuid: String): String? {
-        val url = buildUrl(podcastUuid = podcastUuid)
-        val request = Request.Builder()
-            .cacheControl(CacheControl.Builder().onlyIfCached().build())
-            .url(url)
-            .build()
-        showNotesHttpClient.newCall(request).execute().use { cachedResponse ->
-            val response = readResponse(cachedResponse) ?: return null
-            return response.findEpisode(episodeUuid)?.showNotes
-        }
-    }
-
-    suspend fun downloadShowNotes(podcastUuid: String, episodeUuid: String): String? {
-        val url = buildUrl(podcastUuid = podcastUuid)
-        val request = Request.Builder()
-            .url(url)
-            .build()
-        val networkResponse = showNotesHttpClient.newCall(request).await()
-        val response = readResponse(networkResponse) ?: return null
+    private suspend fun findShowNotesInCache(podcastUuid: String, episodeUuid: String): String? {
+        val response = podcastCacheServerManager.getShowNotesCache(podcastUuid = podcastUuid) ?: return null
         return response.findEpisode(episodeUuid)?.showNotes
     }
 
-    private fun readResponse(response: Response): ShowNotesResponse? {
-        return try {
-            val body = response.body ?: return null
-            val adapter = moshi.adapter(ShowNotesResponse::class.java)
-            return adapter.fromJson(body.string())
-        } catch (e: Exception) {
-            Timber.e(e, "Failed to parse show notes JSON response.")
-            null
-        }
+    suspend fun downloadShowNotes(podcastUuid: String, episodeUuid: String): String? {
+        val response = podcastCacheServerManager.getShowNotes(podcastUuid = podcastUuid)
+        return response.findEpisode(episodeUuid)?.showNotes
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerShowNotesManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerShowNotesManager.kt
@@ -26,6 +26,9 @@ class ServerShowNotesManager @Inject constructor(
         const val URL = "${Settings.SERVER_CACHE_URL}/mobile/show_notes/full/%s"
     }
 
+    /**
+     * Check the cache for show notes then download them if not found or update the cache.
+     */
     fun loadShowNotesFlow(podcastUuid: String, episodeUuid: String): Flow<ShowNotesState> {
         return flow {
             emit(ShowNotesState.Loading)
@@ -56,6 +59,9 @@ class ServerShowNotesManager @Inject constructor(
         }
     }
 
+    /**
+     * Download the show notes, if that fails try the cache.
+     */
     suspend fun loadShowNotes(podcastUuid: String, episodeUuid: String): ShowNotesState {
         val showNotesDownloaded = downloadShowNotes(podcastUuid = podcastUuid, episodeUuid = episodeUuid)
         var downloadException: Exception? = null

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerShowNotesManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerShowNotesManager.kt
@@ -30,8 +30,9 @@ class ServerShowNotesManager @Inject constructor(
                 // download or update cache
                 val showNotesDownloaded = downloadShowNotes(podcastUuid = podcastUuid, episodeUuid = episodeUuid)
                 if (showNotesDownloaded != null) {
-                    if (showNotesDownloaded != showNotesCached) {
+                    if (showNotesDownloaded != showNotesCached || !loaded) {
                         emit(ShowNotesState.Loaded(showNotesDownloaded))
+                        loaded = true
                     }
                 } else {
                     emit(ShowNotesState.NotFound)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
@@ -282,7 +282,7 @@ class ServersModule {
     @Provides
     @PodcastCacheServerRetrofit
     @Singleton
-    internal fun providePodcastRetrofit(@CachedTokenedOkHttpClient okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
+    internal fun providePodcastRetrofit(@CachedOkHttpClient okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
         return Retrofit.Builder()
             .addConverterFactory(MoshiConverterFactory.create(moshi))
             .addCallAdapterFactory(RxJava2CallAdapterFactory.create())

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServer.kt
@@ -61,11 +61,11 @@ data class PodcastRatingsResponse(
 }
 
 interface PodcastCacheServer {
-    @GET("/mobile/podcast/full/{podcastUuid}/{pageNumber}/{sortOption}/{episodeLimit}")
-    fun getPodcastAndEpisodesRaw(@Path("podcastUuid") podcastUuid: String, @Path("pageNumber") pageNumber: Int = 0, @Path("sortOption") sortOption: Int = 3, @Path("episodeLimit") episodeLimit: Int = 0): Single<Response<PodcastResponse>>
+    @GET("/mobile/podcast/full/{podcastUuid}")
+    fun getPodcastAndEpisodesRaw(@Path("podcastUuid") podcastUuid: String): Single<Response<PodcastResponse>>
 
-    @GET("/mobile/podcast/full/{podcastUuid}/{pageNumber}/{sortOption}/{episodeLimit}")
-    fun getPodcastAndEpisodes(@Path("podcastUuid") podcastUuid: String, @Path("pageNumber") pageNumber: Int = 0, @Path("sortOption") sortOption: Int = 3, @Path("episodeLimit") episodeLimit: Int = 0): Single<PodcastResponse>
+    @GET("/mobile/podcast/full/{podcastUuid}")
+    fun getPodcastAndEpisodes(@Path("podcastUuid") podcastUuid: String): Single<PodcastResponse>
 
     @GET("/mobile/podcast/findbyepisode/{podcastUuid}/{episodeUuid}")
     fun getPodcastAndEpisode(@Path("podcastUuid") podcastUuid: String, @Path("episodeUuid") episodeUuid: String): Single<PodcastResponse>

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServer.kt
@@ -8,6 +8,7 @@ import io.reactivex.Single
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Headers
 import retrofit2.http.POST
 import retrofit2.http.Path
 import java.util.Date
@@ -66,6 +67,13 @@ interface PodcastCacheServer {
 
     @GET("/mobile/podcast/full/{podcastUuid}")
     fun getPodcastAndEpisodes(@Path("podcastUuid") podcastUuid: String): Single<PodcastResponse>
+
+    @GET("/mobile/show_notes/full/{podcastUuid}")
+    suspend fun getShowNotes(@Path("podcastUuid") podcastUuid: String): ShowNotesResponse
+
+    @GET("/mobile/show_notes/full/{podcastUuid}")
+    @Headers("Cache-Control: only-if-cached, max-stale=7776000") // Use offline cache available for 90 days
+    suspend fun getShowNotesCache(@Path("podcastUuid") podcastUuid: String): ShowNotesResponse
 
     @GET("/mobile/podcast/findbyepisode/{podcastUuid}/{episodeUuid}")
     fun getPodcastAndEpisode(@Path("podcastUuid") podcastUuid: String, @Path("episodeUuid") episodeUuid: String): Single<PodcastResponse>

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManager.kt
@@ -13,4 +13,6 @@ interface PodcastCacheServerManager {
     fun searchEpisodes(searchTerm: String): Single<EpisodeSearch>
     fun getPodcastResponse(podcastUuid: String): Single<Response<PodcastResponse>>
     suspend fun getPodcastRatings(podcastUuid: String): PodcastRatings
+    suspend fun getShowNotes(podcastUuid: String): ShowNotesResponse
+    suspend fun getShowNotesCache(podcastUuid: String): ShowNotesResponse?
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManager.kt
@@ -7,10 +7,10 @@ import io.reactivex.Single
 import retrofit2.Response
 
 interface PodcastCacheServerManager {
-    fun getPodcast(podcastUuid: String, pageNumber: Int = 0, sortOption: Int = 3, episodeLimit: Int = 0): Single<Podcast>
+    fun getPodcast(podcastUuid: String): Single<Podcast>
     fun getPodcastAndEpisode(podcastUuid: String, episodeUuid: String): Single<Podcast>
     fun searchEpisodes(podcastUuid: String, searchTerm: String): Single<List<String>>
     fun searchEpisodes(searchTerm: String): Single<EpisodeSearch>
-    fun getPodcastResponse(podcastUuid: String, pageNumber: Int = 0, sortOption: Int = 3, episodeLimit: Int = 0): Single<Response<PodcastResponse>>
+    fun getPodcastResponse(podcastUuid: String): Single<Response<PodcastResponse>>
     suspend fun getPodcastRatings(podcastUuid: String): PodcastRatings
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
@@ -6,11 +6,12 @@ import au.com.shiftyjelly.pocketcasts.servers.discover.EpisodeSearch
 import io.reactivex.Single
 import retrofit2.Response
 import retrofit2.Retrofit
+import timber.log.Timber
 import javax.inject.Inject
 
 class PodcastCacheServerManagerImpl @Inject constructor(@PodcastCacheServerRetrofit private val retrofit: Retrofit) : PodcastCacheServerManager {
 
-    val server = retrofit.create(PodcastCacheServer::class.java)
+    private val server = retrofit.create(PodcastCacheServer::class.java)
 
     override fun getPodcastResponse(podcastUuid: String): Single<Response<PodcastResponse>> {
         return server.getPodcastAndEpisodesRaw(podcastUuid)
@@ -37,4 +38,17 @@ class PodcastCacheServerManagerImpl @Inject constructor(@PodcastCacheServerRetro
 
     override suspend fun getPodcastRatings(podcastUuid: String) =
         server.getPodcastRatings(podcastUuid).toPodcastRatings(podcastUuid)
+
+    override suspend fun getShowNotes(podcastUuid: String): ShowNotesResponse {
+        return server.getShowNotes(podcastUuid)
+    }
+
+    override suspend fun getShowNotesCache(podcastUuid: String): ShowNotesResponse? {
+        return try {
+            server.getShowNotesCache(podcastUuid)
+        } catch (e: Exception) {
+            Timber.e(e)
+            null
+        }
+    }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
@@ -47,6 +47,7 @@ class PodcastCacheServerManagerImpl @Inject constructor(@PodcastCacheServerRetro
         return try {
             server.getShowNotesCache(podcastUuid)
         } catch (e: Exception) {
+            // ignore the error when the cache is empty
             Timber.e(e)
             null
         }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
@@ -12,12 +12,12 @@ class PodcastCacheServerManagerImpl @Inject constructor(@PodcastCacheServerRetro
 
     val server = retrofit.create(PodcastCacheServer::class.java)
 
-    override fun getPodcastResponse(podcastUuid: String, pageNumber: Int, sortOption: Int, episodeLimit: Int): Single<Response<PodcastResponse>> {
-        return server.getPodcastAndEpisodesRaw(podcastUuid, pageNumber, sortOption, episodeLimit)
+    override fun getPodcastResponse(podcastUuid: String): Single<Response<PodcastResponse>> {
+        return server.getPodcastAndEpisodesRaw(podcastUuid)
     }
 
-    override fun getPodcast(podcastUuid: String, pageNumber: Int, sortOption: Int, episodeLimit: Int): Single<Podcast> {
-        return server.getPodcastAndEpisodes(podcastUuid, pageNumber, sortOption, episodeLimit)
+    override fun getPodcast(podcastUuid: String): Single<Podcast> {
+        return server.getPodcastAndEpisodes(podcastUuid)
             .map(PodcastResponse::toPodcast)
     }
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/ShowNotesResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/ShowNotesResponse.kt
@@ -1,0 +1,25 @@
+package au.com.shiftyjelly.pocketcasts.servers.podcast
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ShowNotesResponse(
+    @field:Json(name = "podcast") val podcast: ShowNotesPodcast
+) {
+    fun findEpisode(episodeUuid: String): ShowNotesEpisode? {
+        return podcast.episodes.find { it.uuid == episodeUuid }
+    }
+}
+
+@JsonClass(generateAdapter = true)
+data class ShowNotesPodcast(
+    @field:Json(name = "uuid") val uuid: String,
+    @field:Json(name = "episodes") val episodes: List<ShowNotesEpisode>
+)
+
+@JsonClass(generateAdapter = true)
+data class ShowNotesEpisode(
+    @field:Json(name = "uuid") val uuid: String,
+    @field:Json(name = "show_notes") val showNotes: String
+)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/shownotes/ShowNotesState.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/shownotes/ShowNotesState.kt
@@ -1,0 +1,8 @@
+package au.com.shiftyjelly.pocketcasts.servers.shownotes
+
+sealed class ShowNotesState {
+    data class Loaded(val showNotes: String) : ShowNotesState()
+    object NotFound : ShowNotesState()
+    object Loading : ShowNotesState()
+    data class Error(val error: Throwable) : ShowNotesState()
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
@@ -37,6 +37,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.DownloadButtonState
+import au.com.shiftyjelly.pocketcasts.servers.shownotes.ShowNotesState
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ExpandableText
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
@@ -188,11 +189,11 @@ fun EpisodeScreen(
         }
 
         item {
-            if (state.showNotes != null) {
+            if (state.showNotesState is ShowNotesState.Loaded) {
                 val coroutineScope = rememberCoroutineScope()
                 Column {
                     ExpandableText(
-                        text = state.showNotes.parseAsHtml().toString(),
+                        text = state.showNotesState.showNotes.parseAsHtml().toString(),
                         style = MaterialTheme.typography.caption2,
                         textAlign = TextAlign.Center,
                         onClick = { isExpanded ->


### PR DESCRIPTION
## Description

This change switches getting the show notes from the JSON cache.

## Testing Instructions
1. Open a podcast page
2. Tap on an episode row
3. ✅ Verify the show notes are displayed
4. Close the episode fragment
5. Turn on airplane mode
6. Tap another episode row
7. ✅ Verify the show notes are displayed 
8. Turn off airplane mode
9. Go to a different podcast
10. Tap play on an episode row without opening the episode fragment
11. Tap on the mini player
12. Tap on the Notes tab
13. ✅ Verify the show notes are displayed

### Test show notes are cached with an episode download
1. Tap the Profile tab
2. Tap the settings cog
3. Tap General
4. Tap Row action
5. Change it to Download
6. Go to discover and find a podcast that you haven't opened
7. Tap download on the episode row and wait for the download to finish
8. Turn on airplane mode
9. Tap on an episode row
10. ✅ Verify the show notes are displayed
