### PR TITLE
Bookmarks - Add sorting

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/BookmarkDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/BookmarkDaoTest.kt
@@ -7,10 +7,11 @@ import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.models.db.dao.BookmarkDao
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
-import junit.framework.TestCase.assertNotNull
-import junit.framework.TestCase.assertNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -40,19 +41,11 @@ class BookmarkDaoTest {
     fun testInsertBookmark() {
         runTest {
             val uuid = UUID.randomUUID().toString()
-            bookmarkDao.insert(
-                Bookmark(
-                    uuid = uuid,
-                    episodeUuid = UUID.randomUUID().toString(),
-                    podcastUuid = UUID.randomUUID().toString(),
-                    timeSecs = 61,
-                    createdAt = Date(),
-                    deleted = false,
-                    syncStatus = SyncStatus.NOT_SYNCED,
-                    title = ""
-                )
+            bookmarkDao.insert(FakeBookmarksGenerator.create(uuid))
+            assertNotNull(
+                "Inserted bookmark should be able to be found",
+                bookmarkDao.findByUuid(uuid)
             )
-            assertNotNull("Inserted bookmark should be able to be found", bookmarkDao.findByUuid(uuid))
         }
     }
 
@@ -60,16 +53,7 @@ class BookmarkDaoTest {
     fun testUpdateBookmark() {
         runTest {
             val uuid = UUID.randomUUID().toString()
-            val bookmark = Bookmark(
-                uuid = uuid,
-                episodeUuid = UUID.randomUUID().toString(),
-                podcastUuid = UUID.randomUUID().toString(),
-                timeSecs = 61,
-                createdAt = Date(),
-                deleted = false,
-                syncStatus = SyncStatus.NOT_SYNCED,
-                title = ""
-            )
+            val bookmark = FakeBookmarksGenerator.create(uuid)
             bookmarkDao.insert(bookmark)
 
             val createdBookmark = bookmarkDao.findByUuid(uuid)
@@ -91,20 +75,104 @@ class BookmarkDaoTest {
     fun testDeleteBookmark() {
         runTest {
             val uuid = UUID.randomUUID().toString()
-            val bookmark = Bookmark(
-                uuid = uuid,
-                episodeUuid = UUID.randomUUID().toString(),
-                podcastUuid = UUID.randomUUID().toString(),
-                timeSecs = 61,
-                createdAt = Date(),
-                deleted = false,
-                syncStatus = SyncStatus.NOT_SYNCED,
-                title = ""
-            )
+            val bookmark = FakeBookmarksGenerator.create(uuid)
             bookmarkDao.insert(bookmark)
             assertNotNull(bookmarkDao.findByUuid(uuid))
             bookmarkDao.delete(bookmark)
             assertNull(bookmarkDao.findByUuid(uuid))
+        }
+    }
+
+    @Test
+    fun testFindByEpisodeSortCreatedAtAsc() =
+        runTest {
+            val bookmark1 = FakeBookmarksGenerator.create(createdAt = Date(2000))
+            val bookmark2 = FakeBookmarksGenerator.create(createdAt = Date(3000))
+            val bookmark3 = FakeBookmarksGenerator.create(createdAt = Date(1000))
+            bookmarkDao.insert(bookmark1)
+            bookmarkDao.insert(bookmark2)
+            bookmarkDao.insert(bookmark3)
+
+            val result = bookmarkDao.findByEpisodeOrderCreatedAtFlow(
+                episodeUuid = episodeUuid,
+                podcastUuid = podcastUuid,
+                deleted = false,
+                isAsc = true
+            ).first()
+
+            with(result) {
+                assert(get(0).createdAt == bookmark3.createdAt)
+                assert(get(1).createdAt == bookmark1.createdAt)
+                assert(get(2).createdAt == bookmark2.createdAt)
+            }
+        }
+
+    @Test
+    fun testFindByEpisodeSortCreatedAtDesc() =
+        runTest {
+            val bookmark1 = FakeBookmarksGenerator.create(createdAt = Date(2000))
+            val bookmark2 = FakeBookmarksGenerator.create(createdAt = Date(3000))
+            val bookmark3 = FakeBookmarksGenerator.create(createdAt = Date(1000))
+            bookmarkDao.insert(bookmark1)
+            bookmarkDao.insert(bookmark2)
+            bookmarkDao.insert(bookmark3)
+
+            val result = bookmarkDao.findByEpisodeOrderCreatedAtFlow(
+                episodeUuid = episodeUuid,
+                podcastUuid = podcastUuid,
+                deleted = false,
+                isAsc = false
+            ).first()
+
+            with(result) {
+                assert(get(0).createdAt == bookmark2.createdAt)
+                assert(get(1).createdAt == bookmark1.createdAt)
+                assert(get(2).createdAt == bookmark3.createdAt)
+            }
+        }
+
+    @Test
+    fun testFindByEpisodeSortTimeAsc() =
+        runTest {
+            val bookmark1 = FakeBookmarksGenerator.create(time = 100)
+            val bookmark2 = FakeBookmarksGenerator.create(time = 300)
+            val bookmark3 = FakeBookmarksGenerator.create(time = 200)
+            bookmarkDao.insert(bookmark1)
+            bookmarkDao.insert(bookmark2)
+            bookmarkDao.insert(bookmark3)
+
+            val result = bookmarkDao.findByEpisodeOrderTimeFlow(
+                episodeUuid = episodeUuid,
+                podcastUuid = podcastUuid,
+                deleted = false,
+            ).first()
+
+            with(result) {
+                assert(get(0).timeSecs == bookmark1.timeSecs)
+                assert(get(1).timeSecs == bookmark3.timeSecs)
+                assert(get(2).timeSecs == bookmark2.timeSecs)
+            }
+        }
+
+    companion object {
+        private val episodeUuid = UUID.randomUUID().toString()
+        private val podcastUuid = UUID.randomUUID().toString()
+
+        object FakeBookmarksGenerator {
+            fun create(
+                uuid: String? = null,
+                time: Int = 10,
+                createdAt: Date = Date(),
+            ) = Bookmark(
+                uuid = uuid ?: UUID.randomUUID().toString(),
+                episodeUuid = episodeUuid,
+                podcastUuid = podcastUuid,
+                timeSecs = time,
+                createdAt = createdAt,
+                deleted = false,
+                syncStatus = SyncStatus.NOT_SYNCED,
+                title = ""
+            )
         }
     }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerTest.kt
@@ -7,10 +7,8 @@ import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.BookmarksSortType
 import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -105,7 +103,6 @@ class BookmarkManagerTest {
     /**
      * Test findEpisodeBookmarksFlow newest to older order returns newest bookmark first
      */
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun findEpisodeBookmarksOrderNewestToOldest() {
         val episodeUuid = UUID.randomUUID().toString()
@@ -114,7 +111,6 @@ class BookmarkManagerTest {
 
         runTest {
             val bookmarkOne = bookmarkManager.add(episode = episode, timeSecs = 10, title = "")
-            advanceTimeBy(1000)
             val bookmarkTwo = bookmarkManager.add(episode = episode, timeSecs = 20, title = "")
 
             val bookmarks = bookmarkManager.findEpisodeBookmarksFlow(
@@ -130,7 +126,6 @@ class BookmarkManagerTest {
     /**
      * Test findEpisodeBookmarksFlow oldest to newest order returns oldest bookmark first
      */
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun findEpisodeBookmarksOrderOldestToNewest() {
         val episodeUuid = UUID.randomUUID().toString()
@@ -139,7 +134,6 @@ class BookmarkManagerTest {
 
         runTest {
             val bookmarkOne = bookmarkManager.add(episode = episode, timeSecs = 10, title = "")
-            advanceTimeBy(1000)
             val bookmarkTwo = bookmarkManager.add(episode = episode, timeSecs = 20, title = "")
 
             val bookmarks = bookmarkManager.findEpisodeBookmarksFlow(

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerTest.kt
@@ -5,9 +5,12 @@ import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.BookmarksSortType
 import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -19,9 +22,9 @@ import java.util.Date
 import java.util.UUID
 
 class BookmarkManagerTest {
-    lateinit var appDatabase: AppDatabase
-    lateinit var episodeDao: EpisodeDao
-    lateinit var bookmarkManager: BookmarkManager
+    private lateinit var appDatabase: AppDatabase
+    private lateinit var episodeDao: EpisodeDao
+    private lateinit var bookmarkManager: BookmarkManager
 
     @Before
     fun setup() {
@@ -70,29 +73,82 @@ class BookmarkManagerTest {
         runTest {
             val bookmarkOne = bookmarkManager.add(episode = episode, timeSecs = 20, title = "")
             bookmarkManager.add(episode = episode, timeSecs = 20, title = "")
-            val bookmarks = bookmarkManager.findEpisodeBookmarksFlow(episode).take(1).first()
+            val bookmarks = bookmarkManager.findEpisodeBookmarksFlow(episode, BookmarksSortType.DATE_ADDED_NEWEST_TO_OLDEST).take(1).first()
             assertEquals(1, bookmarks.size)
             assertEquals(bookmarkOne.uuid, bookmarks[0].uuid)
         }
     }
 
     /**
-     * Test findEpisodeBookmarks returns the bookmarks for an episode.
+     * Test findEpisodeBookmarksFlow timestamp order returns the bookmarks sorted by timestamp
      */
     @Test
-    fun findEpisodeBookmarks() {
+    fun findEpisodeBookmarksOrderTimestamp() {
         val episodeUuid = UUID.randomUUID().toString()
         val podcastUuid = UUID.randomUUID().toString()
         val episode = PodcastEpisode(uuid = episodeUuid, podcastUuid = podcastUuid, publishedDate = Date())
 
         runTest {
-            val bookmarkOne = bookmarkManager.add(episode = episode, timeSecs = 61, title = "")
+            val bookmarkOne = bookmarkManager.add(episode = episode, timeSecs = 610, title = "")
             val bookmarkTwo = bookmarkManager.add(episode = episode, timeSecs = 122, title = "")
-            val bookmarks = bookmarkManager.findEpisodeBookmarksFlow(episode).take(1).first()
-            assertEquals(2, bookmarks.size)
-            val sortedBookmarks = bookmarks.sortedBy { it.timeSecs }
-            assertEquals(bookmarkOne.uuid, sortedBookmarks[0].uuid)
-            assertEquals(bookmarkTwo.uuid, sortedBookmarks[1].uuid)
+
+            val bookmarks = bookmarkManager.findEpisodeBookmarksFlow(
+                episode = episode,
+                sortType = BookmarksSortType.TIMESTAMP,
+            ).take(1).first()
+
+            assertEquals(bookmarkTwo.uuid, bookmarks[0].uuid)
+            assertEquals(bookmarkOne.uuid, bookmarks[1].uuid)
+        }
+    }
+
+    /**
+     * Test findEpisodeBookmarksFlow newest to older order returns newest bookmark first
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun findEpisodeBookmarksOrderNewestToOldest() {
+        val episodeUuid = UUID.randomUUID().toString()
+        val podcastUuid = UUID.randomUUID().toString()
+        val episode = PodcastEpisode(uuid = episodeUuid, podcastUuid = podcastUuid, publishedDate = Date())
+
+        runTest {
+            val bookmarkOne = bookmarkManager.add(episode = episode, timeSecs = 10, title = "")
+            advanceTimeBy(1000)
+            val bookmarkTwo = bookmarkManager.add(episode = episode, timeSecs = 20, title = "")
+
+            val bookmarks = bookmarkManager.findEpisodeBookmarksFlow(
+                episode = episode,
+                sortType = BookmarksSortType.DATE_ADDED_NEWEST_TO_OLDEST,
+            ).take(1).first()
+
+            assertEquals(bookmarkTwo.uuid, bookmarks[0].uuid)
+            assertEquals(bookmarkOne.uuid, bookmarks[1].uuid)
+        }
+    }
+
+    /**
+     * Test findEpisodeBookmarksFlow oldest to newest order returns oldest bookmark first
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun findEpisodeBookmarksOrderOldestToNewest() {
+        val episodeUuid = UUID.randomUUID().toString()
+        val podcastUuid = UUID.randomUUID().toString()
+        val episode = PodcastEpisode(uuid = episodeUuid, podcastUuid = podcastUuid, publishedDate = Date())
+
+        runTest {
+            val bookmarkOne = bookmarkManager.add(episode = episode, timeSecs = 10, title = "")
+            advanceTimeBy(1000)
+            val bookmarkTwo = bookmarkManager.add(episode = episode, timeSecs = 20, title = "")
+
+            val bookmarks = bookmarkManager.findEpisodeBookmarksFlow(
+                episode = episode,
+                sortType = BookmarksSortType.DATE_ADDED_OLDEST_TO_NEWEST,
+            ).take(1).first()
+
+            assertEquals(bookmarkOne.uuid, bookmarks[0].uuid)
+            assertEquals(bookmarkTwo.uuid, bookmarks[1].uuid)
         }
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
@@ -127,6 +127,13 @@ class BookmarksFragment : BaseFragment() {
             OptionsDialog()
                 .setForceDarkTheme(true)
                 .addTextOption(
+                    titleId = LR.string.bookmarks_select_option,
+                    imageId = IR.drawable.ic_selectall,
+                    click = {
+                        multiSelectHelper.isMultiSelecting = true
+                    }
+                )
+                .addTextOption(
                     titleId = LR.string.bookmarks_sort_option,
                     imageId = IR.drawable.ic_sort,
                     valueId = selectedValue,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
@@ -55,7 +55,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.activityViewModels
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
@@ -70,8 +70,10 @@ import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatPattern
+import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import dagger.hilt.android.AndroidEntryPoint
@@ -85,7 +87,9 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @AndroidEntryPoint
 class BookmarksFragment : BaseFragment() {
     private val playerViewModel: PlayerViewModel by activityViewModels()
+    private val bookmarksViewModel: BookmarksViewModel by viewModels()
     @Inject lateinit var multiSelectHelper: MultiSelectBookmarksHelper
+    @Inject lateinit var settings: Settings
 
     private val overrideTheme: Theme.ThemeType
         get() = if (Theme.isDark(context)) theme.activeTheme else Theme.ThemeType.DARK
@@ -103,6 +107,7 @@ class BookmarksFragment : BaseFragment() {
                 Surface(modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection())) {
                     BookmarksPage(
                         playerViewModel = playerViewModel,
+                        bookmarksViewModel = bookmarksViewModel,
                         onRowLongPressed = { bookmark ->
                             multiSelectHelper.defaultLongPress(
                                 multiSelectable = bookmark,
@@ -110,9 +115,29 @@ class BookmarksFragment : BaseFragment() {
                                 forceDarkTheme = true,
                             )
                         },
+                        showOptionsDialog = { showOptionsDialog(it) }
                     )
                 }
             }
+        }
+    }
+
+    private val showOptionsDialog: (Int) -> Unit = { selectedValue ->
+        activity?.supportFragmentManager?.let {
+            OptionsDialog()
+                .setForceDarkTheme(true)
+                .addTextOption(
+                    titleId = LR.string.bookmarks_sort_option,
+                    imageId = IR.drawable.ic_sort,
+                    valueId = selectedValue,
+                    click = {
+                        BookmarksSortByDialog(settings, bookmarksViewModel::changeSortOrder)
+                            .show(
+                                context = requireContext(),
+                                fragmentManager = it
+                            )
+                    }
+                ).show(it, "bookmarks_options_dialog")
         }
     }
 }
@@ -120,8 +145,9 @@ class BookmarksFragment : BaseFragment() {
 @Composable
 private fun BookmarksPage(
     playerViewModel: PlayerViewModel,
-    bookmarksViewModel: BookmarksViewModel = hiltViewModel(),
+    bookmarksViewModel: BookmarksViewModel,
     onRowLongPressed: (Bookmark) -> Unit,
+    showOptionsDialog: (Int) -> Unit,
 ) {
     val state by bookmarksViewModel.uiState.collectAsStateWithLifecycle()
     val listData = playerViewModel.listDataLive.asFlow().collectAsState(initial = null)
@@ -130,11 +156,16 @@ private fun BookmarksPage(
             state = state,
             backgroundColor = Color(it.podcastHeader.backgroundColor),
             onRowLongPressed = onRowLongPressed,
+            onBookmarksOptionsMenuClicked = { bookmarksViewModel.onOptionsMenuClicked() },
         )
         LaunchedEffect(Unit) {
             bookmarksViewModel.loadBookmarks(
                 episodeUuid = it.podcastHeader.episodeUuid
             )
+            bookmarksViewModel.showOptionsDialog
+                .collect { selectedValue ->
+                    showOptionsDialog(selectedValue)
+                }
         }
     }
 }
@@ -144,6 +175,7 @@ private fun Content(
     state: UiState,
     backgroundColor: Color,
     onRowLongPressed: (Bookmark) -> Unit,
+    onBookmarksOptionsMenuClicked: () -> Unit,
 ) {
     Box(
         modifier = Modifier
@@ -155,6 +187,7 @@ private fun Content(
                 state = state,
                 backgroundColor = backgroundColor,
                 onRowLongPressed = onRowLongPressed,
+                onOptionsMenuClicked = onBookmarksOptionsMenuClicked,
             )
 
             is UiState.Empty -> NoBookmarksView()
@@ -168,6 +201,7 @@ private fun BookmarksView(
     state: UiState.Loaded,
     backgroundColor: Color,
     onRowLongPressed: (Bookmark) -> Unit,
+    onOptionsMenuClicked: () -> Unit,
 ) {
     LazyColumn(
         modifier = Modifier
@@ -182,7 +216,10 @@ private fun BookmarksView(
                 },
                 state.bookmarks.size
             )
-            HeaderItem(title)
+            HeaderItem(
+                title = title,
+                onOptionsMenuClicked = onOptionsMenuClicked,
+            )
         }
         items(state.bookmarks, key = { it }) { bookmark ->
             BookmarkItem(
@@ -203,7 +240,10 @@ private fun BookmarksView(
 }
 
 @Composable
-private fun HeaderItem(title: String) {
+private fun HeaderItem(
+    title: String,
+    onOptionsMenuClicked: () -> Unit,
+) {
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
@@ -216,7 +256,7 @@ private fun HeaderItem(title: String) {
             color = MaterialTheme.theme.colors.playerContrast02,
         )
         IconButton(
-            onClick = { /* TODO */ },
+            onClick = { onOptionsMenuClicked() },
         ) {
             Icon(
                 painter = painterResource(IR.drawable.ic_more_vert_black_24dp),
@@ -484,6 +524,7 @@ private fun BookmarksPreview(
             ),
             backgroundColor = Color.Black,
             onRowLongPressed = {},
+            onBookmarksOptionsMenuClicked = {},
         )
     }
 }
@@ -498,6 +539,7 @@ private fun NoBookmarksPreview(
             state = UiState.Empty,
             backgroundColor = Color.Black,
             onRowLongPressed = {},
+            onBookmarksOptionsMenuClicked = {},
         )
     }
 }
@@ -512,6 +554,7 @@ private fun PlusUpsellPreview(
             state = UiState.PlusUpsell,
             backgroundColor = Color.Black,
             onRowLongPressed = {},
+            onBookmarksOptionsMenuClicked = {},
         )
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
@@ -128,7 +128,7 @@ class BookmarksFragment : BaseFragment() {
                 .setForceDarkTheme(true)
                 .addTextOption(
                     titleId = LR.string.bookmarks_select_option,
-                    imageId = IR.drawable.ic_selectall,
+                    imageId = IR.drawable.ic_multiselect,
                     click = {
                         multiSelectHelper.isMultiSelecting = true
                     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
@@ -67,6 +67,7 @@ import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
+import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
@@ -128,7 +129,7 @@ class BookmarksFragment : BaseFragment() {
                 .setForceDarkTheme(true)
                 .addTextOption(
                     titleId = LR.string.bookmarks_select_option,
-                    imageId = IR.drawable.ic_multiselect,
+                    imageId = R.drawable.ic_multiselect,
                     click = {
                         multiSelectHelper.isMultiSelecting = true
                     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksSortByDialog.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksSortByDialog.kt
@@ -1,0 +1,28 @@
+package au.com.shiftyjelly.pocketcasts.player.view
+
+import android.content.Context
+import androidx.fragment.app.FragmentManager
+import au.com.shiftyjelly.pocketcasts.models.type.BookmarksSortType
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+class BookmarksSortByDialog(
+    val settings: Settings,
+    val changeSortOrder: (BookmarksSortType) -> Unit
+) {
+    fun show(context: Context, fragmentManager: FragmentManager) {
+        val sortOrder = settings.getBookmarksSortType()
+        val dialog = OptionsDialog()
+            .setTitle(context.resources.getString(LR.string.sort_by))
+            .setForceDarkTheme(true)
+        for (order in BookmarksSortType.values()) {
+            dialog.addCheckedOption(
+                titleId = order.labelId,
+                checked = order.labelId == sortOrder.labelId,
+                click = { changeSortOrder(order) }
+            )
+        }
+        dialog.show(fragmentManager, "bookmarks_sort_dialog")
+    }
+}

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.player.viewmodel
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.player.util.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
@@ -47,6 +48,9 @@ class BookmarksViewModelTest {
     @Mock
     private lateinit var signInState: SignInState
 
+    @Mock
+    private lateinit var settings: Settings
+
     private lateinit var bookmarksViewModel: BookmarksViewModel
     private val episodeUuid = UUID.randomUUID().toString()
 
@@ -62,6 +66,7 @@ class BookmarksViewModelTest {
             episodeManager = episodeManager,
             userManager = userManager,
             multiSelectHelper = multiSelectHelper,
+            settings = settings,
             ioDispatcher = UnconfinedTestDispatcher()
         )
     }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1685,7 +1685,7 @@
     <string name="bookmarks_delete_summary_plural">%d bookmarks will be deleted. This cannot be undone.</string>
     <string name="bookmarks_delete_summary_singular">This bookmark will be deleted. This cannot be undone.</string>
     <string name="bookmarks_select_option">Select bookmarks</string>
-    <string name="bookmarks_sort_option">Sort bookmarks</string>
+    <string name="bookmarks_sort_option" translatable="false">@string/sort_by</string>
     <string name="bookmarks_sort_newest_to_oldest" translatable="false">@string/sort_newest_to_oldest</string>
     <string name="bookmarks_sort_oldest_to_newest" translatable="false">@string/sort_oldest_to_newest</string>
     <string name="bookmarks_sort_timestamp">Timestamp</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -66,6 +66,8 @@
     <string name="removed">Removed</string>
     <string name="search">Search</string>
     <string name="selected">Selected</string>
+    <string name="sort_newest_to_oldest">Newest to oldest</string>
+    <string name="sort_oldest_to_newest">Oldest to newest</string>
     <string name="not_selected">Not selected</string>
     <string name="select_all">Select all</string>
     <string name="select_none">Select none</string>
@@ -536,8 +538,8 @@
     <string name="episode_row_waiting_for_power">Waiting for power</string>
     <string name="episode_row_waiting_for_wifi">Waiting for WiFi</string>
     <string name="episode_sort_long_to_short">Longest to shortest</string>
-    <string name="episode_sort_newest_to_oldest">Newest to oldest</string>
-    <string name="episode_sort_oldest_to_newest">Oldest to newest</string>
+    <string name="episode_sort_newest_to_oldest" translatable="false">@string/sort_newest_to_oldest</string>
+    <string name="episode_sort_oldest_to_newest" translatable="false">@string/sort_oldest_to_newest</string>
     <string name="episode_sort_short_to_long">Shortest to longest</string>
     <string name="episode_bonus">Bonus</string>
     <string name="episode_trailer">Trailer</string>
@@ -1682,6 +1684,11 @@
     <string name="bookmarks_deleted_singular">1 bookmark deleted</string>
     <string name="bookmarks_delete_summary_plural">%d bookmarks will be deleted. This cannot be undone.</string>
     <string name="bookmarks_delete_summary_singular">This bookmark will be deleted. This cannot be undone.</string>
+    <string name="bookmarks_select_option">Select bookmarks</string>
+    <string name="bookmarks_sort_option">Sort bookmarks</string>
+    <string name="bookmarks_sort_newest_to_oldest" translatable="false">@string/sort_newest_to_oldest</string>
+    <string name="bookmarks_sort_oldest_to_newest" translatable="false">@string/sort_oldest_to_newest</string>
+    <string name="bookmarks_sort_timestamp">Timestamp</string>
 
     <!--    Tasker Plugin-->
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -31,8 +31,25 @@ abstract class BookmarkDao {
     @Query("SELECT * FROM bookmarks WHERE podcast_uuid = :podcastUuid AND episode_uuid = :episodeUuid AND time = :timeSecs LIMIT 1")
     abstract suspend fun findByEpisodeTime(podcastUuid: String, episodeUuid: String, timeSecs: Int): Bookmark?
 
-    @Query("SELECT * FROM bookmarks WHERE podcast_uuid = :podcastUuid AND episode_uuid = :episodeUuid AND deleted = :deleted")
-    abstract fun findByEpisodeFlow(podcastUuid: String, episodeUuid: String, deleted: Boolean = false): Flow<List<Bookmark>>
+    @Query(
+        "SELECT * FROM bookmarks WHERE podcast_uuid = :podcastUuid AND episode_uuid = :episodeUuid AND deleted = :deleted " +
+            "ORDER BY " +
+            "CASE WHEN :isAsc = 1 THEN created_at END ASC, " +
+            "CASE WHEN :isAsc = 0 THEN created_at END DESC"
+    )
+    abstract fun findByEpisodeOrderCreatedAtFlow(
+        podcastUuid: String,
+        episodeUuid: String,
+        deleted: Boolean = false,
+        isAsc: Boolean,
+    ): Flow<List<Bookmark>>
+
+    @Query("SELECT * FROM bookmarks WHERE podcast_uuid = :podcastUuid AND episode_uuid = :episodeUuid AND deleted = :deleted ORDER BY time ASC")
+    abstract fun findByEpisodeOrderTimeFlow(
+        podcastUuid: String,
+        episodeUuid: String,
+        deleted: Boolean = false,
+    ): Flow<List<Bookmark>>
 
     @Query("UPDATE bookmarks SET deleted = :deleted, deleted_modified = :deletedModified, sync_status = :syncStatus WHERE uuid = :uuid")
     abstract suspend fun updateDeleted(uuid: String, deleted: Boolean, deletedModified: Long, syncStatus: SyncStatus)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/BookmarksSortType.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/BookmarksSortType.kt
@@ -1,0 +1,27 @@
+package au.com.shiftyjelly.pocketcasts.models.type
+
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+enum class BookmarksSortType(
+    val labelId: Int,
+    val analyticsValue: String,
+) {
+    DATE_ADDED_NEWEST_TO_OLDEST(
+        labelId = LR.string.bookmarks_sort_newest_to_oldest,
+        analyticsValue = "date_added_newest_to_oldest"
+    ),
+    DATE_ADDED_OLDEST_TO_NEWEST(
+        labelId = LR.string.bookmarks_sort_oldest_to_newest,
+        analyticsValue = "date_added_oldest_to_newest"
+    ),
+    TIMESTAMP(
+        labelId = LR.string.bookmarks_sort_timestamp,
+        analyticsValue = "timestamp"
+    );
+
+    fun mapToLocalizedString() = when (this) {
+        DATE_ADDED_OLDEST_TO_NEWEST -> LR.string.bookmarks_sort_oldest_to_newest
+        DATE_ADDED_NEWEST_TO_OLDEST -> LR.string.bookmarks_sort_newest_to_oldest
+        TIMESTAMP -> LR.string.bookmarks_sort_timestamp
+    }
+}

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.models.type.BookmarksSortType
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
@@ -107,6 +108,8 @@ interface Settings {
         const val PREFERENCE_DISCOVERY_COUNTRY_CODE = "discovery_country_code"
         const val PREFERENCE_POPULAR_PODCAST_COUNTRY_CODE = "popular_podcast_country_code"
         const val STORAGE_ON_CUSTOM_FOLDER = "custom_folder"
+
+        const val PREFERENCE_BOOKMARKS_SORT = "bookmarksSort"
 
         val SUPPORTED_LANGUAGE_CODES = arrayOf("us", "se", "jp", "gb", "fr", "es", "de", "ca", "au", "it", "ru", "br", "no", "be", "cn", "dk", "sw", "ch", "ie", "pl", "kr", "nl")
 
@@ -318,6 +321,7 @@ interface Settings {
     val headphonePreviousActionFlow: StateFlow<HeadphoneAction>
     val headphoneNextActionFlow: StateFlow<HeadphoneAction>
     val headphonePlayBookmarkConfirmationSoundFlow: StateFlow<Boolean>
+    val bookmarkSortTypeFlow: StateFlow<BookmarksSortType>
 
     fun getVersion(): String
     fun getVersionCode(): Int
@@ -642,4 +646,7 @@ interface Settings {
 
     fun getlastLoadedFromPodcastOrFilterUuid(): String?
     fun setlastLoadedFromPodcastOrFilterUuid(uuid: String?)
+
+    fun setBookmarksSortType(sortType: BookmarksSortType)
+    fun getBookmarksSortType(): BookmarksSortType
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -15,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.models.type.BookmarksSortType
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
@@ -101,6 +102,7 @@ class SettingsImpl @Inject constructor(
     override val headphonePreviousActionFlow = MutableStateFlow(getHeadphoneControlsPreviousAction())
     override val headphoneNextActionFlow = MutableStateFlow(getHeadphoneControlsNextAction())
     override val headphonePlayBookmarkConfirmationSoundFlow = MutableStateFlow(getHeadphoneControlsPlayBookmarkConfirmationSound())
+    override val bookmarkSortTypeFlow = MutableStateFlow(getBookmarksSortType())
 
     override val refreshStateObservable = BehaviorRelay.create<RefreshState>().apply {
         val lastError = getLastRefreshError()
@@ -1442,4 +1444,17 @@ class SettingsImpl @Inject constructor(
 
     override fun getlastLoadedFromPodcastOrFilterUuid(): String? =
         getString(LAST_SELECTED_PODCAST_OR_FILTER_UUID)
+
+    override fun setBookmarksSortType(sortType: BookmarksSortType) {
+        setInt(Settings.PREFERENCE_BOOKMARKS_SORT, sortType.ordinal)
+        bookmarkSortTypeFlow.update { sortType }
+    }
+
+    override fun getBookmarksSortType() =
+        BookmarksSortType.values()[
+            getInt(
+                Settings.PREFERENCE_BOOKMARKS_SORT,
+                BookmarksSortType.DATE_ADDED_NEWEST_TO_OLDEST.ordinal
+            )
+        ]
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
@@ -2,12 +2,18 @@ package au.com.shiftyjelly.pocketcasts.repositories.bookmark
 
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+import au.com.shiftyjelly.pocketcasts.models.type.BookmarksSortType
 import kotlinx.coroutines.flow.Flow
 
 interface BookmarkManager {
     suspend fun add(episode: BaseEpisode, timeSecs: Int, title: String): Bookmark
     suspend fun findBookmark(bookmarkUuid: String): Bookmark?
-    suspend fun findEpisodeBookmarksFlow(episode: BaseEpisode): Flow<List<Bookmark>>
+    suspend fun findEpisodeBookmarksFlow(
+        episode: BaseEpisode,
+        sortType: BookmarksSortType,
+        isAsc: Boolean = false,
+    ): Flow<List<Bookmark>>
+
     suspend fun deleteToSync(bookmarkUuid: String)
     suspend fun deleteSynced(bookmarkUuid: String)
     suspend fun upsertSynced(bookmark: Bookmark): Bookmark

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
@@ -11,7 +11,6 @@ interface BookmarkManager {
     suspend fun findEpisodeBookmarksFlow(
         episode: BaseEpisode,
         sortType: BookmarksSortType,
-        isAsc: Boolean = false,
     ): Flow<List<Bookmark>>
 
     suspend fun deleteToSync(bookmarkUuid: String)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -60,7 +60,6 @@ class BookmarkManagerImpl @Inject constructor(
     override suspend fun findEpisodeBookmarksFlow(
         episode: BaseEpisode,
         sortType: BookmarksSortType,
-        isAsc: Boolean,
     ) = when (sortType) {
         BookmarksSortType.DATE_ADDED_NEWEST_TO_OLDEST ->
             bookmarkDao.findByEpisodeOrderCreatedAtFlow(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -3,17 +3,17 @@ package au.com.shiftyjelly.pocketcasts.repositories.bookmark
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+import au.com.shiftyjelly.pocketcasts.models.type.BookmarksSortType
 import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
 import java.util.Date
 import java.util.UUID
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
 class BookmarkManagerImpl @Inject constructor(
-    appDatabase: AppDatabase
+    appDatabase: AppDatabase,
 ) : BookmarkManager, CoroutineScope {
 
     override val coroutineContext: CoroutineContext
@@ -57,8 +57,30 @@ class BookmarkManagerImpl @Inject constructor(
     /**
      * Find all bookmarks for the given episode. The flow will be updated when the bookmarks change.
      */
-    override suspend fun findEpisodeBookmarksFlow(episode: BaseEpisode): Flow<List<Bookmark>> {
-        return bookmarkDao.findByEpisodeFlow(podcastUuid = episode.podcastOrSubstituteUuid, episodeUuid = episode.uuid)
+    override suspend fun findEpisodeBookmarksFlow(
+        episode: BaseEpisode,
+        sortType: BookmarksSortType,
+        isAsc: Boolean,
+    ) = when (sortType) {
+        BookmarksSortType.DATE_ADDED_NEWEST_TO_OLDEST ->
+            bookmarkDao.findByEpisodeOrderCreatedAtFlow(
+                podcastUuid = episode.podcastOrSubstituteUuid,
+                episodeUuid = episode.uuid,
+                isAsc = false,
+            )
+
+        BookmarksSortType.DATE_ADDED_OLDEST_TO_NEWEST ->
+            bookmarkDao.findByEpisodeOrderCreatedAtFlow(
+                podcastUuid = episode.podcastOrSubstituteUuid,
+                episodeUuid = episode.uuid,
+                isAsc = true,
+            )
+
+        BookmarksSortType.TIMESTAMP ->
+            bookmarkDao.findByEpisodeOrderTimeFlow(
+                podcastUuid = episode.podcastOrSubstituteUuid,
+                episodeUuid = episode.uuid,
+            )
     }
 
     /**

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
@@ -65,6 +65,11 @@ class MultiSelectBookmarksHelper @Inject constructor(
 
     fun delete(resources: Resources, fragmentManager: FragmentManager) {
         val bookmarks = selectedList.toList()
+        if (bookmarks.isEmpty()) {
+            closeMultiSelect()
+            return
+        }
+
         val count = bookmarks.size
         ConfirmationDialog()
             .setForceDarkTheme(true)


### PR DESCRIPTION
## Description

This adds sorting to the bookmarks list.

## Testing Instructions

1. Add a few bookmarks to the bookmarks table with different `create_at` and `time` values
2. Launch the app and login with Plus account
3. Open the Full Screen Player
4. Swipe to the bookmarks list
5. Tap the vertical <kbd>...</kbd> button
6. ✅ Verify you see an options menu with 2 options: Select bookmarks, Sort by
7. ✅ Verify the default sort by option is newest to oldest
8. Tap on Select bookmarks
9. ✅ Verify the view enters multi select mode
10. Tap back arrow, then tap the more (...) button again
11. Tap the Sort by option
12. ✅ Verify a new options menu opens with 3 options: "Newest to oldest", "Oldest to newest", and "Timestamp"
13. Tap on the "Oldest to newest"
14. ✅ Verify the list is now sorted with the oldest bookmarks first
15. Open the sort menu again, choose "Timestamp"
16. ✅ Verify the list is now sorted with the earliest timestamp at the top

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/c57a1b1d-30d8-4bc1-bd66-17ba8f3ea1a8

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
