### PR TITLE
Patron: Update tracks

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
@@ -6,6 +6,8 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.TracksAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_MONTHLY_PRODUCT_ID
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_YEARLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -51,13 +53,19 @@ class CreateAccountViewModel
         private const val ENABLED_KEY = "enabled"
 
         fun trackPurchaseEvent(subscription: Subscription?, purchaseEvent: PurchaseEvent, analyticsTracker: AnalyticsTrackerWrapper) {
-            // extract part of the product id after the last period ("com.pocketcasts.plus.monthly" -> "monthly")
-            val shortProductId = subscription?.productDetails?.productId?.split('.')?.lastOrNull()
-                ?: TracksAnalyticsTracker.INVALID_OR_NULL_VALUE
+            val productKey = subscription?.productDetails?.productId?.let {
+                if (it in listOf(PLUS_MONTHLY_PRODUCT_ID, PLUS_YEARLY_PRODUCT_ID)) {
+                    // retain short product id for plus subscriptions
+                    // extract part of the product id after the last period ("com.pocketcasts.plus.monthly" -> "monthly")
+                    it.split('.').lastOrNull()
+                } else {
+                    it // return full product id for new products
+                }
+            } ?: TracksAnalyticsTracker.INVALID_OR_NULL_VALUE
             val isFreeTrial = subscription is Subscription.WithTrial
 
             val analyticsProperties = mapOf(
-                PRODUCT_KEY to shortProductId,
+                PRODUCT_KEY to productKey,
                 IS_FREE_TRIAL_KEY to isFreeTrial
             )
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -201,7 +201,6 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
                 )
 
             currentSubscription?.let { subscription ->
-                // TODO: Patron - Fix tracking
                 analyticsTracker.track(
                     AnalyticsEvent.SELECT_PAYMENT_FREQUENCY_NEXT_BUTTON_TAPPED,
                     mapOf(OnboardingUpgradeBottomSheetViewModel.flowKey to flow.analyticsValue, OnboardingUpgradeBottomSheetViewModel.selectedSubscriptionKey to subscription.productDetails.productId)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingFlow.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingFlow.kt
@@ -12,7 +12,7 @@ sealed class OnboardingFlow(val analyticsValue: String) : Parcelable {
     @Parcelize class PlusUpsell(
         override val source: OnboardingUpgradeSource,
         val showPatronOnly: Boolean = false,
-    ) : PlusFlow, OnboardingFlow(if (showPatronOnly) "patron_upsell" else "plus_upsell")
+    ) : PlusFlow, OnboardingFlow("plus_upsell")
     @Parcelize class PatronAccountUpgrade(override val source: OnboardingUpgradeSource) : PlusFlow, OnboardingFlow("patron_account_upgrade")
 
     sealed interface PlusFlow {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/TracksAnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/TracksAnalyticsTracker.kt
@@ -34,6 +34,8 @@ class TracksAnalyticsTracker @Inject constructor(
                 ?: false
             val subscriptionType = paidSubscription?.type?.toString()
                 ?: INVALID_OR_NULL_VALUE
+            val subscriptionTier = paidSubscription?.tier?.toString()
+                ?: INVALID_OR_NULL_VALUE
             val subscriptionPlatform = paidSubscription?.platform?.toString()
                 ?: INVALID_OR_NULL_VALUE
             val subscriptionFrequency = paidSubscription?.frequency?.toString()
@@ -45,6 +47,7 @@ class TracksAnalyticsTracker @Inject constructor(
                 PredefinedEventProperty.PLUS_HAS_SUBSCRIPTION to hasSubscription,
                 PredefinedEventProperty.PLUS_HAS_LIFETIME to hasLifetime,
                 PredefinedEventProperty.PLUS_SUBSCRIPTION_TYPE to subscriptionType,
+                PredefinedEventProperty.PLUS_SUBSCRIPTION_TIER to subscriptionTier,
                 PredefinedEventProperty.PLUS_SUBSCRIPTION_PLATFORM to subscriptionPlatform,
                 PredefinedEventProperty.PLUS_SUBSCRIPTION_FREQUENCY to subscriptionFrequency,
                 PredefinedEventProperty.PLATFORM to when (Util.getAppPlatform(appContext)) {
@@ -117,6 +120,7 @@ class TracksAnalyticsTracker @Inject constructor(
         PLUS_HAS_SUBSCRIPTION("plus_has_subscription"),
         PLUS_HAS_LIFETIME("plus_has_lifetime"),
         PLUS_SUBSCRIPTION_TYPE("plus_subscription_type"),
+        PLUS_SUBSCRIPTION_TIER("plus_subscription_tier"),
         PLUS_SUBSCRIPTION_PLATFORM("plus_subscription_platform"),
         PLUS_SUBSCRIPTION_FREQUENCY("plus_subscription_frequency"),
         PLATFORM("platform"),


### PR DESCRIPTION
## Description

This
- Adds global property for the subscription tier and reuses `plus_upsell` analytic value in the "Plus Upsell" flow (Internal ref: p1684957446866019/1684952142.413199-slack-C02ATC80MUM)
- Returns full product id for patron subscriptions in `purchase_`* events

## Testing Instructions

Prerequisites: 
- In-app billing sandbox setup
- Debug build variant
- License test account
- Patron feature flag enabled

1. Login with a `Free`
2. Purchase a `Patron` plan
3. Notice that `subscription_tier` is shown as a global property in logs
4. Notice that the purchase fails and the `purchase_failed` event is shown in logs with the full product id for the `Patron` plan

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack