### PR TITLE
Bookmarks: sync fix

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -158,7 +158,7 @@ class PodcastSyncProcessTest {
                           {
                             "type": "UserBookmark",
                             "fields": {
-                              "uuid": "${bookmarkToUpdate.uuid}",
+                              "bookmark_uuid": "${bookmarkToUpdate.uuid}",
                               "podcast_uuid": "${bookmarkToUpdate.podcastUuid}",
                               "episode_uuid": "${bookmarkToUpdate.episodeUuid}",
                               "created_at": "2023-07-06T23:01:55Z",
@@ -172,7 +172,7 @@ class PodcastSyncProcessTest {
                           {
                             "type": "UserBookmark",
                             "fields": {
-                              "uuid": "$bookmarkUuidToAdd",
+                              "bookmark_uuid": "$bookmarkUuidToAdd",
                               "podcast_uuid": "e979cf2f-58f2-4f47-8ad7-b9b58d511346",
                               "episode_uuid": "b70fcdf2-dc04-44b1-8829-1028374fc656",
                               "created_at": "2023-06-16T02:04:35Z",
@@ -186,7 +186,7 @@ class PodcastSyncProcessTest {
                           {
                             "type": "UserBookmark",
                             "fields": {
-                              "uuid": "${bookmarkToDelete.uuid}",
+                              "bookmark_uuid": "${bookmarkToDelete.uuid}",
                               "podcast_uuid": "${bookmarkToDelete.podcastUuid}",
                               "episode_uuid": "${bookmarkToDelete.episodeUuid}",
                               "created_at": "2023-06-12T01:01:56Z",

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -517,7 +517,7 @@ class PodcastSyncProcess(
     private fun uploadBookmarkChanges(bookmark: Bookmark, records: JSONArray) {
         try {
             val fields = JSONObject().apply {
-                put("uuid", bookmark.uuid)
+                put("bookmark_uuid", bookmark.uuid)
                 put("podcast_uuid", bookmark.podcastUuid)
                 put("episode_uuid", bookmark.episodeUuid)
                 put("time", bookmark.timeSecs)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
@@ -236,7 +236,7 @@ class SyncUpdateResponseParser : JsonAdapter<SyncUpdateResponse>() {
         reader.beginObject()
         while (reader.hasNext()) {
             when (reader.nextName()) {
-                "uuid" -> uuid = reader.nextString()
+                "bookmark_uuid" -> uuid = reader.nextString()
                 "podcast_uuid" -> podcastUuid = reader.nextString()
                 "episode_uuid" -> episodeUuid = reader.nextString()
                 "time" -> time = reader.nextIntOrNull()


### PR DESCRIPTION
## Description

The server implementation of bookmark syncing is complete. After testing, I found the field bookmark `uuid` was called `bookmark_uuid` on the server, this change fixes that.

## Testing Instructions

1. Edit the BookmarksViewModel class to add a bookmark when opening the page. Just above the line with `findEpisodeBookmarksFlow` on it.
```
bookmarkManager.add(episode, 42, "My bookmark")
```
2. Deploy the app
3. Sign in with a Plus account
4. Play an episode
5. In Android Studio open the "App Inspection" window and connect to the process
6. Open the full screen player and tap the bookmarks tap to add the bookmark
7. Go to the Profile tab
8. Tap "Refresh now"
9. Look in the "Network Inspector" and find the `/sync/update` call. 
10. ✅ Verify the response contains the 'UserBookmark' element similar to the one below.
```
{
        "type": "UserBookmark",
        "fields": {
          "episode_uuid": "8c2ecb07-6d63-4718-90d4-5821a8dfa651",
          "podcast_uuid": "5cda9490-4117-012e-1622-00163e1b2012",
          "is_deleted": false,
          "is_deleted_modified": "1689634971731",
          "title": "Bookmark",
          "bookmark_uuid": "918f3e4d-1b3b-47e2-9fb1-a5e91a8e49aa",
          "time": 3439,
          "title_modified": "1689634971731",
          "created_at": "2023-07-17T23:02:51Z"
        }
```