### PR TITLE
Watch: Updated empty state for filter screen

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -580,6 +580,8 @@
 
     <string name="filters">Filters</string>
     <string name="episode_filters">Episode Filters</string>
+    <string name="no_results_for_filters">No results found for filter %s</string>
+    <string name="no_result_found">No results found</string>
     <string name="filters_all_your_podcasts">All your podcasts</string>
     <string name="filters_auto_download_limit" translatable="false">@string/episodes_plural</string>
     <string name="filters_chip_episode_status">Episode Status</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -580,8 +580,6 @@
 
     <string name="filters">Filters</string>
     <string name="episode_filters">Episode Filters</string>
-    <string name="no_results_for_filters">No results found for filter %s</string>
-    <string name="no_result_found">No results found</string>
     <string name="filters_all_your_podcasts">All your podcasts</string>
     <string name="filters_auto_download_limit" translatable="false">@string/episodes_plural</string>
     <string name="filters_chip_episode_status">Episode Status</string>
@@ -623,6 +621,7 @@
     <string name="filters_no_episodes">No Episodes Found</string>
     <string name="filters_no_matching_episodes">The criteria you selected doesn&#x2019;t match any current episodes in your subscriptions.\n\nChoose different criteria, or save this filter if you think it will match episodes in the future.</string>
     <string name="filters_no_matching_episodes_title">No Matching Episodes</string>
+    <string name="filters_not_found">No filters found</string>
     <string name="filters_options_delete">Delete filter</string>
     <string name="filters_options_download_all">Download all</string>
     <string name="filters_options_play_all" translatable="false">@string/play_all</string>

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterScreen.kt
@@ -48,6 +48,7 @@ fun FilterScreen(
             modifier = modifier,
             listState = columnState,
         )
+
         is UiState.Loading -> LoadingScreen()
         is UiState.Empty -> {
             Column(
@@ -58,7 +59,7 @@ fun FilterScreen(
                 state.filter?.let {
                     ScreenHeaderChip(it.title)
                     Text(
-                        text = stringResource(LR.string.no_results_for_filters, state.filter.title),
+                        text = stringResource(LR.string.filters_no_episodes),
                         modifier = Modifier.padding(16.dp),
                         textAlign = TextAlign.Center,
                         color = MaterialTheme.colors.onPrimary,
@@ -66,7 +67,7 @@ fun FilterScreen(
                     )
                 } ?: run {
                     Text(
-                        text = stringResource(LR.string.no_result_found),
+                        text = stringResource(LR.string.filters_not_found),
                         modifier = Modifier.padding(16.dp),
                         textAlign = TextAlign.Center,
                         color = MaterialTheme.colors.onPrimary,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterScreen.kt
@@ -1,12 +1,22 @@
 package au.com.shiftyjelly.pocketcasts.wear.ui.filter
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.EpisodeChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.LoadingScreen
@@ -14,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.filter.FilterViewModel.UiState
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 object FilterScreen {
     const val argumentFilterUuid = "filterUuid"
@@ -38,7 +49,32 @@ fun FilterScreen(
             listState = columnState,
         )
         is UiState.Loading -> LoadingScreen()
-        is UiState.Empty -> Unit
+        is UiState.Empty -> {
+            Column(
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                state.filter?.let {
+                    ScreenHeaderChip(it.title)
+                    Text(
+                        text = stringResource(LR.string.no_results_for_filters, state.filter.title),
+                        modifier = Modifier.padding(16.dp),
+                        textAlign = TextAlign.Center,
+                        color = MaterialTheme.colors.onPrimary,
+                        style = MaterialTheme.typography.body1,
+                    )
+                } ?: run {
+                    Text(
+                        text = stringResource(LR.string.no_result_found),
+                        modifier = Modifier.padding(16.dp),
+                        textAlign = TextAlign.Center,
+                        color = MaterialTheme.colors.onPrimary,
+                        style = MaterialTheme.typography.body1,
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterViewModel.kt
@@ -29,7 +29,9 @@ class FilterViewModel @Inject constructor(
 
     sealed class UiState {
         object Loading : UiState()
-        object Empty : UiState()
+        data class Empty(
+            val filter: Playlist? = null,
+        ) : UiState()
         data class Loaded(
             val filter: Playlist,
             val episodes: List<PodcastEpisode>,
@@ -41,9 +43,11 @@ class FilterViewModel @Inject constructor(
             val filter = filters.firstOrNull()
             if (filter != null) {
                 playlistManager.observeEpisodes(filter, episodeManager, playbackManager)
-                    .map { UiState.Loaded(filter = filter, episodes = it) }
+                    .map {
+                        if (it.isEmpty()) UiState.Empty(filter) else UiState.Loaded(filter = filter, episodes = it)
+                    }
             } else {
-                Flowable.just(UiState.Empty)
+                Flowable.just(UiState.Empty(null))
             }
         }
         .distinctUntilChanged()


### PR DESCRIPTION
## Description

Adds a message in case there are no episodes in the selected filter.

Fixes #1154 

## Testing Instructions
1. Log into a new account with no podcast subscriptions
2. Check the filters screens for New Releases and In Progress.
3. ✅ Verify that the user is displayed a message telling that no results are found.

## Screenshots or Screencast 
![Screenshot_20230716_152508](https://github.com/Automattic/pocket-casts-android/assets/89896473/ede227fd-7bf5-4630-a3fb-8f557f6093f2)


## Checklist
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`