### PR TITLE
Integrate server changes for subscription tier

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -714,7 +714,7 @@ class MainActivity :
                 }
             }
 
-            if (signinState.isSignedInAsPlus) {
+            if (signinState.isSignedInAsPlusOrPatron) {
                 status?.let {
                     if (viewModel.shouldShowCancelled(it)) {
                         val cancelledFragment = SubCancelledFragment.newInstance()

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -49,11 +49,11 @@ class MainActivityViewModel
         get() = signInState.value?.isSignedIn ?: false
 
     fun shouldShowCancelled(subscriptionStatus: SubscriptionStatus): Boolean {
-        val plusStatus = (subscriptionStatus as? SubscriptionStatus.Plus) ?: return false
+        val paidStatus = (subscriptionStatus as? SubscriptionStatus.Paid) ?: return false
         val renewing = subscriptionStatus.autoRenew
         val cancelAcknowledged = settings.getCancelledAcknowledged()
-        val giftDays = plusStatus.giftDays
-        val expired = plusStatus.expiry.before(Date())
+        val giftDays = paidStatus.giftDays
+        val expired = paidStatus.expiry.before(Date())
 
         return !renewing && !cancelAcknowledged && giftDays == 0 && expired
     }

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/SignInStateTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/SignInStateTest.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.models.to
 
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
 import org.junit.Test
 import java.util.Date
@@ -19,6 +20,7 @@ class SignInStateTest {
             platform = SubscriptionPlatform.ANDROID,
             subscriptionList = emptyList(),
             type = SubscriptionType.PLUS,
+            tier = SubscriptionTier.PLUS,
             index = 0
         )
         // test an Android paying Plus subscriber

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/SignInStateTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/SignInStateTest.kt
@@ -23,26 +23,26 @@ class SignInStateTest {
             tier = SubscriptionTier.PLUS,
             index = 0
         )
-        // test an Android paying Plus subscriber
+        // test an Android paying subscriber
         val stateAndroid = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid)
-        assert(stateAndroid.isSignedInAsPlusPaid)
-        // test an iOS paying Plus subscriber
+        assert(stateAndroid.isSignedInAsPaid)
+        // test an iOS paying subscriber
         val stateiOS = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid.copy(platform = SubscriptionPlatform.IOS))
-        assert(stateiOS.isSignedInAsPlusPaid)
-        // test a Web Player paying Plus subscriber
+        assert(stateiOS.isSignedInAsPaid)
+        // test a Web Player paying subscriber
         val stateWebPlayer = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid.copy(platform = SubscriptionPlatform.WEB))
-        assert(stateWebPlayer.isSignedInAsPlusPaid)
-        // test a gift Plus user
+        assert(stateWebPlayer.isSignedInAsPaid)
+        // test a gift user
         val statePayingGift = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid.copy(platform = SubscriptionPlatform.GIFT))
-        assert(!statePayingGift.isSignedInAsPlusPaid)
-        // test a paying Plus subscriber
+        assert(!statePayingGift.isSignedInAsPaid)
+        // test a paying subscriber
         val statePaying = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid)
-        assert(statePaying.isSignedInAsPlusPaid)
-        // a cancelled Plus subscriber should still have access to the paid Plus features, we don't need to check the expiry as loading the state will covert it to a free account
+        assert(statePaying.isSignedInAsPaid)
+        // a cancelled subscriber should still have access to the paid features, we don't need to check the expiry as loading the state will covert it to a free account
         val stateCancelled = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid.copy(autoRenew = false))
-        assert(stateCancelled.isSignedInAsPlusPaid)
-        // free users should not have access to paid Plus features
+        assert(stateCancelled.isSignedInAsPaid)
+        // free users should not have access to paid features
         val stateFree = SignInState.SignedIn(email = email, subscriptionStatus = SubscriptionStatus.Free())
-        assert(!stateFree.isSignedInAsPlusPaid)
+        assert(!stateFree.isSignedInAsPaid)
     }
 }

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/SignInStateTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/SignInStateTest.kt
@@ -12,7 +12,7 @@ class SignInStateTest {
     @Test
     fun isSignedInAsPlusPaid() {
         val email = "support@pocketcasts.com"
-        val statusAndroidPlusPaid = SubscriptionStatus.Plus(
+        val statusAndroidPaidSubscription = SubscriptionStatus.Paid(
             expiry = Date(),
             autoRenew = true,
             giftDays = 0,
@@ -24,22 +24,22 @@ class SignInStateTest {
             index = 0
         )
         // test an Android paying subscriber
-        val stateAndroid = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid)
+        val stateAndroid = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPaidSubscription)
         assert(stateAndroid.isSignedInAsPaid)
         // test an iOS paying subscriber
-        val stateiOS = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid.copy(platform = SubscriptionPlatform.IOS))
+        val stateiOS = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPaidSubscription.copy(platform = SubscriptionPlatform.IOS))
         assert(stateiOS.isSignedInAsPaid)
         // test a Web Player paying subscriber
-        val stateWebPlayer = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid.copy(platform = SubscriptionPlatform.WEB))
+        val stateWebPlayer = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPaidSubscription.copy(platform = SubscriptionPlatform.WEB))
         assert(stateWebPlayer.isSignedInAsPaid)
         // test a gift user
-        val statePayingGift = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid.copy(platform = SubscriptionPlatform.GIFT))
+        val statePayingGift = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPaidSubscription.copy(platform = SubscriptionPlatform.GIFT))
         assert(!statePayingGift.isSignedInAsPaid)
         // test a paying subscriber
-        val statePaying = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid)
+        val statePaying = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPaidSubscription)
         assert(statePaying.isSignedInAsPaid)
         // a cancelled subscriber should still have access to the paid features, we don't need to check the expiry as loading the state will covert it to a free account
