### PR TITLE
Add bookmarks from the player shelf

### DIFF
--- a/modules/features/player/src/main/AndroidManifest.xml
+++ b/modules/features/player/src/main/AndroidManifest.xml
@@ -9,7 +9,10 @@
             android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation"
             android:windowSoftInputMode="stateAlwaysHidden"
             tools:ignore="UnusedAttribute" />
+        <activity
+            android:name=".view.bookmark.BookmarkActivity"
+            android:windowSoftInputMode="adjustResize"
+            android:configChanges="orientation|layoutDirection|screenSize" />
     </application>
-
 
 </manifest>

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -214,6 +214,12 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
         binding?.viewPager?.currentItem = index
     }
 
+    fun openBookmarks() {
+        val index = adapter.indexOfBookmarks
+        if (index == -1) return
+        binding?.viewPager?.currentItem = index
+    }
+
     fun openChaptersAt(chapter: Chapter) {
         val index = adapter.indexOfChapters
         if (index == -1) {
@@ -271,13 +277,16 @@ private class ViewPagerAdapter(fragmentManager: FragmentManager, lifecycle: Life
         object Chapters : Section(LR.string.player_tab_chapters)
     }
 
-    private var sections = listOf<Section>(Section.Player)
+    private var sections = listOf(Section.Player, Section.Bookmarks)
 
     val indexOfPlayer: Int
         get() = sections.indexOf(Section.Player)
 
     val indexOfChapters: Int
         get() = sections.indexOf(Section.Chapters)
+
+    val indexOfBookmarks: Int
+        get() = sections.indexOf(Section.Bookmarks)
 
     fun update(hasNotes: Boolean, hasChapters: Boolean): Boolean {
         val hadNotes = sections.contains(Section.Notes)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.player.view.ShelfFragment.Companion.Analyt
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.ChromeCastAnalytics
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.views.extensions.applyColor
@@ -27,6 +28,7 @@ class ShelfBottomSheet : BaseDialogFragment() {
     @Inject lateinit var castManager: CastManager
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
     @Inject lateinit var chromeCastAnalytics: ChromeCastAnalytics
+    @Inject lateinit var playbackManager: PlaybackManager
 
     override val statusBarColor: StatusBarColor? = null
 
@@ -106,6 +108,9 @@ class ShelfBottomSheet : BaseDialogFragment() {
             }
             is ShelfItem.Archive -> {
                 playerViewModel.archiveCurrentlyPlaying(resources)?.show(parentFragmentManager, "archive")
+            }
+            is ShelfItem.Bookmark -> {
+                (parentFragment as? PlayerHeaderFragment)?.onAddBookmarkClick()
             }
             ShelfItem.Download -> {
                 Timber.e("Unexpected click on ShelfItem.Download")

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfItem.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfItem.kt
@@ -1,6 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.player.view
 
 import androidx.annotation.StringRes
+import au.com.shiftyjelly.pocketcasts.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -11,8 +13,20 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.views.R as VR
 
 object ShelfItems {
-    val itemsList = listOf(ShelfItem.Effects, ShelfItem.Sleep, ShelfItem.Star, ShelfItem.Share, ShelfItem.Podcast, ShelfItem.Cast, ShelfItem.Played, ShelfItem.Archive)
-    val items = itemsList.associateBy { it.id }
+    val itemsList = buildList {
+        add(ShelfItem.Effects)
+        add(ShelfItem.Sleep)
+        add(ShelfItem.Star)
+        add(ShelfItem.Share)
+        add(ShelfItem.Podcast)
+        add(ShelfItem.Cast)
+        add(ShelfItem.Played)
+        if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+            add(ShelfItem.Bookmark)
+        }
+        add(ShelfItem.Archive)
+    }
+    private val items = itemsList.associateBy { it.id }
 
     fun itemForId(id: String): ShelfItem? {
         return items[id]
@@ -24,6 +38,7 @@ sealed class ShelfItem(
     var title: (BaseEpisode?) -> Int,
     var iconRes: (BaseEpisode?) -> Int,
     val shownWhen: Shown,
+    val isPlus: Boolean,
     val analyticsValue: String,
     @StringRes val subtitle: Int? = null
 ) {
@@ -38,7 +53,8 @@ sealed class ShelfItem(
         title = { LR.string.podcast_playback_effects },
         iconRes = { IR.drawable.ic_effects_off },
         shownWhen = Shown.Always,
-        analyticsValue = "playback_effects"
+        analyticsValue = "playback_effects",
+        isPlus = false
     )
 
     object Sleep : ShelfItem(
@@ -46,6 +62,7 @@ sealed class ShelfItem(
         title = { LR.string.player_sleep_timer },
         iconRes = { R.drawable.ic_sleep },
         shownWhen = Shown.Always,
+        isPlus = false,
         analyticsValue = "sleep_timer"
     )
 
@@ -55,7 +72,8 @@ sealed class ShelfItem(
         subtitle = LR.string.player_actions_hidden_for_custom,
         iconRes = { if (it is PodcastEpisode && it.isStarred) IR.drawable.ic_star_filled else IR.drawable.ic_star },
         shownWhen = Shown.EpisodeOnly,
-        analyticsValue = "star_episode"
+        isPlus = false,
+        analyticsValue = "star_episode",
     )
 
     object Share : ShelfItem(
@@ -64,6 +82,7 @@ sealed class ShelfItem(
         subtitle = LR.string.player_actions_hidden_for_custom,
         iconRes = { IR.drawable.ic_share },
         shownWhen = Shown.EpisodeOnly,
+        isPlus = false,
         analyticsValue = "share_episode"
     )
 
@@ -72,6 +91,7 @@ sealed class ShelfItem(
         title = { if (it is UserEpisode) LR.string.go_to_files else LR.string.go_to_podcast },
         iconRes = { R.drawable.ic_arrow_goto },
         shownWhen = Shown.Always,
+        isPlus = false,
         analyticsValue = "go_to_podcast"
     )
 
@@ -80,6 +100,7 @@ sealed class ShelfItem(
         title = { LR.string.chromecast },
         iconRes = { com.google.android.gms.cast.framework.R.drawable.quantum_ic_cast_connected_white_24 },
         shownWhen = Shown.Always,
+        isPlus = false,
         analyticsValue = "chromecast"
     )
 
@@ -88,7 +109,17 @@ sealed class ShelfItem(
         title = { LR.string.mark_as_played },
         iconRes = { R.drawable.ic_markasplayed },
         shownWhen = Shown.Always,
+        isPlus = false,
         analyticsValue = "mark_as_played"
+    )
+
+    object Bookmark : ShelfItem(
+        id = "bookmark",
+        title = { LR.string.add_bookmark },
+        iconRes = { IR.drawable.ic_bookmark },
+        shownWhen = Shown.Always,
+        isPlus = true,
+        analyticsValue = "add_bookmark"
     )
 
     object Archive : ShelfItem(
@@ -97,6 +128,7 @@ sealed class ShelfItem(
         subtitle = LR.string.player_actions_show_as_delete_for_custom,
         iconRes = { if (it is UserEpisode) VR.drawable.ic_delete else IR.drawable.ic_archive },
         shownWhen = Shown.Always,
+        isPlus = false,
         analyticsValue = "archive"
     )
 
@@ -121,6 +153,7 @@ sealed class ShelfItem(
             }
         },
         shownWhen = Shown.Always,
+        isPlus = false,
         analyticsValue = "download"
     )
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkActivity.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkActivity.kt
@@ -1,0 +1,31 @@
+package au.com.shiftyjelly.pocketcasts.player.view.bookmark
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowInsetsControllerCompat
+import dagger.hilt.android.AndroidEntryPoint
+import au.com.shiftyjelly.pocketcasts.views.R as VR
+
+@AndroidEntryPoint
+class BookmarkActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContentView(VR.layout.activity_blank_fragment)
+
+        val arguments = BookmarkArguments.createFromIntent(intent)
+
+        // tint the status bar color
+        window.statusBarColor = arguments.backgroundColor
+        // set the status bar icons to white
+        WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars = false
+
+        if (savedInstanceState == null) {
+            val fragment = arguments.buildFragment()
+            supportFragmentManager.beginTransaction()
+                .replace(VR.id.container, fragment)
+                .commitNow()
+        }
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkActivityContract.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkActivityContract.kt
@@ -1,0 +1,51 @@
+package au.com.shiftyjelly.pocketcasts.player.view.bookmark
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarkActivityContract.BookmarkResult
+
+/**
+ * Handles returning a result from the [BookmarkActivity] to the caller.
+ * The result is a [BookmarkResult] which contains the created bookmark's UUID and title.
+ * Also the tint color so the caller can easily show a Snackbar with the correct action color.
+ */
+class BookmarkActivityContract : ActivityResultContract<Intent, BookmarkActivityContract.BookmarkResult?>() {
+
+    companion object {
+        const val RESULT_BOOKMARK_UUID = "RESULT_BOOKMARK_UUID"
+        const val RESULT_TITLE = "RESULT_TITLE"
+        const val RESULT_TINT_COLOR = "RESULT_TINT_COLOR"
+
+        fun createIntent(bookmarkUuid: String, title: String, tintColor: Color): Intent {
+            return Intent().apply {
+                putExtra(RESULT_BOOKMARK_UUID, bookmarkUuid)
+                putExtra(RESULT_TITLE, title)
+                putExtra(RESULT_TINT_COLOR, tintColor.toArgb())
+            }
+        }
+    }
+
+    data class BookmarkResult(
+        val bookmarkUuid: String,
+        val title: String,
+        val tintColor: Int
+    )
+
+    override fun createIntent(context: Context, input: Intent): Intent = input
+
+    override fun parseResult(resultCode: Int, intent: Intent?): BookmarkResult? {
+        if (resultCode == Activity.RESULT_OK && intent != null) {
+            val bookmarkUuid = intent.getStringExtra(RESULT_BOOKMARK_UUID)
+            val title = intent.getStringExtra(RESULT_TITLE)
+            val tintColor = intent.getIntExtra(RESULT_TINT_COLOR, Color.White.toArgb())
+            if (bookmarkUuid != null) {
+                return BookmarkResult(bookmarkUuid = bookmarkUuid, title = title ?: "", tintColor = tintColor)
+            }
+        }
+        return null
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkArguments.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkArguments.kt
@@ -1,0 +1,68 @@
+package au.com.shiftyjelly.pocketcasts.player.view.bookmark
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.core.os.bundleOf
+
+/**
+ * Arguments for [BookmarkActivity] and [BookmarkFragment].
+ */
+class BookmarkArguments(
+    val bookmarkUuid: String? = null,
+    val episodeUuid: String,
+    val timeSecs: Int,
+    val backgroundColor: Int,
+    val tintColor: Int,
+) {
+
+    companion object {
+        private const val ARGUMENT_BOOKMARK_UUID = "BOOKMARK_UUID"
+        private const val ARGUMENT_EPISODE_UUID = "EPISODE_UUID"
+        private const val ARGUMENT_TIME = "TIME"
+        private const val ARGUMENT_BACKGROUND_COLOR = "BACKGROUND_COLOR"
+        private const val ARGUMENT_TINT_COLOR = "TINT_COLOR"
+
+        fun createFromIntent(intent: Intent): BookmarkArguments {
+            return BookmarkArguments(
+                bookmarkUuid = intent.getStringExtra(ARGUMENT_BOOKMARK_UUID),
+                episodeUuid = intent.getStringExtra(ARGUMENT_EPISODE_UUID) ?: throw IllegalArgumentException("Episode UUID not set"),
+                timeSecs = intent.getIntExtra(ARGUMENT_TIME, 0),
+                backgroundColor = intent.getIntExtra(ARGUMENT_BACKGROUND_COLOR, 0),
+                tintColor = intent.getIntExtra(ARGUMENT_TINT_COLOR, 0)
+            )
+        }
+
+        fun createFromArguments(arguments: Bundle?): BookmarkArguments {
+            return BookmarkArguments(
+                bookmarkUuid = arguments?.getString(ARGUMENT_BOOKMARK_UUID),
+                episodeUuid = arguments?.getString(ARGUMENT_EPISODE_UUID) ?: throw IllegalArgumentException("Episode UUID not set"),
+                timeSecs = arguments.getInt(ARGUMENT_TIME),
+                backgroundColor = arguments.getInt(ARGUMENT_BACKGROUND_COLOR),
+                tintColor = arguments.getInt(ARGUMENT_TINT_COLOR)
+            )
+        }
+    }
+
+    fun getIntent(context: Context): Intent {
+        return Intent(context, BookmarkActivity::class.java).apply {
+            putExtra(ARGUMENT_BOOKMARK_UUID, bookmarkUuid)
+            putExtra(ARGUMENT_EPISODE_UUID, episodeUuid)
+            putExtra(ARGUMENT_TIME, timeSecs)
+            putExtra(ARGUMENT_BACKGROUND_COLOR, backgroundColor)
+            putExtra(ARGUMENT_TINT_COLOR, tintColor)
+        }
+    }
+
+    fun buildFragment(): BookmarkFragment {
+        return BookmarkFragment().apply {
+            arguments = bundleOf(
+                ARGUMENT_BOOKMARK_UUID to bookmarkUuid,
+                ARGUMENT_EPISODE_UUID to episodeUuid,
+                ARGUMENT_TIME to timeSecs,
+                ARGUMENT_BACKGROUND_COLOR to backgroundColor,
+                ARGUMENT_TINT_COLOR to tintColor
+            )
+        }
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkFragment.kt
@@ -1,0 +1,75 @@
+package au.com.shiftyjelly.pocketcasts.player.view.bookmark
+
+import android.app.Activity
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.background
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class BookmarkFragment : Fragment() {
+
+    private val viewModel: BookmarkViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        viewModel.load(BookmarkArguments.createFromArguments(arguments))
+        return ComposeView(requireContext()).apply {
+            setContent {
+                AppThemeWithBackground(Theme.ThemeType.DARK) {
+                    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+                    val uiState: BookmarkViewModel.UiState by viewModel.uiState.collectAsState()
+                    BookmarkPage(
+                        isNewBookmark = uiState.isNewBookmark,
+                        title = uiState.title,
+                        tintColor = uiState.tintColor,
+                        backgroundColor = uiState.backgroundColor,
+                        onTitleChange = { viewModel.changeTitle(it) },
+                        onSave = ::saveBookmark,
+                        onClose = ::close,
+                        modifier = Modifier.background(uiState.backgroundColor)
+                    )
+                }
+            }
+        }
+    }
+
+    private fun saveBookmark() {
+        viewModel.saveBookmark(onSaved = { bookmark -> bookmarkSaved(bookmark) })
+    }
+
+    private fun bookmarkSaved(bookmark: Bookmark) {
+        val intent = BookmarkActivityContract.createIntent(
+            bookmarkUuid = bookmark.uuid,
+            title = bookmark.title,
+            tintColor = viewModel.uiState.value.tintColor
+        )
+        requireActivity().run {
+            setResult(Activity.RESULT_OK, intent)
+            finish()
+        }
+    }
+
+    private fun close() {
+        requireActivity().run {
+            setResult(Activity.RESULT_CANCELED)
+            finish()
+        }
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkPage.kt
@@ -1,0 +1,157 @@
+package au.com.shiftyjelly.pocketcasts.player.view.bookmark
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.LocalTextSelectionColors
+import androidx.compose.foundation.text.selection.TextSelectionColors
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
+import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.extensions.onEnter
+import au.com.shiftyjelly.pocketcasts.compose.extensions.onTabMoveFocus
+import au.com.shiftyjelly.pocketcasts.localization.R
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+
+/***
+ * A page for to set a title for a bookmark and save it.
+ */
+@Composable
+fun BookmarkPage(isNewBookmark: Boolean, title: TextFieldValue, tintColor: Color, backgroundColor: Color, onTitleChange: (TextFieldValue) -> Unit, onSave: () -> Unit, onClose: () -> Unit, modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        Box(contentAlignment = Alignment.Center) {
+            ThemedTopAppBar(
+                backgroundColor = Color.Transparent,
+                navigationButton = NavigationButton.Close,
+                onNavigationClick = onClose,
+                iconColor = tintColor,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Text(
+                text = stringResource(if (isNewBookmark) R.string.add_bookmark_title else R.string.change_title),
+                color = Color.White,
+                fontWeight = FontWeight.Bold
+            )
+        }
+        Content(
+            isNewBookmark = isNewBookmark,
+            title = title,
+            tintColor = tintColor,
+            backgroundColor = backgroundColor,
+            onTitleChange = onTitleChange,
+            onSave = onSave
+        )
+    }
+}
+
+@Composable
+private fun Content(isNewBookmark: Boolean, title: TextFieldValue, tintColor: Color, backgroundColor: Color, onTitleChange: (TextFieldValue) -> Unit, onSave: () -> Unit, modifier: Modifier = Modifier) {
+    val focusRequester = remember { FocusRequester() }
+    val buttonColor = if (tintColor == Color.White) MaterialTheme.colors.primary else tintColor
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .fillMaxHeight()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
+        TextP40(
+            text = stringResource(R.string.add_bookmark_title_hint),
+            color = Color.White.copy(alpha = 0.5f),
+            textAlign = TextAlign.Center,
+            modifier = Modifier.widthIn(100.dp, 240.dp)
+        )
+
+        Spacer(Modifier.weight(1f))
+
+        val tintTextSelectionColors = TextSelectionColors(
+            handleColor = buttonColor,
+            backgroundColor = buttonColor.copy(alpha = 0.4f)
+        )
+        CompositionLocalProvider(LocalTextSelectionColors provides tintTextSelectionColors) {
+            TextField(
+                value = title,
+                onValueChange = { onTitleChange(it) },
+                textStyle = LocalTextStyle.current.copy(
+                    // if the title is too long, reduce the font size
+                    fontSize = if (title.text.length > 20) 18.sp else 26.sp,
+                    fontWeight = FontWeight.Bold
+                ),
+                colors = TextFieldDefaults.textFieldColors(
+                    textColor = Color.White,
+                    backgroundColor = Color.Transparent,
+                    cursorColor = buttonColor,
+                    focusedIndicatorColor = Color(0x33FFFFFF),
+                    unfocusedIndicatorColor = Color(0x33FFFFFF),
+
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester)
+                    .onEnter(onSave)
+                    .onTabMoveFocus()
+            )
+        }
+
+        Spacer(Modifier.weight(1f))
+
+        RowButton(
+            text = stringResource(if (isNewBookmark) R.string.save_bookmark else R.string.change_title),
+            colors = ButtonDefaults.buttonColors(backgroundColor = buttonColor),
+            // if the tint color is too light use the background color for the text
+            textColor = if (buttonColor.luminance() > 0.5) backgroundColor else Color.White,
+            includePadding = false,
+            onClick = onSave
+        )
+    }
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+}
+
+@Preview
+@Composable
+private fun BookmarkPagePreview() {
+    AppThemeWithBackground(Theme.ThemeType.DARK) {
+        BookmarkPage(
+            isNewBookmark = true,
+            title = TextFieldValue(""),
+            tintColor = Color.White,
+            backgroundColor = Color.Black,
+            onTitleChange = {},
+            onSave = {},
+            onClose = {}
+        )
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkViewModel.kt
@@ -1,0 +1,115 @@
+package au.com.shiftyjelly.pocketcasts.player.view.bookmark
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
+
+@HiltViewModel
+class BookmarkViewModel
+@Inject constructor(
+    private val episodeManager: EpisodeManager,
+    private val userEpisodeManager: UserEpisodeManager,
+    private val bookmarkManager: BookmarkManager
+) : ViewModel(), CoroutineScope {
+
+    private lateinit var arguments: BookmarkArguments
+
+    companion object {
+        private const val DEFAULT_TITLE = "Bookmark"
+
+        private fun buildSelectedTextFieldValue(text: String): TextFieldValue {
+            return TextFieldValue(text = text, selection = TextRange(0, text.length))
+        }
+    }
+
+    data class UiState(
+        val bookmarkUuid: String? = null,
+        val title: TextFieldValue = buildSelectedTextFieldValue(DEFAULT_TITLE),
+        val backgroundColor: Color = Color.Black,
+        val tintColor: Color = Color.Blue
+    ) {
+        val isNewBookmark: Boolean = bookmarkUuid == null
+    }
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.Default
+
+    private var mutableUiState: MutableStateFlow<UiState> = MutableStateFlow(UiState())
+    val uiState: StateFlow<UiState> = mutableUiState
+
+    fun load(arguments: BookmarkArguments) {
+        this.arguments = arguments
+        val bookmarkUuid = arguments.bookmarkUuid
+        mutableUiState.value = mutableUiState.value.copy(
+            bookmarkUuid = bookmarkUuid,
+            backgroundColor = Color(arguments.backgroundColor),
+            tintColor = Color(arguments.tintColor)
+        )
+        viewModelScope.launch {
+            // load the existing bookmark
+            val bookmark = if (bookmarkUuid == null) {
+                val episode = episodeManager.findEpisodeByUuid(arguments.episodeUuid) ?: return@launch
+                bookmarkManager.findByEpisodeTime(
+                    episode = episode,
+                    timeSecs = arguments.timeSecs
+                )
+            } else {
+                bookmarkManager.findBookmark(bookmarkUuid)
+            }
+            if (bookmark != null) {
+                mutableUiState.value = mutableUiState.value.copy(
+                    bookmarkUuid = bookmark.uuid,
+                    title = buildSelectedTextFieldValue(bookmark.title)
+                )
+            }
+        }
+    }
+
+    fun changeTitle(title: TextFieldValue) {
+        // limit the title to 100 characters
+        val titleLimited = title.copy(text = title.text.take(100))
+        mutableUiState.value = mutableUiState.value.copy(title = titleLimited)
+    }
+
+    fun saveBookmark(onSaved: (Bookmark) -> Unit) {
+        launch {
+            try {
+                val state = uiState.value
+                val bookmarkUuid = state.bookmarkUuid
+                val episodeUuid = arguments.episodeUuid
+                val bookmark = if (bookmarkUuid == null) {
+                    val episode = episodeManager.findByUuidSuspend(episodeUuid)
+                        ?: userEpisodeManager.findEpisodeByUuid(episodeUuid)
+                        ?: return@launch
+                    bookmarkManager.add(
+                        episode = episode,
+                        timeSecs = arguments.timeSecs,
+                        title = state.title.text
+                    )
+                } else {
+                    bookmarkManager.updateTitle(bookmarkUuid, state.title.text)
+                    bookmarkManager.findBookmark(bookmarkUuid)
+                }
+                if (bookmark != null) {
+                    onSaved(bookmark)
+                }
+            } catch (e: Exception) {
+                Timber.e(e)
+            }
+        }
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -23,8 +23,10 @@ import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.player.view.ShelfItem
 import au.com.shiftyjelly.pocketcasts.player.view.ShelfItems
 import au.com.shiftyjelly.pocketcasts.player.view.UpNextPlaying
+import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarkArguments
 import au.com.shiftyjelly.pocketcasts.player.view.dialog.ClearUpNextDialog
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getUrlForArtwork
@@ -37,6 +39,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -53,6 +56,8 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.Flowables
 import io.reactivex.rxkotlin.Observables
+import io.reactivex.rxkotlin.combineLatest
+import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -70,8 +75,10 @@ class PlayerViewModel @Inject constructor(
     private val playbackManager: PlaybackManager,
     private val episodeManager: EpisodeManager,
     private val userEpisodeManager: UserEpisodeManager,
+    private val userManager: UserManager,
     private val downloadManager: DownloadManager,
     private val podcastManager: PodcastManager,
+    private val bookmarkManager: BookmarkManager,
     private val sleepTimer: SleepTimer,
     private val settings: Settings,
     private val theme: Theme,
@@ -188,6 +195,8 @@ class PlayerViewModel @Inject constructor(
             .switchMap { pair -> episodeManager.observeEpisodeByUuidRx(pair.first).map { Pair(it, pair.second) } }
             .toLiveData()
 
+    private var playbackPositionMs: Int = 0
+
     private val shelfObservable = settings.shelfItemsObservable.map { list ->
         if (list.isEmpty()) {
             ShelfItems.itemsList
@@ -196,7 +205,11 @@ class PlayerViewModel @Inject constructor(
                 ShelfItems.itemForId(id)
             }
         }
-    }.toFlowable(BackpressureStrategy.LATEST)
+    }
+        .toFlowable(BackpressureStrategy.LATEST)
+        .combineLatest(userManager.getSignInState()).map { (shelfItems, signInState) ->
+            shelfItems.filter { item -> !item.isPlus || signInState.isSignedInAsPlusOrPatron }
+        }
 
     private val shelfUpNext = upNextStateObservable.distinctUntilChanged { t1, t2 ->
         val entry1 = t1 as? UpNextQueue.State.Loaded ?: return@distinctUntilChanged false
@@ -285,9 +298,24 @@ class PlayerViewModel @Inject constructor(
 
     init {
         updateSleepTimer()
+        monitorPlaybackPosition()
     }
 
-    fun mergeListData(upNextState: UpNextQueue.State, playbackState: PlaybackState, skipBackwardInSecs: Int, skipForwardInSecs: Int, upNextExpanded: Boolean, chaptersExpanded: Boolean, globalPlaybackEffects: PlaybackEffects): ListData {
+    private fun monitorPlaybackPosition() {
+        playbackStateObservable
+            .map { it.positionMs }
+            .toFlowable(BackpressureStrategy.LATEST)
+            .subscribeBy(
+                onNext = { positionMs ->
+                    playbackPositionMs = positionMs
+                }
+            )
+            .apply {
+                disposables.add(this)
+            }
+    }
+
+    private fun mergeListData(upNextState: UpNextQueue.State, playbackState: PlaybackState, skipBackwardInSecs: Int, skipForwardInSecs: Int, upNextExpanded: Boolean, chaptersExpanded: Boolean, globalPlaybackEffects: PlaybackEffects): ListData {
         val podcast: Podcast? = (upNextState as? UpNextQueue.State.Loaded)?.podcast
         val episode = (upNextState as? UpNextQueue.State.Loaded)?.episode
 
@@ -443,6 +471,25 @@ class PlayerViewModel @Inject constructor(
         }
 
         return null
+    }
+
+    fun buildBookmarkArguments(onSuccess: (BookmarkArguments) -> Unit) {
+        val episode = episode ?: return
+        val timeSecs = playbackPositionMs / 1000
+        launch {
+            val bookmark = bookmarkManager.findByEpisodeTime(episode, timeSecs)
+            val podcast = podcast
+            val backgroundColor = if (podcast == null) 0xFF000000.toInt() else theme.playerBackgroundColor(podcast)
+            val tintColor = if (podcast == null) 0xFFFFFFFF.toInt() else theme.playerHighlightColor(podcast)
+            val arguments = BookmarkArguments(
+                bookmarkUuid = bookmark?.uuid,
+                episodeUuid = episode.uuid,
+                timeSecs = timeSecs,
+                backgroundColor = backgroundColor,
+                tintColor = tintColor
+            )
+            onSuccess(arguments)
+        }
     }
 
     fun downloadCurrentlyPlaying() {

--- a/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
@@ -381,6 +381,13 @@
                 style="@style/shelf_item" />
 
             <ImageButton
+                android:id="@+id/bookmark"
+                android:contentDescription="@string/add_bookmark"
+                app:srcCompat="@drawable/ic_bookmark"
+                app:tint="?attr/player_contrast_03"
+                style="@style/shelf_item" />
+
+            <ImageButton
                 android:id="@+id/archive"
                 android:contentDescription="@string/archive_episode"
                 app:srcCompat="@drawable/ic_archive"

--- a/modules/features/player/src/main/res/layout/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout/adapter_player_header.xml
@@ -422,6 +422,13 @@
                     style="@style/shelf_item" />
 
                 <ImageButton
+                    android:id="@+id/bookmark"
+                    android:contentDescription="@string/add_bookmark"
+                    app:srcCompat="@drawable/ic_bookmark"
+                    app:tint="?attr/player_contrast_03"
+                    style="@style/shelf_item" />
+
+                <ImageButton
                     android:id="@+id/archive"
                     android:contentDescription="@string/archive_episode"
                     app:srcCompat="@drawable/ic_archive_32"

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowButton.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowButton.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
@@ -60,7 +60,7 @@ fun RowButton(
                             .padding(4.dp)
                     )
                 }
-                TextH30(
+                TextP40(
                     text = text,
                     modifier = Modifier
                         .padding(6.dp)

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/FormField.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/FormField.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.compose.components
 
-import android.view.KeyEvent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,23 +12,18 @@ import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.extensions.onEnter
+import au.com.shiftyjelly.pocketcasts.compose.extensions.onTabMoveFocus
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.removeNewLines
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun FormField(
     value: String,
@@ -45,7 +39,6 @@ fun FormField(
     leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null,
 ) {
-    val focusManager = LocalFocusManager.current
     OutlinedTextField(
         value = value,
         onValueChange = { onValueChange(if (singleLine) it.removeNewLines() else it) },
@@ -67,18 +60,9 @@ fun FormField(
         trailingIcon = trailingIcon,
         modifier = modifier
             .fillMaxWidth()
-            .onPreviewKeyEvent {
-                if (singleLine && it.key == Key.Enter && it.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
-                    // the enter key for a single line field should call the next event, but for multiline fields it should be a new line.
-                    onImeAction()
-                    true
-                } else if (it.key == Key.Tab && it.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
-                    // tab should focus on the next field
-                    focusManager.moveFocus(FocusDirection.Down)
-                    true
-                } else {
-                    false
-                }
+            .onTabMoveFocus()
+            .let {
+                if (singleLine) it.onEnter(onImeAction) else it
             }
     )
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Modifier.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Modifier.kt
@@ -1,10 +1,18 @@
 package au.com.shiftyjelly.pocketcasts.compose.extensions
 
+import android.view.KeyEvent
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.platform.LocalFocusManager
 
 // From https://stackoverflow.com/a/71376469/1910286
 fun Modifier.brush(brush: Brush) = this
@@ -15,3 +23,33 @@ fun Modifier.brush(brush: Brush) = this
             drawRect(brush, blendMode = BlendMode.SrcAtop)
         }
     }
+
+/**
+ * When the user presses enter run the action.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+fun Modifier.onEnter(onEnter: () -> Unit): Modifier =
+    this.onPreviewKeyEvent {
+        if (it.key == Key.Enter && it.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
+            onEnter()
+            true
+        } else {
+            false
+        }
+    }
+
+/**
+ * When the user presses tab move the focus to the next field.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+fun Modifier.onTabMoveFocus(): Modifier = composed {
+    val focusManager = LocalFocusManager.current
+    this.onPreviewKeyEvent {
+        if (it.key == Key.Tab && it.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
+            focusManager.moveFocus(FocusDirection.Down)
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/modules/services/images/src/main/res/drawable/ic_bookmark.xml
+++ b/modules/services/images/src/main/res/drawable/ic_bookmark.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M5,6C5,4.895 5.895,4 7,4H17C18.105,4 19,4.895 19,6V18.364C19,20.204 16.724,21.068 15.503,19.69L12,15.737L8.497,19.69C7.276,21.068 5,20.204 5,18.364V6ZM17,6H7V18.364L10.503,14.41C11.299,13.512 12.701,13.512 13.497,14.41L17,18.364V6Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+</vector>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -9,6 +9,12 @@
     <string name="empty" translatable="false" />
 
     <string name="account">Account</string>
+    <string name="add_bookmark">Add bookmark</string>
+    <string name="add_bookmark_title">Add Bookmark</string>
+    <string name="bookmark_added">Bookmark \"%s\" added</string>
+    <string name="change_title">Change title</string>
+    <string name="add_bookmark_title_hint">Add an optional title to identify this bookmark</string>
+    <string name="save_bookmark">Save bookmark</string>
     <string name="add_to_up_next">Add to Up Next</string>
     <string name="add_to_up_next_question">Add to up next?</string>
     <string name="archive">Archive</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -54,6 +54,9 @@ abstract class BookmarkDao {
     @Query("UPDATE bookmarks SET deleted = :deleted, deleted_modified = :deletedModified, sync_status = :syncStatus WHERE uuid = :uuid")
     abstract suspend fun updateDeleted(uuid: String, deleted: Boolean, deletedModified: Long, syncStatus: SyncStatus)
 
+    @Query("UPDATE bookmarks SET title = :title, title_modified = :titleModified, sync_status = :syncStatus WHERE uuid = :bookmarkUuid")
+    abstract suspend fun updateTitle(bookmarkUuid: String, title: String, titleModified: Long, syncStatus: SyncStatus)
+
     @Query("SELECT * FROM bookmarks WHERE sync_status = :syncStatus")
     abstract fun findNotSynced(syncStatus: SyncStatus = SyncStatus.NOT_SYNCED): List<Bookmark>
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -42,6 +42,9 @@ abstract class EpisodeDao {
     abstract fun findByUuid(uuid: String): PodcastEpisode?
 
     @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")
+    abstract suspend fun findByUuidSuspend(uuid: String): PodcastEpisode?
+
+    @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")
     abstract fun findByUuidRx(uuid: String): Maybe<PodcastEpisode>
 
     @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
@@ -7,7 +7,9 @@ import kotlinx.coroutines.flow.Flow
 
 interface BookmarkManager {
     suspend fun add(episode: BaseEpisode, timeSecs: Int, title: String): Bookmark
+    suspend fun updateTitle(bookmarkUuid: String, title: String)
     suspend fun findBookmark(bookmarkUuid: String): Bookmark?
+    suspend fun findByEpisodeTime(episode: BaseEpisode, timeSecs: Int): Bookmark?
     suspend fun findEpisodeBookmarksFlow(
         episode: BaseEpisode,
         sortType: BookmarksSortType,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -26,7 +26,7 @@ class BookmarkManagerImpl @Inject constructor(
      */
     override suspend fun add(episode: BaseEpisode, timeSecs: Int, title: String): Bookmark {
         // Prevent adding more than one bookmark at the same place
-        val existingBookmark = bookmarkDao.findByEpisodeTime(podcastUuid = episode.podcastOrSubstituteUuid, episodeUuid = episode.uuid, timeSecs = timeSecs)
+        val existingBookmark = findByEpisodeTime(episode = episode, timeSecs = timeSecs)
         if (existingBookmark != null) {
             return existingBookmark
         }
@@ -47,11 +47,27 @@ class BookmarkManagerImpl @Inject constructor(
         return bookmark
     }
 
+    override suspend fun updateTitle(bookmarkUuid: String, title: String) {
+        bookmarkDao.updateTitle(
+            bookmarkUuid = bookmarkUuid,
+            title = title,
+            titleModified = System.currentTimeMillis(),
+            syncStatus = SyncStatus.NOT_SYNCED
+        )
+    }
+
     /**
      * Find the bookmark by its UUID.
      */
     override suspend fun findBookmark(bookmarkUuid: String): Bookmark? {
         return bookmarkDao.findByUuid(bookmarkUuid)
+    }
+
+    /**
+     * Find the bookmark by episode and time
+     */
+    override suspend fun findByEpisodeTime(episode: BaseEpisode, timeSecs: Int): Bookmark? {
+        return bookmarkDao.findByEpisodeTime(podcastUuid = episode.podcastOrSubstituteUuid, episodeUuid = episode.uuid, timeSecs = timeSecs)
     }
 
     /**

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -25,6 +25,7 @@ interface EpisodeManager {
 
     /** Find methods  */
     fun findByUuid(uuid: String): PodcastEpisode?
+    suspend fun findByUuidSuspend(uuid: String): PodcastEpisode?
     fun findByUuidRx(uuid: String): Maybe<PodcastEpisode>
     fun observeByUuid(uuid: String): Flow<PodcastEpisode>
     fun observeEpisodeByUuidRx(uuid: String): Flowable<BaseEpisode>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -81,7 +81,7 @@ class EpisodeManagerImpl @Inject constructor(
     private val userEpisodeDao = appDatabase.userEpisodeDao()
 
     override suspend fun findEpisodeByUuid(uuid: String): BaseEpisode? {
-        val episode = findByUuid(uuid)
+        val episode = findByUuidSuspend(uuid)
         if (episode != null) {
             return episode
         }
@@ -91,6 +91,10 @@ class EpisodeManagerImpl @Inject constructor(
 
     override fun findByUuid(uuid: String): PodcastEpisode? {
         return episodeDao.findByUuid(uuid)
+    }
+
+    override suspend fun findByUuidSuspend(uuid: String): PodcastEpisode? {
+        return episodeDao.findByUuidSuspend(uuid)
     }
 
     override fun findByUuidRx(uuid: String): Maybe<PodcastEpisode> {

--- a/modules/services/views/src/main/res/layout/activity_blank_fragment.xml
+++ b/modules/services/views/src/main/res/layout/activity_blank_fragment.xml
@@ -1,0 +1,5 @@
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />


### PR DESCRIPTION
## Description

You can now add bookmarks from the full screen player.

It uses another activity so I could add `android:windowSoftInputMode="adjustResize"` and have the "Save bookmark" button just above the keyboard. I'm not really happy with the amount of code to setup the activity but it might be worth it to be able to add a bookmark quickly. 

## Testing Instructions
1. Play an episode
2. Tap on the mini player to open the full screen player
3. Tap on the shelf three dots icon
4. Tap Add bookmark
5. ✅ Verify the "Add bookmark" page is shown
6. Tap "Save bookmark"
7. ✅ Verify a Snackbar is shown
8. Tap the "View" action in the Snackbar
9. ✅ Verify it takes you to the bookmarks tab and the new bookmark is present
10. Tap the "Now Playing" 
11. Tap on the shelf three dots icon
12. Tap the edit pencil
13. Use the drag handles to move the "Add bookmark" item up to the "Shortcut on player"
14. Tap the back button
15. ✅ Verify the "Add bookmark" icon is on the shelf
16. Tap the icon
17. ✅ Verify it opens the add bookmark page

## Screenshots or Screencast 
<img  width="300" src="https://github.com/Automattic/pocket-casts-android/assets/308331/c593d6d7-9ed1-41a5-ae60-b5341d67ba8a" />
<img  width="300" src="https://github.com/Automattic/pocket-casts-android/assets/308331/41c1552a-5901-4966-ab07-7940cea0084c" />
<img  width="300" src="https://github.com/Automattic/pocket-casts-android/assets/308331/af742050-b764-456f-bfeb-63ffbf5efe44" />
<img  width="300" src="https://github.com/Automattic/pocket-casts-android/assets/308331/471f38d9-9e8b-473a-a30f-8ef4aa7da710" />

https://github.com/Automattic/pocket-casts-android/assets/308331/1786c8dd-42d5-4642-b6aa-3c383cac2ed0
