### PR TITLE
Fixing app crash with Retrofit on the Discover tab

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -173,3 +173,8 @@
 -dontwarn com.google.android.material.R$dimen
 -dontwarn com.google.android.material.R$style
 -dontwarn com.google.android.material.R$styleable
+
+# R8 full mode strips generic signatures from return types if not kept.
+# This stop the app crashing on startup and will only be required until Retrofit 2.10.0 is released as it's included https://github.com/square/retrofit/blob/master/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
+-if interface * { @retrofit2.http.* public *** *(...); }
+-keep,allowoptimization,allowshrinking,allowobfuscation class <3>


### PR DESCRIPTION
## Description

Tapping on the Discover tab throws the following error which crashes the app:
```
  Caused by: java.lang.IllegalArgumentException: Unable to create call adapter for class go.y
      for method ListWebService.getDiscoverFeed
   at retrofit2.Utils.methodError(SourceFile:5)
   at retrofit2.HttpServiceMethod.createCallAdapter(SourceFile:15)
   at retrofit2.HttpServiceMethod.parseAnnotations(SourceFile:69)
   at retrofit2.ServiceMethod.parseAnnotations(SourceFile:20)
   at retrofit2.Retrofit.loadServiceMethod(SourceFile:25)
   at retrofit2.Retrofit$1.invoke(SourceFile:38)
   at java.lang.reflect.Proxy.invoke(Proxy.java:1006)
   at $Proxy13.getDiscoverFeed(Unknown Source)
   at hd.a.b(SourceFile:5)
   at au.com.shiftyjelly.pocketcasts.discover.viewmodel.DiscoverViewModel.K(SourceFile:8)
   at t9.h0.w1(SourceFile:42)
   at androidx.fragment.app.Fragment.Z1(SourceFile:20)
   at androidx.fragment.app.c0.f(SourceFile:199)
   at androidx.fragment.app.c0.m(SourceFile:125)
   at androidx.fragment.app.w.d0(SourceFile:231)
   at androidx.fragment.app.w.l1(SourceFile:92)
   at androidx.fragment.app.w.b0(SourceFile:32)
   at androidx.fragment.app.a.k(SourceFile:7)
   at pa.p.i(SourceFile:42)
   at pa.p.q(SourceFile:28)
   at au.com.shiftyjelly.pocketcasts.navigation.ActivityDelegate.g(SourceFile:11)
   at au.com.shiftyjelly.pocketcasts.navigation.ActivityDelegate.b(SourceFile:1)
   at pa.a.accept(SourceFile:1)
   at po.r.onNext(SourceFile:9)
   ... 26 more
  Caused by: java.lang.IllegalStateException: Single return type must be parameterized as Single<Foo> or Single<? extends Foo>
   at retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory.get(SourceFile:119)
   at retrofit2.Retrofit.nextCallAdapter(SourceFile:36)
   at retrofit2.Retrofit.callAdapter(SourceFile:2)
   at retrofit2.HttpServiceMethod.createCallAdapter(SourceFile:1)
```

This is related to migrating to R8 full mode. More details can be found here: https://r8.googlesource.com/r8/+/refs/heads/main/compatibility-faq.md

## Testing Instructions
1. Build a release version `./gradlew app:assembleRelease`
2. Install it `adb install app/build/outputs/apk/release/app-release.apk`
3. Tap on the Discover tab
4. ✅ Verify it doesn't crash
