### PR TITLE
Remove references to auto download on watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
         ([#1209](https://github.com/Automattic/pocket-casts-android/pull/1209))
     *   Fixed upgrade flow when signing in with Google account
         ([#1204](https://github.com/Automattic/pocket-casts-android/pull/1204))
-
+    *   Fixed watch background refresh description to not reference auto downloads
+        ([#1212](https://github.com/Automattic/pocket-casts-android/pull/1212))
 
 7.44
 -----

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1188,7 +1188,9 @@
     <string name="settings_storage_android_10_custom">We can no longer support custom folders for storage on Android 10+. We have switched your storage option back to your phones default.</string>
     <string name="settings_storage_background_refresh">Background refresh</string>
     <string name="settings_storage_background_refresh_off">Pocket Casts will only refresh when you open the app.\n\nEpisode notifications and auto downloads will only happen when you open the app.</string>
+    <string name="settings_storage_background_refresh_off_watch">Pocket Casts will only sync your account when you open the app.</string>
     <string name="settings_storage_background_refresh_on">Pocket Casts will periodically check for new episodes and auto downloads in the background.</string>
+    <string name="settings_storage_background_refresh_on_watch">Pocket Casts will periodically sync your account in the background.</string>
     <string name="settings_storage_clear_cache">Clearing download cache</string>
     <string name="settings_storage_clear_download_cache">Clear download cache</string>
     <string name="settings_storage_custom_folder">Custom Folder</string>

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsScreen.kt
@@ -95,8 +95,12 @@ private fun Content(
             )
         }
 
-        val backgroundRefreshStringRes =
-            if (state.refreshInBackground) LR.string.settings_storage_background_refresh_on else LR.string.settings_storage_background_refresh_off
+        val backgroundRefreshStringRes = if (state.refreshInBackground) {
+            LR.string.settings_storage_background_refresh_on_watch
+        } else {
+            LR.string.settings_storage_background_refresh_off_watch
+        }
+
         item {
             ToggleChip(
                 label = stringResource(LR.string.settings_storage_background_refresh),


### PR DESCRIPTION
## Description
For the refresh setting we were reusing strings from the app on the watch and they included references to auto download, which does not happen on the watch ([yet](https://github.com/Automattic/pocket-casts-android/issues/1099)). This updates those strings to not reference auto downloading.

In addition, I took this opportunity to shorten the strings since the watch screen is so small.

## Testing Instructions
1. Open the settings on the watch
2. Verify that the text below the "Background refresh" toggle makes sense both when the setting is toggled on and when it is toggled off.

## Screenshots or Screencast 

| Before | After |
|--------|--------|
| ![Screenshot 2023-07-27 at 10 51 11 AM](https://github.com/Automattic/pocket-casts-android/assets/4656348/cc3c12d6-3dbf-46fb-ae1f-86e27fc03aca) | ![Screenshot 2023-07-27 at 1 34 54 PM](https://github.com/Automattic/pocket-casts-android/assets/4656348/e50646a3-d670-43fc-af57-eb68659a2a4f) |
| ![Screenshot 2023-07-27 at 11 00 48 AM](https://github.com/Automattic/pocket-casts-android/assets/4656348/58004cc1-cbd4-4fdb-b7ed-dd8f8a5ea429) | ![Screenshot 2023-07-27 at 1 40 31 PM](https://github.com/Automattic/pocket-casts-android/assets/4656348/2eb57107-b828-4d44-bf17-72d97b7e5f6c) |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
