### PR TITLE
Fix watch episode screen not working for user episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 *   Bug Fixes:
     *   Fixed crash that could occur when rearranging shelf items on the full screen player
         ([#1155](https://github.com/Automattic/pocket-casts-android/pull/1155)).
+    *   Wear OS: Fixed blank screen when showing episode details of cloud files
+        ([#1181](https://github.com/Automattic/pocket-casts-android/pull/1181)).
 
 7.42
 -----


### PR DESCRIPTION
## Description

This fix a bug that was introduced when [we stopped having the showNotesFlow start with a `null`](https://github.com/Automattic/pocket-casts-android/commit/f4e962a3a49daf48d1df68a4eda9c45258cbdf0c#diff-87b79005c0e6fd34c40ee0b5333ed1d800de411a276821016df9fe87660b47ffL166-R171). That change caused the `EpisodeViewModel`'s `stateFlow` to never emit because it would wait for show notes to be emitted, which would never happen for a `UserEpisode` as a result, the watch would only show a blank `EpisodeScreen` for `UserEpisode`s.

The end effect of this is that tapping on a user-uploaded file on the watch would just show a blank screen.

> **Warning**
> I think this should be a betafix, so I'm targeting `release/7.43` with this PR. Let me know if you disagree.

I would like to add a test that ensures the view model creates an episode even if some of the flows don't return anything, but I had a lot of trouble getting the test to work. If you want to take a crack at it, [this](https://gist.github.com/mchowning/b70c70ab88d74b8dd9e8140df0513a83) is basically what I was working with, but I keep getting failed tests even though it seemed like the tests were working. I obviously need to level-up my flow-testing knowledge. If you do take a look at it and see `Cannot invoke "io.reactivex.ObservableSource.subscribe(io.reactivex.Observer)" because "this.$this_asFlow" is null`, that's what I was having trouble with too.

## Testing Instructions
1. Log into an account with user episodes on the watch
2. Tap on `Files`
3. Tap on one of the user episodes
4. Observe that the episode details screen loads as expected (without this change it would be blank)

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 