### PR TITLE
UI updates to wear login flow

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="log_out">Log out</string>
     <string name="log_in_watch_requires_plus">Sign in with a Plus account to use this app or upgrade visiting</string>
     <string name="log_in_with_plus">Please sign in with a Plus account</string>
+    <string name="log_in_free_acccount">%s is using a free account</string>
     <string name="mark_as_played">Mark as played</string>
     <string name="mark_as_unplayed">Mark as unplayed</string>
     <string name="mark_played">Mark played</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1579,6 +1579,7 @@
     <string name="enter_email">Enter email</string>
     <string name="log_in_watch_from_phone_instructions_1">Log into Pocket Casts on a paired Android phone.</string>
     <string name="log_in_watch_from_phone_instructions_2">The next time you open Pocket Casts on your watch and have a network connection, you will be logged in.</string>
+    <string name="log_in_watch_from_phone_instructions_3">If you are having trouble, make sure your phone is running the same version of Pocket Casts as your watch (%s)</string>
     <string name="enter_password">Enter password</string>
     <string name="onboarding_discover_your_next_favorite_podcast">Discover your next favorite podcast</string>
     <string name="onboarding_create_an_account_to">Create an account to sync your listening experience across all your devices.</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -33,8 +33,8 @@
     <string name="log_in">Log in</string>
     <string name="log_in_subtitle">Start listening to your favourite podcasts</string>
     <string name="log_out">Log out</string>
-    <string name="log_in_watch_requires_plus">Sign in with a Plus account to use this app or upgrade visiting</string>
-    <string name="log_in_with_plus">Please sign in with a Plus account</string>
+    <string name="log_in_watch_requires_plus">Log in with a Plus account to use this app or upgrade visiting</string>
+    <string name="log_in_with_plus">Please log in with a Plus account</string>
     <string name="log_in_free_acccount">%s is using a free account</string>
     <string name="mark_as_played">Mark as played</string>
     <string name="mark_as_unplayed">Mark as unplayed</string>

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.NavGraphBuilder
@@ -73,6 +74,7 @@ class MainActivity : ComponentActivity() {
                 val state by viewModel.state.collectAsState()
 
                 WearApp(
+                    email = state.email,
                     signInState = state.signInState,
                     subscriptionStatus = state.subscriptionStatus,
                     showLoggingInScreen = state.showLoggingInScreen,
@@ -91,6 +93,7 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun WearApp(
+    email: String?,
     signInState: SignInState?,
     subscriptionStatus: SubscriptionStatus?,
     showLoggingInScreen: Boolean,
@@ -375,7 +378,12 @@ fun WearApp(
             if (popped) {
                 ScrollToTop.initiate(navController)
             }
-            Toast.makeText(LocalContext.current, LR.string.log_in_with_plus, Toast.LENGTH_LONG).show()
+            val message = if (email != null) {
+                stringResource(LR.string.log_in_free_acccount, email)
+            } else {
+                stringResource(LR.string.log_in_with_plus)
+            }
+            Toast.makeText(LocalContext.current, message, Toast.LENGTH_LONG).show()
         }
         is SubscriptionStatus.Plus -> {
             if (waitingForSignIn.value &&
@@ -437,6 +445,7 @@ private fun NavGraphBuilder.loggingInScreens(
 @Composable
 fun DefaultPreview() {
     WearApp(
+        email = "",
         signInState = null,
         subscriptionStatus = null,
         showLoggingInScreen = false,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginScreen.kt
@@ -1,16 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui.authentication
 
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.material.ChipDefaults
-import androidx.wear.compose.material.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
@@ -35,28 +27,6 @@ fun LoginScreen(
     ScalingLazyColumn(
         columnState = columnState,
     ) {
-        item {
-            Text(
-                text = stringResource(LR.string.log_in),
-                textAlign = TextAlign.Center,
-                color = MaterialTheme.colors.onPrimary,
-                style = MaterialTheme.typography.title2,
-            )
-        }
-
-        item {
-            Text(
-                text = stringResource(LR.string.log_in_subtitle),
-                textAlign = TextAlign.Center,
-                color = MaterialTheme.colors.onPrimary,
-                style = MaterialTheme.typography.body1,
-            )
-        }
-
-        item {
-            Spacer(modifier = Modifier.height(12.dp))
-        }
-
         item {
             Chip(
                 labelId = LR.string.log_in_with_google,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithPhoneScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithPhoneScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
+import au.com.shiftyjelly.pocketcasts.BuildConfig
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -51,6 +52,15 @@ fun LoginWithPhoneScreen(
         item {
             Text(
                 text = "2. ${stringResource(LR.string.log_in_watch_from_phone_instructions_2)}",
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.body2,
+                modifier = Modifier.padding(bottom = 24.dp)
+            )
+        }
+
+        item {
+            Text(
+                text = stringResource(LR.string.log_in_watch_from_phone_instructions_3, BuildConfig.VERSION_NAME),
                 textAlign = TextAlign.Center,
                 style = MaterialTheme.typography.body2,
                 modifier = Modifier.padding(bottom = 24.dp)


### PR DESCRIPTION
## Description
This PR addresses some feedback about the watch login flow by:
1. Updating the toast text for users who log in with a free account to say "xxx@example.com is using a free account" instead of "Please sign with a plus account". The Plus account language was not needed because this toast is displayed over a screen that specifically states a Plus account is required and the updated messaging makes it clearer that there was not a login error.
2. On the login from phone screen, there is added text indicating that users should ensure they have the same version of the app on their watch and phone. I thought about also adding text suggesting that if there are problems to try logging out and back in on their phone, but decided to hold off on that for now. We can always add more later if it turns out to be a problem. Also, the text on this screen is already pretty long to the point that I suspect some users will never see the last section of text.
3. The second login screen has been simplified to only present the login options. The heading and introductory text has been removed. Eventually, we may want to combine the two login screens into a single screen, but this PR is making the simpler change.

## Testing Instructions
1. On a fresh install of the watch app (making sure you're not logged into Pocket Casts on a connected phone)
2. Tap to proceed to the second login screen
3. Observe that the screen no longer has a header or introductory text—only buttons are shown now.
4. Tap "Log in on phone"
5. Scroll to the bottom of the screen and observe that the user is informed they need to have the same version of Pocket Casts installed on their phone.
6. Log into a free account using any login method.
7. Observe that the toast message says "your@email.com is using a free account"

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/4656348/3dc0a295-da1c-46f5-846e-f61ae6178d80

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews