### PR TITLE
+ - 1 min Custom Increments on the Sleep timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 -----
 *   New Feature:
     *   Add capability to add +1 minute on the sleep timer
-        ([#1139](https://github.com/Automattic/pocket-casts-android/pull/1139)).
+        ([#1139](https://github.com/Automattic/pocket-casts-android/pull/1139))
+    * Adds +- 1 increments to the sleep timer if the custom timer is less than 5 Min
+        ([#1144](https://github.com/Automattic/pocket-casts-android/pull/1144)).
+
 
 7.42
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
@@ -143,12 +143,20 @@ class SleepFragment : BaseDialogFragment() {
     }
 
     private fun plusButtonClicked() {
-        viewModel.sleepCustomTimeMins = viewModel.sleepCustomTimeMins + 5
+        if (viewModel.sleepCustomTimeMins < 5) {
+            viewModel.sleepCustomTimeMins += 1
+        } else {
+            viewModel.sleepCustomTimeMins += 5
+        }
         binding?.root?.announceForAccessibility("Custom sleep time ${viewModel.sleepCustomTimeMins}")
     }
 
     private fun minusButtonClicked() {
-        viewModel.sleepCustomTimeMins = viewModel.sleepCustomTimeMins - 5
+        if (viewModel.sleepCustomTimeMins <= 5) {
+            viewModel.sleepCustomTimeMins -= 1
+        } else {
+            viewModel.sleepCustomTimeMins -= 5
+        }
         binding?.root?.announceForAccessibility("Custom sleep time ${viewModel.sleepCustomTimeMins}")
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -274,7 +274,7 @@ class PlayerViewModel @Inject constructor(
     }
     var sleepCustomTimeMins: Int = 5
         set(value) {
-            field = value.coerceIn(5, 240)
+            field = value.coerceIn(1, 240)
             settings.setSleepTimerCustomMins(field)
             sleepCustomTimeText.postValue(calcCustomTimeText())
             updateSleepTimer()


### PR DESCRIPTION
## Description
This PR adds +-1 increments if the custom timer is <5. 
Fixes # N/A

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Tap on the Discover tab
2. Tap on any random podcast and hit play
3. Click on  Sleep timer.
4. Click on - +.
5. If the Custom timer is below 5, it reduces /increases by 1 min

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/95022986/6ea0ba14-2f93-4157-873c-9f38ea1c536d


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
