### PR TITLE
Fix fallback default icon id

### DIFF
--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/AppIcon.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/AppIcon.kt
@@ -194,7 +194,7 @@ class AppIcon @Inject constructor(
     val allAppIconTypes = AppIconType.values()
 
     private fun getAppIconFromPreferences(): AppIconType {
-        val appIconId: String = sharedPreferences.getString(PREFERENCE_APPICON, AppIconType.DEFAULT.id) ?: AppIconType.PRIDE_2023.id
+        val appIconId: String = sharedPreferences.getString(PREFERENCE_APPICON, AppIconType.DEFAULT.id) ?: AppIconType.DEFAULT.id
         return AppIconType.fromString(appIconId, AppIconType.DEFAULT)
     }
 


### PR DESCRIPTION
## Description

This fixes the fallback default icon id although it's unlikely that `AppIconType.DEFAULT.id` will be null.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
