### PR TITLE
Bookmarks - Show on podcast page

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/BookmarksFragment.kt
@@ -50,7 +50,6 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -79,7 +78,6 @@ import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import dagger.hilt.android.AndroidEntryPoint
-import java.util.Calendar
 import java.util.Date
 import java.util.UUID
 import javax.inject.Inject
@@ -466,19 +464,6 @@ private fun LoadingView() {
                 .size(24.dp),
             strokeWidth = 2.dp,
         )
-    }
-}
-
-private fun Bookmark.createdAtDatePattern(): String {
-    val calendar = Calendar.getInstance()
-    val currentYear = calendar.get(Calendar.YEAR)
-    calendar.time = createdAt
-    val createdAtYear = calendar.get(Calendar.YEAR)
-
-    return if (createdAtYear == currentYear) {
-        "MMM d 'at' h:mm a"
-    } else {
-        "MMM d, YYYY 'at' h:mm a"
     }
 }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -16,6 +16,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.TextView
+import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
@@ -40,7 +41,9 @@ import au.com.shiftyjelly.pocketcasts.podcasts.databinding.AdapterEpisodeHeaderB
 import au.com.shiftyjelly.pocketcasts.podcasts.databinding.AdapterPodcastHeaderBinding
 import au.com.shiftyjelly.pocketcasts.podcasts.view.components.PlayButton
 import au.com.shiftyjelly.pocketcasts.podcasts.view.components.StarRatingView
