### PR TITLE
Upgrade subscription from Plus to Patron

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -29,7 +29,7 @@ interface SubscriptionManager {
     suspend fun sendPurchaseToServer(purchase: Purchase)
     fun refreshPurchases()
     suspend fun getPurchases(): PurchasesResult?
-    fun launchBillingFlow(activity: Activity, productDetails: ProductDetails, offerToken: String): BillingResult?
+    fun launchBillingFlow(activity: Activity, productDetails: ProductDetails, offerToken: String)
     fun getCachedStatus(): SubscriptionStatus?
     fun clearCachedStatus()
     fun isFreeTrialEligible(tier: Subscription.SubscriptionTier): Boolean


### PR DESCRIPTION
## Description

This applies recommended proration rate on upgrading to a more expensive plan through Play Store.

## Testing Instructions

Prerequisites: 
- In-app billing sandbox setup
- Release build variant
- License test account
- Feature flag enabled for the release build variant

`Plus` monthly plan
1. Fresh install the release build
2. Login with a `Free` account and purchase a `Plus` monthly plan
3. Tap `Upgrade to Patron` from `Profile` -> `Account` details screen
4. Choose a `Patron` plan (monthly or yearly)
5. Complete payment flow
6. Notice that recommended proration rate is applied 

`Plus` yearly plan
1. Repeat above steps for the `Plus` yearly plan
2. Notice that recommended proration rate is applied 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
