### PR TITLE
added left and right padding to toolbar

### DIFF
--- a/modules/features/profile/src/main/res/layout/activity_add_file.xml
+++ b/modules/features/profile/src/main/res/layout/activity_add_file.xml
@@ -18,7 +18,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="?attr/secondary_ui_01"
-            android:minHeight="?android:attr/actionBarSize" />
+            android:minHeight="?android:attr/actionBarSize"
+            android:paddingLeft="0dp"
+            android:paddingRight="20dp"/>
     </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView

--- a/modules/features/profile/src/main/res/layout/activity_add_file.xml
+++ b/modules/features/profile/src/main/res/layout/activity_add_file.xml
@@ -20,7 +20,9 @@
             android:background="?attr/secondary_ui_01"
             android:minHeight="?android:attr/actionBarSize"
             android:paddingLeft="0dp"
-            android:paddingRight="20dp"/>
+            android:paddingStart="0dp"
+            android:paddingRight="20dp"
+            android:paddingEnd="20dp"/>
     </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
I just want to preface this with this is my first open source contribution. I use the Pocket Casts app almost everyday and am an aspiring software engineer, so I decided to give a few of the issues tagged as "good first issue" a shot. I figured moving the _Save_ button on the Add File screen would be a good start. As it is now, the _Save_ button is a bit too far to the right of the screen as you can see in the before screenshot below.

Fixes #63 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->
1. Go to the user account page.
2. Click on the _Files_ button.
3. Click the _Add_ button (Floating Action Button). 
4. Select a file to upload.
5. You will automatically be taken to the _Add File_ screen.

## Screenshots or Screencast 
<!-- if applicable -->
#### Before:
![image](https://github.com/Automattic/pocket-casts-android/assets/68164093/f43b4e87-38ad-470c-90da-ab7bf5571ce0)

#### After:
![image](https://github.com/Automattic/pocket-casts-android/assets/68164093/dd88ded4-d0f0-404e-b067-011560fb3e11)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- It's just a minor UI tweak.
- [x] I have considered whether it makes sense to add tests for my changes
- I don't think this change needs any tests updated.
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- No strings added.
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- No compose components added or changed.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- Changing the orientation on the _Add File_ screen actually introduces a new bug for me where the entire top toolbar and the audio file's art go away.
- [ ] with the device set to have a large display and font size
- I'm not sure how to change the font.
- [ ] for accessibility with TalkBack
- I don't know how to test this.

## Notes:
I wanted to add that I am getting a warning in Android studio that I should use `paddingStart` and `paddingEnd` rather than `paddingLeft`/`paddingRight`. I tried this, but no change occurred in the position of the _Save_ button. For what it's worth, my emulated device is a Pixel 6 on API 33.