### PR TITLE
Settings Sync - Refactor "General" settings to be UserSettings

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
@@ -1,11 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.models.db
 
+import androidx.preference.PreferenceManager
 import androidx.room.Room
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.SettingsImpl
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
@@ -17,6 +18,7 @@ import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServerManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
 import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshServerManager
 import au.com.shiftyjelly.pocketcasts.utils.Optional
+import com.squareup.moshi.Moshi
 import io.reactivex.Single
 import org.junit.After
 import org.junit.Assert.assertTrue
@@ -42,7 +44,15 @@ class PodcastManagerTest {
 
         val episodeManager = mock<EpisodeManager>()
         val playlistManager = mock<PlaylistManager>()
-        val settings = mock<Settings>()
+
+        val settings = SettingsImpl(
+            sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context),
+            privatePreferences = PreferenceManager.getDefaultSharedPreferences(context),
+            context = context,
+            firebaseRemoteConfig = mock(),
+            moshi = Moshi.Builder().build(),
+        )
+
         val syncManagerSignedOut = mock<SyncManager> {
             on { isLoggedIn() } doReturn false
         }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/CastOptionsProvider.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/CastOptionsProvider.kt
@@ -22,7 +22,7 @@ class CastOptionsProvider : OptionsProvider {
         val compatButtonActionsIndices = intArrayOf(0, 1, 2)
         val notificationOptions = NotificationOptions.Builder()
             .setActions(buttonActions, compatButtonActionsIndices)
-            .setSkipStepMs(application.settings.getSkipForwardInMs())
+            .setSkipStepMs(application.settings.skipForwardInSecs.flow.value * 1000L)
             .setTargetActivityClassName(MainActivity::class.java.name)
             .build()
         val mediaOptions = CastMediaOptions.Builder()

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -673,7 +673,13 @@ class MainActivity :
                 updateNavAndStatusColors(true, state.podcast)
             }
 
