### PR TITLE
Bookmarks - Add search on podcast page

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/BookmarkDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/BookmarkDaoTest.kt
@@ -5,7 +5,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.models.db.dao.BookmarkDao
+import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -22,6 +24,7 @@ import java.util.UUID
 @LargeTest
 class BookmarkDaoTest {
 
+    private lateinit var episodeDao: EpisodeDao
     private lateinit var bookmarkDao: BookmarkDao
     private lateinit var testDatabase: AppDatabase
 
@@ -30,6 +33,7 @@ class BookmarkDaoTest {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         testDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
         bookmarkDao = testDatabase.bookmarkDao()
+        episodeDao = testDatabase.episodeDao()
     }
 
     @After
@@ -94,8 +98,8 @@ class BookmarkDaoTest {
             bookmarkDao.insert(bookmark3)
 
             val result = bookmarkDao.findByEpisodeOrderCreatedAtFlow(
-                episodeUuid = episodeUuid,
-                podcastUuid = podcastUuid,
+                episodeUuid = defaultEpisodeUuid,
+                podcastUuid = defaultPodcastUuid,
                 deleted = false,
                 isAsc = true
             ).first()
@@ -118,8 +122,8 @@ class BookmarkDaoTest {
             bookmarkDao.insert(bookmark3)
 
             val result = bookmarkDao.findByEpisodeOrderCreatedAtFlow(
-                episodeUuid = episodeUuid,
-                podcastUuid = podcastUuid,
+                episodeUuid = defaultEpisodeUuid,
+                podcastUuid = defaultPodcastUuid,
                 deleted = false,
                 isAsc = false
             ).first()
@@ -142,8 +146,8 @@ class BookmarkDaoTest {
             bookmarkDao.insert(bookmark3)
 
             val result = bookmarkDao.findByEpisodeOrderTimeFlow(
-                episodeUuid = episodeUuid,
-                podcastUuid = podcastUuid,
+                episodeUuid = defaultEpisodeUuid,
+                podcastUuid = defaultPodcastUuid,
                 deleted = false,
             ).first()
 
@@ -154,24 +158,79 @@ class BookmarkDaoTest {
             }
         }
 
+    @Test
+    fun testSearchInPodcastByBookmarkTitle() =
+        runTest {
+            val podcastUuid = UUID.randomUUID().toString()
+            val searchTitle = "title"
+            val bookmark1 = FakeBookmarksGenerator.create(podcastUuid = podcastUuid, title = searchTitle, time = 100)
+            val bookmark2 = FakeBookmarksGenerator.create(podcastUuid = podcastUuid, time = 200)
+            bookmarkDao.insert(bookmark1)
+            bookmarkDao.insert(bookmark2)
+
+            val episode = PodcastEpisode(uuid = defaultEpisodeUuid, podcastUuid = "1", isArchived = false, publishedDate = Date())
+            episodeDao.insert(episode)
+
+            val result = bookmarkDao.searchInPodcastByTitle(
+                title = searchTitle,
+                podcastUuid = podcastUuid,
+                deleted = false,
+            )
+
+            with(result) {
+                assert(size == 1)
+                assert(get(0).title == searchTitle)
+            }
+        }
+
+    @Test
+    fun testSearchInPodcastByEpisodeTitle() =
+        runTest {
+            val bookmarkUuid = UUID.randomUUID().toString()
+            val podcastUuid = UUID.randomUUID().toString()
+            val episodeUuid = UUID.randomUUID().toString()
+            val searchTitle = "title"
+            val bookmark1 = FakeBookmarksGenerator.create(uuid = bookmarkUuid, episodeUuid = episodeUuid, podcastUuid = podcastUuid, time = 100)
+            val bookmark2 = FakeBookmarksGenerator.create(podcastUuid = podcastUuid, time = 200)
+            bookmarkDao.insert(bookmark1)
+            bookmarkDao.insert(bookmark2)
+
+            val episode = PodcastEpisode(uuid = episodeUuid, podcastUuid = podcastUuid, title = searchTitle, isArchived = false, publishedDate = Date())
+            episodeDao.insert(episode)
+
+            val result = bookmarkDao.searchInPodcastByTitle(
+                title = searchTitle,
+                podcastUuid = podcastUuid,
+                deleted = false,
+            )
+
+            with(result) {
+                assert(size == 1)
+                assert(get(0).uuid == bookmarkUuid)
+            }
+        }
+
     companion object {
-        private val episodeUuid = UUID.randomUUID().toString()
-        private val podcastUuid = UUID.randomUUID().toString()
+        private val defaultEpisodeUuid = UUID.randomUUID().toString()
+        private val defaultPodcastUuid = UUID.randomUUID().toString()
 
         object FakeBookmarksGenerator {
             fun create(
                 uuid: String? = null,
+                title: String = "",
+                podcastUuid: String? = null,
+                episodeUuid: String? = null,
                 time: Int = 10,
                 createdAt: Date = Date(),
             ) = Bookmark(
                 uuid = uuid ?: UUID.randomUUID().toString(),
-                episodeUuid = episodeUuid,
-                podcastUuid = podcastUuid,
+                episodeUuid = episodeUuid ?: defaultEpisodeUuid,
+                podcastUuid = podcastUuid ?: defaultPodcastUuid,
                 timeSecs = time,
                 createdAt = createdAt,
                 deleted = false,
                 syncStatus = SyncStatus.NOT_SYNCED,
-                title = ""
+                title = title
             )
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/BookmarkSearchHandler.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/BookmarkSearchHandler.kt
@@ -1,0 +1,37 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.helper.search
+
+import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
+import io.reactivex.Observable
+import io.reactivex.Single
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class BookmarkSearchHandler @Inject constructor(
+    private val bookmarkManager: BookmarkManager,
+) : SearchHandler<Bookmark>() {
+    override val searchDebounce = 500L
+
+    override fun getSearchResultsObservable(podcastUuid: String): Observable<SearchResult> =
+        searchQueryRelay.debounce { // Only debounce when search has a value otherwise it slows down loading the pages
+            if (it.isEmpty()) {
+                Observable.empty()
+            } else {
+                Observable.timer(searchDebounce, TimeUnit.MILLISECONDS)
+            }
+        }.switchMapSingle { searchTerm ->
+            if (searchTerm.length > 1) {
+                Single.just(bookmarkManager.searchInPodcastByTitle(podcastUuid, searchTerm))
+                    .map { SearchResult(searchTerm, it) }
+                    .onErrorReturnItem(noSearchResult)
+            } else {
+                Single.just(noSearchResult)
+            }
+        }.distinctUntilChanged()
+
+    override fun trackSearchIfNeeded(oldValue: String, newValue: String) {
+        // TODO: Bookmark search tracking
+    }
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/BookmarkSearchHandler.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/BookmarkSearchHandler.kt
@@ -3,8 +3,7 @@ package au.com.shiftyjelly.pocketcasts.podcasts.helper.search
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import io.reactivex.Observable
-import io.reactivex.Single
-import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.rx2.rxSingle
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -12,22 +11,15 @@ import javax.inject.Singleton
 class BookmarkSearchHandler @Inject constructor(
     private val bookmarkManager: BookmarkManager,
 ) : SearchHandler<Bookmark>() {
-    override val searchDebounce = 500L
 
     override fun getSearchResultsObservable(podcastUuid: String): Observable<SearchResult> =
-        searchQueryRelay.debounce { // Only debounce when search has a value otherwise it slows down loading the pages
-            if (it.isEmpty()) {
-                Observable.empty()
-            } else {
-                Observable.timer(searchDebounce, TimeUnit.MILLISECONDS)
-            }
-        }.switchMapSingle { searchTerm ->
+        searchQueryRelay.switchMapSingle { searchTerm ->
             if (searchTerm.length > 1) {
-                Single.just(bookmarkManager.searchInPodcastByTitle(podcastUuid, searchTerm))
+                rxSingle { bookmarkManager.searchInPodcastByTitle(podcastUuid, searchTerm) }
                     .map { SearchResult(searchTerm, it) }
                     .onErrorReturnItem(noSearchResult)
             } else {
-                Single.just(noSearchResult)
+                rxSingle { noSearchResult }
             }
         }.distinctUntilChanged()
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/EpisodeSearchHandler.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/EpisodeSearchHandler.kt
@@ -17,7 +17,7 @@ class EpisodeSearchHandler @Inject constructor(
     private val cacheServerManager: PodcastCacheServerManagerImpl,
     private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : SearchHandler<BaseEpisode>() {
-    override val searchDebounce = settings.getEpisodeSearchDebounceMs()
+    private val searchDebounce = settings.getEpisodeSearchDebounceMs()
 
     override fun getSearchResultsObservable(podcastUuid: String): Observable<SearchResult> =
         searchQueryRelay.debounce { // Only debounce when search has a value otherwise it slows down loading the pages

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/EpisodeSearchHandler.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/EpisodeSearchHandler.kt
@@ -1,0 +1,46 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.helper.search
+
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManagerImpl
+import io.reactivex.Observable
+import io.reactivex.Single
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class EpisodeSearchHandler @Inject constructor(
+    settings: Settings,
+    private val cacheServerManager: PodcastCacheServerManagerImpl,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+) : SearchHandler<BaseEpisode>() {
+    override val searchDebounce = settings.getEpisodeSearchDebounceMs()
+
+    override fun getSearchResultsObservable(podcastUuid: String): Observable<SearchResult> =
+        searchQueryRelay.debounce { // Only debounce when search has a value otherwise it slows down loading the pages
+            if (it.isEmpty()) {
+                Observable.empty()
+            } else {
+                Observable.timer(searchDebounce, TimeUnit.MILLISECONDS)
+            }
+        }.switchMapSingle { searchTerm ->
+            if (searchTerm.length > 2) {
+                cacheServerManager.searchEpisodes(podcastUuid, searchTerm)
+                    .map { SearchResult(searchTerm, it) }
+                    .onErrorReturnItem(noSearchResult)
+            } else {
+                Single.just(noSearchResult)
+            }
+        }.distinctUntilChanged()
+
+    override fun trackSearchIfNeeded(oldValue: String, newValue: String) {
+        if (oldValue.isEmpty() && newValue.isNotEmpty()) {
+            analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_SEARCH_PERFORMED)
+        } else if (oldValue.isNotEmpty() && newValue.isEmpty()) {
+            analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_SEARCH_CLEARED)
+        }
+    }
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/SearchHandler.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/SearchHandler.kt
@@ -5,7 +5,6 @@ import io.reactivex.Observable
 
 abstract class SearchHandler<T> {
     private var searchTerm = ""
-    abstract val searchDebounce: Long
     protected val searchQueryRelay = BehaviorRelay.create<String>()
         .apply { accept("") }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/SearchHandler.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/SearchHandler.kt
@@ -1,0 +1,29 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.helper.search
+
+import com.jakewharton.rxrelay2.BehaviorRelay
+import io.reactivex.Observable
+
+abstract class SearchHandler<T> {
+    private var searchTerm = ""
+    abstract val searchDebounce: Long
+    protected val searchQueryRelay = BehaviorRelay.create<String>()
+        .apply { accept("") }
+
+    protected val noSearchResult = SearchResult("", null)
+
+    abstract fun getSearchResultsObservable(podcastUuid: String): Observable<SearchResult>
+
+    fun searchQueryUpdated(newValue: String) {
+        val oldValue = searchQueryRelay.value ?: ""
+        searchTerm = newValue
+        searchQueryRelay.accept(newValue)
+        trackSearchIfNeeded(oldValue, newValue)
+    }
+
+    abstract fun trackSearchIfNeeded(oldValue: String, newValue: String)
+
+    data class SearchResult(
+        val searchTerm: String,
+        val searchUuids: List<String>?,
+    )
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -739,6 +739,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                         )
                         PodcastTab.BOOKMARKS -> adapter?.setBookmarks(
                             bookmarks = state.bookmarks,
+                            searchTerm = state.searchTerm,
                         )
                     }
                     if (state.searchTerm.isNotEmpty() && state.searchTerm != lastSearchTerm) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -434,7 +434,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
         }
     }
 
-    private val onTabClicked: (tab: PodcastViewModel.PodcastTab) -> Unit = { tab ->
+    private val onTabClicked: (tab: PodcastTab) -> Unit = { tab ->
         viewModel.onTabClicked(tab)
     }
 
@@ -739,7 +739,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                         )
                         PodcastTab.BOOKMARKS -> adapter?.setBookmarks(
                             bookmarks = state.bookmarks,
-                            searchTerm = state.searchTerm,
+                            searchTerm = state.searchBookmarkTerm,
                         )
                     }
                     if (state.searchTerm.isNotEmpty() && state.searchTerm != lastSearchTerm) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkHeaderViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkHeaderViewHolder.kt
@@ -1,0 +1,118 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.adapter
+
+import android.widget.EditText
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.recyclerview.widget.RecyclerView
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.podcasts.R
+import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.EpisodeSearchView
+import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastAdapter.BookmarkHeader
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+class BookmarkHeaderViewHolder(
+    private val composeView: ComposeView,
+    private val theme: Theme,
+) : RecyclerView.ViewHolder(composeView) {
+    fun bind(bookmarkHeader: BookmarkHeader) {
+        composeView.setContent {
+            AppTheme(theme.activeTheme) {
+                Column(
+                    modifier = Modifier
+                        .background(MaterialTheme.theme.colors.primaryUi02)
+                ) {
+                    SearchHeader(bookmarkHeader)
+                    Divider(color = MaterialTheme.theme.colors.primaryUi05)
+                    if (bookmarkHeader.bookmarksCount > 0) {
+                        BookmarksCountView(bookmarkHeader)
+                    }
+                }
+            }
+        }
+    }
+    @Composable
+    private fun SearchHeader(bookmarkHeader: BookmarkHeader) {
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 16.dp)
+                    .padding(vertical = 16.dp)
+            ) {
+                SearchView(
+                    bookmarkHeader = bookmarkHeader,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+            IconButton(
+                onClick = { },
+                modifier = Modifier
+            ) {
+                Icon(
+                    painter = painterResource(IR.drawable.ic_more_vert_black_24dp),
+                    contentDescription = stringResource(LR.string.more_options),
+                    tint = MaterialTheme.theme.colors.primaryIcon02,
+                )
+            }
+        }
+    }
+    @Composable
+    fun SearchView(
+        bookmarkHeader: BookmarkHeader,
+        modifier: Modifier = Modifier,
+    ) {
+        val hintText = stringResource(id = LR.string.bookmarks_search)
+        AndroidView(
+            modifier = modifier,
+            factory = { context ->
+                EpisodeSearchView(context).apply {
+                    val searchText = findViewById<EditText>(R.id.searchText)
+                    searchText.hint = hintText
+                    this.onFocus = { bookmarkHeader.onSearchFocus() }
+                    onSearch = { query ->
+                        bookmarkHeader.onSearchQueryChanged(query)
+                    }
+                    text = bookmarkHeader.searchTerm
+                }
+            },
+        )
+    }
+    @Composable
+    private fun BookmarksCountView(bookmarkHeader: BookmarkHeader) {
+        TextP60(
+            text = if (bookmarkHeader.bookmarksCount > 1) {
+                stringResource(LR.string.bookmarks_plural, bookmarkHeader.bookmarksCount)
+            } else {
+                stringResource(LR.string.bookmarks_singular)
+            },
+            color = MaterialTheme.theme.colors.primaryText02,
+            modifier = Modifier
+                .padding(start = 16.dp)
+                .padding(vertical = 16.dp)
+        )
+    }
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1687,8 +1687,8 @@
     <string name="bookmarks_create_instructions">You can save timestamps of episodes from the actions menu in the player or by configuring an action with your headphones.</string>
     <string name="bookmarks_not_found">No bookmarks yet</string>
     <string name="bookmarks_headphone_settings">Headphone settings</string>
-    <string name="bookmarks_plural">%s bookmarks</string>
-    <string name="bookmarks_singular">%s bookmark</string>
+    <string name="bookmarks_plural">%d bookmarks</string>
+    <string name="bookmarks_singular">1 bookmark</string>
     <string name="bookmarks_delete_plural">Delete bookmarks</string>
     <string name="bookmarks_delete_singular">Delete bookmark</string>
     <string name="bookmarks_deleted_plural">%1$d bookmarks deleted</string>
@@ -1696,6 +1696,7 @@
     <string name="bookmarks_delete_summary_plural">%d bookmarks will be deleted. This cannot be undone.</string>
     <string name="bookmarks_delete_summary_singular">This bookmark will be deleted. This cannot be undone.</string>
     <string name="bookmarks_select_option">Select bookmarks</string>
+    <string name="bookmarks_search">Search bookmark</string>
     <string name="bookmarks_sort_option" translatable="false">@string/sort_by</string>
     <string name="bookmarks_sort_newest_to_oldest" translatable="false">@string/sort_newest_to_oldest</string>
     <string name="bookmarks_sort_oldest_to_newest" translatable="false">@string/sort_oldest_to_newest</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -71,7 +71,7 @@ abstract class BookmarkDao {
             AND (UPPER(bookmarks.title) LIKE UPPER(:title) OR UPPER(podcast_episodes.title) LIKE UPPER(:title))
             AND deleted = :deleted"""
     )
-    abstract fun searchInPodcastByTitle(
+    abstract suspend fun searchInPodcastByTitle(
         podcastUuid: String,
         title: String,
         deleted: Boolean = false,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -63,7 +63,15 @@ abstract class BookmarkDao {
         deleted: Boolean = false,
     ): Flow<List<PodcastBookmark>>
 
-    @Query("SELECT * FROM bookmarks WHERE podcast_uuid = :podcastUuid AND UPPER(title) LIKE UPPER(:title) AND deleted = :deleted")
+    @Query(
+        """SELECT bookmarks.*
+            FROM bookmarks
+            JOIN podcast_episodes ON bookmarks.episode_uuid = podcast_episodes.uuid 
+            WHERE podcast_uuid = :podcastUuid 
+            AND UPPER(bookmarks.title) LIKE UPPER(:title)
+            OR UPPER(podcast_episodes.title) LIKE UPPER(:title)
+            AND deleted = :deleted"""
+    )
     abstract fun searchInPodcastByTitle(
         podcastUuid: String,
         title: String,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -68,8 +68,7 @@ abstract class BookmarkDao {
             FROM bookmarks
             LEFT JOIN podcast_episodes ON bookmarks.episode_uuid = podcast_episodes.uuid 
             WHERE bookmarks.podcast_uuid = :podcastUuid 
-            AND UPPER(bookmarks.title) LIKE UPPER(:title)
-            OR UPPER(podcast_episodes.title) LIKE UPPER(:title)
+            AND (UPPER(bookmarks.title) LIKE UPPER(:title) OR UPPER(podcast_episodes.title) LIKE UPPER(:title))
             AND deleted = :deleted"""
     )
     abstract fun searchInPodcastByTitle(

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -66,8 +66,8 @@ abstract class BookmarkDao {
     @Query(
         """SELECT bookmarks.*
             FROM bookmarks
-            JOIN podcast_episodes ON bookmarks.episode_uuid = podcast_episodes.uuid 
-            WHERE podcast_uuid = :podcastUuid 
+            LEFT JOIN podcast_episodes ON bookmarks.episode_uuid = podcast_episodes.uuid 
+            WHERE bookmarks.podcast_uuid = :podcastUuid 
             AND UPPER(bookmarks.title) LIKE UPPER(:title)
             OR UPPER(podcast_episodes.title) LIKE UPPER(:title)
             AND deleted = :deleted"""

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -63,6 +63,13 @@ abstract class BookmarkDao {
         deleted: Boolean = false,
     ): Flow<List<PodcastBookmark>>
 
+    @Query("SELECT * FROM bookmarks WHERE podcast_uuid = :podcastUuid AND UPPER(title) LIKE UPPER(:title) AND deleted = :deleted")
+    abstract fun searchInPodcastByTitle(
+        podcastUuid: String,
+        title: String,
+        deleted: Boolean = false,
+    ): List<Bookmark>
+
     @Query("UPDATE bookmarks SET deleted = :deleted, deleted_modified = :deletedModified, sync_status = :syncStatus WHERE uuid = :uuid")
     abstract suspend fun updateDeleted(uuid: String, deleted: Boolean, deletedModified: Long, syncStatus: SyncStatus)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
@@ -19,4 +19,5 @@ interface BookmarkManager {
     suspend fun deleteSynced(bookmarkUuid: String)
     suspend fun upsertSynced(bookmark: Bookmark): Bookmark
     fun findBookmarksToSync(): List<Bookmark>
+    fun searchInPodcastByTitle(podcastUuid: String, title: String): List<String>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
@@ -19,5 +19,5 @@ interface BookmarkManager {
     suspend fun deleteSynced(bookmarkUuid: String)
     suspend fun upsertSynced(bookmark: Bookmark): Bookmark
     fun findBookmarksToSync(): List<Bookmark>
-    fun searchInPodcastByTitle(podcastUuid: String, title: String): List<String>
+    suspend fun searchInPodcastByTitle(podcastUuid: String, title: String): List<String>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -111,7 +111,7 @@ class BookmarkManagerImpl @Inject constructor(
         flowOf(helper.map { it.toBookmark() })
     }
 
-    override fun searchInPodcastByTitle(podcastUuid: String, title: String) =
+    override suspend fun searchInPodcastByTitle(podcastUuid: String, title: String) =
         bookmarkDao.searchInPodcastByTitle(podcastUuid, "%$title%").map { it.uuid }
 
     /**

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -111,6 +111,9 @@ class BookmarkManagerImpl @Inject constructor(
         flowOf(helper.map { it.toBookmark() })
     }
 
+    override fun searchInPodcastByTitle(podcastUuid: String, title: String) =
+        bookmarkDao.searchInPodcastByTitle(podcastUuid, "%$title%").map { it.uuid }
+
     /**
      * Mark the bookmark as deleted so it can be synced to other devices.
      */


### PR DESCRIPTION
## Description

This adds bookmark search on the podcast page.

## Testing Instructions
1. Launch the app
2. Play an episode and add a few bookmarks
3. Go to the corresponding `Podcast Details` page
5. Tap on bookmarks tab
6. Search for bookmark title
7. ✅ Notice that the bookmark is displayed
8. Search for bookmark's episode title
9. ✅ Notice that the bookmark for that episode is displayed

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/b4a4b9e6-9aee-40fc-b1e3-ea9ee42dd764

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
