### PR TITLE
Show plus upsell from plus settings menu

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -205,7 +205,8 @@ private fun Content(
                 OnboardingUpgradeSource.LOGIN,
                 OnboardingUpgradeSource.PLUS_DETAILS,
                 OnboardingUpgradeSource.PROFILE,
-                OnboardingUpgradeSource.ACCOUNT_DETAILS -> false
+                OnboardingUpgradeSource.ACCOUNT_DETAILS,
+                OnboardingUpgradeSource.SETTINGS -> false
 
                 OnboardingUpgradeSource.RECOMMENDATIONS -> true
             }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragmentPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragmentPage.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -21,10 +22,16 @@ import au.com.shiftyjelly.pocketcasts.compose.components.GradientIconData
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRow
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.settings.about.AboutFragment
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.settings.privacy.PrivacyFragment
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.views.fragments.BatteryRestrictionsSettingsFragment
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -38,6 +45,7 @@ fun SettingsFragmentPage(
     onBackPressed: () -> Unit,
     openFragment: (Fragment) -> Unit
 ) {
+    val context = LocalContext.current
     Column {
         ThemedTopAppBar(
             title = stringResource(LR.string.settings),
@@ -64,7 +72,18 @@ fun SettingsFragmentPage(
             }
 
             if (!signInState.isSignedIn || signInState.isSignedInAsFree) {
-                PlusRow(onClick = { openFragment(PlusSettingsFragment()) })
+                PlusRow(onClick = {
+                    if (FeatureFlag.isEnabled(Feature.ADD_PATRON_ENABLED)) {
+                        OnboardingLauncher.openOnboardingFlow(
+                            context.getActivity(),
+                            OnboardingFlow.PlusUpsell(
+                                OnboardingUpgradeSource.SETTINGS
+                            )
+                        )
+                    } else {
+                        openFragment(PlusSettingsFragment())
+                    }
+                })
             }
 
             GeneralRow(onClick = { openFragment(PlaybackSettingsFragment()) })

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
@@ -9,4 +9,5 @@ enum class OnboardingUpgradeSource(val analyticsValue: String) {
     PROFILE("profile"),
     ACCOUNT_DETAILS("account_details"),
     RECOMMENDATIONS("recommendations"),
+    SETTINGS("settings"),
 }


### PR DESCRIPTION
## Description
This matches behavior on iOS to show plus upsell screen from plus settings menu

## Testing Instructions

Prerequisites:

- In-app billing sandbox setup
- Debug build variant
- License test account
- `Patron` feature flag enabled

1. Launch the app (without login)
2. Go to `Profile` -> `Settings` (⚙️)
3. Tap `Pocket Casts Plus` menu
4. Notice that `Plus Upsell` screen is shown
5. Notice in logs that source is `settings` for `plus_promotion_shown` track event

** For the disabled `Patron` feature flag, old plus screen should be shown

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/45c776ca-134f-41d0-b530-3a9610499b3a



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
