### PR TITLE
Bookmarks: Add new tab on player

### DIFF
--- a/modules/features/player/build.gradle
+++ b/modules/features/player/build.gradle
@@ -10,15 +10,16 @@ android {
 }
 
 dependencies {
-    implementation project(':modules:services:localization')
-    implementation project(':modules:services:preferences')
-    implementation project(':modules:services:utils')
-    implementation project(':modules:services:images')
-    implementation project(':modules:services:ui')
-    implementation project(':modules:services:compose')
-    implementation project(':modules:services:views')
-    implementation project(':modules:services:servers')
-    implementation project(':modules:services:repositories')
-    implementation project(':modules:services:model')
     implementation project(':modules:services:analytics')
+    implementation project(':modules:services:compose')
+    implementation project(':modules:services:featureflag')
+    implementation project(':modules:services:images')
+    implementation project(':modules:services:localization')
+    implementation project(':modules:services:model')
+    implementation project(':modules:services:preferences')
+    implementation project(':modules:services:repositories')
+    implementation project(':modules:services:servers')
+    implementation project(':modules:services:utils')
+    implementation project(':modules:services:ui')
+    implementation project(':modules:services:views')
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
@@ -44,7 +44,7 @@ class BookmarksFragment : BaseFragment() {
 }
 
 @Composable
-fun BookmarksPage(
+private fun BookmarksPage(
     playerViewModel: PlayerViewModel,
 ) {
     val listData = playerViewModel.listDataLive.asFlow().collectAsState(initial = null)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
@@ -1,0 +1,64 @@
+package au.com.shiftyjelly.pocketcasts.player.view
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.asFlow
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class BookmarksFragment : BaseFragment() {
+    private val playerViewModel: PlayerViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = ComposeView(requireContext()).apply {
+        setContent {
+            AppThemeWithBackground(theme.activeTheme) {
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+                BookmarksPage(
+                    playerViewModel = playerViewModel
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun BookmarksPage(
+    playerViewModel: PlayerViewModel,
+) {
+    val listData = playerViewModel.listDataLive.asFlow().collectAsState(initial = null)
+    listData.value?.let {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color(it.podcastHeader.backgroundColor))
+        ) {
+            TextH30(
+                text = "Placeholder Text",
+                color = MaterialTheme.theme.colors.playerContrast01
+            )
+        }
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -122,20 +122,20 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
 
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
-                when (adapter.pageTitle(position)) {
-                    LR.string.player_tab_playing -> {
+                when {
+                    adapter.isPlayerTab(position) -> {
                         if (previousPosition == INVALID_TAB_POSITION) return
                         analyticsTracker.track(AnalyticsEvent.PLAYER_TAB_SELECTED, mapOf(TAB_KEY to NOW_PLAYING))
                         FirebaseAnalyticsTracker.nowPlayingOpen()
                     }
-                    LR.string.player_tab_notes -> {
+                    adapter.isNotesTab(position) -> {
                         analyticsTracker.track(AnalyticsEvent.PLAYER_TAB_SELECTED, mapOf(TAB_KEY to SHOW_NOTES))
                         FirebaseAnalyticsTracker.openedPlayerNotes()
                     }
-                    LR.string.player_tab_bookmarks -> {
+                    adapter.isBookmarksTab(position) -> {
                         // TODO: Bookmarks - Add analytics event
                     }
-                    LR.string.player_tab_chapters -> {
+                    adapter.isChaptersTab(position) -> {
                         analyticsTracker.track(AnalyticsEvent.PLAYER_TAB_SELECTED, mapOf(TAB_KEY to CHAPTERS))
                         FirebaseAnalyticsTracker.openedPlayerChapters()
                     }
@@ -307,6 +307,11 @@ private class ViewPagerAdapter(fragmentManager: FragmentManager, lifecycle: Life
     @StringRes fun pageTitle(position: Int): Int {
         return sections[position].titleRes
     }
+
+    fun isPlayerTab(position: Int) = sections[position] is Section.Player
+    fun isNotesTab(position: Int) = sections[position] is Section.Notes
+    fun isBookmarksTab(position: Int) = sections[position] is Section.Bookmarks
+    fun isChaptersTab(position: Int) = sections[position] is Section.Chapters
 }
 
 private const val PLAYER_TOUR_NAME = "player"

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -122,17 +122,20 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
 
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
-                when (position) {
-                    0 -> {
+                when (adapter.pageTitle(position)) {
+                    LR.string.player_tab_playing -> {
                         if (previousPosition == INVALID_TAB_POSITION) return
                         analyticsTracker.track(AnalyticsEvent.PLAYER_TAB_SELECTED, mapOf(TAB_KEY to NOW_PLAYING))
                         FirebaseAnalyticsTracker.nowPlayingOpen()
                     }
-                    1 -> {
+                    LR.string.player_tab_notes -> {
                         analyticsTracker.track(AnalyticsEvent.PLAYER_TAB_SELECTED, mapOf(TAB_KEY to SHOW_NOTES))
                         FirebaseAnalyticsTracker.openedPlayerNotes()
                     }
-                    2 -> {
+                    LR.string.player_tab_bookmarks -> {
+                        // TODO: Bookmarks - Add analytics event
+                    }
+                    LR.string.player_tab_chapters -> {
                         analyticsTracker.track(AnalyticsEvent.PLAYER_TAB_SELECTED, mapOf(TAB_KEY to CHAPTERS))
                         FirebaseAnalyticsTracker.openedPlayerChapters()
                     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -20,6 +20,8 @@ import androidx.viewpager2.widget.ViewPager2
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentPlayerContainerBinding
@@ -237,6 +239,7 @@ private class ViewPagerAdapter(fragmentManager: FragmentManager, lifecycle: Life
     private sealed class Section(@StringRes val titleRes: Int) {
         object Player : Section(VR.string.player_tab_playing)
         object Notes : Section(LR.string.player_tab_notes)
+        object Bookmarks : Section(LR.string.player_tab_bookmarks)
         object Chapters : Section(LR.string.player_tab_chapters)
     }
 
@@ -257,6 +260,10 @@ private class ViewPagerAdapter(fragmentManager: FragmentManager, lifecycle: Life
 
         if (hasNotes) {
             newSections.add(Section.Notes)
+        }
+
+        if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+            newSections.add(Section.Bookmarks)
         }
 
         if (hasChapters) {
@@ -289,6 +296,7 @@ private class ViewPagerAdapter(fragmentManager: FragmentManager, lifecycle: Life
         return when (sections[position]) {
             is Section.Player -> PlayerHeaderFragment()
             is Section.Notes -> NotesFragment()
+            is Section.Bookmarks -> BookmarksFragment()
             is Section.Chapters -> ChaptersFragment()
         }
     }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="archived">Archived</string>
     <string name="auto_archive">Auto archive</string>
     <string name="auto_download">Auto download</string>
+    <string name="bookmarks">Bookmarks</string>
     <string name="cancel">Cancel</string>
     <string name="cancel_download">Cancel download</string>
     <string name="chapters">Chapters</string>
@@ -276,7 +277,7 @@
     <string name="player_sleep_timer_start_failed">Unable to start timer. Please allow \'Alarms &amp; reminders\' permission.</string>
     <string name="player_sleep_when_episode_ends">Sleeping when episode ends</string>
     <string name="player_star" translatable="false">@string/star</string>
-    <string name="player_tab_bookmarks">Bookmarks</string>
+    <string name="player_tab_bookmarks" translatable="false">@string/bookmarks</string>
     <string name="player_tab_chapters" translatable="false">@string/chapters</string>
     <string name="player_tab_notes">Notes</string>
     <string name="player_tab_playing">Playing</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -276,6 +276,7 @@
     <string name="player_sleep_timer_start_failed">Unable to start timer. Please allow \'Alarms &amp; reminders\' permission.</string>
     <string name="player_sleep_when_episode_ends">Sleeping when episode ends</string>
     <string name="player_star" translatable="false">@string/star</string>
+    <string name="player_tab_bookmarks">Bookmarks</string>
     <string name="player_tab_chapters" translatable="false">@string/chapters</string>
     <string name="player_tab_notes">Notes</string>
     <string name="player_tab_playing">Playing</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -30,7 +30,8 @@ class BookmarkManagerImpl @Inject constructor(
             podcastUuid = episode.podcastOrSubstituteUuid,
             timeSecs = timeSecs,
             createdAt = Date(),
-            syncStatus = Bookmark.SYNC_STATUS_NOT_SYNCED
+            syncStatus = Bookmark.SYNC_STATUS_NOT_SYNCED,
+            title = ""
         )
         bookmarkDao.insert(bookmark)
         return bookmark


### PR DESCRIPTION
## Description
This adds a placeholder `Bookmarks` tab to the player.

## Testing Instructions
1. Open the debug build with the bookmarks `Feature Flag`enabled
2. Play any episode having chapters (https://pca.st/upgrade)
3. Open the full player
4. ✅ Verify the `Bookmarks` tab appears at the correct position
5. ✅ Verify tapping on it opens a placeholder view
6. ✅ Verify swiping between tabs works and opens the current view. 
7. Close the player
8. Disable the `Bookmarks` flag and restart the app
9. Open the full player
10. ✅ Verify you don't see the `Bookmarks` tab

## Screenshots or Screencast 

Without Feature Flag | With Feature Flag
-----|-----
<img width =300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/ad160408-d641-4e09-bdcf-94d050e9888c"/> | <img width =300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/73559b97-3a1c-4e09-8545-77f73e8081b6"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
