### PR TITLE
Update autoplay setting name

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -279,7 +279,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                             saved = settings.autoPlayNextEpisodeOnEmptyFlow.collectAsState().value,
                             onSave = {
                                 analyticsTracker.track(
-                                    AnalyticsEvent.SETTINGS_GENERAL_CONTINUOUS_PLAYBACK_TOGGLED,
+                                    AnalyticsEvent.SETTINGS_GENERAL_AUTOPLAY_TOGGLED,
                                     mapOf("enabled" to it)
                                 )
                                 settings.setAutoPlayNextEpisodeOnEmpty(it)
@@ -523,7 +523,7 @@ class PlaybackSettingsFragment : BaseFragment() {
     @Composable
     private fun AutoPlayNextOnEmpty(saved: Boolean, onSave: (Boolean) -> Unit) =
         SettingRow(
-            primaryText = stringResource(LR.string.settings_continuous_playback),
+            primaryText = stringResource(LR.string.settings_autoplay),
             secondaryText = stringResource(LR.string.settings_continuous_playback_summary),
             toggle = SettingRowToggle.Switch(checked = saved),
             modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -476,7 +476,7 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_SHOWN("settings_general_media_notification_controls_shown"),
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_SHOW_CUSTOM_TOGGLED("settings_general_media_notification_controls_show_custom_toggled"),
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_ORDER_CHANGED("settings_general_media_notification_controls_order_changed"),
-    SETTINGS_GENERAL_CONTINUOUS_PLAYBACK_TOGGLED("settings_general_continuous_playback_toggled"),
+    SETTINGS_GENERAL_AUTOPLAY_TOGGLED("settings_general_autoplay_toggled"),
 
     /* Settings - Help */
     SETTINGS_HELP_SHOWN("settings_help_shown"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1209,7 +1209,7 @@
     <string name="settings_up_next_swipe_summary">When swiping from left to right on an episode, the default action will be %s.</string>
     <string name="settings_up_next_tap">Play Up Next episode on tap</string>
     <string name="settings_up_next_tap_summary">If on, tapping on an item in your Up Next queue will play it. Long pressing will show the episode options.</string>
-    <string name="settings_continuous_playback">Continuous playback</string>
+    <string name="settings_autoplay">Autoplay</string>
     <string name="settings_continuous_playback_summary">If your Up Next queue is empty, we\'ll play episodes from the same podcast or list you\'re currently listening to.</string>
     <string name="settings_use_android_light_dark_mode">Use Android Light/Dark Mode</string>
     <string name="settings_use_embedded_podcast_artwork">Use embedded podcast artwork</string>


### PR DESCRIPTION
## Description
This updates the name of the autoplay setting from "Continuous playback" to "Autoplay"

## Testing Instructions
1. With the feature flag enabled, go to the settings and verify that the setting has been renamed to "Autoplay"
2. Toggle the setting
3. Verify that we are tracking the event: `settings_general_autoplay_toggled` with the appropriate boolean for the "enabled" property

## Screenshots or Screencast 

![image](https://github.com/Automattic/pocket-casts-android/assets/4656348/7deb9e17-56cf-4d3b-b979-ac2445bbde4a)

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
