### PR TITLE
Bookmarks: Add delete action

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1676,6 +1676,12 @@
     <string name="bookmarks_headphone_settings">Headphone settings</string>
     <string name="bookmarks_plural">%s bookmarks</string>
     <string name="bookmarks_singular">%s bookmark</string>
+    <string name="bookmarks_delete_plural">Delete bookmarks</string>
+    <string name="bookmarks_delete_singular">Delete bookmark</string>
+    <string name="bookmarks_deleted_plural">%1$d bookmarks deleted</string>
+    <string name="bookmarks_deleted_singular">1 bookmark deleted</string>
+    <string name="bookmarks_delete_summary_plural">%d bookmarks will be deleted. This cannot be undone.</string>
+    <string name="bookmarks_delete_summary_singular">This bookmark will be deleted. This cannot be undone.</string>
 
     <!--    Tasker Plugin-->
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -31,8 +31,8 @@ abstract class BookmarkDao {
     @Query("SELECT * FROM bookmarks WHERE podcast_uuid = :podcastUuid AND episode_uuid = :episodeUuid AND time = :timeSecs LIMIT 1")
     abstract suspend fun findByEpisodeTime(podcastUuid: String, episodeUuid: String, timeSecs: Int): Bookmark?
 
-    @Query("SELECT * FROM bookmarks WHERE podcast_uuid = :podcastUuid AND episode_uuid = :episodeUuid AND deleted = 0")
-    abstract fun findByEpisodeFlow(podcastUuid: String, episodeUuid: String): Flow<List<Bookmark>>
+    @Query("SELECT * FROM bookmarks WHERE podcast_uuid = :podcastUuid AND episode_uuid = :episodeUuid AND deleted = :deleted")
+    abstract fun findByEpisodeFlow(podcastUuid: String, episodeUuid: String, deleted: Boolean = false): Flow<List<Bookmark>>
 
     @Query("UPDATE bookmarks SET deleted = :deleted, deleted_modified = :deletedModified, sync_status = :syncStatus WHERE uuid = :uuid")
     abstract suspend fun updateDeleted(uuid: String, deleted: Boolean, deletedModified: Long, syncStatus: SyncStatus)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -31,7 +31,7 @@ abstract class BookmarkDao {
     @Query("SELECT * FROM bookmarks WHERE podcast_uuid = :podcastUuid AND episode_uuid = :episodeUuid AND time = :timeSecs LIMIT 1")
     abstract suspend fun findByEpisodeTime(podcastUuid: String, episodeUuid: String, timeSecs: Int): Bookmark?
 
-    @Query("SELECT * FROM bookmarks WHERE podcast_uuid = :podcastUuid AND episode_uuid = :episodeUuid")
+    @Query("SELECT * FROM bookmarks WHERE podcast_uuid = :podcastUuid AND episode_uuid = :episodeUuid AND deleted = 0")
     abstract fun findByEpisodeFlow(podcastUuid: String, episodeUuid: String): Flow<List<Bookmark>>
 
     @Query("UPDATE bookmarks SET deleted = :deleted, deleted_modified = :deletedModified, sync_status = :syncStatus WHERE uuid = :uuid")

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
@@ -4,14 +4,23 @@ import android.content.res.Resources
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.map
+import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.views.R
+import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @Singleton
-class MultiSelectBookmarksHelper @Inject constructor() : MultiSelectHelper<Bookmark>() {
+class MultiSelectBookmarksHelper @Inject constructor(
+    private val bookmarkManager: BookmarkManager,
+) : MultiSelectHelper<Bookmark>() {
     override val maxToolbarIcons = 2
 
     override val toolbarActions: LiveData<List<MultiSelectAction>> = _selectedListLive
@@ -41,7 +50,7 @@ class MultiSelectBookmarksHelper @Inject constructor() : MultiSelectHelper<Bookm
             }
 
             R.id.menu_delete -> {
-                // TODO: Bookmark - Add delete action
+                delete(resources, fragmentManager)
                 true
             }
 
@@ -52,5 +61,49 @@ class MultiSelectBookmarksHelper @Inject constructor() : MultiSelectHelper<Bookm
 
             else -> false
         }
+    }
+
+    fun delete(resources: Resources, fragmentManager: FragmentManager) {
+        val bookmarks = selectedList.toList()
+        val count = bookmarks.size
+        ConfirmationDialog()
+            .setForceDarkTheme(true)
+            .setButtonType(
+                ConfirmationDialog.ButtonType.Danger(
+                    resources.getStringPlural(
+                        count = count,
+                        singular = LR.string.bookmarks_delete_singular,
+                        plural = LR.string.bookmarks_delete_plural
+                    )
+                )
+            )
+            .setTitle(resources.getString(LR.string.are_you_sure))
+            .setSummary(
+                resources.getStringPlural(
+                    count = count,
+                    singular = LR.string.bookmarks_delete_summary_singular,
+                    plural = LR.string.bookmarks_delete_summary_plural
+                )
+            )
+            .setIconId(R.drawable.ic_delete)
+            .setIconTint(UR.attr.support_05)
+            .setOnConfirm {
+                launch {
+                    bookmarks.forEach {
+                        bookmarkManager.deleteToSync(it.uuid)
+                    }
+
+                    withContext(Dispatchers.Main) {
+                        val snackText = resources.getStringPlural(
+                            count,
+                            LR.string.bookmarks_deleted_singular,
+                            LR.string.bookmarks_deleted_plural
+                        )
+                        showSnackBar(snackText)
+                    }
+                }
+                closeMultiSelect()
+            }
+            .show(fragmentManager, "delete_bookmarks_warning")
     }
 }


### PR DESCRIPTION
## Description

This adds a delete action on the bookmarks list screen

## Testing Instructions

1. Add a few bookmarks for an episode to the bookmark table (with delete = 0) 
2. Install the debug build and login with a Plus account
3. Open the Full Screen Player for the episode selected in step 1
4. Swipe over to Bookmarks
5. Long press on a row
6. From the multiselect toolbar, tap delete icon
7. Notice that a confirmation dialog is shown
8. Confirm "Delete bookmark"
9. ✅ Notice that the bookmark is deleted
10. Repeat it for multiple bookmarks
11. ✅ Notice that bookmarks are deleted

** Bookmarks are marked deleted locally, they will be synced with the server in a separate sync request.

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/bdf443b1-4a70-4508-ad3f-63085380e86f


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
