### PR TITLE
fix #1226 keyboard reopening bug fixed

### DIFF
--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -118,6 +118,7 @@ class SearchFragment : BaseFragment() {
         super.onPause()
         binding?.let {
             UiUtil.hideKeyboard(it.searchView)
+            it.searchView.clearFocus()
         }
         viewModel.onFragmentPause(activity?.isChangingConfigurations)
     }


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Fixes <!-- issue number, if applicable -->#1226 After performing a search, dismissing then reopening the app also opens the keyboard again.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->
Just follow the same procedure as described in issue #1226

## Screenshots or Screencast 
<!-- if applicable -->
https://github.com/Automattic/pocket-casts-android/assets/52420957/9cb635b9-ab89-466b-9f63-cf92399cdf67


## Checklist

- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
