### PR TITLE
Catch out of bounds exception when moving shelf items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 -----
 *   New Feature:
     *   Add capability to add +1 minute on the sleep timer
-        ([#1139](https://github.com/Automattic/pocket-casts-android/pull/1139))
+        ([#1139](https://github.com/Automattic/pocket-casts-android/pull/1139)).
     * Adds +- 1 increments to the sleep timer if the custom timer is less than 5 Min
         ([#1144](https://github.com/Automattic/pocket-casts-android/pull/1144)).
-
+*   Bug Fixes:
+    *   Fixed crash that could occur when rearranging shelf items on the full screen player
+        ([#1155](https://github.com/Automattic/pocket-casts-android/pull/1155)).
 
 7.42
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
@@ -35,6 +35,7 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.ColorUtils
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.extensions.setRippleBackground
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -163,8 +164,11 @@ class ShelfFragment : BaseFragment(), ShelfTouchCallback.ItemTouchHelperAdapter 
 
     private fun trackShelfItemMovedEvent(position: Int) {
         dragStartPosition?.let {
-            val title = (items[position] as? ShelfItem)?.analyticsValue
-                ?: AnalyticsProp.Value.UNKNOWN
+            val title = try {
+                (items[position] as? ShelfItem)?.analyticsValue
+            } catch (e: ArrayIndexOutOfBoundsException) {
+                LogBuffer.i(LogBuffer.TAG_INVALID_STATE, "Error getting title for position $position in ShelfFragment", e)
+            } ?: AnalyticsProp.Value.UNKNOWN
             val movedFrom = sectionTitleAt(it)
             val movedTo = sectionTitleAt(position)
             val newPosition = if (movedTo == AnalyticsProp.Value.SHELF) {


### PR DESCRIPTION
## Description
This is a quick fix for a crash that can occur when adjusting the shelf items on the full screen player. I've seen this a fair number of times myself and it looks like around 150 other people have encountered it [according to Sentry](https://a8c.sentry.io/issues/4263540831/events/8d7d69e4d842456687fb26500829a45a/).

## Testing Instructions

I can't recreate this with 100% reliability, but it seems to occur about half the time when I try to move the shelf items on the Now Playing screen immediately after doing a fresh install of the app.


1. Freshly install the app and start playing an episode
2. From the full screen player, tap the overflow menu, then tap the edit pencil to reorganize the icons
3. Move two or three icons in a row from the bottom of the list to the top of the list
4. Observe that the app has not crashed and, if the exception would have occurred, the exception was logged with "Error getting title for position -1 in ShelfFragment".

## Screenshots or Screencast 

This is a video of me recreating the crash without the fix from this PR.

https://github.com/Automattic/pocket-casts-android/assets/4656348/bab6b6e1-570a-48be-8471-befcc1e8fc0d


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews

