### PR TITLE
Add autoplay functionality

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -32,6 +32,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImageLoader
+import au.com.shiftyjelly.pocketcasts.repositories.playback.AutomaticUpNextSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getColor
@@ -140,6 +141,7 @@ class FilterEpisodeListFragment : BaseFragment() {
         recyclerView.adapter = adapter
         listSavedState?.let { recyclerView.layoutManager?.onRestoreInstanceState(it) }
         setShowFilterOptions(showingFilterOptionsBeforeModal)
+        AutomaticUpNextSource.mostRecentList = viewModel.playlistUUID
     }
 
     override fun onDestroyView() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -28,6 +28,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.EpisodeListAdapter
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImageLoader
+import au.com.shiftyjelly.pocketcasts.repositories.playback.AutomaticUpNextSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -139,6 +140,11 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
     override fun onResume() {
         super.onResume()
         binding?.recyclerView?.adapter = adapter
+        when (mode) {
+            Mode.Downloaded -> AutomaticUpNextSource.Companion.Predefined.downloads
+            Mode.History -> null
+            Mode.Starred -> AutomaticUpNextSource.Companion.Predefined.starred
+        }?.let { AutomaticUpNextSource.mostRecentList = it }
     }
 
     override fun onDestroyView() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -144,7 +144,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             Mode.Downloaded -> AutomaticUpNextSource.Companion.Predefined.downloads
             Mode.History -> null
             Mode.Starred -> AutomaticUpNextSource.Companion.Predefined.starred
