### PR TITLE
Replacing the backwards compatible code with Android KTX methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
         ([#1101](https://github.com/Automattic/pocket-casts-android/pull/1101)).
     *   Fixed Extra Dark theme not applying proper background on some settings screens
         ([#987](https://github.com/Automattic/pocket-casts-android/pull/987)).
+    *   Fixed Automotive seek bar and playback state issues.
+        ([#1077](https://github.com/Automattic/pocket-casts-android/pull/1077)).
 
 7.41
 -----

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/SignInFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/SignInFragment.kt
@@ -1,12 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.account
 
 import android.app.PendingIntent
-import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
+import androidx.core.os.BundleCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -123,13 +123,9 @@ class SignInFragment : BaseFragment() {
                     } else {
                         activity?.finish()
 
-                        if (arguments?.containsKey(EXTRA_SUCCESS_INTENT) == true) {
-                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                                arguments?.getParcelable(EXTRA_SUCCESS_INTENT, PendingIntent::class.java)
-                            } else {
-                                @Suppress("DEPRECATION")
-                                arguments?.getParcelable(EXTRA_SUCCESS_INTENT)
-                            }?.send()
+                        val arguments = arguments
+                        if (arguments != null && arguments.containsKey(EXTRA_SUCCESS_INTENT)) {
+                            BundleCompat.getParcelable(arguments, EXTRA_SUCCESS_INTENT, PendingIntent::class.java)?.send()
                         }
                     }
                 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
@@ -3,12 +3,12 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
+import androidx.core.content.IntentCompat
 import androidx.core.view.WindowCompat
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContract.OnboardingFinish
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
@@ -36,12 +36,7 @@ class OnboardingActivity : AppCompatActivity() {
             if (currentSignInState != null) {
 
                 val onboardingFlow = remember(savedInstanceState) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                        intent?.getParcelableExtra(ANALYTICS_FLOW_KEY, OnboardingFlow::class.java)
-                    } else {
-                        @Suppress("DEPRECATION")
-                        intent?.getParcelableExtra(ANALYTICS_FLOW_KEY) as OnboardingFlow?
-                    }
+                    IntentCompat.getParcelableExtra(intent, ANALYTICS_FLOW_KEY, OnboardingFlow::class.java)
                 } ?: throw IllegalStateException("Analytics flow not set")
 
                 if (shouldSetupTheme(onboardingFlow)) {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/RegionSelectFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/RegionSelectFragment.kt
@@ -1,10 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.discover.view
 
-import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.BundleCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -49,12 +49,7 @@ class RegionSelectFragment : BaseFragment() {
     }
 
     val regionList: ArrayList<DiscoverRegion>
-        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            arguments?.getParcelableArrayList(ARG_REGION_LIST, DiscoverRegion::class.java)
-        } else {
-            @Suppress("DEPRECATION")
-            arguments?.getParcelableArrayList(ARG_REGION_LIST)
-        } ?: ArrayList()
+        get() = arguments?.let { BundleCompat.getParcelableArrayList(it, ARG_REGION_LIST, DiscoverRegion::class.java) } ?: ArrayList()
 
     var listener: Listener? = null
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ShareResultReceiver.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ShareResultReceiver.kt
@@ -4,7 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.os.Build
+import androidx.core.content.IntentCompat
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -18,13 +18,7 @@ class ShareResultReceiver : BroadcastReceiver() {
     lateinit var shareableTextProvider: ShareableTextProvider
 
     override fun onReceive(context: Context, intent: Intent) {
-        val componentName: ComponentName? =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                intent.getParcelableExtra(Intent.EXTRA_CHOSEN_COMPONENT, ComponentName::class.java)
-            } else {
-                @Suppress("DEPRECATION")
-                intent.getParcelableExtra(Intent.EXTRA_CHOSEN_COMPONENT)
-            }
+        val componentName = IntentCompat.getParcelableExtra(intent, Intent.EXTRA_CHOSEN_COMPONENT, ComponentName::class.java)
         shareableTextProvider.chosenActivity = componentName?.className
     }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -3,13 +3,13 @@ package au.com.shiftyjelly.pocketcasts.filters
 import android.animation.LayoutTransition
 import android.content.Context
 import android.content.res.ColorStateList
-import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.ColorInt
+import androidx.core.os.BundleCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
@@ -100,12 +100,7 @@ class FilterEpisodeListFragment : BaseFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        listSavedState = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            savedInstanceState?.getParcelable(STATE_LAYOUT_MANAGER, Parcelable::class.java)
-        } else {
-            @Suppress("DEPRECATION")
-            savedInstanceState?.getParcelable(STATE_LAYOUT_MANAGER)
-        }
+        listSavedState = savedInstanceState?.let { BundleCompat.getParcelable(it, STATE_LAYOUT_MANAGER, Parcelable::class.java) }
         showingFilterOptionsBeforeModal = arguments?.getBoolean(ARG_FILTER_IS_NEW) ?: false
     }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -8,9 +8,7 @@ import android.content.res.ColorStateList
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
-import android.os.Parcelable
 import android.provider.MediaStore
 import android.provider.OpenableColumns
 import android.view.MenuItem
@@ -21,6 +19,7 @@ import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.content.IntentCompat
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.view.isVisible
 import androidx.media3.common.MediaItem
@@ -257,14 +256,7 @@ class AddFileActivity :
             }
 
             dataUri = when (intent?.action) {
-                Intent.ACTION_SEND -> {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                        intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
-                    } else {
-                        @Suppress("DEPRECATION")
-                        intent.getParcelableExtra<Parcelable>(Intent.EXTRA_STREAM) as? Uri
-                    }
-                }
+                Intent.ACTION_SEND -> IntentCompat.getParcelableExtra(intent, Intent.EXTRA_STREAM, Uri::class.java)
                 Intent.ACTION_VIEW -> intent.data
                 else -> null
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -15,6 +15,7 @@ import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
 import android.view.KeyEvent
 import androidx.annotation.DrawableRes
+import androidx.core.content.IntentCompat
 import androidx.core.os.bundleOf
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
@@ -445,12 +446,8 @@ class MediaSessionManager(
 
         override fun onMediaButtonEvent(mediaButtonEvent: Intent): Boolean {
             if (Intent.ACTION_MEDIA_BUTTON == mediaButtonEvent.action) {
-                val keyEvent: KeyEvent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    mediaButtonEvent.getParcelableExtra(Intent.EXTRA_KEY_EVENT, KeyEvent::class.java)
-                } else {
-                    @Suppress("DEPRECATION")
-                    mediaButtonEvent.getParcelableExtra(Intent.EXTRA_KEY_EVENT)
-                } ?: return false
+                val keyEvent = IntentCompat.getParcelableExtra(mediaButtonEvent, Intent.EXTRA_KEY_EVENT, KeyEvent::class.java)
+                    ?: return false
                 if (keyEvent.action == KeyEvent.ACTION_DOWN) {
                     when (keyEvent.keyCode) {
                         KeyEvent.KEYCODE_HEADSETHOOK -> {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/PodcastSelectFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/PodcastSelectFragment.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.views.fragments
 
 import android.content.Context
 import android.content.res.ColorStateList
-import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
@@ -10,6 +9,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.ColorInt
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.os.BundleCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -61,12 +61,7 @@ class PodcastSelectFragment : BaseFragment() {
             }
 
         private fun extractArgs(bundle: Bundle?): PodcastSelectFragmentArgs? =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                bundle?.getParcelable(NEW_INSTANCE_ARG, PodcastSelectFragmentArgs::class.java)
-            } else {
-                @Suppress("DEPRECATION")
-                bundle?.getParcelable(NEW_INSTANCE_ARG) as PodcastSelectFragmentArgs?
-            }
+            bundle?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, PodcastSelectFragmentArgs::class.java) }
     }
 
     interface Listener {


### PR DESCRIPTION
## Description

In my last pull request, I found Android KTX could reduce some of our code to handle older versions of Android, this makes the change in other areas of the code. It felt like a nice clean up change.

It also added a changelog entry I missed for the Automotive change.

## Testing Instructions

1. Logout of the Pocket Casts account and clear the data
2. Open the app
3. ✅ Verify you are shown the the onboarding pages
4. Tap the Profile tab
5. Tap settings
6. Tap Auto download
7. Turn on "New episodes"
8. Tap Choose podcasts
9. ✅ Verify the page opens and the app doesn't crash
10. Start playing an episode
11. Simulate the headphone key next being pressed
```
adb shell input keyevent 87
```
12. ✅ Verify the episode skips forward
13. Go to the discover tab
14. Scroll to the bottom
15. Tap the region
16. ✅ Verify the region list is displayed





