### PR TITLE
Add logging for network selected by networking rules

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/networking/PocketCastsNetworkingRules.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/networking/PocketCastsNetworkingRules.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.wear.networking
 
 import androidx.annotation.VisibleForTesting
 import au.com.shiftyjelly.pocketcasts.BuildConfig
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.google.android.horologist.networks.data.NetworkInfo
 import com.google.android.horologist.networks.data.NetworkStatus
 import com.google.android.horologist.networks.data.NetworkType
@@ -46,6 +47,8 @@ object PocketCastsNetworkingRules : NetworkingRules {
             else -> {
                 networks.networks.prefer(NetworkType.Wifi)
             }
+        }.also { networkStatus ->
+            LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Preferred network according to networking rules: $networkStatus")
         }
 
     private fun getPreferredNetworkForMedia(


### PR DESCRIPTION
## Description
We've had a few reports of issues downloading episodes on the watch. We're using the horologist network awareness library for downloads, and this PR logs which network is selected by that library. My thinking is that it could be helpful to see in the logs what network is being selected when the user reports that downloads are failing.

Fixes # <!-- issue number, if applicable -->

## Testing Instructions
1. Download an episode in the watch app
2. Verify that the "Preferred network according to networking rules..." line appears in the logs

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews