### PR TITLE
Enable the ratings feature flag

### DIFF
--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/Feature.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/Feature.kt
@@ -13,7 +13,7 @@ enum class Feature(
     SHOW_RATINGS_ENABLED(
         key = "show_ratings_enabled",
         title = "Show Ratings",
-        defaultValue = false
+        defaultValue = true
     ),
     ADD_PATRON_ENABLED(
         key = "add_patron_enabled",

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/DefaultReleaseFeatureProvider.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/DefaultReleaseFeatureProvider.kt
@@ -8,7 +8,7 @@ import javax.inject.Singleton
 
 /**
  * Used to set feature flag values in release builds.
- * Any changes to the feature flags through FeatureFlagManager are not applied to feature flags
+ * Any changes to the feature flags through FeatureFlag are not applied to feature flags
  * provided through this provider.
  */
 @Singleton
@@ -19,11 +19,10 @@ class DefaultReleaseFeatureProvider @Inject constructor() : FeatureProvider {
 
     override fun isEnabled(feature: Feature) =
         when (feature) {
-            Feature.END_OF_YEAR_ENABLED,
-            Feature.SHOW_RATINGS_ENABLED,
-            Feature.ADD_PATRON_ENABLED,
-            Feature.AUTO_PLAY_UP_NEXT_SETTING,
-            Feature.BOOKMARKS_ENABLED,
-            -> false
+            Feature.END_OF_YEAR_ENABLED -> Feature.END_OF_YEAR_ENABLED.defaultValue
+            Feature.SHOW_RATINGS_ENABLED -> Feature.SHOW_RATINGS_ENABLED.defaultValue
+            Feature.ADD_PATRON_ENABLED -> Feature.ADD_PATRON_ENABLED.defaultValue
+            Feature.AUTO_PLAY_UP_NEXT_SETTING -> Feature.AUTO_PLAY_UP_NEXT_SETTING.defaultValue
+            Feature.BOOKMARKS_ENABLED -> Feature.BOOKMARKS_ENABLED.defaultValue
         }
 }


### PR DESCRIPTION
## Description

Enables the flag to enable showing ratings for podcasts. 


## Testing Instructions
Follow the steps here: https://github.com/Automattic/pocket-casts-android/pull/868

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
