### PR TITLE
Upgrade to Android Gradle Plugin 8.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,23 +4,11 @@ buildscript {
         kotlin_version = '1.7.10'
         hilt_version = '2.43.2'
     }
-    repositories {
-        google()
-        mavenLocal()
-
-        maven {
-            url 'https://a8c-libs.s3.amazonaws.com/android' 
-            content {
-                includeGroup "com.automattic.android"
-                includeGroup "com.automattic.android.publish-to-s3"
-            }
-        }
-    }
 
     // Gradle Plugins
     dependencies {
         // Android - https://developer.android.com/studio/releases/gradle-plugin
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.0.2'
         // Google Services - https://developers.google.com/android/guides/google-services-plugin
         classpath "com.google.gms:google-services:4.3.14"
         // Kotlin

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,5 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx8048M
 org.gradle.parallel=true
 org.gradle.caching=true
+# Android Gradle Plugin no longer generates BuildConfig classes by default. This preserves the preivous behavior of generating BuildConfig classes.
+android.defaults.buildfeatures.buildconfig=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,5 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
-distributionSha256Sum=db9c8211ed63f61f60292c69e80d89196f9eb36665e369e7f00ac4cc841c2219
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
+distributionSha256Sum=f30b29580fe11719087d698da23f3b0f0d04031d8995f7dd8275a31f7674dc01

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,18 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+        maven {
+            url 'https://a8c-libs.s3.amazonaws.com/android'
+            content {
+                includeGroup "com.automattic.android"
+                includeGroup "com.automattic.android.publish-to-s3"
+            }
+        }
+    }
+}
+
 include ':app'
 include ':automotive'
 include ':wear'


### PR DESCRIPTION
## Description

This upgrades the project to Android Gradle Plugin 8.0.2. The stable build of Android Studio "Android Studio Flamingo | 2022.2.1 Patch 2" kept prompting me to take this upgrade, so I thought it would be a good idea.

The only one area that I wasn't sure about was the following:

<img width="533" alt="Screenshot 2023-06-16 at 1 45 48 pm" src="https://github.com/Automattic/pocket-casts-android/assets/308331/b137abe0-1668-4824-8842-bc2308a43e25">

By default it leaves it as the old configuration by adding the following to the `gradle.properties` file. But I have removed it as it seems good for build performance. I installed on mobile, Wear, and Automotive without issue but there could be something that I have missed.
```
android.nonFinalResIds=false
```

> Use non-constant R classes
> Use non-constant [R class](https://developer.android.com/reference/android/R) fields in apps and tests to improve the incrementality of Java compilation and allow for more precise resource shrinking. R class fields are always not constant for libraries, as the resources are numbered when packaging the APK for the app or test that depends on that library. This is the default behavior in Android Gradle Plugin 8.0.0 and higher.

https://developer.android.com/build/optimize-your-build#use-non-constant-r-classes
https://web.archive.org/web/20230203152426/http://tools.android.com/tips/non-constant-fields

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

