### PR TITLE
Remove create account for an Automotive build

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountActivity.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountActivity.kt
@@ -4,6 +4,7 @@ import android.accounts.AccountAuthenticatorResponse
 import android.accounts.AccountManager.KEY_ACCOUNT_AUTHENTICATOR_RESPONSE
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -55,8 +56,11 @@ class AccountActivity : AppCompatActivity() {
             val graph = navInflater.inflate(R.navigation.account_nav_graph)
             val arguments = Bundle()
 
+            // Temporary workaround that that can be removed after the upgrade to Android 11 in August 2023.
+            val navigateToSignIn = Build.MANUFACTURER.lowercase() == "mercedes-benz" && Build.VERSION.SDK_INT < Build.VERSION_CODES.R
+
             val accountAuthenticatorResponse = IntentCompat.getParcelableExtra(intent, KEY_ACCOUNT_AUTHENTICATOR_RESPONSE, AccountAuthenticatorResponse::class.java)
-            if (accountAuthenticatorResponse != null) {
+            if (accountAuthenticatorResponse != null || navigateToSignIn) {
                 graph.setStartDestination(R.id.signInFragment)
             } else if (isNewUpgradeInstance(intent)) {
                 viewModel.clearReadyForUpgrade()
@@ -71,8 +75,6 @@ class AccountActivity : AppCompatActivity() {
                 viewModel.clearValues()
                 graph.setStartDestination(R.id.accountFragment)
             }
-
-            viewModel.supporterInstance = intent.getBooleanExtra(SUPPORTER_INTENT, false)
 
             navController.setGraph(graph, arguments)
 
@@ -202,7 +204,6 @@ class AccountActivity : AppCompatActivity() {
         private const val IS_PROMO_CODE = "account_activity.is_promo_code"
         const val PROMO_CODE_VALUE = "account_activity.promo_code"
         const val PROMO_CODE_RETURN_DESCRIPTION = "account_activity.promo_code_return_description"
-        const val SUPPORTER_INTENT = "account_activity.supporter"
 
         fun promoCodeInstance(context: Context?, code: String): Intent {
             val intent = Intent(context, AccountActivity::class.java)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountFragment.kt
@@ -9,14 +9,12 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.sp
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
-import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.findNavController
 import au.com.shiftyjelly.pocketcasts.account.databinding.FragmentAccountBinding
 import au.com.shiftyjelly.pocketcasts.account.onboarding.components.ContinueWithGoogleButton
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.AccountFragmentViewModel
-import au.com.shiftyjelly.pocketcasts.account.viewmodel.CreateAccountViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
@@ -44,7 +42,6 @@ class AccountFragment : BaseFragment() {
     }
 
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
-    private val accountViewModel: CreateAccountViewModel by activityViewModels()
 
     private var realBinding: FragmentAccountBinding? = null
     private val binding: FragmentAccountBinding get() = realBinding ?: throw IllegalStateException("Trying to access the binding outside of the view lifecycle.")
@@ -72,9 +69,6 @@ class AccountFragment : BaseFragment() {
                     binding.imgCreateAccount.setup(view.context.getThemeTintedDrawable(IR.drawable.ic_alert_small, UR.attr.support_05))
                     binding.btnCreate.text = getString(LR.string.done)
                     binding.btnCreate.setOnClickListener { activity?.finish() }
-                } else {
-                    val res = if (accountViewModel.supporterInstance) LR.string.profile_supporter_description else LR.string.profile_save_your_podcasts
-                    binding.lblSaveYourPodcasts.setText(res)
                 }
             }
         )
@@ -112,7 +106,7 @@ class AccountFragment : BaseFragment() {
             )
             FirebaseAnalyticsTracker.createAccountClicked()
             if (view.findNavController().currentDestination?.id == R.id.accountFragment) {
-                if (Util.isCarUiMode(view.context) || accountViewModel.supporterInstance) { // We can't sign up to plus on cars so skip that step
+                if (Util.isCarUiMode(view.context)) { // We can't sign up to plus on cars so skip that step
                     view.findNavController().navigate(R.id.action_accountFragment_to_createEmailFragment)
                 } else {
                     view.findNavController().navigate(R.id.action_accountFragment_to_createAccountFragment)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
@@ -39,7 +39,6 @@ class CreateAccountViewModel
     val createAccountState = MutableLiveData<CreateAccountState>().apply { value = CreateAccountState.CurrentlyValid }
     private val disposables = CompositeDisposable()
     var defaultSubscriptionType = SubscriptionType.FREE
-    var supporterInstance = false
 
     @Inject lateinit var subscriptionManager: SubscriptionManager
 

--- a/modules/features/account/src/main/res/layout-car/fragment_account.xml
+++ b/modules/features/account/src/main/res/layout-car/fragment_account.xml
@@ -7,7 +7,7 @@
     android:layout_height="match_parent"
     android:background="?attr/primary_ui_01"
     android:orientation="vertical"
-    tools:context=".account.AccountFragment">
+    tools:context=".AccountFragment">
 
     <ScrollView
         android:layout_width="match_parent"

--- a/modules/features/account/src/main/res/layout/fragment_account.xml
+++ b/modules/features/account/src/main/res/layout/fragment_account.xml
@@ -7,7 +7,7 @@
     android:layout_height="match_parent"
     android:background="?attr/primary_ui_01"
     android:orientation="vertical"
-    tools:context=".account.AccountFragment">
+    tools:context=".AccountFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/modules/services/localization/src/main/res/values-ar/strings.xml
+++ b/modules/services/localization/src/main/res/values-ar/strings.xml
@@ -544,7 +544,6 @@ Language: ar
     <string name="profile_supporter_support_producer">ساعد على دعم هذا المنتج بالتسجيل للوصول إلى هذه التشكيلة</string>
     <string name="profile_supporter_subscribe_all">الاشتراك للجميع</string>
     <string name="profile_supporter_no_podcasts">لم يتم العثور على أي بث صوتي مؤيد</string>
-    <string name="profile_supporter_description">يلزم حساب على Pocket Casts لعرض البث الصوتي المميز. لا تقلق، إنه مجاني ومن السهل إنشاء حساب واحد!</string>
     <string name="profile_supporter_become_a_supporter">كن مؤيدًا</string>
     <string name="profile_subscribed_current_total">%1$d/⁦%2$d⁩ تم الاشتراك</string>
     <string name="profile_sub_web_goto">لإلغاء اشتراكك، سيتعيَّن عليك الإلغاء من خلال Pocketcasts.com.</string>

--- a/modules/services/localization/src/main/res/values-de/strings.xml
+++ b/modules/services/localization/src/main/res/values-de/strings.xml
@@ -856,7 +856,6 @@ Language: de
     <string name="profile_supporter_support_producer">Unterstütze diesen Produzenten, indem du dich für den Zugriff auf diese Sammlung registrierst</string>
     <string name="profile_supporter_subscribe_all">ALLE ABONNIEREN</string>
     <string name="profile_supporter_no_podcasts">Keine Unterstützer-Podcasts gefunden</string>
-    <string name="profile_supporter_description">Zur Anzeige von Premium-Podcasts benötigst du ein Pocket Casts-Konto. Keine Sorge, es ist leicht und kostet nichts, eines zu erstellen!</string>
     <string name="profile_supporter_become_a_supporter">Werde Unterstützer</string>
     <string name="profile_subscribed_current_total">%1$d/%2$d ABONNIERT</string>
     <string name="profile_sub_web_goto">Besuche Pocketcasts.com, um dein Abonnement zu kündigen.</string>

--- a/modules/services/localization/src/main/res/values-en-rGB/strings.xml
+++ b/modules/services/localization/src/main/res/values-en-rGB/strings.xml
@@ -538,7 +538,6 @@ Language: en_GB
     <string name="profile_supporter_support_producer">Help support this producer by signing up for access to this collection</string>
     <string name="profile_supporter_subscribe_all">SUBSCRIBE ALL</string>
     <string name="profile_supporter_no_podcasts">No supporter podcasts found</string>
-    <string name="profile_supporter_description">A Pocket Casts account is required to view premium podcasts. Don\'t worry, it\'s free and easy to create one!</string>
     <string name="profile_supporter_become_a_supporter">Become a supporter</string>
     <string name="profile_subscribed_current_total">%1$d/%2$d SUBSCRIBED</string>
     <string name="profile_sub_web_goto">To cancel your subscription, you’ll need to cancel via Pocketcasts.com.</string>

--- a/modules/services/localization/src/main/res/values-es-rMX/strings.xml
+++ b/modules/services/localization/src/main/res/values-es-rMX/strings.xml
@@ -856,7 +856,6 @@ Language: es
     <string name="profile_supporter_support_producer">Regístrate para ayudar a este productor y acceder a su colección</string>
     <string name="profile_supporter_subscribe_all">SUSCRIBIRSE A TODO</string>
     <string name="profile_supporter_no_podcasts">No se han encontrado podcasts de seguidores</string>
-    <string name="profile_supporter_description">Se necesita una cuenta de Pocket Casts para ver los podcasts premium. No te preocupes, es gratis y muy fácil de crear.</string>
     <string name="profile_supporter_become_a_supporter">Conviértete en seguidor</string>
     <string name="profile_subscribed_current_total">%1$d/%2$d suscriptores</string>
     <string name="profile_sub_web_goto">Para cancelar la suscripción, deberás hacerlo a través de Pocketcasts.com.</string>

--- a/modules/services/localization/src/main/res/values-es/strings.xml
+++ b/modules/services/localization/src/main/res/values-es/strings.xml
@@ -856,7 +856,6 @@ Language: es
     <string name="profile_supporter_support_producer">Regístrate para ayudar a este productor y acceder a su colección</string>
     <string name="profile_supporter_subscribe_all">SUSCRIBIRSE A TODO</string>
     <string name="profile_supporter_no_podcasts">No se han encontrado podcasts de seguidores</string>
-    <string name="profile_supporter_description">Se necesita una cuenta de Pocket Casts para ver los podcasts premium. No te preocupes, es gratis y muy fácil de crear.</string>
     <string name="profile_supporter_become_a_supporter">Conviértete en seguidor</string>
     <string name="profile_subscribed_current_total">%1$d/%2$d suscriptores</string>
     <string name="profile_sub_web_goto">Para cancelar la suscripción, deberás hacerlo a través de Pocketcasts.com.</string>

--- a/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
@@ -856,7 +856,6 @@ Language: fr
     <string name="profile_supporter_support_producer">Soutenez ce producteur en vous inscrivant pour accéder à cette collection</string>
     <string name="profile_supporter_subscribe_all">S’ABONNER À TOUS</string>
     <string name="profile_supporter_no_podcasts">Aucun podcast d’abonné trouvé</string>
-    <string name="profile_supporter_description">Un compte Pocket Casts est obligatoire pour afficher les podcasts premium. Ne vous inquiétez, c’est gratuit et facile d’en créer un !</string>
     <string name="profile_supporter_become_a_supporter">Devenir abonné</string>
     <string name="profile_subscribed_current_total">%1$d/%2$d ABONNÉ</string>
     <string name="profile_sub_web_goto">Pour annuler votre abonnement, connectez-vous sur le site Pocketcasts.com.</string>

--- a/modules/services/localization/src/main/res/values-fr/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr/strings.xml
@@ -856,7 +856,6 @@ Language: fr
     <string name="profile_supporter_support_producer">Soutenez ce producteur en vous inscrivant pour accéder à cette collection</string>
     <string name="profile_supporter_subscribe_all">S’ABONNER À TOUS</string>
     <string name="profile_supporter_no_podcasts">Aucun podcast d’abonné trouvé</string>
-    <string name="profile_supporter_description">Un compte Pocket Casts est obligatoire pour afficher les podcasts premium. Ne vous inquiétez, c’est gratuit et facile d’en créer un !</string>
     <string name="profile_supporter_become_a_supporter">Devenir abonné</string>
     <string name="profile_subscribed_current_total">%1$d/%2$d ABONNÉ</string>
     <string name="profile_sub_web_goto">Pour annuler votre abonnement, connectez-vous sur le site Pocketcasts.com.</string>

--- a/modules/services/localization/src/main/res/values-it/strings.xml
+++ b/modules/services/localization/src/main/res/values-it/strings.xml
@@ -856,7 +856,6 @@ Language: it
     <string name="profile_supporter_support_producer">Aiutaci a supportare questo produttore iscrivendoti per accedere a questa raccolta</string>
     <string name="profile_supporter_subscribe_all">ABBONATI A TUTTO</string>
     <string name="profile_supporter_no_podcasts">Nessun podcast del promotore trovato</string>
-    <string name="profile_supporter_description">Per visualizzare i podcast premium è necessario un account Pocket Casts. Non preoccuparti, crearne uno è facile e gratuito.</string>
     <string name="profile_supporter_become_a_supporter">Diventa un promotore</string>
     <string name="profile_subscribed_current_total">%1$d/%2$d CON ABBONAMENTO</string>
     <string name="profile_sub_web_goto">Per annullare l\'abbonamento, dovrai annullare tramite Pocketcasts.com.</string>

--- a/modules/services/localization/src/main/res/values-ja/strings.xml
+++ b/modules/services/localization/src/main/res/values-ja/strings.xml
@@ -856,7 +856,6 @@ Language: ja_JP
     <string name="profile_supporter_support_producer">このコレクションにアクセスするには、登録してこのプロデューサーのサポートにご参加ください</string>
     <string name="profile_supporter_subscribe_all">すべてに登録</string>
     <string name="profile_supporter_no_podcasts">サポーターポッドキャストが見つかりません</string>
-    <string name="profile_supporter_description">プレミアムポッドキャストを表示するには Pocket Casts アカウントが必要です。 アカウントは無料で簡単に作成できます。</string>
     <string name="profile_supporter_become_a_supporter">サポーターになる</string>
     <string name="profile_subscribed_current_total">%2$d件中%1$d件に登録済み</string>
     <string name="profile_sub_web_goto">サブスクリプションは Pocketcasts.com からキャンセルする必要があります。</string>

--- a/modules/services/localization/src/main/res/values-ko/strings.xml
+++ b/modules/services/localization/src/main/res/values-ko/strings.xml
@@ -856,7 +856,6 @@ Language: ko_KR
     <string name="profile_supporter_support_producer">이 컬렉션에 대한 액세스 권한을 신청하여 이 프로듀서 후원 돕기</string>
     <string name="profile_supporter_subscribe_all">모두 구독</string>
     <string name="profile_supporter_no_podcasts">후원자 팟캐스트를 찾을 수 없음</string>
-    <string name="profile_supporter_description">프리미엄 팟캐스트를 보려면 Pocket Casts 계정이 필요합니다. 걱정하지 마세요. 무료이며 만들기 쉽습니다!</string>
     <string name="profile_supporter_become_a_supporter">후원자 되기</string>
     <string name="profile_subscribed_current_total">%1$d/%2$d개 구독됨</string>
     <string name="profile_sub_web_goto">구독을 취소하려면 Pocketcasts.com을 통해 취소해야 합니다.</string>

--- a/modules/services/localization/src/main/res/values-nb/strings.xml
+++ b/modules/services/localization/src/main/res/values-nb/strings.xml
@@ -540,7 +540,6 @@ Language: nb_NO
     <string name="profile_supporter_support_producer">Bidra til å støtte denne produsenten ved å registrere deg for tilgang til denne samlingen</string>
     <string name="profile_supporter_subscribe_all">ABONNER PÅ ALLE</string>
     <string name="profile_supporter_no_podcasts">Fant ingen podcaster for støttemedlemmer</string>
-    <string name="profile_supporter_description">En Pocket Casts-konto er påkrevd for å vise premium-podcaster. Slapp av, det er gratis og enkelt å opprette en konto!</string>
     <string name="profile_supporter_become_a_supporter">Bli støttemedlem</string>
     <string name="profile_subscribed_current_total">%1$d/%2$d ABONNERT PÅ</string>
     <string name="profile_sub_web_goto">Hvis du vil annullere abonnementet, må du annullere via Pocketcasts.com.</string>

--- a/modules/services/localization/src/main/res/values-nl/strings.xml
+++ b/modules/services/localization/src/main/res/values-nl/strings.xml
@@ -856,7 +856,6 @@ Language: nl
     <string name="profile_supporter_support_producer">Ondersteun deze producer door je aan te melden voor toegang tot deze collectie</string>
     <string name="profile_supporter_subscribe_all">OP ALLES ABONNEREN</string>
     <string name="profile_supporter_no_podcasts">Geen ondersteunerpodcasts gevonden</string>
-    <string name="profile_supporter_description">Je hebt een Pocket Casts-account vereist om premium-podcasts te bekijken. Gen zorgen, het is gratis en eenvoudig aan te maken.</string>
     <string name="profile_supporter_become_a_supporter">Word een ondersteuner</string>
     <string name="profile_subscribed_current_total">%1$d/%2$d GEABONNEERD</string>
     <string name="profile_sub_web_goto">Om je abonnement te annuleren, moet je het annuleren via Pocketcasts.com.</string>

--- a/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
+++ b/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
@@ -856,7 +856,6 @@ Language: pt_BR
     <string name="profile_supporter_support_producer">Assine para ter acesso a esta coleção e apoiar este produtor</string>
     <string name="profile_supporter_subscribe_all">ASSINAR TUDO</string>
     <string name="profile_supporter_no_podcasts">Nenhum podcast de apoiador encontrado</string>
-    <string name="profile_supporter_description">Para ver os podcasts premium é necessário ter uma conta no Pocket Casts. Não se preocupe! A conta é grátis e fácil de criar.</string>
     <string name="profile_supporter_become_a_supporter">Torne-se um apoiador</string>
     <string name="profile_subscribed_current_total">%1$d/%2$d ASSINADO(S)</string>
     <string name="profile_sub_web_goto">Para cancelar sua assinatura, visite Pocketcasts.com.</string>

--- a/modules/services/localization/src/main/res/values-ru/strings.xml
+++ b/modules/services/localization/src/main/res/values-ru/strings.xml
@@ -856,7 +856,6 @@ Language: ru
     <string name="profile_supporter_support_producer">Поддержите этого производителя, подписавшись на эту коллекцию</string>
     <string name="profile_supporter_subscribe_all">ПОДПИСАТЬСЯ НА ВСЁ</string>
     <string name="profile_supporter_no_podcasts">Спонсорские подкасты не найдены</string>
-    <string name="profile_supporter_description">Для просмотра премиум-подкастов требуется учётная запись Pocket Casts. Не переживайте, она бесплатная, и её легко создать!</string>
     <string name="profile_supporter_become_a_supporter">Стать спонсором</string>
     <string name="profile_subscribed_current_total">ПОДПИСАНО %1$d/%2$d</string>
     <string name="profile_sub_web_goto">Чтобы аннулировать подписку, вам нужно отменить ее на сайте Pocketcasts.com.</string>

--- a/modules/services/localization/src/main/res/values-sv/strings.xml
+++ b/modules/services/localization/src/main/res/values-sv/strings.xml
@@ -856,7 +856,6 @@ Language: sv_SE
     <string name="profile_supporter_support_producer">Stöd den här producenten genom att registrera dig för åtkomst till den här samlingen</string>
     <string name="profile_supporter_subscribe_all">PRENUMERERA PÅ ALLA</string>
     <string name="profile_supporter_no_podcasts">Inga supporterpodcasts hittades</string>
-    <string name="profile_supporter_description">Ett Pocket Casts-konto krävs för att se premiumpodcaster. Oroa dig inte, det är gratis och enkelt att skapa ett!</string>
     <string name="profile_supporter_become_a_supporter">Bli supporter</string>
     <string name="profile_subscribed_current_total">%1$d/%2$d PRENUMERATIONER HAR SKAPATS</string>
     <string name="profile_sub_web_goto">Om du vill avsluta din prenumeration måste du göra detta via Pocketcasts.com.</string>

--- a/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
@@ -856,7 +856,6 @@ Language: zh_TW
     <string name="profile_supporter_support_producer">註冊收聽本系列，幫助支持此節目製作人</string>
     <string name="profile_supporter_subscribe_all">全部訂閱</string>
     <string name="profile_supporter_no_podcasts">找不到支持的 Podcast</string>
-    <string name="profile_supporter_description">需要 Pocket Casts 帳號才能查看進階版 Podcast。 別擔心，建立帳號免費又簡單！</string>
     <string name="profile_supporter_become_a_supporter">成為支持者</string>
     <string name="profile_subscribed_current_total">已訂閱 %1$d 個，共 %2$d 個</string>
     <string name="profile_sub_web_goto">若要取消訂閱，請前往 Pocketcasts.com 取消。</string>

--- a/modules/services/localization/src/main/res/values-zh/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh/strings.xml
@@ -856,7 +856,6 @@ Language: zh_CN
     <string name="profile_supporter_support_producer">通过注册访问此库以为制片人提供支持</string>
     <string name="profile_supporter_subscribe_all">全部订阅</string>
     <string name="profile_supporter_no_podcasts">未找到支持者播客</string>
-    <string name="profile_supporter_description">需要 Pocket Casts 账户才能查看优质播客。 不用担心，可轻松免费创建一个！</string>
     <string name="profile_supporter_become_a_supporter">成为支持者</string>
     <string name="profile_subscribed_current_total">已订阅 %1$d/%2$d</string>
     <string name="profile_sub_web_goto">要取消订阅，您将需要通过 Pocketcasts.com 取消。</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -907,7 +907,6 @@
     <string name="profile_sub_web_goto">To cancel your subscription, you&#x2019;ll need to cancel via Pocketcasts.com.</string>
     <string name="profile_subscribed_current_total">%1$d/%2$d SUBSCRIBED</string>
     <string name="profile_supporter_become_a_supporter">Become a supporter</string>
-    <string name="profile_supporter_description">A Pocket Casts account is required to view premium podcasts. Don\'t worry, it\'s free and easy to create one!</string>
     <string name="profile_supporter_error" translatable="false">@string/error</string>
     <string name="profile_supporter_loading" translatable="false">@string/loading</string>
     <string name="profile_supporter_no_podcasts">No supporter podcasts found</string>


### PR DESCRIPTION
## Description

For an version of Android less than 11 it is locking up for an Automotive build after a create account. 

## Testing Instructions

#### Confirm create account exists for a regular build

1. Deploy the Automotive app
2. Tap the settings cog
3. Tap Set up account
4. On the popup dialog tap sign in
5. ✅ Verify you are taken to the Sign in or create account page
6. Tap Create account
7. Enter an email and password. 
8. Tap Create account
9. ✅ Verify you can successfully create an account

#### Confirm create account doesn't exists for certain builds

1. In AccountActivity.kt change it to the following line
```
val navigateToSignIn = true
```
2. Deploy the Automotive app
3. Tap the settings cog
4. Tap Set up account
5. On the popup dialog tap sign in
6. ✅ Verify you are taken to the sign in form with an input box for the email and password
7. Enter existing account details and login
8. ✅ Verify you are logged in successfully

## Screenshots or Screencast 

[Screen_recording_20230622_223645.webm](https://github.com/Automattic/pocket-casts-android/assets/308331/91920f10-c6eb-4dfb-a3cf-c8b9ade7b0bb)

