### PR TITLE
What's new tracks

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -49,8 +49,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowTextButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
@@ -64,11 +67,14 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @AndroidEntryPoint
 class WhatsNewFragment : BaseFragment() {
+
+    @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -79,6 +85,14 @@ class WhatsNewFragment : BaseFragment() {
             setBackgroundColor(Color.Transparent.toArgb())
             setContent {
                 AppTheme(theme.activeTheme) {
+
+                    CallOnce {
+                        analyticsTracker.track(
+                            AnalyticsEvent.WHATSNEW_SHOWN,
+                            mapOf("version" to Settings.WHATS_NEW_VERSION_CODE)
+                        )
+                    }
+
                     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
                     val onClose: () -> Unit = {
                         @Suppress("DEPRECATION")
@@ -86,10 +100,20 @@ class WhatsNewFragment : BaseFragment() {
                     }
                     WhatsNewPage(
                         onGoToSettings = {
+                            analyticsTracker.track(
+                                AnalyticsEvent.WHATSNEW_CONFIRM_BUTTON_TAPPED,
+                                mapOf("version" to Settings.WHATS_NEW_VERSION_CODE)
+                            )
                             onClose()
                             goToPlaybackSettings()
                         },
-                        onClose = onClose,
+                        onClose = {
+                            analyticsTracker.track(
+                                AnalyticsEvent.WHATSNEW_DISMISSED,
+                                mapOf("version" to Settings.WHATS_NEW_VERSION_CODE)
+                            )
+                            onClose()
+                        },
                     )
                 }
             }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -566,4 +566,9 @@ enum class AnalyticsEvent(val key: String) {
     WEAR_SIGNIN_GOOGLE_TAPPED("wear_signin_google_tapped"),
     WEAR_SIGNIN_PHONE_TAPPED("wear_signin_phone_tapped"),
     WEAR_SIGNIN_EMAIL_TAPPED("wear_signin_email_tapped"),
+
+    /* Whats New Popup */
+    WHATSNEW_SHOWN("whatsnew_shown"),
+    WHATSNEW_DISMISSED("whatsnew_dismissed"),
+    WHATSNEW_CONFIRM_BUTTON_TAPPED("whatsnew_confirm_button_tapped"),
 }


### PR DESCRIPTION
## Description
This adds tracks for the Whats new dialog

## Testing Instructions

For testing this, I would comment out [these lines](https://github.com/Automattic/pocket-casts-android/blob/d4b3363fbdb0793d9c5c9687768be00a19aa047b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt#L740-L742) so the what's new dialog is always presented.

1. Run the app
2. When the What's New popup appears you should see a Tracked: whatsnew_displayed ["version": 9115, ...] in the logs
3. If you tap "Maybe later" or tap outside the dialog, you should see Tracked: whatsnew_dismissed ["version": 9115, ...] in the logs. If you tap "Enable it now" you should see Tracked: whatsnew_confirm_button_tapped ["version": 9115, ...] in the logs. 

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews