### PR TITLE
Filter auto download modification with 3 episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.44
 -----
-
+*   New Feature:
+    *   Added 3 episodes on the Filter AutoDownload
+        ([#1169])(https://github.com/Automattic/pocket-casts-android/pull/1169) 
 
 7.43
 -----

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterFragment.kt
@@ -227,6 +227,7 @@ class CreateFilterFragment : BaseFragment(), CoroutineScope {
 
         layoutDownloadLimit.setOnClickListener {
             val dialog = OptionsDialog()
+                .addTextOption(LR.string.filters_download_limit_3, click = { setDownloadLimit(3) })
                 .addTextOption(LR.string.filters_download_limit_5, click = { setDownloadLimit(5) })
                 .addTextOption(LR.string.filters_download_limit_10, click = { setDownloadLimit(10) })
                 .addTextOption(LR.string.filters_download_limit_20, click = { setDownloadLimit(20) })

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -608,6 +608,7 @@
     <string name="filters_download_limit_100">100 episodes</string>
     <string name="filters_download_limit_20">20 episodes</string>
     <string name="filters_download_limit_40">40 episodes</string>
+    <string name="filters_download_limit_3">3 episodes</string>
     <string name="filters_download_limit_5">5 episodes</string>
     <string name="filters_download_title">Auto download first</string>
     <string name="filters_duration_error_body">Filtering for episodes longer than %1$dm but shorter than %2$dm would cause a rift in our space time continuum. Sorry.</string>


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR adds 3 episodes on the Filter auto download.  

Fixes # @CookieyedCodes niggles

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Tap on the Filters tab -->
2. Tap on In Progress
3. Click on the overflow icon
4. Tap filter Settings
5. toggle autodownload 
6. Tap on first
7. Tap on 3 episodes

## Screenshots or Screencast 
![3episodes](https://github.com/Automattic/pocket-casts-android/assets/95022986/d597097f-4f1d-4ed5-8fcb-bd3070ffc3d8)
![episodes](https://github.com/Automattic/pocket-casts-android/assets/95022986/3128fc9b-667c-48d7-8874-5684045afb37)

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
