### PR TITLE
Long Press Playback Effect Turns Custom Effect On

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
         ([#1139](https://github.com/Automattic/pocket-casts-android/pull/1139))
     * Adds +- 1 increments to the sleep timer if the custom timer is less than 5 Min
         ([#1144](https://github.com/Automattic/pocket-casts-android/pull/1144)).
+    * Adds Long Press Click listener to the playback effect icon, which turns custom effects on.
+        ([#1150](https://github.com/Automattic/pocket-casts-android/pull/1150)).
 
 
 7.42

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerClickListener.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerClickListener.kt
@@ -9,6 +9,7 @@ interface PlayerClickListener {
     fun onSkipForward()
     fun onPlayClicked()
     fun onSkipForwardLongPress()
+    fun onEnableLocalPlayBackEffects()
     fun onClosePlayer()
     fun onEffectsClick()
     fun onSleepClick()

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -152,6 +152,10 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         }
 
         binding.effects.setOnClickListener { onEffectsClick() }
+        binding.effects.setOnLongClickListener {
+            onEnableLocalPlayBackEffects()
+            true
+        }
         binding.previousChapter.setOnClickListener { onPreviousChapter() }
         binding.nextChapter.setOnClickListener { onNextChapter() }
         binding.sleep.setOnClickListener { onSleepClick() }
@@ -442,6 +446,12 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
 
     override fun onSkipForwardLongPress() {
         LongPressOptionsFragment().show(parentFragmentManager, "longpressoptions")
+    }
+
+    override fun onEnableLocalPlayBackEffects() {
+        trackShelfAction(ShelfItem.Effects.analyticsValue)
+        viewModel.updateOverrideGlobalEffects(true)
+        viewModel.toggleNotifications(requireContext())
     }
 
     override fun onEffectsClick() {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.player.viewmodel
 
 import android.content.Context
 import android.content.res.Resources
+import android.widget.Toast
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -393,6 +394,28 @@ class PlayerViewModel @Inject constructor(
         playbackManager.upNextQueue.currentEpisode?.let {
             markAsPlayedConfirmed(it)
         }
+    }
+
+    fun toggleNotifications(context: Context) {
+        Toast.makeText(context, LR.string.player_effects_custom_effects_applied, Toast.LENGTH_SHORT).show()
+    }
+
+    fun updateOverrideGlobalEffects(override: Boolean) {
+        val podcast = this.podcast ?: return
+        launch {
+            podcastManager.updateOverrideGlobalEffects(podcast, override)
+            if (shouldUpdatePlaybackManager()) {
+                val effects = if (override) podcast.playbackEffects else settings.getGlobalPlaybackEffects()
+                playbackManager.updatePlayerEffects(effects)
+            }
+        }
+    }
+
+    private fun shouldUpdatePlaybackManager(): Boolean {
+        val podcast = this.podcast ?: return false
+        val currentEpisode = playbackManager.upNextQueue.currentEpisode
+        val podcastUuid = if (currentEpisode is PodcastEpisode) currentEpisode.podcastUuid else null
+        return podcastUuid == podcast.uuid
     }
 
     fun hasNextEpisode(): Boolean {


### PR DESCRIPTION
## Description
This PR sets up custom playback effects when you long press the Playback effect Icon.  

Fixes # @CookiedCodes niggles

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Tap on the Discover tab
2. Tap on any random podcast
3. Long Press on the Playback effect Icon
## Screenshots or Screencast 
<!-- if applicable -->

https://github.com/Automattic/pocket-casts-android/assets/95022986/0b5afa10-2939-4a31-9920-3f9106e99457


## Checklist
- [X ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
