### PR TITLE
Track when an episode is autoplayed

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -240,6 +240,7 @@ enum class AnalyticsEvent(val key: String) {
     PLAYBACK_SKIP_FORWARD("playback_skip_forward"),
     PLAYBACK_STOP("playback_stop"),
     PLAYBACK_SEEK("playback_seek"),
+    PLAYBACK_EPISODE_AUTOPLAYED("playback_episode_autoplayed"),
 
     /* Privacy */
     PRIVACY_SETTINGS_SHOWN("privacy_settings_shown"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -238,6 +238,10 @@ open class PlaybackManager @Inject constructor(
             }
         }
 
+        analyticsTracker.track(
+            AnalyticsEvent.PLAYBACK_EPISODE_AUTOPLAYED,
+            mapOf("episode_uuid" to autoPlayEpisode.uuid),
+        )
         return autoPlayEpisode
     }
 


### PR DESCRIPTION
## Description
Tracking when an episode is autoplayed.

## Testing Instructions

When referring to the autoplay event in the test steps below, I am referring to the event "playback_episode_autoplayed" with  an "episode_uuid" property reflecting the uuid of the episode being autoplayed.

1. With the autplay feature enabled and an empty up next queue
2. Begin playing an episode
3. Observe that the autoplay event is NOT sent
4. Complete the episode
5. Observe that the autoplay event IS sent
7. Add an episode to your up next queue
8. Complete playing the current episode and the episode in the up next queue
9. Observe that no new autoplay events are sent (should only have 1 autoplay event from following all these test steps)

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews