### PR TITLE
Bookmarks: Display bookmarks list

### DIFF
--- a/base.gradle
+++ b/base.gradle
@@ -170,6 +170,7 @@ dependencies {
     implementation androidLibs.liveDataReactiveStreams
     implementation androidLibs.lifecycleViewModel
     implementation androidLibs.lifecycleScope
+    implementation androidLibs.lifecycleScopeCompose
     implementation androidLibs.lifecycleLiveData
     implementation androidLibs.lifecycleProcess
     implementation androidLibs.paging

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -140,6 +140,7 @@ project.ext {
             liveDataReactiveStreams: "androidx.lifecycle:lifecycle-reactivestreams-ktx:$versionLifecycle",
             lifecycleViewModel: "androidx.lifecycle:lifecycle-viewmodel-ktx:$versionLifecycle",
             lifecycleScope: "androidx.lifecycle:lifecycle-runtime-ktx:$versionLifecycle",
+            lifecycleScopeCompose: "androidx.lifecycle:lifecycle-runtime-compose:$versionLifecycle",
             lifecycleLiveData: "androidx.lifecycle:lifecycle-livedata-ktx:$versionLifecycle",
             lifecycleProcess: "androidx.lifecycle:lifecycle-process:$versionLifecycle",
             billing: "com.android.billingclient:billing:$versionBillingClient",

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
@@ -1,0 +1,159 @@
+package au.com.shiftyjelly.pocketcasts.player.view
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.asFlow
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH60
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@AndroidEntryPoint
+class BookmarksFragment : BaseFragment() {
+    private val playerViewModel: PlayerViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = ComposeView(requireContext()).apply {
+        setContent {
+            AppThemeWithBackground(theme.activeTheme) {
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+                BookmarksPage(
+                    playerViewModel = playerViewModel
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun BookmarksPage(
+    playerViewModel: PlayerViewModel,
+) {
+    val listData = playerViewModel.listDataLive.asFlow().collectAsState(initial = null)
+    listData.value?.let {
+        val backgroundColor = Color(it.podcastHeader.backgroundColor)
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = backgroundColor)
+        ) {
+            item {
+                HeaderItem()
+            }
+            item {
+                BookmarkItem(backgroundColor)
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeaderItem() {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        TextH40(
+            text = stringResource(id = LR.string.bookmarks_singular),
+            color = MaterialTheme.theme.colors.playerContrast02,
+        )
+        Icon(
+            painter = painterResource(id = IR.drawable.ic_more_vert_black_24dp),
+            contentDescription = stringResource(id = LR.string.more_options),
+            tint = MaterialTheme.theme.colors.playerContrast01,
+        )
+    }
+}
+
+@Composable
+private fun BookmarkItem(
+    backgroundColor: Color,
+) {
+    Column {
+        Spacer(
+            modifier = Modifier
+                .height(1.dp)
+                .fillMaxWidth()
+                .background(color = MaterialTheme.theme.colors.playerContrast05)
+        )
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Column {
+                TextH40(
+                    text = "Funny bit",
+                    color = MaterialTheme.theme.colors.playerContrast01,
+                )
+
+                TextH60(
+                    text = "Feb 15, 2023 at 9:41 AM",
+                    color = MaterialTheme.theme.colors.playerContrast02,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .background(
+                        color = MaterialTheme.theme.colors.playerContrast01,
+                        shape = RoundedCornerShape(size = 42.dp)
+                    )
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+            ) {
+                TextH40(
+                    text = "23:10",
+                    color = backgroundColor,
+                )
+                Icon(
+                    painter = painterResource(id = IR.drawable.ic_play),
+                    contentDescription = null,
+                    tint = Color.Black,
+                    modifier = Modifier
+                        .padding(start = 10.dp)
+                        .size(10.dp, 16.dp)
+                )
+            }
+        }
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
@@ -192,7 +192,7 @@ private fun BookmarkItem(
                 )
             }
             Column(
-                Modifier.weight(1f, fill = true)
+                Modifier.weight(1f)
             ) {
                 TextH40(
                     text = bookmark.title,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -14,11 +15,17 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -26,16 +33,30 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.activityViewModels
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.asFlow
-import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH60
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
+import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel
+import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatPattern
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
+import java.util.Date
+import java.util.UUID
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -49,7 +70,7 @@ class BookmarksFragment : BaseFragment() {
         savedInstanceState: Bundle?,
     ) = ComposeView(requireContext()).apply {
         setContent {
-            AppThemeWithBackground(theme.activeTheme) {
+            AppTheme(theme.activeTheme) {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
                 BookmarksPage(
                     playerViewModel = playerViewModel
@@ -62,51 +83,94 @@ class BookmarksFragment : BaseFragment() {
 @Composable
 fun BookmarksPage(
     playerViewModel: PlayerViewModel,
+    bookmarksViewModel: BookmarksViewModel = hiltViewModel(),
 ) {
+    val state by bookmarksViewModel.uiState.collectAsStateWithLifecycle()
     val listData = playerViewModel.listDataLive.asFlow().collectAsState(initial = null)
     listData.value?.let {
         val backgroundColor = Color(it.podcastHeader.backgroundColor)
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(color = backgroundColor)
-        ) {
-            item {
-                HeaderItem()
-            }
-            item {
-                BookmarkItem(backgroundColor)
-            }
+        when (state) {
+            is UiState.Empty,
+            is UiState.Loading,
+            -> Unit
+
+            is UiState.Loaded -> Content(
+                bookmarks = (state as UiState.Loaded).bookmarks,
+                backgroundColor = backgroundColor,
+            )
+        }
+        LaunchedEffect(Unit) {
+            bookmarksViewModel.loadBookmarks(
+                episodeUuid = it.podcastHeader.episodeUuid
+            )
         }
     }
 }
 
 @Composable
-private fun HeaderItem() {
+private fun Content(
+    bookmarks: List<Bookmark>,
+    backgroundColor: Color,
+) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = backgroundColor)
+    ) {
+        item {
+            val title = stringResource(
+                id = if (bookmarks.size > 1) {
+                    LR.string.bookmarks_plural
+                } else {
+                    LR.string.bookmarks_singular
+                },
+                bookmarks.size
+            )
+            HeaderItem(title)
+        }
+        items(bookmarks) { bookmark ->
+            BookmarkItem(
+                bookmark = bookmark,
+                textColor = backgroundColor
+            )
+        }
+    }
+}
+
+@Composable
+private fun HeaderItem(title: String) {
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .padding(start = 16.dp, end = 4.dp, top = 4.dp, bottom = 4.dp)
     ) {
         TextH40(
-            text = stringResource(id = LR.string.bookmarks_singular),
+            text = title,
             color = MaterialTheme.theme.colors.playerContrast02,
         )
-        Icon(
-            painter = painterResource(id = IR.drawable.ic_more_vert_black_24dp),
-            contentDescription = stringResource(id = LR.string.more_options),
-            tint = MaterialTheme.theme.colors.playerContrast01,
-        )
+        IconButton(
+            onClick = { /* TODO */ },
+        ) {
+            Icon(
+                painter = painterResource(IR.drawable.ic_more_vert_black_24dp),
+                contentDescription = stringResource(LR.string.more_options),
+                tint = MaterialTheme.theme.colors.playerContrast01,
+            )
+        }
     }
 }
 
 @Composable
 private fun BookmarkItem(
-    backgroundColor: Color,
+    bookmark: Bookmark,
+    textColor: Color,
 ) {
-    Column {
+    Column(
+        modifier = Modifier
+            .clickable { /* TODO */ }
+    ) {
         Spacer(
             modifier = Modifier
                 .height(1.dp)
@@ -120,40 +184,95 @@ private fun BookmarkItem(
                 .fillMaxWidth()
                 .padding(16.dp)
         ) {
-            Column {
+            val createdAtText by remember {
+                mutableStateOf(
+                    bookmark.createdAt.toLocalizedFormatPattern(
+                        pattern = "MMM d, YYYY 'at' h:mm a"
+                    )
+                )
+            }
+            Column(
+                Modifier.weight(1f, fill = true)
+            ) {
                 TextH40(
-                    text = "Funny bit",
+                    text = bookmark.title,
                     color = MaterialTheme.theme.colors.playerContrast01,
+                    maxLines = 2,
                 )
 
                 TextH60(
-                    text = "Feb 15, 2023 at 9:41 AM",
+                    text = createdAtText,
                     color = MaterialTheme.theme.colors.playerContrast02,
-                    modifier = Modifier.padding(top = 8.dp)
+                    modifier = Modifier.padding(top = 8.dp),
+                    maxLines = 1,
                 )
             }
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier
-                    .background(
-                        color = MaterialTheme.theme.colors.playerContrast01,
-                        shape = RoundedCornerShape(size = 42.dp)
-                    )
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-            ) {
-                TextH40(
-                    text = "23:10",
-                    color = backgroundColor,
-                )
-                Icon(
-                    painter = painterResource(id = IR.drawable.ic_play),
-                    contentDescription = null,
-                    tint = Color.Black,
-                    modifier = Modifier
-                        .padding(start = 10.dp)
-                        .size(10.dp, 16.dp)
-                )
-            }
+            PlayButton(
+                bookmark = bookmark,
+                textColor = textColor,
+            )
         }
+    }
+}
+
+@Composable
+private fun PlayButton(
+    bookmark: Bookmark,
+    textColor: Color,
+) {
+    val timeText by remember {
+        mutableStateOf(TimeHelper.formattedSeconds(bookmark.timeSecs.toDouble()))
+    }
+    val description = stringResource(LR.string.bookmark_play, timeText)
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .background(
+                color = MaterialTheme.theme.colors.playerContrast01,
+                shape = RoundedCornerShape(size = 42.dp)
+            )
+            .clickable { /* TODO */ }
+            .semantics {
+                contentDescription = description
+            },
+    ) {
+        TextH40(
+            text = timeText,
+            color = textColor,
+            modifier = Modifier
+                .padding(start = 16.dp, top = 8.dp, bottom = 8.dp)
+                .clearAndSetSemantics { },
+        )
+        Icon(
+            painter = painterResource(IR.drawable.ic_play),
+            contentDescription = null,
+            tint = Color.Black,
+            modifier = Modifier
+                .padding(start = 10.dp, end = 16.dp)
+                .size(10.dp, 16.dp)
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun BookmarksPreview(
+    theme: Theme.ThemeType = Theme.ThemeType.DARK,
+) {
+    AppTheme(theme) {
+        Content(
+            bookmarks = listOf(
+                Bookmark(
+                    uuid = UUID.randomUUID().toString(),
+                    episodeUuid = UUID.randomUUID().toString(),
+                    podcastUuid = UUID.randomUUID().toString(),
+                    timeSecs = 10,
+                    createdAt = Date(),
+                    syncStatus = 1,
+                    title = "Funny bit",
+                )
+            ),
+            backgroundColor = Color.Black,
+        )
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
@@ -249,7 +249,7 @@ private fun PlayButton(
             tint = Color.Black,
             modifier = Modifier
                 .padding(start = 10.dp, end = 16.dp)
-                .size(10.dp, 16.dp)
+                .size(10.dp, 13.dp)
         )
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
@@ -81,7 +81,7 @@ class BookmarksFragment : BaseFragment() {
 }
 
 @Composable
-fun BookmarksPage(
+private fun BookmarksPage(
     playerViewModel: PlayerViewModel,
     bookmarksViewModel: BookmarksViewModel = hiltViewModel(),
 ) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
@@ -55,6 +55,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatPattern
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
+import java.util.Calendar
 import java.util.Date
 import java.util.UUID
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -187,7 +188,7 @@ private fun BookmarkItem(
             val createdAtText by remember {
                 mutableStateOf(
                     bookmark.createdAt.toLocalizedFormatPattern(
-                        pattern = "MMM d, YYYY 'at' h:mm a"
+                        bookmark.createdAtDatePattern()
                     )
                 )
             }
@@ -251,6 +252,19 @@ private fun PlayButton(
                 .padding(start = 10.dp, end = 16.dp)
                 .size(10.dp, 13.dp)
         )
+    }
+}
+
+private fun Bookmark.createdAtDatePattern(): String {
+    val calendar = Calendar.getInstance()
+    val currentYear = calendar.get(Calendar.YEAR)
+    calendar.time = createdAt
+    val createdAtYear = calendar.get(Calendar.YEAR)
+
+    return if (createdAtYear == currentYear) {
+        "MMM d 'at' h:mm a"
+    } else {
+        "MMM d, YYYY 'at' h:mm a"
     }
 }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -1,9 +1,52 @@
 package au.com.shiftyjelly.pocketcasts.player.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.ui.di.IoDispatcher
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class BookmarksViewModel
-@Inject constructor() : ViewModel()
+@Inject constructor(
+    private val bookmarkManager: BookmarkManager,
+    private val episodeManager: EpisodeManager,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<UiState>(UiState.Empty)
+    val uiState: StateFlow<UiState> = _uiState
+
+    fun loadBookmarks(episodeUuid: String) {
+        viewModelScope.launch(ioDispatcher) {
+            episodeManager.findEpisodeByUuid(episodeUuid)?.let { episode ->
+                _uiState.value = UiState.Loading
+                bookmarkManager.findEpisodeBookmarks(episode)
+                    .stateIn(viewModelScope)
+                    .collect { bookmarks ->
+                        _uiState.value = if (bookmarks.isNotEmpty()) {
+                            UiState.Loaded(bookmarks)
+                        } else {
+                            UiState.Empty
+                        }
+                    }
+            }
+        }
+    }
+
+    sealed class UiState {
+        object Empty : UiState()
+        object Loading : UiState()
+        data class Loaded(
+            val bookmarks: List<Bookmark> = emptyList(),
+        ) : UiState()
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -1,0 +1,9 @@
+package au.com.shiftyjelly.pocketcasts.player.viewmodel
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class BookmarksViewModel
+@Inject constructor() : ViewModel()

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/util/MainCoroutineRule.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/util/MainCoroutineRule.kt
@@ -1,0 +1,24 @@
+package au.com.shiftyjelly.pocketcasts.player.util
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@ExperimentalCoroutinesApi
+class MainCoroutineRule(
+    private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
@@ -1,0 +1,68 @@
+package au.com.shiftyjelly.pocketcasts.player.viewmodel
+
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.player.util.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.UUID
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class BookmarksViewModelTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    @Mock
+    private lateinit var bookmarkManager: BookmarkManager
+
+    @Mock
+    private lateinit var episodeManager: EpisodeManager
+
+    @Mock
+    private lateinit var episode: BaseEpisode
+
+    private lateinit var bookmarksViewModel: BookmarksViewModel
+    private val episodeUuid = UUID.randomUUID().toString()
+
+    @Before
+    fun setUp() = runTest {
+        whenever(episodeManager.findEpisodeByUuid(episodeUuid)).thenReturn(episode)
+
+        bookmarksViewModel = BookmarksViewModel(
+            bookmarkManager = bookmarkManager,
+            episodeManager = episodeManager,
+            ioDispatcher = UnconfinedTestDispatcher()
+        )
+    }
+
+    @Test
+    fun `given no bookmarks, when bookmarks loaded, then Empty state shown`() = runTest {
+        whenever(bookmarkManager.findEpisodeBookmarks(episode)).thenReturn(flowOf(emptyList()))
+
+        bookmarksViewModel.loadBookmarks(episodeUuid)
+
+        assertTrue(bookmarksViewModel.uiState.value is BookmarksViewModel.UiState.Empty)
+    }
+
+    @Test
+    fun `given bookmarks present, when bookmarks loaded, then Loaded state shown`() = runTest {
+        whenever(bookmarkManager.findEpisodeBookmarks(episode)).thenReturn(flowOf(listOf(mock())))
+
+        bookmarksViewModel.loadBookmarks(episodeUuid)
+
+        assertTrue(bookmarksViewModel.uiState.value is BookmarksViewModel.UiState.Loaded)
+    }
+}

--- a/modules/services/images/src/main/res/drawable/ic_play.xml
+++ b/modules/services/images/src/main/res/drawable/ic_play.xml
@@ -1,4 +1,9 @@
-<vector android:height="24dp" android:viewportHeight="13"
-    android:viewportWidth="10" android:width="18.461538dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#000000" android:pathData="M0.499,1.503C0.499,0.95 0.879,0.729 1.352,1.012L9.646,5.989C10.117,6.272 10.119,6.729 9.646,7.012L1.352,11.989C0.881,12.272 0.499,12.045 0.499,11.498V1.503Z"/>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="10dp"
+    android:height="13dp"
+    android:viewportWidth="10"
+    android:viewportHeight="13">
+  <path
+      android:pathData="M0.499,1.503C0.499,0.95 0.879,0.729 1.352,1.012L9.646,5.989C10.117,6.272 10.119,6.729 9.646,7.012L1.352,11.989C0.881,12.272 0.499,12.045 0.499,11.498V1.503Z"
+      android:fillColor="#000000"/>
 </vector>

--- a/modules/services/images/src/main/res/drawable/ic_play.xml
+++ b/modules/services/images/src/main/res/drawable/ic_play.xml
@@ -1,0 +1,4 @@
+<vector android:height="24dp" android:viewportHeight="13"
+    android:viewportWidth="10" android:width="18.461538dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#000000" android:pathData="M0.499,1.503C0.499,0.95 0.879,0.729 1.352,1.012L9.646,5.989C10.117,6.272 10.119,6.729 9.646,7.012L1.352,11.989C0.881,12.272 0.499,12.045 0.499,11.498V1.503Z"/>
+</vector>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1651,6 +1651,11 @@
     <string name="onboarding_import_from_other_apps_step_1">Find the other app\’s export option and export an OPML file.</string>
     <string name="onboarding_import_from_other_apps_step_2">Use your phone\’s \“Share\” menu to send the file to Pocket Casts. Alternatively, import the file from Pocket Casts\’ \“Import &amp; export OPML\” settings menu.</string>
 
+    <!-- Bookmarks -->
+
+    <string name="bookmarks_singular">%s bookmark</string>
+    <string name="bookmarks_plural">%s bookmarks</string>
+
     <!--    Tasker Plugin-->
 
     <string name="must_provide_filter_name">Must provide filter name</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1655,6 +1655,7 @@
 
     <string name="bookmarks_singular">%s bookmark</string>
     <string name="bookmarks_plural">%s bookmarks</string>
+    <string name="bookmark_play">Play at bookmark position %s</string>
 
     <!--    Tasker Plugin-->
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -30,7 +30,8 @@ class BookmarkManagerImpl @Inject constructor(
             podcastUuid = episode.podcastOrSubstituteUuid,
             timeSecs = timeSecs,
             createdAt = Date(),
-            syncStatus = Bookmark.SYNC_STATUS_NOT_SYNCED
+            syncStatus = Bookmark.SYNC_STATUS_NOT_SYNCED,
+            title = ""
         )
         bookmarkDao.insert(bookmark)
         return bookmark

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/DateUtil.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/DateUtil.kt
@@ -1,7 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.utils
 
-import timber.log.Timber
-import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
@@ -34,16 +32,6 @@ object DateUtil {
             .atZone(ZoneId.systemDefault())
             .toLocalDate()
             .format(DateTimeFormatter.ofPattern(pattern))
-    }
-
-    fun toEpochMillis(localDateTime: LocalDateTime) = try {
-        localDateTime
-            .atZone(ZoneId.systemDefault())
-            .toInstant()
-            .toEpochMilli()
-    } catch (e: Exception) {
-        Timber.e("Conversion to epoch millis failed [${e.message}]")
-        null
     }
 }
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/DateUtil.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/DateUtil.kt
@@ -30,7 +30,7 @@ object DateUtil {
         return date
             .toInstant()
             .atZone(ZoneId.systemDefault())
-            .toLocalDate()
+            .toLocalDateTime()
             .format(DateTimeFormatter.ofPattern(pattern))
     }
 }


### PR DESCRIPTION
## Description

This adds bookmarks list on full screen player > `Bookmarks` tab

## Testing Instructions

1. Apply the [patch](https://github.com/Automattic/pocket-casts-android/files/11949580/bookmarks.patch)
2. Install debug build
3. Go to `Discover`
4. Tap a podcast and play an episode
5. Open full player
6. Scroll to the `Bookmarks` tab
7. Notice that the UI matches the `Figma` design (Io7PCz1H1hmOgEE9eljoYW-fi-2033_32210)


## Screenshots or Screencast 

<img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/d244dc99-3de8-4de8-9002-475cc3fe55cd"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack