### PR TITLE
Bookmarks - Add multiselect on podcast page

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -60,6 +60,7 @@ import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.extensions.toggleVisibility
 import au.com.shiftyjelly.pocketcasts.views.helper.AnimatorUtil
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
+import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import io.reactivex.disposables.CompositeDisposable
 import timber.log.Timber
@@ -73,7 +74,7 @@ private val differ: DiffUtil.ItemCallback<Any> = object : DiffUtil.ItemCallback<
             oldItem is PodcastAdapter.TabsHeader && newItem is PodcastAdapter.TabsHeader -> true
             oldItem is PodcastAdapter.EpisodeHeader && newItem is PodcastAdapter.EpisodeHeader -> true
             oldItem is PodcastEpisode && newItem is PodcastEpisode -> oldItem.uuid == newItem.uuid
-            oldItem is Bookmark && newItem is Bookmark -> oldItem.uuid == newItem.uuid
+            oldItem is PodcastAdapter.BookmarkItemData && newItem is PodcastAdapter.BookmarkItemData -> oldItem.bookmark.uuid == newItem.bookmark.uuid
             oldItem is PodcastAdapter.BookmarkHeader && newItem is PodcastAdapter.BookmarkHeader -> true
             oldItem is PodcastAdapter.DividerRow && newItem is PodcastAdapter.DividerRow -> oldItem.groupIndex == newItem.groupIndex
             else -> oldItem == newItem