-        val stateCancelled = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPlusPaid.copy(autoRenew = false))
+        val stateCancelled = SignInState.SignedIn(email = email, subscriptionStatus = statusAndroidPaidSubscription.copy(autoRenew = false))
         assert(stateCancelled.isSignedInAsPaid)
         // free users should not have access to paid features
         val stateFree = SignInState.SignedIn(email = email, subscriptionStatus = SubscriptionStatus.Free())

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
@@ -127,9 +127,9 @@ class AutoPlaybackService : PlaybackService() {
 
     private fun loadProfileRoot(): List<MediaBrowserCompat.MediaItem> {
         return buildList {
-            // Add the user uploaded Files if they are a Plus subscriber
-            val isPlusUser = subscriptionManager.getCachedStatus() is SubscriptionStatus.Plus
-            if (isPlusUser) {
+            // Add the user uploaded Files if they are a paying subscriber
+            val isPaidUser = subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid
+            if (isPaidUser) {
                 add(buildListMediaItem(id = PROFILE_FILES, title = LR.string.profile_navigation_files, drawable = IR.drawable.automotive_files))
             }
             add(buildListMediaItem(id = PROFILE_STARRED, title = LR.string.profile_navigation_starred, drawable = IR.drawable.automotive_filter_star))

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -87,7 +87,7 @@ private fun Content(
             onBackPressed = exitOnboarding,
             onComplete = {
                 navController.navigate(
-                    if (signInState.isSignedInAsPlus) {
+                    if (signInState.isSignedInAsPlusOrPatron) {
                         OnboardingNavRoute.welcome
                     } else {
                         OnboardingNavRoute.PlusUpgrade.routeWithSource(OnboardingUpgradeSource.RECOMMENDATIONS)
@@ -236,13 +236,13 @@ private fun Content(
             OnboardingWelcomePage(
                 activeTheme = theme,
                 flow = flow,
-                isSignedInAsPlus = signInState.isSignedInAsPlus,
+                isSignedInAsPlusOrPatron = signInState.isSignedInAsPlusOrPatron,
                 onDone = exitOnboarding,
                 onContinueToDiscover = completeOnboardingToDiscover,
                 onImportTapped = { navController.navigate(OnboardingImportFlow.route) },
                 onBackPressed = {
                     // Don't allow navigation back to the upgrade screen after the user upgrades
-                    if (signInState.isSignedInAsPlus) {
+                    if (signInState.isSignedInAsPlusOrPatron) {
                         exitOnboarding()
                     } else {
                         navController.popBackStack()

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingWelcomePage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingWelcomePage.kt
@@ -71,7 +71,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 fun OnboardingWelcomePage(
     activeTheme: Theme.ThemeType,
     flow: OnboardingFlow,
-    isSignedInAsPlus: Boolean,
+    isSignedInAsPlusOrPatron: Boolean,
     onDone: () -> Unit,
     onContinueToDiscover: () -> Unit,
     onImportTapped: () -> Unit,
@@ -104,7 +104,7 @@ fun OnboardingWelcomePage(
     val showDiscover = (flow as? OnboardingFlow.PlusFlow)?.source != OnboardingUpgradeSource.FILES
 
     Content(
-        isSignedInAsPlus = isSignedInAsPlus,
+        isSignedInAsPlusOrPatron = isSignedInAsPlusOrPatron,
         showDiscover = showDiscover,
         onContinueToDiscover = {
             viewModel.onContinueToDiscover(flow)
@@ -131,7 +131,7 @@ fun OnboardingWelcomePage(
 
 @Composable
 private fun Content(
-    isSignedInAsPlus: Boolean,
+    isSignedInAsPlusOrPatron: Boolean,
     showDiscover: Boolean,
     onContinueToDiscover: () -> Unit,
     onImportTapped: () -> Unit,
@@ -148,7 +148,7 @@ private fun Content(
         Spacer(Modifier.windowInsetsPadding(WindowInsets.statusBars))
         Spacer(Modifier.weight(1f))
 
-        if (isSignedInAsPlus) {
+        if (isSignedInAsPlusOrPatron) {
             PlusPersonCheckmark()
         } else {
             PersonCheckmark()
@@ -157,7 +157,7 @@ private fun Content(
         Spacer(Modifier.height(8.dp))
         TextH10(
             text = stringResource(
-                if (isSignedInAsPlus) {
+                if (isSignedInAsPlusOrPatron) {
                     LR.string.onboarding_welcome_get_you_listening_plus
                 } else {
                     LR.string.onboarding_welcome_get_you_listening
@@ -360,7 +360,7 @@ private fun PersonCheckmark(
 private fun OnboardingWelcomePagePreview(@PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType) {
     AppThemeWithBackground(themeType) {
         Content(
-            isSignedInAsPlus = false,
+            isSignedInAsPlusOrPatron = false,
             showDiscover = true,
             onContinueToDiscover = {},
             onImportTapped = {},
@@ -376,7 +376,7 @@ private fun OnboardingWelcomePagePreview(@PreviewParameter(ThemePreviewParameter
 private fun OnboardingWelcomePagePlusPreview(@PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType) {
     AppThemeWithBackground(themeType) {
         Content(
-            isSignedInAsPlus = true,
+            isSignedInAsPlusOrPatron = true,
             showDiscover = true,
             onContinueToDiscover = {},
             onImportTapped = {},

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
@@ -6,6 +6,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.TracksAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
@@ -93,7 +94,7 @@ class CreateAccountViewModel
                             .mapNotNull {
                                 Subscription.fromProductDetails(
                                     productDetails = it,
-                                    isFreeTrialEligible = subscriptionManager.isFreeTrialEligible()
+                                    isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(SubscriptionMapper.mapProductIdToTier(it.productId))
                                 )
                             }
                         subscriptionManager.getDefaultSubscription(subscriptions)?.let { updateSubscription(it) }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomS
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
 import au.com.shiftyjelly.pocketcasts.models.type.TrialSubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
@@ -63,7 +64,9 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
                         is ProductDetailsState.Loaded -> productDetails.productDetails.mapNotNull { productDetailsState ->
                             Subscription.fromProductDetails(
                                 productDetails = productDetailsState,
-                                isFreeTrialEligible = subscriptionManager.isFreeTrialEligible()
+                                isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(
+                                    SubscriptionMapper.mapProductIdToTier(productDetailsState.productId)
+                                )
                             )
                         }
                     } ?: emptyList()

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -66,7 +66,9 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
                             is ProductDetailsState.Loaded -> productDetails.productDetails.mapNotNull { productDetailsState ->
                                 Subscription.fromProductDetails(
                                     productDetails = productDetailsState,
-                                    isFreeTrialEligible = subscriptionManager.isFreeTrialEligible()
+                                    isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(
+                                        SubscriptionMapper.mapProductIdToTier(productDetailsState.productId)
+                                    )
                                 )
                             }
                         } ?: emptyList()

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
@@ -53,10 +53,12 @@ class ProfileUpgradeBannerViewModel @Inject constructor(
                 .observeProductDetails()
                 .asFlow()
                 .collect { productDetailsState ->
-                    val isFreeTrialEligible = subscriptionManager.isFreeTrialEligible()
                     val subscriptions = (productDetailsState as? ProductDetailsState.Loaded)
                         ?.productDetails
                         ?.mapNotNull { details ->
+                            val isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(
+                                SubscriptionMapper.mapProductIdToTier(details.productId)
+                            )
                             Subscription.fromProductDetails(
                                 productDetails = details,
                                 isFreeTrialEligible = isFreeTrialEligible

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -131,7 +131,7 @@ class PodcastAdapter(
 
     private var headerExpanded: Boolean = false
     private var tintColor: Int = 0x000000
-    private var signedInAsPlus: Boolean = false
+    private var signedInAsPlusOrPatron: Boolean = false
     var castConnected: Boolean = false
         set(value) {
             field = value
@@ -175,7 +175,7 @@ class PodcastAdapter(
         holder.binding.expanded = headerExpanded
         holder.binding.tintColor = ThemeColor.podcastText02(theme.activeTheme, tintColor)
         holder.binding.headerColor = ThemeColor.podcastUi03(theme.activeTheme, podcast.backgroundColor)
-        holder.binding.isPlusUser = signedInAsPlus
+        holder.binding.isPlusOrPatronUser = signedInAsPlusOrPatron
 
         holder.binding.bottom.ratings.setContent {
             AppTheme(theme.activeTheme) {
@@ -291,8 +291,8 @@ class PodcastAdapter(
         this.tintColor = tintColor
     }
 
-    fun setSignedInAsPlus(signedInAsPlus: Boolean) {
-        this.signedInAsPlus = signedInAsPlus
+    fun setSignedInAsPlusOrPatron(signedInAsPlusOrPatron: Boolean) {
+        this.signedInAsPlusOrPatron = signedInAsPlusOrPatron
         notifyItemChanged(0)
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -634,7 +634,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
         viewModel.loadPodcast(podcastUuid, resources)
 
         viewModel.signInState.observe(viewLifecycleOwner) { signInState ->
-            adapter?.setSignedInAsPlus(signInState.isSignedInAsPlus)
+            adapter?.setSignedInAsPlusOrPatron(signInState.isSignedInAsPlusOrPatron)
         }
 
         viewModel.podcast.observe(

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -113,7 +113,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
             }
             val folder = folderState.folder
             val rootFolder = folder == null
-            val isSignedInAsPlus = folderState.isSignedInAsPlus
+            val isSignedInAsPlus = folderState.isSignedInAsPlusOrPatron
             val toolbar = binding.toolbar
 
             val toolbarColors: ToolbarColors

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -113,7 +113,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
             }
             val folder = folderState.folder
             val rootFolder = folder == null
-            val isSignedInAsPlus = folderState.isSignedInAsPlusOrPatron
+            val isSignedInAsPlusOrPatron = folderState.isSignedInAsPlusOrPatron
             val toolbar = binding.toolbar
 
             val toolbarColors: ToolbarColors
@@ -133,11 +133,11 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
             )
 
             toolbar.menu.findItem(R.id.folders_locked)?.run {
-                isVisible = !isSignedInAsPlus
+                isVisible = !isSignedInAsPlusOrPatron
                 setIcon(theme.folderLockedImageName)
             }
 
-            toolbar.menu.findItem(R.id.create_folder)?.isVisible = rootFolder && isSignedInAsPlus
+            toolbar.menu.findItem(R.id.create_folder)?.isVisible = rootFolder && isSignedInAsPlusOrPatron
             toolbar.menu.findItem(R.id.search_podcasts)?.isVisible = rootFolder
 
             adapter?.setFolderItems(folderState.items)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -51,7 +51,7 @@ class PodcastsViewModel
     data class FolderState(
         val folder: Folder?,
         val items: List<FolderItem>,
-        val isSignedInAsPlus: Boolean
+        val isSignedInAsPlusOrPatron: Boolean
     )
 
     val signInState: LiveData<SignInState> = userManager.getSignInState().toLiveData()
@@ -89,17 +89,17 @@ class PodcastsViewModel
         userManager.getSignInState()
     ) { podcasts, folders, folderUuidOptional, podcastSortOrder, signInState ->
         val folderUuid = folderUuidOptional.orElse(null)
-        if (!signInState.isSignedInAsPlus) {
+        if (!signInState.isSignedInAsPlusOrPatron) {
             FolderState(
                 items = buildPodcastItems(podcasts, podcastSortOrder),
                 folder = null,
-                isSignedInAsPlus = false
+                isSignedInAsPlusOrPatron = false
             )
         } else if (folderUuid == null) {
             FolderState(
                 items = buildHomeFolderItems(podcasts, folders, podcastSortOrder),
                 folder = null,
-                isSignedInAsPlus = true
+                isSignedInAsPlusOrPatron = true
             )
         } else {
             val openFolder = folders.firstOrNull { it.uuid == folderUuid }
@@ -107,13 +107,13 @@ class PodcastsViewModel
                 FolderState(
                     items = emptyList(),
                     folder = null,
-                    isSignedInAsPlus = true
+                    isSignedInAsPlusOrPatron = true
                 )
             } else {
                 FolderState(
                     items = openFolder.podcasts.map { FolderItem.Podcast(it) },
                     folder = openFolder.folder,
-                    isSignedInAsPlus = true
+                    isSignedInAsPlusOrPatron = true
                 )
             }
         }

--- a/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
@@ -7,7 +7,7 @@
         <variable name="tintColor" type="int"/>
         <variable name="headerColor" type="int"/>
         <variable name="expanded" type="boolean" />
-        <variable name="isPlusUser" type="boolean" />
+        <variable name="isPlusOrPatronUser" type="boolean" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -82,7 +82,7 @@
             app:tint="?attr/primary_icon_02"
             app:layout_constraintEnd_toStartOf="@+id/notifications"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:show="@{podcast.isSubscribed &amp;&amp; isPlusUser}" />
+            app:show="@{podcast.isSubscribed &amp;&amp; isPlusOrPatronUser}" />
 
         <ImageView
             android:id="@+id/notifications"

--- a/modules/features/podcasts/src/main/res/layout/adapter_podcast_header.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_podcast_header.xml
@@ -6,7 +6,7 @@
         <variable name="expanded" type="boolean" />
         <variable name="tintColor" type="int"/>
         <variable name="headerColor" type="int"/>
-        <variable name="isPlusUser" type="boolean"/>
+        <variable name="isPlusOrPatronUser" type="boolean"/>
     </data>
 
     <LinearLayout android:id="@+id/podcast_header"
@@ -21,7 +21,7 @@
             app:tintColor="@{tintColor}"
             app:headerColor="@{headerColor}"
             app:expanded="@{expanded}"
-            app:isPlusUser="@{isPlusUser}"/>
+            app:isPlusOrPatronUser="@{isPlusOrPatronUser}"/>
 
         <include
             android:id="@+id/bottom"

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
@@ -7,7 +7,7 @@
         <variable name="tintColor" type="int"/>
         <variable name="headerColor" type="int"/>
         <variable name="expanded" type="boolean" />
-        <variable name="isPlusUser" type="boolean" />
+        <variable name="isPlusOrPatronUser" type="boolean" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -87,7 +87,7 @@
             app:tint="?attr/primary_icon_02"
             app:layout_constraintEnd_toStartOf="@+id/notifications"
             app:layout_constraintTop_toBottomOf="@+id/header"
-            app:show="@{podcast.isSubscribed &amp;&amp; isPlusUser}" />
+            app:show="@{podcast.isSubscribed &amp;&amp; isPlusOrPatronUser}" />
 
         <ImageView
             android:id="@+id/notifications"

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -116,8 +116,8 @@ class AccountDetailsFragment : BaseFragment() {
                 giftExpiring = (daysLessThan30 && !status.autoRenew)
             }
 
-            binding.cancelViewGroup?.isVisible = signInState.isSignedInAsPlusPaid
-            binding.btnCancelSub?.isVisible = signInState.isSignedInAsPlusPaid
+            binding.cancelViewGroup?.isVisible = signInState.isSignedInAsPaid
+            binding.btnCancelSub?.isVisible = signInState.isSignedInAsPaid
             binding.upgradeAccountGroup?.isVisible = signInState.isSignedInAsPlus &&
                 FeatureFlag.isEnabled(Feature.ADD_PATRON_ENABLED)
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -111,8 +111,8 @@ class AccountDetailsFragment : BaseFragment() {
         viewModel.viewState.observe(viewLifecycleOwner) { (signInState, subscription, deleteAccountState) ->
             var giftExpiring = false
             (signInState as? SignInState.SignedIn)?.subscriptionStatus?.let { status ->
-                val plusStatus = status as? SubscriptionStatus.Plus ?: return@let
-                val daysLessThan30 = plusStatus.expiry.before(Date(Date().time + 30.days()))
+                val subscriptionStatus = status as? SubscriptionStatus.Paid ?: return@let
+                val daysLessThan30 = subscriptionStatus.expiry.before(Date(Date().time + 30.days()))
                 giftExpiring = (daysLessThan30 && !status.autoRenew)
             }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -118,8 +118,7 @@ class AccountDetailsFragment : BaseFragment() {
 
             binding.cancelViewGroup?.isVisible = signInState.isSignedInAsPaid
             binding.btnCancelSub?.isVisible = signInState.isSignedInAsPaid
-            binding.upgradeAccountGroup?.isVisible = signInState.isSignedInAsPlus &&
-                FeatureFlag.isEnabled(Feature.ADD_PATRON_ENABLED)
+            binding.upgradeAccountGroup?.isVisible = signInState.isSignedInAsPlus
 
             binding.userUpgradeComposeView?.apply {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -118,7 +118,8 @@ class AccountDetailsFragment : BaseFragment() {
 
             binding.cancelViewGroup?.isVisible = signInState.isSignedInAsPaid
             binding.btnCancelSub?.isVisible = signInState.isSignedInAsPaid
-            binding.upgradeAccountGroup?.isVisible = signInState.isSignedInAsPlus
+            binding.upgradeAccountGroup?.isVisible = signInState.isSignedInAsPlus &&
+                FeatureFlag.isEnabled(Feature.ADD_PATRON_ENABLED)
 
             binding.userUpgradeComposeView?.apply {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -118,7 +118,6 @@ class AccountDetailsFragment : BaseFragment() {
 
             binding.cancelViewGroup?.isVisible = signInState.isSignedInAsPlusPaid
             binding.btnCancelSub?.isVisible = signInState.isSignedInAsPlusPaid
-            // TODO: Patron - hide if upgraded to patron
             binding.upgradeAccountGroup?.isVisible = signInState.isSignedInAsPlus &&
                 FeatureFlag.isEnabled(Feature.ADD_PATRON_ENABLED)
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
@@ -50,7 +51,9 @@ class AccountDetailsViewModel
                 .mapNotNull {
                     Subscription.fromProductDetails(
                         productDetails = it,
-                        isFreeTrialEligible = subscriptionManager.isFreeTrialEligible()
+                        isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(
+                            SubscriptionMapper.mapProductIdToTier(it.productId)
+                        )
                     )
                 }
             Optional.of(subscriptionManager.getDefaultSubscription(subscriptions))

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/CancelConfirmationViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/CancelConfirmationViewModel.kt
@@ -16,12 +16,12 @@ class CancelConfirmationViewModel
     private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ViewModel() {
     var expirationDate: String? = null
-    private val plusSubscription: SubscriptionStatus.Plus?
-        get() = settings.getCachedSubscription() as? SubscriptionStatus.Plus
+    private val paidSubscription: SubscriptionStatus.Paid?
+        get() = settings.getCachedSubscription() as? SubscriptionStatus.Paid
 
     init {
         onViewShown()
-        expirationDate = plusSubscription?.expiryDate?.toLocalizedFormatLongStyle()
+        expirationDate = paidSubscription?.expiryDate?.toLocalizedFormatLongStyle()
     }
 
     private fun onViewShown() {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/SubCancelledFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/SubCancelledFragment.kt
@@ -45,7 +45,7 @@ class SubCancelledFragment : BaseFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         viewModel.viewState.observe(viewLifecycleOwner) { (signInState, _) ->
-            val expiryDate = ((signInState as? SignInState.SignedIn)?.subscriptionStatus as? SubscriptionStatus.Plus)?.expiry ?: Date()
+            val expiryDate = ((signInState as? SignInState.SignedIn)?.subscriptionStatus as? SubscriptionStatus.Paid)?.expiry ?: Date()
             val endDate = dateFormatter.format(expiryDate)
             binding?.txtHint0?.text = getString(LR.string.profile_sub_cancel_hint0) + " " + endDate
         }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheet.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheet.kt
@@ -289,7 +289,7 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
                 val layoutLockedCloud = binding.layoutLockedCloud
                 when (signInState) {
                     is SignInState.SignedIn -> {
-                        if (signInState.subscriptionStatus is SubscriptionStatus.Plus) {
+                        if (signInState.subscriptionStatus is SubscriptionStatus.Paid) {
                             layoutCloud.isVisible = true
                             layoutLockedCloud.isVisible = false
                         } else {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -175,7 +175,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         }
         viewModel.signInState.observe(viewLifecycleOwner) {
             binding?.swipeRefreshLayout?.isEnabled =
-                it is SignInState.SignedIn && it.subscriptionStatus is SubscriptionStatus.Plus
+                it is SignInState.SignedIn && it.subscriptionStatus is SubscriptionStatus.Paid
         }
 
         binding?.fab?.setOnClickListener {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
@@ -69,19 +69,19 @@ class CloudSettingsFragment : BaseFragment() {
         val lblDeleteCloudFileAfterPlaying = binding.lblDeleteCloudFileAfterPlaying
         val swtDeleteCloudFileAfterPlaying = binding.swtDeleteCloudFileAfterPlaying
         viewModel.signInState.observe(viewLifecycleOwner) { signInState ->
-            lblDeleteCloudFileAfterPlaying.isVisible = signInState.isSignedInAsPlus
-            swtDeleteCloudFileAfterPlaying.isVisible = signInState.isSignedInAsPlus
+            lblDeleteCloudFileAfterPlaying.isVisible = signInState.isSignedInAsPlusOrPatron
+            swtDeleteCloudFileAfterPlaying.isVisible = signInState.isSignedInAsPlusOrPatron
 
-            binding.plusLayout.isEnabled = signInState.isSignedInAsPlus
-            binding.plusLayout.alpha = if (signInState.isSignedInAsPlus) 1.0f else 0.5f
-            binding.imgLock.isVisible = !signInState.isSignedInAsPlus
-            binding.btnLock.isVisible = !signInState.isSignedInAsPlus
+            binding.plusLayout.isEnabled = signInState.isSignedInAsPlusOrPatron
+            binding.plusLayout.alpha = if (signInState.isSignedInAsPlusOrPatron) 1.0f else 0.5f
+            binding.imgLock.isVisible = !signInState.isSignedInAsPlusOrPatron
+            binding.btnLock.isVisible = !signInState.isSignedInAsPlusOrPatron
 
-            binding.swtAutoUploadToCloud.isEnabled = signInState.isSignedInAsPlus
-            binding.swtAutoDownloadFromCloud.isEnabled = signInState.isSignedInAsPlus
-            binding.swtCloudOnlyOnWiFi.isEnabled = signInState.isSignedInAsPlus
+            binding.swtAutoUploadToCloud.isEnabled = signInState.isSignedInAsPlusOrPatron
+            binding.swtAutoDownloadFromCloud.isEnabled = signInState.isSignedInAsPlusOrPatron
+            binding.swtCloudOnlyOnWiFi.isEnabled = signInState.isSignedInAsPlusOrPatron
 
-            binding.upgradeLayout.isVisible = !signInState.isSignedInAsPlus && !settings.getUpgradeClosedCloudSettings()
+            binding.upgradeLayout.isVisible = !signInState.isSignedInAsPlusOrPatron && !settings.getUpgradeClosedCloudSettings()
         }
 
         with(binding.swtAutoAddToUpNext) {

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -60,7 +60,7 @@ class SearchHandler @Inject constructor(
             } else {
                 // search folders
                 val folderSearch =
-                    if (signInState.isSignedInAsPlus) {
+                    if (signInState.isSignedInAsPlusOrPatron) {
                         // only show folders if the user has Plus
                         folderManager.findFoldersSingle()
                             .subscribeOn(Schedulers.io())

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModel.kt
@@ -25,7 +25,7 @@ class SearchHistoryViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ViewModel() {
     private val signInState = userManager.getSignInState().asFlow()
-    private var isSignedAsPlus = false
+    private var isSignedInAsPlusOrPatron = false
     private var onlySearchRemote: Boolean = false
     private var source: AnalyticsSource = AnalyticsSource.UNKNOWN
 
@@ -49,7 +49,7 @@ class SearchHistoryViewModel @Inject constructor(
     fun start() {
         viewModelScope.launch(ioDispatcher) {
             signInState.collect { signInState ->
-                isSignedAsPlus = signInState.isSignedInAsPlus
+                isSignedInAsPlusOrPatron = signInState.isSignedInAsPlusOrPatron
                 loadSearchHistory()
             }
         }
@@ -57,7 +57,7 @@ class SearchHistoryViewModel @Inject constructor(
 
     private suspend fun loadSearchHistory() {
         val entries = searchHistoryManager.findAll(
-            showFolders = isSignedAsPlus && !onlySearchRemote
+            showFolders = isSignedInAsPlusOrPatron && !onlySearchRemote
         )
         mutableState.value = mutableState.value.copy(entries = entries)
     }

--- a/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModelTest.kt
+++ b/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModelTest.kt
@@ -5,6 +5,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
@@ -43,6 +44,7 @@ class SearchHistoryViewModelTest {
         platform = SubscriptionPlatform.ANDROID,
         subscriptionList = emptyList(),
         type = SubscriptionType.PLUS,
+        tier = SubscriptionTier.PLUS,
         index = 0
     )
 

--- a/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModelTest.kt
+++ b/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModelTest.kt
@@ -36,7 +36,7 @@ class SearchHistoryViewModelTest {
     @Mock
     private lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
-    private val subscriptionStatusPlus = SubscriptionStatus.Plus(
+    private val subscriptionStatusPaid = SubscriptionStatus.Paid(
         expiry = Date(),
         autoRenew = true,
         giftDays = 0,
@@ -51,7 +51,7 @@ class SearchHistoryViewModelTest {
     private val subscriptionStatusFree = SubscriptionStatus.Free()
 
     @Test
-    fun `given plus user and local + remote search, when search history shown, then folders included`() =
+    fun `given paid subscription status and local + remote search, when search history shown, then folders included`() =
         runTest {
             val viewModel = initViewModel(isPlusUser = true, isOnlySearchRemote = false)
 
@@ -61,7 +61,7 @@ class SearchHistoryViewModelTest {
         }
 
     @Test
-    fun `given free user and local + remote only search, when search history shown, then folders not included`() =
+    fun `given free subscription status and local + remote only search, when search history shown, then folders not included`() =
         runTest {
             val viewModel = initViewModel(isPlusUser = false, isOnlySearchRemote = true)
 
@@ -71,7 +71,7 @@ class SearchHistoryViewModelTest {
         }
 
     @Test
-    fun `given plus user and remote only search, when search history shown, then folders not included`() =
+    fun `given paid subscription status and remote only search, when search history shown, then folders not included`() =
         runTest {
             val viewModel = initViewModel(isPlusUser = true, isOnlySearchRemote = true)
 
@@ -81,7 +81,7 @@ class SearchHistoryViewModelTest {
         }
 
     @Test
-    fun `given free user and remote only search, when search history shown, then folders not included`() =
+    fun `given free subscription status and remote only search, when search history shown, then folders not included`() =
         runTest {
             val viewModel = initViewModel(isPlusUser = false, isOnlySearchRemote = true)
 
@@ -99,7 +99,7 @@ class SearchHistoryViewModelTest {
                 Flowable.just(
                     SignInState.SignedIn(
                         email = "",
-                        subscriptionStatus = if (isPlusUser) subscriptionStatusPlus else subscriptionStatusFree
+                        subscriptionStatus = if (isPlusUser) subscriptionStatusPaid else subscriptionStatusFree
                     )
                 )
             )

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceIconSettingsAdapter.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceIconSettingsAdapter.kt
@@ -123,7 +123,7 @@ class AppearanceIconSettingsAdapter(
 
         private fun isValidIcon(appIcon: AppIcon.AppIconType) =
             (appIcon.tier == SubscriptionTier.NONE) ||
-                (appIcon.tier == SubscriptionTier.PLUS && signInState?.isSignedInAsPlus == true) ||
+                (appIcon.tier == SubscriptionTier.PLUS && signInState?.isSignedInAsPlusOrPatron == true) ||
                 (appIcon.tier == SubscriptionTier.PATRON && signInState?.isSignedInAsPatron == true)
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceIconSettingsAdapter.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceIconSettingsAdapter.kt
@@ -9,7 +9,7 @@ import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
-import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.settings.databinding.AdapterAppearanceAppiconItemBinding
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.AppIcon
@@ -93,10 +93,10 @@ class AppearanceIconSettingsAdapter(
             if (isValidIcon && selected) {
                 tickDrawable = AppCompatResources.getDrawable(itemView.context, R.drawable.ic_circle_tick)
             } else if (!isValidIcon) {
-                val iconDrawable = when (appIcon.type) {
-                    SubscriptionType.PLUS -> R.drawable.ic_locked_plus
-                    SubscriptionType.PATRON -> R.drawable.ic_locked_patron
-                    SubscriptionType.NONE -> throw IllegalStateException("Unknown type found for AppIcon")
+                val iconDrawable = when (appIcon.tier) {
+                    SubscriptionTier.PLUS -> R.drawable.ic_locked_plus
+                    SubscriptionTier.PATRON -> R.drawable.ic_locked_patron
+                    SubscriptionTier.NONE -> throw IllegalStateException("Unknown type found for AppIcon")
                 }
                 tickDrawable = AppCompatResources.getDrawable(itemView.context, iconDrawable)
             }
@@ -122,8 +122,8 @@ class AppearanceIconSettingsAdapter(
         }
 
         private fun isValidIcon(appIcon: AppIcon.AppIconType) =
-            (appIcon.type == SubscriptionType.NONE) ||
-                (appIcon.type == SubscriptionType.PLUS && signInState?.isSignedInAsPlus == true) ||
-                (appIcon.type == SubscriptionType.PATRON && signInState?.isSignedInAsPatron == true)
+            (appIcon.tier == SubscriptionTier.NONE) ||
+                (appIcon.tier == SubscriptionTier.PLUS && signInState?.isSignedInAsPlus == true) ||
+                (appIcon.tier == SubscriptionTier.PATRON && signInState?.isSignedInAsPatron == true)
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
@@ -70,8 +70,8 @@ class AppearanceSettingsFragment : BaseFragment() {
                 is SettingsAppearanceState.ThemesAndIconsLoading -> {}
                 is SettingsAppearanceState.ThemesAndIconsLoaded -> {
                     val mainWidth = activity?.resources?.displayMetrics?.widthPixels // Display metrics gives the app size not the display, it's badly named. Works in chromebooks and split screen
-                    val isSignedInAsPlus = viewModel.signInState.value?.isSignedInAsPlus ?: false
-                    binding.themeRecyclerView.adapter = AppearanceThemeSettingsAdapter(mainWidth, isSignedInAsPlus, state.currentThemeType, state.themeList) { beforeThemeType, afterThemeType, validTheme ->
+                    val isSignedInAsPlusOrPatron = viewModel.signInState.value?.isSignedInAsPlusOrPatron ?: false
+                    binding.themeRecyclerView.adapter = AppearanceThemeSettingsAdapter(mainWidth, isSignedInAsPlusOrPatron, state.currentThemeType, state.themeList) { beforeThemeType, afterThemeType, validTheme ->
                         if (validTheme) {
                             (activity as? AppCompatActivity)?.let {
                                 theme.updateTheme(it, afterThemeType)
@@ -114,7 +114,7 @@ class AppearanceSettingsFragment : BaseFragment() {
                 val afterThemeType = changeThemeType.second
 
                 if (beforeThemeType != null && afterThemeType != null) {
-                    if (signInState.isSignedInAsPlus) {
+                    if (signInState.isSignedInAsPlusOrPatron) {
                         (activity as? AppCompatActivity)?.let {
                             theme.updateTheme(it, afterThemeType)
                             binding.swtSystemTheme.isChecked = theme.getUseSystemTheme() // Update switch if changing the theme updated the setting
@@ -132,7 +132,7 @@ class AppearanceSettingsFragment : BaseFragment() {
                 val afterAppIconType = changeAppIconType.second
 
                 if (beforeAppIconType != null && afterAppIconType != null) {
-                    if (signInState.isSignedInAsPlus) {
+                    if (signInState.isSignedInAsPlusOrPatron) {
                         viewModel.updateGlobalIcon(afterAppIconType)
                         viewModel.updateChangeAppIconType(Pair(null, null))
 
@@ -148,9 +148,9 @@ class AppearanceSettingsFragment : BaseFragment() {
                 }
             }
 
-            (binding.themeRecyclerView.adapter as? AppearanceThemeSettingsAdapter)?.updatePlusSignedIn(signInState.isSignedInAsPlus)
+            (binding.themeRecyclerView.adapter as? AppearanceThemeSettingsAdapter)?.updatePlusSignedIn(signInState.isSignedInAsPlusOrPatron)
             (binding.appIconRecyclerView.adapter as? AppearanceIconSettingsAdapter)?.updatePlusSignedIn(signInState)
-            binding.upgradeGroup.isVisible = !signInState.isSignedInAsPlus && !settings.getUpgradeClosedAppearSettings()
+            binding.upgradeGroup.isVisible = !signInState.isSignedInAsPlusOrPatron && !settings.getUpgradeClosedAppearSettings()
         }
 
         viewModel.loadThemesAndIcons()

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
@@ -11,7 +11,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.settings.databinding.FragmentSettingsAppearanceBinding
@@ -97,7 +97,7 @@ class AppearanceSettingsFragment : BaseFragment() {
                                 .show()
                         } else {
                             viewModel.updateChangeAppIconType(Pair(beforeAppIconType, afterAppIconType))
-                            openOnboardingFlow(afterAppIconType.type)
+                            openOnboardingFlow(afterAppIconType.tier)
                         }
                     }
                     binding.appIconRecyclerView.setHasFixedSize(true)
@@ -192,8 +192,8 @@ class AppearanceSettingsFragment : BaseFragment() {
         viewModel.onShown()
     }
 
-    private fun openOnboardingFlow(type: SubscriptionType? = null) {
-        val onboardingFlow = type?.takeIf { type == SubscriptionType.PATRON }?.let {
+    private fun openOnboardingFlow(tier: SubscriptionTier? = null) {
+        val onboardingFlow = tier?.takeIf { tier == SubscriptionTier.PATRON }?.let {
             OnboardingFlow.PlusUpsell(source = OnboardingUpgradeSource.APPEARANCE, showPatronOnly = true)
         } ?: OnboardingFlow.PlusUpsell(OnboardingUpgradeSource.APPEARANCE)
         OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceThemeSettingsAdapter.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceThemeSettingsAdapter.kt
@@ -19,7 +19,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 class AppearanceThemeSettingsAdapter(
     private var mainWidth: Int?,
-    private var isPlusSignedIn: Boolean,
+    private var isPlusOrPatronSignedIn: Boolean,
     private var selectedTheme: Theme.ThemeType,
     private var list: List<Theme.ThemeType>,
     private val clickListener: (Theme.ThemeType, Theme.ThemeType, Boolean) -> Unit
@@ -53,7 +53,7 @@ class AppearanceThemeSettingsAdapter(
     override fun getItemCount() = list.size
 
     fun updatePlusSignedIn(value: Boolean) {
-        isPlusSignedIn = value
+        isPlusOrPatronSignedIn = value
         notifyDataSetChanged()
     }
 
@@ -84,7 +84,7 @@ class AppearanceThemeSettingsAdapter(
         }
 
         fun bind(theme: Theme.ThemeType, selected: Boolean) {
-            val showOption = !theme.isPlus || isPlusSignedIn
+            val showOption = !theme.isPlus || isPlusOrPatronSignedIn
             binding.themeItem.alpha = if (showOption) 1.0f else 0.65f
 
             val drawable = AppCompatResources.getDrawable(itemView.context, theme.iconResourceId)
@@ -109,7 +109,7 @@ class AppearanceThemeSettingsAdapter(
             }
             val beforeTheme = selectedTheme
             val afterTheme = list[bindingAdapterPosition]
-            val validTheme = !afterTheme.isPlus || isPlusSignedIn
+            val validTheme = !afterTheme.isPlus || isPlusOrPatronSignedIn
 
             selectedTheme = afterTheme
             clickListener(beforeTheme, afterTheme, validTheme)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/DeveloperFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/DeveloperFragment.kt
@@ -6,6 +6,7 @@ import android.widget.Toast
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -80,7 +81,9 @@ class DeveloperFragment : PreferenceFragmentCompat(), CoroutineScope {
                 onSuccess = {
                     if (it is ProductDetailsState.Loaded) {
                         it.productDetails.firstOrNull()?.let { productDetails ->
-                            val isFreeTrialEligible = subscriptionManager.isFreeTrialEligible()
+                            val isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(
+                                SubscriptionMapper.mapProductIdToTier(productDetails.productId)
+                            )
                             Subscription.fromProductDetails(productDetails, isFreeTrialEligible)?.let { subscription ->
                                 subscriptionManager.launchBillingFlow(requireActivity(), productDetails, subscription.offerToken)
                             } ?: Timber.d("Subscription is null")

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
@@ -226,7 +226,7 @@ class HelpFragment : Fragment(), HasBackstack, Toolbar.OnMenuItemClickListener {
     private fun contactSupport() {
         when (subscriptionManager.getCachedStatus()) {
             null, is SubscriptionStatus.Free -> useForumPopup()
-            is SubscriptionStatus.Plus -> sendSupportEmail()
+            is SubscriptionStatus.Paid -> sendSupportEmail()
         }
 
         analyticsTracker.track(AnalyticsEvent.SETTINGS_GET_SUPPORT)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlusSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlusSettingsFragment.kt
@@ -18,6 +18,7 @@ import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
@@ -67,7 +68,9 @@ class PlusSettingsFragment : BaseFragment() {
                     is ProductDetailsState.Loaded -> productDetailsState.productDetails.mapNotNull {
                         Subscription.fromProductDetails(
                             productDetails = it,
-                            isFreeTrialEligible = subscriptionManager.isFreeTrialEligible()
+                            isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(
+                                SubscriptionMapper.mapProductIdToTier(it.productId)
+                            )
                         )
                     }
                 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlusSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlusSettingsFragment.kt
@@ -140,7 +140,7 @@ class PlusSettingsFragment : BaseFragment() {
             .observe(viewLifecycleOwner) { signInState ->
                 // If the user has gone through the upgraded to Plus, we no longer want
                 // to present this screen since it is asking them to sign up for Plus
-                if (signInState.isSignedInAsPlus && isAdded) {
+                if (signInState.isSignedInAsPlusOrPatron && isAdded) {
                     @Suppress("DEPRECATION")
                     activity?.onBackPressed()
                 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragmentPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragmentPage.kt
@@ -70,7 +70,7 @@ fun SettingsFragmentPage(
             GeneralRow(onClick = { openFragment(PlaybackSettingsFragment()) })
             NotificationRow(onClick = { openFragment(NotificationsSettingsFragment()) })
             AppearanceRow(
-                isSignedInAsPlus = signInState.isSignedInAsPlus,
+                isSignedInAsPlusOrPatron = signInState.isSignedInAsPlusOrPatron,
                 onClick = { openFragment(AppearanceSettingsFragment.newInstance()) }
             )
             StorageAndDataUseRow(onClick = { openFragment(StorageSettingsFragment()) })
@@ -165,11 +165,11 @@ private fun NotificationRow(onClick: () -> Unit) {
 }
 
 @Composable
-private fun AppearanceRow(isSignedInAsPlus: Boolean, onClick: () -> Unit) {
+private fun AppearanceRow(isSignedInAsPlusOrPatron: Boolean, onClick: () -> Unit) {
     SettingRow(
         primaryText = stringResource(LR.string.settings_title_appearance),
         icon = GradientIconData(SR.drawable.settings_appearance),
-        primaryTextEndDrawable = if (isSignedInAsPlus) null else IR.drawable.ic_plus,
+        primaryTextEndDrawable = if (isSignedInAsPlusOrPatron) null else IR.drawable.ic_plus,
         modifier = rowModifier(onClick)
     )
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/TracksAnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/TracksAnalyticsTracker.kt
@@ -23,20 +23,20 @@ class TracksAnalyticsTracker @Inject constructor(
 ) : IdentifyingTracker(preferences) {
     private val tracksClient: TracksClient? = TracksClient.getClient(appContext)
     override val anonIdPrefKey: String = TRACKS_ANON_ID
-    private val plusSubscription: SubscriptionStatus.Plus?
-        get() = settings.getCachedSubscription() as? SubscriptionStatus.Plus
+    private val paidSubscription: SubscriptionStatus.Paid?
+        get() = settings.getCachedSubscription() as? SubscriptionStatus.Paid
 
     private val predefinedEventProperties: Map<String, Any>
         get() {
             val isLoggedIn = accountStatusInfo.isLoggedIn()
-            val hasSubscription = plusSubscription != null
-            val hasLifetime = plusSubscription?.isLifetimePlus
+            val hasSubscription = paidSubscription != null
+            val hasLifetime = paidSubscription?.isLifetimePlus
                 ?: false
-            val subscriptionType = plusSubscription?.type?.toString()
+            val subscriptionType = paidSubscription?.type?.toString()
                 ?: INVALID_OR_NULL_VALUE
-            val subscriptionPlatform = plusSubscription?.platform?.toString()
+            val subscriptionPlatform = paidSubscription?.platform?.toString()
                 ?: INVALID_OR_NULL_VALUE
-            val subscriptionFrequency = plusSubscription?.frequency?.toString()
+            val subscriptionFrequency = paidSubscription?.frequency?.toString()
                 ?: INVALID_OR_NULL_VALUE
 
             return mapOf(

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/DefaultReleaseFeatureProvider.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/DefaultReleaseFeatureProvider.kt
@@ -20,8 +20,7 @@ class DefaultReleaseFeatureProvider @Inject constructor() : FeatureProvider {
     override fun isEnabled(feature: Feature) =
         when (feature) {
             Feature.END_OF_YEAR_ENABLED,
-            Feature.SHOW_RATINGS_ENABLED,
-            Feature.ADD_PATRON_ENABLED,
-            -> false
+            Feature.SHOW_RATINGS_ENABLED -> false
+            Feature.ADD_PATRON_ENABLED -> true
         }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
@@ -37,6 +37,9 @@ sealed class SignInState {
             this.subscriptionStatus is SubscriptionStatus.Paid &&
             this.subscriptionStatus.tier == SubscriptionTier.PATRON
 
+    val isSignedInAsPlusOrPatron: Boolean
+        get() = isSignedInAsPlus || isSignedInAsPatron
+
     val isSignedInAsPaid: Boolean
         get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Paid && paidSubscriptionPlatforms.contains(this.subscriptionStatus.platform)
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
@@ -37,7 +37,7 @@ sealed class SignInState {
             this.subscriptionStatus is SubscriptionStatus.Plus &&
             this.subscriptionStatus.tier == SubscriptionTier.PATRON
 
-    val isSignedInAsPlusPaid: Boolean
+    val isSignedInAsPaid: Boolean
         get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && paidSubscriptionPlatforms.contains(this.subscriptionStatus.platform)
 
     val isLifetimePlus: Boolean

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
@@ -23,22 +23,22 @@ sealed class SignInState {
     val isSignedInAsPlus: Boolean
         get() = if (FeatureFlag.isEnabled(Feature.ADD_PATRON_ENABLED)) {
             this is SignedIn &&
-                this.subscriptionStatus is SubscriptionStatus.Plus &&
+                this.subscriptionStatus is SubscriptionStatus.Paid &&
                 this.subscriptionStatus.tier == SubscriptionTier.PLUS
         } else {
             this is SignedIn &&
-                this.subscriptionStatus is SubscriptionStatus.Plus &&
+                this.subscriptionStatus is SubscriptionStatus.Paid &&
                 this.subscriptionStatus.type == SubscriptionType.PLUS
         }
 
     val isSignedInAsPatron: Boolean
         get() = FeatureFlag.isEnabled(Feature.ADD_PATRON_ENABLED) &&
             this is SignedIn &&
-            this.subscriptionStatus is SubscriptionStatus.Plus &&
+            this.subscriptionStatus is SubscriptionStatus.Paid &&
             this.subscriptionStatus.tier == SubscriptionTier.PATRON
 
     val isSignedInAsPaid: Boolean
-        get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && paidSubscriptionPlatforms.contains(this.subscriptionStatus.platform)
+        get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Paid && paidSubscriptionPlatforms.contains(this.subscriptionStatus.platform)
 
     val isLifetimePlus: Boolean
         get() = this is SignedIn && this.subscriptionStatus.isLifetimePlus

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.models.to
 import au.com.shiftyjelly.pocketcasts.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
 import au.com.shiftyjelly.pocketcasts.utils.DateUtil
 import java.util.Date
@@ -23,7 +24,7 @@ sealed class SignInState {
         get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && this.subscriptionStatus.type == SubscriptionType.PLUS
 
     val isSignedInAsPatron: Boolean
-        get() = FeatureFlag.isEnabled(Feature.ADD_PATRON_ENABLED) && this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && this.subscriptionStatus.type == SubscriptionType.PATRON
+        get() = FeatureFlag.isEnabled(Feature.ADD_PATRON_ENABLED) && this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && this.subscriptionStatus.tier == SubscriptionTier.PATRON
 
     val isSignedInAsPlusPaid: Boolean
         get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && paidSubscriptionPlatforms.contains(this.subscriptionStatus.platform)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
@@ -21,10 +21,21 @@ sealed class SignInState {
         get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Free
 
     val isSignedInAsPlus: Boolean
-        get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && this.subscriptionStatus.type == SubscriptionType.PLUS
+        get() = if (FeatureFlag.isEnabled(Feature.ADD_PATRON_ENABLED)) {
+            this is SignedIn &&
+                this.subscriptionStatus is SubscriptionStatus.Plus &&
+                this.subscriptionStatus.tier == SubscriptionTier.PLUS
+        } else {
+            this is SignedIn &&
+                this.subscriptionStatus is SubscriptionStatus.Plus &&
+                this.subscriptionStatus.type == SubscriptionType.PLUS
+        }
 
     val isSignedInAsPatron: Boolean
-        get() = FeatureFlag.isEnabled(Feature.ADD_PATRON_ENABLED) && this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && this.subscriptionStatus.tier == SubscriptionTier.PATRON
+        get() = FeatureFlag.isEnabled(Feature.ADD_PATRON_ENABLED) &&
+            this is SignedIn &&
+            this.subscriptionStatus is SubscriptionStatus.Plus &&
+            this.subscriptionStatus.tier == SubscriptionTier.PATRON
 
     val isSignedInAsPlusPaid: Boolean
         get() = this is SignedIn && this.subscriptionStatus is SubscriptionStatus.Plus && paidSubscriptionPlatforms.contains(this.subscriptionStatus.platform)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SubscriptionStatus.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SubscriptionStatus.kt
@@ -21,7 +21,7 @@ sealed class SubscriptionStatus(val expiryDate: Date?, val subscriptions: List<S
     ) : SubscriptionStatus(expiry, subscriptionList)
 
     @JsonClass(generateAdapter = true)
-    data class Plus(
+    data class Paid(
         @field:Json(name = "expiry") val expiry: Date,
         @field:Json(name = "autoRenew") val autoRenew: Boolean,
         @field:Json(name = "giftDays") val giftDays: Int = 0,
@@ -48,5 +48,5 @@ sealed class SubscriptionStatus(val expiryDate: Date?, val subscriptions: List<S
     }
 
     val isLifetimePlus: Boolean
-        get() = this is Plus && this.platform == SubscriptionPlatform.GIFT && this.giftDays > giftDaysCutOver
+        get() = this is Paid && this.platform == SubscriptionPlatform.GIFT && this.giftDays > giftDaysCutOver
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SubscriptionStatus.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SubscriptionStatus.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.models.to
 
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
@@ -28,12 +29,14 @@ sealed class SubscriptionStatus(val expiryDate: Date?, val subscriptions: List<S
         @field:Json(name = "platform") val platform: SubscriptionPlatform,
         @field:Json(name = "subscriptions") val subscriptionList: List<Subscription> = emptyList(),
         @field:Json(name = "type") val type: SubscriptionType,
+        @field:Json(name = "tier") val tier: SubscriptionTier,
         @field:Json(name = "index") val index: Int
     ) : SubscriptionStatus(expiry, subscriptionList)
 
     @JsonClass(generateAdapter = true)
     data class Subscription(
         @field:Json(name = "type") val type: SubscriptionType,
+        @field:Json(name = "tier") val tier: SubscriptionTier,
         @field:Json(name = "frequency") val frequency: SubscriptionFrequency,
         @field:Json(name = "expiryDate") val expiryDate: Date?,
         @field:Json(name = "autoRenewing") val autoRenewing: Boolean,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionTier.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionTier.kt
@@ -1,0 +1,11 @@
+package au.com.shiftyjelly.pocketcasts.models.type
+
+enum class SubscriptionTier(val label: String) {
+    NONE("none"),
+    PLUS("plus"),
+    PATRON("patron");
+    override fun toString() = label
+    companion object {
+        fun fromString(string: String) = SubscriptionTier.values().find { it.label == string.lowercase() } ?: NONE
+    }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionTier.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionTier.kt
@@ -6,6 +6,8 @@ enum class SubscriptionTier(val label: String) {
     PATRON("patron");
     override fun toString() = label
     companion object {
-        fun fromString(string: String) = SubscriptionTier.values().find { it.label == string.lowercase() } ?: NONE
+        // Till subscriptionTier is not supported, subscriptionType is used as a fallback to determine subscriptionTier
+        fun fromString(string: String?, subscriptionType: SubscriptionType) =
+            SubscriptionTier.values().find { it.label == string?.lowercase() } ?: if (subscriptionType == SubscriptionType.PLUS) PLUS else NONE
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionType.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionType.kt
@@ -1,5 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.models.type
 
+ /* pdeCcb-2fL-p2#comment-2074
+The SubscriptionType field will always be Plus.
+It is being replaced by SubscriptionTier with Plus and Patron tiers but currently not supported in production.
+This can be removed once SubscriptionTier is supported.
+*/
 enum class SubscriptionType(val label: String) {
     NONE("none"),
     PLUS("plus");

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionType.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionType.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.models.type
 
 enum class SubscriptionType(val label: String) {
     NONE("none"),
-    PLUS("plus"),
-    PATRON("patron");
+    PLUS("plus");
     override fun toString() = label
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1192,8 +1192,8 @@ class SettingsImpl @Inject constructor(
     }
 
     override fun setCachedSubscription(subscriptionStatus: SubscriptionStatus?) {
-        if (subscriptionStatus is SubscriptionStatus.Plus) {
-            val adapter = moshi.adapter(SubscriptionStatus.Plus::class.java)
+        if (subscriptionStatus is SubscriptionStatus.Paid) {
+            val adapter = moshi.adapter(SubscriptionStatus.Paid::class.java)
             val str = adapter.toJson(subscriptionStatus)
             privatePreferences.edit().putString("accountstatus", encrypt(str)).apply()
         } else {
@@ -1204,7 +1204,7 @@ class SettingsImpl @Inject constructor(
     override fun getCachedSubscription(): SubscriptionStatus? {
         val str = decrypt(privatePreferences.getString("accountstatus", null)) ?: return null
         try {
-            val adapter = moshi.adapter(SubscriptionStatus.Plus::class.java)
+            val adapter = moshi.adapter(SubscriptionStatus.Paid::class.java)
             return adapter.fromJson(str)
         } catch (e: Exception) {
             return null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -478,7 +478,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
     }
 
     suspend fun loadPodcastsChildren(): List<MediaBrowserCompat.MediaItem> {
-        return if (subscriptionManager.getCachedStatus() is SubscriptionStatus.Plus) {
+        return if (subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid) {
             folderManager.getHomeFolder().mapNotNull { item ->
                 when (item) {
                     is FolderItem.Folder -> convertFolderToMediaItem(this, item.folder)
@@ -493,7 +493,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
     }
 
     suspend fun loadFolderPodcastsChildren(folderUuid: String): List<MediaBrowserCompat.MediaItem> {
-        return if (subscriptionManager.getCachedStatus() is SubscriptionStatus.Plus) {
+        return if (subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid) {
             folderManager.findFolderPodcastsSorted(folderUuid).mapNotNull { podcast ->
                 convertPodcastToMediaItem(podcast = podcast, context = this)
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -385,7 +385,7 @@ class UserEpisodeManagerImpl @Inject constructor(
                 val newEpisode = it.toUserEpisode()
                 add(newEpisode, playbackManager)
 
-                if (settings.getCloudAutoDownload() && subscriptionManager.getCachedStatus() is SubscriptionStatus.Plus) {
+                if (settings.getCloudAutoDownload() && subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid) {
                     userEpisodeDao.updateAutoDownloadStatus(PodcastEpisode.AUTO_DOWNLOAD_STATUS_AUTO_DOWNLOADED, newEpisode.uuid)
                     newEpisode.autoDownloadStatus = PodcastEpisode.AUTO_DOWNLOAD_STATUS_AUTO_DOWNLOADED
                     downloadManager.addEpisodeToQueue(newEpisode, "cloud files sync", false)
@@ -569,7 +569,7 @@ class UserEpisodeManagerImpl @Inject constructor(
     }
 
     override fun autoUploadToCloudIfReq(episode: UserEpisode) {
-        if (settings.getCloudAutoUpload() && subscriptionManager.getCachedStatus() is SubscriptionStatus.Plus) {
+        if (settings.getCloudAutoUpload() && subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid) {
             uploadToServer(episode, settings.getCloudOnlyWifi())
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -32,8 +32,8 @@ interface SubscriptionManager {
     fun launchBillingFlow(activity: Activity, productDetails: ProductDetails, offerToken: String): BillingResult?
     fun getCachedStatus(): SubscriptionStatus?
     fun clearCachedStatus()
-    fun isFreeTrialEligible(): Boolean
-    fun updateFreeTrialEligible(eligible: Boolean)
+    fun isFreeTrialEligible(tier: Subscription.SubscriptionTier): Boolean
+    fun updateFreeTrialEligible(tier: Subscription.SubscriptionTier, eligible: Boolean)
     fun getDefaultSubscription(
         subscriptions: List<Subscription>,
         tier: Subscription.SubscriptionTier? = null,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -410,14 +410,14 @@ private fun SubscriptionStatusResponse.toStatus(): SubscriptionStatus {
     } else {
         val freq = SubscriptionFrequency.values().getOrNull(frequency) ?: SubscriptionFrequency.NONE
         val enumType = SubscriptionType.values().getOrNull(type) ?: SubscriptionType.NONE
-        val enumTier = SubscriptionTier.fromString(tier)
+        val enumTier = SubscriptionTier.fromString(tier, enumType)
         SubscriptionStatus.Plus(expiryDate ?: Date(), autoRenewing, giftDays, freq, originalPlatform, subs, enumType, enumTier, index)
     }
 }
 
 private fun SubscriptionResponse.toSubscription(): SubscriptionStatus.Subscription {
     val enumType = SubscriptionType.values().getOrNull(type) ?: SubscriptionType.NONE
-    val enumTier = SubscriptionTier.fromString(tier)
+    val enumTier = SubscriptionTier.fromString(tier, enumType)
     val freq = SubscriptionFrequency.values().getOrNull(frequency) ?: SubscriptionFrequency.NONE
     return SubscriptionStatus.Subscription(enumType, enumTier, freq, expiryDate, autoRenewing, updateUrl)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -359,7 +359,7 @@ class SubscriptionManagerImpl @Inject constructor(
         subscriptionStatus.accept(Optional.empty())
     }
 
-    override fun isFreeTrialEligible(tier: Subscription.SubscriptionTier) = freeTrialEligible[tier] ?: false
+    override fun isFreeTrialEligible(tier: Subscription.SubscriptionTier) = freeTrialEligible[tier] ?: true
 
     override fun updateFreeTrialEligible(tier: Subscription.SubscriptionTier, eligible: Boolean) {
         freeTrialEligible[tier] = eligible

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -15,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_YE
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPricingPhase
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
@@ -409,12 +410,14 @@ private fun SubscriptionStatusResponse.toStatus(): SubscriptionStatus {
     } else {
         val freq = SubscriptionFrequency.values().getOrNull(frequency) ?: SubscriptionFrequency.NONE
         val enumType = SubscriptionType.values().getOrNull(type) ?: SubscriptionType.NONE
-        SubscriptionStatus.Plus(expiryDate ?: Date(), autoRenewing, giftDays, freq, originalPlatform, subs, enumType, index)
+        val enumTier = SubscriptionTier.fromString(tier)
+        SubscriptionStatus.Plus(expiryDate ?: Date(), autoRenewing, giftDays, freq, originalPlatform, subs, enumType, enumTier, index)
     }
 }
 
 private fun SubscriptionResponse.toSubscription(): SubscriptionStatus.Subscription {
     val enumType = SubscriptionType.values().getOrNull(type) ?: SubscriptionType.NONE
+    val enumTier = SubscriptionTier.fromString(tier)
     val freq = SubscriptionFrequency.values().getOrNull(frequency) ?: SubscriptionFrequency.NONE
-    return SubscriptionStatus.Subscription(enumType, freq, expiryDate, autoRenewing, updateUrl)
+    return SubscriptionStatus.Subscription(enumType, enumTier, freq, expiryDate, autoRenewing, updateUrl)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -117,15 +117,15 @@ class SubscriptionManagerImpl @Inject constructor(
                 subscriptionStatus.accept(Optional.of(it))
                 val oldStatus = cachedSubscriptionStatus
                 if (oldStatus != it) {
-                    if (it is SubscriptionStatus.Plus && oldStatus is SubscriptionStatus.Free) {
+                    if (it is SubscriptionStatus.Paid && oldStatus is SubscriptionStatus.Free) {
                         subscriptionChangedEvents.accept(SubscriptionChangedEvent.AccountUpgradedToPlus)
-                    } else if (it is SubscriptionStatus.Free && oldStatus is SubscriptionStatus.Plus) {
+                    } else if (it is SubscriptionStatus.Free && oldStatus is SubscriptionStatus.Paid) {
                         subscriptionChangedEvents.accept(SubscriptionChangedEvent.AccountDowngradedToFree)
                     }
                 }
                 cachedSubscriptionStatus = it
 
-                if (!it.isLifetimePlus && it is SubscriptionStatus.Plus && it.platform == SubscriptionPlatform.GIFT) { // This account is a trial account
+                if (!it.isLifetimePlus && it is SubscriptionStatus.Paid && it.platform == SubscriptionPlatform.GIFT) { // This account is a trial account
                     settings.setTrialFinishedSeen(false) // Make sure on expiry we show the trial finished dialog
                 }
             }
@@ -419,7 +419,7 @@ private fun SubscriptionStatusResponse.toStatus(): SubscriptionStatus {
         val freq = SubscriptionFrequency.values().getOrNull(frequency) ?: SubscriptionFrequency.NONE
         val enumType = SubscriptionType.values().getOrNull(type) ?: SubscriptionType.NONE
         val enumTier = SubscriptionTier.fromString(tier, enumType)
-        SubscriptionStatus.Plus(expiryDate ?: Date(), autoRenewing, giftDays, freq, originalPlatform, subs, enumType, enumTier, index)
+        SubscriptionStatus.Paid(expiryDate ?: Date(), autoRenewing, giftDays, freq, originalPlatform, subs, enumType, enumTier, index)
     }
 }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -11,10 +11,13 @@ import androidx.core.text.HtmlCompat
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.toPublisher
 import androidx.work.WorkManager
+import au.com.shiftyjelly.pocketcasts.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
@@ -84,10 +87,23 @@ class Support @Inject constructor(
             if (emailSupport) {
                 intent.putExtra(Intent.EXTRA_EMAIL, arrayOf("support@pocketcasts.com"))
             }
-            val isPlus = subscriptionManager.getCachedStatus() is SubscriptionStatus.Plus
+            val isPaid = subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid
+            val accountType = if (isPaid) {
+                if (FeatureFlag.isEnabled(Feature.ADD_PATRON_ENABLED)) {
+                    when ((subscriptionManager.getCachedStatus() as SubscriptionStatus.Paid).tier) {
+                        SubscriptionTier.PATRON -> "Patron Account"
+                        SubscriptionTier.PLUS -> "Plus Account"
+                        SubscriptionTier.NONE -> ""
+                    }
+                } else {
+                    "Plus Account"
+                }
+            } else {
+                ""
+            }
             intent.putExtra(
                 Intent.EXTRA_SUBJECT,
-                "$subject v${settings.getVersion()} ${if (isPlus) " - Plus Account" else ""}"
+                "$subject v${settings.getVersion()} $accountType"
             )
 
             // try to attach the debug information
@@ -142,10 +158,10 @@ class Support @Inject constructor(
             val intent = Intent(Intent.ACTION_SEND)
             intent.type = "text/html"
 
-            val isPlus = subscriptionManager.getCachedStatus() is SubscriptionStatus.Plus
+            val isPaid = subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid
             intent.putExtra(
                 Intent.EXTRA_SUBJECT,
-                "$subject v${settings.getVersion()} ${if (isPlus) " - Plus Account" else ""}"
+                "$subject v${settings.getVersion()} ${if (isPaid) " - Plus Account" else ""}"
             )
 
             try {
@@ -172,10 +188,10 @@ class Support @Inject constructor(
         withContext(Dispatchers.IO) {
             intent.type = "text/html"
             intent.putExtra(Intent.EXTRA_EMAIL, arrayOf("support@pocketcasts.com"))
-            val isPlus = subscriptionManager.getCachedStatus() is SubscriptionStatus.Plus
+            val isPaid = subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid
             intent.putExtra(
                 Intent.EXTRA_SUBJECT,
-                "$subject v${settings.getVersion()} ${if (isPlus) " - Plus Account" else ""}"
+                "$subject v${settings.getVersion()} ${if (isPaid) " - Plus Account" else ""}"
             )
 
             try {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -88,22 +88,9 @@ class Support @Inject constructor(
                 intent.putExtra(Intent.EXTRA_EMAIL, arrayOf("support@pocketcasts.com"))
             }
             val isPaid = subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid
-            val accountType = if (isPaid) {
-                if (FeatureFlag.isEnabled(Feature.ADD_PATRON_ENABLED)) {
-                    when ((subscriptionManager.getCachedStatus() as SubscriptionStatus.Paid).tier) {
-                        SubscriptionTier.PATRON -> "Patron Account"
-                        SubscriptionTier.PLUS -> "Plus Account"
-                        SubscriptionTier.NONE -> ""
-                    }
-                } else {
-                    "Plus Account"
-                }
-            } else {
-                ""
-            }
             intent.putExtra(
                 Intent.EXTRA_SUBJECT,
-                "$subject v${settings.getVersion()} $accountType"
+                "$subject v${settings.getVersion()} ${getAccountType(isPaid)}"
             )
 
             // try to attach the debug information
@@ -161,7 +148,7 @@ class Support @Inject constructor(
             val isPaid = subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid
             intent.putExtra(
                 Intent.EXTRA_SUBJECT,
-                "$subject v${settings.getVersion()} ${if (isPaid) " - Plus Account" else ""}"
+                "$subject v${settings.getVersion()} ${getAccountType(isPaid)}"
             )
 
             try {
@@ -191,7 +178,7 @@ class Support @Inject constructor(
             val isPaid = subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid
             intent.putExtra(
                 Intent.EXTRA_SUBJECT,
-                "$subject v${settings.getVersion()} ${if (isPaid) " - Plus Account" else ""}"
+                "$subject v${settings.getVersion()} ${getAccountType(isPaid)}"
             )
 
             try {
@@ -224,6 +211,20 @@ class Support @Inject constructor(
         }
 
         return intent
+    }
+
+    private fun getAccountType(isPaid: Boolean) = if (isPaid) {
+        if (FeatureFlag.isEnabled(Feature.ADD_PATRON_ENABLED)) {
+            when ((subscriptionManager.getCachedStatus() as SubscriptionStatus.Paid).tier) {
+                SubscriptionTier.PATRON -> "Patron Account"
+                SubscriptionTier.PLUS -> "Plus Account"
+                SubscriptionTier.NONE -> ""
+            }
+        } else {
+            "Plus Account"
+        }
+    } else {
+        ""
     }
 
     suspend fun getLogs(): String =

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -264,7 +264,7 @@ class PodcastSyncProcess(
     private fun syncCloudFiles(): Completable {
         return subscriptionManager.getSubscriptionStatus(allowCache = false)
             .flatMapCompletable {
-                if (it is SubscriptionStatus.Plus) {
+                if (it is SubscriptionStatus.Paid) {
                     rxCompletable { userEpisodeManager.syncFiles(playbackManager) }
                 } else {
                     Completable.complete()

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SubscriptionModel.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SubscriptionModel.kt
@@ -14,14 +14,14 @@ data class SubscriptionStatusResponse(
     @field:Json(name = "frequency") val frequency: Int,
     @field:Json(name = "subscriptions") val subscriptions: List<SubscriptionResponse>?,
     @field:Json(name = "type") val type: Int,
-    @field:Json(name = "tier") val tier: String,
+    @field:Json(name = "tier") val tier: String?,
     @field:Json(name = "index") val index: Int
 )
 
 @JsonClass(generateAdapter = true)
 data class SubscriptionResponse(
     @field:Json(name = "type") val type: Int,
-    @field:Json(name = "tier") val tier: String,
+    @field:Json(name = "tier") val tier: String?,
     @field:Json(name = "frequency") val frequency: Int,
     @field:Json(name = "expiryDate") val expiryDate: Date?,
     @field:Json(name = "autoRenewing") val autoRenewing: Boolean,

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SubscriptionModel.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SubscriptionModel.kt
@@ -14,12 +14,14 @@ data class SubscriptionStatusResponse(
     @field:Json(name = "frequency") val frequency: Int,
     @field:Json(name = "subscriptions") val subscriptions: List<SubscriptionResponse>?,
     @field:Json(name = "type") val type: Int,
+    @field:Json(name = "tier") val tier: String,
     @field:Json(name = "index") val index: Int
 )
 
 @JsonClass(generateAdapter = true)
 data class SubscriptionResponse(
     @field:Json(name = "type") val type: Int,
+    @field:Json(name = "tier") val tier: String,
     @field:Json(name = "frequency") val frequency: Int,
     @field:Json(name = "expiryDate") val expiryDate: Date?,
     @field:Json(name = "autoRenewing") val autoRenewing: Boolean,

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/AppIcon.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/AppIcon.kt
@@ -8,7 +8,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.core.content.edit
 import au.com.shiftyjelly.pocketcasts.localization.BuildConfig
-import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.preferences.di.PublicSharedPreferences
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -24,12 +24,12 @@ class AppIcon @Inject constructor(
     @PublicSharedPreferences private val sharedPreferences: SharedPreferences
 ) {
 
-    enum class AppIconType(val id: String, @StringRes val labelId: Int, @DrawableRes val settingsIcon: Int, val type: SubscriptionType, @DrawableRes val launcherIcon: Int, val aliasName: String) {
+    enum class AppIconType(val id: String, @StringRes val labelId: Int, @DrawableRes val settingsIcon: Int, val tier: SubscriptionTier, @DrawableRes val launcherIcon: Int, val aliasName: String) {
         DEFAULT(
             id = "default",
             labelId = LR.string.settings_app_icon_default,
             settingsIcon = IR.drawable.ic_appicon0,
-            type = SubscriptionType.NONE,
+            tier = SubscriptionTier.NONE,
             launcherIcon = IR.mipmap.ic_launcher,
             aliasName = ".ui.MainActivity_0"
         ),
@@ -37,7 +37,7 @@ class AppIcon @Inject constructor(
             id = "dark",
             labelId = LR.string.settings_app_icon_dark,
             settingsIcon = IR.drawable.ic_appicon1,
-            type = SubscriptionType.NONE,
+            tier = SubscriptionTier.NONE,
             launcherIcon = IR.mipmap.ic_launcher_1,
             aliasName = ".ui.MainActivity_1"
         ),
@@ -45,7 +45,7 @@ class AppIcon @Inject constructor(
             id = "roundedLight",
             labelId = LR.string.settings_app_icon_round_light,
             settingsIcon = IR.drawable.ic_appicon2,
-            type = SubscriptionType.NONE,
+            tier = SubscriptionTier.NONE,
             launcherIcon = IR.mipmap.ic_launcher_2,
             aliasName = ".ui.MainActivity_2"
         ),
@@ -53,7 +53,7 @@ class AppIcon @Inject constructor(
             id = "roundedDark",
             labelId = LR.string.settings_app_icon_round_dark,
             settingsIcon = IR.drawable.ic_appicon3,
-            type = SubscriptionType.NONE,
+            tier = SubscriptionTier.NONE,
             launcherIcon = IR.mipmap.ic_launcher_3,
             aliasName = ".ui.MainActivity_3"
         ),
@@ -61,7 +61,7 @@ class AppIcon @Inject constructor(
             id = "indigo",
             labelId = LR.string.settings_app_icon_indigo,
             settingsIcon = IR.drawable.ic_appicon_indigo,
-            type = SubscriptionType.NONE,
+            tier = SubscriptionTier.NONE,
             launcherIcon = IR.mipmap.ic_launcher_indigo,
             aliasName = ".ui.MainActivity_9"
         ),
@@ -69,7 +69,7 @@ class AppIcon @Inject constructor(
             id = "rose",
             labelId = LR.string.settings_app_icon_rose,
             settingsIcon = IR.drawable.appicon_rose,
-            type = SubscriptionType.NONE,
+            tier = SubscriptionTier.NONE,
             launcherIcon = IR.mipmap.ic_launcher_rose,
             aliasName = ".ui.MainActivity_12"
         ),
@@ -77,7 +77,7 @@ class AppIcon @Inject constructor(
             id = "cat",
             labelId = LR.string.settings_app_icon_pocket_cats,
             settingsIcon = IR.drawable.ic_appicon_pocket_cats,
-            type = SubscriptionType.NONE,
+            tier = SubscriptionTier.NONE,
             launcherIcon = IR.mipmap.ic_launcher_cat,
             aliasName = ".ui.MainActivity_10"
         ),
@@ -85,7 +85,7 @@ class AppIcon @Inject constructor(
             id = "redvelvet",
             labelId = LR.string.settings_app_icon_red_velvet,
             settingsIcon = IR.drawable.appicon_red_velvet,
-            type = SubscriptionType.NONE,
+            tier = SubscriptionTier.NONE,
             launcherIcon = IR.mipmap.ic_launcher_redvelvet,
             aliasName = ".ui.MainActivity_11"
         ),
@@ -93,7 +93,7 @@ class AppIcon @Inject constructor(
             id = "pride_2023",
             labelId = LR.string.settings_app_icon_pride_2023,
             settingsIcon = IR.drawable.appicon_pride_2023,
-            type = SubscriptionType.NONE,
+            tier = SubscriptionTier.NONE,
             launcherIcon = IR.mipmap.ic_launcher_pride_2023,
             aliasName = ".ui.MainActivity_18"
         ),
@@ -101,7 +101,7 @@ class AppIcon @Inject constructor(
             id = "plus",
             labelId = LR.string.settings_app_icon_plus,
             settingsIcon = IR.drawable.ic_appicon4,
-            type = SubscriptionType.PLUS,
+            tier = SubscriptionTier.PLUS,
             launcherIcon = IR.mipmap.ic_launcher_4,
             aliasName = ".ui.MainActivity_4"
         ),
@@ -109,7 +109,7 @@ class AppIcon @Inject constructor(
             id = "classic",
             labelId = LR.string.settings_app_icon_classic,
             settingsIcon = IR.drawable.ic_appicon5,
-            type = SubscriptionType.PLUS,
+            tier = SubscriptionTier.PLUS,
             launcherIcon = IR.mipmap.ic_launcher_5,
             aliasName = ".ui.MainActivity_5"
         ),
@@ -117,7 +117,7 @@ class AppIcon @Inject constructor(
             id = "electricBlue",
             labelId = LR.string.settings_app_icon_electric_blue,
             settingsIcon = IR.drawable.ic_appicon6,
-            type = SubscriptionType.PLUS,
+            tier = SubscriptionTier.PLUS,
             launcherIcon = IR.mipmap.ic_launcher_6,
             aliasName = ".ui.MainActivity_6"
         ),
@@ -125,7 +125,7 @@ class AppIcon @Inject constructor(
             id = "electricPink",
             labelId = LR.string.settings_app_icon_electric_pink,
             settingsIcon = IR.drawable.ic_appicon7,
-            type = SubscriptionType.PLUS,
+            tier = SubscriptionTier.PLUS,
             launcherIcon = IR.mipmap.ic_launcher_7,
             aliasName = ".ui.MainActivity_7"
         ),
@@ -133,7 +133,7 @@ class AppIcon @Inject constructor(
             id = "radioactive",
             labelId = LR.string.settings_app_icon_radioactivity,
             settingsIcon = IR.drawable.appicon_radioactive,
-            type = SubscriptionType.PLUS,
+            tier = SubscriptionTier.PLUS,
             launcherIcon = IR.mipmap.ic_launcher_radioactive,
             aliasName = ".ui.MainActivity_8"
         ),
@@ -141,7 +141,7 @@ class AppIcon @Inject constructor(
             id = "halloween",
             labelId = LR.string.settings_app_icon_halloween,
             settingsIcon = IR.drawable.appicon_halloween,
-            type = SubscriptionType.PLUS,
+            tier = SubscriptionTier.PLUS,
             launcherIcon = IR.mipmap.ic_launcher_halloween,
             aliasName = ".ui.MainActivity_13"
         ),
@@ -149,7 +149,7 @@ class AppIcon @Inject constructor(
             id = "patron_chrome",
             labelId = LR.string.settings_app_icon_patron_chrome,
             settingsIcon = IR.drawable.appicon_patron_chrome,
-            type = SubscriptionType.PATRON,
+            tier = SubscriptionTier.PATRON,
             launcherIcon = IR.mipmap.ic_launcher_patron_chrome,
             aliasName = ".ui.MainActivity_14"
         ),
@@ -157,7 +157,7 @@ class AppIcon @Inject constructor(
             id = "patron_round",
             labelId = LR.string.settings_app_icon_patron_round,
             settingsIcon = IR.drawable.appicon_patron_round,
-            type = SubscriptionType.PATRON,
+            tier = SubscriptionTier.PATRON,
             launcherIcon = IR.mipmap.ic_launcher_patron_round,
             aliasName = ".ui.MainActivity_15"
         ),
@@ -165,7 +165,7 @@ class AppIcon @Inject constructor(
             id = "patron_glow",
             labelId = LR.string.settings_app_icon_patron_glow,
             settingsIcon = IR.drawable.appicon_patron_glow,
-            type = SubscriptionType.PATRON,
+            tier = SubscriptionTier.PATRON,
             launcherIcon = IR.mipmap.ic_launcher_patron_glow,
             aliasName = ".ui.MainActivity_16"
         ),
@@ -173,7 +173,7 @@ class AppIcon @Inject constructor(
             id = "patron_dark",
             labelId = LR.string.settings_app_icon_patron_dark,
             settingsIcon = IR.drawable.appicon_patron_dark,
-            type = SubscriptionType.PATRON,
+            tier = SubscriptionTier.PATRON,
             launcherIcon = IR.mipmap.ic_launcher_patron_dark,
             aliasName = ".ui.MainActivity_17"
         );

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -110,7 +110,7 @@ fun WearApp(
     val userCanAccessWatch = when (subscriptionStatus) {
         is SubscriptionStatus.Free,
         null -> false
-        is SubscriptionStatus.Plus -> true
+        is SubscriptionStatus.Paid -> true
     }
 
     val waitingForSignIn = remember { mutableStateOf(false) }
@@ -377,7 +377,7 @@ fun WearApp(
             }
             Toast.makeText(LocalContext.current, LR.string.log_in_with_plus, Toast.LENGTH_LONG).show()
         }
-        is SubscriptionStatus.Plus -> {
+        is SubscriptionStatus.Paid -> {
             if (waitingForSignIn.value &&
                 signInState is SignInState.SignedIn &&
                 previousSubscriptionStatus.value != subscriptionStatus


### PR DESCRIPTION
## Description

This integrates server changes for introducing subscription tier.

Prerequisites:

- Debug build variant (tier is only available in debug env)
- Changes for debug build variant (see bottom section in pdeCcb-12K-p2)
- Three accounts 
    - `Free`
    - `Plus` (Active - expiry > 30 days)
    - `Patron` (Active - expiry > 30 days) [I gifted `Patron` to `ashita.agrawal+patron@automattic.com` using `Postman` to get the patron tier in a debug environment (pdeCcb-2fL-p2#comment-2070). You can change the pwd from debug admin and use it for testing]


## Testing Instructions


#### Test.1 Free account

1. Fresh install the app and start with a disabled `Patron` feature flag
2. Login with a `Free` account
3. Notice that all features/ menu/ views are enabled or disabled for the `Free` account based on the chart below
4. Enable`Patron` feature flag in `Profile` -> `Settings` -> `Beta Features`
5. Restart the app
6. Repeat step 3.

#### Test.2 Plus account

1. Disable `Patron` feature flag 
2. Restart the app
3. Login with a `Plus` account
4. Notice that all features/ menu/ views are enabled or disabled for the `Plus` account based on the chart below
5. Enable`Patron` feature flag in `Profile` -> `Settings` -> `Beta Features`
6. Restart the app
7. Repeat step 4.

#### Test.3 Patron account

1. Disable `Patron` feature flag
2. Restart the app
3. Login with a `Patron` account
4. Notice that all features/ menu/ views are enabled or disabled for the `Patron` account based on the chart below
5. Enable`Patron` feature flag in `Profile` -> `Settings` -> `Beta Features`
6. Restart the app
7. Repeat step 4.

### Without Feature Flag

- Disable the `Patron` feature flag using `Settings` -> `Beta Features`
- Restart the app
- Repeat the above steps for `Free` and `Plus` accounts
- Notice that all features/ menu/ views are enabled or disabled for the `Free` or `Plus` account based on the chart below

Features | Free | Plus (Active) | Patron (Active)
-- | -- | -- | --
`Profile` -> `Settings` -> `Pocket Casts Plus` menu | ✅  |   |  
Plus icon next to `Settings` -> `Appearance` | ✅ |   |  
Free Themes | ✅ | ✅ | ✅
Free Icons | ✅ | ✅ | ✅
Plus themes |   | ✅ | ✅
Plus icons |   | ✅ | ✅
Patron icons |   |   | ✅
`Profile` -> `Account` -> `Upgrade to Patron` menu |   | ✅ |  
Files Settings |   | ✅ | ✅
`Account` -> Upgrade View (hidden) |   | ✅ | ✅
`Profile` -> (Patron) Badge |   |   | ✅
Folders |   | ✅ | ✅

Below updates will be covered in a separate PR



Features | Free | Plus (Expiring) | Patron (Expiring)
-- | -- | -- | --
`Account` ->  Upgrade View (Hide `Plus` plan) |   |  | ❌ 
`Account` ->  Upgrade View (Upgrade button title -> `Renew your Subscription`) |   | ❌  | ❌ 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack