### PR TITLE
Have autoplay account for podcast grouping

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -296,7 +296,18 @@ class PodcastAdapter(
         notifyItemChanged(0)
     }
 
-    fun setEpisodes(episodes: List<PodcastEpisode>, showingArchived: Boolean, episodeCount: Int, archivedCount: Int, searchTerm: String, episodeLimit: Int?, episodeLimitIndex: Int?, grouping: PodcastGrouping, episodesSortType: EpisodesSortType, context: Context) {
+    fun setEpisodes(
+        episodes: List<PodcastEpisode>,
+        showingArchived: Boolean,
+        episodeCount: Int,
+        archivedCount: Int,
+        searchTerm: String,
+        episodeLimit: Int?,
+        episodeLimitIndex: Int?,
+        podcast: Podcast,
+        context: Context,
+    ) {
+        val grouping = podcast.podcastGrouping
         val groupingFunction = grouping.sortFunction
         val episodesPlusLimit: MutableList<Any> = episodes.toMutableList()
         if (episodeLimit != null && episodeLimitIndex != null && groupingFunction == null) {
@@ -305,13 +316,7 @@ class PodcastAdapter(
             }
         }
         if (groupingFunction != null) {
-            val reversedSort = if (grouping is PodcastGrouping.Season) {
-                episodesSortType == EpisodesSortType.EPISODES_SORT_BY_DATE_DESC
-            } else {
-                false
-            }
-
-            val grouped = grouping.formGroups(episodes, reversedSort, context.resources)
+            val grouped = grouping.formGroups(episodes, podcast, context.resources)
             episodesPlusLimit.clear()
 
             grouped.forEachIndexed { index, list ->

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -684,8 +684,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                             searchTerm = state.searchTerm,
                             episodeLimit = state.episodeLimit,
                             episodeLimitIndex = state.episodeLimitIndex,
-                            grouping = state.grouping,
-                            episodesSortType = state.episodesSortType,
+                            podcast = state.podcast,
                             context = contextRequired
                         )
                         if (state.searchTerm.isNotEmpty() && state.searchTerm != lastSearchTerm) {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PodcastGrouping.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PodcastGrouping.kt
@@ -3,8 +3,10 @@ package au.com.shiftyjelly.pocketcasts.models.to
 import android.content.Context
 import android.content.res.Resources
 import androidx.annotation.StringRes
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping.Season.getSeasonGroupId
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 sealed class PodcastGrouping(@StringRes val groupName: Int, val sortFunction: ((PodcastEpisode) -> Int)?) {
@@ -43,8 +45,8 @@ sealed class PodcastGrouping(@StringRes val groupName: Int, val sortFunction: ((
             return groupTitlesList.getOrNull(index) ?: context.getString(LR.string.podcast_no_season)
         }
 
-        override fun formGroups(episodes: List<PodcastEpisode>, reversedSort: Boolean, resources: Resources): List<List<PodcastEpisode>> {
-            val list = super.formGroups(episodes, reversedSort, resources)
+        override fun formGroups(episodes: List<PodcastEpisode>, podcast: Podcast, resources: Resources): List<List<PodcastEpisode>> {
+            val list = super.formGroups(episodes, podcast, resources)
             val titleList = mutableListOf<String>()
             list.forEach {
                 val firstEpisode = it.firstOrNull()
@@ -81,7 +83,9 @@ sealed class PodcastGrouping(@StringRes val groupName: Int, val sortFunction: ((
      * @param episodes A sorted list of episodes
      * @return A pair of episodes and their group indexes
      */
-    open fun formGroups(episodes: List<PodcastEpisode>, reversedSort: Boolean = false, resources: Resources): List<List<PodcastEpisode>> {
+    open fun formGroups(episodes: List<PodcastEpisode>, podcast: Podcast, resources: Resources): List<List<PodcastEpisode>> {
+        val reversedSort = podcast.podcastGrouping is Season &&
+            podcast.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_DATE_DESC
         val sortFunction = this.sortFunction ?: return listOf(episodes)
         val groups = mutableListOf<MutableList<PodcastEpisode>>()
 


### PR DESCRIPTION
## Description
This has autoplay take the episode grouping setting for a podcast into account when it selects what episode to play next. This is a follow-up to [this comment](https://github.com/Automattic/pocket-casts-android/pull/1132#issuecomment-1614279942).

## Testing Instructions

1. With the autoplay beta flag turned on (it is on by default), and the autoplay setting turned on (it is on by default for new installs), and with an empty up next queue
2. Start playing an episode from a podcast screen, then complete the episode so that another episode is autoplayed
3. Observe that the next unplayed, unarchived episode below the current episode (based on the user's selected sort order), is played. If there are no episodes below the currently playing episode available, the next nearest episode "above" the current episode will be selected. Note that this means that if you play the last episode in the "top" group, then the next episode to be autoplayed will be the first episode in the second group.
4. Repeat steps 2 and 3 with all the possible group options.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews

