### PR TITLE
Add auto play up next setting

### DIFF
--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
@@ -102,9 +102,6 @@ class AutomotiveApplication : Application(), Configuration.Provider {
         if (!settings.contains(Settings.PREFERENCE_AUTO_SUBSCRIBE_ON_PLAY)) {
             settings.setBooleanForKey(Settings.PREFERENCE_AUTO_SUBSCRIBE_ON_PLAY, true)
         }
-        if (!settings.contains(Settings.PREFERENCE_AUTO_PLAY_ON_EMPTY)) {
-            settings.setBooleanForKey(Settings.PREFERENCE_AUTO_PLAY_ON_EMPTY, true)
-        }
     }
 
     private fun setupSentry() {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -47,6 +47,8 @@ import au.com.shiftyjelly.pocketcasts.compose.components.SettingRow
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRowToggle
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingSection
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -271,6 +273,19 @@ class PlaybackSettingsFragment : BaseFragment() {
                             settings.setTapOnUpNextShouldPlay(it)
                         }
                     )
+
+                    if (FeatureFlag.isEnabled(Feature.AUTO_PLAY_UP_NEXT_SETTING)) {
+                        AutoPlayNextOnEmpty(
+                            saved = settings.autoPlayNextEpisodeOnEmptyFlow.collectAsState().value,
+                            onSave = {
+                                analyticsTracker.track(
+                                    AnalyticsEvent.SETTINGS_GENERAL_CONTINUOUS_PLAYBACK_TOGGLED,
+                                    mapOf("enabled" to it)
+                                )
+                                settings.setAutoPlayNextEpisodeOnEmpty(it)
+                            }
+                        )
+                    }
                 }
             }
         }
@@ -501,6 +516,15 @@ class PlaybackSettingsFragment : BaseFragment() {
         SettingRow(
             primaryText = stringResource(LR.string.settings_up_next_tap),
             secondaryText = stringResource(LR.string.settings_up_next_tap_summary),
+            toggle = SettingRowToggle.Switch(checked = saved),
+            modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) }
+        )
+
+    @Composable
+    private fun AutoPlayNextOnEmpty(saved: Boolean, onSave: (Boolean) -> Unit) =
+        SettingRow(
+            primaryText = stringResource(LR.string.settings_continuous_playback),
+            secondaryText = stringResource(LR.string.settings_continuous_playback_summary),
             toggle = SettingRowToggle.Switch(checked = saved),
             modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) }
         )

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -476,6 +476,7 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_SHOWN("settings_general_media_notification_controls_shown"),
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_SHOW_CUSTOM_TOGGLED("settings_general_media_notification_controls_show_custom_toggled"),
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_ORDER_CHANGED("settings_general_media_notification_controls_order_changed"),
+    SETTINGS_GENERAL_CONTINUOUS_PLAYBACK_TOGGLED("settings_general_continuous_playback_toggled"),
 
     /* Settings - Help */
     SETTINGS_HELP_SHOWN("settings_help_shown"),

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/Feature.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/Feature.kt
@@ -20,4 +20,9 @@ enum class Feature(
         title = "Patron",
         defaultValue = false
     ),
+    AUTO_PLAY_UP_NEXT_SETTING(
+        key = "auto_play_when_up_next_empty",
+        title = "Auto Play When Up Next Empty Setting",
+        defaultValue = BuildConfig.DEBUG,
+    ),
 }

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/DefaultReleaseFeatureProvider.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/DefaultReleaseFeatureProvider.kt
@@ -22,6 +22,7 @@ class DefaultReleaseFeatureProvider @Inject constructor() : FeatureProvider {
             Feature.END_OF_YEAR_ENABLED,
             Feature.SHOW_RATINGS_ENABLED,
             Feature.ADD_PATRON_ENABLED,
+            Feature.AUTO_PLAY_UP_NEXT_SETTING,
             -> false
         }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1208,6 +1208,8 @@
     <string name="settings_up_next_swipe_summary">When swiping from left to right on an episode, the default action will be %s.</string>
     <string name="settings_up_next_tap">Play Up Next episode on tap</string>
     <string name="settings_up_next_tap_summary">If on, tapping on an item in your Up Next queue will play it. Long pressing will show the episode options.</string>
