### PR TITLE
Disable patron feature flag

### DIFF
--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/FeatureProvider.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/FeatureProvider.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.featureflag
 
 /**
- * Every provider has an explicit priority so they can override each other (e.g. "Firebase Remote" > Store).
+ * Every provider has an explicit priority so they can override each other (e.g. "Firebase Remote" > "Default Release").
  *
  * Not every provider has to provide a flag value for every feature.
  * E.g. Unless you want the feature flag to be remote, feature should not be provided by the remote feature flag provider and hasFeature should return false for that feature

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/DefaultReleaseFeatureProvider.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/DefaultReleaseFeatureProvider.kt
@@ -20,7 +20,8 @@ class DefaultReleaseFeatureProvider @Inject constructor() : FeatureProvider {
     override fun isEnabled(feature: Feature) =
         when (feature) {
             Feature.END_OF_YEAR_ENABLED,
-            Feature.SHOW_RATINGS_ENABLED -> false
-            Feature.ADD_PATRON_ENABLED -> true
+            Feature.SHOW_RATINGS_ENABLED,
+            Feature.ADD_PATRON_ENABLED,
+            -> false
         }
 }

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/PreferencesFeatureProvider.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/PreferencesFeatureProvider.kt
@@ -10,7 +10,7 @@ import javax.inject.Singleton
 
 /**
  * Used to override values for feature flags at runtime in debug builds.
- * See StoreFeatureFlagProvider to set feature flag values for release builds.
+ * See DefaultReleaseFeatureProvider to set feature flag values for release builds.
  */
 @Singleton
 class PreferencesFeatureProvider @Inject constructor(


### PR DESCRIPTION
## Description

This disables patron feature flag that got enabled while testing [here](https://github.com/Automattic/pocket-casts-android/blob/1f51ab37aae98e7aa592c6ad87dae71c86f84198/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/DefaultReleaseFeatureProvider.kt#L23-L24). 

## Testing Instructions
Make sure that the default release feature provider has all features set to false.