@@ -111,7 +112,8 @@ class PodcastAdapter(
     private val onSubscribeClicked: () -> Unit,
     private val onUnsubscribeClicked: (successCallback: () -> Unit) -> Unit,
     private val onEpisodesOptionsClicked: () -> Unit,
-    private val onRowLongPress: (episode: PodcastEpisode) -> Unit,
+    private val onEpisodeRowLongPress: (PodcastEpisode) -> Unit,
+    private val onBookmarkRowLongPress: (Bookmark) -> Unit,
     private val onFoldersClicked: () -> Unit,
     private val onNotificationsClicked: () -> Unit,
     private val onSettingsClicked: () -> Unit,
@@ -120,7 +122,8 @@ class PodcastAdapter(
     private val onSearchQueryChanged: (String) -> Unit,
     private val onSearchFocus: () -> Unit,
     private val onShowArchivedClicked: () -> Unit,
-    private val multiSelectHelper: MultiSelectEpisodesHelper,
+    private val multiSelectEpisodesHelper: MultiSelectEpisodesHelper,
+    private val multiSelectBookmarksHelper: MultiSelectBookmarksHelper,
     private val onArtworkLongClicked: (successCallback: () -> Unit) -> Unit,
     private val ratingsViewModel: PodcastRatingsViewModel,
     private val swipeButtonLayoutFactory: SwipeButtonLayoutFactory,
@@ -141,6 +144,14 @@ class PodcastAdapter(
         val searchTerm: String,
         val onSearchFocus: () -> Unit,
         val onSearchQueryChanged: (String) -> Unit,
+    )
+    data class BookmarkItemData(
+        val bookmark: Bookmark,
+        val onBookmarkPlayClicked: (Bookmark) -> Unit,
+        val onBookmarkRowLongPress: (Bookmark) -> Unit,
+        val onBookmarkRowClick: (Bookmark, Int) -> Unit,
+        val isMultiSelecting: () -> Boolean,
+        val isSelected: (Bookmark) -> Boolean,
     )
 
     companion object {
@@ -201,7 +212,7 @@ class PodcastAdapter(
             is EpisodeLimitViewHolder -> bindEpisodeLimitRow(holder, position)
             is NoEpisodesViewHolder -> bindNoEpisodesMessage(holder, position)
             is DividerViewHolder -> bindDividerRow(holder, position)
-            is BookmarkViewHolder -> holder.bind(getItem(position) as Bookmark, onBookmarkPlayClicked)
+            is BookmarkViewHolder -> holder.bind(getItem(position) as BookmarkItemData)
             is BookmarkHeaderViewHolder -> holder.bind(getItem(position) as BookmarkHeader)
         }
     }
@@ -276,16 +287,16 @@ class PodcastAdapter(
 
     private fun bindEpisodeViewHolder(holder: EpisodeViewHolder, position: Int, fromListUuid: String?) {
         val episode = getItem(position) as? PodcastEpisode ?: return
-        holder.setup(episode, fromListUuid, ThemeColor.podcastIcon02(theme.activeTheme, tintColor), playButtonListener, settings.streamingMode() || castConnected, settings.getUpNextSwipeAction(), multiSelectHelper.isMultiSelecting, multiSelectHelper.isSelected(episode), disposables)
+        holder.setup(episode, fromListUuid, ThemeColor.podcastIcon02(theme.activeTheme, tintColor), playButtonListener, settings.streamingMode() || castConnected, settings.getUpNextSwipeAction(), multiSelectEpisodesHelper.isMultiSelecting, multiSelectEpisodesHelper.isSelected(episode), disposables)
         holder.episodeRow.setOnClickListener {
-            if (multiSelectHelper.isMultiSelecting) {
-                holder.binding.checkbox.isChecked = multiSelectHelper.toggle(episode)
+            if (multiSelectEpisodesHelper.isMultiSelecting) {
+                holder.binding.checkbox.isChecked = multiSelectEpisodesHelper.toggle(episode)
             } else {
                 onRowClicked(episode)
             }
         }
         holder.episodeRow.setOnLongClickListener {
-            onRowLongPress(episode)
+            onEpisodeRowLongPress(episode)
             true
         }
     }
@@ -404,12 +415,26 @@ class PodcastAdapter(
         searchTerm: String,
     ) {
         val content = mutableListOf<Any>().apply {
-            add(Podcast())
             if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+                add(Podcast())
                 add(TabsHeader(PodcastTab.BOOKMARKS, onTabClicked))
+                add(BookmarkHeader(bookmarks.size, searchTerm, onSearchFocus, onSearchQueryChanged))
+                addAll(
+                    bookmarks.map {
+                        BookmarkItemData(
+                            bookmark = it,
+                            onBookmarkPlayClicked = onBookmarkPlayClicked,
+                            onBookmarkRowLongPress = onBookmarkRowLongPress,
+                            onBookmarkRowClick = { bookmark, adapterPosition ->
+                                multiSelectBookmarksHelper.toggle(bookmark)
+                                notifyItemChanged(adapterPosition)
+                            },
+                            isMultiSelecting = { multiSelectBookmarksHelper.isMultiSelecting },
+                            isSelected = { bookmark -> multiSelectBookmarksHelper.isSelected(bookmark) },
+                        )
+                    }
+                )
             }
-            add(BookmarkHeader(bookmarks.size, searchTerm, onSearchFocus, onSearchQueryChanged))
-            addAll(bookmarks)
         }
         submitList(content)
     }
@@ -427,7 +452,7 @@ class PodcastAdapter(
             is NoEpisodeMessage -> R.layout.adapter_no_episodes
             is DividerRow -> R.layout.adapter_divider_row
             is TabsHeader -> VIEW_TYPE_TABS
-            is Bookmark -> VIEW_TYPE_BOOKMARKS
+            is BookmarkItemData -> VIEW_TYPE_BOOKMARKS
             is BookmarkHeader -> VIEW_TYPE_BOOKMARK_HEADER
             else -> R.layout.adapter_episode
         }
@@ -444,7 +469,7 @@ class PodcastAdapter(
             is BookmarkHeader -> Long.MAX_VALUE - 5
             is DividerRow -> item.groupIndex.toLong()
             is PodcastEpisode -> item.adapterId
-            is Bookmark -> item.adapterId
+            is BookmarkItemData -> item.bookmark.adapterId
             else -> throw IllegalStateException("Unknown item type")
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -67,6 +67,7 @@ import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutViewModel
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
+import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectHelper
 import dagger.hilt.android.AndroidEntryPoint
@@ -118,6 +119,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
     @Inject lateinit var castManager: CastManager
     @Inject lateinit var upNextQueue: UpNextQueue
     @Inject lateinit var multiSelectEpisodesHelper: MultiSelectEpisodesHelper
+    @Inject lateinit var multiSelectBookmarksHelper: MultiSelectBookmarksHelper
     @Inject lateinit var coilManager: CoilManager
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
@@ -199,8 +201,15 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
         }
     }
 
-    private val onRowLongPress: (episode: PodcastEpisode) -> Unit = { episode ->
-        multiSelectEpisodesHelper.defaultLongPress(multiSelectable = episode, fragmentManager = childFragmentManager)
+    private fun <T> onRowLongPress(): (entity: T) -> Unit = {
+        when (it) {
+            is PodcastEpisode ->
+                multiSelectEpisodesHelper
+                    .defaultLongPress(multiSelectable = it, fragmentManager = childFragmentManager)
+            is Bookmark ->
+                multiSelectBookmarksHelper
+                    .defaultLongPress(multiSelectable = it, fragmentManager = childFragmentManager)
+        }
         adapter?.notifyDataSetChanged()
     }
 
@@ -396,6 +405,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
             dialog.show()
         }
         multiSelectEpisodesHelper.isMultiSelecting = false
+        multiSelectBookmarksHelper.isMultiSelecting = false
     }
 
     private val onNotificationsClicked: () -> Unit = {
@@ -408,6 +418,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
         analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_SETTINGS_TAPPED)
         (activity as FragmentHostListener).addFragment(PodcastSettingsFragment.newInstance(viewModel.podcastUuid))
         multiSelectEpisodesHelper.isMultiSelecting = false
+        multiSelectBookmarksHelper.isMultiSelecting = false
     }
 
     private val onSearchFocus: () -> Unit = {
@@ -471,6 +482,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
     override fun onPause() {
         super.onPause()
         multiSelectEpisodesHelper.isMultiSelecting = false
+        multiSelectBookmarksHelper.isMultiSelecting = false
     }
 
     override fun onStop() {
@@ -549,7 +561,8 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                 onSubscribeClicked = onSubscribeClicked,
                 onUnsubscribeClicked = onUnsubscribeClicked,
                 onEpisodesOptionsClicked = onEpisodesOptionsClicked,
-                onRowLongPress = onRowLongPress,
+                onEpisodeRowLongPress = onRowLongPress(),
+                onBookmarkRowLongPress = onRowLongPress(),
                 onFoldersClicked = onFoldersClicked,
                 onNotificationsClicked = onNotificationsClicked,
                 onSettingsClicked = onSettingsClicked,
@@ -558,7 +571,8 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                 onSearchQueryChanged = onSearchQueryChanged,
                 onSearchFocus = onSearchFocus,
                 onShowArchivedClicked = onShowArchivedClicked,
-                multiSelectHelper = multiSelectEpisodesHelper,
+                multiSelectEpisodesHelper = multiSelectEpisodesHelper,
+                multiSelectBookmarksHelper = multiSelectBookmarksHelper,
                 onArtworkLongClicked = onArtworkLongClicked,
                 onTabClicked = onTabClicked,
                 onBookmarkPlayClicked = onBookmarkPlayClicked,
@@ -593,84 +607,51 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
 
         binding.episodesRecyclerView.requestFocus()
 
-        multiSelectEpisodesHelper.isMultiSelectingLive.observe(viewLifecycleOwner) {
-            binding.multiSelectToolbar.isVisible = it
-            binding.toolbar.isVisible = !it
+        multiSelectEpisodesHelper.setUp()
+        multiSelectBookmarksHelper.setUp()
 
+        return binding.root
+    }
+
+    fun <T> MultiSelectHelper<T>.setUp() {
+        isMultiSelectingLive.observe(viewLifecycleOwner) {
+            binding?.multiSelectToolbar?.isVisible = it
+            binding?.toolbar?.isVisible = !it
             adapter?.notifyDataSetChanged()
         }
-        multiSelectEpisodesHelper.coordinatorLayout = (activity as FragmentHostListener).snackBarView()
-        multiSelectEpisodesHelper.listener = object : MultiSelectHelper.Listener<BaseEpisode> {
+        coordinatorLayout = (activity as FragmentHostListener).snackBarView()
+        source = SourceView.PODCAST_SCREEN
+        listener = object : MultiSelectHelper.Listener<T> {
             override fun multiSelectSelectNone() {
-                val episodeState = viewModel.uiState.value
-                if (episodeState is PodcastViewModel.UiState.Loaded) {
-                    episodeState.episodes.forEach { multiSelectEpisodesHelper.deselect(it) }
-                    adapter?.notifyDataSetChanged()
-                }
+                viewModel.multiSelectSelectNone()
+                adapter?.notifyDataSetChanged()
             }
 
-            override fun multiSelectSelectAllUp(multiSelectable: BaseEpisode) {
-                val grouped = viewModel.groupedEpisodes.value
-                if (grouped != null) {
-                    val group = grouped.find { it.contains(multiSelectable) } ?: return
-                    val startIndex = group.indexOf(multiSelectable)
-                    if (startIndex > -1) {
-                        multiSelectEpisodesHelper.selectAllInList(group.subList(0, startIndex + 1))
-                    }
-
-                    adapter?.notifyDataSetChanged()
-                }
+            override fun multiSelectSelectAllUp(multiSelectable: T) {
+                viewModel.multiSelectAllUp(multiSelectable)
+                adapter?.notifyDataSetChanged()
             }
 
-            override fun multiSelectSelectAllDown(multiSelectable: BaseEpisode) {
-                val grouped = viewModel.groupedEpisodes.value
-                if (grouped != null) {
-                    val group = grouped.find { it.contains(multiSelectable) } ?: return
-                    val startIndex = group.indexOf(multiSelectable)
-                    if (startIndex > -1) {
-                        multiSelectEpisodesHelper.selectAllInList(group.subList(startIndex, group.size))
-                    }
-
-                    adapter?.notifyDataSetChanged()
-                }
+            override fun multiSelectSelectAllDown(multiSelectable: T) {
+                viewModel.multiSelectSelectAllDown(multiSelectable)
+                adapter?.notifyDataSetChanged()
             }
 
             override fun multiSelectSelectAll() {
-                val episodeState = viewModel.uiState.value
-                if (episodeState is PodcastViewModel.UiState.Loaded) {
-                    multiSelectEpisodesHelper.selectAllInList(episodeState.episodes)
-                    adapter?.notifyDataSetChanged()
-                }
+                viewModel.multiSelectSelectAll()
+                adapter?.notifyDataSetChanged()
             }
 
-            override fun multiDeselectAllBelow(multiSelectable: BaseEpisode) {
-                val grouped = viewModel.groupedEpisodes.value
-                if (grouped != null) {
-                    val group = grouped.find { it.contains(multiSelectable) } ?: return
-                    val startIndex = group.indexOf(multiSelectable)
-                    if (startIndex > -1) {
-                        group.subList(startIndex, group.size).forEach { multiSelectEpisodesHelper.deselect(it) }
-                        adapter?.notifyDataSetChanged()
-                    }
-                }
+            override fun multiDeselectAllBelow(multiSelectable: T) {
+                viewModel.multiDeselectAllBelow(multiSelectable)
+                adapter?.notifyDataSetChanged()
             }
 
-            override fun multiDeselectAllAbove(multiSelectable: BaseEpisode) {
-                val grouped = viewModel.groupedEpisodes.value
-                if (grouped != null) {
-                    val group = grouped.find { it.contains(multiSelectable) } ?: return
-                    val startIndex = group.indexOf(multiSelectable)
-                    if (startIndex > -1) {
-                        group.subList(0, startIndex + 1).forEach { multiSelectEpisodesHelper.deselect(it) }
-                        adapter?.notifyDataSetChanged()
-                    }
-                }
+            override fun multiDeselectAllAbove(multiSelectable: T) {
+                viewModel.multiDeselectAllAbove(multiSelectable)
+                adapter?.notifyDataSetChanged()
             }
         }
-        multiSelectEpisodesHelper.source = SourceView.PODCAST_SCREEN
-        binding.multiSelectToolbar.setup(viewLifecycleOwner, multiSelectEpisodesHelper, menuRes = null, fragmentManager = parentFragmentManager)
-
-        return binding.root
     }
 
     private fun notifyItemChanged(
@@ -726,21 +707,39 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                 is PodcastViewModel.UiState.Loaded -> {
                     addPaddingForEpisodeSearch(state.episodes)
                     when (state.showTab) {
-                        PodcastTab.EPISODES -> adapter?.setEpisodes(
-                            episodes = state.episodes,
-                            showingArchived = state.showingArchived,
-                            episodeCount = state.episodeCount,
-                            archivedCount = state.archivedCount,
-                            searchTerm = state.searchTerm,
-                            episodeLimit = state.episodeLimit,
-                            episodeLimitIndex = state.episodeLimitIndex,
-                            podcast = state.podcast,
-                            context = requireContext()
-                        )
-                        PodcastTab.BOOKMARKS -> adapter?.setBookmarks(
-                            bookmarks = state.bookmarks,
-                            searchTerm = state.searchBookmarkTerm,
-                        )
+                        PodcastTab.EPISODES -> {
+                            binding?.multiSelectToolbar?.setup(
+                                lifecycleOwner = viewLifecycleOwner,
+                                multiSelectHelper = multiSelectEpisodesHelper,
+                                menuRes = null,
+                                fragmentManager = parentFragmentManager,
+                            )
+
+                            adapter?.setEpisodes(
+                                episodes = state.episodes,
+                                showingArchived = state.showingArchived,
+                                episodeCount = state.episodeCount,
+                                archivedCount = state.archivedCount,
+                                searchTerm = state.searchTerm,
+                                episodeLimit = state.episodeLimit,
+                                episodeLimitIndex = state.episodeLimitIndex,
+                                podcast = state.podcast,
+                                context = requireContext()
+                            )
+                        }
+                        PodcastTab.BOOKMARKS -> {
+                            binding?.multiSelectToolbar?.setup(
+                                lifecycleOwner = viewLifecycleOwner,
+                                multiSelectHelper = multiSelectBookmarksHelper,
+                                menuRes = null,
+                                fragmentManager = parentFragmentManager,
+                            )
+
+                            adapter?.setBookmarks(
+                                bookmarks = state.bookmarks,
+                                searchTerm = state.searchBookmarkTerm,
+                            )
+                        }
                     }
                     if (state.searchTerm.isNotEmpty() && state.searchTerm != lastSearchTerm) {
                         binding?.episodesRecyclerView?.smoothScrollToTop(1)
@@ -838,16 +837,20 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
         dialog?.show(parentFragmentManager, "download_confirm")
     }
 
-    override fun onBackPressed(): Boolean {
-        return if (multiSelectEpisodesHelper.isMultiSelecting) {
-            multiSelectEpisodesHelper.isMultiSelecting = false
-            true
-        } else {
-            super.onBackPressed()
-        }
+    override fun onBackPressed() = if (multiSelectEpisodesHelper.isMultiSelecting) {
+        multiSelectEpisodesHelper.isMultiSelecting = false
+        true
+    } else if (multiSelectBookmarksHelper.isMultiSelecting) {
+        multiSelectBookmarksHelper.isMultiSelecting = false
+        true
+    } else {
+        super.onBackPressed()
     }
 
-    override fun getBackstackCount(): Int {
-        return super.getBackstackCount() + if (multiSelectEpisodesHelper.isMultiSelecting) 1 else 0
-    }
+    override fun getBackstackCount() = super.getBackstackCount() +
+        if (multiSelectEpisodesHelper.isMultiSelecting || multiSelectBookmarksHelper.isMultiSelecting) {
+            1
+        } else {
+            0
+        }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -117,7 +117,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
     @Inject lateinit var playButtonListener: PlayButton.OnClickListener
     @Inject lateinit var castManager: CastManager
     @Inject lateinit var upNextQueue: UpNextQueue
-    @Inject lateinit var multiSelectHelper: MultiSelectEpisodesHelper
+    @Inject lateinit var multiSelectEpisodesHelper: MultiSelectEpisodesHelper
     @Inject lateinit var coilManager: CoilManager
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
@@ -200,7 +200,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
     }
 
     private val onRowLongPress: (episode: PodcastEpisode) -> Unit = { episode ->
-        multiSelectHelper.defaultLongPress(multiSelectable = episode, fragmentManager = childFragmentManager)
+        multiSelectEpisodesHelper.defaultLongPress(multiSelectable = episode, fragmentManager = childFragmentManager)
         adapter?.notifyDataSetChanged()
     }
 
@@ -395,7 +395,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
             )
             dialog.show()
         }
-        multiSelectHelper.isMultiSelecting = false
+        multiSelectEpisodesHelper.isMultiSelecting = false
     }
 
     private val onNotificationsClicked: () -> Unit = {
@@ -407,7 +407,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
     private val onSettingsClicked: () -> Unit = {
         analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_SETTINGS_TAPPED)
         (activity as FragmentHostListener).addFragment(PodcastSettingsFragment.newInstance(viewModel.podcastUuid))
-        multiSelectHelper.isMultiSelecting = false
+        multiSelectEpisodesHelper.isMultiSelecting = false
     }
 
     private val onSearchFocus: () -> Unit = {
@@ -470,7 +470,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
 
     override fun onPause() {
         super.onPause()
-        multiSelectHelper.isMultiSelecting = false
+        multiSelectEpisodesHelper.isMultiSelecting = false
     }
 
     override fun onStop() {
@@ -558,7 +558,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                 onSearchQueryChanged = onSearchQueryChanged,
                 onSearchFocus = onSearchFocus,
                 onShowArchivedClicked = onShowArchivedClicked,
-                multiSelectHelper = multiSelectHelper,
+                multiSelectHelper = multiSelectEpisodesHelper,
                 onArtworkLongClicked = onArtworkLongClicked,
                 onTabClicked = onTabClicked,
                 onBookmarkPlayClicked = onBookmarkPlayClicked,
@@ -593,18 +593,18 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
 
         binding.episodesRecyclerView.requestFocus()
 
-        multiSelectHelper.isMultiSelectingLive.observe(viewLifecycleOwner) {
+        multiSelectEpisodesHelper.isMultiSelectingLive.observe(viewLifecycleOwner) {
             binding.multiSelectToolbar.isVisible = it
             binding.toolbar.isVisible = !it
 
             adapter?.notifyDataSetChanged()
         }
-        multiSelectHelper.coordinatorLayout = (activity as FragmentHostListener).snackBarView()
-        multiSelectHelper.listener = object : MultiSelectHelper.Listener<BaseEpisode> {
+        multiSelectEpisodesHelper.coordinatorLayout = (activity as FragmentHostListener).snackBarView()
+        multiSelectEpisodesHelper.listener = object : MultiSelectHelper.Listener<BaseEpisode> {
             override fun multiSelectSelectNone() {
                 val episodeState = viewModel.uiState.value
                 if (episodeState is PodcastViewModel.UiState.Loaded) {
-                    episodeState.episodes.forEach { multiSelectHelper.deselect(it) }
+                    episodeState.episodes.forEach { multiSelectEpisodesHelper.deselect(it) }
                     adapter?.notifyDataSetChanged()
                 }
             }
@@ -615,7 +615,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                     val group = grouped.find { it.contains(multiSelectable) } ?: return
                     val startIndex = group.indexOf(multiSelectable)
                     if (startIndex > -1) {
-                        multiSelectHelper.selectAllInList(group.subList(0, startIndex + 1))
+                        multiSelectEpisodesHelper.selectAllInList(group.subList(0, startIndex + 1))
                     }
 
                     adapter?.notifyDataSetChanged()
@@ -628,7 +628,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                     val group = grouped.find { it.contains(multiSelectable) } ?: return
                     val startIndex = group.indexOf(multiSelectable)
                     if (startIndex > -1) {
-                        multiSelectHelper.selectAllInList(group.subList(startIndex, group.size))
+                        multiSelectEpisodesHelper.selectAllInList(group.subList(startIndex, group.size))
                     }
 
                     adapter?.notifyDataSetChanged()
@@ -638,7 +638,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
             override fun multiSelectSelectAll() {
                 val episodeState = viewModel.uiState.value
                 if (episodeState is PodcastViewModel.UiState.Loaded) {
-                    multiSelectHelper.selectAllInList(episodeState.episodes)
+                    multiSelectEpisodesHelper.selectAllInList(episodeState.episodes)
                     adapter?.notifyDataSetChanged()
                 }
             }
@@ -649,7 +649,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                     val group = grouped.find { it.contains(multiSelectable) } ?: return
                     val startIndex = group.indexOf(multiSelectable)
                     if (startIndex > -1) {
-                        group.subList(startIndex, group.size).forEach { multiSelectHelper.deselect(it) }
+                        group.subList(startIndex, group.size).forEach { multiSelectEpisodesHelper.deselect(it) }
                         adapter?.notifyDataSetChanged()
                     }
                 }
@@ -661,14 +661,14 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                     val group = grouped.find { it.contains(multiSelectable) } ?: return
                     val startIndex = group.indexOf(multiSelectable)
                     if (startIndex > -1) {
-                        group.subList(0, startIndex + 1).forEach { multiSelectHelper.deselect(it) }
+                        group.subList(0, startIndex + 1).forEach { multiSelectEpisodesHelper.deselect(it) }
                         adapter?.notifyDataSetChanged()
                     }
                 }
             }
         }
-        multiSelectHelper.source = SourceView.PODCAST_SCREEN
-        binding.multiSelectToolbar.setup(viewLifecycleOwner, multiSelectHelper, menuRes = null, fragmentManager = parentFragmentManager)
+        multiSelectEpisodesHelper.source = SourceView.PODCAST_SCREEN
+        binding.multiSelectToolbar.setup(viewLifecycleOwner, multiSelectEpisodesHelper, menuRes = null, fragmentManager = parentFragmentManager)
 
         return binding.root
     }
@@ -839,8 +839,8 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
     }
 
     override fun onBackPressed(): Boolean {
-        return if (multiSelectHelper.isMultiSelecting) {
-            multiSelectHelper.isMultiSelecting = false
+        return if (multiSelectEpisodesHelper.isMultiSelecting) {
+            multiSelectEpisodesHelper.isMultiSelecting = false
             true
         } else {
             super.onBackPressed()
@@ -848,6 +848,6 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
     }
 
     override fun getBackstackCount(): Int {
-        return super.getBackstackCount() + if (multiSelectHelper.isMultiSelecting) 1 else 0
+        return super.getBackstackCount() + if (multiSelectEpisodesHelper.isMultiSelecting) 1 else 0
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkViewHolder.kt
@@ -1,10 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.adapter
 
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.ComposeView
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.bookmark.BookmarkItem
-import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastAdapter
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 
 class BookmarkViewHolder(
@@ -12,15 +15,21 @@ class BookmarkViewHolder(
     private val theme: Theme,
 ) : RecyclerView.ViewHolder(composeView) {
 
-    fun bind(
-        bookmark: Bookmark,
-        onBookmarkPlayClicked: (Bookmark) -> Unit,
-    ) {
+    fun bind(data: PodcastAdapter.BookmarkItemData,) {
         composeView.setContent {
             AppTheme(theme.activeTheme) {
                 BookmarkItem(
-                    bookmark = bookmark,
-                    onPlayClick = { onBookmarkPlayClicked(it) },
+                    bookmark = data.bookmark,
+                    isMultiSelecting = data.isMultiSelecting,
+                    isSelected = data.isSelected,
+                    onPlayClick = { data.onBookmarkPlayClicked(it) },
+                    modifier = Modifier
+                        .pointerInput(data.isSelected(data.bookmark)) {
+                            detectTapGestures(
+                                onLongPress = { data.onBookmarkRowLongPress(data.bookmark) },
+                                onTap = { data.onBookmarkRowClick(data.bookmark, bindingAdapterPosition) }
+                            )
+                        }
                 )
             }
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -33,6 +33,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
+import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
@@ -70,6 +72,8 @@ class PodcastViewModel
     private val bookmarkManager: BookmarkManager,
     private val episodeSearchHandler: EpisodeSearchHandler,
     private val bookmarkSearchHandler: BookmarkSearchHandler,
+    private val multiSelectEpisodesHelper: MultiSelectEpisodesHelper,
+    private val multiSelectBookmarksHelper: MultiSelectBookmarksHelper
 ) : ViewModel(), CoroutineScope {
 
     private val disposables = CompositeDisposable()
@@ -361,6 +365,120 @@ class PodcastViewModel
         val podcast = podcast.value ?: return
         launch {
             folderManager.removePodcast(podcast)
+        }
+    }
+
+    fun multiSelectSelectNone() {
+        val uiState = uiState.value as? UiState.Loaded ?: return
+        when (uiState.showTab) {
+            PodcastTab.EPISODES -> multiSelectEpisodesHelper.deselectAllInList(uiState.episodes)
+            PodcastTab.BOOKMARKS -> multiSelectBookmarksHelper.deselectAllInList(uiState.bookmarks)
+        }
+    }
+
+    fun <T> multiSelectAllUp(multiSelectable: T) {
+        val uiState = uiState.value as? UiState.Loaded ?: return
+        when (multiSelectable) {
+            is PodcastEpisode -> {
+                val grouped = groupedEpisodes.value
+                if (grouped != null) {
+                    val group = grouped.find { it.contains(multiSelectable) } ?: return
+                    val startIndex = group.indexOf(multiSelectable)
+                    if (startIndex > -1) {
+                        multiSelectEpisodesHelper.selectAllInList(group.subList(0, startIndex + 1))
+                    }
+                }
+            }
+            is Bookmark -> {
+                val startIndex = uiState.bookmarks.indexOf(multiSelectable)
+                if (startIndex > -1) {
+                    multiSelectBookmarksHelper.selectAllInList(
+                        uiState.bookmarks.subList(0, startIndex + 1)
+                    )
+                }
+            }
+        }
+    }
+
+    fun <T> multiSelectSelectAllDown(multiSelectable: T) {
+        val uiState = uiState.value as? UiState.Loaded ?: return
+        when (multiSelectable) {
+            is PodcastEpisode -> {
+                val grouped = groupedEpisodes.value
+                if (grouped != null) {
+                    val group = grouped.find { it.contains(multiSelectable) } ?: return
+                    val startIndex = group.indexOf(multiSelectable)
+                    if (startIndex > -1) {
+                        multiSelectEpisodesHelper.selectAllInList(group.subList(startIndex, group.size))
+                    }
+                }
+            }
+            is Bookmark -> {
+                val startIndex = uiState.bookmarks.indexOf(multiSelectable)
+                if (startIndex > -1) {
+                    multiSelectBookmarksHelper.selectAllInList(
+                        uiState.bookmarks.subList(startIndex, uiState.bookmarks.size)
+                    )
+                }
+            }
+        }
+    }
+
+    fun multiSelectSelectAll() {
+        val uiState = uiState.value as? UiState.Loaded ?: return
+        when (uiState.showTab) {
+            PodcastTab.EPISODES -> multiSelectEpisodesHelper.selectAllInList(uiState.episodes)
+            PodcastTab.BOOKMARKS -> multiSelectBookmarksHelper.selectAllInList(uiState.bookmarks)
+        }
+    }
+
+    fun <T> multiDeselectAllBelow(multiSelectable: T) {
+        val uiState = uiState.value as? UiState.Loaded ?: return
+        when (multiSelectable) {
+            is PodcastEpisode -> {
+                val grouped = groupedEpisodes.value
+                if (grouped != null) {
+                    val group = grouped.find { it.contains(multiSelectable) } ?: return
+                    val startIndex = group.indexOf(multiSelectable)
+                    if (startIndex > -1) {
+                        multiSelectEpisodesHelper.deselectAllInList(group.subList(startIndex, group.size))
+                    }
+                }
+            }
+
+            is Bookmark -> {
+                val startIndex = uiState.bookmarks.indexOf(multiSelectable)
+                if (startIndex > -1) {
+                    multiSelectBookmarksHelper.deselectAllInList(
+                        uiState.bookmarks.subList(startIndex, uiState.bookmarks.size)
+                    )
+                }
+            }
+        }
+    }
+
+    fun <T> multiDeselectAllAbove(multiSelectable: T) {
+        val uiState = uiState.value as? UiState.Loaded ?: return
+        when (multiSelectable) {
+            is PodcastEpisode -> {
+                val grouped = groupedEpisodes.value
+                if (grouped != null) {
+                    val group = grouped.find { it.contains(multiSelectable) } ?: return
+                    val startIndex = group.indexOf(multiSelectable)
+                    if (startIndex > -1) {
+                        multiSelectEpisodesHelper.deselectAllInList(group.subList(0, startIndex + 1))
+                    }
+                }
+            }
+
+            is Bookmark -> {
+                val startIndex = uiState.bookmarks.indexOf(multiSelectable)
+                if (startIndex > -1) {
+                    multiSelectBookmarksHelper.deselectAllInList(
+                        uiState.bookmarks.subList(0, startIndex + 1)
+                    )
+                }
+            }
         }
     }
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkItem.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkItem.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.Checkbox
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -16,6 +17,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -35,6 +37,8 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 fun BookmarkItem(
     bookmark: Bookmark,
+    isMultiSelecting: () -> Boolean,
+    isSelected: (Bookmark) -> Boolean,
     onPlayClick: (Bookmark) -> Unit,
     modifier: Modifier = Modifier,
     showIcon: Boolean = true,
@@ -51,13 +55,27 @@ fun BookmarkItem(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .fillMaxWidth()
-                .background(color = MaterialTheme.theme.colors.primaryUi02)
+                .background(
+                    color = if (isMultiSelecting() && isSelected(bookmark)) {
+                        MaterialTheme.theme.colors.primaryUi02Selected
+                    } else {
+                        MaterialTheme.theme.colors.primaryUi02
+                    }
+                )
         ) {
             val createdAtText by remember {
                 mutableStateOf(
                     bookmark.createdAt.toLocalizedFormatPattern(
                         bookmark.createdAtDatePattern()
                     )
+                )
+            }
+            if (isMultiSelecting()) {
+                Checkbox(
+                    checked = isSelected(bookmark),
+                    onCheckedChange = null,
+                    modifier = Modifier
+                        .padding(start = 16.dp)
                 )
             }
 
@@ -100,7 +118,8 @@ fun BookmarkItem(
                 TimePlayButton(
                     timeSecs = bookmark.timeSecs,
                     contentDescriptionId = LR.string.bookmark_play,
-                    onClick = { onPlayClick(bookmark) }
+                    onClick = { onPlayClick(bookmark) },
+                    backgroundColor = Color.Transparent,
                 )
             }
         }
@@ -123,6 +142,8 @@ private fun BookmarkPreview(
                 title = "Bookmark Title",
                 createdAt = Date()
             ),
+            isMultiSelecting = { false },
+            isSelected = { false },
             onPlayClick = {},
             modifier = Modifier,
             showIcon = false


### PR DESCRIPTION
## Description

This adds bookmarks multi-select on the podcast page.

## Testing Instructions
1. Launch the app
2. Play an episode and add a few bookmarks
3. Go to the corresponding Podcast Details page
4. Tap on bookmarks tab
5. Long press on a row
6. ✅ Verify you enter multi selection mode and the action bar appears
7. Tap on a row, ✅ verify the item is now selected
8. ✅ Verify the action bar selection count updated
9. ✅ Verify the edit option is visible
10. Tap the row again to deselect it, ✅ Verify the edit option is hidden
11. Tap Select All from more options in the multi-select toolbar
12. ✅ Verify all the items are selected
13. Tap and hold on a row again
14. ✅ Verify you see the 'Select All Above' , 'Select All ' and 'Select All Below' options
15. Tap each option and ✅ verify the correct items are selected
13. Tap and hold on a row again
14.  ✅ Verify you see the 'Deselect All Above', "Deselect All" and 'Deselect All Below' options
15. Tap each option and ✅ verify the correct items are selected

#### Regression

Test that select/ deselect options for the episodes tab works as before.

## Screenshots or Screencast 

Light Theme | Rose Theme
----|----
![Screenshot_20230728_165305](https://github.com/Automattic/pocket-casts-android/assets/1405144/806e4587-6da4-41a1-86a9-2fd08bd1304a) | ![Screenshot_20230728_165746](https://github.com/Automattic/pocket-casts-android/assets/1405144/121001a4-33ab-4474-bccc-1537cc672bfb)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
