### PR TITLE
Added a positional value to a string

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -215,7 +215,7 @@
     <string name="search_history_clear_all_confirm_button_title">Clear Search History</string>
     <string name="search_history_clear_all_confirmation_message">Are you sure you want to clear all your search history?</string>
     <string name="search_history_recent_searches">Recent searches</string>
-    <string name="search_history_row_type_episode_subtitle">Episode \u2022 %s \u2022 %s</string>
+    <string name="search_history_row_type_episode_subtitle">Episode \u2022 %1$s \u2022 %2$s</string>
     <string name="search_history_row_type_folder_subtitle">Folder \u2022 %s</string>
     <string name="search_history_row_type_podcast_subtitle">Podcast \u2022 %s</string>
     <string name="search_results_all_episodes">All episodes</string>


### PR DESCRIPTION
## Description

This change fixes the following build error. There is one line for each locale. I have updated the GlotPress entries for all the countries.

```
pocket-casts-android/modules/services/localization/build/intermediates/packaged_res/release/values/
values.xml:1146:4: Multiple substitutions specified in non-positional format of string 
resource string/search_history_row_type_episode_subtitle. Did you mean to add the 
formatted="false" attribute?
```

Sorry this is a small change, I tried to upgrade to Android Gradle Plugin 8.0.2 and failed but I thought I should fix something. 🤦 

## Testing Instructions
1. Tap on Discover
2. Tap on Search
3. Enter a search term
4. Tap on an episode result
5. Tap back until you can search again
6. ✅ Verify the recent search episode is in the following format. 
<img width="296" alt="Screenshot 2023-06-16 at 8 14 50 pm" src="https://github.com/Automattic/pocket-casts-android/assets/308331/4a8d210a-c74e-4150-8ad5-a7bdf504b8f7">
