### PR TITLE
Consolidate rxjava undeliverable exception handling

### DIFF
--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
@@ -51,13 +51,12 @@ class AutomotiveApplication : Application(), Configuration.Provider {
     override fun onCreate() {
         super.onCreate()
 
+        RxJavaUncaughtExceptionHandling.setUp()
         setupSentry()
         setupLogging()
         setupAnalytics()
         setupAutomotiveDefaults()
         setupApp()
-
-        RxJavaUncaughtExceptionHandling.setUp()
     }
 
     override fun getWorkManagerConfiguration(): Configuration {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/RxJavaUncaughtExceptionHandling.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/RxJavaUncaughtExceptionHandling.kt
@@ -12,6 +12,7 @@ object RxJavaUncaughtExceptionHandling {
                 is UndeliverableException -> {
                     // Merely log undeliverable exceptions
                     Timber.e(exception)
+                    LogBuffer.i(LogBuffer.TAG_RX_JAVA_DEFAULT_ERROR_HANDLER, "Caught undeliverable exception: ${exception.cause}")
                 }
 
                 else -> {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/RxJavaUncaughtExceptionHandling.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/RxJavaUncaughtExceptionHandling.kt
@@ -1,31 +1,24 @@
 package au.com.shiftyjelly.pocketcasts.utils.log
 
-import au.com.shiftyjelly.pocketcasts.helper.BuildConfig
+import io.reactivex.exceptions.UndeliverableException
 import io.reactivex.plugins.RxJavaPlugins
-import io.sentry.Sentry
-
-// Wrapper that indicates this exception is only thrown in debug builds.
-// We still want to try to fix any of these that occur, but they won't
-// crash the app in release builds.
-class DebugOnlyException(t: Throwable) :
-    Throwable("Exception that is only thrown in debug builds.", t)
+import timber.log.Timber
 
 object RxJavaUncaughtExceptionHandling {
     fun setUp() {
-
-        // RxJava's default error handler crashes the app on any uncaught exception. Allow
-        // that on debug builds, but swallow the error in release builds.
-        // See https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling
         RxJavaPlugins.setErrorHandler { exception ->
-            if (BuildConfig.DEBUG) {
-                throw DebugOnlyException(exception)
-            } else {
-                Sentry.captureException(exception)
-                LogBuffer.e(
-                    tag = LogBuffer.TAG_RX_JAVA_DEFAULT_ERROR_HANDLER,
-                    throwable = exception,
-                    message = "RxJava default error handler caught an exception"
-                )
+            when (exception) {
+
+                is UndeliverableException -> {
+                    // Merely log undeliverable exceptions
+                    Timber.e(exception)
+                }
+
+                else -> {
+                    Thread.currentThread().also { thread ->
+                        thread.uncaughtExceptionHandler?.uncaughtException(thread, exception)
+                    }
+                }
             }
         }
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -59,13 +59,11 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
-
+        RxJavaUncaughtExceptionHandling.setUp()
         setupSentry()
         setupLogging()
         setupAnalytics()
         setupApp()
-
-        RxJavaUncaughtExceptionHandling.setUp()
     }
 
     private fun setupSentry() {


### PR DESCRIPTION
## Description

This is a follow-up to #971 . In that PR I began catching raxjava's `UndeliverableException`s because I noticed that they were getting thrown pretty frequently on logout due to a race condition. I wasn't seeing these on the phone app though so I was concerned that I had something set up wrong on the watch app, so I only caught the exceptions on release builds, allowing them to still crash the app on debug builds.

I later noticed that now the phone app was crashing with these exceptions. Turns out I overlooked that the phone app had the same issue and was already catching the `UndeliverableException`s.

This PR consolidates that handling and, since I now understand that this is a longstanding issue and not unique to the wear app, I'm using the phone app's approach of always catching the exception on all of our apps. This wasn't being done on the automotive app before but I don't see any reason that this exception would not occur on the automotive app, so I think it's better to just handle this consistently on all of our apps. Let me know if you disagree.

I have also started logging the undeliverable exception causes to the log buffer because I wouldn't be surprised if these might be the cause of some issues for our users, but we're not able to help them because we never see that they're occurring. Or, we may see that these are happening so often that they're not helpful at all, in which case we can remove the logging.

## Testing Instructions

1. Create a phone/wear/auto build that forces an `UndeliverableException` (see below)
2. Run the app and cause the exception
3. Observe the exception appears in the logs but does not crash the app.

You can force an `UndeliverableException` by adding this somewhere:

``` kotlin
Observable.create { o ->
    o.onNext(1)
    o.onError(Exception("test"))
}.take(1).subscribe { Timber.d("$it") }
```

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews