### PR TITLE
Autoplay: Rename AnalyticsSource

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -44,10 +44,10 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContr
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContract.OnboardingFinish
 import au.com.shiftyjelly.pocketcasts.account.watchsync.WatchSync
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.databinding.ActivityMainBinding
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesFragment
@@ -927,31 +927,31 @@ class MainActivity :
                 playbackManager.getCurrentEpisode()?.let { episode ->
                     launch(Dispatchers.Main) {
                         if (episode.isDownloaded) {
-                            playbackManager.playQueue(AnalyticsSource.MINIPLAYER)
+                            playbackManager.playQueue(SourceView.MINIPLAYER)
                             warningsHelper.showBatteryWarningSnackbarIfAppropriate()
                         } else {
-                            warningsHelper.streamingWarningDialog(episode = episode, playbackSource = AnalyticsSource.MINIPLAYER)
+                            warningsHelper.streamingWarningDialog(episode = episode, sourceView = SourceView.MINIPLAYER)
                                 .show(supportFragmentManager, "streaming dialog")
                         }
                     }
                 }
             }
         } else {
-            playbackManager.playQueue(AnalyticsSource.MINIPLAYER)
+            playbackManager.playQueue(SourceView.MINIPLAYER)
             warningsHelper.showBatteryWarningSnackbarIfAppropriate()
         }
     }
 
     override fun onPauseClicked() {
-        playbackManager.pause(playbackSource = AnalyticsSource.MINIPLAYER)
+        playbackManager.pause(sourceView = SourceView.MINIPLAYER)
     }
 
     override fun onSkipBackwardClicked() {
-        playbackManager.skipBackward(playbackSource = AnalyticsSource.MINIPLAYER)
+        playbackManager.skipBackward(sourceView = SourceView.MINIPLAYER)
     }
 
     override fun onSkipForwardClicked() {
-        playbackManager.skipForward(playbackSource = AnalyticsSource.MINIPLAYER)
+        playbackManager.skipForward(sourceView = SourceView.MINIPLAYER)
     }
 
     override fun addFragment(fragment: Fragment, onTop: Boolean) {

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
@@ -11,7 +11,7 @@ import androidx.annotation.StringRes
 import androidx.core.os.bundleOf
 import androidx.media.utils.MediaConstants.DESCRIPTION_EXTRAS_KEY_CONTENT_STYLE_BROWSABLE
 import androidx.media.utils.MediaConstants.DESCRIPTION_EXTRAS_VALUE_CONTENT_STYLE_LIST_ITEM
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.helper.tryToLocalise
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -59,7 +59,7 @@ class AutoPlaybackService : PlaybackService() {
         super.onDestroy()
         Log.d(Settings.LOG_TAG_AUTO, "Auto playback service destroyed")
 
-        playbackManager.pause(transientLoss = false, playbackSource = AnalyticsSource.AUTO_PAUSE)
+        playbackManager.pause(transientLoss = false, sourceView = SourceView.AUTO_PAUSE)
     }
 
     override fun onLoadChildren(parentId: String, result: Result<List<MediaBrowserCompat.MediaItem>>) {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
@@ -6,8 +6,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -56,7 +56,7 @@ class OnboardingRecommendationsSearchViewModel @Inject constructor(
     )
 
     init {
-        searchHandler.setSource(AnalyticsSource.ONBOARDING_RECOMMENDATIONS_SEARCH)
+        searchHandler.setSource(SourceView.ONBOARDING_RECOMMENDATIONS_SEARCH)
         searchHandler.setOnlySearchRemote(true)
         viewModelScope.launch {
 
@@ -102,7 +102,7 @@ class OnboardingRecommendationsSearchViewModel @Inject constructor(
         }
         analyticsTracker.track(
             AnalyticsEvent.SEARCH_SHOWN,
-            mapOf(AnalyticsProp.SOURCE to AnalyticsSource.ONBOARDING_RECOMMENDATIONS.analyticsValue)
+            mapOf(AnalyticsProp.SOURCE to SourceView.ONBOARDING_RECOMMENDATIONS.analyticsValue)
         )
     }
 
@@ -151,7 +151,7 @@ class OnboardingRecommendationsSearchViewModel @Inject constructor(
     fun onBackPressed() {
         analyticsTracker.track(
             AnalyticsEvent.SEARCH_DISMISSED,
-            mapOf(AnalyticsProp.SOURCE to AnalyticsSource.ONBOARDING_RECOMMENDATIONS.analyticsValue)
+            mapOf(AnalyticsProp.SOURCE to SourceView.ONBOARDING_RECOMMENDATIONS.analyticsValue)
         )
     }
 
@@ -160,7 +160,7 @@ class OnboardingRecommendationsSearchViewModel @Inject constructor(
             const val UUID = "uuid"
             const val SOURCE = "source"
             fun podcastSubscribeToggled(uuid: String) =
-                mapOf(UUID to uuid, SOURCE to AnalyticsSource.ONBOARDING_RECOMMENDATIONS_SEARCH)
+                mapOf(UUID to uuid, SOURCE to SourceView.ONBOARDING_RECOMMENDATIONS_SEARCH)
         }
     }
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
@@ -5,9 +5,9 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.discover.R
 import au.com.shiftyjelly.pocketcasts.discover.extensions.updateSubscribeButtonIcon
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
@@ -85,7 +85,7 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
                     FirebaseAnalyticsTracker.subscribedToFeaturedPodcast()
                     analyticsTracker.track(AnalyticsEvent.DISCOVER_FEATURED_PODCAST_SUBSCRIBED, AnalyticsProp.featuredPodcastSubscribed(podcast.uuid))
                 }
-                analyticsTracker.track(AnalyticsEvent.PODCAST_SUBSCRIBED, AnalyticsProp.podcastSubscribed(AnalyticsSource.DISCOVER, podcast.uuid))
+                analyticsTracker.track(AnalyticsEvent.PODCAST_SUBSCRIBED, AnalyticsProp.podcastSubscribed(SourceView.DISCOVER, podcast.uuid))
             }
         } else {
             holder.podcast = null
@@ -103,7 +103,7 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
             fun sponsoredPodcastSubscribed(listId: String, uuid: String) = mapOf(LIST_ID_KEY to listId, PODCAST_UUID_KEY to uuid)
             fun featuredPodcastTapped(uuid: String) = mapOf(PODCAST_UUID_KEY to uuid)
             fun featuredPodcastSubscribed(uuid: String) = mapOf(PODCAST_UUID_KEY to uuid)
-            fun podcastSubscribed(source: AnalyticsSource, uuid: String) =
+            fun podcastSubscribed(source: SourceView, uuid: String) =
                 mapOf(SOURCE_KEY to source.analyticsValue, UUID_KEY to uuid)
         }
     }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -10,9 +10,9 @@ import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.discover.databinding.FragmentDiscoverBinding
 import au.com.shiftyjelly.pocketcasts.discover.viewmodel.DiscoverState
 import au.com.shiftyjelly.pocketcasts.discover.viewmodel.DiscoverViewModel
@@ -64,7 +64,7 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
         viewModel.subscribeToPodcast(podcast)
         analyticsTracker.track(
             AnalyticsEvent.PODCAST_SUBSCRIBED,
-            mapOf(SOURCE_KEY to AnalyticsSource.DISCOVER.analyticsValue, UUID_KEY to podcast.uuid)
+            mapOf(SOURCE_KEY to SourceView.DISCOVER.analyticsValue, UUID_KEY to podcast.uuid)
         )
     }
 
@@ -117,7 +117,7 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
         val searchFragment = SearchFragment.newInstance(
             floating = true,
             onlySearchRemote = true,
-            source = AnalyticsSource.DISCOVER
+            source = SourceView.DISCOVER
         )
         (activity as FragmentHostListener).addFragment(searchFragment, onTop = true)
         binding?.recyclerView?.smoothScrollToPosition(0)

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridListFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridListFragment.kt
@@ -12,9 +12,9 @@ import androidx.appcompat.widget.Toolbar
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.discover.R
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.EPISODE_UUID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.LIST_ID_KEY
@@ -128,11 +128,11 @@ open class PodcastGridListFragment : BaseFragment(), Toolbar.OnMenuItemClickList
             FirebaseAnalyticsTracker.podcastSubscribedFromList(it, podcastUuid)
             analyticsTracker.track(AnalyticsEvent.DISCOVER_LIST_PODCAST_SUBSCRIBED, mapOf(LIST_ID_KEY to it, PODCAST_UUID_KEY to podcastUuid))
         }
-        var podcastSubscribedSource = AnalyticsSource.DISCOVER
+        var podcastSubscribedSource = SourceView.DISCOVER
         if (expandedStyle is ExpandedStyle.RankedList) {
-            podcastSubscribedSource = AnalyticsSource.DISCOVER_RANKED_LIST
+            podcastSubscribedSource = SourceView.DISCOVER_RANKED_LIST
         } else if (expandedStyle is ExpandedStyle.PlainList) {
-            podcastSubscribedSource = AnalyticsSource.DISCOVER_PLAIN_LIST
+            podcastSubscribedSource = SourceView.DISCOVER_PLAIN_LIST
         }
         analyticsTracker.track(AnalyticsEvent.PODCAST_SUBSCRIBED, mapOf(SOURCE_KEY to podcastSubscribedSource.analyticsValue, UUID_KEY to podcastUuid))
         podcastManager.subscribeToPodcast(podcastUuid, sync = true)

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -4,8 +4,8 @@ import android.content.res.Resources
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -47,7 +47,7 @@ class DiscoverViewModel @Inject constructor(
     val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ViewModel() {
     private val disposables = CompositeDisposable()
-    private val playbackSource = AnalyticsSource.DISCOVER
+    private val sourceView = SourceView.DISCOVER
     val state = MutableLiveData<DiscoverState>().apply { value = DiscoverState.Loading }
     var currentRegionCode: String? = settings.getDiscoveryCountryCode()
     var replacements = emptyMap<String, String>()
@@ -231,11 +231,11 @@ class DiscoverViewModel @Inject constructor(
     }
 
     fun playEpisode(episode: PodcastEpisode) {
-        playbackManager.playNow(episode = episode, forceStream = true, playbackSource = playbackSource)
+        playbackManager.playNow(episode = episode, forceStream = true, sourceView = sourceView)
     }
 
     fun stopPlayback() {
-        playbackManager.stopAsync(playbackSource = playbackSource)
+        playbackManager.stopAsync(sourceView = sourceView)
     }
 }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/PodcastListViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/PodcastListViewModel.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.discover.viewmodel
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.colors.ColorManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -151,11 +151,11 @@ class PodcastListViewModel @Inject constructor(
     }
 
     fun playEpisode(episode: PodcastEpisode) {
-        playbackManager.playNow(episode, forceStream = true, playbackSource = AnalyticsSource.DISCOVER_PODCAST_LIST)
+        playbackManager.playNow(episode, forceStream = true, sourceView = SourceView.DISCOVER_PODCAST_LIST)
     }
 
     fun stopPlayback() {
-        playbackManager.stopAsync(playbackSource = AnalyticsSource.DISCOVER_PODCAST_LIST)
+        playbackManager.stopAsync(sourceView = SourceView.DISCOVER_PODCAST_LIST)
     }
 }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -17,8 +17,8 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.filters.databinding.FragmentFilterBinding
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralPodcasts
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
@@ -112,7 +112,7 @@ class FilterEpisodeListFragment : BaseFragment() {
             radiusPx = 4.dpToPx(context)
         }.smallPlaceholder()
 