-            if (viewModel.lastPlaybackState != null && (viewModel.lastPlaybackState?.episodeUuid != state.episodeUuid || (viewModel.lastPlaybackState?.isPlaying == false && state.isPlaying)) && settings.openPlayerAutomatically()) {
+            if (viewModel.lastPlaybackState != null &&
+                (
+                    viewModel.lastPlaybackState?.episodeUuid != state.episodeUuid ||
+                        (viewModel.lastPlaybackState?.isPlaying == false && state.isPlaying)
+                    ) &&
+                settings.openPlayerAutomatically.flow.value
+            ) {
                 binding.playerBottomSheet.openPlayer()
             }
 

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -786,7 +786,7 @@ class MainActivity :
     private fun updatePlaybackState(state: PlaybackState) {
         binding.playerBottomSheet.setPlaybackState(state)
 
-        if ((state.isPlaying || state.isBuffering) && settings.keepScreenAwake()) {
+        if ((state.isPlaying || state.isBuffering) && settings.keepScreenAwake.flow.value) {
             window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         } else {
             window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -98,8 +98,10 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
         preferenceSkipBackward?.setOnPreferenceChangeListener { _, newValue ->
             val value = newValue.toString().toIntOrNull() ?: 0
             if (value > 0) {
-                settings.setSkipBackwardInSec(value)
-                settings.setSkipBackNeedsSync(true)
+                settings.skipBackInSecs.run {
+                    set(value)
+                    needsSync = true
+                }
                 changeSkipTitles()
                 true
             } else {
@@ -136,7 +138,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
     private fun changeSkipTitles() {
         val skipForwardSummary = resources.getStringPluralSeconds(settings.skipForwardInSecs.flow.value)
         preferenceSkipForward?.summary = skipForwardSummary
-        val skipBackwardSummary = resources.getStringPluralSeconds(settings.getSkipBackwardInSecs())
+        val skipBackwardSummary = resources.getStringPluralSeconds(settings.skipBackInSecs.flow.value)
         preferenceSkipBackward?.summary = skipBackwardSummary
     }
 }

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -84,8 +84,10 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
         preferenceSkipForward?.setOnPreferenceChangeListener { _, newValue ->
             val value = newValue.toString().toIntOrNull() ?: 0
             if (value > 0) {
-                settings.setSkipForwardInSec(value)
-                settings.setSkipForwardNeedsSync(true)
+                settings.skipForwardInSecs.run {
+                    set(value)
+                    needsSync = true
+                }
                 changeSkipTitles()
                 true
             } else {
@@ -132,7 +134,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
     }
 
     private fun changeSkipTitles() {
-        val skipForwardSummary = resources.getStringPluralSeconds(settings.getSkipForwardInSecs())
+        val skipForwardSummary = resources.getStringPluralSeconds(settings.skipForwardInSecs.flow.value)
         preferenceSkipForward?.summary = skipForwardSummary
         val skipBackwardSummary = resources.getStringPluralSeconds(settings.getSkipBackwardInSecs())
         preferenceSkipBackward?.summary = skipBackwardSummary

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -109,7 +109,7 @@ class FilterEpisodeListFragment : BaseFragment() {
             swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                 swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
                 onItemUpdated = this::lazyNotifyAdapterChanged,
-                defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
+                defaultUpNextSwipeAction = { settings.upNextSwipe.flow.value },
                 context = requireContext(),
                 fragmentManager = parentFragmentManager,
                 swipeSource = EpisodeItemTouchHelper.SwipeSource.FILTERS,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -27,6 +27,7 @@ import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.rx2.asObservable
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
@@ -63,7 +64,11 @@ class FilterEpisodeListViewModel @Inject constructor(
     fun setup(playlistUUID: String) {
         this.playlistUUID = playlistUUID
 
-        val episodes = Observables.combineLatest(settings.upNextSwipeActionObservable, settings.rowActionObservable).toFlowable(BackpressureStrategy.LATEST)
+        val episodes = Observables.combineLatest(
+            settings.upNextSwipeActionObservable,
+            settings.streamingMode.flow.asObservable(coroutineContext)
+        )
+            .toFlowable(BackpressureStrategy.LATEST)
             .switchMap { playlistManager.observeByUuidAsList(playlistUUID) }
             .switchMap { playlists ->
                 Timber.d("Loading playlist $playlist")

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -65,8 +65,8 @@ class FilterEpisodeListViewModel @Inject constructor(
         this.playlistUUID = playlistUUID
 
         val episodes = Observables.combineLatest(
-            settings.upNextSwipeActionObservable,
-            settings.streamingMode.flow.asObservable(coroutineContext)
+            settings.upNextSwipe.flow.asObservable(coroutineContext),
+            settings.streamingMode.flow.asObservable(coroutineContext),
         )
             .toFlowable(BackpressureStrategy.LATEST)
             .switchMap { playlistManager.observeByUuidAsList(playlistUUID) }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -106,7 +106,7 @@ class UpNextAdapter(
                 holder.binding.checkbox.isChecked = multiSelectHelper.toggle(episode)
             } else {
                 val podcastUuid = (episode as? PodcastEpisode)?.podcastUuid
-                val playOnTap = settings.getTapOnUpNextShouldPlay()
+                val playOnTap = settings.tapOnUpNextShouldPlay.flow.value
                 trackUpNextEvent(AnalyticsEvent.UP_NEXT_QUEUE_EPISODE_TAPPED, mapOf(WILL_PLAY_KEY to playOnTap))
                 listener.onEpisodeActionsClick(episodeUuid = episode.uuid, podcastUuid = podcastUuid)
             }
@@ -116,7 +116,7 @@ class UpNextAdapter(
                 multiSelectHelper.defaultLongPress(multiSelectable = episode, fragmentManager = fragmentManager)
             } else {
                 val podcastUuid = (episode as? PodcastEpisode)?.podcastUuid
-                val playOnLongPress = !settings.getTapOnUpNextShouldPlay()
+                val playOnLongPress = !settings.tapOnUpNextShouldPlay.flow.value
                 trackUpNextEvent(AnalyticsEvent.UP_NEXT_QUEUE_EPISODE_LONG_PRESSED, mapOf(WILL_PLAY_KEY to playOnLongPress))
                 listener.onEpisodeActionsLongPress(episodeUuid = episode.uuid, podcastUuid = podcastUuid)
             }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -347,7 +347,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
     }
 
     override fun onEpisodeActionsClick(episodeUuid: String, podcastUuid: String?) {
-        if (settings.getTapOnUpNextShouldPlay()) {
+        if (settings.tapOnUpNextShouldPlay.flow.value) {
             playerViewModel.playEpisode(uuid = episodeUuid, sourceView = sourceView)
         } else {
             (activity as? FragmentHostListener)?.openEpisodeDialog(
@@ -360,7 +360,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
     }
 
     override fun onEpisodeActionsLongPress(episodeUuid: String, podcastUuid: String?) {
-        if (settings.getTapOnUpNextShouldPlay()) {
+        if (settings.tapOnUpNextShouldPlay.flow.value) {
             (activity as? FragmentHostListener)?.openEpisodeDialog(
                 episodeUuid = episodeUuid,
                 source = EpisodeViewSource.UP_NEXT,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -143,7 +143,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
             swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                 swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
                 onItemUpdated = this::clearViewAtPosition,
-                defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
+                defaultUpNextSwipeAction = { settings.upNextSwipe.flow.value },
                 context = context,
                 fragmentManager = parentFragmentManager,
                 swipeSource = SwipeSource.UP_NEXT,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
@@ -69,7 +69,7 @@ class VideoFragment : Fragment(), PlayerSeekBar.OnUserSeekListener {
         binding.seekBar.changeListener = this
         binding.toolbar.setNavigationOnClickListener { activity?.finish() }
 
-        binding.skipBackwardInSecs = "${settings.getSkipBackwardInSecs()}"
+        binding.skipBackwardInSecs = "${settings.skipBackInSecs.flow.value}"
         binding.skipForwardInSecs = "${settings.skipForwardInSecs.flow.value}"
 
         binding.playButton.setCircleTintColor(ContextCompat.getColor(context, UR.color.transparent))

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
@@ -70,7 +70,7 @@ class VideoFragment : Fragment(), PlayerSeekBar.OnUserSeekListener {
         binding.toolbar.setNavigationOnClickListener { activity?.finish() }
 
         binding.skipBackwardInSecs = "${settings.getSkipBackwardInSecs()}"
-        binding.skipForwardInSecs = "${settings.getSkipForwardInSecs()}"
+        binding.skipForwardInSecs = "${settings.skipForwardInSecs.flow.value}"
 
         binding.playButton.setCircleTintColor(ContextCompat.getColor(context, UR.color.transparent))
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -64,6 +64,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.rx2.asObservable
 import timber.log.Timber
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -180,7 +181,7 @@ class PlayerViewModel @Inject constructor(
         upNextStateObservable,
         playbackStateObservable,
         settings.skipBackwardInSecsObservable,
-        settings.skipForwardInSecsObservable,
+        settings.skipForwardInSecs.flow.asObservable(coroutineContext),
         upNextExpandedObservable,
         chaptersExpandedObservable,
         settings.playbackEffectsObservable,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -180,7 +180,7 @@ class PlayerViewModel @Inject constructor(
     val listDataRx = Observables.combineLatest(
         upNextStateObservable,
         playbackStateObservable,
-        settings.skipBackwardInSecsObservable,
+        settings.skipBackInSecs.flow.asObservable(coroutineContext),
         settings.skipForwardInSecs.flow.asObservable(coroutineContext),
         upNextExpandedObservable,
         chaptersExpandedObservable,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -129,7 +129,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                 swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
                 onItemUpdated = ::lazyNotifyItemChanged,
-                defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
+                defaultUpNextSwipeAction = { settings.upNextSwipe.flow.value },
                 context = requireContext(),
                 fragmentManager = parentFragmentManager,
                 swipeSource = when (mode) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
@@ -99,7 +99,17 @@ class EpisodeListAdapter(
         val episode = getItem(position) as PodcastEpisode
 
         val tintColor = this.tintColor ?: holder.itemView.context.getThemeColor(UR.attr.primary_icon_01)
-        holder.setup(episode, fromListUuid, tintColor, playButtonListener, settings.streamingMode(), settings.getUpNextSwipeAction(), multiSelectHelper.isMultiSelecting, multiSelectHelper.isSelected(episode), disposables)
+        holder.setup(
+            episode = episode,
+            fromListUuid = fromListUuid,
+            tintColor = tintColor,
+            playButtonListener = playButtonListener,
+            streamByDefault = settings.streamingMode.flow.value,
+            upNextAction = settings.getUpNextSwipeAction(),
+            multiSelectEnabled = multiSelectHelper.isMultiSelecting,
+            isSelected = multiSelectHelper.isSelected(episode),
+            disposables = disposables
+        )
         holder.episodeRow.setOnClickListener {
             if (multiSelectHelper.isMultiSelecting) {
                 holder.binding.checkbox.isChecked = multiSelectHelper.toggle(episode)
@@ -117,7 +127,15 @@ class EpisodeListAdapter(
     private fun bindUserEpisodeViewHolder(position: Int, holder: UserEpisodeViewHolder) {
         val userEpisode = getItem(position) as UserEpisode
         val tintColor = this.tintColor ?: holder.itemView.context.getThemeColor(UR.attr.primary_icon_01)
-        holder.setup(userEpisode, tintColor, playButtonListener, settings.streamingMode(), settings.getUpNextSwipeAction(), multiSelectHelper.isMultiSelecting, multiSelectHelper.isSelected(userEpisode))
+        holder.setup(
+            episode = userEpisode,
+            tintColor = tintColor,
+            playButtonListener = playButtonListener,
+            streamByDefault = settings.streamingMode.flow.value,
+            upNextAction = settings.getUpNextSwipeAction(),
+            multiSelectEnabled = multiSelectHelper.isMultiSelecting,
+            isSelected = multiSelectHelper.isSelected(userEpisode)
+        )
         holder.episodeRow.setOnClickListener {
             if (multiSelectHelper.isMultiSelecting) {
                 holder.binding.checkbox.isChecked = multiSelectHelper.toggle(userEpisode)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
@@ -105,7 +105,7 @@ class EpisodeListAdapter(
             tintColor = tintColor,
             playButtonListener = playButtonListener,
             streamByDefault = settings.streamingMode.flow.value,
-            upNextAction = settings.getUpNextSwipeAction(),
+            upNextAction = settings.upNextSwipe.flow.value,
             multiSelectEnabled = multiSelectHelper.isMultiSelecting,
             isSelected = multiSelectHelper.isSelected(episode),
             disposables = disposables
@@ -132,7 +132,7 @@ class EpisodeListAdapter(
             tintColor = tintColor,
             playButtonListener = playButtonListener,
             streamByDefault = settings.streamingMode.flow.value,
-            upNextAction = settings.getUpNextSwipeAction(),
+            upNextAction = settings.upNextSwipe.flow.value,
             multiSelectEnabled = multiSelectHelper.isMultiSelecting,
             isSelected = multiSelectHelper.isSelected(userEpisode)
         )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -263,7 +263,17 @@ class PodcastAdapter(
 
     private fun bindEpisodeViewHolder(holder: EpisodeViewHolder, position: Int, fromListUuid: String?) {
         val episode = getItem(position) as? PodcastEpisode ?: return
-        holder.setup(episode, fromListUuid, ThemeColor.podcastIcon02(theme.activeTheme, tintColor), playButtonListener, settings.streamingMode() || castConnected, settings.getUpNextSwipeAction(), multiSelectHelper.isMultiSelecting, multiSelectHelper.isSelected(episode), disposables)
+        holder.setup(
+            episode = episode,
+            fromListUuid = fromListUuid,
+            tintColor = ThemeColor.podcastIcon02(theme.activeTheme, tintColor),
+            playButtonListener = playButtonListener,
+            streamByDefault = settings.streamingMode.flow.value || castConnected,
+            upNextAction = settings.getUpNextSwipeAction(),
+            multiSelectEnabled = multiSelectHelper.isMultiSelecting,
+            isSelected = multiSelectHelper.isSelected(episode),
+            disposables = disposables
+        )
         holder.episodeRow.setOnClickListener {
             if (multiSelectHelper.isMultiSelecting) {
                 holder.binding.checkbox.isChecked = multiSelectHelper.toggle(episode)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -269,7 +269,7 @@ class PodcastAdapter(
             tintColor = ThemeColor.podcastIcon02(theme.activeTheme, tintColor),
             playButtonListener = playButtonListener,
             streamByDefault = settings.streamingMode.flow.value || castConnected,
-            upNextAction = settings.getUpNextSwipeAction(),
+            upNextAction = settings.upNextSwipe.flow.value,
             multiSelectEnabled = multiSelectHelper.isMultiSelecting,
             isSelected = multiSelectHelper.isSelected(episode),
             disposables = disposables

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -566,7 +566,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                 swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                     swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
                     onItemUpdated = ::notifyItemChanged,
-                    defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
+                    defaultUpNextSwipeAction = { settings.upNextSwipe.flow.value },
                     context = context,
                     fragmentManager = parentFragmentManager,
                     swipeSource = EpisodeItemTouchHelper.SwipeSource.PODCAST_DETAILS,

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -83,7 +83,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                 swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
                 onItemUpdated = ::lazyNotifyItemChanged,
-                defaultUpNextSwipeAction = { settings.getUpNextSwipeAction() },
+                defaultUpNextSwipeAction = { settings.upNextSwipe.flow.value },
                 context = requireContext(),
                 fragmentManager = parentFragmentManager,
                 swipeSource = EpisodeItemTouchHelper.SwipeSource.FILES,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/MediaNotificationControlsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/MediaNotificationControlsFragment.kt
@@ -120,7 +120,7 @@ class MediaNotificationControlsFragment : BaseFragment(), MediaActionTouchCallba
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                settings.defaultMediaNotificationControlsFlow.collect {
+                settings.mediaControlItems.flow.collect {
                     val itemsPlusTitles = mutableListOf<Any>()
                     itemsPlusTitles.addAll(it)
                     itemsPlusTitles.add(3, otherActionsTitle)
@@ -282,7 +282,7 @@ class MediaNotificationControlsFragment : BaseFragment(), MediaActionTouchCallba
         // Reset mediaActionMove now that we've tracked it
         mediaActionMove = null
 
-        settings.setMediaNotificationControlItems(items.filterIsInstance<Settings.MediaNotificationControls>().map { it.key })
+        settings.mediaControlItems.set(items.filterIsInstance<Settings.MediaNotificationControls>())
     }
 }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/MediaNotificationControlsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/MediaNotificationControlsFragment.kt
@@ -112,7 +112,7 @@ class MediaNotificationControlsFragment : BaseFragment(), MediaActionTouchCallba
         recyclerView.adapter = adapter
         (recyclerView.itemAnimator as? SimpleItemAnimator)?.supportsChangeAnimations = false
         (recyclerView.itemAnimator as? SimpleItemAnimator)?.changeDuration = 0
-        updateMediaActionsVisibility(settings.areCustomMediaActionsVisible())
+        updateMediaActionsVisibility(settings.customMediaActionsVisibility.flow.value)
 
         val callback = MediaActionTouchCallback(listener = this)
         itemTouchHelper = ItemTouchHelper(callback)
@@ -136,9 +136,9 @@ class MediaNotificationControlsFragment : BaseFragment(), MediaActionTouchCallba
             setContent {
                 AppThemeWithBackground(theme.activeTheme) {
                     ShowCustomMediaActionsSettingsRow(
-                        shouldShowCustomMediaActions = settings.customMediaActionsVisibilityFlow.collectAsState().value,
+                        shouldShowCustomMediaActions = settings.customMediaActionsVisibility.flow.collectAsState().value,
                         onShowCustomMediaActionsToggled = { showCustomActions ->
-                            settings.setCustomMediaActionsVisible(showCustomActions)
+                            settings.customMediaActionsVisibility.set(showCustomActions)
                             updateMediaActionsVisibility(showCustomActions)
                         }
                     )

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -226,16 +226,18 @@ class PlaybackSettingsFragment : BaseFragment() {
                     // Skip forward time
                     SkipTime(
                         primaryText = stringResource(LR.string.settings_skip_forward_time),
-                        saved = settings.skipForwardInSecsObservable
-                            .subscribeAsState(settings.getSkipForwardInSecs())
+                        saved = settings.skipForwardInSecs.flow
+                            .collectAsState()
                             .value,
                         onSave = {
                             analyticsTracker.track(
                                 AnalyticsEvent.SETTINGS_GENERAL_SKIP_FORWARD_CHANGED,
                                 mapOf("value" to it)
                             )
-                            settings.setSkipForwardNeedsSync(true)
-                            settings.setSkipForwardInSec(it)
+                            settings.skipForwardInSecs.run {
+                                set(it)
+                                needsSync = true
+                            }
                         }
                     )
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -264,13 +264,13 @@ class PlaybackSettingsFragment : BaseFragment() {
                     )
 
                     OpenPlayerAutomatically(
-                        saved = settings.openPlayerAutomaticallyFlow.collectAsState().value,
+                        saved = settings.openPlayerAutomatically.flow.collectAsState().value,
                         onSave = {
                             analyticsTracker.track(
                                 AnalyticsEvent.SETTINGS_GENERAL_OPEN_PLAYER_AUTOMATICALLY_TOGGLED,
                                 mapOf("enabled" to it)
                             )
-                            settings.setOpenPlayerAutomatically(it)
+                            settings.openPlayerAutomatically.set(it)
                         }
                     )
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -191,7 +191,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                     )
 
                     ShowArchived(
-                        saved = settings.defaultShowArchivedFlow.collectAsState().value,
+                        saved = settings.showArchivedDefault.flow.collectAsState().value,
                         onSave = {
                             analyticsTracker.track(
                                 AnalyticsEvent.SETTINGS_GENERAL_ARCHIVED_EPISODES_CHANGED,
@@ -202,7 +202,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                     }
                                 )
                             )
-                            settings.setDefaultShowArchived(it)
+                            settings.showArchivedDefault.set(it)
                             showSetAllArchiveDialog(it)
                         }
                     )

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -140,9 +140,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                 SettingSection(heading = stringResource(LR.string.settings_general_defaults)) {
 
                     RowAction(
-                        saved = settings.rowActionObservable
-                            .subscribeAsState(settings.streamingMode())
-                            .value,
+                        saved = settings.streamingMode.flow.collectAsState().value,
                         onSave = {
                             analyticsTracker.track(
                                 AnalyticsEvent.SETTINGS_GENERAL_ROW_ACTION_CHANGED,
@@ -153,7 +151,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                     }
                                 )
                             )
-                            settings.setStreamingMode(it)
+                            settings.streamingMode.set(it)
                         }
                     )
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -286,13 +286,13 @@ class PlaybackSettingsFragment : BaseFragment() {
                     )
 
                     PlayUpNextOnTap(
-                        saved = settings.tapOnUpNextShouldPlayFlow.collectAsState().value,
+                        saved = settings.tapOnUpNextShouldPlay.flow.collectAsState().value,
                         onSave = {
                             analyticsTracker.track(
                                 AnalyticsEvent.SETTINGS_GENERAL_PLAY_UP_NEXT_ON_TAP_TOGGLED,
                                 mapOf("enabled" to it)
                             )
-                            settings.setTapOnUpNextShouldPlay(it)
+                            settings.tapOnUpNextShouldPlay.set(it)
                         }
                     )
 
@@ -300,7 +300,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                     // in the list. If it's position is changed, make sure you update the handling when
                     // we scroll to this item as well.
                     AutoPlayNextOnEmpty(
-                        saved = settings.autoPlayNextEpisodeOnEmptyFlow.collectAsState().value,
+                        saved = settings.autoPlayNextEpisodeOnEmpty.flow.collectAsState().value,
                         showFlashWithDelay = if (scrollToAutoPlay) {
                             // Have flash occur after scroll to autoplay
                             scrollToAutoPlayDelay * 2
@@ -312,7 +312,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                 AnalyticsEvent.SETTINGS_GENERAL_AUTOPLAY_TOGGLED,
                                 mapOf("enabled" to it)
                             )
-                            settings.setAutoPlayNextEpisodeOnEmpty(it)
+                            settings.autoPlayNextEpisodeOnEmpty.set(it)
                         }
                     )
                 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -275,13 +275,13 @@ class PlaybackSettingsFragment : BaseFragment() {
                     )
 
                     IntelligentPlaybackResumption(
-                        saved = settings.intelligentPlaybackResumptionFlow.collectAsState().value,
+                        saved = settings.intelligentPlaybackResumption.flow.collectAsState().value,
                         onSave = {
                             analyticsTracker.track(
                                 AnalyticsEvent.SETTINGS_GENERAL_INTELLIGENT_PLAYBACK_TOGGLED,
                                 mapOf("enabled" to it)
                             )
-                            settings.setIntelligentPlaybackResumption(it)
+                            settings.intelligentPlaybackResumption.set(it)
                         }
                     )
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -244,16 +244,16 @@ class PlaybackSettingsFragment : BaseFragment() {
                     // Skip back time
                     SkipTime(
                         primaryText = stringResource(LR.string.settings_skip_back_time),
-                        saved = settings.skipBackwardInSecsObservable
-                            .subscribeAsState(settings.getSkipBackwardInSecs())
-                            .value,
+                        saved = settings.skipBackInSecs.flow.collectAsState().value,
                         onSave = {
                             analyticsTracker.track(
                                 AnalyticsEvent.SETTINGS_GENERAL_SKIP_BACK_CHANGED,
                                 mapOf("value" to it)
                             )
-                            settings.setSkipBackNeedsSync(true)
-                            settings.setSkipBackwardInSec(it)
+                            settings.skipBackInSecs.run {
+                                set(it)
+                                needsSync = true
+                            }
                         }
                     )
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -171,7 +171,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                     )
 
                     PodcastEpisodeGrouping(
-                        saved = settings.defaultPodcastGroupingFlow.collectAsState().value,
+                        saved = settings.podcastGroupingDefault.flow.collectAsState().value,
                         onSave = {
                             analyticsTracker.track(
                                 AnalyticsEvent.SETTINGS_GENERAL_EPISODE_GROUPING_CHANGED,
@@ -185,7 +185,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                     }
                                 )
                             )
-                            settings.setDefaultPodcastGrouping(it)
+                            settings.podcastGroupingDefault.set(it)
                             showSetAllGroupingDialog(it)
                         }
                     )

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rxjava2.subscribeAsState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -156,9 +155,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                     )
 
                     UpNextSwipe(
-                        saved = settings.upNextSwipeActionObservable
-                            .subscribeAsState(settings.getUpNextSwipeAction())
-                            .value,
+                        saved = settings.upNextSwipe.flow.collectAsState().value,
                         onSave = {
                             analyticsTracker.track(
                                 AnalyticsEvent.SETTINGS_GENERAL_UP_NEXT_SWIPE_CHANGED,
@@ -169,7 +166,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                     }
                                 )
                             )
-                            settings.setUpNextSwipeAction(it)
+                            settings.upNextSwipe.set(it)
                         }
                     )
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -253,13 +253,13 @@ class PlaybackSettingsFragment : BaseFragment() {
                     )
 
                     KeepScreenAwake(
-                        saved = settings.keepScreenAwakeFlow.collectAsState().value,
+                        saved = settings.keepScreenAwake.flow.collectAsState().value,
                         onSave = {
                             analyticsTracker.track(
                                 AnalyticsEvent.SETTINGS_GENERAL_KEEP_SCREEN_AWAKE_TOGGLED,
                                 mapOf("enabled" to it)
                             )
-                            settings.setKeepScreenAwake(it)
+                            settings.keepScreenAwake.set(it)
                         }
                     )
 

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -94,7 +94,7 @@ class AppLifecycleObserver constructor(
                 AppPlatform.WearOs -> {}
 
                 // For new users we want to auto play when the queue is empty by default
-                AppPlatform.Phone -> settings.setAutoPlayNextEpisodeOnEmpty(true)
+                AppPlatform.Phone -> settings.autoPlayNextEpisodeOnEmpty.set(true)
             }
         } else if (previousVersionCode < versionCode) {
             appLifecycleAnalytics.onApplicationUpgrade(previousVersionCode)

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
@@ -8,6 +8,7 @@ import au.com.shiftyjelly.pocketcasts.featureflag.providers.DefaultReleaseFeatur
 import au.com.shiftyjelly.pocketcasts.featureflag.providers.FirebaseRemoteFeatureProvider
 import au.com.shiftyjelly.pocketcasts.featureflag.providers.PreferencesFeatureProvider
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.PackageUtil
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -32,6 +33,7 @@ class AppLifecycleObserverTest {
 
     @Mock @ApplicationContext private lateinit var context: Context
     @Mock private lateinit var settings: Settings
+    @Mock private lateinit var autoPlayNextEpisodeSetting: UserSetting<Boolean>
     @Mock private lateinit var packageUtil: PackageUtil
     @Mock private lateinit var appLifecycleAnalytics: AppLifecycleAnalytics
     @Mock private lateinit var preferencesFeatureProvider: PreferencesFeatureProvider
@@ -44,6 +46,8 @@ class AppLifecycleObserverTest {
 
     @Before
     fun setUp() {
+        whenever(settings.autoPlayNextEpisodeOnEmpty).thenReturn(autoPlayNextEpisodeSetting)
+
         whenever(appLifecycleOwner.lifecycle).thenReturn(appLifecycle)
 
         appLifecycleObserver = AppLifecycleObserver(
@@ -70,7 +74,7 @@ class AppLifecycleObserverTest {
         appLifecycleObserver.setup()
 
         verify(appLifecycleAnalytics).onNewApplicationInstall()
-        verify(settings).setAutoPlayNextEpisodeOnEmpty(true)
+        verify(autoPlayNextEpisodeSetting).set(true)
 
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
     }
@@ -86,7 +90,7 @@ class AppLifecycleObserverTest {
 
         verify(appLifecycleAnalytics).onNewApplicationInstall()
 
-        verify(settings, never()).setAutoPlayNextEpisodeOnEmpty(any())
+        verify(autoPlayNextEpisodeSetting, never()).set(any())
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
     }
 
@@ -101,7 +105,7 @@ class AppLifecycleObserverTest {
 
         verify(appLifecycleAnalytics).onNewApplicationInstall()
 
-        verify(settings, never()).setAutoPlayNextEpisodeOnEmpty(any())
+        verify(autoPlayNextEpisodeSetting, never()).set(any())
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
     }
 
@@ -117,6 +121,6 @@ class AppLifecycleObserverTest {
         verify(appLifecycleAnalytics).onApplicationUpgrade(VERSION_CODE_AFTER_FIRST_INSTALL)
 
         verify(appLifecycleAnalytics, never()).onNewApplicationInstall()
-        verify(settings, never()).setAutoPlayNextEpisodeOnEmpty(any())
+        verify(autoPlayNextEpisodeSetting, never()).set(any())
     }
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -92,7 +92,6 @@ interface Settings {
         const val PREFERENCE_PODCAST_AUTO_DOWNLOAD_WHEN_CHARGING = "autoDownloadOnlyDownloadWhenCharging"
         const val PREFERENCE_ALLOW_OTHER_APPS_ACCESS = "allowOtherAppsAccess"
         const val PREFERENCE_HIDE_SYNC_SETUP_MENU = "hideSyncSetupMenu"
-        const val PREFERENCE_KEEP_SCREEN_AWAKE = "keepScreenAwake4"
         const val PREFERENCE_OPEN_PLAYER_AUTOMATICALLY = "openPlayerAutomatically"
         const val PREFERENCE_SHOW_NOTE_IMAGES_ON = "showNotesImagesOn"
         const val PREFERENCE_SELECTED_FILTER = "selectedFilter"
@@ -302,7 +301,6 @@ interface Settings {
     val autoAddUpNextLimit: Observable<Int>
 
     val intelligentPlaybackResumptionFlow: StateFlow<Boolean>
-    val keepScreenAwakeFlow: StateFlow<Boolean>
     val openPlayerAutomaticallyFlow: StateFlow<Boolean>
     val tapOnUpNextShouldPlayFlow: StateFlow<Boolean>
     val customMediaActionsVisibilityFlow: StateFlow<Boolean>
@@ -404,9 +402,7 @@ interface Settings {
     fun hideNotificationOnPause(): Boolean
 
     val streamingMode: UserSetting<Boolean>
-
-    fun keepScreenAwake(): Boolean
-    fun setKeepScreenAwake(newValue: Boolean)
+    val keepScreenAwake: UserSetting<Boolean>
 
     fun openPlayerAutomatically(): Boolean
     fun setOpenPlayerAutomatically(newValue: Boolean)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -301,7 +301,6 @@ interface Settings {
     val autoAddUpNextLimitBehaviour: Observable<AutoAddUpNextLimitBehaviour>
     val autoAddUpNextLimit: Observable<Int>
 
-    val defaultPodcastGroupingFlow: StateFlow<PodcastGrouping>
     val defaultMediaNotificationControlsFlow: StateFlow<List<MediaNotificationControls>>
     val defaultShowArchivedFlow: StateFlow<Boolean>
     val intelligentPlaybackResumptionFlow: StateFlow<Boolean>
@@ -503,8 +502,7 @@ interface Settings {
     fun getPeriodicSaveTimeMs(): Long
     fun getPodcastSearchDebounceMs(): Long
     fun getEpisodeSearchDebounceMs(): Long
-    fun defaultPodcastGrouping(): PodcastGrouping
-    fun setDefaultPodcastGrouping(podcastGrouping: PodcastGrouping)
+    val podcastGroupingDefault: UserSetting<PodcastGrouping>
 
     fun getMarketingOptIn(): Boolean
     fun setMarketingOptIn(value: Boolean)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -299,7 +299,6 @@ interface Settings {
     val autoAddUpNextLimitBehaviour: Observable<AutoAddUpNextLimitBehaviour>
     val autoAddUpNextLimit: Observable<Int>
 
-    val intelligentPlaybackResumptionFlow: StateFlow<Boolean>
     val tapOnUpNextShouldPlayFlow: StateFlow<Boolean>
     val customMediaActionsVisibilityFlow: StateFlow<Boolean>
     val autoPlayNextEpisodeOnEmptyFlow: StateFlow<Boolean>
@@ -558,8 +557,7 @@ interface Settings {
     fun getLastPausedUUID(): String?
     fun setLastPausedAt(pausedAt: Int)
     fun getLastPausedAt(): Int?
-    fun getIntelligentPlaybackResumption(): Boolean
-    fun setIntelligentPlaybackResumption(value: Boolean)
+    val intelligentPlaybackResumption: UserSetting<Boolean>
     fun getAutoAddUpNextLimit(): Int
     fun setAutoAddUpNextLimit(limit: Int)
     fun setAutoAddUpNextLimitBehaviour(value: AutoAddUpNextLimitBehaviour)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -294,7 +294,6 @@ interface Settings {
     val selectPodcastSortTypeObservable: Observable<PodcastsSortType>
     val playbackEffectsObservable: Observable<PlaybackEffects>
     val refreshStateObservable: Observable<RefreshState>
-    val upNextSwipeActionObservable: Observable<UpNextAction>
     val marketingOptObservable: Observable<Boolean>
     val isFirstSyncRunObservable: Observable<Boolean>
     val shelfItemsObservable: Observable<List<String>>
@@ -489,8 +488,7 @@ interface Settings {
     fun contains(key: String): Boolean
     fun getLastRefreshError(): String?
 
-    fun getUpNextSwipeAction(): UpNextAction
-    fun setUpNextSwipeAction(action: UpNextAction)
+    val upNextSwipe: UserSetting<UpNextAction>
     fun getTapOnUpNextShouldPlay(): Boolean
     fun setTapOnUpNextShouldPlay(value: Boolean)
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -302,7 +302,6 @@ interface Settings {
     val autoAddUpNextLimit: Observable<Int>
 
     val defaultMediaNotificationControlsFlow: StateFlow<List<MediaNotificationControls>>
-    val defaultShowArchivedFlow: StateFlow<Boolean>
     val intelligentPlaybackResumptionFlow: StateFlow<Boolean>
     val keepScreenAwakeFlow: StateFlow<Boolean>
     val openPlayerAutomaticallyFlow: StateFlow<Boolean>
@@ -558,8 +557,7 @@ interface Settings {
     fun getAutoShowPlayed(): Boolean
     fun getAutoPlayNextEpisodeOnEmpty(): Boolean
     fun setAutoPlayNextEpisodeOnEmpty(enabled: Boolean)
-    fun defaultShowArchived(): Boolean
-    fun setDefaultShowArchived(value: Boolean)
+    val showArchivedDefault: UserSetting<Boolean>
     fun getMediaNotificationControlItems(): List<MediaNotificationControls>
     fun setMediaNotificationControlItems(items: List<String>)
     fun setMultiSelectItems(items: List<Int>)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -301,7 +301,6 @@ interface Settings {
     val autoAddUpNextLimitBehaviour: Observable<AutoAddUpNextLimitBehaviour>
     val autoAddUpNextLimit: Observable<Int>
 
-    val defaultMediaNotificationControlsFlow: StateFlow<List<MediaNotificationControls>>
     val intelligentPlaybackResumptionFlow: StateFlow<Boolean>
     val keepScreenAwakeFlow: StateFlow<Boolean>
     val openPlayerAutomaticallyFlow: StateFlow<Boolean>
@@ -558,8 +557,7 @@ interface Settings {
     fun getAutoPlayNextEpisodeOnEmpty(): Boolean
     fun setAutoPlayNextEpisodeOnEmpty(enabled: Boolean)
     val showArchivedDefault: UserSetting<Boolean>
-    fun getMediaNotificationControlItems(): List<MediaNotificationControls>
-    fun setMediaNotificationControlItems(items: List<String>)
+    val mediaControlItems: UserSetting<List<MediaNotificationControls>>
     fun setMultiSelectItems(items: List<Int>)
     fun getMultiSelectItems(): List<Int>
     fun setLastPauseTime(date: Date)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -62,7 +62,6 @@ interface Settings {
         const val LAST_SYNC_TIME = "LastSyncTime"
         const val PREFERENCE_SKIP_FORWARD = "skipForward"
         const val PREFERENCE_SKIP_BACKWARD = "skipBack"
-        const val PREFERENCE_SKIP_BACK_NEEDS_SYNC = "skipBackNeedsSync"
 
         const val PREFERENCE_MARKETING_OPT_IN = "marketingOptIn"
         const val PREFERENCE_MARKETING_OPT_IN_NEEDS_SYNC = "marketingOptInNeedsSync"
@@ -116,9 +115,6 @@ interface Settings {
         // legacy settings
         const val LEGACY_STORAGE_ON_PHONE = "phone"
         const val LEGACY_STORAGE_ON_SD_CARD = "external"
-
-        const val SKIP_FORWARD_DEFAULT = "30"
-        const val SKIP_BACKWARD_DEFAULT = "10"
 
         const val LAST_MAIN_NAV_SCREEN_OPENED = "last_main_screen"
 
@@ -296,7 +292,6 @@ interface Settings {
     val podcastBadgeTypeObservable: Observable<BadgeType>
     val podcastSortTypeObservable: Observable<PodcastsSortType>
     val selectPodcastSortTypeObservable: Observable<PodcastsSortType>
-    val skipBackwardInSecsObservable: Observable<Int>
     val playbackEffectsObservable: Observable<PlaybackEffects>
     val refreshStateObservable: Observable<RefreshState>
     val upNextSwipeActionObservable: Observable<UpNextAction>
@@ -332,8 +327,7 @@ interface Settings {
     fun isScreenReaderOn(): Boolean
 
     val skipForwardInSecs: UserSetting<Int>
-    fun getSkipBackwardInSecs(): Int
-    fun getSkipBackwardInMs(): Long
+    val skipBackInSecs: UserSetting<Int>
 
     fun getLastScreenOpened(): String?
     fun setLastScreenOpened(screenId: String)
@@ -515,9 +509,6 @@ interface Settings {
     fun getEpisodeSearchDebounceMs(): Long
     fun defaultPodcastGrouping(): PodcastGrouping
     fun setDefaultPodcastGrouping(podcastGrouping: PodcastGrouping)
-    fun setSkipBackwardInSec(value: Int)
-    fun setSkipBackNeedsSync(value: Boolean)
-    fun getSkipBackNeedsSync(): Boolean
 
     fun getMarketingOptIn(): Boolean
     fun setMarketingOptIn(value: Boolean)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -298,7 +298,6 @@ interface Settings {
     val autoAddUpNextLimitBehaviour: Observable<AutoAddUpNextLimitBehaviour>
     val autoAddUpNextLimit: Observable<Int>
 
-    val customMediaActionsVisibilityFlow: StateFlow<Boolean>
     val headphonePreviousActionFlow: StateFlow<HeadphoneAction>
     val headphoneNextActionFlow: StateFlow<HeadphoneAction>
     val headphonePlayBookmarkConfirmationSoundFlow: StateFlow<Boolean>
@@ -585,8 +584,7 @@ interface Settings {
     fun hasCompletedOnboarding(): Boolean
     fun setHasDoneInitialOnboarding()
 
-    fun areCustomMediaActionsVisible(): Boolean
-    fun setCustomMediaActionsVisible(value: Boolean)
+    val customMediaActionsVisibility: UserSetting<Boolean>
 
     fun isNotificationsDisabledMessageShown(): Boolean
     fun setNotificationsDisabledMessageShown(value: Boolean)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -92,7 +92,6 @@ interface Settings {
         const val PREFERENCE_PODCAST_AUTO_DOWNLOAD_WHEN_CHARGING = "autoDownloadOnlyDownloadWhenCharging"
         const val PREFERENCE_ALLOW_OTHER_APPS_ACCESS = "allowOtherAppsAccess"
         const val PREFERENCE_HIDE_SYNC_SETUP_MENU = "hideSyncSetupMenu"
-        const val PREFERENCE_OPEN_PLAYER_AUTOMATICALLY = "openPlayerAutomatically"
         const val PREFERENCE_SHOW_NOTE_IMAGES_ON = "showNotesImagesOn"
         const val PREFERENCE_SELECTED_FILTER = "selectedFilter"
         const val PREFERENCE_CHAPTERS_EXPANDED = "chaptersExpanded"
@@ -301,7 +300,6 @@ interface Settings {
     val autoAddUpNextLimit: Observable<Int>
 
     val intelligentPlaybackResumptionFlow: StateFlow<Boolean>
-    val openPlayerAutomaticallyFlow: StateFlow<Boolean>
     val tapOnUpNextShouldPlayFlow: StateFlow<Boolean>
     val customMediaActionsVisibilityFlow: StateFlow<Boolean>
     val autoPlayNextEpisodeOnEmptyFlow: StateFlow<Boolean>
@@ -403,9 +401,7 @@ interface Settings {
 
     val streamingMode: UserSetting<Boolean>
     val keepScreenAwake: UserSetting<Boolean>
-
-    fun openPlayerAutomatically(): Boolean
-    fun setOpenPlayerAutomatically(newValue: Boolean)
+    val openPlayerAutomatically: UserSetting<Boolean>
 
     fun isPodcastAutoDownloadUnmeteredOnly(): Boolean
     fun isPodcastAutoDownloadPowerOnly(): Boolean

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -62,7 +62,6 @@ interface Settings {
         const val LAST_SYNC_TIME = "LastSyncTime"
         const val PREFERENCE_SKIP_FORWARD = "skipForward"
         const val PREFERENCE_SKIP_BACKWARD = "skipBack"
-        const val PREFERENCE_SKIP_FORWARD_NEEDS_SYNC = "skipForwardNeedsSync"
         const val PREFERENCE_SKIP_BACK_NEEDS_SYNC = "skipBackNeedsSync"
 
         const val PREFERENCE_MARKETING_OPT_IN = "marketingOptIn"
@@ -297,7 +296,6 @@ interface Settings {
     val podcastBadgeTypeObservable: Observable<BadgeType>
     val podcastSortTypeObservable: Observable<PodcastsSortType>
     val selectPodcastSortTypeObservable: Observable<PodcastsSortType>
-    val skipForwardInSecsObservable: Observable<Int>
     val skipBackwardInSecsObservable: Observable<Int>
     val playbackEffectsObservable: Observable<PlaybackEffects>
     val refreshStateObservable: Observable<RefreshState>
@@ -333,8 +331,7 @@ interface Settings {
 
     fun isScreenReaderOn(): Boolean
 
-    fun getSkipForwardInSecs(): Int
-    fun getSkipForwardInMs(): Long
+    val skipForwardInSecs: UserSetting<Int>
     fun getSkipBackwardInSecs(): Int
     fun getSkipBackwardInMs(): Long
 
@@ -518,11 +515,8 @@ interface Settings {
     fun getEpisodeSearchDebounceMs(): Long
     fun defaultPodcastGrouping(): PodcastGrouping
     fun setDefaultPodcastGrouping(podcastGrouping: PodcastGrouping)
-    fun setSkipForwardInSec(value: Int)
     fun setSkipBackwardInSec(value: Int)
-    fun setSkipForwardNeedsSync(value: Boolean)
     fun setSkipBackNeedsSync(value: Boolean)
-    fun getSkipForwardNeedsSync(): Boolean
     fun getSkipBackNeedsSync(): Boolean
 
     fun getMarketingOptIn(): Boolean

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -98,7 +98,6 @@ interface Settings {
         const val PREFERENCE_UPNEXT_EXPANDED = "upnextExpanded"
         const val INTELLIGENT_PLAYBACK_RESUMPTION = "intelligentPlaybackResumption"
 
-        const val PREFERENCE_AUTO_PLAY_ON_EMPTY = "autoUpNextEmpty"
         const val PREFERENCE_AUTO_SUBSCRIBE_ON_PLAY = "autoSubscribeToPlayed"
         const val PREFERENCE_AUTO_SHOW_PLAYED = "autoShowPlayed"
 
@@ -299,9 +298,7 @@ interface Settings {
     val autoAddUpNextLimitBehaviour: Observable<AutoAddUpNextLimitBehaviour>
     val autoAddUpNextLimit: Observable<Int>
 
-    val tapOnUpNextShouldPlayFlow: StateFlow<Boolean>
     val customMediaActionsVisibilityFlow: StateFlow<Boolean>
-    val autoPlayNextEpisodeOnEmptyFlow: StateFlow<Boolean>
     val headphonePreviousActionFlow: StateFlow<HeadphoneAction>
     val headphoneNextActionFlow: StateFlow<HeadphoneAction>
     val headphonePlayBookmarkConfirmationSoundFlow: StateFlow<Boolean>
@@ -477,8 +474,7 @@ interface Settings {
     fun getLastRefreshError(): String?
 
     val upNextSwipe: UserSetting<UpNextAction>
-    fun getTapOnUpNextShouldPlay(): Boolean
-    fun setTapOnUpNextShouldPlay(value: Boolean)
+    val tapOnUpNextShouldPlay: UserSetting<Boolean>
 
     fun getHeadphoneControlsNextAction(): HeadphoneAction
     fun setHeadphoneControlsNextAction(action: HeadphoneAction)
@@ -545,8 +541,7 @@ interface Settings {
     fun getTrialFinishedSeen(): Boolean
     fun getAutoSubscribeToPlayed(): Boolean
     fun getAutoShowPlayed(): Boolean
-    fun getAutoPlayNextEpisodeOnEmpty(): Boolean
-    fun setAutoPlayNextEpisodeOnEmpty(enabled: Boolean)
+    val autoPlayNextEpisodeOnEmpty: UserSetting<Boolean>
     val showArchivedDefault: UserSetting<Boolean>
     val mediaControlItems: UserSetting<List<MediaNotificationControls>>
     fun setMultiSelectItems(items: List<Int>)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -295,7 +295,6 @@ interface Settings {
     val playbackEffectsObservable: Observable<PlaybackEffects>
     val refreshStateObservable: Observable<RefreshState>
     val upNextSwipeActionObservable: Observable<UpNextAction>
-    val rowActionObservable: Observable<Boolean>
     val marketingOptObservable: Observable<Boolean>
     val isFirstSyncRunObservable: Observable<Boolean>
     val shelfItemsObservable: Observable<List<String>>
@@ -408,8 +407,7 @@ interface Settings {
 
     fun hideNotificationOnPause(): Boolean
 
-    fun streamingMode(): Boolean
-    fun setStreamingMode(newValue: Boolean)
+    val streamingMode: UserSetting<Boolean>
 
     fun keepScreenAwake(): Boolean
     fun setKeepScreenAwake(newValue: Boolean)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -153,7 +153,7 @@ class SettingsImpl @Inject constructor(
         return context.isScreenReaderOn()
     }
 
-    override val skipForwardInSecs = UserSetting.IntFromString(
+    override val skipForwardInSecs = UserSetting.IntFromStringPref(
         sharedPrefKey = Settings.PREFERENCE_SKIP_FORWARD,
         defaultValue = 30,
         allowNegative = false,
@@ -161,7 +161,7 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override val skipBackInSecs: UserSetting<Int> = UserSetting.IntFromString(
+    override val skipBackInSecs: UserSetting<Int> = UserSetting.IntFromStringPref(
         sharedPrefKey = Settings.PREFERENCE_SKIP_BACKWARD,
         defaultValue = 10,
         allowNegative = false,

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -79,7 +79,6 @@ class SettingsImpl @Inject constructor(
     override val podcastSortTypeObservable = BehaviorRelay.create<PodcastsSortType>().apply { accept(getPodcastsSortType()) }
     override val selectPodcastSortTypeObservable = BehaviorRelay.create<PodcastsSortType>().apply { accept(getSelectPodcastsSortType()) }
     override val playbackEffectsObservable = BehaviorRelay.create<PlaybackEffects>().apply { accept(getGlobalPlaybackEffects()) }
-    override val upNextSwipeActionObservable = BehaviorRelay.create<Settings.UpNextAction>().apply { accept(getUpNextSwipeAction()) }
     override val marketingOptObservable = BehaviorRelay.create<Boolean>().apply { accept(getMarketingOptIn()) }
     override val isFirstSyncRunObservable = BehaviorRelay.create<Boolean>().apply { accept(isFirstSyncRun()) }
     override val shelfItemsObservable = BehaviorRelay.create<List<String>>().apply { accept(getShelfItems()) }
@@ -1015,13 +1014,16 @@ class SettingsImpl @Inject constructor(
         return if (value == 0L) (FirebaseConfig.defaults[key] as? Long ?: 0L) else value
     }
 
-    override fun getUpNextSwipeAction(): Settings.UpNextAction {
-        return Settings.UpNextAction.values()[getInt("up_next_action", Settings.UpNextAction.PLAY_NEXT.ordinal)]
-    }
+    override val upNextSwipe = object : UserSetting.PrefFromInt<Settings.UpNextAction>(
+        sharedPrefKey = "up_next_action",
+        defaultValue = Settings.UpNextAction.PLAY_NEXT,
+        sharedPrefs = sharedPreferences
+    ) {
+        override fun fromInt(value: Int): Settings.UpNextAction =
+            Settings.UpNextAction.values()[value]
 
-    override fun setUpNextSwipeAction(action: Settings.UpNextAction) {
-        setInt("up_next_action", action.ordinal)
-        upNextSwipeActionObservable.accept(action)
+        override fun toInt(value: Settings.UpNextAction): Int =
+            value.ordinal
     }
 
     override fun getTapOnUpNextShouldPlay(): Boolean {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -86,7 +86,6 @@ class SettingsImpl @Inject constructor(
     override val autoAddUpNextLimitBehaviour = BehaviorRelay.create<Settings.AutoAddUpNextLimitBehaviour>().apply { accept(getAutoAddUpNextLimitBehaviour()) }
     override val autoAddUpNextLimit = BehaviorRelay.create<Int>().apply { accept(getAutoAddUpNextLimit()) }
 
-    override val intelligentPlaybackResumptionFlow = MutableStateFlow(getIntelligentPlaybackResumption())
     override val tapOnUpNextShouldPlayFlow = MutableStateFlow(getTapOnUpNextShouldPlay())
     override val customMediaActionsVisibilityFlow = MutableStateFlow(areCustomMediaActionsVisible())
     override val autoPlayNextEpisodeOnEmptyFlow = MutableStateFlow(getAutoPlayNextEpisodeOnEmpty())
@@ -856,14 +855,11 @@ class SettingsImpl @Inject constructor(
         return if (lastPausedAt != 0) lastPausedAt else null
     }
 
-    override fun getIntelligentPlaybackResumption(): Boolean {
-        return getBoolean(Settings.INTELLIGENT_PLAYBACK_RESUMPTION, true)
-    }
-
-    override fun setIntelligentPlaybackResumption(value: Boolean) {
-        setBoolean(Settings.INTELLIGENT_PLAYBACK_RESUMPTION, value)
-        intelligentPlaybackResumptionFlow.update { value }
-    }
+    override val intelligentPlaybackResumption = UserSetting.BoolPref(
+        sharedPrefKey = Settings.INTELLIGENT_PLAYBACK_RESUMPTION,
+        defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
 
     private fun setDate(preference: String, date: Date?) {
         val editor = sharedPreferences.edit()

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -152,17 +152,15 @@ class SettingsImpl @Inject constructor(
         return context.isScreenReaderOn()
     }
 
-    override val skipForwardInSecs = UserSetting.IntFromStringPref(
-        sharedPrefKey = Settings.PREFERENCE_SKIP_FORWARD,
-        defaultValue = 30,
-        allowNegative = false,
+    override val skipBackInSecs = UserSetting.PrefFromString.SkipAmount(
+        sharedPrefKey = Settings.PREFERENCE_SKIP_BACKWARD,
+        defaultValue = 10,
         sharedPrefs = sharedPreferences,
     )
 
-    override val skipBackInSecs: UserSetting<Int> = UserSetting.IntFromStringPref(
-        sharedPrefKey = Settings.PREFERENCE_SKIP_BACKWARD,
-        defaultValue = 10,
-        allowNegative = false,
+    override val skipForwardInSecs = UserSetting.PrefFromString.SkipAmount(
+        sharedPrefKey = Settings.PREFERENCE_SKIP_FORWARD,
+        defaultValue = 30,
         sharedPrefs = sharedPreferences,
     )
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -80,7 +80,6 @@ class SettingsImpl @Inject constructor(
     override val selectPodcastSortTypeObservable = BehaviorRelay.create<PodcastsSortType>().apply { accept(getSelectPodcastsSortType()) }
     override val playbackEffectsObservable = BehaviorRelay.create<PlaybackEffects>().apply { accept(getGlobalPlaybackEffects()) }
     override val upNextSwipeActionObservable = BehaviorRelay.create<Settings.UpNextAction>().apply { accept(getUpNextSwipeAction()) }
-    override val rowActionObservable = BehaviorRelay.create<Boolean>().apply { accept(streamingMode()) }
     override val marketingOptObservable = BehaviorRelay.create<Boolean>().apply { accept(getMarketingOptIn()) }
     override val isFirstSyncRunObservable = BehaviorRelay.create<Boolean>().apply { accept(isFirstSyncRun()) }
     override val shelfItemsObservable = BehaviorRelay.create<List<String>>().apply { accept(getShelfItems()) }
@@ -612,14 +611,12 @@ class SettingsImpl @Inject constructor(
         return sharedPreferences.getBoolean(Settings.PREFERENCE_HIDE_NOTIFICATION_ON_PAUSE, false)
     }
 
-    override fun streamingMode(): Boolean {
-        return sharedPreferences.getBoolean(Settings.PREFERENCE_GLOBAL_STREAMING_MODE, true)
-    }
-
-    override fun setStreamingMode(newValue: Boolean) {
-        setBoolean(Settings.PREFERENCE_GLOBAL_STREAMING_MODE, newValue)
-        rowActionObservable.accept(newValue)
-    }
+    override val streamingMode: UserSetting<Boolean> = UserSetting.BoolPref(
+        sharedPrefKey = Settings.PREFERENCE_GLOBAL_STREAMING_MODE,
+        defaultValue = true,
+        syncable = false,
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun keepScreenAwake(): Boolean {
         return sharedPreferences.getBoolean(Settings.PREFERENCE_KEEP_SCREEN_AWAKE, false)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -86,7 +86,6 @@ class SettingsImpl @Inject constructor(
     override val autoAddUpNextLimitBehaviour = BehaviorRelay.create<Settings.AutoAddUpNextLimitBehaviour>().apply { accept(getAutoAddUpNextLimitBehaviour()) }
     override val autoAddUpNextLimit = BehaviorRelay.create<Int>().apply { accept(getAutoAddUpNextLimit()) }
 
-    override val defaultPodcastGroupingFlow = MutableStateFlow(defaultPodcastGrouping())
     override val defaultMediaNotificationControlsFlow = MutableStateFlow(getMediaNotificationControlItems())
     override val defaultShowArchivedFlow = MutableStateFlow(defaultShowArchived())
     override val keepScreenAwakeFlow = MutableStateFlow(keepScreenAwake())
@@ -1080,14 +1079,15 @@ class SettingsImpl @Inject constructor(
         defaultMediaNotificationControlsFlow.update { items.mapNotNull { MediaNotificationControls.itemForId(it) } }
     }
 
-    override fun defaultPodcastGrouping(): PodcastGrouping {
-        val index = getInt("default_podcast_grouping", 0)
-        return PodcastGrouping.All.getOrNull(index) ?: PodcastGrouping.None
-    }
-
-    override fun setDefaultPodcastGrouping(podcastGrouping: PodcastGrouping) {
-        setInt("default_podcast_grouping", PodcastGrouping.All.indexOf(podcastGrouping))
-        defaultPodcastGroupingFlow.update { podcastGrouping }
+    override val podcastGroupingDefault = run {
+        val default = PodcastGrouping.None
+        UserSetting.PrefFromInt<PodcastGrouping>(
+            sharedPrefKey = "default_podcast_grouping",
+            defaultValue = default,
+            sharedPrefs = sharedPreferences,
+            fromInt = { PodcastGrouping.All.getOrNull(it) ?: default },
+            toInt = { PodcastGrouping.All.indexOf(it) }
+        )
     }
 
     override fun setCloudSortOrder(sortOrder: Settings.CloudSortOrder) {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1014,17 +1014,13 @@ class SettingsImpl @Inject constructor(
         return if (value == 0L) (FirebaseConfig.defaults[key] as? Long ?: 0L) else value
     }
 
-    override val upNextSwipe = object : UserSetting.PrefFromInt<Settings.UpNextAction>(
+    override val upNextSwipe = UserSetting.PrefFromInt(
         sharedPrefKey = "up_next_action",
         defaultValue = Settings.UpNextAction.PLAY_NEXT,
-        sharedPrefs = sharedPreferences
-    ) {
-        override fun fromInt(value: Int): Settings.UpNextAction =
-            Settings.UpNextAction.values()[value]
-
-        override fun toInt(value: Settings.UpNextAction): Int =
-            value.ordinal
-    }
+        sharedPrefs = sharedPreferences,
+        fromInt = { Settings.UpNextAction.values()[it] },
+        toInt = { it.ordinal }
+    )
 
     override fun getTapOnUpNextShouldPlay(): Boolean {
         return getBoolean("tap_on_up_next_should_play", false)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -65,7 +65,6 @@ class SettingsImpl @Inject constructor(
         private const val END_OF_YEAR_SHOW_BADGE_2022_KEY = "EndOfYearShowBadge2022Key"
         private const val END_OF_YEAR_MODAL_HAS_BEEN_SHOWN_KEY = "EndOfYearModalHasBeenShownKey"
         private const val DONE_INITIAL_ONBOARDING_KEY = "CompletedOnboardingKey"
-        private const val CUSTOM_MEDIA_ACTIONS_VISIBLE_KEY = "CustomMediaActionsVisibleKey"
         private const val LAST_SELECTED_SUBSCRIPTION_TIER_KEY = "LastSelectedSubscriptionTierKey"
         private const val LAST_SELECTED_SUBSCRIPTION_FREQUENCY_KEY = "LastSelectedSubscriptionFrequencyKey"
         private const val PROCESSED_SIGNOUT_KEY = "ProcessedSignout"
@@ -86,7 +85,6 @@ class SettingsImpl @Inject constructor(
     override val autoAddUpNextLimitBehaviour = BehaviorRelay.create<Settings.AutoAddUpNextLimitBehaviour>().apply { accept(getAutoAddUpNextLimitBehaviour()) }
     override val autoAddUpNextLimit = BehaviorRelay.create<Int>().apply { accept(getAutoAddUpNextLimit()) }
 
-    override val customMediaActionsVisibilityFlow = MutableStateFlow(areCustomMediaActionsVisible())
     override val headphonePreviousActionFlow = MutableStateFlow(getHeadphoneControlsPreviousAction())
     override val headphoneNextActionFlow = MutableStateFlow(getHeadphoneControlsNextAction())
     override val headphonePlayBookmarkConfirmationSoundFlow = MutableStateFlow(getHeadphoneControlsPlayBookmarkConfirmationSound())
@@ -1328,13 +1326,11 @@ class SettingsImpl @Inject constructor(
         setBoolean(DONE_INITIAL_ONBOARDING_KEY, true)
     }
 
-    override fun areCustomMediaActionsVisible() =
-        getBoolean(CUSTOM_MEDIA_ACTIONS_VISIBLE_KEY, true)
-
-    override fun setCustomMediaActionsVisible(value: Boolean) {
-        setBoolean(CUSTOM_MEDIA_ACTIONS_VISIBLE_KEY, value)
-        customMediaActionsVisibilityFlow.update { value }
-    }
+    override val customMediaActionsVisibility = UserSetting.BoolPref(
+        sharedPrefKey = "CustomMediaActionsVisibleKey",
+        defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun isNotificationsDisabledMessageShown() =
         getBoolean(NOTIFICATIONS_DISABLED_MESSAGE_SHOWN, false)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -86,9 +86,7 @@ class SettingsImpl @Inject constructor(
     override val autoAddUpNextLimitBehaviour = BehaviorRelay.create<Settings.AutoAddUpNextLimitBehaviour>().apply { accept(getAutoAddUpNextLimitBehaviour()) }
     override val autoAddUpNextLimit = BehaviorRelay.create<Int>().apply { accept(getAutoAddUpNextLimit()) }
 
-    override val tapOnUpNextShouldPlayFlow = MutableStateFlow(getTapOnUpNextShouldPlay())
     override val customMediaActionsVisibilityFlow = MutableStateFlow(areCustomMediaActionsVisible())
-    override val autoPlayNextEpisodeOnEmptyFlow = MutableStateFlow(getAutoPlayNextEpisodeOnEmpty())
     override val headphonePreviousActionFlow = MutableStateFlow(getHeadphoneControlsPreviousAction())
     override val headphoneNextActionFlow = MutableStateFlow(getHeadphoneControlsNextAction())
     override val headphonePlayBookmarkConfirmationSoundFlow = MutableStateFlow(getHeadphoneControlsPlayBookmarkConfirmationSound())
@@ -950,19 +948,15 @@ class SettingsImpl @Inject constructor(
         sharedPreferences.edit().putStringSet(Settings.AUTO_ARCHIVE_EXCLUDED_PODCASTS, excluded.toSet()).apply()
     }
 
-    override fun getAutoPlayNextEpisodeOnEmpty(): Boolean {
-        val defaultValue = when (Util.getAppPlatform(context)) {
+    override val autoPlayNextEpisodeOnEmpty = UserSetting.BoolPref(
+        sharedPrefKey = "autoUpNextEmpty",
+        defaultValue = when (Util.getAppPlatform(context)) {
             AppPlatform.Automotive -> true
-            AppPlatform.Phone -> false
+            AppPlatform.Phone,
             AppPlatform.WearOs -> false
-        }
-        return getBoolean(Settings.PREFERENCE_AUTO_PLAY_ON_EMPTY, defaultValue)
-    }
-
-    override fun setAutoPlayNextEpisodeOnEmpty(enabled: Boolean) {
-        setBoolean(Settings.PREFERENCE_AUTO_PLAY_ON_EMPTY, enabled)
-        autoPlayNextEpisodeOnEmptyFlow.update { enabled }
-    }
+        },
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun getAutoArchiveIncludeStarred(): Boolean {
         return getBoolean(Settings.AUTO_ARCHIVE_INCLUDE_STARRED, false)
@@ -1007,14 +1001,11 @@ class SettingsImpl @Inject constructor(
         toInt = { it.ordinal }
     )
 
-    override fun getTapOnUpNextShouldPlay(): Boolean {
-        return getBoolean("tap_on_up_next_should_play", false)
-    }
-
-    override fun setTapOnUpNextShouldPlay(value: Boolean) {
-        setBoolean("tap_on_up_next_should_play", value)
-        tapOnUpNextShouldPlayFlow.update { value }
-    }
+    override val tapOnUpNextShouldPlay = UserSetting.BoolPref(
+        sharedPrefKey = "tap_on_up_next_should_play",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun getHeadphoneControlsNextAction(): Settings.HeadphoneAction {
         return Settings.HeadphoneAction.values()[getInt("headphone_controls_next_action", Settings.HeadphoneAction.SKIP_FORWARD.ordinal)]

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -87,7 +87,6 @@ class SettingsImpl @Inject constructor(
     override val autoAddUpNextLimit = BehaviorRelay.create<Int>().apply { accept(getAutoAddUpNextLimit()) }
 
     override val defaultMediaNotificationControlsFlow = MutableStateFlow(getMediaNotificationControlItems())
-    override val defaultShowArchivedFlow = MutableStateFlow(defaultShowArchived())
     override val keepScreenAwakeFlow = MutableStateFlow(keepScreenAwake())
     override val openPlayerAutomaticallyFlow = MutableStateFlow(openPlayerAutomatically())
     override val intelligentPlaybackResumptionFlow = MutableStateFlow(getIntelligentPlaybackResumption())
@@ -1057,14 +1056,11 @@ class SettingsImpl @Inject constructor(
         headphonePlayBookmarkConfirmationSoundFlow.update { value }
     }
 
-    override fun defaultShowArchived(): Boolean {
-        return getBoolean("default_show_archived", false)
-    }
-
-    override fun setDefaultShowArchived(value: Boolean) {
-        setBoolean("default_show_archived", value)
-        defaultShowArchivedFlow.update { value }
-    }
+    override val showArchivedDefault = UserSetting.BoolPref(
+        sharedPrefKey = "default_show_archived",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun getMediaNotificationControlItems(): List<MediaNotificationControls> {
         var items = getStringList("media_notification_controls_action")

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -86,7 +86,6 @@ class SettingsImpl @Inject constructor(
     override val autoAddUpNextLimitBehaviour = BehaviorRelay.create<Settings.AutoAddUpNextLimitBehaviour>().apply { accept(getAutoAddUpNextLimitBehaviour()) }
     override val autoAddUpNextLimit = BehaviorRelay.create<Int>().apply { accept(getAutoAddUpNextLimit()) }
 
-    override val defaultMediaNotificationControlsFlow = MutableStateFlow(getMediaNotificationControlItems())
     override val keepScreenAwakeFlow = MutableStateFlow(keepScreenAwake())
     override val openPlayerAutomaticallyFlow = MutableStateFlow(openPlayerAutomatically())
     override val intelligentPlaybackResumptionFlow = MutableStateFlow(getIntelligentPlaybackResumption())
@@ -1062,18 +1061,13 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override fun getMediaNotificationControlItems(): List<MediaNotificationControls> {
-        var items = getStringList("media_notification_controls_action")
-
-        if (items.isEmpty())
-            items = MediaNotificationControls.All.map { it.key }
-        return items.mapNotNull { MediaNotificationControls.itemForId(it) }
-    }
-
-    override fun setMediaNotificationControlItems(items: List<String>) {
-        setStringList("media_notification_controls_action", items)
-        defaultMediaNotificationControlsFlow.update { items.mapNotNull { MediaNotificationControls.itemForId(it) } }
-    }
+    override val mediaControlItems = UserSetting.PrefListFromString<MediaNotificationControls>(
+        sharedPrefKey = "media_notification_controls_action",
+        sharedPrefs = sharedPreferences,
+        defaultValue = MediaNotificationControls.All,
+        fromString = { MediaNotificationControls.itemForId(it) },
+        toString = { it.key }
+    )
 
     override val podcastGroupingDefault = run {
         val default = PodcastGrouping.None

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -86,7 +86,6 @@ class SettingsImpl @Inject constructor(
     override val autoAddUpNextLimitBehaviour = BehaviorRelay.create<Settings.AutoAddUpNextLimitBehaviour>().apply { accept(getAutoAddUpNextLimitBehaviour()) }
     override val autoAddUpNextLimit = BehaviorRelay.create<Int>().apply { accept(getAutoAddUpNextLimit()) }
 
-    override val keepScreenAwakeFlow = MutableStateFlow(keepScreenAwake())
     override val openPlayerAutomaticallyFlow = MutableStateFlow(openPlayerAutomatically())
     override val intelligentPlaybackResumptionFlow = MutableStateFlow(getIntelligentPlaybackResumption())
     override val tapOnUpNextShouldPlayFlow = MutableStateFlow(getTapOnUpNextShouldPlay())
@@ -609,14 +608,11 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override fun keepScreenAwake(): Boolean {
-        return sharedPreferences.getBoolean(Settings.PREFERENCE_KEEP_SCREEN_AWAKE, false)
-    }
-
-    override fun setKeepScreenAwake(newValue: Boolean) {
-        setBoolean(Settings.PREFERENCE_KEEP_SCREEN_AWAKE, newValue)
-        keepScreenAwakeFlow.update { newValue }
-    }
+    override val keepScreenAwake = UserSetting.BoolPref(
+        sharedPrefKey = "keepScreenAwake4", // Yes, there is a 4 at the end. I don't know why.
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun openPlayerAutomatically(): Boolean {
         return sharedPreferences.getBoolean(Settings.PREFERENCE_OPEN_PLAYER_AUTOMATICALLY, false)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -156,7 +156,6 @@ class SettingsImpl @Inject constructor(
         sharedPrefKey = Settings.PREFERENCE_SKIP_FORWARD,
         defaultValue = 30,
         allowNegative = false,
-        syncable = true,
         sharedPrefs = sharedPreferences,
     )
 
@@ -164,7 +163,6 @@ class SettingsImpl @Inject constructor(
         sharedPrefKey = Settings.PREFERENCE_SKIP_BACKWARD,
         defaultValue = 10,
         allowNegative = false,
-        syncable = true,
         sharedPrefs = sharedPreferences,
     )
 
@@ -614,7 +612,6 @@ class SettingsImpl @Inject constructor(
     override val streamingMode: UserSetting<Boolean> = UserSetting.BoolPref(
         sharedPrefKey = Settings.PREFERENCE_GLOBAL_STREAMING_MODE,
         defaultValue = true,
-        syncable = false,
         sharedPrefs = sharedPreferences,
     )
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -75,7 +75,6 @@ class SettingsImpl @Inject constructor(
     private var languageCode: String? = null
 
     override val podcastLayoutObservable = BehaviorRelay.create<Int>().apply { accept(getPodcastsLayout()) }
-    override val skipForwardInSecsObservable = BehaviorRelay.create<Int>().apply { accept(getSkipForwardInSecs()) }
     override val skipBackwardInSecsObservable = BehaviorRelay.create<Int>().apply { accept(getSkipBackwardInSecs()) }
     override val podcastBadgeTypeObservable = BehaviorRelay.create<Settings.BadgeType>().apply { accept(getPodcastBadgeType()) }
     override val podcastSortTypeObservable = BehaviorRelay.create<PodcastsSortType>().apply { accept(getPodcastsSortType()) }
@@ -155,9 +154,13 @@ class SettingsImpl @Inject constructor(
         return context.isScreenReaderOn()
     }
 
-    override fun getSkipForwardInSecs(): Int {
-        return getSkipAmountInSecs(key = Settings.PREFERENCE_SKIP_FORWARD, defaultValue = Settings.SKIP_FORWARD_DEFAULT)
-    }
+    override val skipForwardInSecs = UserSetting.IntFromString(
+        sharedPrefs = sharedPreferences,
+        sharedPrefKey = Settings.PREFERENCE_SKIP_FORWARD,
+        defaultValue = 30,
+        allowNegative = false,
+        syncable = true,
+    )
 
     private fun getSkipAmountInSecs(key: String, defaultValue: String): Int {
         val value = sharedPreferences.getString(key, defaultValue) ?: defaultValue
@@ -167,15 +170,6 @@ class SettingsImpl @Inject constructor(
         } catch (nfe: NumberFormatException) {
             defaultValue.toInt()
         }
-    }
-
-    override fun getSkipForwardInMs(): Long {
-        return getSkipForwardInSecs() * 1000L
-    }
-
-    override fun setSkipForwardInSec(value: Int) {
-        setString(Settings.PREFERENCE_SKIP_FORWARD, if (value <= 0) Settings.SKIP_FORWARD_DEFAULT else value.toString())
-        skipForwardInSecsObservable.accept(value)
     }
 
     override fun getSkipBackwardInSecs(): Int {
@@ -189,14 +183,6 @@ class SettingsImpl @Inject constructor(
     override fun setSkipBackwardInSec(value: Int) {
         setString(Settings.PREFERENCE_SKIP_BACKWARD, if (value <= 0) Settings.SKIP_BACKWARD_DEFAULT else value.toString())
         skipBackwardInSecsObservable.accept(value)
-    }
-
-    override fun getSkipForwardNeedsSync(): Boolean {
-        return getBoolean(Settings.PREFERENCE_SKIP_FORWARD_NEEDS_SYNC, false)
-    }
-
-    override fun setSkipForwardNeedsSync(value: Boolean) {
-        setBoolean(Settings.PREFERENCE_SKIP_FORWARD_NEEDS_SYNC, value)
     }
 
     override fun getSkipBackNeedsSync(): Boolean {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -75,7 +75,6 @@ class SettingsImpl @Inject constructor(
     private var languageCode: String? = null
 
     override val podcastLayoutObservable = BehaviorRelay.create<Int>().apply { accept(getPodcastsLayout()) }
-    override val skipBackwardInSecsObservable = BehaviorRelay.create<Int>().apply { accept(getSkipBackwardInSecs()) }
     override val podcastBadgeTypeObservable = BehaviorRelay.create<Settings.BadgeType>().apply { accept(getPodcastBadgeType()) }
     override val podcastSortTypeObservable = BehaviorRelay.create<PodcastsSortType>().apply { accept(getPodcastsSortType()) }
     override val selectPodcastSortTypeObservable = BehaviorRelay.create<PodcastsSortType>().apply { accept(getSelectPodcastsSortType()) }
@@ -155,43 +154,20 @@ class SettingsImpl @Inject constructor(
     }
 
     override val skipForwardInSecs = UserSetting.IntFromString(
-        sharedPrefs = sharedPreferences,
         sharedPrefKey = Settings.PREFERENCE_SKIP_FORWARD,
         defaultValue = 30,
         allowNegative = false,
         syncable = true,
+        sharedPrefs = sharedPreferences,
     )
 
-    private fun getSkipAmountInSecs(key: String, defaultValue: String): Int {
-        val value = sharedPreferences.getString(key, defaultValue) ?: defaultValue
-        return try {
-            val valueInt = Integer.parseInt(value)
-            if (valueInt <= 0) defaultValue.toInt() else valueInt
-        } catch (nfe: NumberFormatException) {
-            defaultValue.toInt()
-        }
-    }
-
-    override fun getSkipBackwardInSecs(): Int {
-        return getSkipAmountInSecs(key = Settings.PREFERENCE_SKIP_BACKWARD, defaultValue = Settings.SKIP_BACKWARD_DEFAULT)
-    }
-
-    override fun getSkipBackwardInMs(): Long {
-        return getSkipBackwardInSecs() * 1000L
-    }
-
-    override fun setSkipBackwardInSec(value: Int) {
-        setString(Settings.PREFERENCE_SKIP_BACKWARD, if (value <= 0) Settings.SKIP_BACKWARD_DEFAULT else value.toString())
-        skipBackwardInSecsObservable.accept(value)
-    }
-
-    override fun getSkipBackNeedsSync(): Boolean {
-        return getBoolean(Settings.PREFERENCE_SKIP_BACK_NEEDS_SYNC, false)
-    }
-
-    override fun setSkipBackNeedsSync(value: Boolean) {
-        setBoolean(Settings.PREFERENCE_SKIP_BACK_NEEDS_SYNC, value)
-    }
+    override val skipBackInSecs: UserSetting<Int> = UserSetting.IntFromString(
+        sharedPrefKey = Settings.PREFERENCE_SKIP_BACKWARD,
+        defaultValue = 10,
+        allowNegative = false,
+        syncable = true,
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun getMarketingOptIn(): Boolean {
         return getBoolean(Settings.PREFERENCE_MARKETING_OPT_IN, false)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -86,7 +86,6 @@ class SettingsImpl @Inject constructor(
     override val autoAddUpNextLimitBehaviour = BehaviorRelay.create<Settings.AutoAddUpNextLimitBehaviour>().apply { accept(getAutoAddUpNextLimitBehaviour()) }
     override val autoAddUpNextLimit = BehaviorRelay.create<Int>().apply { accept(getAutoAddUpNextLimit()) }
 
-    override val openPlayerAutomaticallyFlow = MutableStateFlow(openPlayerAutomatically())
     override val intelligentPlaybackResumptionFlow = MutableStateFlow(getIntelligentPlaybackResumption())
     override val tapOnUpNextShouldPlayFlow = MutableStateFlow(getTapOnUpNextShouldPlay())
     override val customMediaActionsVisibilityFlow = MutableStateFlow(areCustomMediaActionsVisible())
@@ -614,14 +613,11 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override fun openPlayerAutomatically(): Boolean {
-        return sharedPreferences.getBoolean(Settings.PREFERENCE_OPEN_PLAYER_AUTOMATICALLY, false)
-    }
-
-    override fun setOpenPlayerAutomatically(newValue: Boolean) {
-        setBoolean(Settings.PREFERENCE_OPEN_PLAYER_AUTOMATICALLY, newValue)
-        openPlayerAutomaticallyFlow.update { newValue }
-    }
+    override val openPlayerAutomatically = UserSetting.BoolPref(
+        sharedPrefKey = "openPlayerAutomatically",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun isPodcastAutoDownloadUnmeteredOnly(): Boolean {
         return sharedPreferences.getBoolean(Settings.PREFERENCE_PODCAST_AUTO_DOWNLOAD_ON_UNMETERED, true)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -5,20 +5,15 @@ import kotlinx.coroutines.flow.MutableStateFlow
 
 sealed class UserSetting<T>(
     protected val sharedPrefKey: String,
-    private val syncable: Boolean,
     protected val sharedPrefs: SharedPreferences,
 ) {
 
     var needsSync: Boolean
         get() = sharedPrefs.getBoolean("${sharedPrefKey}NeedsSync", false)
         set(value) {
-            if (syncable) {
-                sharedPrefs.edit().run {
-                    putBoolean("${sharedPrefKey}NeedsSync", value)
-                    apply()
-                }
-            } else {
-                throw IllegalStateException("Cannot set needsSync on a UserSetting ($sharedPrefKey) that is not syncable")
+            sharedPrefs.edit().run {
+                putBoolean("${sharedPrefKey}NeedsSync", value)
+                apply()
             }
         }
 
@@ -41,12 +36,10 @@ sealed class UserSetting<T>(
     class BoolPref(
         sharedPrefKey: String,
         private val defaultValue: Boolean,
-        syncable: Boolean,
         sharedPrefs: SharedPreferences,
     ) : UserSetting<Boolean>(
         sharedPrefKey = sharedPrefKey,
         sharedPrefs = sharedPrefs,
-        syncable = syncable,
     ) {
 
         override fun set(value: Boolean) {
@@ -66,12 +59,10 @@ sealed class UserSetting<T>(
         sharedPrefKey: String,
         private val defaultValue: Int,
         private val allowNegative: Boolean = true,
-        syncable: Boolean,
         sharedPrefs: SharedPreferences,
     ) : UserSetting<Int>(
         sharedPrefKey = sharedPrefKey,
         sharedPrefs = sharedPrefs,
-        syncable = syncable
     ) {
 
         override fun get(): Int {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -1,0 +1,97 @@
+package au.com.shiftyjelly.pocketcasts.preferences
+
+import android.annotation.SuppressLint
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+
+sealed class UserSetting<T>(
+    protected val sharedPrefKey: String,
+    protected val sharedPrefs: SharedPreferences,
+    private val syncable: Boolean,
+) {
+
+    var needsSync: Boolean
+        get() = sharedPrefs.getBoolean("${sharedPrefKey}NeedsSync", false)
+        set(value) {
+            if (syncable) {
+                sharedPrefs.edit().run {
+                    putBoolean("${sharedPrefKey}NeedsSync", value)
+                    apply()
+                }
+            } else {
+                throw IllegalStateException("Cannot set needsSync on a UserSetting ($sharedPrefKey) that is not syncable")
+            }
+        }
+
+    fun getSyncValue(): T? =
+        if (needsSync) get() else null
+
+    private val _flow by lazy { MutableStateFlow(get()) }
+    val flow by lazy { _flow }
+
+    // external callers should use the flow.value to get the current value or, even
+    // better, use the flow itself to observe changes.
+    protected abstract fun get(): T
+
+    abstract val defaultValue: T
+
+    protected fun updateFlow(value: T) {
+        _flow.value = value
+    }
+
+    abstract fun set(value: T, now: Boolean = false)
+
+//    sealed class Boolean(sharedPrefKey: String): UserSetting<Boolean> {
+//
+//    }
+
+//    sealed class String(sharedPrefKey: String): UserSetting<String> {
+//
+//    }
+
+//    sealed class Int(sharedPrefKey: String): UserSetting<Int> {
+//
+//    }
+
+    // This stores an Int preference as a String and only exists for legacy
+    // reasons. No new preferences should use this class.
+    open class IntFromString(
+        sharedPrefKey: String,
+        override val defaultValue: Int,
+        private val allowNegative: Boolean = true,
+        sharedPrefs: SharedPreferences,
+        syncable: Boolean,
+    ) : UserSetting<Int>(
+        sharedPrefKey = sharedPrefKey,
+        sharedPrefs = sharedPrefs,
+        syncable = syncable
+    ) {
+
+        override fun get(): Int {
+            val defaultAsString = defaultValue.toString()
+            val value = sharedPrefs.getString(sharedPrefKey, defaultAsString)
+                ?: defaultAsString
+            return try {
+                val valueInt = Integer.parseInt(value)
+                if (valueInt <= 0) defaultValue else valueInt
+            } catch (nfe: NumberFormatException) {
+                defaultValue
+            }
+        }
+
+        @SuppressLint("ApplySharedPref")
+        override fun set(value: Int, now: Boolean) {
+            val adjustedValue = if (value <= 0 && !allowNegative) defaultValue else value
+
+            val editor = sharedPrefs.edit()
+            editor.putString(sharedPrefKey, adjustedValue.toString())
+            if (now) {
+                editor.commit()
+            } else {
+                editor.apply()
+            }
+
+            updateFlow(value)
+        }
+    }
+}

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -33,8 +33,6 @@ sealed class UserSetting<T>(
     // better, use the flow itself to observe changes.
     protected abstract fun get(): T
 
-    abstract val defaultValue: T
-
     protected fun updateFlow(value: T) {
         _flow.value = value
     }
@@ -57,10 +55,10 @@ sealed class UserSetting<T>(
     // reasons. No new preferences should use this class.
     open class IntFromString(
         sharedPrefKey: String,
-        override val defaultValue: Int,
+        private val defaultValue: Int,
         private val allowNegative: Boolean = true,
-        sharedPrefs: SharedPreferences,
         syncable: Boolean,
+        sharedPrefs: SharedPreferences,
     ) : UserSetting<Int>(
         sharedPrefKey = sharedPrefKey,
         sharedPrefs = sharedPrefs,

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -22,7 +22,9 @@ abstract class UserSetting<T>(
         if (needsSync) get() else null
 
     private val _flow by lazy { MutableStateFlow(get()) }
-    // lazy because the class needs to initialize before calling get()
+    // lazy (1) because the class needs to initialize before calling get() and (2) we don't
+    // want to get the current value from SharedPreferences for every setting immediately on
+    // app startup.
     val flow: StateFlow<T> by lazy { _flow }
 
     // external callers should use the flow.value to get the current value or, even

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.preferences
 
 import android.content.SharedPreferences
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 abstract class UserSetting<T>(
     protected val sharedPrefKey: String,
@@ -22,7 +23,7 @@ abstract class UserSetting<T>(
 
     private val _flow by lazy { MutableStateFlow(get()) }
     // lazy because the class needs to initialize before calling get()
-    val flow by lazy { _flow }
+    val flow: StateFlow<T> by lazy { _flow }
 
     // external callers should use the flow.value to get the current value or, even
     // better, use the flow itself to observe changes.

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -6,8 +6,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 
 sealed class UserSetting<T>(
     protected val sharedPrefKey: String,
-    protected val sharedPrefs: SharedPreferences,
     private val syncable: Boolean,
+    protected val sharedPrefs: SharedPreferences,
 ) {
 
     var needsSync: Boolean
@@ -53,7 +53,7 @@ sealed class UserSetting<T>(
 
     // This stores an Int preference as a String and only exists for legacy
     // reasons. No new preferences should use this class.
-    open class IntFromString(
+    open class IntFromStringPref(
         sharedPrefKey: String,
         private val defaultValue: Int,
         private val allowNegative: Boolean = true,

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -129,4 +129,38 @@ abstract class UserSetting<T>(
             }
         )
     }
+
+    class PrefListFromString<T>(
+        sharedPrefKey: String,
+        sharedPrefs: SharedPreferences,
+        private val defaultValue: List<T>,
+        private val fromString: (String) -> T?,
+        private val toString: (T) -> String,
+    ) : UserSetting<List<T>>(
+        sharedPrefKey = sharedPrefKey,
+        sharedPrefs = sharedPrefs,
+    ) {
+
+        override fun get(): List<T> {
+            val strValue = sharedPrefs.getString(sharedPrefKey, "")
+            return if (strValue.isNullOrEmpty()) {
+                defaultValue
+            } else {
+                val commaSeparatedString = strValue.split(",")
+                commaSeparatedString.mapNotNull(fromString)
+            }
+        }
+
+        override fun set(value: List<T>) {
+            sharedPrefs.edit().run {
+                val commaSeparatedString = value.joinToString(
+                    separator = ",",
+                    transform = toString
+                )
+                putString(sharedPrefKey, commaSeparatedString)
+                apply()
+            }
+            super.set(value)
+        }
+    }
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.preferences
 
 import android.content.SharedPreferences
-import androidx.annotation.CallSuper
 import kotlinx.coroutines.flow.MutableStateFlow
 
 abstract class UserSetting<T>(
@@ -29,8 +28,10 @@ abstract class UserSetting<T>(
     // better, use the flow itself to observe changes.
     protected abstract fun get(): T
 
-    @CallSuper
-    open fun set(value: T) {
+    protected abstract fun persist(value: T)
+
+    fun set(value: T) {
+        persist(value)
         _flow.value = value
     }
 
@@ -43,13 +44,11 @@ abstract class UserSetting<T>(
         sharedPrefs = sharedPrefs,
     ) {
 
-        override fun set(value: Boolean) {
+        override fun persist(value: Boolean) {
             sharedPrefs.edit().run {
                 putBoolean(sharedPrefKey, value)
                 apply()
             }
-
-            super.set(value)
         }
 
         override fun get(): Boolean = sharedPrefs.getBoolean(sharedPrefKey, defaultValue)
@@ -70,13 +69,12 @@ abstract class UserSetting<T>(
             return fromInt(persistedInt)
         }
 
-        override fun set(value: T) {
+        override fun persist(value: T) {
             val intValue = toInt(value)
             sharedPrefs.edit().run {
                 putInt(sharedPrefKey, intValue)
                 apply()
             }
-            super.set(value)
         }
     }
 
@@ -97,13 +95,12 @@ abstract class UserSetting<T>(
             return fromString(persistedString)
         }
 
-        override fun set(value: T) {
+        override fun persist(value: T) {
             val stringValue = toString(value)
             sharedPrefs.edit().run {
                 putString(sharedPrefKey, stringValue)
                 apply()
             }
-            super.set(value)
         }
 
         // This stores an the skip value Int as a String in shared preferences.
@@ -151,7 +148,7 @@ abstract class UserSetting<T>(
             }
         }
 
-        override fun set(value: List<T>) {
+        override fun persist(value: List<T>) {
             sharedPrefs.edit().run {
                 val commaSeparatedString = value.joinToString(
                     separator = ",",
@@ -160,7 +157,6 @@ abstract class UserSetting<T>(
                 putString(sharedPrefKey, commaSeparatedString)
                 apply()
             }
-            super.set(value)
         }
     }
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -53,31 +53,31 @@ abstract class UserSetting<T>(
         override fun get(): Boolean = sharedPrefs.getBoolean(sharedPrefKey, defaultValue)
     }
 
-//    abstract class PrefFromInt<T>(
-//        sharedPrefKey: String,
-//        private val defaultValue: T,
-//        sharedPrefs: SharedPreferences,
-//    ) : UserSetting<T>(
-//        sharedPrefKey = sharedPrefKey,
-//        sharedPrefs = sharedPrefs,
-//    ) {
-//        protected abstract fun fromInt(value: Int): T
-//        protected abstract fun toInt(value: T): Int
-//
-//        override fun get(): T {
-//            val persistedInt = sharedPrefs.getInt(sharedPrefKey, toInt(defaultValue))
-//            return fromInt(persistedInt)
-//        }
-//
-//        override fun set(value: T) {
-//            val intValue = toInt(value)
-//            sharedPrefs.edit().run {
-//                putInt(sharedPrefKey, intValue)
-//                apply()
-//            }
-//            updateFlow(value)
-//        }
-//    }
+    abstract class PrefFromInt<T>(
+        sharedPrefKey: String,
+        private val defaultValue: T,
+        sharedPrefs: SharedPreferences,
+    ) : UserSetting<T>(
+        sharedPrefKey = sharedPrefKey,
+        sharedPrefs = sharedPrefs,
+    ) {
+        protected abstract fun fromInt(value: Int): T
+        protected abstract fun toInt(value: T): Int
+
+        override fun get(): T {
+            val persistedInt = sharedPrefs.getInt(sharedPrefKey, toInt(defaultValue))
+            return fromInt(persistedInt)
+        }
+
+        override fun set(value: T) {
+            val intValue = toInt(value)
+            sharedPrefs.edit().run {
+                putInt(sharedPrefKey, intValue)
+                apply()
+            }
+            updateFlow(value)
+        }
+    }
 
     abstract class PrefFromString<T>(
         sharedPrefKey: String,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
@@ -181,12 +181,12 @@ class VersionMigrationsJob : JobService() {
 
     private fun performV7Migration() {
         // We want v6 users to keep defaulting to download, new users should get the new stream default
-        val currentStreamingPreference = if (settings.contains(Settings.PREFERENCE_GLOBAL_STREAMING_MODE)) settings.streamingMode() else false
-        settings.setStreamingMode(currentStreamingPreference)
+        val currentStreamingPreference = if (settings.contains(Settings.PREFERENCE_GLOBAL_STREAMING_MODE)) settings.streamingMode.flow.value else false
+        settings.streamingMode.set(currentStreamingPreference)
     }
 
     private fun addUpNextAutoDownload() {
-        settings.setUpNextAutoDownloaded(!settings.streamingMode())
+        settings.setUpNextAutoDownloaded(!settings.streamingMode.flow.value)
     }
 
     private fun deletePodcastImages() {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
@@ -40,7 +40,7 @@ class NotificationDrawerImpl @Inject constructor(
     private val playAction = NotificationCompat.Action(IR.drawable.notification_play, context.getString(LR.string.play), MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PLAY))
     private val pauseAction = NotificationCompat.Action(IR.drawable.notification_pause, context.getString(LR.string.pause), MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PAUSE))
     private val skipBackAction = NotificationCompat.Action(IR.drawable.notification_skipbackwards, context.getString(LR.string.player_notification_skip_back, settings.getSkipBackwardInSecs()), MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_SKIP_TO_PREVIOUS))
-    private val skipForwardAction = NotificationCompat.Action(IR.drawable.notification_skipforward, context.getString(LR.string.player_notification_skip_forward, settings.getSkipForwardInSecs()), MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_SKIP_TO_NEXT))
+    private val skipForwardAction = NotificationCompat.Action(IR.drawable.notification_skipforward, context.getString(LR.string.player_notification_skip_forward, settings.skipForwardInSecs.flow.value), MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_SKIP_TO_NEXT))
     private val stopPendingIntent = MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_STOP)
 
     private var notificationData: NotificationData? = null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
@@ -39,7 +39,7 @@ class NotificationDrawerImpl @Inject constructor(
 
     private val playAction = NotificationCompat.Action(IR.drawable.notification_play, context.getString(LR.string.play), MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PLAY))
     private val pauseAction = NotificationCompat.Action(IR.drawable.notification_pause, context.getString(LR.string.pause), MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PAUSE))
-    private val skipBackAction = NotificationCompat.Action(IR.drawable.notification_skipbackwards, context.getString(LR.string.player_notification_skip_back, settings.getSkipBackwardInSecs()), MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_SKIP_TO_PREVIOUS))
+    private val skipBackAction = NotificationCompat.Action(IR.drawable.notification_skipbackwards, context.getString(LR.string.player_notification_skip_back, settings.skipBackInSecs.flow.value), MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_SKIP_TO_PREVIOUS))
     private val skipForwardAction = NotificationCompat.Action(IR.drawable.notification_skipforward, context.getString(LR.string.player_notification_skip_forward, settings.skipForwardInSecs.flow.value), MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_SKIP_TO_NEXT))
     private val stopPendingIntent = MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_STOP)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -130,7 +130,7 @@ class MediaSessionManager(
 
     private fun observeCustomMediaActionsVisibility() {
         launch {
-            settings.customMediaActionsVisibilityFlow.collect {
+            settings.customMediaActionsVisibility.flow.collect {
                 withContext(Dispatchers.Main) {
                     val playbackStateCompat = getPlaybackStateCompat(playbackManager.playbackStateRelay.blockingFirst(), currentEpisode = playbackManager.getCurrentEpisode())
                     // Called to update playback state with updated custom media actions visibility
@@ -375,7 +375,7 @@ class MediaSessionManager(
             addCustomAction(stateBuilder, APP_ACTION_SKIP_FWD, "Skip forward", IR.drawable.auto_skipforward)
         }
 
-        val visibleCount = if (settings.areCustomMediaActionsVisible()) MediaNotificationControls.MAX_VISIBLE_OPTIONS else 0
+        val visibleCount = if (settings.customMediaActionsVisibility.flow.value) MediaNotificationControls.MAX_VISIBLE_OPTIONS else 0
         settings.mediaControlItems.flow.value.take(visibleCount).forEach { mediaControl ->
             when (mediaControl) {
                 MediaNotificationControls.Archive -> addCustomAction(stateBuilder, APP_ACTION_ARCHIVE, "Archive", IR.drawable.ic_archive)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -142,7 +142,7 @@ class MediaSessionManager(
 
     private fun observeMediaNotificationControls() {
         launch {
-            settings.defaultMediaNotificationControlsFlow.collect {
+            settings.mediaControlItems.flow.collect {
                 withContext(Dispatchers.Main) {
                     val playbackStateCompat = getPlaybackStateCompat(playbackManager.playbackStateRelay.blockingFirst(), currentEpisode = playbackManager.getCurrentEpisode())
                     updatePlaybackState(playbackStateCompat)
@@ -376,7 +376,7 @@ class MediaSessionManager(
         }
 
         val visibleCount = if (settings.areCustomMediaActionsVisible()) MediaNotificationControls.MAX_VISIBLE_OPTIONS else 0
-        settings.getMediaNotificationControlItems().take(visibleCount).forEach { mediaControl ->
+        settings.mediaControlItems.flow.value.take(visibleCount).forEach { mediaControl ->
             when (mediaControl) {
                 MediaNotificationControls.Archive -> addCustomAction(stateBuilder, APP_ACTION_ARCHIVE, "Archive", IR.drawable.ic_archive)
                 MediaNotificationControls.MarkAsPlayed -> addCustomAction(stateBuilder, APP_ACTION_MARK_AS_PLAYED, "Mark as played", IR.drawable.auto_markasplayed)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -710,7 +710,10 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    fun skipForward(sourceView: SourceView = SourceView.UNKNOWN, jumpAmountSeconds: Int = settings.getSkipForwardInSecs()) {
+    fun skipForward(
+        sourceView: SourceView = SourceView.UNKNOWN,
+        jumpAmountSeconds: Int = settings.skipForwardInSecs.flow.value,
+    ) {
         launch {
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Skip forward tapped")
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -737,7 +737,7 @@ open class PlaybackManager @Inject constructor(
         trackPlayback(AnalyticsEvent.PLAYBACK_SKIP_FORWARD, sourceView)
     }
 
-    fun skipBackward(sourceView: SourceView = SourceView.UNKNOWN, jumpAmountSeconds: Int = settings.getSkipBackwardInSecs()) {
+    fun skipBackward(sourceView: SourceView = SourceView.UNKNOWN, jumpAmountSeconds: Int = settings.skipBackInSecs.flow.value) {
         launch {
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Skip backward tapped")
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -226,7 +226,7 @@ open class PlaybackManager @Inject constructor(
             return nextEpisode
         }
 
-        if (!settings.getAutoPlayNextEpisodeOnEmpty()) {
+        if (!settings.autoPlayNextEpisodeOnEmpty.flow.value) {
             return null
         }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ResumptionHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ResumptionHelper.kt
@@ -13,7 +13,11 @@ class ResumptionHelper(val settings: Settings) {
     private var lastPauseTime: Date? = settings.getLastPauseTime()
 
     fun adjustedStartTimeMsFor(episode: BaseEpisode): Int {
-        if (!settings.getIntelligentPlaybackResumption() || settings.getLastPausedUUID() != episode.uuid || (settings.getLastPausedAt() ?: 0) != episode.playedUpToMs) return episode.playedUpToMs
+        if (!settings.intelligentPlaybackResumption.flow.value ||
+            settings.getLastPausedUUID() != episode.uuid ||
+            (settings.getLastPausedAt() ?: 0) != episode.playedUpToMs
+        ) return episode.playedUpToMs
+
         val lastPauseTime = this.lastPauseTime ?: return episode.playedUpToMs
 
         val adjustedTime = when {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -192,7 +192,7 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
             .setTrackSelector(trackSelector)
             .setLoadControl(loadControl)
             .setSeekForwardIncrementMs(settings.skipForwardInSecs.flow.value * 1000L)
-            .setSeekBackIncrementMs(settings.getSkipBackwardInMs())
+            .setSeekBackIncrementMs(settings.skipBackInSecs.flow.value * 1000L)
             .build()
 
         renderer.onAudioSessionId(player.audioSessionId)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -191,7 +191,7 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
         val player = ExoPlayer.Builder(context, renderer)
             .setTrackSelector(trackSelector)
             .setLoadControl(loadControl)
-            .setSeekForwardIncrementMs(settings.getSkipForwardInMs())
+            .setSeekForwardIncrementMs(settings.skipForwardInSecs.flow.value * 1000L)
             .setSeekBackIncrementMs(settings.getSkipBackwardInMs())
             .build()
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -129,7 +129,7 @@ class SubscribeManager @Inject constructor(
         // set subscribed to true and update the sync status
         val updateObservable = podcastDao.updateSubscribedRx(subscribed = true, uuid = podcastUuid)
             .andThen(podcastDao.updateSyncStatusRx(syncStatus = if (sync) Podcast.SYNC_STATUS_NOT_SYNCED else Podcast.SYNC_STATUS_SYNCED, uuid = podcastUuid))
-            .andThen(Completable.fromAction { podcastDao.updateGrouping(PodcastGrouping.All.indexOf(settings.defaultPodcastGrouping()), podcastUuid) })
+            .andThen(Completable.fromAction { podcastDao.updateGrouping(PodcastGrouping.All.indexOf(settings.podcastGroupingDefault.flow.value), podcastUuid) })
             .andThen(rxCompletable { podcastDao.updateShowArchived(podcastUuid, settings.defaultShowArchived()) })
         // return the final podcast
         val findObservable = podcastDao.findByUuidRx(podcastUuid)
@@ -143,7 +143,7 @@ class SubscribeManager @Inject constructor(
                 // mark sync status
                 podcast.syncStatus = if (sync) Podcast.SYNC_STATUS_NOT_SYNCED else Podcast.SYNC_STATUS_SYNCED
                 podcast.isSubscribed = subscribed
-                podcast.grouping = PodcastGrouping.All.indexOf(settings.defaultPodcastGrouping())
+                podcast.grouping = PodcastGrouping.All.indexOf(settings.podcastGroupingDefault.flow.value)
                 podcast.showArchived = settings.defaultShowArchived()
             }
         // add the podcast

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -130,7 +130,7 @@ class SubscribeManager @Inject constructor(
         val updateObservable = podcastDao.updateSubscribedRx(subscribed = true, uuid = podcastUuid)
             .andThen(podcastDao.updateSyncStatusRx(syncStatus = if (sync) Podcast.SYNC_STATUS_NOT_SYNCED else Podcast.SYNC_STATUS_SYNCED, uuid = podcastUuid))
             .andThen(Completable.fromAction { podcastDao.updateGrouping(PodcastGrouping.All.indexOf(settings.podcastGroupingDefault.flow.value), podcastUuid) })
-            .andThen(rxCompletable { podcastDao.updateShowArchived(podcastUuid, settings.defaultShowArchived()) })
+            .andThen(rxCompletable { podcastDao.updateShowArchived(podcastUuid, settings.showArchivedDefault.flow.value) })
         // return the final podcast
         val findObservable = podcastDao.findByUuidRx(podcastUuid)
         return updateObservable.andThen(findObservable.toSingle())
@@ -144,7 +144,7 @@ class SubscribeManager @Inject constructor(
                 podcast.syncStatus = if (sync) Podcast.SYNC_STATUS_NOT_SYNCED else Podcast.SYNC_STATUS_SYNCED
                 podcast.isSubscribed = subscribed
                 podcast.grouping = PodcastGrouping.All.indexOf(settings.podcastGroupingDefault.flow.value)
-                podcast.showArchived = settings.defaultShowArchived()
+                podcast.showArchived = settings.showArchivedDefault.flow.value
             }
         // add the podcast
         val insertPodcastObservable = podcastObservable.flatMap { podcast ->

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
@@ -132,7 +132,7 @@ class WidgetManagerImpl @Inject constructor(
 
     private fun updateSkipAmounts(views: RemoteViews, settings: Settings) {
         val jumpFwdAmount = settings.skipForwardInSecs.flow.value
-        val jumpBackAmount = settings.getSkipBackwardInSecs()
+        val jumpBackAmount = settings.skipBackInSecs.flow.value
 
         views.setTextViewText(R.id.widget_skip_back_text, "$jumpBackAmount")
         views.setContentDescription(R.id.widget_skip_back_text, "Skip back $jumpBackAmount seconds")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
@@ -131,7 +131,7 @@ class WidgetManagerImpl @Inject constructor(
     }
 
     private fun updateSkipAmounts(views: RemoteViews, settings: Settings) {
-        val jumpFwdAmount = settings.getSkipForwardInSecs()
+        val jumpFwdAmount = settings.skipForwardInSecs.flow.value
         val jumpBackAmount = settings.getSkipBackwardInSecs()
 
         views.setTextViewText(R.id.widget_skip_back_text, "$jumpBackAmount")

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -15,7 +15,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 val request = NamedSettingsRequest(
                     settings = NamedSettingsSettings(
                         skipForward = settings.skipForwardInSecs.getSyncValue(),
-                        skipBack = if (settings.getSkipBackNeedsSync()) settings.getSkipBackwardInSecs() else null,
+                        skipBack = settings.skipBackInSecs.getSyncValue(),
                         marketingOptIn = if (settings.getMarketingOptInNeedsSync()) settings.getMarketingOptIn() else null,
                         freeGiftAcknowledged = if (settings.getFreeGiftAcknowledgedNeedsSync()) settings.getFreeGiftAcknowledged() else null,
                         gridOrder = if (settings.getPodcastsSortTypeNeedsSync()) settings.getPodcastsSortType().serverId else null,
@@ -30,7 +30,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         if (value.value is Number) { // Probably will have to change this when we do other settings, but for now just Number is fine
                             when (key) {
                                 "skipForward" -> settings.skipForwardInSecs.set(value.value.toInt())
-                                "skipBack" -> settings.setSkipBackwardInSec(value.value.toInt())
+                                "skipBack" -> settings.skipBackInSecs.set(value.value.toInt())
                                 "gridOrder" -> settings.setPodcastsSortType(sortType = PodcastsSortType.fromServerId(value.value.toInt()), sync = false)
                             }
                         } else if (value.value is Boolean) {
@@ -48,7 +48,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 return Result.failure()
             }
 
-            settings.setSkipBackNeedsSync(false)
+            settings.skipBackInSecs.needsSync = false
             settings.skipForwardInSecs.needsSync = false
             settings.setMarketingOptInNeedsSync(false)
             settings.setFreeGiftAcknowledgedNeedsSync(false)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -14,7 +14,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
             try {
                 val request = NamedSettingsRequest(
                     settings = NamedSettingsSettings(
-                        skipForward = if (settings.getSkipForwardNeedsSync()) settings.getSkipForwardInSecs() else null,
+                        skipForward = settings.skipForwardInSecs.getSyncValue(),
                         skipBack = if (settings.getSkipBackNeedsSync()) settings.getSkipBackwardInSecs() else null,
                         marketingOptIn = if (settings.getMarketingOptInNeedsSync()) settings.getMarketingOptIn() else null,
                         freeGiftAcknowledged = if (settings.getFreeGiftAcknowledgedNeedsSync()) settings.getFreeGiftAcknowledged() else null,
@@ -29,7 +29,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
 
                         if (value.value is Number) { // Probably will have to change this when we do other settings, but for now just Number is fine
                             when (key) {
-                                "skipForward" -> settings.setSkipForwardInSec(value.value.toInt())
+                                "skipForward" -> settings.skipForwardInSecs.set(value.value.toInt())
                                 "skipBack" -> settings.setSkipBackwardInSec(value.value.toInt())
                                 "gridOrder" -> settings.setPodcastsSortType(sortType = PodcastsSortType.fromServerId(value.value.toInt()), sync = false)
                             }
@@ -49,7 +49,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
             }
 
             settings.setSkipBackNeedsSync(false)
-            settings.setSkipForwardNeedsSync(false)
+            settings.skipForwardInSecs.needsSync = false
             settings.setMarketingOptInNeedsSync(false)
             settings.setFreeGiftAcknowledgedNeedsSync(false)
             settings.setPodcastsSortTypeNeedsSync(false)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
@@ -53,7 +53,7 @@ class NowPlayingViewModel @Inject constructor(
         combine(
             playbackManager.playbackStateRelay.asFlow(),
             settings.skipBackwardInSecsObservable.asFlow(),
-            settings.skipForwardInSecsObservable.asFlow(),
+            settings.skipForwardInSecs.flow,
         ) { playbackState, skipBackwardSecs, skipForwardSecs ->
 
             if (playbackState.isEmpty) {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
@@ -52,7 +52,7 @@ class NowPlayingViewModel @Inject constructor(
     val state: StateFlow<State> =
         combine(
             playbackManager.playbackStateRelay.asFlow(),
-            settings.skipBackwardInSecsObservable.asFlow(),
+            settings.skipBackInSecs.flow,
             settings.skipForwardInSecs.flow,
         ) { playbackState, skipBackwardSecs, skipForwardSecs ->
 


### PR DESCRIPTION
## Description
This PR is the first step toward refactoring our settings to be `UserSettings` in an effort to make it easier to sync our settings in the future (and easy to have new settings be synced).

I'm only including the settings from the "General" screen in order to get early feedback on this before I invest more time in this direction. Also, this helps make it a bit easier to review the PR (only 32 changed files ! 😅 ).

The main point of this is to simplify what it takes to add a syncable setting so it is easier to add synced settings in the future. For example, with this change, instead of the SettingsImpl class needing to implement four methods/fields:

1. skipForwardInSecsObservable
2. getSkipForwardInSecs
3. setSkipForwardInSecs
4. getSkipForwardNeedsSync

We now just need a single val skipForwardInSecs: UserSetting field, and that also covers the coroutine flow as well (which would be a another field that needed to be implemented before this PR).

> **Note**
> I have this PR targeting a feature branch because I think it would be good to hold these changes back for now. That will allow me to make further changes to how `UserSetting`s work if necessary without having that directly impact our production users. Also, this reserves for us the option of not rolling this change out until we start syncing settings more broadly (I'm not sure that's a good idea, but I'm not sure that it isn't either). Let me know if you think we're better off merging to `main` because I don't feel strongly.

## Testing Instructions
For each setting in the "General" settings:
1. Fresh install the app
2. Verify that the setting has the same default value that it had before
3. Log into an account
4. Change the setting to a new value
5. Force close the app
6. Verify that the setting has retained the new value
7. If the setting is one that is synced (skip-forward and skip-back times):
    1. Sync the app
    2. uninstall the app
    3. reinstall the app and log into the account
    4. Once the account has synced, verify that the updated setting value is shown
8. Verify that the app's behavior reflects the updated setting value (i.e., that skip forward actually skips forward based on the new value).

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
