### PR TITLE
Add share option to multiselect menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 -----
 *   New Feature:
     *   Added 3 episodes on the Filter AutoDownload
-        ([#1169])(https://github.com/Automattic/pocket-casts-android/pull/1169)
+        ([#1169](https://github.com/Automattic/pocket-casts-android/pull/1169))
     *   Added capability to deselect all/below and above on the multiselect feature
         ([#1172](https://github.com/Automattic/pocket-casts-android/pull/1172))
-    *   Added share option to episode swipe menu
-        ([#1190](https://github.com/Automattic/pocket-casts-android/pull/1190))
+    *   Added share option to episode swipe and multiselect menus
+        ([#1190](https://github.com/Automattic/pocket-casts-android/pull/1190)),
+        ([#1191](https://github.com/Automattic/pocket-casts-android/pull/1191))
 
 7.43
 -----

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
@@ -30,7 +30,8 @@ enum class SourceView(val analyticsValue: String) {
     ONBOARDING_RECOMMENDATIONS_SEARCH("onboarding_recommendations_search"),
     UNKNOWN("unknown"),
     TASKER("tasker"),
-    EPISODE_SWIPE_ACTION("episode_swipe_action");
+    EPISODE_SWIPE_ACTION("episode_swipe_action"),
+    MULTI_SELECT("multi_select");
 
     fun skipTracking() = this in listOf(AUTO_PLAY, AUTO_PAUSE)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -428,6 +428,7 @@ open class PlaybackManager @Inject constructor(
             SourceView.DISCOVER_RANKED_LIST,
             SourceView.FULL_SCREEN_VIDEO,
             SourceView.MINIPLAYER,
+            SourceView.MULTI_SELECT,
             SourceView.ONBOARDING_RECOMMENDATIONS,
             SourceView.ONBOARDING_RECOMMENDATIONS_SEARCH,
             SourceView.PODCAST_LIST,

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/ShareDialog.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/ShareDialog.kt
@@ -29,6 +29,8 @@ class ShareDialog(
         }
     }
 
+    // If the share dialog is not appearing, make sure you're setting an appropriate fragmentManager
+    // when constructing this class, i.e., you might need a parentFragmentManager instead of a childFragmentManager
     fun show(sourceView: SourceView) {
         if (fragmentManager == null || context == null) {
             return

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBottomSheet.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBottomSheet.kt
@@ -85,7 +85,7 @@ class MultiSelectBottomSheet : BaseDialogFragment() {
     }
 
     private fun onClick(item: MultiSelectAction) {
-        multiSelectHelper?.onMenuItemSelected(item.actionId, resources, childFragmentManager)
+        multiSelectHelper?.onMenuItemSelected(item.actionId, resources, parentFragmentManager)
         dismiss()
     }
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodeAction.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodeAction.kt
@@ -163,7 +163,11 @@ sealed class MultiSelectEpisodeAction(
                 }
                 R.id.menu_playnext -> return PlayNext
                 R.id.menu_playlast -> return PlayLast
-                R.id.menu_share -> if (selected.size == 1) return Share
+                R.id.menu_share -> {
+                    if (selected.size == 1 &&
+                        selected.firstOrNull() is PodcastEpisode
+                    ) return Share
+                }
             }
 
             return null

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodeAction.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodeAction.kt
@@ -60,6 +60,13 @@ sealed class MultiSelectEpisodeAction(
         R.drawable.ic_delete,
         "delete"
     )
+    object Share : MultiSelectEpisodeAction(
+        groupId = R.id.menu_share,
+        actionId = R.id.menu_share,
+        title = LR.string.share,
+        iconRes = IR.drawable.ic_share,
+        analyticsValue = "share",
+    )
     object MarkAsUnplayed : MultiSelectEpisodeAction(
         R.id.menu_mark_played,
         UR.id.menu_markasunplayed,
@@ -104,7 +111,7 @@ sealed class MultiSelectEpisodeAction(
     )
 
     companion object {
-        val STANDARD = listOf(Download, Archive, MarkAsPlayed, PlayNext, PlayLast, Star)
+        val STANDARD = listOf(Download, Archive, MarkAsPlayed, PlayNext, PlayLast, Star, Share)
         val ALL = STANDARD + listOf(DeleteDownload, DeleteUserEpisode, MarkAsUnplayed, Unstar, Unarchive)
         val STANDARD_BY_ID = STANDARD.associateBy { it.actionId }
         val ALL_BY_ID = ALL.associateBy { it.actionId }
@@ -156,6 +163,7 @@ sealed class MultiSelectEpisodeAction(
                 }
                 R.id.menu_playnext -> return PlayNext
                 R.id.menu_playlast -> return PlayLast
+                R.id.menu_share -> if (selected.size == 1) return Share
             }
 
             return null

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -6,7 +6,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.map
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -18,8 +20,10 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.utils.combineLatest
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.R
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
+import au.com.shiftyjelly.pocketcasts.views.dialog.ShareDialog
 import au.com.shiftyjelly.pocketcasts.views.helper.CloudDeleteHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.DeleteState
 import io.reactivex.BackpressureStrategy
@@ -42,6 +46,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
     val podcastManager: PodcastManager,
     val playbackManager: PlaybackManager,
     val downloadManager: DownloadManager,
+    val analyticsTracker: AnalyticsTrackerWrapper,
     val settings: Settings,
     private val episodeAnalytics: EpisodeAnalytics
 ) : MultiSelectHelper<BaseEpisode>() {
@@ -75,6 +80,10 @@ class MultiSelectEpisodesHelper @Inject constructor(
             }
             R.id.menu_delete -> {
                 delete(resources, fragmentManager)
+                true
+            }
+            R.id.menu_share -> {
+                share(fragmentManager)
                 true
             }
             R.id.menu_download -> {
@@ -379,6 +388,41 @@ class MultiSelectEpisodesHelper @Inject constructor(
             closeMultiSelect()
         }
         CloudDeleteHelper.getDeleteDialog(episodes, deleteState, deleteFunction, resources).show(fragmentManager, "delete_warning")
+    }
+
+    fun share(fragmentManager: FragmentManager) {
+
+        val episode = selectedList.let { list ->
+            if (list.size != 1) {
+                LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Can only share one episode, but trying to share ${selectedList.size} episodes when multi selecting")
+                return
+            } else {
+                list.first()
+            }
+        }
+
+        if (episode !is PodcastEpisode) {
+            LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Can only share a ${PodcastEpisode::class.java.simpleName}")
+            return
+        }
+
+        launch {
+            val podcast = podcastManager.findPodcastByUuidSuspend(episode.podcastUuid) ?: run {
+                LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Share failed because unable to find podcast from uuid")
+                return@launch
+            }
+
+            ShareDialog(
+                episode = episode,
+                podcast = podcast,
+                fragmentManager = fragmentManager,
+                context = context,
+                shouldShowPodcast = false,
+                analyticsTracker = analyticsTracker,
+            ).show(sourceView = SourceView.MULTI_SELECT)
+        }
+
+        closeMultiSelect()
     }
 
     fun removeFromUpNext(resources: Resources) {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.views.multiselect
 
 import android.content.res.Resources
+import android.widget.Toast
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.map
@@ -403,6 +404,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
 
         if (episode !is PodcastEpisode) {
             LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Can only share a ${PodcastEpisode::class.java.simpleName}")
+            Toast.makeText(context, LR.string.podcasts_share_failed, Toast.LENGTH_SHORT).show()
             return
         }
 

--- a/modules/services/views/src/main/res/menu/menu_multiselect.xml
+++ b/modules/services/views/src/main/res/menu/menu_multiselect.xml
@@ -13,6 +13,10 @@
         android:icon="@drawable/ic_delete"
         android:title="@string/delete"
         app:showAsAction="always" />
+    <item android:id="@+id/menu_share"
+        android:icon="@drawable/ic_share"
+        android:title="@string/share"
+        app:showAsAction="always" />
     <item android:id="@+id/menu_mark_played"
         android:icon="@drawable/ic_markasplayed"
         android:title="@string/mark_as_played"


### PR DESCRIPTION
## Description

This adds a share option to the multiselect menus as requested in the https://github.com/Automattic/pocket-casts-android/discussions/1168 discussion.

Related iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/969

## Testing Instructions

### Showing the new option for previous users

1. Checkout and run `main`
2. Go to any podcast and long press any episode
3. Tap "..."
4. Tap the pencil icon
5. Reorder and tap "Done"
6. Run this branch
7. Go to any podcast and long press an episode
8. Tap "..."
9. ✅ "Share" should appear

### Testing share action

2. Go to any podcast and long press a single episode
3. Tap "..."
4. Tap "Share"
5. ✅ The share sheet should appear
6. Dismiss it
7. Select more episodes
8. ✅ "Share" should not be available (only sharing a single episode is available)

### Reordering

2. Go to any podcast and long press a single episode
3. Tap "..."
4. Tap the pencil icon
5. Move "Share" to be one of the first two actions
6. Tap "Done"
7. ✅ Share should be displayed on the action bar
8. Tap it
9. ✅ The share sheet should appear
10. Dismiss it
11. Select more episodes
12. ✅ The share button will be replaced by the next available action
13. Tap "..." and then the pencil icon
14. Move "Share" to below
15. Tap "Done"
16. ✅ "Share" should not be available as you have multiple selected episodes

### User Episodes

1. Go to Files and long press one of your files
2. ✅ Observe that the share option does not appear in either the toolbar or the overflow menu

### Events

#### Sharing
3. Go to any podcast and long press any episode
4. Tap Share
5. ✅ When showing the share sheet you should see a `podcast_shared` event with `"type": "episode"` and `"source": "multi_select"]`.

#### Reordering
1. To to any podcast and long press any episode
2. Tap "..." and then the pencil icon
3. Move the share action
4. ✅ You should see a `multi_select_view_overflow_menu_rearrange_action_moved` event with an `"action": "share"` property.

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/4656348/502e2950-bb72-4068-87c2-a9b9037cd95b

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
