### PR TITLE
Fix max icons count in episodes multi-select

### DIFF
--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -51,7 +51,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
     val settings: Settings,
     private val episodeAnalytics: EpisodeAnalytics
 ) : MultiSelectHelper<BaseEpisode>() {
-    override val maxToolbarIcons = 2
+    override val maxToolbarIcons = 4
 
     override val toolbarActions: LiveData<List<MultiSelectAction>> = settings.multiSelectItemsObservable
         .toFlowable(BackpressureStrategy.LATEST)


### PR DESCRIPTION
## Description

This fixes the max icons count for episodes multi-select.

Fixes #1199

## Testing Instructions

- Open a podcast
- Long press an episode
- ✅ Notice that multi-select toolbar appears with 4 icons

## Screenshots or Screencast 
<img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/279b300f-407e-4369-aeb0-85ff4944a594"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