+    <string name="settings_continuous_playback">Continuous playback</string>
+    <string name="settings_continuous_playback_summary">If your Up Next queue is empty, we\'ll play episodes from the same podcast or list you\'re currently listening to.</string>
     <string name="settings_use_android_light_dark_mode">Use Android Light/Dark Mode</string>
     <string name="settings_use_embedded_podcast_artwork">Use embedded podcast artwork</string>
     <string name="settings_version">Version %1$s (%2$s)</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -306,6 +306,7 @@ interface Settings {
     val openPlayerAutomaticallyFlow: StateFlow<Boolean>
     val tapOnUpNextShouldPlayFlow: StateFlow<Boolean>
     val customMediaActionsVisibilityFlow: StateFlow<Boolean>
+    val autoPlayNextEpisodeOnEmptyFlow: StateFlow<Boolean>
 
     fun getVersion(): String
     fun getVersionCode(): Int
@@ -554,6 +555,7 @@ interface Settings {
     fun getAutoSubscribeToPlayed(): Boolean
     fun getAutoShowPlayed(): Boolean
     fun getAutoPlayNextEpisodeOnEmpty(): Boolean
+    fun setAutoPlayNextEpisodeOnEmpty(enabled: Boolean)
     fun defaultShowArchived(): Boolean
     fun setDefaultShowArchived(value: Boolean)
     fun getMediaNotificationControlItems(): List<MediaNotificationControls>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -25,6 +25,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.SETTINGS_EN
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationControls
 import au.com.shiftyjelly.pocketcasts.preferences.di.PrivateSharedPreferences
 import au.com.shiftyjelly.pocketcasts.preferences.di.PublicSharedPreferences
+import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.config.FirebaseConfig
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isScreenReaderOn
@@ -98,6 +99,7 @@ class SettingsImpl @Inject constructor(
     override val intelligentPlaybackResumptionFlow = MutableStateFlow(getIntelligentPlaybackResumption())
     override val tapOnUpNextShouldPlayFlow = MutableStateFlow(getTapOnUpNextShouldPlay())
     override val customMediaActionsVisibilityFlow = MutableStateFlow(areCustomMediaActionsVisible())
+    override val autoPlayNextEpisodeOnEmptyFlow = MutableStateFlow(getAutoPlayNextEpisodeOnEmpty())
 
     override val refreshStateObservable = BehaviorRelay.create<RefreshState>().apply {
         val lastError = getLastRefreshError()
@@ -999,7 +1001,17 @@ class SettingsImpl @Inject constructor(
     }
 
     override fun getAutoPlayNextEpisodeOnEmpty(): Boolean {
-        return getBoolean(Settings.PREFERENCE_AUTO_PLAY_ON_EMPTY, false)
+        val defaultValue = when (Util.getAppPlatform(context)) {
+            AppPlatform.Automotive -> true
+            AppPlatform.Phone -> true
+            AppPlatform.WearOs -> false
+        }
+        return getBoolean(Settings.PREFERENCE_AUTO_PLAY_ON_EMPTY, defaultValue)
+    }
+
+    override fun setAutoPlayNextEpisodeOnEmpty(enabled: Boolean) {
+        setBoolean(Settings.PREFERENCE_AUTO_PLAY_ON_EMPTY, enabled)
+        autoPlayNextEpisodeOnEmptyFlow.update { enabled }
     }
 
     override fun getAutoArchiveIncludeStarred(): Boolean {


### PR DESCRIPTION
## Description
This adds a setting for auto playing up next to the phone app. No functionality beyond just adding a setting for this is added in this PR—that will be handled in follow-up PRs.

## Testing Instructions
- On debug builds, verify that when the "Auto Play When Up Next Empty Setting" beta toggle is off, the "Continuous playback" setting is not present at the bottom of the "General" settings, and that the setting is present when the toggle is on.
    - Verify that both settings persist after the app has been killed and restarted
- Verify that flipping the continuous playback toggle fires off the `settings_general_continuous_playback_toggled` event with the appropriate "enabled" boolean property.
- On a release build, verify that the "Continuous playback" setting is not present at the bottom of the "General" settings
- On an automotive build, verify that auto play continues to default to `true` by checking the settings in the automotive app.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews