### PR TITLE
Add ExportSettingsViewModel Test

### DIFF
--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ExportSettingsViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ExportSettingsViewModelTest.kt
@@ -1,0 +1,47 @@
+package au.com.shiftyjelly.pocketcasts.settings.viewmodel
+
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.verify
+
+@RunWith(MockitoJUnitRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class ExportSettingsViewModelTest {
+    @Mock
+    private lateinit var analyticsTracker: AnalyticsTrackerWrapper
+    private lateinit var testSubject: ExportSettingsViewModel
+
+    @Before
+    fun setup() {
+        testSubject = ExportSettingsViewModel(analyticsTracker)
+    }
+
+    @Test
+    fun `onImportSelectFile should track analytics event`() = runTest {
+        testSubject.onImportSelectFile()
+        verify(analyticsTracker).track(AnalyticsEvent.SETTINGS_IMPORT_SELECT_FILE)
+    }
+
+    @Test
+    fun `onImportByUrlClicked should track analytics event`() = runTest {
+        testSubject.onImportByUrlClicked()
+        verify(analyticsTracker).track(AnalyticsEvent.SETTINGS_IMPORT_BY_URL)
+    }
+    @Test
+    fun `onExportByEmail should track analytics event`() = runTest {
+        testSubject.onExportByEmail()
+        verify(analyticsTracker).track(AnalyticsEvent.SETTINGS_IMPORT_EXPORT_EMAIL_TAPPED)
+    }
+    @Test
+    fun `onExportFile should track analytics event`() = runTest {
+        testSubject.onExportFile()
+        verify(analyticsTracker).track(AnalyticsEvent.SETTINGS_IMPORT_EXPORT_FILE_TAPPED)
+    }
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR adds ExportSettingsViewModel Tests. Includes test cases for onExportFile, onExportByEmail, onImportByUrlClicked and onImportSelectFile which should track analytics event

Fixes # N/A

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