-        playButtonListener.source = AnalyticsSource.FILTERS
+        playButtonListener.source = SourceView.FILTERS
         adapter = EpisodeListAdapter(downloadManager, playbackManager, upNextQueue, settings, this::onRowClick, playButtonListener, imageLoader, multiSelectHelper, childFragmentManager)
     }
 
@@ -386,7 +386,7 @@ class FilterEpisodeListFragment : BaseFragment() {
         itemTouchHelper.attachToRecyclerView(recyclerView)
 
         val multiSelectToolbar = binding.multiSelectToolbar
-        multiSelectHelper.source = AnalyticsSource.FILTERS
+        multiSelectHelper.source = SourceView.FILTERS
         multiSelectHelper.isMultiSelectingLive.observe(
             viewLifecycleOwner,
             Observer {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -5,10 +5,10 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -110,11 +110,11 @@ class FilterEpisodeListViewModel @Inject constructor(
             if (!episode.isArchived) {
                 episodeManager.archive(episode, playbackManager)
                 trackSwipeAction(SwipeAction.ARCHIVE)
-                episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_ARCHIVED, AnalyticsSource.FILTERS, episode.uuid)
+                episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_ARCHIVED, SourceView.FILTERS, episode.uuid)
             } else {
                 episodeManager.unarchive(episode)
                 trackSwipeAction(SwipeAction.UNARCHIVE)
-                episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_UNARCHIVED, AnalyticsSource.FILTERS, episode.uuid)
+                episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_UNARCHIVED, SourceView.FILTERS, episode.uuid)
             }
         }
     }
@@ -126,7 +126,7 @@ class FilterEpisodeListViewModel @Inject constructor(
             if (startIndex > -1) {
                 playbackManager.upNextQueue.removeAll()
                 val count = min(episodes.size - startIndex, settings.getMaxUpNextEpisodes())
-                playbackManager.playEpisodes(episodes = episodes.subList(startIndex, startIndex + count), playbackSource = AnalyticsSource.FILTERS)
+                playbackManager.playEpisodes(episodes = episodes.subList(startIndex, startIndex + count), sourceView = SourceView.FILTERS)
             }
         }
     }
