### PR TITLE
Add dontwarn Proguard rule for com.google.android.gms.cast.framework.R

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -173,6 +173,7 @@
 -dontwarn com.google.android.material.R$dimen
 -dontwarn com.google.android.material.R$style
 -dontwarn com.google.android.material.R$styleable
+-dontwarn com.google.android.gms.cast.framework.R$drawable
 
 # The following Retrofit rules are only be required until Retrofit 2.10.0 is released as it's included https://github.com/square/retrofit/blob/master/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
 


### PR DESCRIPTION
We had some issues in other projects related to Proguard, so even though we tested the release builds for this project, I wanted to double check that everything is still working correctly. I ran `./gradlew bundleRelease` in current `main` and got the error below which did not exist when we tested https://github.com/Automattic/pocket-casts-android/pull/1208:

```
> Task :modules:services:repositories:minifyReleaseWithR8 FAILED
ERROR: Missing classes detected while running R8. Please add the missing classes or apply additional keep rules that are generated in ./pocket-casts-android/modules/services/repositories/build/outputs/mapping/release/missing_rules.txt.
ERROR: R8: Missing class com.google.android.gms.cast.framework.R$drawable (referenced from: void au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.sendDataWarningNotification(au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode))
```

_P.S:_ I double checked the [AGP `8.1.0` update PR](https://github.com/Automattic/pocket-casts-android/pull/1208) and I am still not getting that ^ error.

---

This PR adds the `-dontwarn com.google.android.gms.cast.framework.R$drawable` Proguard rule as suggested by Android Gradle Plugin. However, I just realized while working on this PR description that these classes are currently in use:

```
[02:36] ~/Dev/Pro/pocket-casts-android $ rg com.google.android.gms.cast.framework.R
modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfItem.kt
101:        iconRes = { com.google.android.gms.cast.framework.R.drawable.quantum_ic_cast_connected_white_24 },

modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
1674:            NotificationCompat.Action(com.google.android.gms.cast.framework.R.drawable.cast_ic_mini_controller_skip_next, "Play next downloaded", skipIntent)

modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
383:                MediaNotificationControls.PlayNext -> addCustomAction(stateBuilder, APP_ACTION_PLAY_NEXT, "Play next", com.google.android.gms.cast.framework.R.drawable.cast_ic_mini_controller_skip_next)

modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
257:        object PlayNext : MediaNotificationControls(LR.string.play_next, com.google.android.gms.cast.framework.R.drawable.cast_ic_mini_controller_skip_next, PLAY_NEXT_KEY)
```

Now, I am wondering if this is the correct solution. I am going to still open this PR to share all this, but I think the better solution might be to revert the `android.enableR8.fullMode` to `false`. [The default value of this flag used to be `false` before AGP `8.0`, but they changed it to `true` in AGP `8.0`](https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes). It's very hard to verify the behavior resulting from this, so I think we should revert it back, at least for now.