### PR TITLE
Add share action to swipe menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 -----
 *   New Feature:
     *   Added 3 episodes on the Filter AutoDownload
-        ([#1169])(https://github.com/Automattic/pocket-casts-android/pull/1169)
+        ([#1169](https://github.com/Automattic/pocket-casts-android/pull/1169))
     *   Added capability to deselect all/below and above on the multiselect feature
         ([#1172](https://github.com/Automattic/pocket-casts-android/pull/1172))
-    *   Added share option to episode swipe menu
-        ([#1190](https://github.com/Automattic/pocket-casts-android/pull/1190))
+    *   Added share option to episode swipe and multiselect menus
+        ([#1190](https://github.com/Automattic/pocket-casts-android/pull/1190)),
+        ([#1191](https://github.com/Automattic/pocket-casts-android/pull/1191))
 
 7.43
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
         ([#1169])(https://github.com/Automattic/pocket-casts-android/pull/1169)
     *   Added capability to deselect all/below and above on the multiselect feature
         ([#1172](https://github.com/Automattic/pocket-casts-android/pull/1172))
+    *   Added share option to episode swipe menu
+        ([#1190](https://github.com/Automattic/pocket-casts-android/pull/1190))
 
 7.43
 -----

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -383,7 +383,18 @@ class FilterEpisodeListFragment : BaseFragment() {
         binding.btnChevron.setOnClickListener(clickListener)
         toolbar.setOnClickListener(clickListener)
 
-        val itemTouchHelper = EpisodeItemTouchHelper(this::episodeSwipedRightItem1, this::episodeSwipedRightItem2, viewModel::episodeSwiped)
+        val itemTouchHelper = EpisodeItemTouchHelper(
+            onLeftItem1 = this::episodeSwipeLeftItem1,
+            onLeftItem2 = this::episodeSwipeLeftItem2,
+            onRightItem1 = viewModel::episodeSwipeRightItem1,
+            onRightItem2 = { baseEpisode, _ ->
+                viewModel.episodeSwipeRightItem2(
+                    baseEpisode = baseEpisode,
+                    context = context ?: return@EpisodeItemTouchHelper,
+                    fragmentManager = parentFragmentManager,
+                )
+            },
+        )
         itemTouchHelper.attachToRecyclerView(recyclerView)
 
         val multiSelectToolbar = binding.multiSelectToolbar
@@ -563,7 +574,7 @@ class FilterEpisodeListFragment : BaseFragment() {
             .show(childFragmentManager, "confirm")
     }
 
-    private fun episodeSwipedRightItem1(episode: BaseEpisode, index: Int) {
+    private fun episodeSwipeLeftItem1(episode: BaseEpisode, index: Int) {
         when (settings.getUpNextSwipeAction()) {
             Settings.UpNextAction.PLAY_NEXT -> viewModel.episodeSwipeUpNext(episode)
             Settings.UpNextAction.PLAY_LAST -> viewModel.episodeSwipeUpLast(episode)
@@ -571,7 +582,7 @@ class FilterEpisodeListFragment : BaseFragment() {
         adapter.notifyItemChanged(index)
     }
 
-    private fun episodeSwipedRightItem2(episode: BaseEpisode, index: Int) {
+    private fun episodeSwipeLeftItem2(episode: BaseEpisode, index: Int) {
         when (settings.getUpNextSwipeAction()) {
             Settings.UpNextAction.PLAY_NEXT -> viewModel.episodeSwipeUpLast(episode)
             Settings.UpNextAction.PLAY_LAST -> viewModel.episodeSwipeUpNext(episode)

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -95,7 +95,28 @@ class FilterEpisodeListFragment : BaseFragment() {
 
     private lateinit var imageLoader: PodcastImageLoader
 
-    private lateinit var adapter: EpisodeListAdapter
+    private val adapter: EpisodeListAdapter by lazy {
+        EpisodeListAdapter(
+            downloadManager = downloadManager,
+            playbackManager = playbackManager,
+            upNextQueue = upNextQueue,
+            settings = settings,
+            onRowClick = this::onRowClick,
+            playButtonListener = playButtonListener,
+            imageLoader = imageLoader,
+            multiSelectHelper = multiSelectHelper,
+            fragmentManager = childFragmentManager,
+            swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
+                swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
+                onItemUpdated = this::lazyNotifyAdapterChanged,
+                defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
+                context = requireContext(),
+                fragmentManager = parentFragmentManager,
+                swipeSource = EpisodeItemTouchHelper.SwipeSource.FILTERS,
+            )
+        )
+    }
+
     private var showingFilterOptionsBeforeMultiSelect: Boolean = false
     private var multiSelectLoaded: Boolean = false
     private var listSavedState: Parcelable? = null
@@ -117,25 +138,6 @@ class FilterEpisodeListFragment : BaseFragment() {
         }.smallPlaceholder()
 
         playButtonListener.source = SourceView.FILTERS
-        adapter = EpisodeListAdapter(
-            downloadManager = downloadManager,
-            playbackManager = playbackManager,
-            upNextQueue = upNextQueue,
-            settings = settings,
-            onRowClick = this::onRowClick,
-            playButtonListener = playButtonListener,
-            imageLoader = imageLoader,
-            multiSelectHelper = multiSelectHelper,
-            fragmentManager = childFragmentManager,
-            swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
-                swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
-                onItemUpdated = this::lazyNotifyAdapterChanged,
-                defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
-                context = context,
-                fragmentManager = parentFragmentManager,
-                swipeSource = EpisodeItemTouchHelper.SwipeSource.FILTERS,
-            )
-        )
     }
 
     // Cannot call notify.notifyItemChanged directly because the compiler gets confused

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -130,9 +130,6 @@ class FilterEpisodeListFragment : BaseFragment() {
             swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                 swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
                 onItemUpdated = this::lazyNotifyAdapterChanged,
-                onDeleteOrArchiveClick = { baseEpisode, _ ->
-                    viewModel.updateArchive(baseEpisode)
-                },
                 defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
                 context = context,
                 fragmentManager = parentFragmentManager,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -50,6 +50,7 @@ import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.Chrome
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
+import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutViewModel
 import au.com.shiftyjelly.pocketcasts.views.helper.ToolbarColors
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectHelper
@@ -81,6 +82,7 @@ class FilterEpisodeListFragment : BaseFragment() {
     }
 
     private val viewModel by viewModels<FilterEpisodeListViewModel>()
+    private val swipeButtonLayoutViewModel: SwipeButtonLayoutViewModel by viewModels()
 
     @Inject lateinit var downloadManager: DownloadManager
     @Inject lateinit var playbackManager: PlaybackManager
@@ -126,20 +128,17 @@ class FilterEpisodeListFragment : BaseFragment() {
             multiSelectHelper = multiSelectHelper,
             fragmentManager = childFragmentManager,
             swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
+                swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
                 onQueueUpNextTopClick = this::episodeSwipeLeftItem1,
                 onQueueUpNextBottomClick = this::episodeSwipeLeftItem2,
                 onDeleteOrArchiveClick = { baseEpisode, _ ->
                     viewModel.updateArchive(baseEpisode)
                 },
-                onShareClick = { baseEpisode, _ ->
-                    viewModel.share(
-                        baseEpisode = baseEpisode,
-                        context = context,
-                        fragmentManager = parentFragmentManager,
-                    )
-                },
                 playbackManager = playbackManager,
                 defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
+                context = context,
+                fragmentManager = parentFragmentManager,
+                swipeSource = EpisodeItemTouchHelper.SwipeSource.FILTERS,
             )
         )
     }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -129,18 +129,25 @@ class FilterEpisodeListFragment : BaseFragment() {
             fragmentManager = childFragmentManager,
             swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                 swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
-                onQueueUpNextTopClick = this::episodeSwipeLeftItem1,
-                onQueueUpNextBottomClick = this::episodeSwipeLeftItem2,
+                onItemUpdated = this::lazyNotifyAdapterChanged,
                 onDeleteOrArchiveClick = { baseEpisode, _ ->
                     viewModel.updateArchive(baseEpisode)
                 },
-                playbackManager = playbackManager,
                 defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
                 context = context,
                 fragmentManager = parentFragmentManager,
                 swipeSource = EpisodeItemTouchHelper.SwipeSource.FILTERS,
             )
         )
+    }
+
+    // Cannot call notify.notifyItemChanged directly because the compiler gets confused
+    // when the adapter's constructor includes references to the adapter
+    private fun lazyNotifyAdapterChanged(
+        @Suppress("UNUSED_PARAMETER") episode: BaseEpisode,
+        index: Int,
+    ) {
+        adapter.notifyItemChanged(index)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -587,22 +594,6 @@ class FilterEpisodeListFragment : BaseFragment() {
                 activity?.onBackPressed()
             }
             .show(childFragmentManager, "confirm")
-    }
-
-    private fun episodeSwipeLeftItem1(episode: BaseEpisode, index: Int) {
-        when (settings.getUpNextSwipeAction()) {
-            Settings.UpNextAction.PLAY_NEXT -> viewModel.episodeSwipeUpNext(episode)
-            Settings.UpNextAction.PLAY_LAST -> viewModel.episodeSwipeUpLast(episode)
-        }
-        adapter.notifyItemChanged(index)
-    }
-
-    private fun episodeSwipeLeftItem2(episode: BaseEpisode, index: Int) {
-        when (settings.getUpNextSwipeAction()) {
-            Settings.UpNextAction.PLAY_NEXT -> viewModel.episodeSwipeUpLast(episode)
-            Settings.UpNextAction.PLAY_LAST -> viewModel.episodeSwipeUpNext(episode)
-        }
-        adapter.notifyItemChanged(index)
     }
 
     private fun downloadAll() {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -1,12 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.filters
 
-import android.content.Context
-import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
-import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
@@ -22,9 +19,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistProperty
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistUpdateSource
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserPlaylistUpdate
-import au.com.shiftyjelly.pocketcasts.views.dialog.ShareDialog
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeAction
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeSource
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -49,7 +44,6 @@ class FilterEpisodeListViewModel @Inject constructor(
     val episodeManager: EpisodeManager,
     val playbackManager: PlaybackManager,
     val downloadManager: DownloadManager,
-    val podcastManager: PodcastManager,
     val settings: Settings,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val episodeAnalytics: EpisodeAnalytics,
@@ -121,29 +115,6 @@ class FilterEpisodeListViewModel @Inject constructor(
                 trackSwipeAction(SwipeAction.UNARCHIVE)
                 episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_UNARCHIVED, SourceView.FILTERS, episode.uuid)
             }
-        }
-    }
-
-    fun share(
-        baseEpisode: BaseEpisode,
-        context: Context,
-        fragmentManager: FragmentManager,
-    ) {
-        viewModelScope.launch(Dispatchers.Default) {
-
-            trackSwipeAction(SwipeAction.SHARE)
-
-            val episode = baseEpisode as? PodcastEpisode ?: return@launch
-            val podcast = podcastManager.findPodcastByUuid(episode.podcastUuid) ?: return@launch
-
-            ShareDialog(
-                episode = episode,
-                podcast = podcast,
-                fragmentManager = fragmentManager,
-                context = context,
-                shouldShowPodcast = false,
-                analyticsTracker = analyticsTracker,
-            ).show(sourceView = SourceView.SWIPE_ACTION)
         }
     }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -108,8 +108,7 @@ class FilterEpisodeListViewModel @Inject constructor(
         }
     }
 
-    @Suppress("UNUSED_PARAMETER")
-    fun episodeSwipeRightItem1(episode: BaseEpisode, index: Int) {
+    fun updateArchive(episode: BaseEpisode) {
         if (episode !is PodcastEpisode) return
 
         launch {
@@ -125,22 +124,26 @@ class FilterEpisodeListViewModel @Inject constructor(
         }
     }
 
-    fun episodeSwipeRightItem2(
+    fun share(
         baseEpisode: BaseEpisode,
         context: Context,
         fragmentManager: FragmentManager,
     ) {
         viewModelScope.launch(Dispatchers.Default) {
+
+            trackSwipeAction(SwipeAction.SHARE)
+
             val episode = baseEpisode as? PodcastEpisode ?: return@launch
             val podcast = podcastManager.findPodcastByUuid(episode.podcastUuid) ?: return@launch
+
             ShareDialog(
-                podcast = podcast,
                 episode = episode,
+                podcast = podcast,
                 fragmentManager = fragmentManager,
                 context = context,
                 shouldShowPodcast = false,
                 analyticsTracker = analyticsTracker,
-            ).show()
+            ).show(sourceView = SourceView.SWIPE_ACTION)
         }
     }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -158,30 +158,6 @@ class FilterEpisodeListViewModel @Inject constructor(
         }
     }
 
-    fun episodeSwipeUpNext(episode: BaseEpisode) {
-        launch {
-            if (playbackManager.upNextQueue.contains(episode.uuid)) {
-                playbackManager.removeEpisode(episodeToRemove = episode, source = SourceView.FILTERS)
-                trackSwipeAction(SwipeAction.UP_NEXT_REMOVE)
-            } else {
-                playbackManager.playNext(episode = episode, source = SourceView.FILTERS)
-                trackSwipeAction(SwipeAction.UP_NEXT_ADD_TOP)
-            }
-        }
-    }
-
-    fun episodeSwipeUpLast(episode: BaseEpisode) {
-        launch {
-            if (playbackManager.upNextQueue.contains(episode.uuid)) {
-                playbackManager.removeEpisode(episodeToRemove = episode, source = SourceView.FILTERS)
-                trackSwipeAction(SwipeAction.UP_NEXT_REMOVE)
-            } else {
-                playbackManager.playLast(episode = episode, source = SourceView.FILTERS)
-                trackSwipeAction(SwipeAction.UP_NEXT_ADD_BOTTOM)
-            }
-        }
-    }
-
     fun downloadAll() {
         val episodes = (episodesList.value ?: emptyList())
         val trimmedList = episodes.subList(0, min(MAX_DOWNLOAD_ALL, episodes.count()))

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -30,6 +30,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -44,7 +45,8 @@ class UpNextAdapter(
     val fragmentManager: FragmentManager,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val upNextSource: UpNextSource,
-    private val settings: Settings
+    private val settings: Settings,
+    private val swipeButtonLayoutFactory: SwipeButtonLayoutFactory,
 ) : ListAdapter<Any, RecyclerView.ViewHolder>(UPNEXT_ADAPTER_DIFF) {
     private val dateFormatter = RelativeDateFormatter(context)
 
@@ -63,7 +65,14 @@ class UpNextAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
         return when (viewType) {
-            R.layout.adapter_up_next -> UpNextEpisodeViewHolder(DataBindingUtil.inflate(inflater, R.layout.adapter_up_next, parent, false), listener, dateFormatter, imageLoader, episodeManager)
+            R.layout.adapter_up_next -> UpNextEpisodeViewHolder(
+                binding = DataBindingUtil.inflate(inflater, R.layout.adapter_up_next, parent, false),
+                listener = listener,
+                dateFormatter = dateFormatter,
+                imageLoader = imageLoader,
+                episodeManager = episodeManager,
+                swipeButtonLayoutFactory = swipeButtonLayoutFactory,
+            )
             R.layout.adapter_up_next_footer -> HeaderViewHolder(DataBindingUtil.inflate(inflater, R.layout.adapter_up_next_footer, parent, false))
             R.layout.adapter_up_next_playing -> PlayingViewHolder(DataBindingUtil.inflate(inflater, R.layout.adapter_up_next_playing, parent, false))
             else -> throw IllegalStateException("Unknown view type in up next")

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
@@ -32,6 +32,8 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.views.extensions.setRippleBackground
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.RowSwipeable
+import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayout
+import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.rxkotlin.subscribeBy
@@ -45,12 +47,15 @@ class UpNextEpisodeViewHolder(
     val listener: UpNextListener?,
     val dateFormatter: RelativeDateFormatter,
     val imageLoader: PodcastImageLoader,
-    val episodeManager: EpisodeManager
+    val episodeManager: EpisodeManager,
+    private val swipeButtonLayoutFactory: SwipeButtonLayoutFactory,
 ) : RecyclerView.ViewHolder(binding.root),
     UpNextTouchCallback.ItemTouchHelperViewHolder,
     RowSwipeable {
     private val elevatedBackground = ContextCompat.getColor(binding.root.context, R.color.elevatedBackground)
     private val selectedBackground = ContextCompat.getColor(binding.root.context, R.color.selectedBackground)
+
+    override lateinit var swipeButtonLayout: SwipeButtonLayout
 
     var disposable: Disposable? = null
         set(value) {
@@ -95,6 +100,13 @@ class UpNextEpisodeViewHolder(
                 binding.executePendingBindings()
             }
             .subscribeBy(onError = { Timber.e(it) })
+
+        swipeButtonLayout = swipeButtonLayoutFactory.forEpisode(
+            episode = episode,
+            isShowingUpNextQueue = true,
+            ignoreUserSwipePreference = true,
+        )
+
         binding.episode = episode
         binding.date.text = episode.getSummaryText(dateFormatter = dateFormatter, tintColor = tintColor, showDuration = false, context = binding.date.context)
         binding.executePendingBindings()

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
@@ -138,14 +138,16 @@ class UpNextEpisodeViewHolder(
         get() = binding.itemContainer
     override val episode: BaseEpisode?
         get() = binding.episode
-    override val swipeLeftIcon: ImageView
-        get() = binding.archiveIcon
     override val positionAdapter: Int
         get() = bindingAdapterPosition
     override val leftRightIcon1: ImageView
         get() = binding.leftRightIcon1
     override val leftRightIcon2: ImageView
         get() = binding.leftRightIcon2
+    override val rightLeftIcon1: ImageView
+        get() = binding.rightLeftIcon1
+    override val rightLeftIcon2: ImageView
+        get() = binding.rightLeftIcon2
     override val isMultiSelecting: Boolean
         get() = binding.checkbox.isVisible
     override val rightToLeftSwipeLayout: ViewGroup
@@ -159,6 +161,6 @@ class UpNextEpisodeViewHolder(
             EpisodeItemTouchHelper.IconWithBackground(R.drawable.ic_upnext_movetotop, binding.itemContainer.context.getThemeColor(UR.attr.support_04)),
             EpisodeItemTouchHelper.IconWithBackground(R.drawable.ic_upnext_movetobottom, binding.itemContainer.context.getThemeColor(UR.attr.support_03))
         )
-    override val rightIconDrawableRes: List<EpisodeItemTouchHelper.IconWithBackground>
+    override val rightIconDrawablesRes: List<EpisodeItemTouchHelper.IconWithBackground>
         get() = listOf(EpisodeItemTouchHelper.IconWithBackground(R.drawable.ic_upnext_remove, binding.itemContainer.context.getThemeColor(UR.attr.support_05)))
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
@@ -101,11 +101,7 @@ class UpNextEpisodeViewHolder(
             }
             .subscribeBy(onError = { Timber.e(it) })
 
-        swipeButtonLayout = swipeButtonLayoutFactory.forEpisode(
-            episode = episode,
-            isShowingUpNextQueue = true,
-            ignoreUserSwipePreference = true,
-        )
+        swipeButtonLayout = swipeButtonLayoutFactory.forEpisode(episode)
 
         binding.episode = episode
         binding.date.text = episode.getSummaryText(dateFormatter = dateFormatter, tintColor = tintColor, showDuration = false, context = binding.date.context)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -144,10 +144,8 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
             settings = settings,
             swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                 swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
-                onQueueUpNextTopClick = this::moveToTop,
-                onQueueUpNextBottomClick = this::moveToBottom,
+                onItemUpdated = this::clearViewAtPosition,
                 onDeleteOrArchiveClick = { _, index -> removeFromUpNext(index) },
-                playbackManager = playbackManager,
                 defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
                 context = context,
                 fragmentManager = parentFragmentManager,
@@ -159,6 +157,16 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
         if (!isEmbedded) {
             updateStatusAndNavColors()
             FirebaseAnalyticsTracker.openedUpNext()
+        }
+    }
+
+    private fun clearViewAtPosition(
+        @Suppress("UNUSED_PARAMETER") episode: BaseEpisode,
+        position: Int,
+    ) {
+        val recyclerView = realBinding?.recyclerView ?: return
+        recyclerView.findViewHolderForAdapterPosition(position)?.let {
+            episodeItemTouchHelper?.clearView(recyclerView, it)
         }
     }
 
@@ -297,24 +305,6 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
         if (multiSelectHelper.isMultiSelecting) {
             multiSelectHelper.isMultiSelecting = false
         }
-    }
-
-    fun moveToTop(episode: BaseEpisode, position: Int) {
-        val recyclerView = realBinding?.recyclerView ?: return
-        recyclerView.findViewHolderForAdapterPosition(position)?.let {
-            episodeItemTouchHelper?.clearView(recyclerView, it)
-        }
-        playbackManager.playEpisodesNext(episodes = listOf(episode), source = SourceView.UP_NEXT)
-        trackSwipeAction(SwipeAction.UP_NEXT_MOVE_TOP)
-    }
-
-    fun moveToBottom(episode: BaseEpisode, position: Int) {
-        val recyclerView = realBinding?.recyclerView ?: return
-        recyclerView.findViewHolderForAdapterPosition(position)?.let {
-            episodeItemTouchHelper?.clearView(recyclerView, it)
-        }
-        playbackManager.playEpisodesLast(episodes = listOf(episode), source = SourceView.UP_NEXT)
-        trackSwipeAction(SwipeAction.UP_NEXT_MOVE_BOTTOM)
     }
 
     fun removeFromUpNext(position: Int) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextTouchCallback.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextTouchCallback.kt
@@ -13,7 +13,6 @@ class UpNextTouchCallback(
 
     interface ItemTouchHelperAdapter {
         fun onUpNextEpisodeMove(fromPosition: Int, toPosition: Int)
-        fun onUpNextEpisodeRemove(position: Int)
         fun onUpNextEpisodeStartDrag(viewHolder: RecyclerView.ViewHolder)
         fun onUpNextItemTouchHelperFinished(position: Int)
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -472,10 +472,6 @@ class PlayerViewModel @Inject constructor(
         disposables.clear()
     }
 
-    fun removeFromUpNext(episode: BaseEpisode) {
-        playbackManager.removeEpisode(episodeToRemove = episode, source = source)
-    }
-
     private fun calcCustomTimeText(): String {
         return context.resources.getString(LR.string.minutes_plural, sleepCustomTimeMins)
     }

--- a/modules/features/player/src/main/res/layout/adapter_up_next.xml
+++ b/modules/features/player/src/main/res/layout/adapter_up_next.xml
@@ -29,7 +29,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:padding="23dp"
-                    android:layout_gravity="center_vertical|right"
+                    android:layout_gravity="center_vertical|left"
                     app:tint="@android:color/white"/>
             </FrameLayout>
             <FrameLayout
@@ -43,7 +43,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:padding="23dp"
-                    android:layout_gravity="center_vertical|right"
+                    android:layout_gravity="center_vertical|left"
                     android:src="@drawable/ic_archive"
                     app:tint="@android:color/white"/>
             </FrameLayout>

--- a/modules/features/player/src/main/res/layout/adapter_up_next.xml
+++ b/modules/features/player/src/main/res/layout/adapter_up_next.xml
@@ -44,7 +44,6 @@
                     android:layout_height="wrap_content"
                     android:padding="23dp"
                     android:layout_gravity="center_vertical|left"
-                    android:src="@drawable/ic_archive"
                     app:tint="@android:color/white"/>
             </FrameLayout>
         </FrameLayout>

--- a/modules/features/player/src/main/res/layout/adapter_up_next.xml
+++ b/modules/features/player/src/main/res/layout/adapter_up_next.xml
@@ -18,14 +18,35 @@
             android:background="?attr/support_06"
             android:importantForAccessibility="noHideDescendants">
 
-            <ImageView
-                android:id="@+id/archiveIcon"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:padding="23dp"
-                android:src="@drawable/ic_archive"
-                app:tint="@android:color/white" />
+
+            <FrameLayout
+                android:id="@id/rightLeftItem2"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="?attr/support_03">
+                <ImageView
+                    android:id="@+id/rightLeftIcon2"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="23dp"
+                    android:layout_gravity="center_vertical|right"
+                    app:tint="@android:color/white"/>
+            </FrameLayout>
+            <FrameLayout
+                android:id="@id/rightLeftItem1"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="?attr/support_04"
+                android:importantForAccessibility="noHideDescendants">
+                <ImageView
+                    android:id="@+id/rightLeftIcon1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="23dp"
+                    android:layout_gravity="center_vertical|right"
+                    android:src="@drawable/ic_archive"
+                    app:tint="@android:color/white"/>
+            </FrameLayout>
         </FrameLayout>
 
         <FrameLayout

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -129,9 +129,6 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                 swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
                 onItemUpdated = ::lazyNotifyItemChanged,
-                onDeleteOrArchiveClick = { baseEpisode, _ ->
-                    viewModel.swipeToUpdateArchive(baseEpisode)
-                },
                 defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
                 context = requireContext(),
                 fragmentManager = parentFragmentManager,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -44,6 +44,7 @@ import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
+import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutViewModel
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectHelper
 import dagger.hilt.android.AndroidEntryPoint
@@ -90,6 +91,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     private val viewModel: ProfileEpisodeListViewModel by viewModels()
+    private val swipeButtonLayoutViewModel: SwipeButtonLayoutViewModel by viewModels()
     private lateinit var imageLoader: PodcastImageLoader
     private var binding: FragmentProfileEpisodeListBinding? = null
 
@@ -125,20 +127,21 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             multiSelectHelper = multiSelectHelper,
             fragmentManager = childFragmentManager,
             swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
+                swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
                 onQueueUpNextTopClick = this::episodeSwipeLeftItem1,
                 onQueueUpNextBottomClick = this::episodeSwipeLeftItem2,
                 onDeleteOrArchiveClick = { baseEpisode, _ ->
                     viewModel.swipeToUpdateArchive(baseEpisode)
                 },
-                onShareClick = { episode, _ ->
-                    viewModel.swipeToShare(
-                        baseEpisode = episode,
-                        context = context ?: return@SwipeButtonLayoutFactory,
-                        fragmentManager = parentFragmentManager,
-                    )
-                },
                 playbackManager = playbackManager,
                 defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
+                context = requireContext(),
+                fragmentManager = parentFragmentManager,
+                swipeSource = when (mode) {
+                    Mode.Downloaded -> EpisodeItemTouchHelper.SwipeSource.DOWNLOADS
+                    Mode.History -> EpisodeItemTouchHelper.SwipeSource.LISTENING_HISTORY
+                    Mode.Starred -> EpisodeItemTouchHelper.SwipeSource.STARRED
+                },
             )
         )
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -128,12 +128,10 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             fragmentManager = childFragmentManager,
             swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                 swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
-                onQueueUpNextTopClick = this::episodeSwipeLeftItem1,
-                onQueueUpNextBottomClick = this::episodeSwipeLeftItem2,
+                onItemUpdated = ::lazyNotifyItemChanged,
                 onDeleteOrArchiveClick = { baseEpisode, _ ->
                     viewModel.swipeToUpdateArchive(baseEpisode)
                 },
-                playbackManager = playbackManager,
                 defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
                 context = requireContext(),
                 fragmentManager = parentFragmentManager,
@@ -144,6 +142,15 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
                 },
             )
         )
+    }
+
+    // Cannot inline this because the compiler gets confused
+    // when the adapter's constructor includes references to the adapter
+    private fun lazyNotifyItemChanged(
+        @Suppress("UNUSED_PARAMETER") episode: BaseEpisode,
+        index: Int,
+    ) {
+        adapter.notifyItemChanged(index)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -375,22 +382,6 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
 
     private fun showFragment(fragment: Fragment) {
         (activity as? FragmentHostListener)?.addFragment(fragment)
-    }
-
-    private fun episodeSwipeLeftItem1(episode: BaseEpisode, index: Int) {
-        when (settings.getUpNextSwipeAction()) {
-            Settings.UpNextAction.PLAY_NEXT -> viewModel.episodeSwipeUpNext(episode)
-            Settings.UpNextAction.PLAY_LAST -> viewModel.episodeSwipeUpLast(episode)
-        }
-        adapter.notifyItemChanged(index)
-    }
-
-    private fun episodeSwipeLeftItem2(episode: BaseEpisode, index: Int) {
-        when (settings.getUpNextSwipeAction()) {
-            Settings.UpNextAction.PLAY_NEXT -> viewModel.episodeSwipeUpLast(episode)
-            Settings.UpNextAction.PLAY_LAST -> viewModel.episodeSwipeUpNext(episode)
-        }
-        adapter.notifyItemChanged(index)
     }
 
     override fun onBackPressed(): Boolean {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -164,7 +164,18 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             it.layoutManager = LinearLayoutManager(it.context, RecyclerView.VERTICAL, false)
             it.adapter = adapter
             (it.itemAnimator as SimpleItemAnimator).changeDuration = 0
-            val itemTouchHelper = EpisodeItemTouchHelper(this::episodeSwipedRightItem1, this::episodeSwipedRightItem2, viewModel::episodeSwiped)
+            val itemTouchHelper = EpisodeItemTouchHelper(
+                onLeftItem1 = this::episodeSwipeLeftItem1,
+                onLeftItem2 = this::episodeSwipeLeftItem2,
+                onRightItem1 = { episode, _ -> viewModel.episodeSwipeRightItem1(episode) },
+                onRightItem2 = { episode, _ ->
+                    viewModel.episodeSwipeRightItem2(
+                        baseEpisode = episode,
+                        context = context ?: return@EpisodeItemTouchHelper,
+                        fragmentManager = parentFragmentManager,
+                    )
+                }
+            )
             itemTouchHelper.attachToRecyclerView(it)
         }
 
@@ -345,7 +356,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
         (activity as? FragmentHostListener)?.addFragment(fragment)
     }
 
-    private fun episodeSwipedRightItem1(episode: BaseEpisode, index: Int) {
+    private fun episodeSwipeLeftItem1(episode: BaseEpisode, index: Int) {
         when (settings.getUpNextSwipeAction()) {
             Settings.UpNextAction.PLAY_NEXT -> viewModel.episodeSwipeUpNext(episode)
             Settings.UpNextAction.PLAY_LAST -> viewModel.episodeSwipeUpLast(episode)
@@ -353,7 +364,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
         adapter.notifyItemChanged(index)
     }
 
-    private fun episodeSwipedRightItem2(episode: BaseEpisode, index: Int) {
+    private fun episodeSwipeLeftItem2(episode: BaseEpisode, index: Int) {
         when (settings.getUpNextSwipeAction()) {
             Settings.UpNextAction.PLAY_NEXT -> viewModel.episodeSwipeUpLast(episode)
             Settings.UpNextAction.PLAY_LAST -> viewModel.episodeSwipeUpNext(episode)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
@@ -5,13 +5,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
-import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
-import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
-import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeAction
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -24,16 +20,13 @@ class ProfileEpisodeListViewModel @Inject constructor(
     val episodeManager: EpisodeManager,
     val playbackManager: PlaybackManager,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-    private val episodeAnalytics: EpisodeAnalytics,
 ) : ViewModel(), CoroutineScope {
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
 
     lateinit var episodeList: LiveData<List<PodcastEpisode>>
-    private lateinit var mode: ProfileEpisodeListFragment.Mode
 
     fun setup(mode: ProfileEpisodeListFragment.Mode) {
-        this.mode = mode
         val episodeListFlowable = when (mode) {
             is ProfileEpisodeListFragment.Mode.Downloaded -> episodeManager.observeDownloadEpisodes()
             is ProfileEpisodeListFragment.Mode.Starred -> episodeManager.observeStarredEpisodes()
@@ -43,49 +36,10 @@ class ProfileEpisodeListViewModel @Inject constructor(
         episodeList = episodeListFlowable.toLiveData()
     }
 
-    fun swipeToUpdateArchive(episode: BaseEpisode) {
-        if (episode !is PodcastEpisode) return
-
-        launch {
-            val source = getAnalyticsSource()
-            if (!episode.isArchived) {
-                episodeManager.archive(episode, playbackManager)
-                trackSwipeAction(SwipeAction.ARCHIVE)
-                episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_ARCHIVED, source, episode.uuid)
-            } else {
-                episodeManager.unarchive(episode)
-                trackSwipeAction(SwipeAction.UNARCHIVE)
-                episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_UNARCHIVED, source, episode.uuid)
-            }
-        }
-    }
-
     fun clearAllEpisodeHistory() {
         launch {
             analyticsTracker.track(AnalyticsEvent.LISTENING_HISTORY_CLEARED)
             episodeManager.clearAllEpisodeHistory()
         }
-    }
-
-    private fun trackSwipeAction(swipeAction: SwipeAction) {
-        val source = getAnalyticsSource()
-        analyticsTracker.track(
-            AnalyticsEvent.EPISODE_SWIPE_ACTION_PERFORMED,
-            mapOf(
-                ACTION_KEY to swipeAction.analyticsValue,
-                SOURCE_KEY to source.analyticsValue
-            )
-        )
-    }
-
-    private fun getAnalyticsSource() = when (mode) {
-        ProfileEpisodeListFragment.Mode.Downloaded -> SourceView.DOWNLOADS
-        ProfileEpisodeListFragment.Mode.History -> SourceView.LISTENING_HISTORY
-        ProfileEpisodeListFragment.Mode.Starred -> SourceView.STARRED
-    }
-
-    companion object {
-        private const val ACTION_KEY = "action"
-        private const val SOURCE_KEY = "source"
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
@@ -1,8 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view
 
+import android.content.Context
+import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
+import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
@@ -11,6 +14,8 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.views.dialog.ShareDialog
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeAction
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
@@ -24,6 +29,7 @@ import kotlin.math.max
 class ProfileEpisodeListViewModel @Inject constructor(
     val episodeManager: EpisodeManager,
     val playbackManager: PlaybackManager,
+    val podcastManager: PodcastManager,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val episodeAnalytics: EpisodeAnalytics,
 ) : ViewModel(), CoroutineScope {
@@ -44,8 +50,7 @@ class ProfileEpisodeListViewModel @Inject constructor(
         episodeList = episodeListFlowable.toLiveData()
     }
 
-    @Suppress("UNUSED_PARAMETER")
-    fun episodeSwiped(episode: BaseEpisode, index: Int) {
+    fun episodeSwipeRightItem1(episode: BaseEpisode) {
         if (episode !is PodcastEpisode) return
 
         launch {
@@ -59,6 +64,25 @@ class ProfileEpisodeListViewModel @Inject constructor(
                 trackSwipeAction(SwipeAction.UNARCHIVE)
                 episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_UNARCHIVED, source, episode.uuid)
             }
+        }
+    }
+
+    fun episodeSwipeRightItem2(
+        baseEpisode: BaseEpisode,
+        context: Context,
+        fragmentManager: FragmentManager,
+    ) {
+        viewModelScope.launch(Dispatchers.Default) {
+            val episode = baseEpisode as? PodcastEpisode ?: return@launch
+            val podcast = podcastManager.findPodcastByUuid(episode.podcastUuid) ?: return@launch
+            ShareDialog(
+                podcast = podcast,
+                episode = episode,
+                fragmentManager = fragmentManager,
+                context = context,
+                shouldShowPodcast = false,
+                analyticsTracker = analyticsTracker,
+            ).show()
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
@@ -1,11 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view
 
-import android.content.Context
-import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
-import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
@@ -14,8 +11,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.views.dialog.ShareDialog
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeAction
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
@@ -29,7 +24,6 @@ import kotlin.math.max
 class ProfileEpisodeListViewModel @Inject constructor(
     val episodeManager: EpisodeManager,
     val playbackManager: PlaybackManager,
-    val podcastManager: PodcastManager,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val episodeAnalytics: EpisodeAnalytics,
 ) : ViewModel(), CoroutineScope {
@@ -64,28 +58,6 @@ class ProfileEpisodeListViewModel @Inject constructor(
                 trackSwipeAction(SwipeAction.UNARCHIVE)
                 episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_UNARCHIVED, source, episode.uuid)
             }
-        }
-    }
-
-    fun swipeToShare(
-        baseEpisode: BaseEpisode,
-        context: Context,
-        fragmentManager: FragmentManager,
-    ) {
-        viewModelScope.launch(Dispatchers.Default) {
-
-            trackSwipeAction(SwipeAction.SHARE)
-
-            val episode = baseEpisode as? PodcastEpisode ?: return@launch
-            val podcast = podcastManager.findPodcastByUuid(episode.podcastUuid) ?: return@launch
-            ShareDialog(
-                podcast = podcast,
-                episode = episode,
-                fragmentManager = fragmentManager,
-                context = context,
-                shouldShowPodcast = false,
-                analyticsTracker = analyticsTracker,
-            ).show(sourceView = SourceView.SWIPE_ACTION)
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
-import kotlin.math.max
 
 @HiltViewModel
 class ProfileEpisodeListViewModel @Inject constructor(
@@ -59,36 +58,6 @@ class ProfileEpisodeListViewModel @Inject constructor(
                 episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_UNARCHIVED, source, episode.uuid)
             }
         }
-    }
-
-    fun episodeSwipeUpNext(episode: BaseEpisode) {
-        launch {
-            if (playbackManager.upNextQueue.contains(episode.uuid)) {
-                playbackManager.removeEpisode(episodeToRemove = episode, source = getAnalyticsSource())
-                trackSwipeAction(SwipeAction.UP_NEXT_REMOVE)
-            } else {
-                playbackManager.playNext(episode = episode, source = getAnalyticsSource())
-                trackSwipeAction(SwipeAction.UP_NEXT_ADD_TOP)
-            }
-        }
-    }
-
-    fun episodeSwipeUpLast(episode: BaseEpisode) {
-        launch {
-            if (playbackManager.upNextQueue.contains(episode.uuid)) {
-                playbackManager.removeEpisode(episodeToRemove = episode, source = getAnalyticsSource())
-                trackSwipeAction(SwipeAction.UP_NEXT_REMOVE)
-            } else {
-                playbackManager.playLast(episode = episode, source = getAnalyticsSource())
-                trackSwipeAction(SwipeAction.UP_NEXT_ADD_BOTTOM)
-            }
-        }
-    }
-
-    fun onArchiveFromHereCount(episode: PodcastEpisode): Int {
-        val episodes = episodeList.value ?: return 0
-        val index = max(episodes.indexOf(episode), 0) // -1 on not found
-        return episodes.count() - index
     }
 
     fun clearAllEpisodeHistory() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
@@ -50,7 +50,7 @@ class ProfileEpisodeListViewModel @Inject constructor(
         episodeList = episodeListFlowable.toLiveData()
     }
 
-    fun episodeSwipeRightItem1(episode: BaseEpisode) {
+    fun swipeToUpdateArchive(episode: BaseEpisode) {
         if (episode !is PodcastEpisode) return
 
         launch {
@@ -67,12 +67,15 @@ class ProfileEpisodeListViewModel @Inject constructor(
         }
     }
 
-    fun episodeSwipeRightItem2(
+    fun swipeToShare(
         baseEpisode: BaseEpisode,
         context: Context,
         fragmentManager: FragmentManager,
     ) {
         viewModelScope.launch(Dispatchers.Default) {
+
+            trackSwipeAction(SwipeAction.SHARE)
+
             val episode = baseEpisode as? PodcastEpisode ?: return@launch
             val podcast = podcastManager.findPodcastByUuid(episode.podcastUuid) ?: return@launch
             ShareDialog(
@@ -82,7 +85,7 @@ class ProfileEpisodeListViewModel @Inject constructor(
                 context = context,
                 shouldShowPodcast = false,
                 analyticsTracker = analyticsTracker,
-            ).show()
+            ).show(sourceView = SourceView.SWIPE_ACTION)
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.Observer
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
@@ -599,6 +600,6 @@ class EpisodeFragment : BaseDialogFragment() {
             context,
             shouldShowPodcast = false,
             analyticsTracker = analyticsTracker,
-        ).show()
+        ).show(sourceView = SourceView.EPISODE_DETAILS)
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
@@ -21,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImageLoader
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
+import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import io.reactivex.disposables.CompositeDisposable
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
@@ -47,6 +48,7 @@ class EpisodeListAdapter(
     val multiSelectHelper: MultiSelectEpisodesHelper,
     val fragmentManager: FragmentManager,
     val fromListUuid: String? = null,
+    val swipeButtonLayoutFactory: SwipeButtonLayoutFactory,
 ) : ListAdapter<BaseEpisode, RecyclerView.ViewHolder>(PLAYBACK_DIFF) {
 
     val disposables = CompositeDisposable()
@@ -64,8 +66,24 @@ class EpisodeListAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
         return when (viewType) {
-            R.layout.adapter_episode -> EpisodeViewHolder(AdapterEpisodeBinding.inflate(inflater, parent, false), EpisodeViewHolder.ViewMode.Artwork, downloadManager.progressUpdateRelay, playbackManager.playbackStateRelay, upNextQueue.changesObservable, imageLoader)
-            R.layout.adapter_user_episode -> UserEpisodeViewHolder(AdapterUserEpisodeBinding.inflate(inflater, parent, false), UserEpisodeViewHolder.ViewMode.Artwork, downloadManager.progressUpdateRelay, playbackManager.playbackStateRelay, upNextQueue.changesObservable, imageLoader)
+            R.layout.adapter_episode -> EpisodeViewHolder(
+                binding = AdapterEpisodeBinding.inflate(inflater, parent, false),
+                viewMode = EpisodeViewHolder.ViewMode.Artwork,
+                downloadProgressUpdates = downloadManager.progressUpdateRelay,
+                playbackStateUpdates = playbackManager.playbackStateRelay,
+                upNextChangesObservable = upNextQueue.changesObservable,
+                imageLoader = imageLoader,
+                swipeButtonLayoutFactory = swipeButtonLayoutFactory
+            )
+            R.layout.adapter_user_episode -> UserEpisodeViewHolder(
+                binding = AdapterUserEpisodeBinding.inflate(inflater, parent, false),
+                viewMode = UserEpisodeViewHolder.ViewMode.Artwork,
+                downloadProgressUpdates = downloadManager.progressUpdateRelay,
+                playbackStateUpdates = playbackManager.playbackStateRelay,
+                upNextChangesObservable = upNextQueue.changesObservable,
+                imageLoader = imageLoader,
+                swipeButtonLayoutFactory = swipeButtonLayoutFactory
+            )
             else -> throw IllegalStateException("Unknown playable type")
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
@@ -35,6 +35,8 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.ColorUtils
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.RowSwipeable
+import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayout
+import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -49,13 +51,14 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
-class EpisodeViewHolder(
+class EpisodeViewHolder constructor(
     val binding: AdapterEpisodeBinding,
     val viewMode: ViewMode,
     val downloadProgressUpdates: Observable<DownloadProgressUpdate>,
     val playbackStateUpdates: Observable<PlaybackState>,
     val upNextChangesObservable: Observable<UpNextQueue.State>,
-    val imageLoader: PodcastImageLoader? = null
+    val imageLoader: PodcastImageLoader? = null,
+    private val swipeButtonLayoutFactory: SwipeButtonLayoutFactory,
 ) : RecyclerView.ViewHolder(binding.root), RowSwipeable {
     override val episodeRow: ViewGroup
         get() = binding.episodeRow
@@ -80,6 +83,8 @@ class EpisodeViewHolder(
         object NoArtwork : ViewMode()
         object Artwork : ViewMode()
     }
+
+    override lateinit var swipeButtonLayout: SwipeButtonLayout
 
     val dateFormatter = RelativeDateFormatter(context)
     val context: Context
@@ -140,6 +145,8 @@ class EpisodeViewHolder(
             updateTimeLeft(textView = binding.lblStatus, episode = episode)
         }
         binding.episode = episode
+        swipeButtonLayout = swipeButtonLayoutFactory.forEpisode(episode)
+
         binding.playButton.listener = playButtonListener
 
         val captionColor = context.getThemeColor(UR.attr.primary_text_02)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
@@ -59,12 +59,14 @@ class EpisodeViewHolder(
 ) : RecyclerView.ViewHolder(binding.root), RowSwipeable {
     override val episodeRow: ViewGroup
         get() = binding.episodeRow
-    override val swipeLeftIcon: ImageView
-        get() = binding.archiveIcon
     override val leftRightIcon1: ImageView
         get() = binding.leftRightIcon1
     override val leftRightIcon2: ImageView
         get() = binding.leftRightIcon2
+    override val rightLeftIcon1: ImageView
+        get() = binding.rightLeftIcon1
+    override val rightLeftIcon2: ImageView
+        get() = binding.rightLeftIcon2
     override val episode: BaseEpisode?
         get() = binding.episode
     override val positionAdapter: Int
@@ -105,12 +107,24 @@ class EpisodeViewHolder(
                 )
             }
         }
-    override val rightIconDrawableRes: List<EpisodeItemTouchHelper.IconWithBackground>
+    override val rightIconDrawablesRes: List<EpisodeItemTouchHelper.IconWithBackground>
         get() {
-            return if (episode?.isArchived == true)
-                listOf(EpisodeItemTouchHelper.IconWithBackground(IR.drawable.ic_unarchive, binding.episodeRow.context.getThemeColor(UR.attr.support_06)))
-            else
-                listOf(EpisodeItemTouchHelper.IconWithBackground(IR.drawable.ic_archive, binding.episodeRow.context.getThemeColor(UR.attr.support_06)))
+
+            val archiveItem = EpisodeItemTouchHelper.IconWithBackground(
+                iconRes = if (episode?.isArchived == true) {
+                    IR.drawable.ic_unarchive
+                } else {
+                    IR.drawable.ic_archive
+                },
+                backgroundColor = binding.episodeRow.context.getThemeColor(UR.attr.support_06)
+            )
+
+            val shareItem = EpisodeItemTouchHelper.IconWithBackground(
+                iconRes = IR.drawable.ic_share,
+                backgroundColor = binding.episodeRow.context.getThemeColor(UR.attr.support_01)
+            )
+
+            return listOf(archiveItem, shareItem)
         }
 
     fun setup(episode: PodcastEpisode, fromListUuid: String?, tintColor: Int, playButtonListener: PlayButton.OnClickListener, streamByDefault: Boolean, upNextAction: Settings.UpNextAction, multiSelectEnabled: Boolean = false, isSelected: Boolean = false, disposables: CompositeDisposable) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -53,6 +53,7 @@ import au.com.shiftyjelly.pocketcasts.views.extensions.hide
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.extensions.toggleVisibility
 import au.com.shiftyjelly.pocketcasts.views.helper.AnimatorUtil
+import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import io.reactivex.disposables.CompositeDisposable
 import timber.log.Timber
@@ -111,6 +112,7 @@ class PodcastAdapter(
     private val multiSelectHelper: MultiSelectEpisodesHelper,
     private val onArtworkLongClicked: (successCallback: () -> Unit) -> Unit,
     private val ratingsViewModel: PodcastRatingsViewModel,
+    private val swipeButtonLayoutFactory: SwipeButtonLayoutFactory,
 ) : LargeListAdapter<Any, RecyclerView.ViewHolder>(1500, differ) {
 
     data class EpisodeLimitRow(val episodeLimit: Int)
@@ -150,7 +152,14 @@ class PodcastAdapter(
             VIEW_TYPE_EPISODE_LIMIT_ROW -> EpisodeLimitViewHolder(inflater.inflate(R.layout.adapter_episode_limit, parent, false))
             VIEW_TYPE_NO_EPISODE -> NoEpisodesViewHolder(inflater.inflate(R.layout.adapter_no_episodes, parent, false))
             VIEW_TYPE_DIVIDER -> DividerViewHolder(inflater.inflate(R.layout.adapter_divider_row, parent, false))
-            else -> EpisodeViewHolder(AdapterEpisodeBinding.inflate(inflater, parent, false), EpisodeViewHolder.ViewMode.NoArtwork, downloadManager.progressUpdateRelay, playbackManager.playbackStateRelay, upNextQueue.changesObservable)
+            else -> EpisodeViewHolder(
+                binding = AdapterEpisodeBinding.inflate(inflater, parent, false),
+                viewMode = EpisodeViewHolder.ViewMode.NoArtwork,
+                downloadProgressUpdates = downloadManager.progressUpdateRelay,
+                playbackStateUpdates = playbackManager.playbackStateRelay,
+                upNextChangesObservable = upNextQueue.changesObservable,
+                swipeButtonLayoutFactory = swipeButtonLayoutFactory,
+            )
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -63,6 +63,7 @@ import au.com.shiftyjelly.pocketcasts.views.extensions.tintIcons
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
+import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutViewModel
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectHelper
@@ -120,6 +121,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
 
     private val viewModel: PodcastViewModel by viewModels()
     private val ratingsViewModel: PodcastRatingsViewModel by viewModels()
+    private val swipeButtonLayoutViewModel: SwipeButtonLayoutViewModel by viewModels()
     private var adapter: PodcastAdapter? = null
     private var binding: FragmentPodcastBinding? = null
 
@@ -500,15 +502,6 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
         viewModel.episodeSwipeArchive(episode)
     }
 
-    fun episodeSwipeRightItem2(baseEpisode: BaseEpisode) {
-        viewModel.episodeSwipeShare(
-            episode = baseEpisode as? PodcastEpisode ?: return,
-            podcast = binding?.podcast ?: return,
-            context = context ?: return,
-            fragmentManager = parentFragmentManager
-        )
-    }
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         val binding = FragmentPodcastBinding.inflate(inflater, container, false)
         this.binding = binding
@@ -569,12 +562,15 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                 onArtworkLongClicked = onArtworkLongClicked,
                 ratingsViewModel = ratingsViewModel,
                 swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
+                    swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
                     onQueueUpNextTopClick = ::episodeSwipeLeftItem1,
                     onQueueUpNextBottomClick = ::episodeSwipeLeftItem2,
                     onDeleteOrArchiveClick = ::episodeSwipeRightItem1,
-                    onShareClick = { episode, _ -> episodeSwipeRightItem2(episode) },
                     playbackManager = playbackManager,
                     defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
+                    context = context,
+                    fragmentManager = parentFragmentManager,
+                    swipeSource = EpisodeItemTouchHelper.SwipeSource.PODCAST_DETAILS,
                 )
             )
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -57,6 +57,7 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
+import au.com.shiftyjelly.pocketcasts.views.dialog.ShareDialog
 import au.com.shiftyjelly.pocketcasts.views.extensions.setupChromeCastButton
 import au.com.shiftyjelly.pocketcasts.views.extensions.smoothScrollToTop
 import au.com.shiftyjelly.pocketcasts.views.extensions.tintIcons
@@ -489,7 +490,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
         binding?.episodesRecyclerView?.layoutManager?.onRestoreInstanceState(listState)
     }
 
-    fun episodeSwipeArchive(episode: BaseEpisode, index: Int) {
+    fun episodeSwipeRightItem1(episode: BaseEpisode, index: Int) {
         val binding = binding ?: return
 
         binding.episodesRecyclerView.findViewHolderForAdapterPosition(index)?.let {
@@ -497,6 +498,19 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
         }
 
         viewModel.episodeSwipeArchive(episode, index)
+    }
+
+    fun episodeSwipeRightItem2(baseEpisode: BaseEpisode) {
+        val episode = baseEpisode as? PodcastEpisode ?: return
+        val podcast = binding?.podcast ?: return
+        ShareDialog(
+            podcast = podcast,
+            episode = episode,
+            fragmentManager = parentFragmentManager,
+            context = context,
+            shouldShowPodcast = false,
+            analyticsTracker = analyticsTracker,
+        ).show()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -510,9 +524,10 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
         updateStatusBar()
 
         itemTouchHelper = EpisodeItemTouchHelper(
-            onLeftItem1 = this::episodeSwipedRightItem1,
-            onLeftItem2 = this::episodeSwipedRightItem2,
-            onRightItem1 = this::episodeSwipeArchive
+            onLeftItem1 = this::episodeSwipeLeftItem1,
+            onLeftItem2 = this::episodeSwipeLeftItem2,
+            onRightItem1 = this::episodeSwipeRightItem1,
+            onRightItem2 = { episode, _ -> episodeSwipeRightItem2(episode) },
         )
 
         loadData()
@@ -769,7 +784,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
         binding = null
     }
 
-    private fun episodeSwipedRightItem1(episode: BaseEpisode, index: Int) {
+    private fun episodeSwipeLeftItem1(episode: BaseEpisode, index: Int) {
         when (settings.getUpNextSwipeAction()) {
             Settings.UpNextAction.PLAY_NEXT -> viewModel.episodeSwipeUpNext(episode)
             Settings.UpNextAction.PLAY_LAST -> viewModel.episodeSwipeUpLast(episode)
@@ -784,7 +799,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
         adapter?.notifyItemChanged(index)
     }
 
-    private fun episodeSwipedRightItem2(episode: BaseEpisode, index: Int) {
+    private fun episodeSwipeLeftItem2(episode: BaseEpisode, index: Int) {
         when (settings.getUpNextSwipeAction()) {
             Settings.UpNextAction.PLAY_NEXT -> viewModel.episodeSwipeUpLast(episode)
             Settings.UpNextAction.PLAY_LAST -> viewModel.episodeSwipeUpNext(episode)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -509,7 +509,11 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
         statusBarColor = StatusBarColor.Custom(headerColor, true)
         updateStatusBar()
 
-        itemTouchHelper = EpisodeItemTouchHelper(this::episodeSwipedRightItem1, this::episodeSwipedRightItem2, this::episodeSwipeArchive)
+        itemTouchHelper = EpisodeItemTouchHelper(
+            onLeftItem1 = this::episodeSwipedRightItem1,
+            onLeftItem2 = this::episodeSwipedRightItem2,
+            onRightItem1 = this::episodeSwipeArchive
+        )
 
         loadData()
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -563,10 +563,8 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                 ratingsViewModel = ratingsViewModel,
                 swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                     swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
-                    onQueueUpNextTopClick = ::episodeSwipeLeftItem1,
-                    onQueueUpNextBottomClick = ::episodeSwipeLeftItem2,
+                    onItemUpdated = ::notifyItemChanged,
                     onDeleteOrArchiveClick = ::episodeSwipeRightItem1,
-                    playbackManager = playbackManager,
                     defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
                     context = context,
                     fragmentManager = parentFragmentManager,
@@ -674,6 +672,19 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
         return binding.root
     }
 
+    private fun notifyItemChanged(
+        @Suppress("UNUSED_PARAMETER") episode: BaseEpisode,
+        index: Int,
+    ) {
+        binding?.episodesRecyclerView?.let { recyclerView ->
+            recyclerView.findViewHolderForAdapterPosition(index)?.let {
+                itemTouchHelper.clearView(recyclerView, it)
+            }
+        }
+
+        adapter?.notifyItemChanged(index)
+    }
+
     private fun loadData() {
         LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Loading podcast page for $podcastUuid")
         viewModel.loadPodcast(podcastUuid, resources)
@@ -777,35 +788,6 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
         binding?.episodesRecyclerView?.removeOnScrollListener(onScrollListener)
         binding?.episodesRecyclerView?.adapter = null
         binding = null
-    }
-
-    private fun episodeSwipeLeftItem1(episode: BaseEpisode, index: Int) {
-        when (settings.getUpNextSwipeAction()) {
-            Settings.UpNextAction.PLAY_NEXT -> viewModel.episodeSwipeUpNext(episode)
-            Settings.UpNextAction.PLAY_LAST -> viewModel.episodeSwipeUpLast(episode)
-        }
-
-        binding?.episodesRecyclerView?.let { recyclerView ->
-            recyclerView.findViewHolderForAdapterPosition(index)?.let {
-                itemTouchHelper.clearView(recyclerView, it)
-            }
-        }
-
-        adapter?.notifyItemChanged(index)
-    }
-
-    private fun episodeSwipeLeftItem2(episode: BaseEpisode, index: Int) {
-        when (settings.getUpNextSwipeAction()) {
-            Settings.UpNextAction.PLAY_NEXT -> viewModel.episodeSwipeUpLast(episode)
-            Settings.UpNextAction.PLAY_LAST -> viewModel.episodeSwipeUpNext(episode)
-        }
-
-        binding?.episodesRecyclerView?.let { recyclerView ->
-            recyclerView.findViewHolderForAdapterPosition(index)?.let {
-                itemTouchHelper.clearView(recyclerView, it)
-            }
-        }
-        adapter?.notifyItemChanged(index)
     }
 
     private fun archiveAllPlayed() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -492,16 +492,6 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
         binding?.episodesRecyclerView?.layoutManager?.onRestoreInstanceState(listState)
     }
 
-    fun episodeSwipeRightItem1(episode: BaseEpisode, index: Int) {
-        val binding = binding ?: return
-
-        binding.episodesRecyclerView.findViewHolderForAdapterPosition(index)?.let {
-            itemTouchHelper.clearView(binding.episodesRecyclerView, it)
-        }
-
-        viewModel.episodeSwipeArchive(episode)
-    }
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         val binding = FragmentPodcastBinding.inflate(inflater, container, false)
         this.binding = binding
@@ -564,7 +554,6 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                 swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                     swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
                     onItemUpdated = ::notifyItemChanged,
-                    onDeleteOrArchiveClick = ::episodeSwipeRightItem1,
                     defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
                     context = context,
                     fragmentManager = parentFragmentManager,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/UserEpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/UserEpisodeViewHolder.kt
@@ -56,12 +56,14 @@ class UserEpisodeViewHolder(
 ) : RecyclerView.ViewHolder(binding.root), RowSwipeable {
     override val episodeRow: ViewGroup
         get() = binding.episodeRow
-    override val swipeLeftIcon: ImageView
-        get() = binding.archiveIcon
     override val leftRightIcon1: ImageView
         get() = binding.leftRightIcon1
     override val leftRightIcon2: ImageView
         get() = binding.leftRightIcon2
+    override val rightLeftIcon1: ImageView
+        get() = binding.rightLeftIcon1
+    override val rightLeftIcon2: ImageView
+        get() = binding.rightLeftIcon2
     override val episode: BaseEpisode?
         get() = binding.episode
     override val positionAdapter: Int
@@ -105,13 +107,8 @@ class UserEpisodeViewHolder(
                 )
             }
         }
-    override val rightIconDrawableRes: List<EpisodeItemTouchHelper.IconWithBackground>
-        get() {
-            return if (episode?.isArchived == true)
-                listOf(EpisodeItemTouchHelper.IconWithBackground(VR.drawable.ic_delete, binding.episodeRow.context.getThemeColor(UR.attr.support_05)))
-            else
-                listOf(EpisodeItemTouchHelper.IconWithBackground(VR.drawable.ic_delete, binding.episodeRow.context.getThemeColor(UR.attr.support_05)))
-        }
+    override val rightIconDrawablesRes: List<EpisodeItemTouchHelper.IconWithBackground> =
+        listOf(EpisodeItemTouchHelper.IconWithBackground(VR.drawable.ic_delete, binding.episodeRow.context.getThemeColor(UR.attr.support_05)))
 
     fun setup(episode: UserEpisode, tintColor: Int, playButtonListener: PlayButton.OnClickListener, streamByDefault: Boolean, upNextAction: Settings.UpNextAction, multiSelectEnabled: Boolean = false, isSelected: Boolean = false) {
         this.upNextAction = upNextAction

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/UserEpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/UserEpisodeViewHolder.kt
@@ -108,7 +108,12 @@ class UserEpisodeViewHolder(
             }
         }
     override val rightIconDrawablesRes: List<EpisodeItemTouchHelper.IconWithBackground> =
-        listOf(EpisodeItemTouchHelper.IconWithBackground(VR.drawable.ic_delete, binding.episodeRow.context.getThemeColor(UR.attr.support_05)))
+        listOf(
+            EpisodeItemTouchHelper.IconWithBackground(
+                iconRes = VR.drawable.ic_delete,
+                backgroundColor = binding.episodeRow.context.getThemeColor(UR.attr.support_05)
+            )
+        )
 
     fun setup(episode: UserEpisode, tintColor: Int, playButtonListener: PlayButton.OnClickListener, streamByDefault: Boolean, upNextAction: Settings.UpNextAction, multiSelectEnabled: Boolean = false, isSelected: Boolean = false) {
         this.upNextAction = upNextAction

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/UserEpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/UserEpisodeViewHolder.kt
@@ -33,6 +33,8 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.ColorUtils
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.RowSwipeable
+import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayout
+import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
 import com.jakewharton.rxrelay2.BehaviorRelay
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Observable
@@ -52,7 +54,8 @@ class UserEpisodeViewHolder(
     val downloadProgressUpdates: Observable<DownloadProgressUpdate>,
     val playbackStateUpdates: Observable<PlaybackState>,
     val upNextChangesObservable: Observable<UpNextQueue.State>,
-    val imageLoader: PodcastImageLoader? = null
+    val imageLoader: PodcastImageLoader? = null,
+    private val swipeButtonLayoutFactory: SwipeButtonLayoutFactory,
 ) : RecyclerView.ViewHolder(binding.root), RowSwipeable {
     override val episodeRow: ViewGroup
         get() = binding.episodeRow
@@ -77,6 +80,8 @@ class UserEpisodeViewHolder(
         object NoArtwork : ViewMode()
         object Artwork : ViewMode()
     }
+
+    override lateinit var swipeButtonLayout: SwipeButtonLayout
 
     val dateFormatter = RelativeDateFormatter(context)
     val context: Context
@@ -118,6 +123,8 @@ class UserEpisodeViewHolder(
     fun setup(episode: UserEpisode, tintColor: Int, playButtonListener: PlayButton.OnClickListener, streamByDefault: Boolean, upNextAction: Settings.UpNextAction, multiSelectEnabled: Boolean = false, isSelected: Boolean = false) {
         this.upNextAction = upNextAction
         this.isMultiSelecting = multiSelectEnabled
+
+        swipeButtonLayout = swipeButtonLayoutFactory.forEpisode(episode)
 
         val playButtonType = PlayButton.calculateButtonType(episode, streamByDefault)
         binding.playButtonType = playButtonType

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -302,30 +302,6 @@ class PodcastViewModel
         }
     }
 
-    fun episodeSwipeUpNext(episode: BaseEpisode) {
-        launch {
-            if (playbackManager.upNextQueue.contains(episode.uuid)) {
-                playbackManager.removeEpisode(episodeToRemove = episode, source = SourceView.PODCAST_SCREEN)
-                trackSwipeAction(SwipeAction.UP_NEXT_REMOVE)
-            } else {
-                playbackManager.playNext(episode = episode, source = SourceView.PODCAST_SCREEN)
-                trackSwipeAction(SwipeAction.UP_NEXT_ADD_TOP)
-            }
-        }
-    }
-
-    fun episodeSwipeUpLast(episode: BaseEpisode) {
-        launch {
-            if (playbackManager.upNextQueue.contains(episode.uuid)) {
-                playbackManager.removeEpisode(episodeToRemove = episode, source = SourceView.PODCAST_SCREEN)
-                trackSwipeAction(SwipeAction.UP_NEXT_REMOVE)
-            } else {
-                playbackManager.playLast(episode = episode, source = SourceView.PODCAST_SCREEN)
-                trackSwipeAction(SwipeAction.UP_NEXT_ADD_BOTTOM)
-            }
-        }
-    }
-
     fun shouldShowArchiveAll(): Boolean {
         val episodes = (episodes.value as? EpisodeState.Loaded)?.episodes ?: return false
         return episodes.find { !it.isArchived } != null

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.podcasts.viewmodel
 import android.content.Context
 import android.content.res.Resources
 import android.widget.Toast
+import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -28,6 +29,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManagerImpl
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import au.com.shiftyjelly.pocketcasts.views.dialog.ShareDialog
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeAction
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeSource
 import com.jakewharton.rxrelay2.BehaviorRelay
@@ -286,8 +288,7 @@ class PodcastViewModel
         }
     }
 
-    @Suppress("UNUSED_PARAMETER")
-    fun episodeSwipeArchive(episode: BaseEpisode, index: Int) {
+    fun episodeSwipeArchive(episode: BaseEpisode) {
         if (episode !is PodcastEpisode) return
 
         launch {
@@ -325,6 +326,25 @@ class PodcastViewModel
                 trackSwipeAction(SwipeAction.UP_NEXT_ADD_BOTTOM)
             }
         }
+    }
+
+    fun episodeSwipeShare(
+        episode: PodcastEpisode,
+        podcast: Podcast,
+        context: Context,
+        fragmentManager: FragmentManager,
+    ) {
+
+        trackSwipeAction(SwipeAction.SHARE)
+
+        ShareDialog(
+            podcast = podcast,
+            episode = episode,
+            fragmentManager = fragmentManager,
+            context = context,
+            shouldShowPodcast = false,
+            analyticsTracker = analyticsTracker,
+        ).show(sourceView = SourceView.SWIPE_ACTION)
     }
 
     fun shouldShowArchiveAll(): Boolean {
@@ -456,7 +476,7 @@ class PodcastViewModel
         fun podcastSubscribeToggled(source: SourceView, uuid: String) =
             mapOf(SOURCE_KEY to source.analyticsValue, UUID_KEY to uuid)
         fun swipePerformed(source: SwipeSource, action: SwipeAction) =
-            mapOf(SOURCE_KEY to source, ACTION_KEY to action.analyticsValue)
+            mapOf(SOURCE_KEY to source.analyticsValue, ACTION_KEY to action.analyticsValue)
     }
 }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.podcasts.viewmodel
 import android.content.Context
 import android.content.res.Resources
 import android.widget.Toast
-import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -29,7 +28,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManagerImpl
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
-import au.com.shiftyjelly.pocketcasts.views.dialog.ShareDialog
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeAction
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeSource
 import com.jakewharton.rxrelay2.BehaviorRelay
@@ -326,25 +324,6 @@ class PodcastViewModel
                 trackSwipeAction(SwipeAction.UP_NEXT_ADD_BOTTOM)
             }
         }
-    }
-
-    fun episodeSwipeShare(
-        episode: PodcastEpisode,
-        podcast: Podcast,
-        context: Context,
-        fragmentManager: FragmentManager,
-    ) {
-
-        trackSwipeAction(SwipeAction.SHARE)
-
-        ShareDialog(
-            podcast = podcast,
-            episode = episode,
-            fragmentManager = fragmentManager,
-            context = context,
-            shouldShowPodcast = false,
-            analyticsTracker = analyticsTracker,
-        ).show(sourceView = SourceView.SWIPE_ACTION)
     }
 
     fun shouldShowArchiveAll(): Boolean {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -11,7 +11,6 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -28,8 +27,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManagerImpl
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
-import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeAction
-import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeSource
 import com.jakewharton.rxrelay2.BehaviorRelay
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.BackpressureStrategy
@@ -71,7 +68,6 @@ class PodcastViewModel
     private val disposables = CompositeDisposable()
     val podcast = MutableLiveData<Podcast>()
     var searchTerm = ""
-    var searchOpen = false
     lateinit var podcastUuid: String
     lateinit var episodes: LiveData<EpisodeState>
     val groupedEpisodes: MutableLiveData<List<List<PodcastEpisode>>> = MutableLiveData()
@@ -286,22 +282,6 @@ class PodcastViewModel
         }
     }
 
-    fun episodeSwipeArchive(episode: BaseEpisode) {
-        if (episode !is PodcastEpisode) return
-
-        launch {
-            if (!episode.isArchived) {
-                episodeManager.archive(episode, playbackManager)
-                trackSwipeAction(SwipeAction.ARCHIVE)
-                trackEpisodeEvent(AnalyticsEvent.EPISODE_ARCHIVED, episode)
-            } else {
-                episodeManager.unarchive(episode)
-                trackSwipeAction(SwipeAction.UNARCHIVE)
-                trackEpisodeEvent(AnalyticsEvent.EPISODE_UNARCHIVED, episode)
-            }
-        }
-    }
-
     fun shouldShowArchiveAll(): Boolean {
         val episodes = (episodes.value as? EpisodeState.Loaded)?.episodes ?: return false
         return episodes.find { !it.isArchived } != null
@@ -367,24 +347,6 @@ class PodcastViewModel
         }
     }
 
-    private fun trackSwipeAction(swipeAction: SwipeAction) {
-        analyticsTracker.track(
-            AnalyticsEvent.EPISODE_SWIPE_ACTION_PERFORMED,
-            AnalyticsProp.swipePerformed(
-                action = swipeAction,
-                source = SwipeSource.PODCAST_DETAILS
-            )
-
-        )
-    }
-    private fun trackEpisodeEvent(event: AnalyticsEvent, episode: PodcastEpisode) {
-        episodeAnalytics.trackEvent(
-            event,
-            source = SourceView.PODCAST_SCREEN,
-            uuid = episode.uuid
-        )
-    }
-
     private fun trackEpisodeBulkEvent(event: AnalyticsEvent, count: Int) {
         episodeAnalytics.trackBulkEvent(
             event,
@@ -419,7 +381,6 @@ class PodcastViewModel
     }
 
     private object AnalyticsProp {
-        private const val ACTION_KEY = "action"
         private const val ENABLED_KEY = "enabled"
         private const val SHOW_ARCHIVED = "show_archived"
         private const val SOURCE_KEY = "source"
@@ -430,8 +391,6 @@ class PodcastViewModel
             mapOf(ENABLED_KEY to show)
         fun podcastSubscribeToggled(source: SourceView, uuid: String) =
             mapOf(SOURCE_KEY to source.analyticsValue, UUID_KEY to uuid)
-        fun swipePerformed(source: SwipeSource, action: SwipeAction) =
-            mapOf(SOURCE_KEY to source.analyticsValue, ACTION_KEY to action.analyticsValue)
     }
 }
 

--- a/modules/features/podcasts/src/main/res/layout/adapter_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_episode.xml
@@ -15,17 +15,38 @@
             android:id="@+id/rightToLeftSwipeLayout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="?attr/support_06"
+            android:background="@color/green_90"
             android:visibility="gone"
             android:importantForAccessibility="noHideDescendants">
-            <ImageView
-                android:id="@+id/archiveIcon"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:padding="23dp"
-                android:src="@drawable/ic_archive"
-                app:tint="@android:color/white"/>
+
+            <FrameLayout
+                android:id="@id/rightLeftItem2"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="?attr/support_03">
+                <ImageView
+                    android:id="@+id/rightLeftIcon2"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="23dp"
+                    android:layout_gravity="center_vertical|left"
+                    app:tint="@android:color/white"/>
+            </FrameLayout>
+            <FrameLayout
+                android:id="@id/rightLeftItem1"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="?attr/support_04"
+                android:importantForAccessibility="noHideDescendants">
+                <ImageView
+                    android:id="@+id/rightLeftIcon1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="23dp"
+                    android:layout_gravity="center_vertical|left"
+                    android:src="@drawable/ic_archive"
+                    app:tint="@android:color/white"/>
+            </FrameLayout>
         </FrameLayout>
 
         <FrameLayout

--- a/modules/features/podcasts/src/main/res/layout/adapter_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_episode.xml
@@ -44,7 +44,6 @@
                     android:layout_height="wrap_content"
                     android:padding="23dp"
                     android:layout_gravity="center_vertical|left"
-                    android:src="@drawable/ic_archive"
                     app:tint="@android:color/white"/>
             </FrameLayout>
         </FrameLayout>

--- a/modules/features/podcasts/src/main/res/layout/adapter_user_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_user_episode.xml
@@ -46,7 +46,6 @@
                     android:layout_height="wrap_content"
                     android:padding="23dp"
                     android:layout_gravity="center_vertical|left"
-                    android:src="@drawable/ic_delete"
                     app:tint="@android:color/white"/>
             </FrameLayout>
         </FrameLayout>

--- a/modules/features/podcasts/src/main/res/layout/adapter_user_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_user_episode.xml
@@ -20,14 +20,35 @@
             android:layout_height="match_parent"
             android:background="?attr/support_05"
             android:importantForAccessibility="noHideDescendants">
-            <ImageView
-                android:id="@+id/archiveIcon"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:padding="23dp"
-                android:src="@drawable/ic_delete"
-                app:tint="@android:color/white"/>
+
+            <FrameLayout
+                android:id="@id/rightLeftItem2"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="?attr/support_03">
+                <ImageView
+                    android:id="@+id/rightLeftIcon2"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="23dp"
+                    android:layout_gravity="center_vertical|left"
+                    app:tint="@android:color/white"/>
+            </FrameLayout>
+            <FrameLayout
+                android:id="@id/rightLeftItem1"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="?attr/support_04"
+                android:importantForAccessibility="noHideDescendants">
+                <ImageView
+                    android:id="@+id/rightLeftIcon1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="23dp"
+                    android:layout_gravity="center_vertical|left"
+                    android:src="@drawable/ic_delete"
+                    app:tint="@android:color/white"/>
+            </FrameLayout>
         </FrameLayout>
 
         <FrameLayout

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -44,6 +44,7 @@ import au.com.shiftyjelly.pocketcasts.views.helper.CloudDeleteHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
+import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutViewModel
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectHelper
 import dagger.hilt.android.AndroidEntryPoint
@@ -67,6 +68,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
     lateinit var itemTouchHelper: EpisodeItemTouchHelper
 
     private val viewModel: CloudFilesViewModel by viewModels()
+    private val swipeButtonLayoutViewModel: SwipeButtonLayoutViewModel by viewModels()
     private var binding: FragmentCloudFilesBinding? = null
 
     val adapter by lazy {
@@ -81,11 +83,15 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             multiSelectHelper = multiSelectHelper,
             fragmentManager = childFragmentManager,
             swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
+                swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
                 onQueueUpNextTopClick = ::episodeSwipedRightItem1,
                 onQueueUpNextBottomClick = ::episodeSwipedRightItem2,
                 onDeleteOrArchiveClick = ::episodeDeleteSwiped,
                 playbackManager = playbackManager,
                 defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
+                context = requireContext(),
+                fragmentManager = parentFragmentManager,
+                swipeSource = EpisodeItemTouchHelper.SwipeSource.FILES,
             )
         )
     }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -84,16 +84,23 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             fragmentManager = childFragmentManager,
             swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                 swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
-                onQueueUpNextTopClick = ::episodeSwipedRightItem1,
-                onQueueUpNextBottomClick = ::episodeSwipedRightItem2,
+                onItemUpdated = ::lazyNotifyItemChanged,
                 onDeleteOrArchiveClick = ::episodeDeleteSwiped,
-                playbackManager = playbackManager,
                 defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
                 context = requireContext(),
                 fragmentManager = parentFragmentManager,
                 swipeSource = EpisodeItemTouchHelper.SwipeSource.FILES,
             )
         )
+    }
+
+    // Cannot call notify.notifyItemChanged directly because the compiler gets confused
+    // when the adapter's constructor includes references to the adapter
+    private fun lazyNotifyItemChanged(
+        @Suppress("UNUSED_PARAMETER") episode: BaseEpisode,
+        index: Int
+    ) {
+        adapter.notifyItemChanged(index)
     }
 
     private val onRowClick = { episode: BaseEpisode ->
@@ -391,22 +398,6 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                 }
             }
         confirmationDialog.show(parentFragmentManager, "delete_confirm")
-    }
-
-    private fun episodeSwipedRightItem1(episode: BaseEpisode, index: Int) {
-        when (settings.getUpNextSwipeAction()) {
-            Settings.UpNextAction.PLAY_NEXT -> viewModel.episodeSwipeUpNext(episode)
-            Settings.UpNextAction.PLAY_LAST -> viewModel.episodeSwipeUpLast(episode)
-        }
-        adapter.notifyItemChanged(index)
-    }
-
-    private fun episodeSwipedRightItem2(episode: BaseEpisode, index: Int) {
-        when (settings.getUpNextSwipeAction()) {
-            Settings.UpNextAction.PLAY_NEXT -> viewModel.episodeSwipeUpLast(episode)
-            Settings.UpNextAction.PLAY_LAST -> viewModel.episodeSwipeUpNext(episode)
-        }
-        adapter.notifyItemChanged(index)
     }
 
     override fun onBackPressed(): Boolean {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -43,6 +43,7 @@ import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.Chrome
 import au.com.shiftyjelly.pocketcasts.views.helper.CloudDeleteHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
+import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectHelper
 import dagger.hilt.android.AndroidEntryPoint
@@ -68,7 +69,26 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
     private val viewModel: CloudFilesViewModel by viewModels()
     private var binding: FragmentCloudFilesBinding? = null
 
-    val adapter by lazy { EpisodeListAdapter(downloadManager, playbackManager, upNextQueue, settings, onRowClick, playButtonListener, imageLoader, multiSelectHelper, childFragmentManager) }
+    val adapter by lazy {
+        EpisodeListAdapter(
+            downloadManager = downloadManager,
+            playbackManager = playbackManager,
+            upNextQueue = upNextQueue,
+            settings = settings,
+            onRowClick = onRowClick,
+            playButtonListener = playButtonListener,
+            imageLoader = imageLoader,
+            multiSelectHelper = multiSelectHelper,
+            fragmentManager = childFragmentManager,
+            swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
+                onQueueUpNextTopClick = ::episodeSwipedRightItem1,
+                onQueueUpNextBottomClick = ::episodeSwipedRightItem2,
+                onDeleteOrArchiveClick = ::episodeDeleteSwiped,
+                playbackManager = playbackManager,
+                defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
+            )
+        )
+    }
 
     private val onRowClick = { episode: BaseEpisode ->
         analyticsTracker.track(AnalyticsEvent.USER_FILE_DETAIL_SHOWN)
@@ -129,7 +149,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             it.layoutManager = LinearLayoutManager(it.context, RecyclerView.VERTICAL, false)
             it.adapter = adapter
             (it.itemAnimator as SimpleItemAnimator).changeDuration = 0
-            itemTouchHelper = EpisodeItemTouchHelper(this::episodeSwipedRightItem1, this::episodeSwipedRightItem2, this::episodeDeleteSwiped)
+            itemTouchHelper = EpisodeItemTouchHelper()
             itemTouchHelper.attachToRecyclerView(it)
         }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
@@ -6,7 +6,6 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.file.CloudFilesManager
@@ -19,10 +18,6 @@ import au.com.shiftyjelly.pocketcasts.views.helper.DeleteState
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeAction
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeSource
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -55,32 +50,6 @@ class CloudFilesViewModel @Inject constructor(
             )
         }
         userEpisodeManager.syncFilesInBackground(playbackManager)
-    }
-
-    @OptIn(DelicateCoroutinesApi::class)
-    fun episodeSwipeUpNext(episode: BaseEpisode) {
-        GlobalScope.launch(Dispatchers.Default) {
-            if (playbackManager.upNextQueue.contains(episode.uuid)) {
-                playbackManager.removeEpisode(episodeToRemove = episode, source = SourceView.FILES)
-                trackSwipeAction(SwipeAction.UP_NEXT_REMOVE)
-            } else {
-                playbackManager.playNext(episode = episode, source = SourceView.FILES)
-                trackSwipeAction(SwipeAction.UP_NEXT_ADD_TOP)
-            }
-        }
-    }
-
-    @OptIn(DelicateCoroutinesApi::class)
-    fun episodeSwipeUpLast(episode: BaseEpisode) {
-        GlobalScope.launch(Dispatchers.Default) {
-            if (playbackManager.upNextQueue.contains(episode.uuid)) {
-                playbackManager.removeEpisode(episodeToRemove = episode, source = SourceView.FILES)
-                trackSwipeAction(SwipeAction.UP_NEXT_REMOVE)
-            } else {
-                playbackManager.playLast(episode = episode, source = SourceView.FILES)
-                trackSwipeAction(SwipeAction.UP_NEXT_ADD_BOTTOM)
-            }
-        }
     }
 
     fun getDeleteStateOnSwipeDelete(episode: UserEpisode): DeleteState {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
@@ -4,19 +4,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
-import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
-import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.file.CloudFilesManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
-import au.com.shiftyjelly.pocketcasts.views.helper.CloudDeleteHelper
-import au.com.shiftyjelly.pocketcasts.views.helper.DeleteState
-import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeAction
-import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeSource
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -24,11 +16,9 @@ import javax.inject.Inject
 class CloudFilesViewModel @Inject constructor(
     private val userEpisodeManager: UserEpisodeManager,
     private val playbackManager: PlaybackManager,
-    private val episodeManager: EpisodeManager,
     private val settings: Settings,
     userManager: UserManager,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-    private val episodeAnalytics: EpisodeAnalytics,
     private val cloudFilesManager: CloudFilesManager,
 ) : ViewModel() {
 
@@ -52,20 +42,6 @@ class CloudFilesViewModel @Inject constructor(
         userEpisodeManager.syncFilesInBackground(playbackManager)
     }
 
-    fun getDeleteStateOnSwipeDelete(episode: UserEpisode): DeleteState {
-        trackSwipeAction(SwipeAction.DELETE)
-        return CloudDeleteHelper.getDeleteState(episode)
-    }
-
-    fun deleteEpisode(episode: UserEpisode, deleteState: DeleteState) {
-        CloudDeleteHelper.deleteEpisode(episode, deleteState, playbackManager, episodeManager, userEpisodeManager)
-        episodeAnalytics.trackEvent(
-            event = if (deleteState == DeleteState.Cloud && !episode.isDownloaded) AnalyticsEvent.EPISODE_DELETED_FROM_CLOUD else AnalyticsEvent.EPISODE_DOWNLOAD_DELETED,
-            source = SourceView.FILES,
-            uuid = episode.uuid,
-        )
-    }
-
     fun changeSort(sortOrder: Settings.CloudSortOrder) {
         settings.setCloudSortOrder(sortOrder)
         cloudFilesManager.sortOrderRelay.accept(sortOrder)
@@ -73,16 +49,6 @@ class CloudFilesViewModel @Inject constructor(
 
     fun getSortOrder(): Settings.CloudSortOrder {
         return cloudFilesManager.sortOrderRelay.value ?: settings.getCloudSortOrder()
-    }
-
-    private fun trackSwipeAction(swipeAction: SwipeAction) {
-        analyticsTracker.track(
-            AnalyticsEvent.EPISODE_SWIPE_ACTION_PERFORMED,
-            mapOf(
-                ACTION_KEY to swipeAction.analyticsValue,
-                SOURCE_KEY to SwipeSource.FILES.analyticsValue
-            )
-        )
     }
 
     companion object {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
@@ -38,8 +38,16 @@ class EpisodeAnalytics @Inject constructor(
         analyticsTracker.track(event, AnalyticsProp.uuidMap(uuid))
     }
 
-    fun trackEvent(event: AnalyticsEvent, source: SourceView, toTop: Boolean) {
-        analyticsTracker.track(event, AnalyticsProp.sourceAndToTopMap(source, toTop))
+    fun trackEvent(
+        event: AnalyticsEvent,
+        source: SourceView,
+        toTop: Boolean,
+        episode: BaseEpisode,
+    ) {
+        analyticsTracker.track(
+            event,
+            AnalyticsProp.sourceAndToTopMap(source, toTop, episode)
+        )
     }
 
     fun trackBulkEvent(event: AnalyticsEvent, source: SourceView, count: Int) {
@@ -72,8 +80,12 @@ class EpisodeAnalytics @Inject constructor(
             mapOf(source to eventSource.analyticsValue, episode_uuid to uuid)
 
         fun uuidMap(uuid: String) = mapOf(episode_uuid to uuid)
-        fun sourceAndToTopMap(eventSource: SourceView, toTop: Boolean) =
-            mapOf(source to eventSource.analyticsValue, to_top to toTop)
+        fun sourceAndToTopMap(eventSource: SourceView, toTop: Boolean, episode: BaseEpisode) =
+            mapOf(
+                source to eventSource.analyticsValue,
+                to_top to toTop,
+                episode_uuid to episode.uuid,
+            )
 
         fun bulkMap(eventSource: SourceView, count: Int) =
             mapOf(source to eventSource.analyticsValue, this.count to count)

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
@@ -30,7 +30,7 @@ enum class SourceView(val analyticsValue: String) {
     ONBOARDING_RECOMMENDATIONS_SEARCH("onboarding_recommendations_search"),
     UNKNOWN("unknown"),
     TASKER("tasker"),
-    SWIPE_ACTION("swipe_action");
+    EPISODE_SWIPE_ACTION("episode_swipe_action");
 
     fun skipTracking() = this in listOf(AUTO_PLAY, AUTO_PAUSE)
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
@@ -30,7 +30,8 @@ enum class SourceView(val analyticsValue: String) {
     ONBOARDING_RECOMMENDATIONS_SEARCH("onboarding_recommendations_search"),
     UNKNOWN("unknown"),
     TASKER("tasker"),
-    EPISODE_SWIPE_ACTION("episode_swipe_action");
+    EPISODE_SWIPE_ACTION("episode_swipe_action"),
+    MULTI_SELECT("multi_select");
 
     fun skipTracking() = this in listOf(AUTO_PLAY, AUTO_PAUSE)
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
@@ -29,7 +29,8 @@ enum class SourceView(val analyticsValue: String) {
     ONBOARDING_RECOMMENDATIONS("onboarding_recommendations"),
     ONBOARDING_RECOMMENDATIONS_SEARCH("onboarding_recommendations_search"),
     UNKNOWN("unknown"),
-    TASKER("tasker");
+    TASKER("tasker"),
+    SWIPE_ACTION("swipe_action");
 
     fun skipTracking() = this in listOf(AUTO_PLAY, AUTO_PAUSE)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -428,6 +428,7 @@ open class PlaybackManager @Inject constructor(
             SourceView.DISCOVER_RANKED_LIST,
             SourceView.FULL_SCREEN_VIDEO,
             SourceView.MINIPLAYER,
+            SourceView.MULTI_SELECT,
             SourceView.ONBOARDING_RECOMMENDATIONS,
             SourceView.ONBOARDING_RECOMMENDATIONS_SEARCH,
             SourceView.PODCAST_LIST,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -435,6 +435,7 @@ open class PlaybackManager @Inject constructor(
             SourceView.PLAYER,
             SourceView.PLAYER_BROADCAST_ACTION,
             SourceView.PLAYER_PLAYBACK_EFFECTS,
+            SourceView.SWIPE_ACTION,
             SourceView.TASKER,
             SourceView.UNKNOWN,
             SourceView.UP_NEXT,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -435,7 +435,7 @@ open class PlaybackManager @Inject constructor(
             SourceView.PLAYER,
             SourceView.PLAYER_BROADCAST_ACTION,
             SourceView.PLAYER_PLAYBACK_EFFECTS,
-            SourceView.SWIPE_ACTION,
+            SourceView.EPISODE_SWIPE_ACTION,
             SourceView.TASKER,
             SourceView.UNKNOWN,
             SourceView.UP_NEXT,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -479,7 +479,7 @@ open class PlaybackManager @Inject constructor(
         val wasEmpty: Boolean = upNextQueue.isEmpty
         upNextQueue.playNext(episode, downloadManager, null)
         if (userInitiated) {
-            episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_ADDED_TO_UP_NEXT, source, true)
+            episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_ADDED_TO_UP_NEXT, source, true, episode)
         }
         if (wasEmpty) {
             loadCurrentEpisode(play = false)
@@ -494,7 +494,7 @@ open class PlaybackManager @Inject constructor(
         val wasEmpty: Boolean = upNextQueue.isEmpty
         upNextQueue.playLast(episode, downloadManager, null)
         if (userInitiated) {
-            episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_ADDED_TO_UP_NEXT, source, false)
+            episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_ADDED_TO_UP_NEXT, source, false, episode)
         }
         if (wasEmpty) {
             loadCurrentEpisode(play = false)

--- a/modules/services/ui/src/main/res/values/ids.xml
+++ b/modules/services/ui/src/main/res/values/ids.xml
@@ -4,6 +4,8 @@
     <item name="tour_background" type="id" />
     <item name="leftRightItem1" type="id" />
     <item name="leftRightItem2" type="id" />
+    <item name="rightLeftItem1" type="id" />
+    <item name="rightLeftItem2" type="id" />
     <item name="menu_markasunplayed" type="id" />
     <item name="menu_unstar" type="id" />
     <item name="menu_undownload" type="id" />

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/ShareDialog.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/ShareDialog.kt
@@ -29,6 +29,8 @@ class ShareDialog(
         }
     }
 
+    // If the share dialog is not appearing, make sure you're setting an appropriate fragmentManager
+    // when constructing this class, i.e., you might need a parentFragmentManager instead of a childFragmentManager
     fun show(sourceView: SourceView) {
         if (fragmentManager == null || context == null) {
             return

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/ShareDialog.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/ShareDialog.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.views.dialog
 
+import android.app.Application
 import android.content.Context
 import androidx.fragment.app.FragmentManager
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
@@ -19,6 +20,14 @@ class ShareDialog(
     private val forceDarkTheme: Boolean = false,
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) {
+
+    init {
+        if (context is Application) {
+            // Cannot use application context here because it will cause a crash when
+            // the show method tries to start a new activity.
+            throw IllegalArgumentException("ShareDialog cannot use the application context")
+        }
+    }
 
     fun show(sourceView: SourceView) {
         if (fragmentManager == null || context == null) {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/ShareDialog.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/ShareDialog.kt
@@ -20,8 +20,7 @@ class ShareDialog(
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) {
 
-    private val source = SourceView.EPISODE_DETAILS
-    fun show() {
+    fun show(sourceView: SourceView) {
         if (fragmentManager == null || context == null) {
             return
         }
@@ -37,7 +36,7 @@ class ShareDialog(
                         null,
                         context,
                         ShareType.PODCAST,
-                        source,
+                        sourceView,
                         analyticsTracker
                     ).showShareDialogDirect()
                 }
@@ -53,7 +52,7 @@ class ShareDialog(
                         null,
                         context,
                         ShareType.EPISODE,
-                        source,
+                        sourceView,
                         analyticsTracker
                     ).showShareDialogDirect()
                 }
@@ -67,7 +66,7 @@ class ShareDialog(
                         episode.playedUpTo,
                         context,
                         ShareType.CURRENT_TIME,
-                        source,
+                        sourceView,
                         analyticsTracker
                     ).showShareDialogDirect()
                 }
@@ -82,7 +81,7 @@ class ShareDialog(
                             episode.playedUpTo,
                             context,
                             ShareType.EPISODE_FILE,
-                            source,
+                            sourceView,
                             analyticsTracker
                         ).sendFile()
                     }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/MultiSwipeHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/MultiSwipeHelper.kt
@@ -483,7 +483,7 @@ open class MultiSwipeHelper(internal var mCallback: Callback) : RecyclerView.Ite
                         if (abs(currentTranslateX) > mRecyclerView!!.width * mCallback.getMultiItemCutoffThreshold()) {
                             targetTranslateX = Math.signum(mDx) * mRecyclerView!!.width
                         } else {
-                            targetTranslateX = -mCallback.getMultiItemStopSize(mSelected!!)
+                            targetTranslateX = -mCallback.getMultiItemStopSize(mSelected!!, SwipeDirection.Left)
                         }
                     }
                     RIGHT, END -> {
@@ -491,7 +491,7 @@ open class MultiSwipeHelper(internal var mCallback: Callback) : RecyclerView.Ite
                         if (currentTranslateX > mRecyclerView!!.width * mCallback.getMultiItemCutoffThreshold()) {
                             targetTranslateX = Math.signum(mDx) * mRecyclerView!!.width
                         } else {
-                            targetTranslateX = mCallback.getMultiItemStopSize(mSelected!!)
+                            targetTranslateX = mCallback.getMultiItemStopSize(mSelected!!, SwipeDirection.Right)
                         }
                     }
                     UP, DOWN -> {
@@ -1485,7 +1485,7 @@ open class MultiSwipeHelper(internal var mCallback: Callback) : RecyclerView.Ite
             return .4f
         }
 
-        abstract fun getMultiItemStopSize(viewHolder: ViewHolder): Float
+        abstract fun getMultiItemStopSize(viewHolder: ViewHolder, swipeDirection: SwipeDirection): Float
 
         open fun augmentUpdateDxDy(dx: Float, dy: Float): Pair<Float, Float> {
             return Pair(dx, dy)

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayout.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayout.kt
@@ -159,9 +159,6 @@ sealed interface SwipeButton {
     }
 }
 
-/**
- * - [onDeleteOrArchiveClick] will delete [UserEpisode]s and archive [PodcastEpisode]s
- */
 class SwipeButtonLayoutFactory(
     private val swipeButtonLayoutViewModel: SwipeButtonLayoutViewModel,
     private val onItemUpdated: (BaseEpisode, RowIndex) -> Unit,

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayout.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayout.kt
@@ -1,0 +1,206 @@
+package au.com.shiftyjelly.pocketcasts.views.helper
+
+import android.content.Context
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.ui.R as UR
+import au.com.shiftyjelly.pocketcasts.views.R as VR
+
+data class SwipeButtonLayout(
+    val leftPrimary: () -> SwipeButton,
+    val leftSecondary: () -> SwipeButton?,
+    val rightPrimary: () -> SwipeButton,
+    val rightSecondary: () -> SwipeButton?,
+)
+
+typealias RowIndex = Int
+
+sealed interface SwipeButton {
+    val iconRes: Int
+    val backgroundColor: (Context) -> Int
+    val onClick: (BaseEpisode, RowIndex) -> Unit
+
+    companion object {
+        private val removeUpNextIconRes = IR.drawable.ic_upnext_remove
+        private val removeUpNextBackgroundColorAttr = UR.attr.support_05
+    }
+
+    // Shows the remove from up next button if the episode is already queued
+    class AddToUpNextTopOrRemove(
+        private val episode: BaseEpisode,
+        private val playbackManager: PlaybackManager,
+        private val alwaysShowAddQueueOptions: Boolean,
+        override val onClick: (BaseEpisode, RowIndex) -> Unit,
+    ) : SwipeButton {
+
+        override val iconRes
+            get() =
+                if (playbackManager.upNextQueue.contains(episode.uuid) && !alwaysShowAddQueueOptions) {
+                    removeUpNextIconRes
+                } else {
+                    IR.drawable.ic_upnext_movetotop
+                }
+
+        override val backgroundColor: (Context) -> Int
+            get() = {
+                if (playbackManager.upNextQueue.contains(episode.uuid) && !alwaysShowAddQueueOptions) {
+                    it.getThemeColor(removeUpNextBackgroundColorAttr)
+                } else {
+                    it.getThemeColor(UR.attr.support_04)
+                }
+            }
+    }
+
+    // Shows the remove from up next button if the episode is already queued
+    class AddToUpNextBottom(
+        private val episode: BaseEpisode,
+        private val playbackManager: PlaybackManager,
+        private val alwaysShowAddQueueOptions: Boolean,
+        override val onClick: (BaseEpisode, RowIndex) -> Unit
+    ) : SwipeButton {
+
+        override val iconRes
+            get() = if (playbackManager.upNextQueue.contains(episode.uuid) && !alwaysShowAddQueueOptions) {
+                removeUpNextIconRes
+            } else {
+                IR.drawable.ic_upnext_movetobottom
+            }
+
+        override val backgroundColor: (Context) -> Int
+            get() = {
+                it.getThemeColor(
+                    if (playbackManager.upNextQueue.contains(episode.uuid) && !alwaysShowAddQueueOptions) {
+                        removeUpNextBackgroundColorAttr
+                    } else {
+                        UR.attr.support_03
+                    }
+                )
+            }
+    }
+
+    class DeleteFileButton(
+        override val onClick: (BaseEpisode, RowIndex) -> Unit
+    ) : SwipeButton {
+        override val iconRes = VR.drawable.ic_delete
+        override val backgroundColor: (Context) -> Int =
+            { it.getThemeColor(UR.attr.support_05) }
+    }
+
+    class ArchiveButton(
+        private val episode: BaseEpisode,
+        override val onClick: (BaseEpisode, RowIndex) -> Unit
+    ) : SwipeButton {
+        override val iconRes
+            get() = if (episode.isArchived) {
+                IR.drawable.ic_unarchive
+            } else {
+                IR.drawable.ic_archive
+            }
+        override val backgroundColor: (Context) -> Int =
+            { it.getThemeColor(UR.attr.support_06) }
+    }
+
+    class ShareButton(onClick: (PodcastEpisode, RowIndex) -> Unit) : SwipeButton {
+        override val iconRes = IR.drawable.ic_share
+        override val backgroundColor: (Context) -> Int =
+            { it.getThemeColor(UR.attr.support_01) }
+        override val onClick: (BaseEpisode, RowIndex) -> Unit = { baseEpisode, rowIndex ->
+            (baseEpisode as? PodcastEpisode)?.let { episode ->
+                onClick(episode, rowIndex)
+            }
+        }
+    }
+}
+
+/**
+ * - [onDeleteOrArchiveClick] will delete [UserEpisode]s and archive [PodcastEpisode]s
+ * - Share button will not be shown if [onShareClick] is null
+ */
+class SwipeButtonLayoutFactory(
+    private val onQueueUpNextTopClick: (BaseEpisode, RowIndex) -> Unit,
+    private val onQueueUpNextBottomClick: (BaseEpisode, RowIndex) -> Unit,
+    private val onDeleteOrArchiveClick: (BaseEpisode, RowIndex) -> Unit,
+    private val onShareClick: ((BaseEpisode, RowIndex) -> Unit)? = null,
+    private val playbackManager: PlaybackManager,
+    private val defaultUpNextSwipeAction: () -> Settings.UpNextAction,
+) {
+    fun forEpisode(
+        episode: BaseEpisode,
+        isShowingUpNextQueue: Boolean = false,
+        ignoreUserSwipePreference: Boolean = false,
+    ): SwipeButtonLayout {
+        val isQueued = { playbackManager.upNextQueue.contains(episode.uuid) }
+        val addToUpNextTop = SwipeButton.AddToUpNextTopOrRemove(
+            episode = episode,
+            playbackManager = playbackManager,
+            alwaysShowAddQueueOptions = isShowingUpNextQueue,
+            onClick = onQueueUpNextTopClick,
+        )
+        val addToUpNextBottom = SwipeButton.AddToUpNextBottom(
+            episode = episode,
+            playbackManager = playbackManager,
+            alwaysShowAddQueueOptions = isShowingUpNextQueue,
+            onClick = onQueueUpNextBottomClick,
+        )
+
+        return SwipeButtonLayout(
+            leftPrimary = {
+                if (ignoreUserSwipePreference) {
+                    addToUpNextTop
+                } else {
+                    // The left primary button is the action that is taken when the user swipes to the right
+                    when (defaultUpNextSwipeAction()) {
+                        Settings.UpNextAction.PLAY_NEXT -> addToUpNextTop
+                        Settings.UpNextAction.PLAY_LAST -> addToUpNextBottom
+                    }
+                }
+            },
+            leftSecondary = {
+                if (isQueued() && !isShowingUpNextQueue) {
+                    null
+                } else {
+                    if (ignoreUserSwipePreference) {
+                        addToUpNextBottom
+                    } else {
+                        when (defaultUpNextSwipeAction()) {
+                            Settings.UpNextAction.PLAY_NEXT -> addToUpNextBottom
+                            Settings.UpNextAction.PLAY_LAST -> addToUpNextTop
+                        }
+                    }
+                }
+            },
+            rightPrimary = {
+                if (isShowingUpNextQueue) {
+                    // When an episode is queued, the button shows the remove from queue option
+                    SwipeButton.AddToUpNextTopOrRemove(
+                        episode = episode,
+                        playbackManager = playbackManager,
+                        alwaysShowAddQueueOptions = false, // ensures this button shows the remove option
+                        onClick = onQueueUpNextTopClick,
+                    )
+                } else {
+                    when (episode) {
+                        is PodcastEpisode -> SwipeButton.ArchiveButton(episode, onDeleteOrArchiveClick)
+
+                        is UserEpisode -> SwipeButton.DeleteFileButton(onDeleteOrArchiveClick)
+                    }
+                }
+            },
+            rightSecondary = {
+                if (isShowingUpNextQueue) {
+                    null
+                } else {
+                    when (episode) {
+                        is PodcastEpisode -> onShareClick?.let { SwipeButton.ShareButton(onClick = it) }
+                        is UserEpisode -> null
+                    }
+                }
+            },
+        )
+    }
+}

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayout.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayout.kt
@@ -25,11 +25,6 @@ sealed interface SwipeButton {
     val backgroundColor: (Context) -> Int
     val onClick: (BaseEpisode, RowIndex) -> Unit
 
-    companion object {
-        private val removeUpNextIconRes = IR.drawable.ic_upnext_remove
-        private val removeUpNextBackgroundColorAttr = UR.attr.support_05
-    }
-
     // Shows the remove from up next button if the episode is already queued
     class AddToUpNextTop(
         private val onItemUpdated: (BaseEpisode, RowIndex) -> Unit,
@@ -79,9 +74,9 @@ sealed interface SwipeButton {
         private val viewModel: SwipeButtonLayoutViewModel,
     ) : SwipeButton {
 
-        override val iconRes = removeUpNextIconRes
+        override val iconRes = IR.drawable.ic_upnext_remove
 
-        override val backgroundColor: (Context) -> Int = { it.getThemeColor(removeUpNextBackgroundColorAttr) }
+        override val backgroundColor: (Context) -> Int = { it.getThemeColor(UR.attr.support_05) }
 
         override val onClick: (BaseEpisode, RowIndex) -> Unit = { baseEpisode, rowIndex ->
             viewModel.episodeSwipeRemoveUpNext(

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
@@ -57,7 +57,7 @@ class SwipeButtonLayoutViewModel @Inject constructor(
                 context = context,
                 shouldShowPodcast = false,
                 analyticsTracker = analyticsTracker,
-            ).show(sourceView = SourceView.SWIPE_ACTION)
+            ).show(sourceView = SourceView.EPISODE_SWIPE_ACTION)
         }
     }
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
@@ -79,13 +79,13 @@ class SwipeButtonLayoutViewModel @Inject constructor(
         swipeSource: EpisodeItemTouchHelper.SwipeSource,
     ) {
         viewModelScope.launch(Dispatchers.Default) {
-            playbackManager.playNext(
-                episode = episode,
-                source = swipeSourceToSourceView(swipeSource)
-            )
             trackSwipeAction(
                 swipeSource = swipeSource,
                 swipeAction = EpisodeItemTouchHelper.SwipeAction.UP_NEXT_ADD_TOP
+            )
+            playbackManager.playNext(
+                episode = episode,
+                source = swipeSourceToSourceView(swipeSource)
             )
         }
     }
@@ -95,13 +95,13 @@ class SwipeButtonLayoutViewModel @Inject constructor(
         swipeSource: EpisodeItemTouchHelper.SwipeSource,
     ) {
         viewModelScope.launch(Dispatchers.Default) {
-            playbackManager.playLast(
-                episode = episode,
-                source = swipeSourceToSourceView(swipeSource)
-            )
             trackSwipeAction(
                 swipeSource = swipeSource,
                 swipeAction = EpisodeItemTouchHelper.SwipeAction.UP_NEXT_ADD_BOTTOM
+            )
+            playbackManager.playLast(
+                episode = episode,
+                source = swipeSourceToSourceView(swipeSource)
             )
         }
     }
@@ -111,13 +111,13 @@ class SwipeButtonLayoutViewModel @Inject constructor(
         swipeSource: EpisodeItemTouchHelper.SwipeSource,
     ) {
         viewModelScope.launch(Dispatchers.Default) {
-            playbackManager.removeEpisode(
-                episodeToRemove = episode,
-                source = swipeSourceToSourceView(swipeSource)
-            )
             trackSwipeAction(
                 swipeSource = swipeSource,
                 swipeAction = EpisodeItemTouchHelper.SwipeAction.UP_NEXT_REMOVE
+            )
+            playbackManager.removeEpisode(
+                episodeToRemove = episode,
+                source = swipeSourceToSourceView(swipeSource)
             )
         }
     }
@@ -125,16 +125,16 @@ class SwipeButtonLayoutViewModel @Inject constructor(
     fun updateArchive(episode: PodcastEpisode, swipeSource: EpisodeItemTouchHelper.SwipeSource) {
         viewModelScope.launch(Dispatchers.Default) {
             if (!episode.isArchived) {
-                episodeManager.archive(episode, playbackManager)
                 trackSwipeAction(swipeSource, EpisodeItemTouchHelper.SwipeAction.ARCHIVE)
+                episodeManager.archive(episode, playbackManager)
                 episodeAnalytics.trackEvent(
                     event = AnalyticsEvent.EPISODE_ARCHIVED,
                     source = swipeSourceToSourceView(swipeSource),
                     uuid = episode.uuid
                 )
             } else {
-                episodeManager.unarchive(episode)
                 trackSwipeAction(swipeSource, EpisodeItemTouchHelper.SwipeAction.UNARCHIVE)
+                episodeManager.unarchive(episode)
                 episodeAnalytics.trackEvent(
                     event = AnalyticsEvent.EPISODE_UNARCHIVED,
                     source = swipeSourceToSourceView(swipeSource),

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
@@ -1,0 +1,63 @@
+package au.com.shiftyjelly.pocketcasts.views.helper
+
+import android.content.Context
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.views.dialog.ShareDialog
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SwipeButtonLayoutViewModel @Inject constructor(
+    val analyticsTracker: AnalyticsTrackerWrapper,
+    val podcastManager: PodcastManager,
+) : ViewModel() {
+
+    fun share(
+        episode: PodcastEpisode,
+        fragmentManager: FragmentManager,
+        context: Context,
+        swipeSource: EpisodeItemTouchHelper.SwipeSource
+    ) {
+
+        viewModelScope.launch(Dispatchers.Default) {
+
+            trackSwipeAction(
+                swipeSource = swipeSource,
+                swipeAction = EpisodeItemTouchHelper.SwipeAction.SHARE,
+            )
+
+            val podcast = podcastManager.findPodcastByUuid(episode.podcastUuid) ?: return@launch
+
+            ShareDialog(
+                episode = episode,
+                podcast = podcast,
+                fragmentManager = fragmentManager,
+                context = context,
+                shouldShowPodcast = false,
+                analyticsTracker = analyticsTracker,
+            ).show(sourceView = SourceView.SWIPE_ACTION)
+        }
+    }
+
+    fun trackSwipeAction(
+        swipeSource: EpisodeItemTouchHelper.SwipeSource,
+        swipeAction: EpisodeItemTouchHelper.SwipeAction,
+    ) {
+        analyticsTracker.track(
+            AnalyticsEvent.EPISODE_SWIPE_ACTION_PERFORMED,
+            mapOf(
+                "action" to swipeAction.analyticsValue,
+                "source" to swipeSource.analyticsValue
+            )
+        )
+    }
+}

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
@@ -6,22 +6,31 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.views.dialog.ShareDialog
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SwipeButtonLayoutViewModel @Inject constructor(
-    val analyticsTracker: AnalyticsTrackerWrapper,
-    val playbackManager: PlaybackManager,
-    val podcastManager: PodcastManager,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    @ApplicationContext private val context: Context,
+    private val episodeAnalytics: EpisodeAnalytics,
+    private val episodeManager: EpisodeManager,
+    private val playbackManager: PlaybackManager,
+    private val podcastManager: PodcastManager,
+    private val userEpisodeManager: UserEpisodeManager,
 ) : ViewModel() {
 
     fun share(
@@ -112,6 +121,59 @@ class SwipeButtonLayoutViewModel @Inject constructor(
         }
     }
 
+    fun updateArchive(episode: PodcastEpisode, swipeSource: EpisodeItemTouchHelper.SwipeSource) {
+        viewModelScope.launch(Dispatchers.Default) {
+            if (!episode.isArchived) {
+                episodeManager.archive(episode, playbackManager)
+                trackSwipeAction(swipeSource, EpisodeItemTouchHelper.SwipeAction.ARCHIVE)
+                episodeAnalytics.trackEvent(
+                    event = AnalyticsEvent.EPISODE_ARCHIVED,
+                    source = swipeSourceToSourceView(swipeSource),
+                    uuid = episode.uuid
+                )
+            } else {
+                episodeManager.unarchive(episode)
+                trackSwipeAction(swipeSource, EpisodeItemTouchHelper.SwipeAction.UNARCHIVE)
+                episodeAnalytics.trackEvent(
+                    event = AnalyticsEvent.EPISODE_UNARCHIVED,
+                    source = swipeSourceToSourceView(swipeSource),
+                    uuid = episode.uuid
+                )
+            }
+        }
+    }
+
+    fun deleteEpisode(
+        episode: UserEpisode,
+        swipeSource: EpisodeItemTouchHelper.SwipeSource,
+        fragmentManager: FragmentManager,
+        onDismiss: () -> Unit,
+    ) {
+        trackSwipeAction(swipeSource, EpisodeItemTouchHelper.SwipeAction.DELETE)
+        CloudDeleteHelper.getDeleteDialog(
+            episode = episode,
+            deleteState = CloudDeleteHelper.getDeleteState(episode),
+            deleteFunction = { userEpisode, deleteState ->
+                CloudDeleteHelper.deleteEpisode(
+                    episode = userEpisode,
+                    deleteState = deleteState,
+                    playbackManager = playbackManager,
+                    episodeManager = episodeManager,
+                    userEpisodeManager = userEpisodeManager,
+                )
+                episodeAnalytics.trackEvent(
+                    event = if (deleteState == DeleteState.Cloud && !episode.isDownloaded) AnalyticsEvent.EPISODE_DELETED_FROM_CLOUD else AnalyticsEvent.EPISODE_DOWNLOAD_DELETED,
+                    source = SourceView.FILES,
+                    uuid = episode.uuid,
+                )
+            },
+            resources = context.resources
+        ).apply {
+            setOnDismiss { onDismiss() }
+            show(fragmentManager, "delete_confirm")
+        }
+    }
+
     fun isEpisodeQueued(episode: BaseEpisode) = playbackManager.upNextQueue.contains(episode.uuid)
 
     private fun swipeSourceToSourceView(swipeSource: EpisodeItemTouchHelper.SwipeSource) = when (swipeSource) {
@@ -122,19 +184,5 @@ class SwipeButtonLayoutViewModel @Inject constructor(
         EpisodeItemTouchHelper.SwipeSource.STARRED -> SourceView.STARRED
         EpisodeItemTouchHelper.SwipeSource.FILES -> SourceView.FILES
         EpisodeItemTouchHelper.SwipeSource.UP_NEXT -> SourceView.UP_NEXT
-    }
-
-    private fun removeEpisode(
-        episode: BaseEpisode,
-        swipeSource: EpisodeItemTouchHelper.SwipeSource,
-    ) {
-        playbackManager.removeEpisode(
-            episodeToRemove = episode,
-            source = swipeSourceToSourceView(swipeSource)
-        )
-        trackSwipeAction(
-            swipeSource = swipeSource,
-            swipeAction = EpisodeItemTouchHelper.SwipeAction.UP_NEXT_REMOVE
-        )
     }
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
@@ -7,7 +7,9 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.views.dialog.ShareDialog
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -18,6 +20,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SwipeButtonLayoutViewModel @Inject constructor(
     val analyticsTracker: AnalyticsTrackerWrapper,
+    val playbackManager: PlaybackManager,
     val podcastManager: PodcastManager,
 ) : ViewModel() {
 
@@ -58,6 +61,80 @@ class SwipeButtonLayoutViewModel @Inject constructor(
                 "action" to swipeAction.analyticsValue,
                 "source" to swipeSource.analyticsValue
             )
+        )
+    }
+
+    fun episodeSwipeUpNextTop(
+        episode: BaseEpisode,
+        swipeSource: EpisodeItemTouchHelper.SwipeSource,
+    ) {
+        viewModelScope.launch(Dispatchers.Default) {
+            playbackManager.playNext(
+                episode = episode,
+                source = swipeSourceToSourceView(swipeSource)
+            )
+            trackSwipeAction(
+                swipeSource = swipeSource,
+                swipeAction = EpisodeItemTouchHelper.SwipeAction.UP_NEXT_ADD_TOP
+            )
+        }
+    }
+
+    fun episodeSwipeUpNextBottom(
+        episode: BaseEpisode,
+        swipeSource: EpisodeItemTouchHelper.SwipeSource,
+    ) {
+        viewModelScope.launch(Dispatchers.Default) {
+            playbackManager.playLast(
+                episode = episode,
+                source = swipeSourceToSourceView(swipeSource)
+            )
+            trackSwipeAction(
+                swipeSource = swipeSource,
+                swipeAction = EpisodeItemTouchHelper.SwipeAction.UP_NEXT_ADD_BOTTOM
+            )
+        }
+    }
+
+    fun episodeSwipeRemoveUpNext(
+        episode: BaseEpisode,
+        swipeSource: EpisodeItemTouchHelper.SwipeSource,
+    ) {
+        viewModelScope.launch(Dispatchers.Default) {
+            playbackManager.removeEpisode(
+                episodeToRemove = episode,
+                source = swipeSourceToSourceView(swipeSource)
+            )
+            trackSwipeAction(
+                swipeSource = swipeSource,
+                swipeAction = EpisodeItemTouchHelper.SwipeAction.UP_NEXT_REMOVE
+            )
+        }
+    }
+
+    fun isEpisodeQueued(episode: BaseEpisode) = playbackManager.upNextQueue.contains(episode.uuid)
+
+    private fun swipeSourceToSourceView(swipeSource: EpisodeItemTouchHelper.SwipeSource) = when (swipeSource) {
+        EpisodeItemTouchHelper.SwipeSource.PODCAST_DETAILS -> SourceView.PODCAST_SCREEN
+        EpisodeItemTouchHelper.SwipeSource.FILTERS -> SourceView.FILTERS
+        EpisodeItemTouchHelper.SwipeSource.DOWNLOADS -> SourceView.DOWNLOADS
+        EpisodeItemTouchHelper.SwipeSource.LISTENING_HISTORY -> SourceView.LISTENING_HISTORY
+        EpisodeItemTouchHelper.SwipeSource.STARRED -> SourceView.STARRED
+        EpisodeItemTouchHelper.SwipeSource.FILES -> SourceView.FILES
+        EpisodeItemTouchHelper.SwipeSource.UP_NEXT -> SourceView.UP_NEXT
+    }
+
+    private fun removeEpisode(
+        episode: BaseEpisode,
+        swipeSource: EpisodeItemTouchHelper.SwipeSource,
+    ) {
+        playbackManager.removeEpisode(
+            episodeToRemove = episode,
+            source = swipeSourceToSourceView(swipeSource)
+        )
+        trackSwipeAction(
+            swipeSource = swipeSource,
+            swipeAction = EpisodeItemTouchHelper.SwipeAction.UP_NEXT_REMOVE
         )
     }
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
@@ -41,14 +41,14 @@ class SwipeButtonLayoutViewModel @Inject constructor(
         swipeSource: EpisodeItemTouchHelper.SwipeSource
     ) {
 
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
 
             trackSwipeAction(
                 swipeSource = swipeSource,
                 swipeAction = EpisodeItemTouchHelper.SwipeAction.SHARE,
             )
 
-            val podcast = podcastManager.findPodcastByUuid(episode.podcastUuid) ?: return@launch
+            val podcast = podcastManager.findPodcastByUuidSuspend(episode.podcastUuid) ?: return@launch
 
             ShareDialog(
                 episode = episode,

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeDirection.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeDirection.kt
@@ -1,0 +1,6 @@
+package au.com.shiftyjelly.pocketcasts.views.helper
+
+enum class SwipeDirection {
+    Left,
+    Right
+}

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBottomSheet.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBottomSheet.kt
@@ -85,7 +85,7 @@ class MultiSelectBottomSheet : BaseDialogFragment() {
     }
 
     private fun onClick(item: MultiSelectAction) {
-        multiSelectHelper?.onMenuItemSelected(item.actionId, resources, childFragmentManager)
+        multiSelectHelper?.onMenuItemSelected(item.actionId, resources, parentFragmentManager)
         dismiss()
     }
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodeAction.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodeAction.kt
@@ -60,6 +60,13 @@ sealed class MultiSelectEpisodeAction(
         R.drawable.ic_delete,
         "delete"
     )
+    object Share : MultiSelectEpisodeAction(
+        groupId = R.id.menu_share,
+        actionId = R.id.menu_share,
+        title = LR.string.share,
+        iconRes = IR.drawable.ic_share,
+        analyticsValue = "share",
+    )
     object MarkAsUnplayed : MultiSelectEpisodeAction(
         R.id.menu_mark_played,
         UR.id.menu_markasunplayed,
@@ -104,7 +111,7 @@ sealed class MultiSelectEpisodeAction(
     )
 
     companion object {
-        val STANDARD = listOf(Download, Archive, MarkAsPlayed, PlayNext, PlayLast, Star)
+        val STANDARD = listOf(Download, Archive, MarkAsPlayed, PlayNext, PlayLast, Star, Share)
         val ALL = STANDARD + listOf(DeleteDownload, DeleteUserEpisode, MarkAsUnplayed, Unstar, Unarchive)
         val STANDARD_BY_ID = STANDARD.associateBy { it.actionId }
         val ALL_BY_ID = ALL.associateBy { it.actionId }
@@ -156,6 +163,11 @@ sealed class MultiSelectEpisodeAction(
                 }
                 R.id.menu_playnext -> return PlayNext
                 R.id.menu_playlast -> return PlayLast
+                R.id.menu_share -> {
+                    if (selected.size == 1 &&
+                        selected.firstOrNull() is PodcastEpisode
+                    ) return Share
+                }
             }
 
             return null

--- a/modules/services/views/src/main/res/menu/menu_multiselect.xml
+++ b/modules/services/views/src/main/res/menu/menu_multiselect.xml
@@ -13,6 +13,10 @@
         android:icon="@drawable/ic_delete"
         android:title="@string/delete"
         app:showAsAction="always" />
+    <item android:id="@+id/menu_share"
+        android:icon="@drawable/ic_share"
+        android:title="@string/share"
+        app:showAsAction="always" />
     <item android:id="@+id/menu_mark_played"
         android:icon="@drawable/ic_markasplayed"
         android:title="@string/mark_as_played"

--- a/modules/services/views/src/test/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModelTest.kt
+++ b/modules/services/views/src/test/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModelTest.kt
@@ -1,0 +1,298 @@
+package au.com.shiftyjelly.pocketcasts.views.helper
+
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(MockitoJUnitRunner::class)
+class SwipeButtonLayoutViewModelTest {
+
+    @Mock private lateinit var playbackManager: PlaybackManager
+
+    @Mock private lateinit var upNextQueue: UpNextQueue
+
+    private val buttons: SwipeButtonLayoutViewModel.SwipeButtons =
+        SwipeButtonLayoutViewModel.SwipeButtons(
+            addToUpNextTop = mock(name = "addToUpNextTop"),
+            addToUpNextBottom = mock(name = "addToUpNextBottom"),
+            removeFromUpNext = mock(name = "removeFromUpNext"),
+            archive = mock(name = "archive"),
+            deleteFile = mock(name = "deleteFile"),
+            share = mock(name = "share"),
+        )
+
+    private lateinit var testSubject: SwipeButtonLayoutViewModel
+
+    @Before
+    fun setup() {
+        testSubject = SwipeButtonLayoutViewModel(
+            analyticsTracker = mock(),
+            context = mock(),
+            episodeAnalytics = mock(),
+            episodeManager = mock(),
+            playbackManager = playbackManager,
+            podcastManager = mock(),
+            userEpisodeManager = mock(),
+        )
+    }
+
+    /*
+     * Add/Remove from queue
+     */
+
+    @Test
+    fun `show queue buttons in user settings order when not on up next screen when defaulting to top`() {
+        val topDefault = getSwipeButtonLayout(
+            onUpNextScreen = false,
+            defaultUpNextSwipeAction = Settings.UpNextAction.PLAY_NEXT
+        )
+        assertEquals(buttons.addToUpNextTop, topDefault.leftPrimary())
+        assertEquals(buttons.addToUpNextBottom, topDefault.leftSecondary())
+    }
+
+    @Test
+    fun `show queue buttons in user setting order when not on up next screen when defaulting to bottom`() {
+        val bottomDefault = getSwipeButtonLayout(
+            onUpNextScreen = false,
+            defaultUpNextSwipeAction = Settings.UpNextAction.PLAY_LAST
+        )
+        assertEquals(buttons.addToUpNextBottom, bottomDefault.leftPrimary())
+        assertEquals(buttons.addToUpNextTop, bottomDefault.leftSecondary())
+    }
+
+    @Test
+    fun `ignores user setting for queue actions order when on up next screen`() {
+        val verifyTopFirst = { layout: SwipeButtonLayout ->
+            assertEquals(buttons.addToUpNextTop, layout.leftPrimary())
+            assertEquals(buttons.addToUpNextBottom, layout.leftSecondary())
+        }
+
+        val defaultNext = getSwipeButtonLayout(
+            onUpNextScreen = true,
+            defaultUpNextSwipeAction = Settings.UpNextAction.PLAY_NEXT
+        )
+        verifyTopFirst(defaultNext)
+
+        val defaultLast = getSwipeButtonLayout(
+            onUpNextScreen = true,
+            defaultUpNextSwipeAction = Settings.UpNextAction.PLAY_LAST
+        )
+        verifyTopFirst(defaultLast)
+    }
+
+    @Test
+    fun `if episode is queued, shows remove queue button on left when not on Up Next screen`() {
+        val verifyRemoveButton = { layout: SwipeButtonLayout ->
+            assertEquals(buttons.removeFromUpNext, layout.leftPrimary())
+            assertNull(layout.leftSecondary())
+        }
+
+        val withPodcastEpisode = getSwipeButtonLayout(
+            onUpNextScreen = false,
+            episode = mock<PodcastEpisode>(),
+            episodeInUpNext = true
+        )
+        verifyRemoveButton(withPodcastEpisode)
+
+        val withUserEpisode = getSwipeButtonLayout(
+            onUpNextScreen = false,
+            episode = mock<UserEpisode>(),
+            episodeInUpNext = true
+        )
+        verifyRemoveButton(withUserEpisode)
+    }
+
+    @Test
+    fun `shows remove from queue button always on right on Up Next screen`() {
+        val verifyRemoveButton = { layout: SwipeButtonLayout ->
+            // remove button is right primary...
+            assertEquals(buttons.removeFromUpNext, layout.rightPrimary())
+
+            // ...and nowhere else
+            assertNull(layout.rightSecondary())
+            assertNotEquals(buttons.removeFromUpNext, layout.leftPrimary())
+            assertNotEquals(buttons.removeFromUpNext, layout.leftSecondary())
+        }
+
+        val withPodcastEpisode = getSwipeButtonLayout(
+            episode = mock<PodcastEpisode>(),
+            onUpNextScreen = true,
+            episodeInUpNext = true
+        )
+        verifyRemoveButton(withPodcastEpisode)
+
+        val withUserEpisode = getSwipeButtonLayout(
+            episode = mock<UserEpisode>(),
+            onUpNextScreen = true,
+            episodeInUpNext = true
+        )
+        verifyRemoveButton(withUserEpisode)
+    }
+
+    /*
+     * Delete / archive buttons
+     */
+
+    @Test
+    fun `shows archive button for podcast episodes when not on Up Next screen`() {
+        val verifyArchiveButton = { layout: SwipeButtonLayout ->
+            // archive button is right primary...
+            assertEquals(buttons.archive, layout.rightPrimary())
+
+            // ...and nowhere else
+            assertNotEquals(buttons.archive, layout.rightSecondary())
+            assertNotEquals(buttons.archive, layout.leftPrimary())
+            assertNotEquals(buttons.archive, layout.leftSecondary())
+
+            // ...and there's no deleteFile button
+            assertNotEquals(buttons.deleteFile, layout.rightSecondary())
+            assertNotEquals(buttons.deleteFile, layout.leftPrimary())
+            assertNotEquals(buttons.deleteFile, layout.leftSecondary())
+        }
+
+        val default = getSwipeButtonLayout(
+            episode = mock<PodcastEpisode>(),
+        )
+        verifyArchiveButton(default)
+
+        val inUpNextQueue = getSwipeButtonLayout(
+            episode = mock<PodcastEpisode>(),
+            episodeInUpNext = true
+        )
+        verifyArchiveButton(inUpNextQueue)
+    }
+
+    @Test
+    fun `shows archive button for user episodes when not on Up Next Screen`() {
+        val verifyDeleteFileButton = { layout: SwipeButtonLayout ->
+            // deleteFile button is right primary...
+            assertEquals(buttons.deleteFile, layout.rightPrimary())
+
+            // ...and nowhere else
+            assertNotEquals(buttons.deleteFile, layout.rightSecondary())
+            assertNotEquals(buttons.deleteFile, layout.leftPrimary())
+            assertNotEquals(buttons.deleteFile, layout.leftSecondary())
+
+            // ...and there's no archive button
+            assertNotEquals(buttons.archive, layout.rightSecondary())
+            assertNotEquals(buttons.archive, layout.leftPrimary())
+            assertNotEquals(buttons.archive, layout.leftSecondary())
+        }
+
+        val default = getSwipeButtonLayout(
+            episode = mock<UserEpisode>(),
+        )
+        verifyDeleteFileButton(default)
+
+        val inUpNextQueue = getSwipeButtonLayout(
+            episode = mock<UserEpisode>(),
+            episodeInUpNext = true
+        )
+        verifyDeleteFileButton(inUpNextQueue)
+    }
+
+    /*
+     * Share Button
+     */
+
+    @Test
+    fun `shows share button when not on Up Next Screen`() {
+        val withShare = getSwipeButtonLayout(
+            onUpNextScreen = false,
+            showShareButton = true
+        )
+        assertEquals(buttons.share, withShare.rightSecondary())
+    }
+
+    @Test
+    fun `does not show share button if showShareButton is false`() {
+        val shareSetToFalse = getSwipeButtonLayout(
+            onUpNextScreen = false,
+            showShareButton = false
+        )
+        verifyNoShareButton(shareSetToFalse)
+    }
+
+    @Test
+    fun `does not show share button for User Episodes`() {
+        val withUserEpisode = getSwipeButtonLayout(
+            episode = mock<UserEpisode>(),
+            onUpNextScreen = false,
+            showShareButton = false
+        )
+        verifyNoShareButton(withUserEpisode)
+    }
+
+    @Test
+    fun `does not show share button on Up Next screen, even if showShareButton is true`() {
+        val layout = getSwipeButtonLayout(
+            episode = mock<PodcastEpisode>(),
+            onUpNextScreen = true,
+            showShareButton = true
+        )
+        verifyNoShareButton(layout)
+    }
+
+    private fun verifyNoShareButton(layout: SwipeButtonLayout) {
+        assertNotEquals(buttons.share, layout.leftPrimary())
+        assertNotEquals(buttons.share, layout.leftSecondary())
+        assertNotEquals(buttons.share, layout.rightPrimary())
+        assertNotEquals(buttons.share, layout.rightSecondary())
+    }
+
+    /*
+     * Helpers
+     */
+
+    private fun getSwipeButtonLayout(
+        episode: BaseEpisode = mock<PodcastEpisode>(),
+        episodeInUpNext: Boolean = false,
+        showShareButton: Boolean = true,
+        onUpNextScreen: Boolean = false,
+        defaultUpNextSwipeAction: Settings.UpNextAction = Settings.UpNextAction.PLAY_NEXT,
+    ): SwipeButtonLayout {
+
+        if (!onUpNextScreen) {
+            // Only stub these when we're not on the up next screen. Otherwise mockito gets upset about
+            // unnecessary stubbings
+            whenever(playbackManager.upNextQueue).thenReturn(upNextQueue)
+            whenever(upNextQueue.contains(episode.uuid)).thenReturn(episodeInUpNext)
+        }
+
+        val swipeSource = if (onUpNextScreen) {
+            EpisodeItemTouchHelper.SwipeSource.UP_NEXT
+        } else {
+            // All of these are treated the same, so picking one at random
+            // to make sure they're all (kind of) covered. Better would be
+            // to convert this to a parameterized test at some point.
+            listOf(
+                EpisodeItemTouchHelper.SwipeSource.PODCAST_DETAILS,
+                EpisodeItemTouchHelper.SwipeSource.FILES,
+                EpisodeItemTouchHelper.SwipeSource.FILTERS,
+                EpisodeItemTouchHelper.SwipeSource.DOWNLOADS,
+                EpisodeItemTouchHelper.SwipeSource.LISTENING_HISTORY,
+                EpisodeItemTouchHelper.SwipeSource.STARRED,
+            ).random()
+        }
+        return testSubject.getSwipeButtonLayout(
+            episode = episode,
+            swipeSource = swipeSource,
+            showShareButton = showShareButton,
+            defaultUpNextSwipeAction = { defaultUpNextSwipeAction },
+            buttons = buttons
+        )
+    }
+}


### PR DESCRIPTION
## Description

This adds a share option to the swipe menus as requested in the [Increase "Share" discoverability](https://github.com/Automattic/pocket-casts-android/discussions/1168) discussion. 

Because our swipe menus are custom made to handle up to two icons on the left and only a single icon on the right, adding a second icon to the right was a bit tricky. 

In addition, the way this was set up before was kind of complex because the click listener for the buttons came from a completely different place from where the icon and background color was set. This made it very difficult to avoid bugs due to these two sources of information getting out of sync. After spending a day or so playing whack-a-mole fixing a bug, and then fixing a new bug the previous fix caused, and then fixing a new bug the previous..., etc., I decided to do a broader refactor. Now a lot more of the swipe button logic is consolidated in the `SwipeButtonLayoutViewModel`.

I think this consolidates the logic around the share buttons nicely, but it does not consolidate the view handling itself—everywhere we want to use a swipe layout still requires a fair bit of manual XML work, but addressing that didn't seem worth it because (1) I already spent more time on this than I wanted and (2) the whole app will be written in compose soon anyway. 😉 

![Screenshot 2023-07-21 at 2 29 46 PM](https://github.com/Automattic/pocket-casts-android/assets/4656348/17fca221-8294-49dc-9733-573b2454d6ef)

Related iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/966

## Testing Instructions

Because of the refactoring, when testing this PR, we should test all the possible swipe actions, not just the share action. Apart from adding the share button to the Podcast, Filter, Downloads, Starred, and Listening History screens, all other swipe behavior should be unchanged.

Some things to watch out for include:
1. Make sure that when you release the swipe menu so the buttons remain visible, that the buttons have the right width (had a lot of bugs where it wasn't 1-button-wide when showing 1 button and 2-buttons-wide when showing two buttons).
2. Do multiple actions that change the buttons on a single row (i.e., adding and removing the same episode from the up next queue) to make sure the buttons up date appropriately for the episode's new state.

### 1. Podcast, Filter, Downloads, Starred, and Listening History:

* **For unqueued episodes:** LtR swipes reveal the add to up next options. The left button should be the default that user has selected under the General settings. Doing a full-swipe should apply the left button. The only way to apply the right button is the menu open a small amount, release the swipe so the buttons remain visible, and tap the right button.
* **For queued episodes:** LtR swipes reveal the remove from queue option.
* **For archived episodes:** RtL swipes reveal the share and archive buttons. The archive button is on the right and is the action that is taken with a full swipe.
* **For unarchived episodes:** RtL swipes are the same as for archived episodes except the archive action is changed to an unarchived action.

### 2. Files

The Files screen's swipe behavior should be unchanged by this PR. 
* LtR swipes will reveal the add to up next options (ordered based on the user's setting). 
* RtL swipes will reveal only the delete option.

### 3. Up Next Queue

* LtR swipes will always reveal the add-to-queue (or in this case move-in-queue) buttons. Unlike on the other screens, the order here never changes. The left button is move-to-top and the right button is move-to-bottom regardless of what the user's setting says should be the default action.
* RtL swipes reveal the remove from queue button

### 4. Analytics
* For each swipe action, we should send an appropriate`episode_swipe_action_performed` with `action` and `source`, and `episode_uuid` properties. 
* When sharing an episode from the swipe menu, the `podcast_shared` event is sent with a `source` of "swipe_action"
* I have added the `episode_uuid` as a property to the `episode_*_to_up_next` events since we were missing that, but it was identified on the tracking document

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
