### PR TITLE
Add more debugging to catch show notes task null pointer

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateShowNotesTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateShowNotesTask.kt
@@ -5,10 +5,15 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.servers.ServerShowNotesManager
+import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import timber.log.Timber
+import retrofit2.HttpException
 
+/**
+ * Try to cache the show notes so they can be viewed offline. This task happens when the user downloads an episode.
+ */
 @HiltWorker
 class UpdateShowNotesTask @AssistedInject constructor(
     @Assisted context: Context,
@@ -20,16 +25,20 @@ class UpdateShowNotesTask @AssistedInject constructor(
         const val INPUT_EPISODE_UUID = "episode_uuid"
     }
 
-    private val podcastUuid = inputData.getString(INPUT_PODCAST_UUID)!!
-    private val episodeUuid = inputData.getString(INPUT_EPISODE_UUID)!!
+    private val podcastUuid = inputData.getString(INPUT_PODCAST_UUID) ?: ""
+    private val episodeUuid = inputData.getString(INPUT_EPISODE_UUID) ?: ""
 
     override suspend fun doWork(): Result {
         return try {
             showNotesManager.downloadShowNotes(podcastUuid = podcastUuid, episodeUuid = episodeUuid)
             Result.success()
         } catch (e: Exception) {
-            Timber.e(e)
-            Result.failure()
+            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, e, "Failed to update show notes")
+            if (e !is HttpException) {
+                SentryHelper.recordException(e)
+            }
+            // Don't keep retrying if the download fails. The user can download the show notes when viewing them.
+            Result.success()
         }
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerShowNotesManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerShowNotesManager.kt
@@ -80,6 +80,9 @@ class ServerShowNotesManager @Inject constructor(
     }
 
     suspend fun downloadShowNotes(podcastUuid: String, episodeUuid: String): String? {
+        if (podcastUuid.isBlank() || episodeUuid.isBlank()) {
+            return null
+        }
         val response = podcastCacheServerManager.getShowNotes(podcastUuid = podcastUuid)
         return response.findEpisode(episodeUuid)?.showNotes
     }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
@@ -4,6 +4,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.servers.di.PodcastCacheServerRetrofit
 import au.com.shiftyjelly.pocketcasts.servers.discover.EpisodeSearch
 import io.reactivex.Single
+import retrofit2.HttpException
 import retrofit2.Response
 import retrofit2.Retrofit
 import timber.log.Timber
@@ -47,8 +48,11 @@ class PodcastCacheServerManagerImpl @Inject constructor(@PodcastCacheServerRetro
         return try {
             server.getShowNotesCache(podcastUuid)
         } catch (e: Exception) {
+            // if the cache can't be found a HTTP 504 Unsatisfiable Request will be thrown
+            if (e !is HttpException) {
+                Timber.e(e)
+            }
             // ignore the error when the cache is empty
-            Timber.e(e)
             null
         }
     }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/ShowNotesResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/ShowNotesResponse.kt
@@ -5,21 +5,21 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class ShowNotesResponse(
-    @field:Json(name = "podcast") val podcast: ShowNotesPodcast
+    @field:Json(name = "podcast") val podcast: ShowNotesPodcast?
 ) {
     fun findEpisode(episodeUuid: String): ShowNotesEpisode? {
-        return podcast.episodes.find { it.uuid == episodeUuid }
+        return podcast?.episodes?.find { it.uuid == episodeUuid }
     }
 }
 
 @JsonClass(generateAdapter = true)
 data class ShowNotesPodcast(
     @field:Json(name = "uuid") val uuid: String,
-    @field:Json(name = "episodes") val episodes: List<ShowNotesEpisode>
+    @field:Json(name = "episodes") val episodes: List<ShowNotesEpisode>?
 )
 
 @JsonClass(generateAdapter = true)
 data class ShowNotesEpisode(
     @field:Json(name = "uuid") val uuid: String,
-    @field:Json(name = "show_notes") val showNotes: String
+    @field:Json(name = "show_notes") val showNotes: String?
 )


### PR DESCRIPTION
## Description

There is an exception happening in Sentry.

```
NullPointerException
au.com.shiftyjelly.pocketcasts.repositories.download.task.UpdateShowNotesTask in <init> at line 33
```

I haven't been unable to figure out the issue. Initially, I thought it might be happening with a user file as they don't have a podcast UUID but there is an if statement to check this before creating the job.

This change adds some more debugging and reduces the chance of a null pointer happening.

## Testing Instructions
1. Open a podcast page you haven't downloaded show notes for
2. Swipe the notification shade down
3. Tap the Internet control and turn off WiFi and mobile data
4. Close the notification shade
5. Tap an episode row, the show notes shouldn't load if the internet is disabled
6. Enable the internet again
7. Tap download on the episode and wait for it to finish
8. Disable the internet again
9. Close the episode dialog
10. Open the episode dialog
11. ✅ Verify the show notes load offline
