### PR TITLE
Converted from kapt to KSP

### DIFF
--- a/base.gradle
+++ b/base.gradle
@@ -2,6 +2,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'dagger.hilt.android.plugin'
+apply plugin: 'com.google.devtools.ksp'
 
 def SERVER_MAIN_URL_PROD = "\"https://refresh.pocketcasts.com\""
 def SERVER_API_URL_PROD = "\"https://api.pocketcasts.com\""
@@ -243,8 +244,9 @@ dependencies {
     implementation libs.media3Extractor
     implementation libs.media3Ui
 
-    kapt libs.moshiKotlinCompile
-    kapt libs.glideCompile
+    ksp libs.moshiKotlinCompile
+    ksp libs.glideCompile
+    // Dagger doesn't support KSP yet https://github.com/google/dagger/issues/2349
     kapt libs.hiltCompiler
     kapt libs.hiltDaggerCompiler
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     ext {
         kotlin_version = '1.7.10'
         // KSP releases need to match the Kotlin version - https://github.com/google/ksp/releases
-        ksp_version = '1.7.10-1.0.6'
+        ksp_version = "$kotlin_version-1.0.6"
         hilt_version = '2.43.2'
     }
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@
 buildscript {
     ext {
         kotlin_version = '1.7.10'
+        // KSP releases need to match the Kotlin version - https://github.com/google/ksp/releases
+        ksp_version = '1.7.10-1.0.6'
         hilt_version = '2.43.2'
     }
     repositories {
@@ -44,6 +46,7 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.42.0'
     id 'com.diffplug.spotless' version '6.2.2'
     id 'io.sentry.android.gradle' version '3.10.0' apply false
+    id 'com.google.devtools.ksp' version "$ksp_version" apply false
 }
 
 apply plugin: 'base'

--- a/modules/services/model/build.gradle
+++ b/modules/services/model/build.gradle
@@ -5,10 +5,8 @@ apply plugin: 'kotlin-parcelize'
 android {
     namespace 'au.com.shiftyjelly.pocketcasts.model'
     defaultConfig {
-        javaCompileOptions {
-            annotationProcessorOptions {
-                arguments = ["room.schemaLocation": "$projectDir/schemas".toString()]
-            }
+        ksp {
+            arg("room.schemaLocation", "$projectDir/schemas")
         }
     }
 }
@@ -22,5 +20,5 @@ dependencies {
     implementation androidLibs.roomRx
     implementation androidLibs.roomKtx
 
-    kapt androidLibs.roomCompile
+    ksp androidLibs.roomCompile
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/PodcastsSortType.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/PodcastsSortType.kt
@@ -8,6 +8,11 @@ import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import java.util.Locale
 
+private val replaceTheRegex = "^the ".toRegex(RegexOption.IGNORE_CASE)
+private fun cleanStringForSortInternal(value: String): String {
+    return value.lowercase(Locale.getDefault()).replaceFirst(replaceTheRegex, "")
+}
+
 enum class PodcastsSortType(
     val clientId: Int,
     val serverId: Int,
@@ -28,8 +33,8 @@ enum class PodcastsSortType(
         clientId = 2,
         serverId = 1,
         labelId = R.string.name,
-        podcastComparator = compareBy { cleanStringForSort(it.title) },
-        folderComparator = compareBy { cleanStringForSort(it.title) },
+        podcastComparator = compareBy { cleanStringForSortInternal(it.title) },
+        folderComparator = compareBy { cleanStringForSortInternal(it.title) },
         analyticsValue = "name"
     ),
     EPISODE_DATE_NEWEST_TO_OLDEST(
@@ -56,10 +61,8 @@ enum class PodcastsSortType(
             return values().firstOrNull { it.serverId == id } ?: DATE_ADDED_OLDEST_TO_NEWEST
         }
 
-        private val replaceTheRegex = "^the ".toRegex(RegexOption.IGNORE_CASE)
-
         fun cleanStringForSort(value: String): String {
-            return value.lowercase(Locale.getDefault()).replaceFirst(replaceTheRegex, "")
+            return cleanStringForSortInternal(value)
         }
     }
 


### PR DESCRIPTION
## Description

Google recommends migrating from kapt to KSP. "[it’s up to 2x faster](https://android-developers.googleblog.com/2021/09/accelerated-kotlin-build-times-with.html)". And it helps with my next PR of introducing Showkase, as it doesn't work well with kapt.

I followed [the guide](https://developer.android.com/build/migrate-to-ksp) to migrate the code. There is an issue that Daggger / Hilt don't support KSP yet but it seems fine to run them along side each other. Room, Moshi, and Glide will be using KSP.

## Testing Instructions

### Build a production APK
1. Assemble all the builds `./gradlew assemble`.
2. Install the release build to an emulator `app/build/outputs/apk/release/app-release.apk`.
3. ✅ Verify the release installs and runs on the emulator. 

