### PR TITLE
Add intent for opml import from share sheet

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,6 +85,13 @@
                         android:mimeType="text/xml"
                         android:scheme="content"/>
             </intent-filter>
+             <!-- allows opml import from share sheet-->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="text/x-opml"/>
+                <data android:mimeType="application/octet-stream"/>
+            </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.content.ContextCompat
+import androidx.core.content.IntentCompat
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
@@ -1147,6 +1148,12 @@ class MainActivity :
                     val uri = intent.data ?: return
                     OpmlImportTask.run(uri, this)
                 }
+            } else if (action == Intent.ACTION_SEND &&
+                intent.type in listOf("text/x-opml", "application/octet-stream")
+            ) {
+                // Import opml from share sheet
+                val uri = IntentCompat.getParcelableExtra(intent, Intent.EXTRA_STREAM, Uri::class.java) ?: return
+                OpmlImportTask.run(uri, this)
             } else if (action == MediaStore.INTENT_ACTION_MEDIA_PLAY_FROM_SEARCH) {
                 val bundle = intent.extras ?: return
                 playbackManager.mediaSessionManager.playFromSearchExternal(bundle)


### PR DESCRIPTION
## Description

This adds intent for opml import from share sheet

## Testing Instructions

1. Save an opml to your device 
2. Open files app
3. Select opml file and tap share menu
4. Notice that Pocket Casts app is shown in the share sheet
5. Select the app
6. Notice that podcasts are imported from the opml into the app

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/189ce08c-8fb6-4e8a-b46e-df92b2f8c3f4

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
