### PR TITLE
Enable sharing logs from watch

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -551,6 +551,19 @@
             </intent-filter>
         </service>
 
+        <service
+            android:name=".PocketCastsWearListenerService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.gms.wearable.MESSAGE_RECEIVED" />
+                <data
+                    android:scheme="wear"
+                    android:host="*"
+                    android:pathPrefix="/pocket_casts_wear_communication"
+                    />
+            </intent-filter>
+        </service>
+
         <!-- A receiver that will receive media buttons and send as
             intents to your MediaBrowserServiceCompat implementation.
             Required on pre-Lollipop. More information at

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsWearListenerService.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsWearListenerService.kt
@@ -11,8 +11,8 @@ class PocketCastsWearListenerService : WearableListenerService() {
 
     @Inject lateinit var watchPhoneCommunication: WatchPhoneCommunication.Phone
 
-    override fun onMessageReceived(p0: MessageEvent) {
-        watchPhoneCommunication.handleMessage(p0)
-        super.onMessageReceived(p0)
+    override fun onMessageReceived(event: MessageEvent) {
+        watchPhoneCommunication.handleMessage(event)
+        super.onMessageReceived(event)
     }
 }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsWearListenerService.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsWearListenerService.kt
@@ -1,0 +1,18 @@
+package au.com.shiftyjelly.pocketcasts
+
+import au.com.shiftyjelly.pocketcasts.shared.WatchPhoneCommunication
+import com.google.android.gms.wearable.MessageEvent
+import com.google.android.gms.wearable.WearableListenerService
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class PocketCastsWearListenerService : WearableListenerService() {
+
+    @Inject lateinit var watchPhoneCommunication: WatchPhoneCommunication.Phone
+
+    override fun onMessageReceived(p0: MessageEvent) {
+        watchPhoneCommunication.handleMessage(p0)
+        super.onMessageReceived(p0)
+    }
+}

--- a/app/src/main/res/values/wear.xml
+++ b/app/src/main/res/values/wear.xml
@@ -14,12 +14,14 @@
      limitations under the License.
 -->
 
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@array/android_wear_capabilities">
     <string-array
         name="android_wear_capabilities"
         translatable="false"
         tools:ignore="UnusedResources">
-        <!-- declaring the provided capabilities -->
         <item>horologist_phone</item>
+        <item>pocket_casts_wear_listener</item>
     </string-array>
 </resources>

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/LogsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/LogsViewModel.kt
@@ -4,14 +4,12 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.repositories.support.Support
-import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.io.ByteArrayOutputStream
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -28,14 +26,11 @@ class LogsViewModel @Inject constructor(
     val state = _state.asStateFlow()
 
     init {
-        viewModelScope.launch(Dispatchers.IO) {
-            val logs = buildString {
-                append(support.getUserDebug(false))
-                val outputStream = ByteArrayOutputStream()
-                LogBuffer.output(outputStream)
-                append(outputStream.toString())
+        viewModelScope.launch {
+            _state.update {
+                val logs = support.getLogs()
+                it.copy(logs = logs)
             }
-            _state.update { it.copy(logs = logs) }
         }
     }
 

--- a/modules/features/shared/build.gradle
+++ b/modules/features/shared/build.gradle
@@ -11,6 +11,7 @@ android {
 
 dependencies {
     implementation project(':modules:services:analytics')
+    implementation project(':modules:services:localization')
     implementation project(':modules:services:repositories')
     implementation project(':modules:services:utils')
 }

--- a/modules/features/shared/build.gradle
+++ b/modules/features/shared/build.gradle
@@ -11,4 +11,6 @@ android {
 
 dependencies {
     implementation project(':modules:services:analytics')
+    implementation project(':modules:services:repositories')
+    implementation project(':modules:services:utils')
 }

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/WatchPhoneCommunication.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/WatchPhoneCommunication.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import android.content.Intent
 import au.com.shiftyjelly.pocketcasts.repositories.support.Support
 import au.com.shiftyjelly.pocketcasts.shared.WatchPhoneCommunication.Companion.Paths.emailLogsToSupport
+import au.com.shiftyjelly.pocketcasts.shared.WatchPhoneCommunication.Companion.Paths.sendLogsToPhone
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.google.android.gms.wearable.CapabilityClient
 import com.google.android.gms.wearable.CapabilityInfo
 import com.google.android.gms.wearable.MessageEvent
+import com.google.android.gms.wearable.Node
 import com.google.android.gms.wearable.Wearable
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
@@ -21,6 +23,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 class WatchPhoneCommunication {
 
@@ -28,6 +31,7 @@ class WatchPhoneCommunication {
         private object Paths {
             private const val prefix = "/pocket_casts_wear_communication"
             const val emailLogsToSupport = "$prefix/email_support"
+            const val sendLogsToPhone = "$prefix/send_logs_to_phone"
         }
 
         private const val capabilityName = "pocket_casts_wear_listener"
@@ -73,19 +77,37 @@ class WatchPhoneCommunication {
 
         suspend fun emailLogsToSupportMessage() {
             withContext(Dispatchers.IO) {
-
-                val node = availableNodeFlow.value
-                if (node == null) {
-                    LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "failed to email logs to support because no nodes available")
-                    return@withContext
+                withAvailableNode { node ->
+                    val path = emailLogsToSupport
+                    val data = support.getLogs().toByteArray()
+                    Wearable
+                        .getMessageClient(appContext)
+                        .sendMessage(node.id, path, data)
                 }
-
-                val path = emailLogsToSupport
-                val data = support.getLogs().toByteArray()
-                Wearable
-                    .getMessageClient(appContext)
-                    .sendMessage(node.id, path, data)
             }
+        }
+
+        suspend fun sendLogsToPhoneMessage() {
+            withContext(Dispatchers.IO) {
+                withAvailableNode { node ->
+                    val path = sendLogsToPhone
+                    val data = support.getLogs().toByteArray()
+                    Wearable
+                        .getMessageClient(appContext)
+                        .sendMessage(node.id, path, data)
+                }
+            }
+        }
+
+        private suspend fun withAvailableNode(continuation: suspend (node: Node) -> Unit) {
+            val node = availableNodeFlow.value
+            if (node == null) {
+                // This should not happen because we should be preventing the user from selecting
+                // an option requiring a node when no nodes are available
+                LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "cannot communicate with phone because no nodes are available")
+                return
+            }
+            continuation(node)
         }
     }
 
@@ -100,6 +122,7 @@ class WatchPhoneCommunication {
             when (messageEvent.path) {
 
                 emailLogsToSupport -> handleEmailLogsToSupportMessage(messageEvent)
+                sendLogsToPhone -> handleSendLogsToPhoneMessage(messageEvent)
 
                 else -> {
                     val message = "${this::class.java.simpleName} received message with unexpected path: ${messageEvent.path}"
@@ -111,6 +134,19 @@ class WatchPhoneCommunication {
         private fun handleEmailLogsToSupportMessage(messageEvent: MessageEvent) {
             coroutineScope.launch {
                 val intent = support.emailWearLogsToSupportIntent(messageEvent.data, appContext).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                appContext.startActivity(intent)
+            }
+        }
+
+        private fun handleSendLogsToPhoneMessage(messageEvent: MessageEvent) {
+            coroutineScope.launch(Dispatchers.IO) {
+                val intent = support.shareWearLogs(
+                    logBytes = messageEvent.data,
+                    subject = appContext.getString(LR.string.settings_watch_logs),
+                    context = appContext
+                ).apply {
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 }
                 appContext.startActivity(intent)

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/WatchPhoneCommunication.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/WatchPhoneCommunication.kt
@@ -1,0 +1,117 @@
+package au.com.shiftyjelly.pocketcasts.shared
+
+import android.content.Context
+import au.com.shiftyjelly.pocketcasts.repositories.support.Support
+import au.com.shiftyjelly.pocketcasts.shared.WatchPhoneCommunication.Companion.Paths.emailLogsToSupport
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import com.google.android.gms.wearable.CapabilityClient
+import com.google.android.gms.wearable.CapabilityInfo
+import com.google.android.gms.wearable.MessageEvent
+import com.google.android.gms.wearable.Wearable
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class WatchPhoneCommunication {
+
+    companion object {
+        private object Paths {
+            private const val prefix = "/pocket_casts_wear_communication"
+            const val emailLogsToSupport = "$prefix/email_support"
+        }
+
+        private const val capabilityName = "pocket_casts_wear_listener"
+    }
+
+    class Watch @Inject constructor(
+        @ApplicationContext private val appContext: Context,
+        private val support: Support,
+    ) {
+
+        private val coroutineScope = CoroutineScope(Dispatchers.IO + Job())
+        private val capabilityInfoFlow = MutableStateFlow<CapabilityInfo?>(null)
+        private val availableNodeFlow = capabilityInfoFlow
+            .map { it?.nodes?.firstOrNull() } // just using the first available node
+            .stateIn(coroutineScope, SharingStarted.Lazily, null)
+        val watchPhoneCommunicationStateFlow = availableNodeFlow
+            .map {
+                when (it) {
+                    null -> WatchPhoneCommunicationState.NOT_CONNECTED
+                    else -> WatchPhoneCommunicationState.AVAILABLE
+                }
+            }.stateIn(coroutineScope, SharingStarted.Lazily, WatchPhoneCommunicationState.NOT_CONNECTED)
+
+        private val onCapabilityChangedListener = CapabilityClient.OnCapabilityChangedListener {
+            capabilityInfoFlow.value = it
+        }
+
+        init {
+
+            coroutineScope.launch {
+                val capabilityInfo =
+                    Wearable.getCapabilityClient(appContext)
+                        .getCapability(capabilityName, CapabilityClient.FILTER_REACHABLE)
+                        .await()
+                onCapabilityChangedListener.onCapabilityChanged(capabilityInfo)
+            }
+
+            Wearable.getCapabilityClient(appContext)
+                .addListener({
+                    onCapabilityChangedListener.onCapabilityChanged(it)
+                }, capabilityName)
+        }
+
+        suspend fun emailLogsToSupportMessage() {
+            withContext(Dispatchers.IO) {
+
+                val node = availableNodeFlow.value
+                if (node == null) {
+                    LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "failed to email logs to support because no nodes available")
+                    return@withContext
+                }
+
+                val path = emailLogsToSupport
+                val data = support.getLogs().toByteArray()
+                Wearable
+                    .getMessageClient(appContext)
+                    .sendMessage(node.id, path, data)
+            }
+        }
+    }
+
+    class Phone @Inject constructor(
+        @ApplicationContext appContext: Context,
+    ) {
+
+        fun handleMessage(messageEvent: MessageEvent) {
+            when (messageEvent.path) {
+
+                emailLogsToSupport -> handleEmailLogsToSupportMessage(messageEvent)
+
+                else -> {
+                    val message = "${this::class.java.simpleName} received message with unexpected path: ${messageEvent.path}"
+                    throw RuntimeException(message)
+                }
+            }
+        }
+
+        private fun handleEmailLogsToSupportMessage(messageEvent: MessageEvent) {
+            val logs = String(messageEvent.data)
+            TODO("send email to support")
+        }
+    }
+}
+
+enum class WatchPhoneCommunicationState {
+    AVAILABLE,
+    NOT_CONNECTED,
+}

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/WatchPhoneCommunication.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/WatchPhoneCommunication.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.shared
 
 import android.content.Context
+import android.content.Intent
 import au.com.shiftyjelly.pocketcasts.repositories.support.Support
 import au.com.shiftyjelly.pocketcasts.shared.WatchPhoneCommunication.Companion.Paths.emailLogsToSupport
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -89,8 +90,11 @@ class WatchPhoneCommunication {
     }
 
     class Phone @Inject constructor(
-        @ApplicationContext appContext: Context,
+        @ApplicationContext private val appContext: Context,
+        private val support: Support,
     ) {
+
+        private val coroutineScope = CoroutineScope(Dispatchers.IO + Job())
 
         fun handleMessage(messageEvent: MessageEvent) {
             when (messageEvent.path) {
@@ -105,8 +109,12 @@ class WatchPhoneCommunication {
         }
 
         private fun handleEmailLogsToSupportMessage(messageEvent: MessageEvent) {
-            val logs = String(messageEvent.data)
-            TODO("send email to support")
+            coroutineScope.launch {
+                val intent = support.emailWearLogsToSupportIntent(messageEvent.data, appContext).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                appContext.startActivity(intent)
+            }
         }
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1054,10 +1054,11 @@
     <string name="settings_get_plus_and_more">Get Pocket Casts Plus to unlock this feature and more!</string>
     <string name="settings_help_cant_load">Could not load Help &amp; Feedback.\nPlease check your internet connection and try again.</string>
     <string name="settings_help_contact_support">Contact Support</string>
-    <string name="settings_help_contact_support_email_sent_to_phone">Check your phone for a pop-up to email support with your logs attached</string>
+    <string name="settings_help_contact_support_email_sent_to_phone">If your phone is nearby, it will show a pop-up to email support with your logs attached</string>
     <string name="settings_help_contact_support_no_phone_connection">Please pair your watch with a phone that has Pocket Casts installed to view your logs or contact support</string>
     <string name="settings_help_send_logs_to_phone">Send Logs To Phone</string>
-    <string name="settings_help_logs_sent_to_phone_check_phone">Check your phone for a pop-up with your logs</string>
+    <string name="settings_help_logs_sent_to_phone_check_phone">If your phone is nearby, it will show a pop-up with your logs</string>
+    <string name="settings_help_phone_unavailable_message">Please try again when your phone is connected to your watch.</string>
     <string name="settings_import_choose_file">Choose an OPML file.</string>
     <string name="settings_import_file">Select file</string>
     <string name="settings_import_file_summary">If you have podcast subscriptions in another app or service, Pocket Casts can import them from an OPML file.</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1054,6 +1054,7 @@
     <string name="settings_get_plus_and_more">Get Pocket Casts Plus to unlock this feature and more!</string>
     <string name="settings_help_cant_load">Could not load Help &amp; Feedback.\nPlease check your internet connection and try again.</string>
     <string name="settings_help_contact_support">Contact Support</string>
+    <string name="settings_help_contact_support_no_phone_connection">Please pair your watch with a phone that has Pocket Casts installed to view your logs or contact support</string>
     <string name="settings_import_choose_file">Choose an OPML file.</string>
     <string name="settings_import_file">Select file</string>
     <string name="settings_import_file_summary">If you have podcast subscriptions in another app or service, Pocket Casts can import them from an OPML file.</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1054,8 +1054,10 @@
     <string name="settings_get_plus_and_more">Get Pocket Casts Plus to unlock this feature and more!</string>
     <string name="settings_help_cant_load">Could not load Help &amp; Feedback.\nPlease check your internet connection and try again.</string>
     <string name="settings_help_contact_support">Contact Support</string>
-    <string name="settings_help_contact_support_email_sent_to_phone">Check your phone for a pop-up to email support with your logs attached.</string>
+    <string name="settings_help_contact_support_email_sent_to_phone">Check your phone for a pop-up to email support with your logs attached</string>
     <string name="settings_help_contact_support_no_phone_connection">Please pair your watch with a phone that has Pocket Casts installed to view your logs or contact support</string>
+    <string name="settings_help_send_logs_to_phone">Send Logs To Phone</string>
+    <string name="settings_help_logs_sent_to_phone_check_phone">Check your phone for a pop-up with your logs</string>
     <string name="settings_import_choose_file">Choose an OPML file.</string>
     <string name="settings_import_file">Select file</string>
     <string name="settings_import_file_summary">If you have podcast subscriptions in another app or service, Pocket Casts can import them from an OPML file.</string>
@@ -1288,6 +1290,7 @@
     <string name="settings_import_title">Import subscriptions</string>
     <string name="settings_status_page">Status Page</string>
     <string name="settings_logs">Logs</string>
+    <string name="settings_watch_logs">Watch logs</string>
     <string name="settings_status_description">Check your connection with important services. This helps diagnose issues with your network, proxies, VPN, ad-blocking and security apps.</string>
     <string name="settings_status_service_internet">Internet Connection</string>
     <string name="settings_status_run">Run now</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1056,6 +1056,7 @@
     <string name="settings_help_contact_support">Contact Support</string>
     <string name="settings_help_contact_support_email_sent_to_phone">If your phone is nearby, it will show a pop-up to email support with your logs attached</string>
     <string name="settings_help_contact_support_no_phone_connection">Please pair your watch with a phone that has Pocket Casts installed to view your logs or contact support</string>
+    <string name="settings_help_contact_support_wear_requires_nearby_phone">Please pair your watch with a phone that has Pocket Casts installed before proceeding.</string>
     <string name="settings_help_send_logs_to_phone">Send Logs To Phone</string>
     <string name="settings_help_logs_sent_to_phone_check_phone">If your phone is nearby, it will show a pop-up with your logs</string>
     <string name="settings_help_phone_unavailable_message">Please try again when your phone is connected to your watch.</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1054,6 +1054,7 @@
     <string name="settings_get_plus_and_more">Get Pocket Casts Plus to unlock this feature and more!</string>
     <string name="settings_help_cant_load">Could not load Help &amp; Feedback.\nPlease check your internet connection and try again.</string>
     <string name="settings_help_contact_support">Contact Support</string>
+    <string name="settings_help_contact_support_email_sent_to_phone">Check your phone for a pop-up to email support with your logs attached.</string>
     <string name="settings_help_contact_support_no_phone_connection">Please pair your watch with a phone that has Pocket Casts installed to view your logs or contact support</string>
     <string name="settings_import_choose_file">Choose an OPML file.</string>
     <string name="settings_import_file">Select file</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1054,11 +1054,11 @@
     <string name="settings_get_plus_and_more">Get Pocket Casts Plus to unlock this feature and more!</string>
     <string name="settings_help_cant_load">Could not load Help &amp; Feedback.\nPlease check your internet connection and try again.</string>
     <string name="settings_help_contact_support">Contact Support</string>
-    <string name="settings_help_contact_support_email_sent_to_phone">If your phone is nearby, it will show a pop-up to email support with your logs attached</string>
+    <string name="settings_help_contact_support_email_sent_to_phone">If your phone is currently paired, it will show a pop-up to email support with your logs attached</string>
     <string name="settings_help_contact_support_no_phone_connection">Please pair your watch with a phone that has Pocket Casts installed to view your logs or contact support</string>
     <string name="settings_help_contact_support_wear_requires_nearby_phone">Please pair your watch with a phone that has Pocket Casts installed before proceeding.</string>
     <string name="settings_help_send_logs_to_phone">Send Logs To Phone</string>
-    <string name="settings_help_logs_sent_to_phone_check_phone">If your phone is nearby, it will show a pop-up with your logs</string>
+    <string name="settings_help_logs_sent_to_phone_check_phone">If your phone is currently paired, it will show a pop-up with your logs</string>
     <string name="settings_help_phone_unavailable_message">Please try again when your phone is connected to your watch.</string>
     <string name="settings_import_choose_file">Choose an OPML file.</string>
     <string name="settings_import_file">Select file</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.reactive.awaitFirst
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.BufferedWriter
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStreamWriter
@@ -135,6 +136,16 @@ class Support @Inject constructor(
 
         return intent
     }
+
+    suspend fun getLogs(): String =
+        withContext(Dispatchers.IO) {
+            buildString {
+                append(getUserDebug(false))
+                val outputStream = ByteArrayOutputStream()
+                LogBuffer.output(outputStream)
+                append(outputStream.toString())
+            }
+        }
 
     @Suppress("DEPRECATION")
     suspend fun getUserDebug(html: Boolean): String {

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -91,6 +91,17 @@
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="true"/>
 
+        <!-- File sharing / Opml export -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths"/>
+        </provider>
+
         <!-- Work Manager -->
         <provider
             android:name="androidx.startup.InitializationProvider"

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -48,11 +48,7 @@ import au.com.shiftyjelly.pocketcasts.wear.ui.player.PCVolumeScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.StreamingConfirmationScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcast.PodcastScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcasts.PodcastsScreen
-import au.com.shiftyjelly.pocketcasts.wear.ui.settings.PrivacySettingsScreen
-import au.com.shiftyjelly.pocketcasts.wear.ui.settings.SettingsScreen
-import au.com.shiftyjelly.pocketcasts.wear.ui.settings.UrlScreenRoutes
-import au.com.shiftyjelly.pocketcasts.wear.ui.settings.WearAboutScreen
-import au.com.shiftyjelly.pocketcasts.wear.ui.settings.settingsUrlScreens
+import au.com.shiftyjelly.pocketcasts.wear.ui.settings.settingsRoutes
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
 import com.google.android.horologist.compose.navscaffold.ScrollableScaffoldContext
 import com.google.android.horologist.compose.navscaffold.WearNavScaffold
@@ -308,29 +304,6 @@ fun WearApp(
             }
         }
 
-        scrollable(SettingsScreen.route) {
-            SettingsScreen(
-                scrollState = it.columnState,
-                signInClick = { navController.navigate(authenticationSubGraph) },
-                navigateToPrivacySettings = { navController.navigate(PrivacySettingsScreen.route) },
-                navigateToAbout = { navController.navigate(WearAboutScreen.route) }
-            )
-        }
-
-        scrollable(PrivacySettingsScreen.route) {
-            PrivacySettingsScreen(scrollState = it.columnState)
-        }
-
-        scrollable(WearAboutScreen.route) {
-            WearAboutScreen(
-                columnState = it.columnState,
-                onTermsOfServiceClick = { navController.navigate(UrlScreenRoutes.termsOfService) },
-                onPrivacyClick = { navController.navigate(UrlScreenRoutes.privacy) }
-            )
-        }
-
-        settingsUrlScreens()
-
         val popToStartDestination: () -> Unit = {
             when (startDestination) {
                 WatchListScreen.route -> {
@@ -353,6 +326,8 @@ fun WearApp(
                 else -> throw IllegalStateException("Unexpected start destination $startDestination")
             }
         }
+
+        settingsRoutes(navController)
 
         authenticationNavGraph(
             navController = navController,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -23,6 +23,7 @@ import au.com.shiftyjelly.pocketcasts.shared.AppLifecycleObserver
 import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import au.com.shiftyjelly.pocketcasts.utils.SentryHelper.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.log.RxJavaUncaughtExceptionHandling
 import com.google.firebase.FirebaseApp
 import com.google.firebase.analytics.FirebaseAnalytics
@@ -34,6 +35,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+import java.io.File
 import java.util.concurrent.Executors
 import javax.inject.Inject
 
@@ -85,6 +87,7 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
     }
 
     private fun setupLogging() {
+        LogBuffer.setup(File(filesDir, "logs").absolutePath)
         if (BuildConfig.DEBUG) {
             Timber.plant(TimberDebugTree())
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.ScalingLazyListScope
+import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
@@ -51,6 +52,19 @@ private fun ScalingLazyListScope.phoneAvailableContent(
     onEmailLogsToSupport: () -> Unit,
     onSendLogsToPhone: () -> Unit,
 ) {
+    item {
+        Text(
+            text = stringResource(id = LR.string.settings_help_contact_support_wear_requires_nearby_phone),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.caption3,
+            color = MaterialTheme.colors.onSecondary,
+        )
+    }
+
+    item {
+        Spacer(Modifier.height(8.dp))
+    }
+
     item {
         WatchListChip(
             title = stringResource(LR.string.settings_help_contact_support),

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -26,6 +27,7 @@ fun HelpScreen(columnState: ScalingLazyColumnState) {
 
     val viewModel = hiltViewModel<HelpScreenViewModel>()
     val state = viewModel.state.collectAsState().value
+    val context = LocalContext.current
 
     ScalingLazyColumn(columnState = columnState) {
         item {
@@ -36,7 +38,7 @@ fun HelpScreen(columnState: ScalingLazyColumnState) {
             return@ScalingLazyColumn
         } else if (state.isPhoneAvailable) {
             phoneAvailableContent(
-                onEmailLogsToSupport = viewModel::emailLogsToSupport
+                onEmailLogsToSupport = { viewModel.emailLogsToSupport(context) }
             )
         } else {
             noPhoneAvailableContent()

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreen.kt
@@ -40,7 +40,6 @@ fun HelpScreen(columnState: ScalingLazyColumnState) {
         } else if (state.isPhoneAvailable) {
             phoneAvailableContent(
                 onEmailLogsToSupport = { viewModel.emailLogsToSupport(context) },
-                onSendLogsToPhone = { viewModel.sendLogsToPhone(context) },
             )
         } else {
             noPhoneAvailableContent()
@@ -50,7 +49,6 @@ fun HelpScreen(columnState: ScalingLazyColumnState) {
 
 private fun ScalingLazyListScope.phoneAvailableContent(
     onEmailLogsToSupport: () -> Unit,
-    onSendLogsToPhone: () -> Unit,
 ) {
     item {
         Text(
@@ -69,13 +67,6 @@ private fun ScalingLazyListScope.phoneAvailableContent(
         WatchListChip(
             title = stringResource(LR.string.settings_help_contact_support),
             onClick = onEmailLogsToSupport,
-        )
-    }
-
-    item {
-        WatchListChip(
-            title = stringResource(LR.string.settings_help_send_logs_to_phone),
-            onClick = onSendLogsToPhone,
         )
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreen.kt
@@ -1,0 +1,70 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui.settings
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.wear.compose.foundation.lazy.ScalingLazyListScope
+import androidx.wear.compose.material.Text
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+object HelpScreen {
+    const val route = "help_screen"
+}
+
+@Composable
+fun HelpScreen(columnState: ScalingLazyColumnState) {
+
+    val viewModel = hiltViewModel<HelpScreenViewModel>()
+    val state = viewModel.state.collectAsState().value
+
+    ScalingLazyColumn(columnState = columnState) {
+        item {
+            ScreenHeaderChip(text = LR.string.settings_title_help)
+        }
+
+        if (state == null) {
+            return@ScalingLazyColumn
+        } else if (state.isPhoneAvailable) {
+            phoneAvailableContent(
+                onEmailLogsToSupport = viewModel::emailLogsToSupport
+            )
+        } else {
+            noPhoneAvailableContent()
+        }
+    }
+}
+
+private fun ScalingLazyListScope.phoneAvailableContent(
+    onEmailLogsToSupport: () -> Unit,
+) {
+    item {
+        WatchListChip(
+            title = stringResource(LR.string.settings_help_contact_support),
+            onClick = onEmailLogsToSupport,
+        )
+    }
+}
+
+private fun ScalingLazyListScope.noPhoneAvailableContent() {
+    item {
+        Text(
+            text = stringResource(id = LR.string.settings_help_contact_support_no_phone_connection),
+            textAlign = TextAlign.Center,
+        )
+    }
+
+    item {
+        // Make sure that the bottom of the text can be scrolled onto the screen of a circular watch
+        Spacer(Modifier.height(24.dp))
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreen.kt
@@ -38,7 +38,8 @@ fun HelpScreen(columnState: ScalingLazyColumnState) {
             return@ScalingLazyColumn
         } else if (state.isPhoneAvailable) {
             phoneAvailableContent(
-                onEmailLogsToSupport = { viewModel.emailLogsToSupport(context) }
+                onEmailLogsToSupport = { viewModel.emailLogsToSupport(context) },
+                onSendLogsToPhone = { viewModel.sendLogsToPhone(context) },
             )
         } else {
             noPhoneAvailableContent()
@@ -48,11 +49,19 @@ fun HelpScreen(columnState: ScalingLazyColumnState) {
 
 private fun ScalingLazyListScope.phoneAvailableContent(
     onEmailLogsToSupport: () -> Unit,
+    onSendLogsToPhone: () -> Unit,
 ) {
     item {
         WatchListChip(
             title = stringResource(LR.string.settings_help_contact_support),
             onClick = onEmailLogsToSupport,
+        )
+    }
+
+    item {
+        WatchListChip(
+            title = stringResource(LR.string.settings_help_send_logs_to_phone),
+            onClick = onSendLogsToPhone,
         )
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreenViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreenViewModel.kt
@@ -37,4 +37,13 @@ class HelpScreenViewModel @Inject constructor(
                 .show()
         }
     }
+
+    fun sendLogsToPhone(context: Context) {
+        viewModelScope.launch {
+            watchPhoneCommunication.sendLogsToPhoneMessage()
+            delay(1.seconds)
+            Toast.makeText(context, LR.string.settings_help_logs_sent_to_phone_check_phone, Toast.LENGTH_LONG)
+                .show()
+        }
+    }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreenViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreenViewModel.kt
@@ -1,16 +1,21 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui.settings
 
+import android.content.Context
+import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.shared.WatchPhoneCommunication
 import au.com.shiftyjelly.pocketcasts.shared.WatchPhoneCommunicationState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
 class HelpScreenViewModel @Inject constructor(
@@ -24,9 +29,12 @@ class HelpScreenViewModel @Inject constructor(
             State(isPhoneAvailable = it == WatchPhoneCommunicationState.AVAILABLE)
         }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    fun emailLogsToSupport() {
+    fun emailLogsToSupport(context: Context) {
         viewModelScope.launch {
             watchPhoneCommunication.emailLogsToSupportMessage()
+            delay(1.seconds)
+            Toast.makeText(context, LR.string.settings_help_contact_support_email_sent_to_phone, Toast.LENGTH_LONG)
+                .show()
         }
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreenViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreenViewModel.kt
@@ -46,21 +46,4 @@ class HelpScreenViewModel @Inject constructor(
             Toast.makeText(context, message, Toast.LENGTH_LONG).show()
         }
     }
-
-    fun sendLogsToPhone(context: Context) {
-        viewModelScope.launch {
-            val result = watchPhoneCommunication.sendLogsToPhoneMessage()
-            val message = when (result) {
-                WatchMessageSendState.QUEUED -> LR.string.settings_help_logs_sent_to_phone_check_phone
-                WatchMessageSendState.FAILED_TO_QUEUE -> LR.string.settings_help_phone_unavailable_message
-            }
-
-            if (result == WatchMessageSendState.QUEUED) {
-                // There is a bit of delay between an item being queued and it being received on the phone,
-                // so add a short delay before directing the user to their phone.
-                delay(2.seconds)
-            }
-            Toast.makeText(context, message, Toast.LENGTH_LONG).show()
-        }
-    }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreenViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreenViewModel.kt
@@ -4,17 +4,16 @@ import android.content.Context
 import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.shared.WatchMessageSendState
 import au.com.shiftyjelly.pocketcasts.shared.WatchPhoneCommunication
 import au.com.shiftyjelly.pocketcasts.shared.WatchPhoneCommunicationState
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.time.Duration.Companion.seconds
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
@@ -31,19 +30,24 @@ class HelpScreenViewModel @Inject constructor(
 
     fun emailLogsToSupport(context: Context) {
         viewModelScope.launch {
-            watchPhoneCommunication.emailLogsToSupportMessage()
-            delay(1.seconds)
-            Toast.makeText(context, LR.string.settings_help_contact_support_email_sent_to_phone, Toast.LENGTH_LONG)
-                .show()
+            val result = watchPhoneCommunication.emailLogsToSupportMessage()
+            val message = when (result) {
+                WatchMessageSendState.QUEUED -> LR.string.settings_help_contact_support_email_sent_to_phone
+                WatchMessageSendState.FAILED_TO_QUEUE -> LR.string.settings_help_phone_unavailable_message
+            }
+
+            Toast.makeText(context, message, Toast.LENGTH_LONG).show()
         }
     }
 
     fun sendLogsToPhone(context: Context) {
         viewModelScope.launch {
-            watchPhoneCommunication.sendLogsToPhoneMessage()
-            delay(1.seconds)
-            Toast.makeText(context, LR.string.settings_help_logs_sent_to_phone_check_phone, Toast.LENGTH_LONG)
-                .show()
+            val result = watchPhoneCommunication.sendLogsToPhoneMessage()
+            val message = when (result) {
+                WatchMessageSendState.QUEUED -> LR.string.settings_help_logs_sent_to_phone_check_phone
+                WatchMessageSendState.FAILED_TO_QUEUE -> LR.string.settings_help_phone_unavailable_message
+            }
+            Toast.makeText(context, message, Toast.LENGTH_LONG).show()
         }
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreenViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreenViewModel.kt
@@ -8,12 +8,14 @@ import au.com.shiftyjelly.pocketcasts.shared.WatchMessageSendState
 import au.com.shiftyjelly.pocketcasts.shared.WatchPhoneCommunication
 import au.com.shiftyjelly.pocketcasts.shared.WatchPhoneCommunicationState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
@@ -36,6 +38,11 @@ class HelpScreenViewModel @Inject constructor(
                 WatchMessageSendState.FAILED_TO_QUEUE -> LR.string.settings_help_phone_unavailable_message
             }
 
+            if (result == WatchMessageSendState.QUEUED) {
+                // There is a bit of delay between an item being queued and it being received on the phone,
+                // so add a short delay before directing the user to their phone.
+                delay(2.seconds)
+            }
             Toast.makeText(context, message, Toast.LENGTH_LONG).show()
         }
     }
@@ -46,6 +53,12 @@ class HelpScreenViewModel @Inject constructor(
             val message = when (result) {
                 WatchMessageSendState.QUEUED -> LR.string.settings_help_logs_sent_to_phone_check_phone
                 WatchMessageSendState.FAILED_TO_QUEUE -> LR.string.settings_help_phone_unavailable_message
+            }
+
+            if (result == WatchMessageSendState.QUEUED) {
+                // There is a bit of delay between an item being queued and it being received on the phone,
+                // so add a short delay before directing the user to their phone.
+                delay(2.seconds)
             }
             Toast.makeText(context, message, Toast.LENGTH_LONG).show()
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreenViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreenViewModel.kt
@@ -1,0 +1,32 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.shared.WatchPhoneCommunication
+import au.com.shiftyjelly.pocketcasts.shared.WatchPhoneCommunicationState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HelpScreenViewModel @Inject constructor(
+    private val watchPhoneCommunication: WatchPhoneCommunication.Watch,
+) : ViewModel() {
+
+    data class State(val isPhoneAvailable: Boolean)
+
+    val state: StateFlow<State?> = watchPhoneCommunication.watchPhoneCommunicationStateFlow
+        .map {
+            State(isPhoneAvailable = it == WatchPhoneCommunicationState.AVAILABLE)
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    fun emailLogsToSupport() {
+        viewModelScope.launch {
+            watchPhoneCommunication.emailLogsToSupportMessage()
+        }
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsRoutes.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsRoutes.kt
@@ -1,0 +1,36 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui.settings
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import au.com.shiftyjelly.pocketcasts.wear.ui.authentication.authenticationSubGraph
+import com.google.android.horologist.compose.navscaffold.scrollable
+
+fun NavGraphBuilder.settingsRoutes(navController: NavController) {
+    settingsUrlScreens()
+
+    scrollable(SettingsScreen.route) {
+        SettingsScreen(
+            scrollState = it.columnState,
+            signInClick = { navController.navigate(authenticationSubGraph) },
+            navigateToPrivacySettings = { navController.navigate(PrivacySettingsScreen.route) },
+            navigateToAbout = { navController.navigate(WearAboutScreen.route) },
+            navigateToHelp = { navController.navigate(HelpScreen.route) }
+        )
+    }
+
+    scrollable(PrivacySettingsScreen.route) {
+        PrivacySettingsScreen(scrollState = it.columnState)
+    }
+
+    scrollable(WearAboutScreen.route) {
+        WearAboutScreen(
+            columnState = it.columnState,
+            onTermsOfServiceClick = { navController.navigate(UrlScreenRoutes.termsOfService) },
+            onPrivacyClick = { navController.navigate(UrlScreenRoutes.privacy) }
+        )
+    }
+
+    scrollable(HelpScreen.route) {
+        HelpScreen(columnState = it.columnState)
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsScreen.kt
@@ -50,6 +50,7 @@ fun SettingsScreen(
     signInClick: () -> Unit,
     navigateToPrivacySettings: () -> Unit,
     navigateToAbout: () -> Unit,
+    navigateToHelp: () -> Unit,
 ) {
 
     val viewModel = hiltViewModel<SettingsViewModel>()
@@ -65,6 +66,7 @@ fun SettingsScreen(
         onRefreshClicked = viewModel::refresh,
         onPrivacyClicked = navigateToPrivacySettings,
         onAboutClicked = navigateToAbout,
+        onHelpClicked = navigateToHelp,
     )
 }
 
@@ -79,6 +81,7 @@ private fun Content(
     onRefreshClicked: () -> Unit,
     onPrivacyClicked: () -> Unit,
     onAboutClicked: () -> Unit,
+    onHelpClicked: () -> Unit,
 ) {
     ScalingLazyColumn(columnState = scrollState) {
 
@@ -166,6 +169,14 @@ private fun Content(
                     )
                 }
             }
+        }
+
+        item {
+            WatchListChip(
+                title = stringResource(LR.string.settings_title_help),
+                iconRes = SR.drawable.settings_help,
+                onClick = onHelpClicked
+            )
         }
 
         item {
@@ -273,6 +284,7 @@ private fun SettingsScreenPreview_unchecked() {
             onRefreshClicked = {},
             onPrivacyClicked = {},
             onAboutClicked = {},
+            onHelpClicked = {},
         )
     }
 }
@@ -303,6 +315,7 @@ private fun SettingsScreenPreview_checked() {
             onRefreshClicked = {},
             onPrivacyClicked = {},
             onAboutClicked = {},
+            onHelpClicked = {},
         )
     }
 }


### PR DESCRIPTION
## Description
This adds a "Help & feedback" section to the settings and gives users a way to either (1) send an email to support with their watch logs attached or (2) send their watch logs to the phone.

Fixes #1069

> **Warning**
> I am targeting `release/7.41`. I think it is important that we get this in with the initial Wear OS release since it will be critical to helping us debug issues. Let me know if you disagree though.

Since it is not possible to send an email from the watch or send an email-triggering intent directly from the watch to the phone, I'm taking the approach of sending a message from the watch to the phone with the watch's logs. The phone app then takes that message and constructs an appropriate intent with it. This does mean that this functionality will only work if the user has the watch paired and actively connected to a phone with the Pocket Casts Android app.

### Challenges detecting if the phone is available

In order to detect whether the phone is available, I am listening for changes to the availability of the phone (it is called a "node"), and displaying a prompt to the user instead of the contact buttons if the phone is not available.

Unfortunately, this listener seems to frequently not get triggered when the phone becomes unavailable. For that reason, I am also checking to ensure that the message is queued, and if it is not queued (which is what happens when a node is unavailable), I display a toast message indicating that they need to connect their watch to their phone.

Unfortunately, I have found that sometimes a message reports as queued, but will never get delivered. This seems to happen most commonly when the message is sent while the phone is in the process of connecting/disconnecting from the watch. For that reason, when a message is successfully queued I am starting the confirmation Toast that gets displayed the text "If your phone is currently paired..." as a way to give the user a hint as to what the problem is if the message does not get sent and received.

## Testing Instructions
### A. Happy path
1. Install the app from this PR on both a phone and a currently paired watch
2. On the watch go to `Settings` → `Help & Feedback`
3. Tap on "Contact Support"
4. That you are shown a toast message directing you to your phone
5. Observe that you get a share prompt on your phone
6. Tap an email client and observe you have an email prepared that will send the user's logs to support (the resulting ticket from sending this email would look like this: 6413683-zen)
7. From your watch, tap "Send Logs To Phone"
8. Observe that  you are shown a toast message directing you to your phone
9. Observe that you get a share prompt on your phone and that you can share your logs with an application on your phone (this is very similar to "Contact Support" with the main difference being that if you share to an email client you don't get our support email address pre-filled or the short little introductory blurb in the email text).

### B. Sad path

Unfortunately I have not found a way to consistently create each of these sad paths in the code as I discussed earlier in this PR description. Here are some situations to try when contacting support or sending logs to phone:

1. Switching the phone between having airplane mode on and off while periodically trying to contact support or send logs to your phone from your watch.
2. Turning off the paired phone before installing the app on the watch.

You should expect to see either that:
1. The "Contact Support" and "Send Logs To Phone" buttons are hidden and the user is directed to connect to their phone
2. Tapping either button brings up a toast error message asking the user to connect to their phone; or
3. Unfortunately, sometimes the message queues successfully and silently fails. In this case, the watch will respond in the same way as the happy path, but the phone will never receive the logs and open the share dialog. I think/hope this is a bit of an edge case that only occurs when the phone is in the middle of connecting/disconnecting.

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/4656348/8d556560-dbd7-4e72-8ed0-f4729d6a73c1

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
