### PR TITLE
Update account details upgrade button title

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -141,7 +141,16 @@ private fun FeatureCard(
         Spacer(modifier = Modifier.weight(1f))
         Spacer(modifier = Modifier.height(8.dp))
 
-        val primaryText = stringResource(LR.string.upgrade_to, stringResource(button.shortNameRes))
+        val primaryText = when (button.planType) {
+            UpgradeButton.PlanType.RENEW -> stringResource(LR.string.renew_your_subscription)
+            UpgradeButton.PlanType.SUBSCRIBE -> {
+                when (button.subscription) {
+                    is Subscription.Simple -> stringResource(LR.string.subscribe_to, stringResource(button.shortNameRes))
+                    is Subscription.WithTrial -> stringResource(LR.string.trial_start)
+                }
+            }
+            UpgradeButton.PlanType.UPGRADE -> stringResource(LR.string.upgrade_to, stringResource(button.shortNameRes))
+        }
         OnboardingUpgradeHelper.UpgradeRowButton(
             primaryText = primaryText,
             backgroundColor = colorResource(button.backgroundColorRes),

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeButton.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeButton.kt
@@ -11,28 +11,37 @@ sealed class UpgradeButton(
     @ColorRes val backgroundColorRes: Int,
     @ColorRes val textColorRes: Int,
     open val subscription: Subscription,
+    open val planType: PlanType,
 ) {
     data class Plus(
         override val subscription: Subscription,
+        override val planType: PlanType,
     ) : UpgradeButton(
         shortNameRes = LR.string.pocket_casts_plus_short,
         backgroundColorRes = UR.color.plus_gold,
         textColorRes = UR.color.black,
         subscription = subscription,
+        planType = planType,
     )
 
     data class Patron(
         override val subscription: Subscription,
+        override val planType: PlanType,
     ) : UpgradeButton(
         shortNameRes = LR.string.pocket_casts_patron_short,
         backgroundColorRes = UR.color.patron_purple,
         textColorRes = UR.color.white,
         subscription = subscription,
+        planType = planType,
     )
+
+    enum class PlanType { RENEW, SUBSCRIBE, UPGRADE }
 }
 
-fun Subscription.toUpgradeButton() = when (this.tier) {
-    Subscription.SubscriptionTier.PLUS -> UpgradeButton.Plus(this)
-    Subscription.SubscriptionTier.PATRON -> UpgradeButton.Patron(this)
+fun Subscription.toUpgradeButton(
+    planType: UpgradeButton.PlanType = UpgradeButton.PlanType.SUBSCRIBE,
+) = when (this.tier) {
+    Subscription.SubscriptionTier.PLUS -> UpgradeButton.Plus(this, planType)
+    Subscription.SubscriptionTier.PATRON -> UpgradeButton.Patron(this, planType)
     Subscription.SubscriptionTier.UNKNOWN -> throw IllegalStateException("Unknown subscription tier")
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
@@ -5,14 +5,17 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.FeatureCardsState
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.UpgradeButton
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.UpgradeButton.PlanType
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.UpgradeFeatureCard
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.toUpgradeButton
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.toUpgradeFeatureCard
 import au.com.shiftyjelly.pocketcasts.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
@@ -38,7 +41,7 @@ class ProfileUpgradeBannerViewModel @Inject constructor(
         ) : State()
 
         data class OldLoaded(
-            val numPeriodFree: String?
+            val numPeriodFree: String?,
         ) : State()
 
         object Loading : State()
@@ -53,6 +56,7 @@ class ProfileUpgradeBannerViewModel @Inject constructor(
                 .observeProductDetails()
                 .asFlow()
                 .collect { productDetailsState ->
+                    // Map product details to subscriptions
                     val subscriptions = (productDetailsState as? ProductDetailsState.Loaded)
                         ?.productDetails
                         ?.mapNotNull { details ->
@@ -64,22 +68,46 @@ class ProfileUpgradeBannerViewModel @Inject constructor(
                                 isFreeTrialEligible = isFreeTrialEligible
                             )
                         } ?: emptyList()
-                    val defaultSubscription = subscriptionManager.getDefaultSubscription(subscriptions)
+
+                    // Get user's subscription status from cache
+                    val cachedSubscriptionStatus = subscriptionManager.getCachedStatus()
+
+                    // If the user is a patron, only show the patron subscription
+                    val cachedTier = (cachedSubscriptionStatus as? SubscriptionStatus.Paid)?.tier
+                    val filteredSubscriptions = if (cachedTier == SubscriptionTier.PATRON) {
+                        subscriptions.filter { it.tier == Subscription.SubscriptionTier.PATRON }
+                    } else {
+                        subscriptions
+                    }
+                    val defaultSubscription = getDefaultSubscription(
+                        filteredSubscriptions = filteredSubscriptions,
+                        cachedTier = cachedTier,
+                        cachedSubscriptionStatus = cachedSubscriptionStatus,
+                    )
+
                     if (FeatureFlag.isEnabled(Feature.ADD_PATRON_ENABLED)) {
                         defaultSubscription?.let {
-                            val upgradeButtons = subscriptions.map { it.tier }
-                                .mapNotNull { tier ->
+                            val upgradeButtons = filteredSubscriptions.map { it.tier }
+                                .mapNotNull { productTier ->
                                     subscriptionManager.getDefaultSubscription(
-                                        subscriptions = subscriptions,
-                                        tier = tier,
-                                        frequency = SubscriptionFrequency.YEARLY
-                                    )?.toUpgradeButton()
+                                        subscriptions = filteredSubscriptions,
+                                        tier = productTier,
+                                        frequency = getSubscriptionFrequency(cachedSubscriptionStatus)
+                                    )?.toUpgradeButton(
+                                        planType = getPlanType(
+                                            productTier = productTier,
+                                            cachedTier = cachedTier,
+                                            cachedSubscriptionStatus = cachedSubscriptionStatus,
+                                        )
+                                    )
                                 }
 
-                            val currentTier = SubscriptionMapper.mapProductIdToTier(defaultSubscription.productDetails.productId)
+                            val currentTier = SubscriptionMapper
+                                .mapProductIdToTier(defaultSubscription.productDetails.productId)
+
                             _state.value = State.Loaded(
                                 featureCardsState = FeatureCardsState(
-                                    subscriptions = subscriptions,
+                                    subscriptions = filteredSubscriptions,
                                     currentFeatureCard = currentTier.toUpgradeFeatureCard()
                                 ),
                                 upgradeButtons = upgradeButtons
@@ -103,6 +131,52 @@ class ProfileUpgradeBannerViewModel @Inject constructor(
         (_state.value as? State.Loaded)?.let {
             settings.setLastSelectedSubscriptionFrequency(SubscriptionFrequency.YEARLY)
             settings.setLastSelectedSubscriptionTier(upgradeFeatureCard.subscriptionTier)
+        }
+    }
+
+    private fun getDefaultSubscription(
+        filteredSubscriptions: List<Subscription>,
+        cachedTier: SubscriptionTier?,
+        cachedSubscriptionStatus: SubscriptionStatus?,
+    ) = subscriptionManager.getDefaultSubscription(
+        subscriptions = filteredSubscriptions,
+        tier = if (cachedTier == SubscriptionTier.PATRON) {
+            Subscription.SubscriptionTier.PATRON
+        } else {
+            Subscription.SubscriptionTier.PLUS
+        },
+        frequency = getSubscriptionFrequency(cachedSubscriptionStatus)
+    )
+
+    private fun getSubscriptionFrequency(cachedSubscriptionStatus: SubscriptionStatus?) =
+        if (cachedSubscriptionStatus is SubscriptionStatus.Paid) {
+            when (cachedSubscriptionStatus.frequency) {
+                SubscriptionFrequency.NONE -> SubscriptionFrequency.YEARLY
+                SubscriptionFrequency.MONTHLY -> SubscriptionFrequency.MONTHLY
+                SubscriptionFrequency.YEARLY -> SubscriptionFrequency.YEARLY
+            }
+        } else {
+            SubscriptionFrequency.YEARLY
+        }
+
+    private fun getPlanType(
+        productTier: Subscription.SubscriptionTier,
+        cachedTier: SubscriptionTier?,
+        cachedSubscriptionStatus: SubscriptionStatus?,
+    ): PlanType {
+        val productTierMatchesUserSubscriptionTier =
+            productTier.name.lowercase() == cachedTier?.label?.lowercase()
+        val isExpiring = if (productTierMatchesUserSubscriptionTier) {
+            (cachedSubscriptionStatus as? SubscriptionStatus.Paid)?.isExpiring ?: false
+        } else {
+            false
+        }
+        return when {
+            isExpiring -> PlanType.RENEW
+            cachedSubscriptionStatus is SubscriptionStatus.Paid &&
+                cachedTier == SubscriptionTier.PLUS &&
+                productTier == Subscription.SubscriptionTier.PATRON -> PlanType.UPGRADE
+            else -> PlanType.SUBSCRIBE
         }
     }
 }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -44,12 +44,10 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.Util
-import au.com.shiftyjelly.pocketcasts.utils.days
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
-import java.util.Date
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.cartheme.R as CR
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -112,8 +110,7 @@ class AccountDetailsFragment : BaseFragment() {
             var giftExpiring = false
             (signInState as? SignInState.SignedIn)?.subscriptionStatus?.let { status ->
                 val subscriptionStatus = status as? SubscriptionStatus.Paid ?: return@let
-                val daysLessThan30 = subscriptionStatus.expiry.before(Date(Date().time + 30.days()))
-                giftExpiring = (daysLessThan30 && !status.autoRenew)
+                giftExpiring = subscriptionStatus.isExpiring
             }
 
             binding.cancelViewGroup?.isVisible = signInState.isSignedInAsPaid

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -116,6 +116,7 @@ class AccountDetailsFragment : BaseFragment() {
             binding.cancelViewGroup?.isVisible = signInState.isSignedInAsPaid
             binding.btnCancelSub?.isVisible = signInState.isSignedInAsPaid
             binding.upgradeAccountGroup?.isVisible = signInState.isSignedInAsPlus &&
+                !giftExpiring &&
                 FeatureFlag.isEnabled(Feature.ADD_PATRON_ENABLED)
 
             binding.userUpgradeComposeView?.apply {

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -91,6 +92,8 @@ fun HorizontalPagerWrapper(
                 pagerState = pagerState,
                 color = pageIndicatorColor,
             )
+        } else {
+            Spacer(modifier = Modifier.height(16.dp))
         }
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="play_on">Play on&#8230;</string>
     <string name="played">Played</string>
     <string name="remove_from_up_next">Remove from Up Next</string>
+    <string name="renew_your_subscription">Renew your Subscription</string>
     <string name="removed">Removed</string>
     <string name="search">Search</string>
     <string name="selected">Selected</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SubscriptionStatus.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SubscriptionStatus.kt
@@ -4,6 +4,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
+import au.com.shiftyjelly.pocketcasts.utils.days
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import java.util.Date
@@ -31,7 +32,10 @@ sealed class SubscriptionStatus(val expiryDate: Date?, val subscriptions: List<S
         @field:Json(name = "type") val type: SubscriptionType,
         @field:Json(name = "tier") val tier: SubscriptionTier,
         @field:Json(name = "index") val index: Int
-    ) : SubscriptionStatus(expiry, subscriptionList)
+    ) : SubscriptionStatus(expiry, subscriptionList) {
+        val isExpiring: Boolean
+            get() = expiry.before(Date(Date().time + 30.days())) && !autoRenew
+    }
 
     @JsonClass(generateAdapter = true)
     data class Subscription(


### PR DESCRIPTION
## Description

This updates account details upgrade view as described in testing steps

## Testing Instructions

Prerequisite

- Debug build variant (tier is only available in debug env)
- Changes for debug build variant (see bottom section in pdeCcb-12K-p2)
- Three accounts 
    - `Free`
    - `Plus` (Expiring - expiry < 30 days)
    - `Patron` (Expiring - expiry < 30 days) (`ashita.agrawal+patron@automattic.com` is set for this)
- Enable `Patron` feature flag and restart the app

#### Test.1 Free account

1. Login with a `Free` account
2. Go to `Profile` -> `Account` screen
3. Notice that upgrade view is shown and upgrade button title is set to 
     -  `Subscribe to <plan name>` (if plan has no free trial)
     -  `Start my free trial` (if plan has free trial & user is eligible for free trial)

Start free trial | Subscribe
----|----
<img src="https://github.com/Automattic/pocket-casts-android/assets/1405144/cd89f38d-999c-4385-971f-80e0c5eb63f0" width=150/>| <img src="https://github.com/Automattic/pocket-casts-android/assets/1405144/f7ddf46b-7b58-437c-9e43-8f34c016599b" width=150/>

#### Test.2 Plus expiring account
1. Login with a `Plus` expiring account
2. Go to `Profile` -> `Account` screen
3. Notice that upgrade view is shown and upgrade button title is set to 
     -  `Renew your Subscription` (for `Plus` cardl)
     -  `Upgrade to Patron` (for `Patron` card)

`Plus` cardl | `Patron` card
----|----
<img src="https://github.com/Automattic/pocket-casts-android/assets/1405144/1aac4f57-ab12-4a44-a8d1-5dc6ae9f3268" width=150/>| <img src="https://github.com/Automattic/pocket-casts-android/assets/1405144/92d09dd4-86f8-47cb-bdff-240cc7e6ac2e" width=150/>


#### Test.3 Patron expiring account
1. Login with a `Patron` expiring account
2. Go to `Profile` -> `Account` screen
3. Notice that upgrade view is shown and upgrade button title is set to 
     -  `Renew your Subscription` (for `Patron` cardl)
4. `Plus` card is not shown


|`Patron` card|
|----|
<img src="https://github.com/Automattic/pocket-casts-android/assets/1405144/196c2e1a-aa18-4e98-a7b6-5c93a0912a79" width=150/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
