### PR TITLE
Disable R8 fullMode

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,7 @@
 #Mon Mar 30 10:47:43 AEDT 2020
 android.nonTransitiveRClass=true
 android.useAndroidX=true
+android.enableR8.fullMode=false
 
 # Disable unused Android Gradle Plugin features
 android.defaults.buildfeatures.aidl=false


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

In Android Gradle Plugin `8.0`+, the default value for `android.enableR8.fullMode` changed from `false` to `true`. The resulting changes from this is very hard to verify and we seem to be getting [new Proguard related errors](https://github.com/Automattic/pocket-casts-android/pull/1221) that didn't seem to happen in the [original AGP update PR](https://github.com/Automattic/pocket-casts-android/pull/1208).

For the new proguard error, I suggested we add a new Proguard rule in https://github.com/Automattic/pocket-casts-android/pull/1221, but I am not sure if it's the correct solution. I am worried about a resource or a class being stripped in a release version and us not realizing it until it makes it to the users, so I think this solution is the safer one.

## Testing Instructions

* Run `./gradlew clean && ./gradlew bundleRelease --rerun-tasks` and verify that it succeeds.
* Smoke test the resulting artifact
