### PR TITLE
Enable swipe up in now playing landscape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Bug Fixes:
     *   Added audio ducking as an option when playing over notifications
         ([#1009](https://github.com/Automattic/pocket-casts-android/pull/1009))
+    *   Fixed swiping to open Up Next queue in landscape and on foldables
+        ([#1209](https://github.com/Automattic/pocket-casts-android/pull/1209))
 
 7.44
 -----

--- a/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
@@ -10,411 +10,426 @@
             type="au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel.PlayerHeader" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/playerGroup"
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:theme="@style/PlayerTheme"
-        android:background="@{viewModel.backgroundColor}"
-        android:clipChildren="false"
-        android:clipToPadding="false">
+        android:fillViewport="true">
 
-        <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/firstPage"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintGuide_begin="500dp"
-            android:orientation="horizontal" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/playerGroup"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:theme="@style/PlayerTheme"
+            android:background="@{viewModel.backgroundColor}"
+            android:clipChildren="false"
+            android:clipToPadding="false">
 
-        <ImageView
-            android:id="@+id/artwork"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:layout_constraintWidth_max="192dp"
-            app:layout_constraintHeight_max="192dp"
-            android:background="@drawable/round_corners_8dp"
-            android:outlineProvider="background"
-            android:visibility="@{viewModel.isPodcastArtworkVisible()}"
-            tools:src="@tools:sample/avatars"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            android:importantForAccessibility="no"
-            app:layout_constraintDimensionRatio="W,1:1"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toTopOf="@+id/shelf" />
-
-        <ImageView
-            android:id="@+id/chapterArtwork"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:background="@drawable/round_corners_8dp"
-            android:outlineProvider="background"
-            android:visibility="@{viewModel.isChapterArtworkVisible()}"
-            tools:src="@tools:sample/avatars"
-            android:importantForAccessibility="no"
-            app:layout_constraintDimensionRatio="W,1:1"
-            app:layout_constraintStart_toStartOf="@id/artwork"
-            app:layout_constraintTop_toTopOf="@id/artwork"
-            app:layout_constraintBottom_toBottomOf="@id/artwork"
-            app:layout_constraintEnd_toEndOf="@id/artwork" />
-
-        <FrameLayout
-            android:id="@+id/chapterUrl"
-            android:layout_width="36dp"
-            android:layout_height="36dp"
-            android:layout_gravity="center_vertical"
-            app:showIfPresent="@{viewModel.chapter.url}"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:layout_marginEnd="8dp"
-            android:layout_marginTop="8dp"
-            app:layout_constraintTop_toTopOf="@id/artwork"
-            app:layout_constraintEnd_toEndOf="@id/artwork">
-
-            <ImageView
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_gravity="center"
-                android:src="@drawable/ic_link_back" />
-
-            <ImageView
-                android:layout_width="20dp"
-                android:layout_height="20dp"
-                android:layout_gravity="center"
-                android:src="@drawable/ic_link" />
-        </FrameLayout>
-
-        <au.com.shiftyjelly.pocketcasts.player.view.video.VideoView
-            android:id="@+id/videoView"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:visibility="@{viewModel.isVideoVisible()}"
-            app:layout_constraintStart_toStartOf="@id/artwork"
-            app:layout_constraintTop_toTopOf="@id/artwork"
-            app:layout_constraintBottom_toBottomOf="@id/artwork"
-            app:layout_constraintEnd_toEndOf="@id/artwork" />
-
-        <TextView
-            android:id="@+id/episodeTitle"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
-            android:ellipsize="end"
-            android:fontFamily="sans-serif-medium"
-            android:gravity="center"
-            android:includeFontPadding="false"
-            android:lineSpacingMultiplier="1.2"
-            android:maxLines="2"
-            android:text="@{viewModel.title}"
-            android:textColor="#FFFFFFFF"
-            android:textSize="18sp"
-            android:layout_marginTop="16dp"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/artwork"
-            app:layout_constraintBottom_toTopOf="@+id/chapterSummary"
-            tools:text="@tools:sample/lorem" />
-
-        <TextView
-            android:id="@+id/chapterSummary"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
-            android:gravity="center"
-            android:text="@{viewModel.chapterSummary}"
-            android:textAppearance="?attr/textCaption"
-            android:visibility="@{viewModel.isChaptersPresent}"
-            app:layout_constraintStart_toStartOf="@id/episodeTitle"
-            app:layout_constraintEnd_toEndOf="@id/episodeTitle"
-            app:layout_constraintBottom_toTopOf="@+id/seekBar"
-            app:layout_constraintTop_toBottomOf="@id/episodeTitle"
-            tools:text="@tools:sample/lorem" />
-
-        <ImageButton
-            android:id="@+id/previousChapter"
-            android:layout_width="44dp"
-            android:layout_height="44dp"
-            android:src="@drawable/ic_chapter_skipbackwards"
-            android:layout_marginStart="8dp"
-            android:alpha="@{viewModel.isFirstChapter ? 0.5f : 1f}"
-            android:enabled="@{!viewModel.isFirstChapter}"
-            app:layout_constraintStart_toStartOf="@id/episodeTitle"
-            app:layout_constraintTop_toTopOf="@+id/episodeTitle"
-            app:layout_constraintBottom_toBottomOf="@+id/episodeTitle"
-            android:contentDescription="@string/player_action_previous_chapter"
-            android:visibility="@{viewModel.isChaptersPresent}"
-            android:background="?android:attr/actionBarItemBackground" />
-
-        <ImageButton
-            android:id="@+id/nextChapter"
-            android:layout_width="44dp"
-            android:layout_height="44dp"
-            android:src="@drawable/ic_chapter_skipforward"
-            android:layout_marginEnd="8dp"
-            android:alpha="@{viewModel.isLastChapter ? 0.5f : 1f}"
-            android:enabled="@{!viewModel.isLastChapter}"
-            android:contentDescription="@string/player_action_next_chapter"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@+id/episodeTitle"
-            app:layout_constraintBottom_toBottomOf="@+id/episodeTitle"
-            android:visibility="@{viewModel.isChaptersPresent}"
-            android:background="?android:attr/actionBarItemBackground" />
-
-        <au.com.shiftyjelly.pocketcasts.player.view.ChapterProgressCircle
-            android:layout_width="30dp"
-            android:layout_height="30dp"
-            android:visibility="@{viewModel.isChaptersPresent}"
-            app:progress="@{viewModel.chapter}"
-            app:layout_constraintStart_toStartOf="@+id/nextChapter"
-            app:layout_constraintEnd_toEndOf="@+id/nextChapter"
-            app:layout_constraintTop_toTopOf="@+id/nextChapter"
-            app:layout_constraintBottom_toBottomOf="@+id/nextChapter" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            tools:text="9m"
-            app:textRemaining="@{viewModel.chapter}"
-            android:layout_marginTop="6dp"
-            android:textAppearance="@style/H70"
-            android:textColor="@color/white"
-            android:alpha="0.4"
-            app:layout_constraintStart_toStartOf="@+id/nextChapter"
-            app:layout_constraintEnd_toEndOf="@+id/nextChapter"
-            app:layout_constraintTop_toBottomOf="@+id/nextChapter" />
-
-        <au.com.shiftyjelly.pocketcasts.player.view.PlayerSeekBar
-            android:id="@+id/seekBar"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="10dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/episodeTitle"
-            app:layout_constraintBottom_toTopOf="@+id/largePlayButton"
-            app:layout_constraintTop_toBottomOf="@id/chapterSummary"
-            app:duration="@{viewModel.durationMs}"
-            app:position="@{viewModel.positionMs}"
-            app:theme="@{viewModel.theme}"
-            app:tintColor="@{viewModel.iconTintColor}"
-            app:bufferedUpTo="@{viewModel.bufferedUpToMs}"
-            app:isBuffering="@{viewModel.isBuffering}" />
-
-        <au.com.shiftyjelly.pocketcasts.views.buttons.AnimatedPlayButton
-            android:id="@+id/largePlayButton"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:icon_tint="?attr/player_contrast_06"
-            tools:src="@tools:sample/avatars"
-            android:layout_marginBottom="12dp"
-            app:layout_constraintWidth_min="44dp"
-            app:layout_constraintWidth_max="90dp"
-            app:layout_constraintDimensionRatio="1:1"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/episodeTitle"
-            app:layout_constraintTop_toBottomOf="@id/seekBar"
-            app:layout_constraintBottom_toTopOf="@+id/shelf" />
-
-        <com.airbnb.lottie.LottieAnimationView
-            android:id="@+id/skipForward"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_marginEnd="8dp"
-            android:scaleX="-1"
-            android:scaleType="centerInside"
-            android:background="?android:attr/selectableItemBackgroundBorderless"
-            tools:src="@tools:sample/avatars"
-            app:circle="@{true}"
-            android:contentDescription="@string/skip_forward"
-            app:layout_constraintBottom_toBottomOf="@+id/largePlayButton"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/largePlayButton"
-            app:layout_constraintTop_toTopOf="@+id/largePlayButton"
-            app:lottie_rawRes="@raw/skip_button" />
-
-        <TextView
-            android:id="@+id/jumpForwardText"
-            android:layout_width="45dp"
-            android:layout_height="53dp"
-            android:gravity="center"
-            android:includeFontPadding="false"
-            android:fontFamily="sans-serif-medium"
-            android:paddingTop="8dp"
-            android:textColor="#FFFFFF"
-            android:importantForAccessibility="no"
-            android:textSize="15sp"
-            android:text="@{``+viewModel.skipForwardInSecs}"
-            tools:text="30"
-            app:layout_constraintStart_toStartOf="@+id/skipForward"
-            app:layout_constraintEnd_toEndOf="@+id/skipForward"
-            app:layout_constraintTop_toTopOf="@+id/skipForward"
-            app:layout_constraintBottom_toBottomOf="@+id/skipForward" />
-
-        <com.airbnb.lottie.LottieAnimationView
-            android:id="@+id/skipBack"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_marginStart="8dp"
-            android:scaleType="centerInside"
-            android:background="?android:attr/selectableItemBackgroundBorderless"
-            tools:src="@tools:sample/avatars"
-            app:circle="@{true}"
-            android:contentDescription="@string/skip_back"
-            app:layout_constraintBottom_toBottomOf="@+id/largePlayButton"
-            app:layout_constraintEnd_toStartOf="@+id/largePlayButton"
-            app:layout_constraintStart_toStartOf="@id/episodeTitle"
-            app:layout_constraintTop_toTopOf="@+id/largePlayButton"
-            app:lottie_rawRes="@raw/skip_button" />
-
-        <TextView
-            android:id="@+id/skipBackText"
-            android:layout_width="45dp"
-            android:layout_height="53dp"
-            android:gravity="center"
-            android:includeFontPadding="false"
-            android:fontFamily="sans-serif-medium"
-            android:paddingTop="8dp"
-            android:textColor="#FFFFFF"
-            android:importantForAccessibility="no"
-            android:textSize="15sp"
-            android:text="@{``+viewModel.skipBackwardInSecs}"
-            tools:text="15"
-            app:layout_constraintStart_toStartOf="@+id/skipBack"
-            app:layout_constraintEnd_toEndOf="@+id/skipBack"
-            app:layout_constraintTop_toTopOf="@+id/skipBack"
-            app:layout_constraintBottom_toBottomOf="@+id/skipBack" />
-
-        <LinearLayout
-            android:id="@+id/shelf"
-            android:layout_width="0dp"
-            android:layout_height="56dp"
-            android:orientation="horizontal"
-            android:background="@drawable/shelf"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginStart="20dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginTop="30dp"
-            android:layout_marginBottom="16dp"
-            android:paddingLeft="8dp"
-            android:paddingRight="8dp"
-            android:weightSum="5"
-            android:gravity="center">
-
-            <ImageButton
-                android:id="@+id/effects"
-                android:layout_width="0dp"
-                android:layout_height="48dp"
-                android:layout_marginBottom="2dp"
-                android:layout_weight="1"
-                android:background="?android:attr/actionBarItemBackground"
-                android:contentDescription="@string/player_effects"
-                android:scaleX="1.2"
-                android:scaleY="1.2"
-                app:srcCompat="@drawable/ic_effects_off"
-                app:tint="?attr/player_contrast_03" />
-
-            <com.airbnb.lottie.LottieAnimationView
-                android:id="@+id/sleep"
-                android:layout_width="0dp"
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/firstPage"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:background="?android:attr/actionBarItemBackground"
-                android:clickable="true"
-                android:contentDescription="@string/player_sleep_timer"
-                android:focusable="true"
-                android:scaleType="centerInside"
-                app:lottie_loop="true"
-                app:lottie_progress="0.5"
-                app:lottie_rawRes="@raw/sleep_button"
-                app:play="@{viewModel.isSleepRunning}" />
+                app:layout_constraintGuide_begin="500dp"
+                android:orientation="horizontal" />
 
-            <ImageButton
-                android:id="@+id/star"
+            <ImageView
+                android:id="@+id/artwork"
                 android:layout_width="0dp"
-                android:layout_height="48dp"
-                android:layout_weight="1"
-                android:background="?android:attr/actionBarItemBackground"
-                android:contentDescription="@string/player_star"
-                android:scaleX="1.2"
-                android:scaleY="1.2"
-                app:tint="?attr/player_contrast_03" />
+                android:layout_height="0dp"
+                app:layout_constraintWidth_max="192dp"
+                app:layout_constraintHeight_max="192dp"
+                android:background="@drawable/round_corners_8dp"
+                android:outlineProvider="background"
+                android:visibility="@{viewModel.isPodcastArtworkVisible()}"
+                tools:src="@tools:sample/avatars"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="16dp"
+                android:importantForAccessibility="no"
+                app:layout_constraintDimensionRatio="W,1:1"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toTopOf="@+id/shelf" />
 
-            <ImageButton
-                android:id="@+id/podcast"
-                android:contentDescription="@string/go_to_podcast"
-                app:srcCompat="@drawable/ic_goto_32"
-                app:tint="?attr/player_contrast_03"
-                style="@style/shelf_item" />
-
-            <ImageButton
-                android:id="@+id/share"
-                android:contentDescription="@string/share_podcast"
-                app:srcCompat="@drawable/ic_share"
-                app:tint="?attr/player_contrast_03"
-                style="@style/shelf_item" />
+            <ImageView
+                android:id="@+id/chapterArtwork"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:background="@drawable/round_corners_8dp"
+                android:outlineProvider="background"
+                android:visibility="@{viewModel.isChapterArtworkVisible()}"
+                tools:src="@tools:sample/avatars"
+                android:importantForAccessibility="no"
+                app:layout_constraintDimensionRatio="W,1:1"
+                app:layout_constraintStart_toStartOf="@id/artwork"
+                app:layout_constraintTop_toTopOf="@id/artwork"
+                app:layout_constraintBottom_toBottomOf="@id/artwork"
+                app:layout_constraintEnd_toEndOf="@id/artwork" />
 
             <FrameLayout
-                android:id="@+id/cast"
-                android:layout_width="0dp"
-                android:layout_height="48dp"
-                android:layout_weight="1">
+                android:id="@+id/chapterUrl"
+                android:layout_width="36dp"
+                android:layout_height="36dp"
+                android:layout_gravity="center_vertical"
+                app:showIfPresent="@{viewModel.chapter.url}"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:layout_marginEnd="8dp"
+                android:layout_marginTop="8dp"
+                app:layout_constraintTop_toTopOf="@id/artwork"
+                app:layout_constraintEnd_toEndOf="@id/artwork">
 
-                <androidx.mediarouter.app.MediaRouteButton
-                    android:id="@+id/castButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:mediaRouteTypes="user" />
+                <ImageView
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_gravity="center"
+                    android:src="@drawable/ic_link_back" />
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:layout_gravity="center"
+                    android:src="@drawable/ic_link" />
             </FrameLayout>
 
-            <ImageButton
-                android:id="@+id/played"
-                android:contentDescription="@string/mark_as_played"
-                app:srcCompat="@drawable/ic_markasplayed"
-                app:tint="?attr/player_contrast_03"
-                style="@style/shelf_item" />
-
-            <ImageButton
-                android:id="@+id/bookmark"
-                android:contentDescription="@string/add_bookmark"
-                app:srcCompat="@drawable/ic_bookmark"
-                app:tint="?attr/player_contrast_03"
-                style="@style/shelf_item" />
-
-            <ImageButton
-                android:id="@+id/archive"
-                android:contentDescription="@string/archive_episode"
-                app:srcCompat="@drawable/ic_archive"
-                app:tint="?attr/player_contrast_03"
-                style="@style/shelf_item" />
-
-            <ImageButton
-                android:id="@+id/download"
-                android:contentDescription="@string/download"
-                app:srcCompat="@drawable/ic_download"
-                app:tint="?attr/player_contrast_03"
-                style="@style/shelf_item" />
-
-            <ImageButton
-                android:id="@+id/playerActions"
+            <au.com.shiftyjelly.pocketcasts.player.view.video.VideoView
+                android:id="@+id/videoView"
                 android:layout_width="0dp"
-                android:layout_height="48dp"
-                android:layout_weight="1"
-                android:background="?android:attr/actionBarItemBackground"
-                android:contentDescription="@string/more"
-                android:scaleX="1.2"
-                android:scaleY="1.2"
-                app:srcCompat="@drawable/ic_more"
-                app:tint="?attr/player_contrast_03" />
+                android:layout_height="0dp"
+                android:visibility="@{viewModel.isVideoVisible()}"
+                app:layout_constraintStart_toStartOf="@id/artwork"
+                app:layout_constraintTop_toTopOf="@id/artwork"
+                app:layout_constraintBottom_toBottomOf="@id/artwork"
+                app:layout_constraintEnd_toEndOf="@id/artwork" />
 
-        </LinearLayout>
+            <TextView
+                android:id="@+id/episodeTitle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:ellipsize="end"
+                android:fontFamily="sans-serif-medium"
+                android:gravity="center"
+                android:includeFontPadding="false"
+                android:lineSpacingMultiplier="1.2"
+                android:maxLines="2"
+                android:text="@{viewModel.title}"
+                android:textColor="#FFFFFFFF"
+                android:textSize="18sp"
+                android:layout_marginTop="16dp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/artwork"
+                app:layout_constraintBottom_toTopOf="@+id/chapterSummary"
+                tools:text="@tools:sample/lorem" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <TextView
+                android:id="@+id/chapterSummary"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:gravity="center"
+                android:text="@{viewModel.chapterSummary}"
+                android:textAppearance="?attr/textCaption"
+                android:visibility="@{viewModel.isChaptersPresent}"
+                app:layout_constraintStart_toStartOf="@id/episodeTitle"
+                app:layout_constraintEnd_toEndOf="@id/episodeTitle"
+                app:layout_constraintBottom_toTopOf="@+id/seekBar"
+                app:layout_constraintTop_toBottomOf="@id/episodeTitle"
+                tools:text="@tools:sample/lorem" />
+
+            <ImageButton
+                android:id="@+id/previousChapter"
+                android:layout_width="44dp"
+                android:layout_height="44dp"
+                android:src="@drawable/ic_chapter_skipbackwards"
+                android:layout_marginStart="8dp"
+                android:alpha="@{viewModel.isFirstChapter ? 0.5f : 1f}"
+                android:enabled="@{!viewModel.isFirstChapter}"
+                app:layout_constraintStart_toStartOf="@id/episodeTitle"
+                app:layout_constraintTop_toTopOf="@+id/episodeTitle"
+                app:layout_constraintBottom_toBottomOf="@+id/episodeTitle"
+                android:contentDescription="@string/player_action_previous_chapter"
+                android:visibility="@{viewModel.isChaptersPresent}"
+                android:background="?android:attr/actionBarItemBackground" />
+
+            <ImageButton
+                android:id="@+id/nextChapter"
+                android:layout_width="44dp"
+                android:layout_height="44dp"
+                android:src="@drawable/ic_chapter_skipforward"
+                android:layout_marginEnd="8dp"
+                android:alpha="@{viewModel.isLastChapter ? 0.5f : 1f}"
+                android:enabled="@{!viewModel.isLastChapter}"
+                android:contentDescription="@string/player_action_next_chapter"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/episodeTitle"
+                app:layout_constraintBottom_toBottomOf="@+id/episodeTitle"
+                android:visibility="@{viewModel.isChaptersPresent}"
+                android:background="?android:attr/actionBarItemBackground" />
+
+            <au.com.shiftyjelly.pocketcasts.player.view.ChapterProgressCircle
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:visibility="@{viewModel.isChaptersPresent}"
+                app:progress="@{viewModel.chapter}"
+                app:layout_constraintStart_toStartOf="@+id/nextChapter"
+                app:layout_constraintEnd_toEndOf="@+id/nextChapter"
+                app:layout_constraintTop_toTopOf="@+id/nextChapter"
+                app:layout_constraintBottom_toBottomOf="@+id/nextChapter" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="9m"
+                app:textRemaining="@{viewModel.chapter}"
+                android:layout_marginTop="6dp"
+                android:textAppearance="@style/H70"
+                android:textColor="@color/white"
+                android:alpha="0.4"
+                app:layout_constraintStart_toStartOf="@+id/nextChapter"
+                app:layout_constraintEnd_toEndOf="@+id/nextChapter"
+                app:layout_constraintTop_toBottomOf="@+id/nextChapter" />
+
+            <au.com.shiftyjelly.pocketcasts.player.view.PlayerSeekBar
+                android:id="@+id/seekBar"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="10dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/episodeTitle"
+                app:layout_constraintBottom_toTopOf="@+id/largePlayButton"
+                app:layout_constraintTop_toBottomOf="@id/chapterSummary"
+                app:duration="@{viewModel.durationMs}"
+                app:position="@{viewModel.positionMs}"
+                app:theme="@{viewModel.theme}"
+                app:tintColor="@{viewModel.iconTintColor}"
+                app:bufferedUpTo="@{viewModel.bufferedUpToMs}"
+                app:isBuffering="@{viewModel.isBuffering}" />
+
+            <au.com.shiftyjelly.pocketcasts.views.buttons.AnimatedPlayButton
+                android:id="@+id/largePlayButton"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:icon_tint="?attr/player_contrast_06"
+                tools:src="@tools:sample/avatars"
+                android:layout_marginBottom="12dp"
+                app:layout_constraintWidth_min="44dp"
+                app:layout_constraintWidth_max="90dp"
+                app:layout_constraintDimensionRatio="1:1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/episodeTitle"
+                app:layout_constraintTop_toBottomOf="@id/seekBar"
+                app:layout_constraintBottom_toTopOf="@+id/shelf" />
+
+            <com.airbnb.lottie.LottieAnimationView
+                android:id="@+id/skipForward"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginEnd="8dp"
+                android:scaleX="-1"
+                android:scaleType="centerInside"
+                android:background="?android:attr/selectableItemBackgroundBorderless"
+                tools:src="@tools:sample/avatars"
+                app:circle="@{true}"
+                android:contentDescription="@string/skip_forward"
+                app:layout_constraintBottom_toBottomOf="@+id/largePlayButton"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/largePlayButton"
+                app:layout_constraintTop_toTopOf="@+id/largePlayButton"
+                app:lottie_rawRes="@raw/skip_button" />
+
+            <TextView
+                android:id="@+id/jumpForwardText"
+                android:layout_width="45dp"
+                android:layout_height="53dp"
+                android:gravity="center"
+                android:includeFontPadding="false"
+                android:fontFamily="sans-serif-medium"
+                android:paddingTop="8dp"
+                android:textColor="#FFFFFF"
+                android:importantForAccessibility="no"
+                android:textSize="15sp"
+                android:text="@{``+viewModel.skipForwardInSecs}"
+                tools:text="30"
+                app:layout_constraintStart_toStartOf="@+id/skipForward"
+                app:layout_constraintEnd_toEndOf="@+id/skipForward"
+                app:layout_constraintTop_toTopOf="@+id/skipForward"
+                app:layout_constraintBottom_toBottomOf="@+id/skipForward" />
+
+            <com.airbnb.lottie.LottieAnimationView
+                android:id="@+id/skipBack"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginStart="8dp"
+                android:scaleType="centerInside"
+                android:background="?android:attr/selectableItemBackgroundBorderless"
+                tools:src="@tools:sample/avatars"
+                app:circle="@{true}"
+                android:contentDescription="@string/skip_back"
+                app:layout_constraintBottom_toBottomOf="@+id/largePlayButton"
+                app:layout_constraintEnd_toStartOf="@+id/largePlayButton"
+                app:layout_constraintStart_toStartOf="@id/episodeTitle"
+                app:layout_constraintTop_toTopOf="@+id/largePlayButton"
+                app:lottie_rawRes="@raw/skip_button" />
+
+            <TextView
+                android:id="@+id/skipBackText"
+                android:layout_width="45dp"
+                android:layout_height="53dp"
+                android:gravity="center"
+                android:includeFontPadding="false"
+                android:fontFamily="sans-serif-medium"
+                android:paddingTop="8dp"
+                android:textColor="#FFFFFF"
+                android:importantForAccessibility="no"
+                android:textSize="15sp"
+                android:text="@{``+viewModel.skipBackwardInSecs}"
+                tools:text="15"
+                app:layout_constraintStart_toStartOf="@+id/skipBack"
+                app:layout_constraintEnd_toEndOf="@+id/skipBack"
+                app:layout_constraintTop_toTopOf="@+id/skipBack"
+                app:layout_constraintBottom_toBottomOf="@+id/skipBack" />
+
+            <LinearLayout
+                android:id="@+id/shelf"
+                android:layout_width="0dp"
+                android:layout_height="56dp"
+                android:orientation="horizontal"
+                android:background="@drawable/shelf"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:layout_marginStart="20dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginTop="30dp"
+                android:layout_marginBottom="16dp"
+                android:paddingLeft="8dp"
+                android:paddingRight="8dp"
+                android:weightSum="5"
+                android:gravity="center">
+
+                <ImageButton
+                    android:id="@+id/effects"
+                    android:layout_width="0dp"
+                    android:layout_height="48dp"
+                    android:layout_marginBottom="2dp"
+                    android:layout_weight="1"
+                    android:background="?android:attr/actionBarItemBackground"
+                    android:contentDescription="@string/player_effects"
+                    android:scaleX="1.2"
+                    android:scaleY="1.2"
+                    app:srcCompat="@drawable/ic_effects_off"
+                    app:tint="?attr/player_contrast_03" />
+
+                <com.airbnb.lottie.LottieAnimationView
+                    android:id="@+id/sleep"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:background="?android:attr/actionBarItemBackground"
+                    android:clickable="true"
+                    android:contentDescription="@string/player_sleep_timer"
+                    android:focusable="true"
+                    android:scaleType="centerInside"
+                    app:lottie_loop="true"
+                    app:lottie_progress="0.5"
+                    app:lottie_rawRes="@raw/sleep_button"
+                    app:play="@{viewModel.isSleepRunning}" />
+
+                <ImageButton
+                    android:id="@+id/star"
+                    android:layout_width="0dp"
+                    android:layout_height="48dp"
+                    android:layout_weight="1"
+                    android:background="?android:attr/actionBarItemBackground"
+                    android:contentDescription="@string/player_star"
+                    android:scaleX="1.2"
+                    android:scaleY="1.2"
+                    app:tint="?attr/player_contrast_03" />
+
+                <ImageButton
+                    android:id="@+id/podcast"
+                    android:contentDescription="@string/go_to_podcast"
+                    app:srcCompat="@drawable/ic_goto_32"
+                    app:tint="?attr/player_contrast_03"
+                    style="@style/shelf_item" />
+
+                <ImageButton
+                    android:id="@+id/share"
+                    android:contentDescription="@string/share_podcast"
+                    app:srcCompat="@drawable/ic_share"
+                    app:tint="?attr/player_contrast_03"
+                    style="@style/shelf_item" />
+
+                <FrameLayout
+                    android:id="@+id/cast"
+                    android:layout_width="0dp"
+                    android:layout_height="48dp"
+                    android:layout_weight="1">
+
+                    <androidx.mediarouter.app.MediaRouteButton
+                        android:id="@+id/castButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:mediaRouteTypes="user" />
+                </FrameLayout>
+
+                <ImageButton
+                    android:id="@+id/played"
+                    android:contentDescription="@string/mark_as_played"
+                    app:srcCompat="@drawable/ic_markasplayed"
+                    app:tint="?attr/player_contrast_03"
+                    style="@style/shelf_item" />
+
+                <ImageButton
+                    android:id="@+id/bookmark"
+                    android:contentDescription="@string/add_bookmark"
+                    app:srcCompat="@drawable/ic_bookmark"
+                    app:tint="?attr/player_contrast_03"
+                    style="@style/shelf_item" />
+
+                <ImageButton
+                    android:id="@+id/archive"
+                    android:contentDescription="@string/archive_episode"
+                    app:srcCompat="@drawable/ic_archive"
+                    app:tint="?attr/player_contrast_03"
+                    style="@style/shelf_item" />
+
+                <ImageButton
+                    android:id="@+id/download"
+                    android:contentDescription="@string/download"
+                    app:srcCompat="@drawable/ic_download"
+                    app:tint="?attr/player_contrast_03"
+                    style="@style/shelf_item" />
+
+                <ImageButton
+                    android:id="@+id/playerActions"
+                    android:layout_width="0dp"
+                    android:layout_height="48dp"
+                    android:layout_weight="1"
+                    android:background="?android:attr/actionBarItemBackground"
+                    android:contentDescription="@string/more"
+                    android:scaleX="1.2"
+                    android:scaleY="1.2"
+                    app:srcCompat="@drawable/ic_more"
+                    app:tint="?attr/player_contrast_03" />
+
+            </LinearLayout>
+
+            <View
+                android:id="@+id/topView"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
 
 </layout>


### PR DESCRIPTION
## Description

Fixes: Swiping up to get to "Up Next" doesn't work when unfolded (p1690329518000709-slack-C028JAG44VD)
Test Device : Pixel Fold


## Testing Instructions
1. Open the app on Pixel Fold emulator - landscape mode
3. Play an episode
4. Go to Now Playing
5. Swipe up
6. Notice that Up Next is shown
7. Repeat steps 3-6 after fold/ unfold phone
8. Notice that Up Next is still shown

**  The issue is not limited to foldable devices. Swiping up to get to "Up Next" on Now Playing never worked in landscape mode, and I just enabled it.

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/53b9d9dc-2049-4b81-a9ce-e81b34a5c34c

I also tested that the screen is not shown for Automotive or Android Auto so it does not affect those platforms.

Automotive| Android Auto
----| ----
![Screenshot_20230726_112836](https://github.com/Automattic/pocket-casts-android/assets/1405144/3a6ed7c0-78e8-499a-b480-220eb98a545f)| <img  alt="Screenshot 2023-07-26 at 11 36 25 AM" src="https://github.com/Automattic/pocket-casts-android/assets/1405144/c5f62efa-d661-462b-bef9-a6aae55e275e">



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack