### PR TITLE
Automotive: Show the hidden Acknowledgements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 *   Bug Fixes:
     *   Fixed crash that could occur when rearranging shelf items on the full screen player
         ([#1155](https://github.com/Automattic/pocket-casts-android/pull/1155)).
+    *   Fixed the acknowledgements being hidden in the Automotive about page.
+        ([#1166](https://github.com/Automattic/pocket-casts-android/pull/1166)).
 
 7.42
 -----

--- a/automotive/src/main/res/layout/activity_automotive_settings.xml
+++ b/automotive/src/main/res/layout/activity_automotive_settings.xml
@@ -1,23 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     android:background="?attr/primary_ui_04"
     tools:context=".AutomotiveSettingsActivity">
 
     <include
         android:id="@+id/carHeader"
-        layout="@layout/car_header"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"/>
+        layout="@layout/car_header" />
 
     <FrameLayout
         android:id="@+id/frameMain"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@id/carHeader"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/modules/features/account/src/main/res/layout-land/car_header.xml
+++ b/modules/features/account/src/main/res/layout-land/car_header.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -13,8 +12,8 @@
         android:background="?attr/actionBarItemBackground"
         android:contentDescription="@string/cancel"
         android:scaleType="fitCenter"
-        android:tint="?attr/primary_icon_01"
         android:padding="20dp"
+        app:tint="?attr/primary_icon_01"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_cancel" />


### PR DESCRIPTION
## Description

I discovered in Automotive the acknowledgements section is hidden on the About page. It seemed to be an issue with the Constraint Layout, as it was a simple screen I switched it over to a Linear Layout and it worked.

## Testing Instructions
1. Deploy the Automotive app
2. Tap the settings cog
3. Scroll down and tap About
4. ✅ Verify you can see the Acknowledgements menu option

## Screenshots 
| Before | After |
| --- | --- |
| ![Screenshot_20230710_170430](https://github.com/Automattic/pocket-casts-android/assets/308331/85096981-73ac-4070-996e-c63fd6617765) | ![Screenshot_20230710_170055](https://github.com/Automattic/pocket-casts-android/assets/308331/ccfaa27e-ec82-4052-ae91-d745030a84fc) |
