### PR TITLE
Watch: added some padding to Up Next screen

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rxjava2.subscribeAsState
@@ -76,7 +77,7 @@ private fun EmptyQueueState() {
     Column(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp)
     ) {
         Text(
             text = stringResource(LR.string.player_up_next_empty),


### PR DESCRIPTION
## Description

Adds some padding to watch's up next screen.

Fixes #1153 

## Testing Instructions
1. Load an account with an empty up next queue on the watch.
2. Go to the up next screen.
3. ✅ Verify that text is not too close and there is some gap between the edge of watch and screen

## Screenshots or Screencast 
Tested with largest font
![Screenshot_20230716_202641](https://github.com/Automattic/pocket-casts-android/assets/89896473/3503e3a9-05ee-48e1-bfba-4938a96f2eb6)
