### PR TITLE
Coroutine Rule Cleanup on Viewmodels

### DIFF
--- a/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
+++ b/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
@@ -1,19 +1,17 @@
 package au.com.shiftyjelly.pocketcasts.endofyear
 
+import au.com.shiftyjelly.pocketcasts.endofyear.utils.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManager
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.Story
 import au.com.shiftyjelly.pocketcasts.utils.FileUtilWrapper
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
@@ -28,16 +26,14 @@ private val story2 = mock<Story>()
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(MockitoJUnitRunner::class)
 class StoriesViewModelTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
     @Mock
     private lateinit var fileUtilWrapper: FileUtilWrapper
 
     @Mock
     private lateinit var endOfYearManager: EndOfYearManager
-
-    @Before
-    fun setUp() {
-        Dispatchers.setMain(UnconfinedTestDispatcher())
-    }
 
     @Test
     fun `when vm starts, then progress is zero`() = runTest {

--- a/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/utils/MainCoroutineRule.kt
+++ b/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/utils/MainCoroutineRule.kt
@@ -1,0 +1,24 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.utils
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@ExperimentalCoroutinesApi
+class MainCoroutineRule(
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModelTest.kt
+++ b/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModelTest.kt
@@ -4,12 +4,11 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
-import kotlinx.coroutines.Dispatchers
+import au.com.shiftyjelly.pocketcasts.search.utils.MainCoroutineRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
@@ -23,6 +22,9 @@ import java.util.UUID
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(MockitoJUnitRunner::class)
 class SearchViewModelTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
     @Mock
     private lateinit var searchHandler: SearchHandler
 
@@ -39,7 +41,6 @@ class SearchViewModelTest {
 
     @Before
     fun setUp() {
-        Dispatchers.setMain(UnconfinedTestDispatcher())
         whenever(searchHandler.searchResults).thenReturn(mock())
         whenever(searchHandler.loading).thenReturn(mock())
         viewModel =

--- a/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/utils/MainCoroutineRule.kt
+++ b/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/utils/MainCoroutineRule.kt
@@ -1,0 +1,24 @@
+package au.com.shiftyjelly.pocketcasts.search.utils
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@ExperimentalCoroutinesApi
+class MainCoroutineRule(
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModelTest.kt
@@ -3,22 +3,23 @@ package au.com.shiftyjelly.pocketcasts.settings.viewmodel
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.settings.viewmodel.utils.MainCoroutineRule
 import dagger.hilt.android.qualifiers.ApplicationContext
 import junit.framework.TestCase
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.setMain
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.mockito.kotlin.times
 import org.mockito.kotlin.whenever
 
 @RunWith(MockitoJUnitRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class AdvancedSettingsViewModelTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
 
     @Mock
     private lateinit var settings: Settings
@@ -31,10 +32,8 @@ class AdvancedSettingsViewModelTest {
     private lateinit var context: Context
     private lateinit var viewModel: AdvancedSettingsViewModel
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Before
     fun setUp() {
-        Dispatchers.setMain(UnconfinedTestDispatcher())
         whenever(settings.syncOnMeteredNetwork()).thenReturn(false)
         viewModel = AdvancedSettingsViewModel(
             settings,

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModelTest.kt
@@ -4,14 +4,13 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.settings.viewmodel.utils.MainCoroutineRule
 import io.reactivex.Flowable
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.setMain
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -21,7 +20,10 @@ import org.mockito.kotlin.whenever
 import java.util.Date
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ManualCleanupViewModelTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
     private lateinit var episodeManager: EpisodeManager
     private lateinit var playbackManager: PlaybackManager
     private lateinit var analyticsTracker: AnalyticsTrackerWrapper
@@ -32,10 +34,8 @@ class ManualCleanupViewModelTest {
     private val diskSpaceView =
         ManualCleanupViewModel.State.DiskSpaceView(title = LR.string.unplayed, episodes = episodes)
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Before
     fun setUp() {
-        Dispatchers.setMain(UnconfinedTestDispatcher())
         episodeManager = mock()
         playbackManager = mock()
         analyticsTracker = mock()

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModelTest.kt
@@ -7,19 +7,18 @@ import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
 import au.com.shiftyjelly.pocketcasts.repositories.file.FolderLocation
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.settings.viewmodel.utils.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.utils.FileUtilWrapper
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.Flowable
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -37,7 +36,11 @@ private const val CUSTOM_FOLDER_NEW_PATH = "custom_folder_new_path"
 private const val CUSTOM_FOLDER_NEW_LABEL = "CustomFolderNew"
 
 @RunWith(MockitoJUnitRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class StorageSettingsViewModelTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
     @Mock
     private lateinit var podcastManager: PodcastManager
 
@@ -65,10 +68,8 @@ class StorageSettingsViewModelTest {
     @JvmField
     val temporaryFolder = TemporaryFolder()
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Before
     fun setUp() {
-        Dispatchers.setMain(UnconfinedTestDispatcher())
         whenever(context.getString(any())).thenReturn("")
         whenever(context.getString(any(), any())).thenReturn("")
         whenever(settings.getStorageChoiceName()).thenReturn("")

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/utils/MainCoroutineRule.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/utils/MainCoroutineRule.kt
@@ -1,0 +1,24 @@
+package au.com.shiftyjelly.pocketcasts.settings.viewmodel.utils
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@ExperimentalCoroutinesApi
+class MainCoroutineRule(
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
## Description
This PR cleans up main coroutine rule on the AdvancedSettingsViewmodel, StoriesViewmodel, ManualCleanupViewmodel, StorageSettingsViewModel, AdvancedSettingsViewModel and SearchViewModelViewModel Tests. 

Fixes # N/A

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
