### PR TITLE
Prevent percent value of Nan

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
@@ -60,7 +60,11 @@ class NowPlayingViewModel @Inject constructor(
             } else {
 
                 val trackPositionUiModel = TrackPositionUiModel.Actual(
-                    percent = with(playbackState) { positionMs.toFloat() / durationMs },
+                    percent = with(playbackState) {
+                        if (durationMs != 0) {
+                            positionMs.toFloat() / durationMs
+                        } else 0f
+                    },
                     duration = playbackState.durationMs.toDuration(DurationUnit.MILLISECONDS),
                     position = playbackState.positionMs.toDuration(DurationUnit.MILLISECONDS),
                     shouldAnimate = true


### PR DESCRIPTION
## Description
I got my account to a state where I had a podcast reporting a duration of 0. Because we were dividing by the duration, that was giving use a `Nan` result, which was causing this crash within horologist on the 7.41 release branch:

```
java.lang.IllegalArgumentException: current must not be NaN
at androidx.compose.ui.semantics.ProgressBarRangeInfo.<init>(SemanticsProperties.kt:499)
at androidx.compose.foundation.ProgressSemanticsKt$progressSemantics$1.invoke(ProgressSemantics.kt:52)
at androidx.compose.foundation.ProgressSemanticsKt$progressSemantics$1.invoke(ProgressSemantics.kt:50)
at androidx.compose.ui.semantics.AppendedSemanticsModifierNodeElement.<init>(SemanticsModifier.kt:125)
at androidx.compose.ui.semantics.SemanticsModifierKt.semantics(SemanticsModifier.kt:109)
at androidx.compose.foundation.ProgressSemanticsKt.progressSemantics(ProgressSemantics.kt:50)
at androidx.compose.foundation.ProgressSemanticsKt.progressSemantics$default(ProgressSemantics.kt:41)
at androidx.wear.compose.material.ProgressIndicatorKt.CircularProgressIndicator-xWeB9-s(ProgressIndicator.kt:96)
at au.com.shiftyjelly.pocketcasts.wear.ui.component.horologist.PlayPauseProgressButtonStyledKt$PlayPauseProgressButtonStyled$1.invoke(PlayPauseProgressButtonStyled.kt:63)
at au.com.shiftyjelly.pocketcasts.wear.ui.component.horologist.PlayPauseProgressButtonStyledKt$PlayPauseProgressButtonStyled$1.invoke(PlayPauseProgressButtonStyled.kt:52)
```

Fortunately this crash is not happening on the `main` branch. I suspect the updated version of horologist on that branch avoids the crash as a result of this PR: https://github.com/google/horologist/pull/1317. Even though this isn't a crash on `main`, it seems like it's worth avoiding setting a percent value of `Nan` to avoid any potential future problems.

## Testing Instructions
On the  Now Playing screen use the skip buttons to skip around the beginning of an episode some. I also tested this while hardcoding the durationMs to be `0`, but I don't think that's really needed unless you want to.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`