+import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.adapter.TabsViewHolder
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastRatingsViewModel
+import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastViewModel.PodcastTab
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -64,6 +67,7 @@ private val differ: DiffUtil.ItemCallback<Any> = object : DiffUtil.ItemCallback<
     override fun areItemsTheSame(oldItem: Any, newItem: Any): Boolean {
         return when {
             oldItem is Podcast && newItem is Podcast -> true
+            oldItem is PodcastAdapter.TabsHeader && newItem is PodcastAdapter.TabsHeader -> true
             oldItem is PodcastAdapter.EpisodeHeader && newItem is PodcastAdapter.EpisodeHeader -> true
             oldItem is PodcastEpisode && newItem is PodcastEpisode -> oldItem.uuid == newItem.uuid
             oldItem is PodcastAdapter.DividerRow && newItem is PodcastAdapter.DividerRow -> oldItem.groupIndex == newItem.groupIndex
@@ -113,14 +117,20 @@ class PodcastAdapter(
     private val onArtworkLongClicked: (successCallback: () -> Unit) -> Unit,
     private val ratingsViewModel: PodcastRatingsViewModel,
     private val swipeButtonLayoutFactory: SwipeButtonLayoutFactory,
+    private val onTabClicked: (PodcastTab) -> Unit,
 ) : LargeListAdapter<Any, RecyclerView.ViewHolder>(1500, differ) {
 
     data class EpisodeLimitRow(val episodeLimit: Int)
     class DividerRow(val grouping: PodcastGrouping, val groupIndex: Int)
     data class NoEpisodeMessage(val bodyText: String, val showButton: Boolean)
     data class EpisodeHeader(val showingArchived: Boolean, val episodeCount: Int, val archivedCount: Int, val searchTerm: String, val episodeLimit: Int?)
+    data class TabsHeader(
+        val selectedTab: PodcastTab,
+        val onTabClicked: (PodcastTab) -> Unit,
+    )
 
     companion object {
+        private val VIEW_TYPE_TABS = 100
         val VIEW_TYPE_EPISODE_HEADER = R.layout.adapter_episode_header
         val VIEW_TYPE_PODCAST_HEADER = R.layout.adapter_podcast_header
         val VIEW_TYPE_EPISODE_LIMIT_ROW = R.layout.adapter_episode_limit
@@ -148,6 +158,7 @@ class PodcastAdapter(
         val inflater = LayoutInflater.from(parent.context)
         return when (viewType) {
             VIEW_TYPE_PODCAST_HEADER -> PodcastViewHolder(AdapterPodcastHeaderBinding.inflate(inflater, parent, false), this)
+            VIEW_TYPE_TABS -> TabsViewHolder(ComposeView(parent.context), theme)
             VIEW_TYPE_EPISODE_HEADER -> EpisodeHeaderViewHolder(AdapterEpisodeHeaderBinding.inflate(inflater, parent, false), onEpisodesOptionsClicked, onSearchFocus)
             VIEW_TYPE_EPISODE_LIMIT_ROW -> EpisodeLimitViewHolder(inflater.inflate(R.layout.adapter_episode_limit, parent, false))
             VIEW_TYPE_NO_EPISODE -> NoEpisodesViewHolder(inflater.inflate(R.layout.adapter_no_episodes, parent, false))
@@ -167,6 +178,7 @@ class PodcastAdapter(
         when (holder) {
             is EpisodeViewHolder -> bindEpisodeViewHolder(holder, position, fromListUuid)
             is PodcastViewHolder -> bindPodcastViewHolder(holder)
+            is TabsViewHolder -> holder.bind(getItem(position) as TabsHeader)
             is EpisodeHeaderViewHolder -> bindingEpisodeHeaderViewHolder(holder, position)
             is EpisodeLimitViewHolder -> bindEpisodeLimitRow(holder, position)
             is NoEpisodesViewHolder -> bindNoEpisodesMessage(holder, position)
@@ -306,6 +318,7 @@ class PodcastAdapter(
     }
 
     fun setEpisodes(
+        showTab: PodcastTab,
         episodes: List<PodcastEpisode>,
         showingArchived: Boolean,
         episodeCount: Int,
@@ -316,37 +329,65 @@ class PodcastAdapter(
         podcast: Podcast,
         context: Context,
     ) {
-        val grouping = podcast.podcastGrouping
-        val groupingFunction = grouping.sortFunction
-        val episodesPlusLimit: MutableList<Any> = episodes.toMutableList()
-        if (episodeLimit != null && episodeLimitIndex != null && groupingFunction == null) {
-            if (searchTerm.isEmpty() && (podcast.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_DATE_ASC || podcast.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_DATE_DESC)) {
-                episodesPlusLimit.add(episodeLimitIndex, EpisodeLimitRow(episodeLimit))
-            }
-        }
-        if (groupingFunction != null) {
-            val grouped = grouping.formGroups(episodes, podcast, context.resources)
-            episodesPlusLimit.clear()
-
-            grouped.forEachIndexed { index, list ->
-                if (list.isNotEmpty()) {
-                    episodesPlusLimit.add(DividerRow(grouping, index))
-                    episodesPlusLimit.addAll(list)
+        val content = when (showTab) {
+            PodcastTab.EPISODES -> {
+                val grouping = podcast.podcastGrouping
+                val groupingFunction = grouping.sortFunction
+                val episodesPlusLimit: MutableList<Any> = episodes.toMutableList()
+                if (episodeLimit != null && episodeLimitIndex != null && groupingFunction == null) {
+                    if (searchTerm.isEmpty() && (podcast.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_DATE_ASC || podcast.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_DATE_DESC)) {
+                        episodesPlusLimit.add(episodeLimitIndex, EpisodeLimitRow(episodeLimit))
+                    }
                 }
-            }
-        }
-        val content = mutableListOf(Podcast(), EpisodeHeader(showingArchived, episodeCount, archivedCount, searchTerm, if (podcast.overrideGlobalArchive) podcast.autoArchiveEpisodeLimit else null))
-        content.addAll(episodesPlusLimit)
+                if (groupingFunction != null) {
+                    val grouped = grouping.formGroups(episodes, podcast, context.resources)
+                    episodesPlusLimit.clear()
 
-        if (episodes.isEmpty()) {
-            if (searchTerm.isEmpty()) {
-                if (archivedCount == 0) {
-                    content.add(NoEpisodeMessage(context.getString(LR.string.podcast_no_episodes), false))
-                } else {
-                    content.add(NoEpisodeMessage(context.getString(LR.string.podcast_no_episodes_all_archived, archivedCount), true))
+                    grouped.forEachIndexed { index, list ->
+                        if (list.isNotEmpty()) {
+                            episodesPlusLimit.add(DividerRow(grouping, index))
+                            episodesPlusLimit.addAll(list)
+                        }
+                    }
                 }
-            } else {
-                content.add(NoEpisodeMessage(context.getString(LR.string.podcast_no_episodes_matching), false))
+                val content = mutableListOf<Any>().apply {
+                    add(Podcast())
+                    if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+                        add(TabsHeader(PodcastTab.EPISODES, onTabClicked))
+                    }
+                    add(
+                        EpisodeHeader(
+                            showingArchived = showingArchived,
+                            episodeCount = episodeCount,
+                            archivedCount = archivedCount,
+                            searchTerm = searchTerm,
+                            episodeLimit = if (podcast.overrideGlobalArchive) podcast.autoArchiveEpisodeLimit else null
+                        )
+                    )
+                    addAll(episodesPlusLimit)
+                }
+
+                if (episodes.isEmpty()) {
+                    if (searchTerm.isEmpty()) {
+                        if (archivedCount == 0) {
+                            content.add(NoEpisodeMessage(context.getString(LR.string.podcast_no_episodes), false))
+                        } else {
+                            content.add(NoEpisodeMessage(context.getString(LR.string.podcast_no_episodes_all_archived, archivedCount), true))
+                        }
+                    } else {
+                        content.add(NoEpisodeMessage(context.getString(LR.string.podcast_no_episodes_matching), false))
+                    }
+                }
+                content
+            }
+            PodcastTab.BOOKMARKS -> {
+                val content = mutableListOf<Any>().apply {
+                    add(Podcast())
+                    if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+                        add(TabsHeader(PodcastTab.BOOKMARKS, onTabClicked))
+                    }
+                }
+                content
             }
         }
 
@@ -365,6 +406,7 @@ class PodcastAdapter(
             is EpisodeLimitRow -> R.layout.adapter_episode_limit
             is NoEpisodeMessage -> R.layout.adapter_no_episodes
             is DividerRow -> R.layout.adapter_divider_row
+            is TabsHeader -> 100
             else -> R.layout.adapter_episode
         }
     }
@@ -376,6 +418,7 @@ class PodcastAdapter(
             is EpisodeHeader -> Long.MAX_VALUE - 1
             is EpisodeLimitRow -> Long.MAX_VALUE - 2
             is NoEpisodeMessage -> Long.MAX_VALUE - 3
+            is TabsHeader -> Long.MAX_VALUE - 4
             is DividerRow -> item.groupIndex.toLong()
             is PodcastEpisode -> item.adapterId
             else -> throw IllegalStateException("Unknown item type")

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -325,8 +325,6 @@ class PodcastAdapter(
     }
 
     fun setEpisodes(
-        showTab: PodcastTab,
-        bookmarks: List<Bookmark>,
         episodes: List<PodcastEpisode>,
         showingArchived: Boolean,
         episodeCount: Int,
@@ -337,69 +335,67 @@ class PodcastAdapter(
         podcast: Podcast,
         context: Context,
     ) {
-        val content = when (showTab) {
-            PodcastTab.EPISODES -> {
-                val grouping = podcast.podcastGrouping
-                val groupingFunction = grouping.sortFunction
-                val episodesPlusLimit: MutableList<Any> = episodes.toMutableList()
-                if (episodeLimit != null && episodeLimitIndex != null && groupingFunction == null) {
-                    if (searchTerm.isEmpty() && (podcast.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_DATE_ASC || podcast.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_DATE_DESC)) {
-                        episodesPlusLimit.add(episodeLimitIndex, EpisodeLimitRow(episodeLimit))
-                    }
-                }
-                if (groupingFunction != null) {
-                    val grouped = grouping.formGroups(episodes, podcast, context.resources)
-                    episodesPlusLimit.clear()
-
-                    grouped.forEachIndexed { index, list ->
-                        if (list.isNotEmpty()) {
-                            episodesPlusLimit.add(DividerRow(grouping, index))
-                            episodesPlusLimit.addAll(list)
-                        }
-                    }
-                }
-                val content = mutableListOf<Any>().apply {
-                    add(Podcast())
-                    if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-                        add(TabsHeader(PodcastTab.EPISODES, onTabClicked))
-                    }
-                    add(
-                        EpisodeHeader(
-                            showingArchived = showingArchived,
-                            episodeCount = episodeCount,
-                            archivedCount = archivedCount,
-                            searchTerm = searchTerm,
-                            episodeLimit = if (podcast.overrideGlobalArchive) podcast.autoArchiveEpisodeLimit else null
-                        )
-                    )
-                    addAll(episodesPlusLimit)
-                }
-
-                if (episodes.isEmpty()) {
-                    if (searchTerm.isEmpty()) {
-                        if (archivedCount == 0) {
-                            content.add(NoEpisodeMessage(context.getString(LR.string.podcast_no_episodes), false))
-                        } else {
-                            content.add(NoEpisodeMessage(context.getString(LR.string.podcast_no_episodes_all_archived, archivedCount), true))
-                        }
-                    } else {
-                        content.add(NoEpisodeMessage(context.getString(LR.string.podcast_no_episodes_matching), false))
-                    }
-                }
-                content
+        val grouping = podcast.podcastGrouping
+        val groupingFunction = grouping.sortFunction
+        val episodesPlusLimit: MutableList<Any> = episodes.toMutableList()
+        if (episodeLimit != null && episodeLimitIndex != null && groupingFunction == null) {
+            if (searchTerm.isEmpty() && (podcast.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_DATE_ASC || podcast.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_DATE_DESC)) {
+                episodesPlusLimit.add(episodeLimitIndex, EpisodeLimitRow(episodeLimit))
             }
-            PodcastTab.BOOKMARKS -> {
-                val content = mutableListOf<Any>().apply {
-                    add(Podcast())
-                    if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-                        add(TabsHeader(PodcastTab.BOOKMARKS, onTabClicked))
-                    }
-                    addAll(bookmarks)
+        }
+        if (groupingFunction != null) {
+            val grouped = grouping.formGroups(episodes, podcast, context.resources)
+            episodesPlusLimit.clear()
+
+            grouped.forEachIndexed { index, list ->
+                if (list.isNotEmpty()) {
+                    episodesPlusLimit.add(DividerRow(grouping, index))
+                    episodesPlusLimit.addAll(list)
                 }
-                content
+            }
+        }
+        val content = mutableListOf<Any>().apply {
+            add(Podcast())
+            if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+                add(TabsHeader(PodcastTab.EPISODES, onTabClicked))
+            }
+            add(
+                EpisodeHeader(
+                    showingArchived = showingArchived,
+                    episodeCount = episodeCount,
+                    archivedCount = archivedCount,
+                    searchTerm = searchTerm,
+                    episodeLimit = if (podcast.overrideGlobalArchive) podcast.autoArchiveEpisodeLimit else null
+                )
+            )
+            addAll(episodesPlusLimit)
+        }
+
+        if (episodes.isEmpty()) {
+            if (searchTerm.isEmpty()) {
+                if (archivedCount == 0) {
+                    content.add(NoEpisodeMessage(context.getString(LR.string.podcast_no_episodes), false))
+                } else {
+                    content.add(NoEpisodeMessage(context.getString(LR.string.podcast_no_episodes_all_archived, archivedCount), true))
+                }
+            } else {
+                content.add(NoEpisodeMessage(context.getString(LR.string.podcast_no_episodes_matching), false))
             }
         }
 
+        submitList(content)
+    }
+
+    fun setBookmarks(
+        bookmarks: List<Bookmark>,
+    ) {
+        val content = mutableListOf<Any>().apply {
+            add(Podcast())
+            if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+                add(TabsHeader(PodcastTab.BOOKMARKS, onTabClicked))
+            }
+            addAll(bookmarks)
+        }
         submitList(content)
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -432,6 +432,10 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
         }
     }
 
+    private val onTabClicked: (tab: PodcastViewModel.PodcastTab) -> Unit = { tab ->
+        viewModel.onTabClicked(tab)
+    }
+
     val podcastUuid
         get() = arguments?.getString(ARG_PODCAST_UUID)!!
 
@@ -550,6 +554,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                 onShowArchivedClicked = onShowArchivedClicked,
                 multiSelectHelper = multiSelectHelper,
                 onArtworkLongClicked = onArtworkLongClicked,
+                onTabClicked = onTabClicked,
                 ratingsViewModel = ratingsViewModel,
                 swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                     swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
@@ -716,6 +721,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                         addPaddingForEpisodeSearch(state.episodes)
                         val contextRequired = context ?: return@Observer
                         adapter?.setEpisodes(
+                            showTab = state.showTab,
                             episodes = state.episodes,
                             showingArchived = state.showingArchived,
                             episodeCount = state.episodeCount,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -39,6 +39,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderChooserFragmen
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcasts.PodcastsFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastRatingsViewModel
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastViewModel
+import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastViewModel.PodcastTab
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
@@ -724,19 +725,22 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                 is PodcastViewModel.UiState.Loading -> Unit
                 is PodcastViewModel.UiState.Loaded -> {
                     addPaddingForEpisodeSearch(state.episodes)
-                    adapter?.setEpisodes(
-                        showTab = state.showTab,
-                        episodes = state.episodes,
-                        bookmarks = state.bookmarks,
-                        showingArchived = state.showingArchived,
-                        episodeCount = state.episodeCount,
-                        archivedCount = state.archivedCount,
-                        searchTerm = state.searchTerm,
-                        episodeLimit = state.episodeLimit,
-                        episodeLimitIndex = state.episodeLimitIndex,
-                        podcast = state.podcast,
-                        context = requireContext()
-                    )
+                    when (state.showTab) {
+                        PodcastTab.EPISODES -> adapter?.setEpisodes(
+                            episodes = state.episodes,
+                            showingArchived = state.showingArchived,
+                            episodeCount = state.episodeCount,
+                            archivedCount = state.archivedCount,
+                            searchTerm = state.searchTerm,
+                            episodeLimit = state.episodeLimit,
+                            episodeLimitIndex = state.episodeLimitIndex,
+                            podcast = state.podcast,
+                            context = requireContext()
+                        )
+                        PodcastTab.BOOKMARKS -> adapter?.setBookmarks(
+                            bookmarks = state.bookmarks,
+                        )
+                    }
                     if (state.searchTerm.isNotEmpty() && state.searchTerm != lastSearchTerm) {
                         binding?.episodesRecyclerView?.smoothScrollToTop(1)
                     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkViewHolder.kt
@@ -1,0 +1,28 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.adapter
+
+import androidx.compose.ui.platform.ComposeView
+import androidx.recyclerview.widget.RecyclerView
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.bookmark.BookmarkItem
+import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+
+class BookmarkViewHolder(
+    private val composeView: ComposeView,
+    private val theme: Theme,
+) : RecyclerView.ViewHolder(composeView) {
+
+    fun bind(
+        bookmark: Bookmark,
+        onBookmarkPlayClicked: (Bookmark) -> Unit,
+    ) {
+        composeView.setContent {
+            AppTheme(theme.activeTheme) {
+                BookmarkItem(
+                    bookmark = bookmark,
+                    onPlayClick = { onBookmarkPlayClicked(it) },
+                )
+            }
+        }
+    }
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/TabsViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/TabsViewHolder.kt
@@ -1,0 +1,70 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.adapter
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ScrollableTabRow
+import androidx.compose.material.Tab
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import androidx.recyclerview.widget.RecyclerView
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastAdapter.TabsHeader
+import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastViewModel.PodcastTab
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+
+class TabsViewHolder(
+    private val composeView: ComposeView,
+    private val theme: Theme,
+) : RecyclerView.ViewHolder(composeView) {
+    fun bind(tabsHeader: TabsHeader) {
+        composeView.setContent {
+            AppTheme(theme.activeTheme) {
+                TabsRow(tabsHeader)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TabsRow(
+    tabsHeader: TabsHeader,
+) {
+    val selectedTabIndex = tabsHeader.selectedTab.ordinal
+    ScrollableTabRow(
+        selectedTabIndex = selectedTabIndex,
+        backgroundColor = MaterialTheme.theme.colors.primaryUi02,
+        contentColor = MaterialTheme.theme.colors.primaryText01,
+        edgePadding = 0.dp,
+        divider = {},
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        PodcastTab.values().toList()
+            .map { stringResource(it.labelResId) }
+            .forEachIndexed { i, text ->
+                Tab(
+                    selected = selectedTabIndex == i,
+                    onClick = { tabsHeader.onTabClicked(PodcastTab.values()[i]) },
+                    text = { au.com.shiftyjelly.pocketcasts.compose.components.TextH40(text = text) },
+                )
+            }
+    }
+}
+
+@Preview
+@Composable
+private fun TabsRowPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppTheme(themeType) {
+        TabsRow(
+            tabsHeader = TabsHeader(PodcastTab.EPISODES) {},
+        )
+    }
+}

--- a/modules/features/podcasts/src/main/res/layout/adapter_episode_header.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_episode_header.xml
@@ -8,7 +8,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/primary_ui_02"
-        android:paddingTop="8dp">
+        android:paddingTop="16dp">
 
         <au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.EpisodeSearchView
             android:id="@+id/episodeSearchView"

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkItem.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkItem.kt
@@ -1,0 +1,137 @@
+package au.com.shiftyjelly.pocketcasts.compose.bookmark
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.buttons.TimePlayButton
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.TextC70
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatPattern
+import java.util.Date
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun BookmarkItem(
+    bookmark: Bookmark,
+    onPlayClick: (Bookmark) -> Unit,
+    modifier: Modifier = Modifier,
+    showIcon: Boolean = true,
+) {
+    Column(
+        modifier = modifier
+    ) {
+        Divider(
+            color = MaterialTheme.theme.colors.primaryUi05,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = MaterialTheme.theme.colors.primaryUi02)
+        ) {
+            val createdAtText by remember {
+                mutableStateOf(
+                    bookmark.createdAt.toLocalizedFormatPattern(
+                        bookmark.createdAtDatePattern()
+                    )
+                )
+            }
+
+            if (showIcon) {
+                Box(modifier = Modifier.padding(start = 16.dp)) {
+                    PodcastImage(
+                        uuid = bookmark.podcastUuid,
+                        modifier = modifier.size(56.dp)
+                    )
+                }
+            }
+
+            Column(Modifier.Companion.weight(1f)) {
+                TextC70(
+                    text = bookmark.episodeTitle,
+                    maxLines = 1,
+                    modifier = Modifier.padding(
+                        top = 8.dp,
+                        start = 16.dp
+                    ),
+                    isUpperCase = false,
+                )
+
+                TextH40(
+                    text = bookmark.title,
+                    maxLines = 2,
+                    modifier = Modifier.padding(
+                        top = 4.dp,
+                        start = 16.dp
+                    ),
+                )
+
+                TextC70(
+                    text = createdAtText,
+                    maxLines = 1,
+                    modifier = Modifier.padding(
+                        top = 4.dp,
+                        bottom = 8.dp,
+                        start = 16.dp
+                    ),
+                    isUpperCase = false,
+                )
+            }
+
+            Box(modifier = Modifier.padding(end = 16.dp)) {
+                TimePlayButton(
+                    timeSecs = bookmark.timeSecs,
+                    contentDescriptionId = LR.string.bookmark_play,
+                    onClick = { onPlayClick(bookmark) }
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun BookmarkPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class)
+    themeType: Theme.ThemeType,
+) {
+    AppThemeWithBackground(themeType) {
+        BookmarkItem(
+            bookmark = Bookmark(
+                uuid = "",
+                podcastUuid = "",
+                episodeTitle = "Episode Title",
+                timeSecs = 10,
+                title = "Bookmark Title",
+                createdAt = Date()
+            ),
+            onPlayClick = {},
+            modifier = Modifier,
+            showIcon = false
+        )
+    }
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkItem.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkItem.kt
@@ -70,34 +70,28 @@ fun BookmarkItem(
                 }
             }
 
-            Column(Modifier.Companion.weight(1f)) {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 16.dp)
+            ) {
                 TextC70(
                     text = bookmark.episodeTitle,
                     maxLines = 1,
-                    modifier = Modifier.padding(
-                        top = 8.dp,
-                        start = 16.dp
-                    ),
+                    modifier = Modifier.padding(top = 8.dp),
                     isUpperCase = false,
                 )
 
                 TextH40(
                     text = bookmark.title,
                     maxLines = 2,
-                    modifier = Modifier.padding(
-                        top = 4.dp,
-                        start = 16.dp
-                    ),
+                    modifier = Modifier.padding(top = 4.dp),
                 )
 
                 TextC70(
                     text = createdAtText,
                     maxLines = 1,
-                    modifier = Modifier.padding(
-                        top = 4.dp,
-                        bottom = 8.dp,
-                        start = 16.dp
-                    ),
+                    modifier = Modifier.padding(top = 4.dp, bottom = 8.dp),
                     isUpperCase = false,
                 )
             }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
@@ -339,10 +339,11 @@ fun TextC50(
 fun TextC70(
     text: String,
     modifier: Modifier = Modifier,
-    maxLines: Int = Int.MAX_VALUE
+    maxLines: Int = Int.MAX_VALUE,
+    isUpperCase: Boolean = true,
 ) {
     Text(
-        text = text.uppercase(Locale.getDefault()),
+        text = if (isUpperCase) text.uppercase(Locale.getDefault()) else text,
         color = MaterialTheme.theme.colors.primaryText02,
         fontFamily = FontFamily.SansSerif,
         fontSize = 12.sp,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -51,6 +51,12 @@ abstract class BookmarkDao {
         deleted: Boolean = false,
     ): Flow<List<Bookmark>>
 
+    @Query("SELECT * FROM bookmarks WHERE podcast_uuid = :podcastUuid AND deleted = :deleted")
+    abstract fun findByPodcastFlow(
+        podcastUuid: String,
+        deleted: Boolean = false,
+    ): Flow<List<Bookmark>>
+
     @Query("UPDATE bookmarks SET deleted = :deleted, deleted_modified = :deletedModified, sync_status = :syncStatus WHERE uuid = :uuid")
     abstract suspend fun updateDeleted(uuid: String, deleted: Boolean, deletedModified: Long, syncStatus: SyncStatus)
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -6,6 +6,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import au.com.shiftyjelly.pocketcasts.models.db.helper.PodcastBookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
 import kotlinx.coroutines.flow.Flow
@@ -51,11 +52,16 @@ abstract class BookmarkDao {
         deleted: Boolean = false,
     ): Flow<List<Bookmark>>
 
-    @Query("SELECT * FROM bookmarks WHERE podcast_uuid = :podcastUuid AND deleted = :deleted")
+    @Query(
+        """SELECT bookmarks.*, podcast_episodes.title as episodeTitle
+            FROM bookmarks
+            JOIN podcast_episodes ON bookmarks.episode_uuid = podcast_episodes.uuid 
+            WHERE podcast_uuid = :podcastUuid AND deleted = :deleted"""
+    )
     abstract fun findByPodcastFlow(
         podcastUuid: String,
         deleted: Boolean = false,
-    ): Flow<List<Bookmark>>
+    ): Flow<List<PodcastBookmark>>
 
     @Query("UPDATE bookmarks SET deleted = :deleted, deleted_modified = :deletedModified, sync_status = :syncStatus WHERE uuid = :uuid")
     abstract suspend fun updateDeleted(uuid: String, deleted: Boolean, deletedModified: Long, syncStatus: SyncStatus)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/PodcastBookmark.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/PodcastBookmark.kt
@@ -1,0 +1,11 @@
+package au.com.shiftyjelly.pocketcasts.models.db.helper
+
+import androidx.room.Embedded
+import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+
+data class PodcastBookmark(
+    @Embedded var bookmark: Bookmark,
+    val episodeTitle: String = "",
+) {
+    fun toBookmark() = bookmark.copy(episodeTitle = episodeTitle)
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Bookmark.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Bookmark.kt
@@ -7,7 +7,9 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
 import java.io.Serializable
+import java.util.Calendar
 import java.util.Date
+import java.util.UUID
 
 @Entity(
     tableName = "bookmarks",
@@ -29,4 +31,20 @@ data class Bookmark(
     @Ignore val episodeTitle: String = "",
 ) : Serializable {
     constructor() : this(uuid = "")
+
+    val adapterId: Long
+        get() = UUID.nameUUIDFromBytes(uuid.toByteArray()).mostSignificantBits
+
+    fun createdAtDatePattern(): String {
+        val calendar = Calendar.getInstance()
+        val currentYear = calendar.get(Calendar.YEAR)
+        calendar.time = createdAt
+        val createdAtYear = calendar.get(Calendar.YEAR)
+
+        return if (createdAtYear == currentYear) {
+            "MMM d 'at' h:mm a"
+        } else {
+            "MMM d, YYYY 'at' h:mm a"
+        }
+    }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Bookmark.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Bookmark.kt
@@ -42,9 +42,9 @@ data class Bookmark(
         val createdAtYear = calendar.get(Calendar.YEAR)
 
         return if (createdAtYear == currentYear) {
-            "MMM d 'at' h:mm a"
+            "MMM d, h:mm a"
         } else {
-            "MMM d, YYYY 'at' h:mm a"
+            "MMM d, YYYY h:mm a"
         }
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Bookmark.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Bookmark.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.models.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.Ignore
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
@@ -16,13 +17,16 @@ import java.util.Date
 )
 data class Bookmark(
     @PrimaryKey(autoGenerate = false) @ColumnInfo(name = "uuid") var uuid: String,
-    @ColumnInfo(name = "podcast_uuid") var podcastUuid: String,
-    @ColumnInfo(name = "episode_uuid") var episodeUuid: String,
-    @ColumnInfo(name = "time") var timeSecs: Int,
-    @ColumnInfo(name = "created_at") var createdAt: Date,
-    @ColumnInfo(name = "title") var title: String,
+    @ColumnInfo(name = "podcast_uuid") var podcastUuid: String = "",
+    @ColumnInfo(name = "episode_uuid") var episodeUuid: String = "",
+    @ColumnInfo(name = "time") var timeSecs: Int = 0,
+    @ColumnInfo(name = "created_at") var createdAt: Date = Date(),
+    @ColumnInfo(name = "title") var title: String = "",
     @ColumnInfo(name = "title_modified") var titleModified: Long? = null,
     @ColumnInfo(name = "deleted") var deleted: Boolean = false,
     @ColumnInfo(name = "deleted_modified") var deletedModified: Long? = null,
-    @ColumnInfo(name = "sync_status") var syncStatus: SyncStatus
-) : Serializable
+    @ColumnInfo(name = "sync_status") var syncStatus: SyncStatus = SyncStatus.NOT_SYNCED,
+    @Ignore val episodeTitle: String = "",
+) : Serializable {
+    constructor() : this(uuid = "")
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
@@ -14,7 +14,7 @@ interface BookmarkManager {
         episode: BaseEpisode,
         sortType: BookmarksSortType,
     ): Flow<List<Bookmark>>
-
+    fun findPodcastBookmarksFlow(podcastUuid: String): Flow<List<Bookmark>>
     suspend fun deleteToSync(bookmarkUuid: String)
     suspend fun deleteSynced(bookmarkUuid: String)
     suspend fun upsertSynced(bookmark: Bookmark): Bookmark

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -7,6 +7,9 @@ import au.com.shiftyjelly.pocketcasts.models.type.BookmarksSortType
 import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import java.util.Date
 import java.util.UUID
 import javax.inject.Inject
@@ -101,9 +104,12 @@ class BookmarkManagerImpl @Inject constructor(
     /**
      * Find all bookmarks for the given podcast.
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     override fun findPodcastBookmarksFlow(
         podcastUuid: String,
-    ) = bookmarkDao.findByPodcastFlow(podcastUuid)
+    ) = bookmarkDao.findByPodcastFlow(podcastUuid = podcastUuid).flatMapLatest { helper ->
+        flowOf(helper.map { it.toBookmark() })
+    }
 
     /**
      * Mark the bookmark as deleted so it can be synced to other devices.

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -99,6 +99,13 @@ class BookmarkManagerImpl @Inject constructor(
     }
 
     /**
+     * Find all bookmarks for the given podcast.
+     */
+    override fun findPodcastBookmarksFlow(
+        podcastUuid: String,
+    ) = bookmarkDao.findByPodcastFlow(podcastUuid)
+
+    /**
      * Mark the bookmark as deleted so it can be synced to other devices.
      */
     override suspend fun deleteToSync(bookmarkUuid: String) {


### PR DESCRIPTION
## Description

This displays bookmarks on the podcast details page.

## Testing Instructions

1. Launch the app
2. Play an episode and add a few bookmarks
3. Go to corresponding `Podcast Details` page
4. ✅  Notice that tabs are displayed
5. Tap on bookmarks tab
6. ✅ Notice that bookmarks are displayed

P.S. I have not added any empty view/ search/ sorting to keep the PR small and to get validation on the direction. 

A few bigger diffs are due to indentation changes and other changes include supporting a new view holder for tabs and bookmarks.

## Screenshots or Screencast 

<img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/6c833e0b-51c4-4df9-bee8-ca382a16d994"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