-        }?.let { AutomaticUpNextSource.mostRecentList = it }
+        }.let { AutomaticUpNextSource.mostRecentList = it }
     }
 
     override fun onDestroyView() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -41,6 +41,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.AutomaticUpNextSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -446,6 +447,11 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
             analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_SHOWN)
             FirebaseAnalyticsTracker.openedPodcast(podcastUuid)
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        AutomaticUpNextSource.mostRecentList = podcastUuid
     }
 
     override fun onPause() {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -28,6 +28,7 @@ import au.com.shiftyjelly.pocketcasts.profile.databinding.FragmentCloudFilesBind
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImageLoader
+import au.com.shiftyjelly.pocketcasts.repositories.playback.AutomaticUpNextSource
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
@@ -83,6 +84,11 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         binding?.recyclerView?.adapter = null
         super.onDestroyView()
         binding = null
+    }
+
+    override fun onResume() {
+        super.onResume()
+        AutomaticUpNextSource.mostRecentList = AutomaticUpNextSource.Companion.Predefined.files
     }
 
     override fun onPause() {

--- a/modules/services/preferences/build.gradle
+++ b/modules/services/preferences/build.gradle
@@ -7,6 +7,7 @@ android {
 }
 
 dependencies {
+    implementation project(':modules:services:featureflag')
     implementation project(':modules:services:images')
     implementation project(':modules:services:localization')
     implementation project(':modules:services:model')

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -621,4 +621,7 @@ interface Settings {
     // account management settings).
     fun setFullySignedOut(boolean: Boolean)
     fun getFullySignedOut(): Boolean
+
+    fun getlastLoadedFromPodcastOrFilterUuid(): String?
+    fun setlastLoadedFromPodcastOrFilterUuid(uuid: String?)
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -11,6 +11,8 @@ import android.os.Build
 import android.util.Base64
 import androidx.core.content.edit
 import androidx.work.NetworkType
+import au.com.shiftyjelly.pocketcasts.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
@@ -68,9 +70,7 @@ class SettingsImpl @Inject constructor(
         private const val LAST_SELECTED_SUBSCRIPTION_TIER_KEY = "LastSelectedSubscriptionTierKey"
         private const val LAST_SELECTED_SUBSCRIPTION_FREQUENCY_KEY = "LastSelectedSubscriptionFrequencyKey"
         private const val PROCESSED_SIGNOUT_KEY = "ProcessedSignout"
-        private const val USERNAME_FIRST = "UsernameFirst"
-        private const val USERNAME_LAST = "UsernameLast"
-        private const val USERNAME_DISPLAY = "UsernameDisplay"
+        private const val LAST_SELECTED_PODCAST_OR_FILTER_UUID = "LastSelectedPodcastOrFilterUuid"
     }
 
     private var languageCode: String? = null
@@ -1001,6 +1001,9 @@ class SettingsImpl @Inject constructor(
     }
 
     override fun getAutoPlayNextEpisodeOnEmpty(): Boolean {
+        if (!FeatureFlag.isEnabled(Feature.AUTO_PLAY_UP_NEXT_SETTING)) {
+            return false
+        }
         val defaultValue = when (Util.getAppPlatform(context)) {
             AppPlatform.Automotive -> true
             AppPlatform.Phone -> true
@@ -1407,4 +1410,11 @@ class SettingsImpl @Inject constructor(
 
     override fun getFullySignedOut(): Boolean =
         getBoolean(PROCESSED_SIGNOUT_KEY, true)
+
+    override fun setlastLoadedFromPodcastOrFilterUuid(uuid: String?) {
+        setString(LAST_SELECTED_PODCAST_OR_FILTER_UUID, uuid)
+    }
+
+    override fun getlastLoadedFromPodcastOrFilterUuid(): String? =
+        getString(LAST_SELECTED_PODCAST_OR_FILTER_UUID)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/CloudFilesManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/CloudFilesManager.kt
@@ -1,0 +1,17 @@
+package au.com.shiftyjelly.pocketcasts.repositories.file
+
+import androidx.lifecycle.toLiveData
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
+import com.jakewharton.rxrelay2.BehaviorRelay
+import io.reactivex.BackpressureStrategy
+import javax.inject.Inject
+
+class CloudFilesManager @Inject constructor(
+    private val settings: Settings,
+    private val userEpisodeManager: UserEpisodeManager,
+) {
+    val sortOrderRelay = BehaviorRelay.create<Settings.CloudSortOrder>().apply { accept(settings.getCloudSortOrder()) }
+    val sortedCloudFiles = sortOrderRelay.toFlowable(BackpressureStrategy.LATEST).switchMap { userEpisodeManager.observeUserEpisodesSorted(it) }
+    val cloudFilesList = sortedCloudFiles.toLiveData()
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/AutomaticUpNextSource.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/AutomaticUpNextSource.kt
@@ -2,7 +2,10 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 
-open class AutomaticUpNextSource(val uuid: String) {
+class AutomaticUpNextSource private constructor(val uuid: String?) {
+
+    constructor() : this(mostRecentList)
+    constructor(episode: PodcastEpisode) : this(episode.podcastUuid)
 
     companion object {
         var mostRecentList: String? = null
@@ -12,8 +15,5 @@ open class AutomaticUpNextSource(val uuid: String) {
             const val files = "files"
             const val starred = "starred"
         }
-
-        fun create(): AutomaticUpNextSource? = mostRecentList?.let { AutomaticUpNextSource(it) }
-        fun create(episode: PodcastEpisode): AutomaticUpNextSource = AutomaticUpNextSource(episode.podcastUuid)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/AutomaticUpNextSource.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/AutomaticUpNextSource.kt
@@ -1,0 +1,19 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+
+open class AutomaticUpNextSource(val uuid: String) {
+
+    companion object {
+        var mostRecentList: String? = null
+
+        object Predefined {
+            const val downloads = "downloads"
+            const val files = "files"
+            const val starred = "starred"
+        }
+
+        fun create(): AutomaticUpNextSource? = mostRecentList?.let { AutomaticUpNextSource(it) }
+        fun create(episode: PodcastEpisode): AutomaticUpNextSource = AutomaticUpNextSource(episode.podcastUuid)
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -571,8 +571,7 @@ class MediaSessionManager(
                 val episodeId = autoMediaId.episodeId
                 episodeManager.findEpisodeByUuid(episodeId)?.let { episode ->
                     playbackManager.playNow(episode, playbackSource = source)
-
-                    playbackManager.lastLoadedFromPodcastOrPlaylistUuid = autoMediaId.sourceId
+                    settings.setlastLoadedFromPodcastOrFilterUuid(autoMediaId.sourceId)
                 }
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -419,8 +419,6 @@ open class PlaybackManager @Inject constructor(
             AnalyticsSource.DISCOVER_RANKED_LIST,
             AnalyticsSource.FULL_SCREEN_VIDEO,
             AnalyticsSource.LISTENING_HISTORY,
-            AnalyticsSource.MEDIA_BUTTON_BROADCAST_ACTION,
-            AnalyticsSource.MEDIA_BUTTON_BROADCAST_SEARCH_ACTION,
             AnalyticsSource.MINIPLAYER,
             AnalyticsSource.ONBOARDING_RECOMMENDATIONS,
             AnalyticsSource.ONBOARDING_RECOMMENDATIONS_SEARCH,
@@ -434,6 +432,8 @@ open class PlaybackManager @Inject constructor(
             AnalyticsSource.UP_NEXT,
             -> null
 
+            AnalyticsSource.MEDIA_BUTTON_BROADCAST_SEARCH_ACTION,
+            AnalyticsSource.MEDIA_BUTTON_BROADCAST_ACTION,
             AnalyticsSource.NOTIFICATION,
             -> (episode as? PodcastEpisode)?.let { AutomaticUpNextSource.create(it) }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -408,6 +408,9 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
+    // Returning null means a source should not affect the auto play behavior. Listening history is not
+    // returning null because it should actively disable auto play if a user plays an episode from the
+    // listening history screen.
     private fun automaticUpNextSource(analyticsSource: AnalyticsSource, episode: BaseEpisode): AutomaticUpNextSource? =
         when (analyticsSource) {
             AnalyticsSource.AUTO_PAUSE,
@@ -418,7 +421,6 @@ open class PlaybackManager @Inject constructor(
             AnalyticsSource.DISCOVER_PODCAST_LIST,
             AnalyticsSource.DISCOVER_RANKED_LIST,
             AnalyticsSource.FULL_SCREEN_VIDEO,
-            AnalyticsSource.LISTENING_HISTORY,
             AnalyticsSource.MINIPLAYER,
             AnalyticsSource.ONBOARDING_RECOMMENDATIONS,
             AnalyticsSource.ONBOARDING_RECOMMENDATIONS_SEARCH,
@@ -435,18 +437,19 @@ open class PlaybackManager @Inject constructor(
             AnalyticsSource.MEDIA_BUTTON_BROADCAST_SEARCH_ACTION,
             AnalyticsSource.MEDIA_BUTTON_BROADCAST_ACTION,
             AnalyticsSource.NOTIFICATION,
-            -> (episode as? PodcastEpisode)?.let { AutomaticUpNextSource.create(it) }
+            -> (episode as? PodcastEpisode)?.let { AutomaticUpNextSource(it) }
 
-            // These following screens should be setting an appropriate [AutomaticUpNextSource.mostRecentList] when
-            // the user views them, otherwise [AutomaticUpNextSource.create] will not return the proper
+            // These screens should be setting an appropriate value for [AutomaticUpNextSource.mostRecentList]
+            // when the user views them, otherwise [AutomaticUpNextSource.create] will not return the proper
             // value.
+            AnalyticsSource.LISTENING_HISTORY,
             AnalyticsSource.DOWNLOADS,
             AnalyticsSource.EPISODE_DETAILS,
             AnalyticsSource.FILES,
             AnalyticsSource.FILTERS,
             AnalyticsSource.PODCAST_SCREEN,
             AnalyticsSource.STARRED,
-            -> AutomaticUpNextSource.create()
+            -> AutomaticUpNextSource()
         }
 
     suspend fun play(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
@@ -20,7 +20,7 @@ interface UpNextQueue {
 
     val allEpisodes get(): List<BaseEpisode> = currentEpisode?.let { listOf(it) + queueEpisodes } ?: queueEpisodes
     fun isCurrentEpisode(episode: BaseEpisode): Boolean
-    suspend fun playNow(episode: BaseEpisode, onAdd: (() -> Unit)?)
+    suspend fun playNow(episode: BaseEpisode, automaticUpNextSource: AutomaticUpNextSource?, onAdd: (() -> Unit)?)
     suspend fun playNext(episode: BaseEpisode, downloadManager: DownloadManager, onAdd: (() -> Unit)?)
     suspend fun playLast(episode: BaseEpisode, downloadManager: DownloadManager, onAdd: (() -> Unit)?)
     suspend fun playAllNext(episodes: List<BaseEpisode>, downloadManager: DownloadManager)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -496,7 +496,8 @@ class PlaylistManagerImpl @Inject constructor(
         where.append("archived = 0")
 
         val playingEpisode = playbackManager?.getCurrentEpisode()?.uuid
-        if (playingEpisode != null && playbackManager.lastLoadedFromPodcastOrPlaylistUuid == playlist.uuid) {
+        val lastLoadedFromPodcastOrFilterUuid = settings.getlastLoadedFromPodcastOrFilterUuid()
+        if (playingEpisode != null && lastLoadedFromPodcastOrFilterUuid == playlist.uuid) {
             where.insert(0, "(podcast_episodes.uuid = '$playingEpisode' OR (")
             where.append("))")
         }


### PR DESCRIPTION
# Description
This adds an initial version of autoplay for users who have no episodes in their up next queue. This feature is still a bit in flux as we figure out exactly what we want this to look like.

I made a few different attempts at doing this by passing the information up from the relevant views, but that just didn't seem to work well at all. One particular difficulty with that approach is that the Episode Details screen can be accessed from so many places and it would need to know how it was created to pass that information up. We could certainly do it, but it seemed overly complicated and required a lot of changes.

The solution I'm going with here uses a global variable—so it feels a bit hacky—but it seems to work well and require much less change. For each screen that should change what is auto played, we set a global variable each time the user visits that screen ([for example](https://github.com/Automattic/pocket-casts-android/blob/dd7804324e62aaa62c8cd2fa457e54490877b697/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt#L452-L455)). Then when playback happens, the `PlaybackManager` uses the `AnalyticsSource` [to determine if it should record an autoplay list/episode or not and, if it should, it fetches the most recently persisted autoplay source (or, if appropriate, the currently playing episode)](https://github.com/Automattic/pocket-casts-android/blob/dd7804324e62aaa62c8cd2fa457e54490877b697/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt#L414-L453). 

# Testing Instructions

So many things to test... 😅 

The expected order of playback for autoplay currently is that the "next" episode lower in the list will be selected (taking account of the user's sort option). If there are no episodes "below" the current episode, then the nearest episode "above" the episode will be selected. In both cases, episodes that have been played or archived are skipped.

## 1. Phone

In all of these scenarios, autoplay should never happen if either 
1. the feature flag is disabled,
2. the settings is turned off in the settings, or
3. The up next queue was not empty either when playback started or at any point during playback

In all of these scenarios, autoplay should not behave differently regardless of whether you:
1. Allow an episode to complete on its own,
2. Skip forward to the end of the episode, or
3. Mark the episode as played

<details><summary>i. Playing from Podcasts screen</summary>

When playing an episode from the screen for a podcast, autoplay should continue playing episodes from that podcast. 
* This happens regardless of where the podcast screen is opened from (i.e., the podcasts tab, the search results, the discover screen, the now playing screen).
* This also happens regardless of whether the playback is started from the Podcast screen itself or if the episode details screen is opened from there and play is tapped on that screen.
</details> 

<details><summary>ii. Playing from Filter, Starred, Downloads, or Files</summary>
When playing an episode from a list on any of these screens (or by opening the episode details from one of these screens and tapping play), should allow autoplay after the episode is complete. 
</details>

<details><summary>iii. Autoplay does not happen if an episode is added to the up next queue</summary>
Test 1:
1. Start playing a single episode in a way that auto play would happen.
4. Add an episode to the up next queue
5. Mark both episodes as played
6. Confirm that playback stops

Test 2:
1. Start playing a single episode in a way that auto play would happen.
2. Add an episode to the up next queue
3. Remove the episode you just added to your up next queue from the up next queue
4. Mark the currently playing episode as played
5. Confirm that playback stops
</details>

<details><summary>iv. Playing from new episode notification</summary>
1. With an empty up next queue, trigger a new episode notification from the developer settings
2. Tap "Play" on the notification
3. Complete the episode
4. Verify that playback continues with episodes from the current podcast
</details>

<details><summary>v. Takes account of sort order</summary>

1. Play an episode from the middle of a podcasts list of episodes
2. Sort the list from oldest to newest, and note the name of the episode below the currently playing episode (so the next newest episode) that has not already been played or archived
3. Complete the currently playing episode
4. Observe that the next newest episode is autoplayed
5. Change the sort order to be newest to oldest, and now the name of the episode that is now below the currently playing episode (so the next oldest episode) that has not been played or achived.
6. Complete the currently playing episode
7. Observe that the next oldest episode is autoplayed
</details>

<details><summary>vi. Stream warning permits autoplay</summary>

1. Use a metered network and have the stream warning setting enabled
2. Begin streaming an episode without an up next queue
3. Complete the episode
4. Observe that an episode is autoplayed such that the stream warning is presented and that choosing to go ahead and stream the episode will begin playback.
</details>

<details><summary>vii. Does not autoplay from Listening History</summary>
If you start playback from the Listening History screen (or by opening the episode details from the screen and then tapping play), there should not be any autoplay after the episode is completed.
</details>

<details><summary>viii. Playback continues when started from Google Assistant</summary>
1. Using a release build (or a debug build with the release package name should work too)
2. On your device with an empty up next queue, trigger the Google Assistant and ask to play a podcast on Pocket Casts (i.e., "Play This American Life on Pocket Casts").
3. Playback should start in Pocket Casts
4. Complete the episode
6. Observe that playback continues
</details>

<details><summary>ix. Autoplay stops after all episodes are played on a list on phone (Automotive behaves differently—see below)</summary>
1. Start playing an episode from a short list
2. Complete playing each episode until every episode in the list has been played
3. Confirm that playback stops
</details>

## 2. Confirm no Automotive Regressions

<details><summary>i. Autoplay toggle defaults to on and works on automotive</summary>
1. Fresh install of Android Automotive
2. Play an episode
3. Mark it as played
4. Observe another episode starts playing
5. Go to settings and turn off autoplay
8. Mark the currently playing episode as played
9. Observe that playback stops
</details>

<details><summary>ii. Autoplay continues after all episodes in a list are played on Automotive</summary>

1. Subscribe to a podcast, but create create a filter with only a few episodes in it
2. Log into this account on Android automotive
3. Make sure autoplay is turned on
4. Start playing a an episode from teh screen for that filter
5. Mark the episodes as played until you've listened to all the episodes on that filter
6. Observe that playback on continues with other episodes (this is different from the behavior we want on the phone).
</details>

# Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