@@ -162,10 +162,10 @@ class FilterEpisodeListViewModel @Inject constructor(
     fun episodeSwipeUpNext(episode: BaseEpisode) {
         launch {
             if (playbackManager.upNextQueue.contains(episode.uuid)) {
-                playbackManager.removeEpisode(episodeToRemove = episode, source = AnalyticsSource.FILTERS)
+                playbackManager.removeEpisode(episodeToRemove = episode, source = SourceView.FILTERS)
                 trackSwipeAction(SwipeAction.UP_NEXT_REMOVE)
             } else {
-                playbackManager.playNext(episode = episode, source = AnalyticsSource.FILTERS)
+                playbackManager.playNext(episode = episode, source = SourceView.FILTERS)
                 trackSwipeAction(SwipeAction.UP_NEXT_ADD_TOP)
             }
         }
@@ -174,10 +174,10 @@ class FilterEpisodeListViewModel @Inject constructor(
     fun episodeSwipeUpLast(episode: BaseEpisode) {
         launch {
             if (playbackManager.upNextQueue.contains(episode.uuid)) {
-                playbackManager.removeEpisode(episodeToRemove = episode, source = AnalyticsSource.FILTERS)
+                playbackManager.removeEpisode(episodeToRemove = episode, source = SourceView.FILTERS)
                 trackSwipeAction(SwipeAction.UP_NEXT_REMOVE)
             } else {
-                playbackManager.playLast(episode = episode, source = AnalyticsSource.FILTERS)
+                playbackManager.playLast(episode = episode, source = SourceView.FILTERS)
                 trackSwipeAction(SwipeAction.UP_NEXT_ADD_BOTTOM)
             }
         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
@@ -11,7 +11,7 @@ import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.fragment.app.activityViewModels
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
@@ -253,6 +253,6 @@ class EffectsFragment : BaseDialogFragment(), CompoundButton.OnCheckedChangeList
     }
 
     private fun trackPlaybackEffectsEvent(event: AnalyticsEvent, props: Map<String, Any> = emptyMap()) {
-        playbackManager.trackPlaybackEffectsEvent(event, props, AnalyticsSource.PLAYER_PLAYBACK_EFFECTS)
+        playbackManager.trackPlaybackEffectsEvent(event, props, SourceView.PLAYER_PLAYBACK_EFFECTS)
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -18,8 +18,8 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.player.R
@@ -79,7 +79,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
     private var binding: AdapterPlayerHeaderBinding? = null
     private var skippedFirstTouch: Boolean = false
     private var hasReceivedOnTouchDown = false
-    private val playbackSource = AnalyticsSource.PLAYER
+    private val sourceView = SourceView.PLAYER
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = AdapterPlayerHeaderBinding.inflate(inflater, container, false)
@@ -121,7 +121,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         binding.seekBar.changeListener = object : PlayerSeekBar.OnUserSeekListener {
             override fun onSeekPositionChangeStop(progress: Int, seekComplete: () -> Unit) {
                 viewModel.seekToMs(progress, seekComplete)
-                playbackManager.trackPlaybackSeek(progress, AnalyticsSource.PLAYER)
+                playbackManager.trackPlaybackSeek(progress, SourceView.PLAYER)
             }
 
             override fun onSeekPositionChanging(progress: Int) {}
@@ -497,7 +497,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
     override fun onPlayClicked() {
         if (playbackManager.isPlaying()) {
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Pause clicked in player")
-            playbackManager.pause(playbackSource = playbackSource)
+            playbackManager.pause(sourceView = sourceView)
         } else {
             if (playbackManager.shouldWarnAboutPlayback()) {
                 launch {
@@ -508,7 +508,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
                                 viewModel.play()
                                 warningsHelper.showBatteryWarningSnackbarIfAppropriate(snackbarParentView = view)
                             } else {
-                                warningsHelper.streamingWarningDialog(episode = episode, snackbarParentView = view, playbackSource = playbackSource)
+                                warningsHelper.streamingWarningDialog(episode = episode, snackbarParentView = view, sourceView = sourceView)
                                     .show(parentFragmentManager, "streaming dialog")
                             }
                         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShareFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShareFragment.kt
@@ -6,8 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentShareBinding
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
@@ -53,7 +53,7 @@ class ShareFragment : BaseDialogFragment() {
                     null,
                     requireContext(),
                     ShareType.PODCAST,
-                    AnalyticsSource.PLAYER,
+                    SourceView.PLAYER,
                     analyticsTracker
                 ).showShareDialogDirect()
             }
@@ -67,7 +67,7 @@ class ShareFragment : BaseDialogFragment() {
                     null,
                     requireContext(),
                     ShareType.EPISODE,
-                    AnalyticsSource.PLAYER,
+                    SourceView.PLAYER,
                     analyticsTracker
                 ).showShareDialogDirect()
             }
@@ -81,7 +81,7 @@ class ShareFragment : BaseDialogFragment() {
                     episode.playedUpTo,
                     requireContext(),
                     ShareType.CURRENT_TIME,
-                    AnalyticsSource.PLAYER,
+                    SourceView.PLAYER,
                     analyticsTracker
                 ).showShareDialogDirect()
             }
@@ -95,7 +95,7 @@ class ShareFragment : BaseDialogFragment() {
                     episode.playedUpTo,
                     requireContext(),
                     ShareType.EPISODE_FILE,
-                    AnalyticsSource.PLAYER,
+                    SourceView.PLAYER,
                     analyticsTracker
                 ).sendFile()
             }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -16,9 +16,9 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
 import au.com.shiftyjelly.pocketcasts.player.R
@@ -81,7 +81,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     lateinit var adapter: UpNextAdapter
-    private val playbackSource = AnalyticsSource.UP_NEXT
+    private val sourceView = SourceView.UP_NEXT
     private val playerViewModel: PlayerViewModel by activityViewModels()
     private var userRearrangingFrom: Int? = null
     private var userDraggingStart: Int? = null
@@ -127,7 +127,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
     override fun onAttach(context: Context) {
         super.onAttach(context)
         val imageLoader = PodcastImageLoaderThemed(context)
-        multiSelectHelper.source = AnalyticsSource.UP_NEXT
+        multiSelectHelper.source = SourceView.UP_NEXT
         adapter = UpNextAdapter(
             context = context,
             imageLoader = imageLoader,
@@ -273,7 +273,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
         recyclerView.findViewHolderForAdapterPosition(position)?.let {
             episodeItemTouchHelper?.clearView(recyclerView, it)
         }
-        playbackManager.playEpisodesNext(episodes = listOf(episode), source = AnalyticsSource.UP_NEXT)
+        playbackManager.playEpisodesNext(episodes = listOf(episode), source = SourceView.UP_NEXT)
         trackSwipeAction(SwipeAction.UP_NEXT_MOVE_TOP)
     }
 
@@ -282,7 +282,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
         recyclerView.findViewHolderForAdapterPosition(position)?.let {
             episodeItemTouchHelper?.clearView(recyclerView, it)
         }
-        playbackManager.playEpisodesLast(episodes = listOf(episode), source = AnalyticsSource.UP_NEXT)
+        playbackManager.playEpisodesLast(episodes = listOf(episode), source = SourceView.UP_NEXT)
         trackSwipeAction(SwipeAction.UP_NEXT_MOVE_BOTTOM)
     }
 
@@ -336,7 +336,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
 
     override fun onEpisodeActionsClick(episodeUuid: String, podcastUuid: String?) {
         if (settings.getTapOnUpNextShouldPlay()) {
-            playerViewModel.playEpisode(uuid = episodeUuid, playbackSource = playbackSource)
+            playerViewModel.playEpisode(uuid = episodeUuid, sourceView = sourceView)
         } else {
             (activity as? FragmentHostListener)?.openEpisodeDialog(
                 episodeUuid = episodeUuid,
@@ -356,7 +356,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
                 forceDark = true
             )
         } else {
-            playerViewModel.playEpisode(uuid = episodeUuid, playbackSource = playbackSource)
+            playerViewModel.playEpisode(uuid = episodeUuid, sourceView = sourceView)
         }
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/dialog/MiniPlayerDialog.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/dialog/MiniPlayerDialog.kt
@@ -3,9 +3,9 @@ package au.com.shiftyjelly.pocketcasts.player.view.dialog
 import android.content.Context
 import androidx.fragment.app.FragmentManager
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -74,7 +74,7 @@ class MiniPlayerDialog(
     private fun markAsPlayed() {
         val episode = playbackManager.upNextQueue.currentEpisode ?: return
         episodeManager.markAsPlayedAsync(episode, playbackManager, podcastManager)
-        episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_MARKED_AS_PLAYED, AnalyticsSource.MINIPLAYER, episode.uuid)
+        episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_MARKED_AS_PLAYED, SourceView.MINIPLAYER, episode.uuid)
     }
 
     companion object {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
@@ -11,7 +11,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentVideoBinding
 import au.com.shiftyjelly.pocketcasts.player.view.PlayerSeekBar
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.VideoViewModel
@@ -159,7 +159,7 @@ class VideoFragment : Fragment(), PlayerSeekBar.OnUserSeekListener {
 
     override fun onSeekPositionChangeStop(progress: Int, seekComplete: () -> Unit) {
         viewModel.seekToMs(progress)
-        playbackManager.trackPlaybackSeek(progress, AnalyticsSource.FULL_SCREEN_VIDEO)
+        playbackManager.trackPlaybackSeek(progress, SourceView.FULL_SCREEN_VIDEO)
         seekComplete()
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -7,9 +7,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -152,7 +152,7 @@ class PlayerViewModel @Inject constructor(
     ) {
         fun isSameChapter(chapter: Chapter) = currentChapter?.let { it.index == chapter.index } ?: false
     }
-    private val source = AnalyticsSource.PLAYER
+    private val source = SourceView.PLAYER
     private val _showPlayerFlow = MutableSharedFlow<Unit>()
     val showPlayerFlow: SharedFlow<Unit> = _showPlayerFlow
 
@@ -371,22 +371,22 @@ class PlayerViewModel @Inject constructor(
 
     fun play() {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Play clicked in player")
-        playbackManager.playQueue(playbackSource = source)
+        playbackManager.playQueue(sourceView = source)
     }
 
-    fun playEpisode(uuid: String, playbackSource: AnalyticsSource = AnalyticsSource.UNKNOWN) {
+    fun playEpisode(uuid: String, sourceView: SourceView = SourceView.UNKNOWN) {
         launch {
             val episode = episodeManager.findEpisodeByUuid(uuid) ?: return@launch
-            playbackManager.playNow(episode = episode, playbackSource = playbackSource)
+            playbackManager.playNow(episode = episode, sourceView = sourceView)
         }
     }
 
     fun skipBackward() {
-        playbackManager.skipBackward(playbackSource = source)
+        playbackManager.skipBackward(sourceView = source)
     }
 
     fun skipForward() {
-        playbackManager.skipForward(playbackSource = source)
+        playbackManager.skipForward(sourceView = source)
     }
 
     fun onMarkAsPlayedClick() {
@@ -400,7 +400,7 @@ class PlayerViewModel @Inject constructor(
     }
 
     fun onNextEpisodeClick() {
-        playbackManager.playNextInQueue(playbackSource = source)
+        playbackManager.playNextInQueue(sourceView = source)
     }
 
     private fun markAsPlayedConfirmed(episode: BaseEpisode) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/VideoViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/VideoViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -29,25 +29,25 @@ class VideoViewModel @Inject constructor(
     private var lastTimeHidingControls = 0L
 
     private var controlsVisibleMutable = MutableLiveData(true)
-    private val playbackSource = AnalyticsSource.FULL_SCREEN_VIDEO
+    private val sourceView = SourceView.FULL_SCREEN_VIDEO
     val controlsVisible: LiveData<Boolean> get() = controlsVisibleMutable
 
     fun play() {
-        playbackManager.playQueue(playbackSource = playbackSource)
+        playbackManager.playQueue(sourceView = sourceView)
         startHideControlsTimer()
     }
 
     fun pause() {
-        playbackManager.pause(playbackSource = playbackSource)
+        playbackManager.pause(sourceView = sourceView)
     }
 
     fun skipBackward() {
-        playbackManager.skipBackward(playbackSource = playbackSource)
+        playbackManager.skipBackward(sourceView = sourceView)
         startHideControlsTimer()
     }
 
     fun skipForward() {
-        playbackManager.skipForward(playbackSource = playbackSource)
+        playbackManager.skipForward(sourceView = sourceView)
         startHideControlsTimer()
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
@@ -3,8 +3,8 @@ package au.com.shiftyjelly.pocketcasts.podcasts.helper
 import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.podcasts.view.components.PlayButton
@@ -34,7 +34,7 @@ class PlayButtonListener @Inject constructor(
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
 
-    override var source = AnalyticsSource.UNKNOWN
+    override var source = SourceView.UNKNOWN
 
     override fun onPlayClicked(episodeUuid: String) {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "In app play button pushed for $episodeUuid")
@@ -46,7 +46,7 @@ class PlayButtonListener @Inject constructor(
                         if (episode.isDownloaded) {
                             play(episode)
                         } else if (activity is AppCompatActivity) {
-                            warningsHelper.streamingWarningDialog(episode = episode, playbackSource = source)
+                            warningsHelper.streamingWarningDialog(episode = episode, sourceView = source)
                                 .show(activity.supportFragmentManager, "streaming dialog")
                         }
                     }
@@ -58,12 +58,12 @@ class PlayButtonListener @Inject constructor(
     }
 
     private fun play(episode: BaseEpisode, force: Boolean = true) {
-        playbackManager.playNow(episode = episode, forceStream = force, playbackSource = source)
+        playbackManager.playNow(episode = episode, forceStream = force, sourceView = source)
         warningsHelper.showBatteryWarningSnackbarIfAppropriate()
     }
 
     override fun onPauseClicked() {
-        playbackManager.pause(playbackSource = source)
+        playbackManager.pause(sourceView = source)
     }
 
     override fun onPlayedClicked(episodeUuid: String) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -15,8 +15,8 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
@@ -401,8 +401,8 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
     }
 
     private fun getAnalyticsEventSource() = when (mode) {
-        Mode.Downloaded -> AnalyticsSource.DOWNLOADS
-        Mode.Starred -> AnalyticsSource.STARRED
-        Mode.History -> AnalyticsSource.LISTENING_HISTORY
+        Mode.Downloaded -> SourceView.DOWNLOADS
+        Mode.Starred -> SourceView.STARRED
+        Mode.History -> SourceView.LISTENING_HISTORY
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -111,9 +111,9 @@ class ProfileEpisodeListViewModel @Inject constructor(
     }
 
     private fun getAnalyticsSource() = when (mode) {
-        ProfileEpisodeListFragment.Mode.Downloaded -> AnalyticsSource.DOWNLOADS
-        ProfileEpisodeListFragment.Mode.History -> AnalyticsSource.LISTENING_HISTORY
-        ProfileEpisodeListFragment.Mode.Starred -> AnalyticsSource.STARRED
+        ProfileEpisodeListFragment.Mode.Downloaded -> SourceView.DOWNLOADS
+        ProfileEpisodeListFragment.Mode.History -> SourceView.LISTENING_HISTORY
+        ProfileEpisodeListFragment.Mode.Starred -> SourceView.STARRED
     }
 
     companion object {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/PlayButton.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/PlayButton.kt
@@ -8,9 +8,9 @@ import android.widget.ImageView
 import android.widget.PopupMenu
 import androidx.annotation.ColorInt
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
@@ -69,7 +69,7 @@ class PlayButton @JvmOverloads constructor(
     }
 
     interface OnClickListener {
-        var source: AnalyticsSource
+        var source: SourceView
         fun onPlayClicked(episodeUuid: String)
         fun onPauseClicked()
         fun onPlayNext(episodeUuid: String)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -8,10 +8,10 @@ import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.map
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -58,7 +58,7 @@ class EpisodeFragmentViewModel @Inject constructor(
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
 
-    private val source = AnalyticsSource.EPISODE_DETAILS
+    private val source = SourceView.EPISODE_DETAILS
     lateinit var state: LiveData<EpisodeFragmentState>
     lateinit var showNotesState: LiveData<ShowNotesState>
     lateinit var inUpNext: LiveData<Boolean>
@@ -256,14 +256,14 @@ class EpisodeFragmentViewModel @Inject constructor(
     ): Boolean {
         episode?.let { episode ->
             if (isPlaying.value == true) {
-                playbackManager.pause(playbackSource = source)
+                playbackManager.pause(sourceView = source)
                 return false
             } else {
                 fromListUuid?.let {
                     FirebaseAnalyticsTracker.podcastEpisodePlayedFromList(it, episode.podcastUuid)
                     analyticsTracker.track(AnalyticsEvent.DISCOVER_LIST_EPISODE_PLAY, mapOf(LIST_ID_KEY to it, PODCAST_ID_KEY to episode.podcastUuid))
                 }
-                playbackManager.playNow(episode, forceStream = force, playbackSource = source)
+                playbackManager.playNow(episode, forceStream = force, sourceView = source)
                 warningsHelper.showBatteryWarningSnackbarIfAppropriate()
                 return true
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -18,9 +18,9 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -532,7 +532,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
             }
         }
 
-        playButtonListener.source = AnalyticsSource.PODCAST_SCREEN
+        playButtonListener.source = SourceView.PODCAST_SCREEN
         if (adapter == null) {
             adapter = PodcastAdapter(
                 downloadManager = downloadManager,
@@ -629,7 +629,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                 }
             }
         }
-        multiSelectHelper.source = AnalyticsSource.PODCAST_SCREEN
+        multiSelectHelper.source = SourceView.PODCAST_SCREEN
         binding.multiSelectToolbar.setup(viewLifecycleOwner, multiSelectHelper, menuRes = null, fragmentManager = parentFragmentManager)
 
         return binding.root
@@ -800,7 +800,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                 null,
                 context,
                 SharePodcastHelper.ShareType.PODCAST,
-                AnalyticsSource.PODCAST_SCREEN,
+                SourceView.PODCAST_SCREEN,
                 analyticsTracker
             ).showShareDialogDirect()
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -16,8 +16,8 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
@@ -240,7 +240,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
     }
 
     private fun search() {
-        val searchFragment = SearchFragment.newInstance(source = AnalyticsSource.PODCAST_LIST)
+        val searchFragment = SearchFragment.newInstance(source = SourceView.PODCAST_LIST)
         (activity as FragmentHostListener).addFragment(searchFragment, onTop = true)
         realBinding?.recyclerView?.smoothScrollToPosition(0)
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
@@ -111,6 +111,6 @@ class PodcastEffectsViewModel
     }
 
     fun trackPlaybackEffectsEvent(event: AnalyticsEvent, props: Map<String, Any> = emptyMap()) {
-        playbackManager.trackPlaybackEffectsEvent(event, props, AnalyticsSource.PODCAST_SETTINGS)
+        playbackManager.trackPlaybackEffectsEvent(event, props, SourceView.PODCAST_SETTINGS)
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
@@ -4,8 +4,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -120,7 +120,7 @@ class PodcastSettingsViewModel @Inject constructor(
             podcastManager.unsubscribe(podcast.uuid, playbackManager)
             analyticsTracker.track(
                 AnalyticsEvent.PODCAST_UNSUBSCRIBED,
-                AnalyticsProp.podcastUnsubscribed(AnalyticsSource.PODCAST_SETTINGS, podcast.uuid)
+                AnalyticsProp.podcastUnsubscribed(SourceView.PODCAST_SETTINGS, podcast.uuid)
             )
         }
     }
@@ -160,7 +160,7 @@ class PodcastSettingsViewModel @Inject constructor(
     private object AnalyticsProp {
         private const val SOURCE_KEY = "source"
         private const val UUID_KEY = "uuid"
-        fun podcastUnsubscribed(source: AnalyticsSource, uuid: String) =
+        fun podcastUnsubscribed(source: SourceView, uuid: String) =
             mapOf(SOURCE_KEY to source.analyticsValue, UUID_KEY to uuid)
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -8,9 +8,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -184,7 +184,7 @@ class PodcastViewModel
             podcastManager.subscribeToPodcast(podcastUuid = it.uuid, sync = true)
             analyticsTracker.track(
                 AnalyticsEvent.PODCAST_SUBSCRIBED,
-                AnalyticsProp.podcastSubscribeToggled(uuid = it.uuid, source = AnalyticsSource.PODCAST_SCREEN)
+                AnalyticsProp.podcastSubscribeToggled(uuid = it.uuid, source = SourceView.PODCAST_SCREEN)
             )
         }
     }
@@ -194,7 +194,7 @@ class PodcastViewModel
             podcastManager.unsubscribeAsync(podcastUuid = it.uuid, playbackManager = playbackManager)
             analyticsTracker.track(
                 AnalyticsEvent.PODCAST_UNSUBSCRIBED,
-                AnalyticsProp.podcastSubscribeToggled(uuid = it.uuid, source = AnalyticsSource.PODCAST_SCREEN)
+                AnalyticsProp.podcastSubscribeToggled(uuid = it.uuid, source = SourceView.PODCAST_SCREEN)
             )
         }
     }
@@ -310,10 +310,10 @@ class PodcastViewModel
     fun episodeSwipeUpNext(episode: BaseEpisode) {
         launch {
             if (playbackManager.upNextQueue.contains(episode.uuid)) {
-                playbackManager.removeEpisode(episodeToRemove = episode, source = AnalyticsSource.PODCAST_SCREEN)
+                playbackManager.removeEpisode(episodeToRemove = episode, source = SourceView.PODCAST_SCREEN)
                 trackSwipeAction(SwipeAction.UP_NEXT_REMOVE)
             } else {
-                playbackManager.playNext(episode = episode, source = AnalyticsSource.PODCAST_SCREEN)
+                playbackManager.playNext(episode = episode, source = SourceView.PODCAST_SCREEN)
                 trackSwipeAction(SwipeAction.UP_NEXT_ADD_TOP)
             }
         }
@@ -322,10 +322,10 @@ class PodcastViewModel
     fun episodeSwipeUpLast(episode: BaseEpisode) {
         launch {
             if (playbackManager.upNextQueue.contains(episode.uuid)) {
-                playbackManager.removeEpisode(episodeToRemove = episode, source = AnalyticsSource.PODCAST_SCREEN)
+                playbackManager.removeEpisode(episodeToRemove = episode, source = SourceView.PODCAST_SCREEN)
                 trackSwipeAction(SwipeAction.UP_NEXT_REMOVE)
             } else {
-                playbackManager.playLast(episode = episode, source = AnalyticsSource.PODCAST_SCREEN)
+                playbackManager.playLast(episode = episode, source = SourceView.PODCAST_SCREEN)
                 trackSwipeAction(SwipeAction.UP_NEXT_ADD_BOTTOM)
             }
         }
@@ -409,7 +409,7 @@ class PodcastViewModel
     private fun trackEpisodeEvent(event: AnalyticsEvent, episode: PodcastEpisode) {
         episodeAnalytics.trackEvent(
             event,
-            source = AnalyticsSource.PODCAST_SCREEN,
+            source = SourceView.PODCAST_SCREEN,
             uuid = episode.uuid
         )
     }
@@ -417,7 +417,7 @@ class PodcastViewModel
     private fun trackEpisodeBulkEvent(event: AnalyticsEvent, count: Int) {
         episodeAnalytics.trackBulkEvent(
             event,
-            source = AnalyticsSource.PODCAST_SCREEN,
+            source = SourceView.PODCAST_SCREEN,
             count = count
         )
     }
@@ -458,7 +458,7 @@ class PodcastViewModel
             mapOf(SHOW_ARCHIVED to archived)
         fun notificationEnabled(show: Boolean) =
             mapOf(ENABLED_KEY to show)
-        fun podcastSubscribeToggled(source: AnalyticsSource, uuid: String) =
+        fun podcastSubscribeToggled(source: SourceView, uuid: String) =
             mapOf(SOURCE_KEY to source.analyticsValue, UUID_KEY to uuid)
         fun swipePerformed(source: SwipeSource, action: SwipeAction) =
             mapOf(SOURCE_KEY to source, ACTION_KEY to action.analyticsValue)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
@@ -41,7 +41,7 @@ class CloudBottomSheetViewModel @Inject constructor(
 ) : ViewModel() {
     lateinit var state: LiveData<BottomSheetState>
     var signInState = userManager.getSignInState().toLiveData()
-    private val source = AnalyticsSource.FILES
+    private val source = SourceView.FILES
 
     fun setup(uuid: String) {
         val isPlayingFlowable = playbackManager.playbackStateRelay.filter { it.episodeUuid == uuid }.map { it.isPlaying }.startWith(false).toFlowable(BackpressureStrategy.LATEST)
@@ -134,12 +134,12 @@ class CloudBottomSheetViewModel @Inject constructor(
     }
 
     fun playNow(episode: UserEpisode, forceStream: Boolean) {
-        playbackManager.playNow(episode = episode, forceStream = forceStream, playbackSource = source)
+        playbackManager.playNow(episode = episode, forceStream = forceStream, sourceView = source)
         analyticsTracker.track(AnalyticsEvent.USER_FILE_PLAY_PAUSE_BUTTON_TAPPED, mapOf(OPTION_KEY to PLAY))
     }
 
     fun pause() {
-        playbackManager.pause(playbackSource = source)
+        playbackManager.pause(sourceView = source)
         analyticsTracker.track(AnalyticsEvent.USER_FILE_PLAY_PAUSE_BUTTON_TAPPED, mapOf(OPTION_KEY to PAUSE))
     }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheet.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheet.kt
@@ -15,8 +15,8 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
@@ -329,7 +329,7 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
     private fun upload(episode: UserEpisode, isOnWifi: Boolean) {
         viewModel.trackOptionTapped(UPLOAD)
         if (settings.warnOnMeteredNetwork() && !isOnWifi) {
-            warningsHelper.uploadWarning(episodeUUID, source = AnalyticsSource.FILES)
+            warningsHelper.uploadWarning(episodeUUID, source = SourceView.FILES)
                 .show(parentFragmentManager, "upload_warning")
         } else {
             viewModel.uploadEpisode(episode)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -14,8 +14,8 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
@@ -103,8 +103,8 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             radiusPx = 4.dpToPx(context)
         }.smallPlaceholder()
 
-        playButtonListener.source = AnalyticsSource.FILES
-        multiSelectHelper.source = AnalyticsSource.FILES
+        playButtonListener.source = SourceView.FILES
+        multiSelectHelper.source = SourceView.FILES
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -250,7 +250,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             }
         }
         multiSelectHelper.coordinatorLayout = (activity as FragmentHostListener).snackBarView()
-        multiSelectHelper.source = AnalyticsSource.FILES
+        multiSelectHelper.source = SourceView.FILES
         binding?.multiSelectToolbar?.setup(viewLifecycleOwner, multiSelectHelper, menuRes = null, fragmentManager = parentFragmentManager)
     }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
@@ -3,9 +3,9 @@ package au.com.shiftyjelly.pocketcasts.profile.cloud
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -61,10 +61,10 @@ class CloudFilesViewModel @Inject constructor(
     fun episodeSwipeUpNext(episode: BaseEpisode) {
         GlobalScope.launch(Dispatchers.Default) {
             if (playbackManager.upNextQueue.contains(episode.uuid)) {
-                playbackManager.removeEpisode(episodeToRemove = episode, source = AnalyticsSource.FILES)
+                playbackManager.removeEpisode(episodeToRemove = episode, source = SourceView.FILES)
                 trackSwipeAction(SwipeAction.UP_NEXT_REMOVE)
             } else {
-                playbackManager.playNext(episode = episode, source = AnalyticsSource.FILES)
+                playbackManager.playNext(episode = episode, source = SourceView.FILES)
                 trackSwipeAction(SwipeAction.UP_NEXT_ADD_TOP)
             }
         }
@@ -74,10 +74,10 @@ class CloudFilesViewModel @Inject constructor(
     fun episodeSwipeUpLast(episode: BaseEpisode) {
         GlobalScope.launch(Dispatchers.Default) {
             if (playbackManager.upNextQueue.contains(episode.uuid)) {
-                playbackManager.removeEpisode(episodeToRemove = episode, source = AnalyticsSource.FILES)
+                playbackManager.removeEpisode(episodeToRemove = episode, source = SourceView.FILES)
                 trackSwipeAction(SwipeAction.UP_NEXT_REMOVE)
             } else {
-                playbackManager.playLast(episode = episode, source = AnalyticsSource.FILES)
+                playbackManager.playLast(episode = episode, source = SourceView.FILES)
                 trackSwipeAction(SwipeAction.UP_NEXT_ADD_BOTTOM)
             }
         }
@@ -92,7 +92,7 @@ class CloudFilesViewModel @Inject constructor(
         CloudDeleteHelper.deleteEpisode(episode, deleteState, playbackManager, episodeManager, userEpisodeManager)
         episodeAnalytics.trackEvent(
             event = if (deleteState == DeleteState.Cloud && !episode.isDownloaded) AnalyticsEvent.EPISODE_DELETED_FROM_CLOUD else AnalyticsEvent.EPISODE_DOWNLOAD_DELETED,
-            source = AnalyticsSource.FILES,
+            source = SourceView.FILES,
             uuid = episode.uuid,
         )
     }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -13,8 +13,8 @@ import androidx.appcompat.widget.SearchView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
@@ -61,7 +61,7 @@ class SearchFragment : BaseFragment() {
         fun newInstance(
             floating: Boolean = false,
             onlySearchRemote: Boolean = false,
-            source: AnalyticsSource
+            source: SourceView
         ): SearchFragment {
             val fragment = SearchFragment()
             val arguments = Bundle().apply {
@@ -83,8 +83,8 @@ class SearchFragment : BaseFragment() {
         get() = arguments?.getBoolean(ARG_FLOATING) ?: false
     val onlySearchRemote: Boolean
         get() = arguments?.getBoolean(ARG_ONLY_SEARCH_REMOTE) ?: false
-    val source: AnalyticsSource
-        get() = AnalyticsSource.fromString(arguments?.getString(ARG_SOURCE))
+    val source: SourceView
+        get() = SourceView.fromString(arguments?.getString(ARG_SOURCE))
 
     override fun onAttach(context: Context) {
         super.onAttach(context)

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -3,8 +3,8 @@ package au.com.shiftyjelly.pocketcasts.search
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
@@ -36,7 +36,7 @@ class SearchHandler @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     folderManager: FolderManager
 ) {
-    private var source: AnalyticsSource = AnalyticsSource.UNKNOWN
+    private var source: SourceView = SourceView.UNKNOWN
     private val searchQuery = BehaviorRelay.create<Query>().apply {
         accept(Query(""))
     }
@@ -211,7 +211,7 @@ class SearchHandler @Inject constructor(
         onlySearchRemoteObservable.accept(remote)
     }
 
-    fun setSource(source: AnalyticsSource) {
+    fun setSource(source: SourceView) {
         this.source = source
     }
 
@@ -219,6 +219,6 @@ class SearchHandler @Inject constructor(
 
     private object AnalyticsProp {
         private const val SOURCE = "source"
-        fun sourceMap(source: AnalyticsSource) = mapOf(SOURCE to source.analyticsValue)
+        fun sourceMap(source: SourceView) = mapOf(SOURCE to source.analyticsValue)
     }
 }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsFragment.kt
@@ -8,7 +8,7 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -31,8 +31,8 @@ class SearchResultsFragment : BaseFragment() {
 
     private val onlySearchRemote: Boolean
         get() = arguments?.getBoolean(ARG_ONLY_SEARCH_REMOTE) ?: false
-    private val source: AnalyticsSource
-        get() = AnalyticsSource.fromString(arguments?.getString(ARG_SOURCE))
+    private val source: SourceView
+        get() = SourceView.fromString(arguments?.getString(ARG_SOURCE))
     private val type: ResultsType
         get() = ResultsType.fromString(arguments?.getString(ARG_TYPE))
 
@@ -143,7 +143,7 @@ class SearchResultsFragment : BaseFragment() {
         fun newInstance(
             type: ResultsType,
             onlySearchRemote: Boolean = false,
-            source: AnalyticsSource
+            source: SourceView
         ): SearchResultsFragment {
             val fragment = SearchResultsFragment()
             val arguments = Bundle().apply {

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -5,8 +5,8 @@ import androidx.lifecycle.asFlow
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
@@ -42,7 +42,7 @@ class SearchViewModel @Inject constructor(
         searchState
     }
     val loading = searchHandler.loading
-    private var source: AnalyticsSource = AnalyticsSource.UNKNOWN
+    private var source: SourceView = SourceView.UNKNOWN
 
     private val _state: MutableStateFlow<SearchState> = MutableStateFlow(
         SearchState.Results(
@@ -100,7 +100,7 @@ class SearchViewModel @Inject constructor(
         searchHandler.setOnlySearchRemote(remote)
     }
 
-    fun setSource(source: AnalyticsSource) {
+    fun setSource(source: SourceView) {
         this.source = source
         searchHandler.setSource(source)
     }
@@ -137,7 +137,7 @@ class SearchViewModel @Inject constructor(
     }
 
     fun trackSearchResultTapped(
-        source: AnalyticsSource,
+        source: SourceView,
         uuid: String,
         type: SearchResultType
     ) {
@@ -149,7 +149,7 @@ class SearchViewModel @Inject constructor(
 
     fun trackSearchShownOrDismissed(
         event: AnalyticsEvent,
-        source: AnalyticsSource,
+        source: SourceView,
     ) {
         analyticsTracker.track(
             event,
@@ -157,7 +157,7 @@ class SearchViewModel @Inject constructor(
         )
     }
 
-    fun trackSearchListShown(source: AnalyticsSource, type: ResultsType) {
+    fun trackSearchListShown(source: SourceView, type: ResultsType) {
         analyticsTracker.track(
             AnalyticsEvent.SEARCH_LIST_SHOWN,
             AnalyticsProp.searchListShown(source = source, type = type)
@@ -177,16 +177,16 @@ class SearchViewModel @Inject constructor(
         private const val RESULT_TYPE = "result_type"
         private const val DISPLAYING = "displaying"
 
-        fun searchResultTapped(source: AnalyticsSource, uuid: String, type: SearchResultType) =
+        fun searchResultTapped(source: SourceView, uuid: String, type: SearchResultType) =
             mapOf(SOURCE to source.analyticsValue, UUID to uuid, RESULT_TYPE to type.value)
 
-        fun searchShownOrDismissed(source: AnalyticsSource) =
+        fun searchShownOrDismissed(source: SourceView) =
             mapOf(SOURCE to source.analyticsValue)
 
-        fun podcastSubscribed(source: AnalyticsSource, uuid: String) =
+        fun podcastSubscribed(source: SourceView, uuid: String) =
             mapOf(SOURCE to "${source.analyticsValue}_search", UUID to uuid)
 
-        fun searchListShown(source: AnalyticsSource, type: ResultsType) =
+        fun searchListShown(source: SourceView, type: ResultsType) =
             mapOf(SOURCE to source.analyticsValue, DISPLAYING to type.value)
     }
 }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModel.kt
@@ -3,8 +3,8 @@ package au.com.shiftyjelly.pocketcasts.search.searchhistory
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
@@ -27,7 +27,7 @@ class SearchHistoryViewModel @Inject constructor(
     private val signInState = userManager.getSignInState().asFlow()
     private var isSignedInAsPlusOrPatron = false
     private var onlySearchRemote: Boolean = false
-    private var source: AnalyticsSource = AnalyticsSource.UNKNOWN
+    private var source: SourceView = SourceView.UNKNOWN
 
     private val mutableState = MutableStateFlow(
         State(entries = emptyList())
@@ -42,7 +42,7 @@ class SearchHistoryViewModel @Inject constructor(
         onlySearchRemote = value
     }
 
-    fun setSource(source: AnalyticsSource) {
+    fun setSource(source: SourceView) {
         this.source = source
     }
 
@@ -118,9 +118,9 @@ class SearchHistoryViewModel @Inject constructor(
             const val SOURCE = "source"
             const val TYPE = "type"
             const val UUID = "uuid"
-            fun sourceMap(source: AnalyticsSource) = mapOf(SOURCE to source.analyticsValue)
+            fun sourceMap(source: SourceView) = mapOf(SOURCE to source.analyticsValue)
             fun searchHistoryEntryMap(
-                source: AnalyticsSource,
+                source: SourceView,
                 type: SearchHistoryType,
                 uuid: String? = null,
             ) = HashMap<String, String>().apply {

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/addtoupnext/ActionRunnerAddToUpNext.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/addtoupnext/ActionRunnerAddToUpNext.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.taskerplugin.addtoupnext
 
 import android.content.Context
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.episodeManager
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.playbackManager
@@ -40,7 +40,7 @@ class ActionRunnerAddToUpNext : TaskerPluginRunnerActionNoOutput<InputAddToUpNex
         }
 
         if (regularInput.startPlaying?.toBooleanStrictOrNull() == true) {
-            playbackManager.playEpisodes(episodesToPlay, AnalyticsSource.TASKER)
+            playbackManager.playEpisodes(episodesToPlay, SourceView.TASKER)
         } else {
             upNextQueue.changeList(episodesToPlay)
         }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.taskerplugin.controlplayback
 
 import android.content.Context
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.saveToGlobalSettings
@@ -46,13 +46,13 @@ class ActionRunnerControlPlayback : TaskerPluginRunnerActionNoOutput<InputContro
                 val jumpAmountSeconds = input.regular.skipSeconds?.toIntOrNull() ?: return TaskerPluginResultError(ERROR_INVALID_TIME_TO_SKIP_PROVIDED, context.getString(R.string.time_to_skip_not_valid, input.regular.skipSeconds))
 
                 if (commandEnum == InputControlPlayback.PlaybackCommand.SkipBack) {
-                    playbackManager.skipBackward(jumpAmountSeconds = jumpAmountSeconds, playbackSource = AnalyticsSource.TASKER)
+                    playbackManager.skipBackward(jumpAmountSeconds = jumpAmountSeconds, sourceView = SourceView.TASKER)
                 } else {
-                    playbackManager.skipForward(jumpAmountSeconds = jumpAmountSeconds, playbackSource = AnalyticsSource.TASKER)
+                    playbackManager.skipForward(jumpAmountSeconds = jumpAmountSeconds, sourceView = SourceView.TASKER)
                 }
             }
             InputControlPlayback.PlaybackCommand.PlayNextInQueue -> playbackManager.playNextInQueue(
-                AnalyticsSource.TASKER
+                SourceView.TASKER
             )
             InputControlPlayback.PlaybackCommand.SetPlaybackSpeed -> {
                 val speed = input.regular.playbackSpeed?.toDoubleOrNull() ?: return TaskerPluginResultError(ERROR_INVALID_PLAYBACK_SPEED_PROVIDED, context.getString(R.string.playback_speed_not_valid, input.regular.playbackSpeed))

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/playplaylist/ActionRunnerPlayPlaylist.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/playplaylist/ActionRunnerPlayPlaylist.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.taskerplugin.playplaylist
 
 import android.content.Context
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.episodeManager
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.playbackManager
@@ -31,7 +31,7 @@ class ActionRunnerPlayPlaylist : TaskerPluginRunnerActionNoOutput<InputPlayPlayl
         val episodes = playlistManager.findEpisodes(playlist, episodeManager, playbackManager)
         if (episodes.isEmpty()) return TaskerPluginResultError(ERROR_PLAYLIST_NO_EPISODES, context.getString(R.string.no_episodes_in_filter_x, title))
 
-        playbackManager.playEpisodes(episodes, AnalyticsSource.TASKER)
+        playbackManager.playEpisodes(episodes, SourceView.TASKER)
         return TaskerPluginResultSucess()
     }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
@@ -11,7 +11,7 @@ class EpisodeAnalytics @Inject constructor(
     private val downloadEpisodeUuidQueue = mutableListOf<String>()
     private val uploadEpisodeUuidQueue = mutableListOf<String>()
 
-    fun trackEvent(event: AnalyticsEvent, source: AnalyticsSource, uuid: String) {
+    fun trackEvent(event: AnalyticsEvent, source: SourceView, uuid: String) {
         if (event == AnalyticsEvent.EPISODE_DOWNLOAD_QUEUED) {
             downloadEpisodeUuidQueue.add(uuid)
         } else if (event == AnalyticsEvent.EPISODE_UPLOAD_QUEUED) {
@@ -38,15 +38,15 @@ class EpisodeAnalytics @Inject constructor(
         analyticsTracker.track(event, AnalyticsProp.uuidMap(uuid))
     }
 
-    fun trackEvent(event: AnalyticsEvent, source: AnalyticsSource, toTop: Boolean) {
+    fun trackEvent(event: AnalyticsEvent, source: SourceView, toTop: Boolean) {
         analyticsTracker.track(event, AnalyticsProp.sourceAndToTopMap(source, toTop))
     }
 
-    fun trackBulkEvent(event: AnalyticsEvent, source: AnalyticsSource, count: Int) {
+    fun trackBulkEvent(event: AnalyticsEvent, source: SourceView, count: Int) {
         analyticsTracker.track(event, AnalyticsProp.bulkMap(source, count))
     }
 
-    fun trackBulkEvent(event: AnalyticsEvent, source: AnalyticsSource, episodes: List<BaseEpisode>) {
+    fun trackBulkEvent(event: AnalyticsEvent, source: SourceView, episodes: List<BaseEpisode>) {
         if (event == AnalyticsEvent.EPISODE_BULK_DOWNLOAD_QUEUED) {
             downloadEpisodeUuidQueue.clear()
             downloadEpisodeUuidQueue.addAll(downloadEpisodeUuidQueue.union(episodes.map { it.uuid }))
@@ -56,7 +56,7 @@ class EpisodeAnalytics @Inject constructor(
 
     fun trackBulkEvent(
         event: AnalyticsEvent,
-        source: AnalyticsSource,
+        source: SourceView,
         count: Int,
         toTop: Boolean,
     ) {
@@ -68,17 +68,17 @@ class EpisodeAnalytics @Inject constructor(
         private const val episode_uuid = "episode_uuid"
         private const val count = "count"
         private const val to_top = "to_top"
-        fun sourceAndUuidMap(eventSource: AnalyticsSource, uuid: String) =
+        fun sourceAndUuidMap(eventSource: SourceView, uuid: String) =
             mapOf(source to eventSource.analyticsValue, episode_uuid to uuid)
 
         fun uuidMap(uuid: String) = mapOf(episode_uuid to uuid)
-        fun sourceAndToTopMap(eventSource: AnalyticsSource, toTop: Boolean) =
+        fun sourceAndToTopMap(eventSource: SourceView, toTop: Boolean) =
             mapOf(source to eventSource.analyticsValue, to_top to toTop)
 
-        fun bulkMap(eventSource: AnalyticsSource, count: Int) =
+        fun bulkMap(eventSource: SourceView, count: Int) =
             mapOf(source to eventSource.analyticsValue, this.count to count)
 
-        fun bulkToTopMap(eventSource: AnalyticsSource, count: Int, toTop: Boolean) = mapOf(
+        fun bulkToTopMap(eventSource: SourceView, count: Int, toTop: Boolean) = mapOf(
             source to eventSource.analyticsValue,
             this.count to count,
             to_top to toTop

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
@@ -1,6 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.analytics
 
-enum class AnalyticsSource(val analyticsValue: String) {
+enum class SourceView(val analyticsValue: String) {
     PODCAST_SCREEN("podcast_screen"),
     PODCAST_LIST("podcast_list"),
     FILTERS("filters"),
@@ -35,6 +35,6 @@ enum class AnalyticsSource(val analyticsValue: String) {
 
     companion object {
         fun fromString(source: String?) =
-            AnalyticsSource.values().find { it.analyticsValue == source } ?: UNKNOWN
+            SourceView.values().find { it.analyticsValue == source } ?: UNKNOWN
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
@@ -7,7 +7,7 @@ import android.app.job.JobScheduler
 import android.app.job.JobService
 import android.content.ComponentName
 import android.content.Context
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -171,7 +171,7 @@ class VersionMigrationsJob : JobService() {
         episodes.forEach { episode ->
             playbackManager.removeEpisode(
                 episodeToRemove = episode,
-                source = AnalyticsSource.UNKNOWN,
+                source = SourceView.UNKNOWN,
                 userInitiated = false
             )
             appDatabase.episodeDao().delete(episode)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -18,8 +18,8 @@ import androidx.annotation.DrawableRes
 import androidx.core.content.IntentCompat
 import androidx.core.os.bundleOf
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -90,7 +90,7 @@ class MediaSessionManager(
 
     val mediaSession = MediaSessionCompat(context, "PocketCastsMediaSession")
     val disposables = CompositeDisposable()
-    private val source = AnalyticsSource.MEDIA_BUTTON_BROADCAST_ACTION
+    private val source = SourceView.MEDIA_BUTTON_BROADCAST_ACTION
 
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
@@ -487,7 +487,7 @@ class MediaSessionManager(
                         object : TimerTask() {
                             override fun run() {
                                 logEvent("play from headset hook", inSessionCallback = false)
-                                playbackManager.playPause(playbackSource = source)
+                                playbackManager.playPause(sourceView = source)
                                 playPauseTimer = null
                             }
                         },
@@ -500,7 +500,7 @@ class MediaSessionManager(
                 playPauseTimer = null
 
                 logEvent("skip forwards from headset hook")
-                playbackManager.skipForward(playbackSource = source)
+                playbackManager.skipForward(sourceView = source)
             }
         }
 
@@ -518,12 +518,12 @@ class MediaSessionManager(
 
         override fun onPlay() {
             logEvent("play")
-            playbackManager.playQueue(playbackSource = source)
+            playbackManager.playQueue(sourceView = source)
         }
 
         override fun onPause() {
             logEvent("pause")
-            playbackManager.pause(playbackSource = source)
+            playbackManager.pause(sourceView = source)
         }
 
         override fun onPlayFromSearch(query: String?, extras: Bundle?) {
@@ -538,18 +538,18 @@ class MediaSessionManager(
             logEvent("stop")
             launch {
                 // note: the stop event is called from cars when they only want to pause, this is less destructive and doesn't cause issues if they try to play again
-                playbackManager.pause(playbackSource = source)
+                playbackManager.pause(sourceView = source)
             }
         }
 
         override fun onSkipToPrevious() {
             logEvent("skip backwards")
-            playbackManager.skipBackward(playbackSource = source)
+            playbackManager.skipBackward(sourceView = source)
         }
 
         override fun onSkipToNext() {
             logEvent("skip forwards")
-            playbackManager.skipForward(playbackSource = source)
+            playbackManager.skipForward(sourceView = source)
         }
 
         override fun onSetRating(rating: RatingCompat?) {
@@ -570,7 +570,7 @@ class MediaSessionManager(
                 val autoMediaId = AutoMediaId.fromMediaId(mediaId)
                 val episodeId = autoMediaId.episodeId
                 episodeManager.findEpisodeByUuid(episodeId)?.let { episode ->
-                    playbackManager.playNow(episode, playbackSource = source)
+                    playbackManager.playNow(episode, sourceView = source)
                     settings.setlastLoadedFromPodcastOrFilterUuid(autoMediaId.sourceId)
                 }
             }
@@ -596,7 +596,7 @@ class MediaSessionManager(
             if (state is UpNextQueue.State.Loaded) {
                 state.queue.find { it.adapterId == id }?.let { episode ->
                     logEvent("play from skip to queue item")
-                    playbackManager.playNow(episode = episode, playbackSource = source)
+                    playbackManager.playNow(episode = episode, sourceView = source)
                 }
             }
         }
@@ -605,7 +605,7 @@ class MediaSessionManager(
             logEvent("seek to $pos")
             launch {
                 playbackManager.seekToTimeMs(pos.toInt())
-                playbackManager.trackPlaybackSeek(pos.toInt(), AnalyticsSource.MEDIA_BUTTON_BROADCAST_ACTION)
+                playbackManager.trackPlaybackSeek(pos.toInt(), SourceView.MEDIA_BUTTON_BROADCAST_ACTION)
             }
         }
     }
@@ -710,10 +710,10 @@ class MediaSessionManager(
 
         Timber.i("performPlayFromSearch query: $query")
 
-        val playbackSource = AnalyticsSource.MEDIA_BUTTON_BROADCAST_SEARCH_ACTION
+        val sourceView = SourceView.MEDIA_BUTTON_BROADCAST_SEARCH_ACTION
         launch {
             if (query.startsWith("up next")) {
-                playbackManager.playQueue(playbackSource = playbackSource)
+                playbackManager.playQueue(sourceView = sourceView)
                 return@launch
             }
 
@@ -730,7 +730,7 @@ class MediaSessionManager(
                 val matchingPodcast: Podcast? = podcastManager.searchPodcastByTitle(option)
                 if (matchingPodcast != null) {
                     LogBuffer.i(LogBuffer.TAG_PLAYBACK, "User played podcast from search %s.", option)
-                    playPodcast(podcast = matchingPodcast, playbackSource = playbackSource)
+                    playPodcast(podcast = matchingPodcast, sourceView = sourceView)
                     return@launch
                 }
             }
@@ -738,7 +738,7 @@ class MediaSessionManager(
             for (option in options) {
                 val matchingEpisode = episodeManager.findFirstBySearchQuery(option) ?: continue
                 LogBuffer.i(LogBuffer.TAG_PLAYBACK, "User played episode from search %s.", option)
-                playbackManager.playNow(episode = matchingEpisode, playbackSource = playbackSource)
+                playbackManager.playNow(episode = matchingEpisode, sourceView = sourceView)
                 return@launch
             }
 
@@ -753,7 +753,7 @@ class MediaSessionManager(
                 val episodesToPlay = playlistManager.findEpisodes(playlist, episodeManager, playbackManager).take(5)
                 if (episodesToPlay.isEmpty()) return@launch
 
-                playEpisodes(episodesToPlay, playbackSource)
+                playEpisodes(episodesToPlay, sourceView)
 
                 return@launch
             }
@@ -780,17 +780,17 @@ class MediaSessionManager(
         return Completable.fromAction { performPlayFromSearch(searchTerm) }
     }
 
-    private fun playEpisodes(episodes: List<PodcastEpisode>, playbackSource: AnalyticsSource) {
+    private fun playEpisodes(episodes: List<PodcastEpisode>, sourceView: SourceView) {
         if (episodes.isEmpty()) {
             return
         }
 
-        playbackManager.playEpisodes(episodes = episodes, playbackSource = playbackSource)
+        playbackManager.playEpisodes(episodes = episodes, sourceView = sourceView)
     }
 
-    private suspend fun playPodcast(podcast: Podcast, playbackSource: AnalyticsSource = AnalyticsSource.UNKNOWN) {
+    private suspend fun playPodcast(podcast: Podcast, sourceView: SourceView = SourceView.UNKNOWN) {
         val latestEpisode = withContext(Dispatchers.Default) { episodeManager.findLatestUnfinishedEpisodeByPodcast(podcast) } ?: return
-        playbackManager.playNow(episode = latestEpisode, playbackSource = playbackSource)
+        playbackManager.playNow(episode = latestEpisode, sourceView = sourceView)
     }
 
     private fun shouldHideCustomSkipButtons(): Boolean {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiver.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.AndroidEntryPoint
@@ -28,7 +28,7 @@ class PlayerBroadcastReceiver : BroadcastReceiver() {
 
     @Inject lateinit var podcastManager: PodcastManager
     @Inject lateinit var playbackManager: PlaybackManager
-    private val playbackSource = AnalyticsSource.PLAYER_BROADCAST_ACTION
+    private val sourceView = SourceView.PLAYER_BROADCAST_ACTION
 
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action == INTENT_ACTION_REFRESH_PODCASTS) {
@@ -53,26 +53,26 @@ class PlayerBroadcastReceiver : BroadcastReceiver() {
     }
 
     private fun skipBackward() {
-        playbackManager.skipBackward(playbackSource = playbackSource)
+        playbackManager.skipBackward(sourceView = sourceView)
     }
 
     private fun skipForward() {
-        playbackManager.skipForward(playbackSource = playbackSource)
+        playbackManager.skipForward(sourceView = sourceView)
     }
 
     private fun pause() {
-        playbackManager.pause(playbackSource = playbackSource)
+        playbackManager.pause(sourceView = sourceView)
     }
 
     private fun play() {
-        playbackManager.playQueue(playbackSource = playbackSource)
+        playbackManager.playQueue(sourceView = sourceView)
     }
 
     private fun playNext() {
-        playbackManager.playNextInQueue(playbackSource = playbackSource)
+        playbackManager.playNextInQueue(sourceView = sourceView)
     }
 
     private fun stop() {
-        playbackManager.stopAsync(playbackSource = playbackSource)
+        playbackManager.stopAsync(sourceView = sourceView)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerReceiver.kt
@@ -4,7 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -17,7 +17,7 @@ class SleepTimerReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Paused from sleep timer.")
         Toast.makeText(context, "Sleep timer stopped your podcast.\nNight night!", Toast.LENGTH_LONG).show()
-        playbackManager.pause(playbackSource = AnalyticsSource.AUTO_PAUSE)
+        playbackManager.pause(sourceView = SourceView.AUTO_PAUSE)
         playbackManager.updateSleepTimerStatus(running = false)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -11,7 +11,7 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
@@ -476,7 +476,7 @@ class EpisodeManagerImpl @Inject constructor(
         justEpisodes.chunked(500).forEach { episodeDao.updateAllPlayingStatus(it.map { it.uuid }, System.currentTimeMillis(), EpisodePlayingStatus.COMPLETED) }
         archiveAllPlayedEpisodes(justEpisodes, playbackManager, podcastManager)
 
-        justEpisodes.forEach { playbackManager.removeEpisode(episodeToRemove = it, source = AnalyticsSource.UNKNOWN, userInitiated = false) }
+        justEpisodes.forEach { playbackManager.removeEpisode(episodeToRemove = it, source = SourceView.UNKNOWN, userInitiated = false) }
 
         userEpisodeManager.markAllAsPlayed(episodes.filterIsInstance<UserEpisode>(), playbackManager)
     }
@@ -495,7 +495,7 @@ class EpisodeManagerImpl @Inject constructor(
     }
 
     override fun markedAsPlayedExternally(episode: PodcastEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager) {
-        playbackManager.removeEpisode(episode, source = AnalyticsSource.UNKNOWN, userInitiated = false)
+        playbackManager.removeEpisode(episode, source = SourceView.UNKNOWN, userInitiated = false)
 
         // Auto archive after playing if the episode isn't already archived
         if (!episode.isArchived) {
@@ -514,7 +514,7 @@ class EpisodeManagerImpl @Inject constructor(
             return
         }
 
-        playbackManager.removeEpisode(episode, source = AnalyticsSource.UNKNOWN, userInitiated = false)
+        playbackManager.removeEpisode(episode, source = SourceView.UNKNOWN, userInitiated = false)
 
         episode.playingStatus = EpisodePlayingStatus.COMPLETED
 
@@ -552,7 +552,7 @@ class EpisodeManagerImpl @Inject constructor(
 
         // if the episode is currently playing, then stop it. Note: it will not be stopped if coming from the player as it is controlling the playback logic.
         if (removeFromUpNext) {
-            playbackManager?.removeEpisode(episode, source = AnalyticsSource.UNKNOWN, userInitiated = false)
+            playbackManager?.removeEpisode(episode, source = SourceView.UNKNOWN, userInitiated = false)
         }
 
         cleanUpDownloadFiles(episode)
@@ -598,7 +598,7 @@ class EpisodeManagerImpl @Inject constructor(
     override fun deleteCustomFolderEpisode(episode: PodcastEpisode?, playbackManager: PlaybackManager) {
         episode ?: return
 
-        playbackManager.removeEpisode(episode, source = AnalyticsSource.UNKNOWN, userInitiated = false)
+        playbackManager.removeEpisode(episode, source = SourceView.UNKNOWN, userInitiated = false)
 
         episodeDao.delete(episode)
     }
@@ -713,7 +713,7 @@ class EpisodeManagerImpl @Inject constructor(
             downloadManager.removeEpisodeFromQueue(episode, "episode manager")
         }
         deleteEpisodeFile(episode, playbackManager, disableAutoDownload = true, updateDatabase = true, removeFromUpNext = true)
-        playbackManager.removeEpisode(episode, source = AnalyticsSource.UNKNOWN, userInitiated = false)
+        playbackManager.removeEpisode(episode, source = SourceView.UNKNOWN, userInitiated = false)
     }
 
     override suspend fun findStaleDownloads(): List<PodcastEpisode> {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SharePodcastHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SharePodcastHelper.kt
@@ -3,8 +3,8 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 import android.content.Context
 import android.content.Intent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -21,7 +21,7 @@ data class SharePodcastHelper(
     val upToInSeconds: Double? = null, // Share a position in an episode of a podcast.
     val context: Context,
     private val shareType: ShareType,
-    private val source: AnalyticsSource,
+    private val source: SourceView,
     private val analyticsTracker: AnalyticsTrackerWrapper,
 ) {
 
@@ -69,12 +69,12 @@ data class SharePodcastHelper(
     }
 
     private fun shouldTrackShareEvent() =
-        source != AnalyticsSource.PODCAST_SCREEN // Podcast screen has it's own share event
+        source != SourceView.PODCAST_SCREEN // Podcast screen has it's own share event
 
     private object AnalyticsProp {
         const val SOURCE = "source"
         const val TYPE = "type"
-        fun shareMap(type: ShareType, source: AnalyticsSource) =
+        fun shareMap(type: ShareType, source: SourceView) =
             mapOf(TYPE to type.value, SOURCE to source.analyticsValue)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -8,8 +8,8 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -174,7 +174,7 @@ class UserEpisodeManagerImpl @Inject constructor(
         userEpisodeDao.insert(episode)
 
         if (settings.getCloudAddToUpNext()) {
-            playbackManager.playLast(episode = episode, source = AnalyticsSource.FILES)
+            playbackManager.playLast(episode = episode, source = SourceView.FILES)
         }
     }
 
@@ -188,7 +188,7 @@ class UserEpisodeManagerImpl @Inject constructor(
 
     override suspend fun delete(episode: UserEpisode, playbackManager: PlaybackManager) {
         deleteFilesForEpisode(episode)
-        playbackManager.removeEpisode(episodeToRemove = episode, source = AnalyticsSource.FILES, userInitiated = false)
+        playbackManager.removeEpisode(episodeToRemove = episode, source = SourceView.FILES, userInitiated = false)
         cancelUpload(episode)
         userEpisodeDao.delete(episode)
     }
@@ -202,7 +202,7 @@ class UserEpisodeManagerImpl @Inject constructor(
 
     override suspend fun deleteAll(episodes: List<UserEpisode>, playbackManager: PlaybackManager) {
         episodes.forEach {
-            playbackManager.removeEpisode(episodeToRemove = it, source = AnalyticsSource.FILES, userInitiated = false)
+            playbackManager.removeEpisode(episodeToRemove = it, source = SourceView.FILES, userInitiated = false)
         }
         userEpisodeDao.deleteAll(episodes)
     }
@@ -399,7 +399,7 @@ class UserEpisodeManagerImpl @Inject constructor(
             if (episode != null) {
                 if (!episode.isDownloaded) {
                     // File deleted from server
-                    playbackManager.removeEpisode(episode, source = AnalyticsSource.UNKNOWN, userInitiated = false)
+                    playbackManager.removeEpisode(episode, source = SourceView.UNKNOWN, userInitiated = false)
                     userEpisodeDao.delete(episode)
                 } else {
                     if (episode.serverStatus == UserEpisodeServerStatus.UPLOADED) {
@@ -594,7 +594,7 @@ class UserEpisodeManagerImpl @Inject constructor(
 
     override suspend fun markAllAsPlayed(episodes: List<UserEpisode>, playbackManager: PlaybackManager) {
         episodes.map { it.uuid }.chunked(500).forEach { userEpisodeDao.updateAllPlayingStatus(it, System.currentTimeMillis(), EpisodePlayingStatus.COMPLETED) }
-        episodes.forEach { playbackManager.removeEpisode(it, source = AnalyticsSource.UNKNOWN, userInitiated = false) }
+        episodes.forEach { playbackManager.removeEpisode(it, source = SourceView.UNKNOWN, userInitiated = false) }
     }
 
     override suspend fun markAllAsUnplayed(episodes: List<UserEpisode>) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -14,7 +14,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
 import androidx.work.ListenableWorker
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.BuildConfig
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -330,16 +330,16 @@ class RefreshPodcastsThread(
             episodesToAddToUpNext.forEach {
                 if (playbackManager.upNextQueue.queueEpisodes.size < upNextLimit) {
                     when (it.first) {
-                        AddToUpNext.Next -> playbackManager.playNext(it.second, source = AnalyticsSource.UNKNOWN, userInitiated = false)
-                        AddToUpNext.Last -> playbackManager.playLast(it.second, source = AnalyticsSource.UNKNOWN, userInitiated = false)
+                        AddToUpNext.Next -> playbackManager.playNext(it.second, source = SourceView.UNKNOWN, userInitiated = false)
+                        AddToUpNext.Last -> playbackManager.playLast(it.second, source = SourceView.UNKNOWN, userInitiated = false)
                     }
                 } else if (playbackManager.upNextQueue.queueEpisodes.size >= upNextLimit &&
                     settings.getAutoAddUpNextLimitBehaviour() == Settings.AutoAddUpNextLimitBehaviour.ONLY_ADD_TO_TOP &&
                     it.first == AddToUpNext.Next
                 ) {
-                    playbackManager.playNext(it.second, source = AnalyticsSource.UNKNOWN, userInitiated = false)
+                    playbackManager.playNext(it.second, source = SourceView.UNKNOWN, userInitiated = false)
                     playbackManager.upNextQueue.queueEpisodes.lastOrNull()?.let { lastEpisode ->
-                        playbackManager.removeEpisode(lastEpisode, source = AnalyticsSource.UNKNOWN, userInitiated = false)
+                        playbackManager.removeEpisode(lastEpisode, source = SourceView.UNKNOWN, userInitiated = false)
                     }
                 }
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/NotificationBroadcastReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/NotificationBroadcastReceiver.kt
@@ -5,8 +5,8 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
@@ -30,7 +30,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver(), CoroutineScope {
     @Inject lateinit var playbackManager: PlaybackManager
     @Inject lateinit var episodeAnalytics: EpisodeAnalytics
 
-    private val source = AnalyticsSource.NOTIFICATION
+    private val source = SourceView.NOTIFICATION
 
     companion object {
 
@@ -95,7 +95,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver(), CoroutineScope {
     private fun playNow(episodeUuid: String, forceStream: Boolean) {
         launch {
             episodeManager.findEpisodeByUuid(episodeUuid)?.let { episode ->
-                playbackManager.playNow(episode, forceStream = forceStream, playbackSource = source)
+                playbackManager.playNow(episode, forceStream = forceStream, sourceView = source)
             }
         }
     }
@@ -139,7 +139,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver(), CoroutineScope {
             episodeManager.findEpisodeByUuid(episodeUuid)?.let { episode ->
                 playbackManager.playLast(episode = episode, source = source)
                 if (playNext) {
-                    playbackManager.playNextInQueue(playbackSource = source)
+                    playbackManager.playNextInQueue(sourceView = source)
                 }
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -4,8 +4,8 @@ import android.accounts.AccountManager
 import android.accounts.OnAccountsUpdateListener
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -146,7 +146,7 @@ class UserManagerImpl @Inject constructor(
         playbackManager.removeEpisode(
             episodeToRemove = playbackManager.getCurrentEpisode(),
             // Unknown is fine here because we don't send analytics when the user did not initiate the action
-            source = AnalyticsSource.UNKNOWN,
+            source = SourceView.UNKNOWN,
             userInitiated = false,
         )
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/ShareDialog.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/ShareDialog.kt
@@ -2,8 +2,8 @@ package au.com.shiftyjelly.pocketcasts.views.dialog
 
 import android.content.Context
 import androidx.fragment.app.FragmentManager
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SharePodcastHelper
@@ -20,7 +20,7 @@ class ShareDialog(
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) {
 
-    private val source = AnalyticsSource.EPISODE_DETAILS
+    private val source = SourceView.EPISODE_DETAILS
     fun show() {
         if (fragmentManager == null || context == null) {
             return

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
@@ -5,8 +5,8 @@ import android.content.Context
 import android.view.View
 import androidx.fragment.app.Fragment
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -45,11 +45,11 @@ class WarningsHelper @Inject constructor(
     fun streamingWarningDialog(
         episode: BaseEpisode,
         snackbarParentView: View? = null,
-        playbackSource: AnalyticsSource
+        sourceView: SourceView
     ): ConfirmationDialog {
         return streamingWarningDialog(onConfirm = {
             GlobalScope.launch {
-                playbackManager.playNow(episode = episode, forceStream = true, playbackSource = playbackSource)
+                playbackManager.playNow(episode = episode, forceStream = true, sourceView = sourceView)
                 showBatteryWarningSnackbarIfAppropriate(snackbarParentView)
             }
         })
@@ -79,7 +79,7 @@ class WarningsHelper @Inject constructor(
             .setOnSecondary { download(episodeUuid, waitForWifi = true, from = from) }
     }
 
-    fun uploadWarning(episodeUuid: String, source: AnalyticsSource): ConfirmationDialog {
+    fun uploadWarning(episodeUuid: String, source: SourceView): ConfirmationDialog {
         val titleRes =
             if (Network.isWifiConnection(activity)) LR.string.profile_cloud_upload_warning_title_metered_wifi else LR.string.profile_cloud_upload_warning_title_on_wifi
         return ConfirmationDialog()
@@ -93,7 +93,7 @@ class WarningsHelper @Inject constructor(
     }
 
     @OptIn(DelicateCoroutinesApi::class)
-    private fun upload(episodeUuid: String, waitForWifi: Boolean, source: AnalyticsSource) {
+    private fun upload(episodeUuid: String, waitForWifi: Boolean, source: SourceView) {
         GlobalScope.launch {
             episodeManager.findEpisodeByUuid(episodeUuid)?.let {
                 if (it !is UserEpisode) return@let

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBottomSheet.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBottomSheet.kt
@@ -8,8 +8,8 @@ import androidx.core.os.bundleOf
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
@@ -74,7 +74,7 @@ class MultiSelectBottomSheet : BaseDialogFragment() {
         }
 
         binding.btnEdit.setOnClickListener {
-            val source = (multiSelectHelper?.source ?: AnalyticsSource.UNKNOWN)
+            val source = (multiSelectHelper?.source ?: SourceView.UNKNOWN)
             analyticsTracker.track(
                 AnalyticsEvent.MULTI_SELECT_VIEW_OVERFLOW_MENU_REARRANGE_STARTED,
                 AnalyticsProp.sourceMap(source)
@@ -92,7 +92,7 @@ class MultiSelectBottomSheet : BaseDialogFragment() {
     private object AnalyticsProp {
         private const val source = "source"
 
-        fun sourceMap(eventSource: AnalyticsSource) =
+        fun sourceMap(eventSource: SourceView) =
             mapOf(source to eventSource.analyticsValue)
     }
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectFragment.kt
@@ -9,8 +9,8 @@ import androidx.lifecycle.toLiveData
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.SimpleItemAnimator
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.databinding.FragmentMultiselectBinding
@@ -29,7 +29,7 @@ class MultiSelectFragment : BaseFragment(), MultiSelectTouchCallback.ItemTouchHe
     @Inject lateinit var settings: Settings
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
     private val source: String
-        get() = arguments?.getString(ARG_SOURCE) ?: AnalyticsSource.UNKNOWN.analyticsValue
+        get() = arguments?.getString(ARG_SOURCE) ?: SourceView.UNKNOWN.analyticsValue
 
     private val adapter = MultiSelectAdapter(editable = true, listener = null, dragListener = this::onItemStartDrag)
     private lateinit var itemTouchHelper: ItemTouchHelper
@@ -183,7 +183,7 @@ class MultiSelectFragment : BaseFragment(), MultiSelectTouchCallback.ItemTouchHe
 
     companion object {
         private const val ARG_SOURCE = "source"
-        fun newInstance(source: AnalyticsSource) = MultiSelectFragment().apply {
+        fun newInstance(source: SourceView) = MultiSelectFragment().apply {
             arguments = bundleOf(
                 ARG_SOURCE to source.analyticsValue,
             )

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectHelper.kt
@@ -10,9 +10,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.map
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -93,7 +93,7 @@ class MultiSelectHelper @Inject constructor(
 
     var coordinatorLayout: View? = null
     var context: Context? = null
-    var source = AnalyticsSource.UNKNOWN
+    var source = SourceView.UNKNOWN
 
     lateinit var listener: Listener
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectToolbar.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectToolbar.kt
@@ -11,8 +11,8 @@ import androidx.core.graphics.drawable.DrawableCompat
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LifecycleOwner
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.views.R
 import au.com.shiftyjelly.pocketcasts.views.extensions.tintIcons
@@ -120,7 +120,7 @@ class MultiSelectToolbar @JvmOverloads constructor(
     private object AnalyticsProp {
         private const val source = "source"
 
-        fun sourceMap(eventSource: AnalyticsSource) =
+        fun sourceMap(eventSource: SourceView) =
             mapOf(source to eventSource.analyticsValue)
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -11,8 +11,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.palette.graphics.Palette
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -81,7 +81,7 @@ class EpisodeViewModel @Inject constructor(
     private val audioOutputSelectorHelper: AudioOutputSelectorHelper,
 ) : AndroidViewModel(appContext as Application) {
     private var playAttempt: Job? = null
-    private val analyticsSource = AnalyticsSource.EPISODE_DETAILS
+    private val sourceView = SourceView.EPISODE_DETAILS
 
     sealed class State {
         data class Loaded(
@@ -264,7 +264,7 @@ class EpisodeViewModel @Inject constructor(
 
                 episodeAnalytics.trackEvent(
                     event = AnalyticsEvent.EPISODE_DOWNLOAD_CANCELLED,
-                    source = analyticsSource,
+                    source = sourceView,
                     uuid = episode.uuid
                 )
             } else if (!episode.isDownloaded) {
@@ -274,7 +274,7 @@ class EpisodeViewModel @Inject constructor(
 
                 episodeAnalytics.trackEvent(
                     event = AnalyticsEvent.EPISODE_DOWNLOAD_QUEUED,
-                    source = analyticsSource,
+                    source = sourceView,
                     uuid = episode.uuid
                 )
             }
@@ -301,7 +301,7 @@ class EpisodeViewModel @Inject constructor(
             )
             episodeAnalytics.trackEvent(
                 event = AnalyticsEvent.EPISODE_DOWNLOAD_DELETED,
-                source = analyticsSource,
+                source = sourceView,
                 uuid = episode.uuid,
             )
         }
@@ -335,7 +335,7 @@ class EpisodeViewModel @Inject constructor(
             }
             playbackManager.playNowSync(
                 episode = episode,
-                playbackSource = analyticsSource,
+                sourceView = sourceView,
             )
             _showNowPlaying.emit(true)
         }
@@ -349,7 +349,7 @@ class EpisodeViewModel @Inject constructor(
         playAttempt?.cancel()
 
         viewModelScope.launch {
-            playbackManager.pause(playbackSource = analyticsSource)
+            playbackManager.pause(sourceView = sourceView)
         }
     }
 
@@ -359,7 +359,7 @@ class EpisodeViewModel @Inject constructor(
             playbackManager.play(
                 upNextPosition = upNextPosition,
                 episode = state.episode,
-                source = analyticsSource
+                source = sourceView
             )
         }
     }
@@ -368,7 +368,7 @@ class EpisodeViewModel @Inject constructor(
         val state = stateFlow.value as? State.Loaded ?: return
         playbackManager.removeEpisode(
             episodeToRemove = state.episode,
-            source = AnalyticsSource.EPISODE_DETAILS
+            source = SourceView.EPISODE_DETAILS
         )
     }
 
@@ -402,14 +402,14 @@ class EpisodeViewModel @Inject constructor(
                 episodeManager.unarchive(episode)
                 episodeAnalytics.trackEvent(
                     AnalyticsEvent.EPISODE_UNARCHIVED,
-                    analyticsSource,
+                    sourceView,
                     episode.uuid
                 )
             } else {
                 episodeManager.archive(episode, playbackManager)
                 episodeAnalytics.trackEvent(
                     AnalyticsEvent.EPISODE_ARCHIVED,
-                    analyticsSource,
+                    sourceView,
                     episode.uuid
                 )
             }
@@ -426,7 +426,7 @@ class EpisodeViewModel @Inject constructor(
             episodeManager.toggleStarEpisodeAsync(episode)
             val event =
                 if (episode.isStarred) AnalyticsEvent.EPISODE_UNSTARRED else AnalyticsEvent.EPISODE_STARRED
-            episodeAnalytics.trackEvent(event, analyticsSource, episode.uuid)
+            episodeAnalytics.trackEvent(event, sourceView, episode.uuid)
         }
     }
 
@@ -440,7 +440,7 @@ class EpisodeViewModel @Inject constructor(
                     episodeManager.markAsPlayed(episode, playbackManager, podcastManager)
                     AnalyticsEvent.EPISODE_MARKED_AS_PLAYED
                 }
-                episodeAnalytics.trackEvent(event, analyticsSource, episode.uuid)
+                episodeAnalytics.trackEvent(event, sourceView, episode.uuid)
             }
         }
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.wear.ui.player
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsSource
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -104,15 +104,15 @@ class NowPlayingViewModel @Inject constructor(
     fun onPauseButtonClick() {
         playAttempt?.cancel()
 
-        playbackManager.pause(playbackSource = AnalyticsSource.PLAYER)
+        playbackManager.pause(sourceView = SourceView.PLAYER)
     }
 
     fun onSeekBackButtonClick() {
-        playbackManager.skipBackward(AnalyticsSource.PLAYER)
+        playbackManager.skipBackward(SourceView.PLAYER)
     }
 
     fun onSeekForwardButtonClick() {
-        playbackManager.skipForward(AnalyticsSource.PLAYER)
+        playbackManager.skipForward(SourceView.PLAYER)
     }
 
     fun onStreamingConfirmationResult(result: StreamingConfirmationScreen.Result) {
@@ -125,6 +125,6 @@ class NowPlayingViewModel @Inject constructor(
     }
 
     private fun play() {
-        playbackManager.playQueue(AnalyticsSource.PLAYER)
+        playbackManager.playQueue(SourceView.PLAYER)
     }
 }


### PR DESCRIPTION
## Description
This builds on https://github.com/Automattic/pocket-casts-android/pull/1132 by renaming the `AnalyticsSource` class since we're no longer just using it for analytics. There are no other changes in this PR. This is really a part of that PR, but I wanted to separate it out so to make that PR more reviewable, so you probably want to review that before merging this.

I thought about also moving it out of the analytics package, but I didn't see a great other place to put it at this point (utils would be ok, but doesn't seem like a perfect fit), so I figured I'd leave it in analytics for now, and we can move it later if we want.

I also don't love the name `SourceView` so let me know if you have any better ideas.

## Testing Instructions
If CI is happy, this should be good.