### PR TITLE
Settings Sync - Refactor archive settings to be UserSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unknown
+-----
+*   Bug Fixes:
+    *   Fixed auto archive settings getting lost when switching languages
+        ([#1234](https://github.com/Automattic/pocket-casts-android/pull/1234))
+
 7.45
 -----
 *   Bug Fixes:

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveViewModel.kt
@@ -39,7 +39,7 @@ class PodcastAutoArchiveViewModel @Inject constructor(
         launch {
             val podcast = podcast.value ?: return@launch
             podcast.overrideGlobalArchive = checked
-            podcast.autoArchiveAfterPlaying = settings.getAutoArchiveAfterPlaying().toIndex()
+            podcast.autoArchiveAfterPlaying = settings.autoArchiveAfterPlaying.flow.value.toIndex()
             podcast.autoArchiveInactive = settings.getAutoArchiveInactive().toIndex()
             podcastManager.updatePodcast(podcast)
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveViewModel.kt
@@ -40,7 +40,7 @@ class PodcastAutoArchiveViewModel @Inject constructor(
             val podcast = podcast.value ?: return@launch
             podcast.overrideGlobalArchive = checked
             podcast.autoArchiveAfterPlaying = settings.autoArchiveAfterPlaying.flow.value.toIndex()
-            podcast.autoArchiveInactive = settings.getAutoArchiveInactive().toIndex()
+            podcast.autoArchiveInactive = settings.autoArchiveInactive.flow.value.toIndex()
             podcastManager.updatePodcast(podcast)
         }
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoArchiveFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoArchiveFragment.kt
@@ -27,6 +27,7 @@ class AutoArchiveFragment : PreferenceFragmentCompat(), HasBackstack, SharedPref
     private val viewModel: AutoArchiveFragmentViewModel by viewModels()
 
     private lateinit var autoArchivePlayedEpisodes: ListPreference
+    private lateinit var autoArchiveInactiveEpisodes: ListPreference
 
     val toolbar: Toolbar?
         get() = view?.findViewById(R.id.toolbar)
@@ -37,6 +38,13 @@ class AutoArchiveFragment : PreferenceFragmentCompat(), HasBackstack, SharedPref
             .apply {
                 setOnPreferenceChangeListener { _, newValue ->
                     viewModel.onPlayedEpisodesAfterChanged(newValue as String)
+                    true
+                }
+            }
+        autoArchiveInactiveEpisodes = preferenceManager.findPreference<ListPreference>("autoArchiveInactiveEpisodes")!!
+            .apply {
+                setOnPreferenceChangeListener { _, newValue ->
+                    viewModel.onInactiveChanged(newValue as String)
                     true
                 }
             }
@@ -52,6 +60,7 @@ class AutoArchiveFragment : PreferenceFragmentCompat(), HasBackstack, SharedPref
     override fun onResume() {
         super.onResume()
         setupAutoArchiveAfterPlaying()
+        setupAutoArchiveInactive()
         preferenceScreen.sharedPreferences?.registerOnSharedPreferenceChangeListener(this)
     }
 
@@ -72,9 +81,6 @@ class AutoArchiveFragment : PreferenceFragmentCompat(), HasBackstack, SharedPref
             Settings.AUTO_ARCHIVE_INCLUDE_STARRED -> {
                 updateStarredSummary()
                 viewModel.onStarredChanged()
-            }
-            Settings.AUTO_ARCHIVE_INACTIVE -> {
-                viewModel.onInactiveChanged()
             }
             else -> Timber.d("Unknown preference changed: $key")
         }
@@ -97,5 +103,10 @@ class AutoArchiveFragment : PreferenceFragmentCompat(), HasBackstack, SharedPref
     private fun setupAutoArchiveAfterPlaying() {
         val stringArray = resources.getStringArray(LR.array.settings_auto_archive_played_values)
         autoArchivePlayedEpisodes.value = stringArray[settings.autoArchiveAfterPlaying.flow.value.toIndex()]
+    }
+
+    private fun setupAutoArchiveInactive() {
+        val stringArray = resources.getStringArray(LR.array.settings_auto_archive_inactive_values)
+        autoArchiveInactiveEpisodes.value = stringArray[settings.autoArchiveInactive.flow.value.toIndex()]
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoArchiveFragmentViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoArchiveFragmentViewModel.kt
@@ -6,6 +6,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveInactiveSetting
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -40,20 +41,12 @@ class AutoArchiveFragmentViewModel @Inject constructor(
         )
     }
 
-    fun onInactiveChanged() {
+    fun onInactiveChanged(newStringValue: String) {
+        val newValue = AutoArchiveInactiveSetting.fromString(newStringValue, context)
+        settings.autoArchiveInactive.set(newValue)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_ARCHIVE_INACTIVE_CHANGED,
-            mapOf(
-                "value" to when (settings.getAutoArchiveInactive()) {
-                    Settings.AutoArchiveInactive.Never -> "never"
-                    Settings.AutoArchiveInactive.Hours24 -> "after_24_hours"
-                    Settings.AutoArchiveInactive.Days2 -> "after_2_days"
-                    Settings.AutoArchiveInactive.Weeks1 -> "after_1_week"
-                    Settings.AutoArchiveInactive.Weeks2 -> "after_2_weeks"
-                    Settings.AutoArchiveInactive.Days30 -> "after_30_days"
-                    Settings.AutoArchiveInactive.Days90 -> "after 3 months"
-                }
-            )
+            mapOf("value" to newValue.analyticsValue)
         )
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoArchiveFragmentViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoArchiveFragmentViewModel.kt
@@ -25,10 +25,11 @@ class AutoArchiveFragmentViewModel @Inject constructor(
         }
     }
 
-    fun onStarredChanged() {
+    fun onStarredChanged(newValue: Boolean) {
+        settings.autoArchiveIncludeStarred.set(newValue)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_ARCHIVE_INCLUDE_STARRED_TOGGLED,
-            mapOf("enabled" to settings.getAutoArchiveIncludeStarred())
+            mapOf("enabled" to newValue)
         )
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoArchiveFragmentViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoArchiveFragmentViewModel.kt
@@ -1,16 +1,20 @@
 package au.com.shiftyjelly.pocketcasts.settings.viewmodel
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 @HiltViewModel
 class AutoArchiveFragmentViewModel @Inject constructor(
     private val settings: Settings,
     private val analyticsTracker: AnalyticsTrackerWrapper,
+    @ApplicationContext private val context: Context,
 ) : ViewModel() {
     private var isFragmentChangingConfigurations: Boolean = false
 
@@ -27,18 +31,12 @@ class AutoArchiveFragmentViewModel @Inject constructor(
         )
     }
 
-    fun onPlayedEpisodesAfterChanged() {
+    fun onPlayedEpisodesAfterChanged(newStringValue: String) {
+        val newValue = AutoArchiveAfterPlayingSetting.fromString(newStringValue, context)
+        settings.autoArchiveAfterPlaying.set(newValue)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_ARCHIVE_PLAYED_CHANGED,
-            mapOf(
-                "value" to when (settings.getAutoArchiveAfterPlaying()) {
-                    Settings.AutoArchiveAfterPlaying.Never -> "never"
-                    Settings.AutoArchiveAfterPlaying.AfterPlaying -> "after_playing"
-                    Settings.AutoArchiveAfterPlaying.Hours24 -> "after_24_hours"
-                    Settings.AutoArchiveAfterPlaying.Days2 -> "after_2_days"
-                    Settings.AutoArchiveAfterPlaying.Weeks1 -> "after_1_week"
-                }
-            )
+            mapOf("value" to newValue.analyticsValue)
         )
     }
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.preferences
 
-import android.content.Context
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.work.NetworkType
@@ -15,6 +14,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.model.AppIconSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveInactiveSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.NewEpisodeNotificationActionSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.NotificationVibrateSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
@@ -112,7 +112,6 @@ interface Settings {
 
         const val AUTO_ARCHIVE_EXCLUDED_PODCASTS = "autoArchiveExcludedPodcasts"
         const val AUTO_ARCHIVE_INCLUDE_STARRED = "autoArchiveIncludeStarred"
-        const val AUTO_ARCHIVE_INACTIVE = "autoArchiveInactiveEpisodes"
 
         const val INTENT_OPEN_APP_NEW_EPISODES = "INTENT_OPEN_APP_NEW_EPISODES"
         const val INTENT_OPEN_APP_DOWNLOADING = "INTENT_OPEN_APP_DOWNLOADING"
@@ -214,38 +213,6 @@ interface Settings {
         object PlaybackSpeed : MediaNotificationControls(LR.string.playback_speed, IR.drawable.auto_1x, PLAYBACK_SPEED_KEY)
 
         object Star : MediaNotificationControls(LR.string.star, IR.drawable.ic_star, STAR_KEY)
-    }
-
-    sealed class AutoArchiveInactive(val timeSeconds: Int) {
-        object Never : AutoArchiveInactive(-1)
-        object Hours24 : AutoArchiveInactive(24 * 60 * 60)
-        object Days2 : AutoArchiveInactive(2 * 24 * 60 * 60)
-        object Weeks1 : AutoArchiveInactive(7 * 24 * 60 * 60)
-        object Weeks2 : AutoArchiveInactive(14 * 24 * 60 * 60)
-        object Days30 : AutoArchiveInactive(30 * 24 * 60 * 60)
-        object Days90 : AutoArchiveInactive(90 * 24 * 60 * 60)
-
-        companion object {
-            fun fromString(context: Context, value: String?): AutoArchiveInactive {
-                return when (value) {
-                    context.getString(LR.string.settings_auto_archive_inactive_never) -> Never
-                    context.getString(LR.string.settings_auto_archive_inactive_24_hours) -> Hours24
-                    context.getString(LR.string.settings_auto_archive_inactive_2_days) -> Days2
-                    context.getString(LR.string.settings_auto_archive_inactive_1_week) -> Weeks1
-                    context.getString(LR.string.settings_auto_archive_inactive_2_weeks) -> Weeks2
-                    context.getString(LR.string.settings_auto_archive_inactive_30_days) -> Days30
-                    context.getString(LR.string.settings_auto_archive_inactive_3_months) -> Days90
-                    else -> Never
-                }
-            }
-
-            val options
-                get() = listOf(Never, Hours24, Days2, Weeks1, Weeks2, Days30, Days90)
-
-            fun fromIndex(index: Int) = options[index]
-        }
-
-        fun toIndex(): Int = options.indexOf(this)
     }
 
     val podcastLayoutObservable: Observable<Int>
@@ -414,7 +381,7 @@ interface Settings {
     fun setAutoArchiveExcludedPodcasts(excluded: List<String>)
     fun getAutoArchiveIncludeStarred(): Boolean
     val autoArchiveAfterPlaying: UserSetting<AutoArchiveAfterPlayingSetting>
-    fun getAutoArchiveInactive(): AutoArchiveInactive
+    val autoArchiveInactive: UserSetting<AutoArchiveInactiveSetting>
 
     fun selectedFilter(): String?
     fun setSelectedFilter(filterUUID: String?)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -14,11 +14,11 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.model.AppIconSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.NewEpisodeNotificationActionSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.NotificationVibrateSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.ThemeSetting
-import au.com.shiftyjelly.pocketcasts.utils.Util
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.StateFlow
 import java.util.Date
@@ -112,7 +112,6 @@ interface Settings {
 
         const val AUTO_ARCHIVE_EXCLUDED_PODCASTS = "autoArchiveExcludedPodcasts"
         const val AUTO_ARCHIVE_INCLUDE_STARRED = "autoArchiveIncludeStarred"
-        const val AUTO_ARCHIVE_PLAYED_EPISODES_AFTER = "autoArchivePlayedEpisodes"
         const val AUTO_ARCHIVE_INACTIVE = "autoArchiveInactiveEpisodes"
 
         const val INTENT_OPEN_APP_NEW_EPISODES = "INTENT_OPEN_APP_NEW_EPISODES"
@@ -184,37 +183,6 @@ interface Settings {
         SKIP_FORWARD,
         NEXT_CHAPTER,
         PREVIOUS_CHAPTER,
-    }
-
-    sealed class AutoArchiveAfterPlaying(val timeSeconds: Int) {
-        companion object {
-            fun fromString(context: Context, value: String?): AutoArchiveAfterPlaying {
-                val isAutomotive = Util.isAutomotive(context)
-                val defaultValue = if (isAutomotive) Never else AfterPlaying
-
-                return when (value) {
-                    context.getString(LR.string.settings_auto_archive_played_never) -> Never
-                    context.getString(LR.string.settings_auto_archive_played_after_playing) -> AfterPlaying
-                    context.getString(LR.string.settings_auto_archive_played_after_24_hours) -> Hours24
-                    context.getString(LR.string.settings_auto_archive_played_after_2_days) -> Days2
-                    context.getString(LR.string.settings_auto_archive_played_after_1_week) -> Weeks1
-                    else -> defaultValue
-                }
-            }
-
-            val options
-                get() = listOf(Never, AfterPlaying, Hours24, Days2, Weeks1)
-
-            fun fromIndex(index: Int) = options[index]
-        }
-
-        object Never : AutoArchiveAfterPlaying(-1)
-        object AfterPlaying : AutoArchiveAfterPlaying(0)
-        object Hours24 : AutoArchiveAfterPlaying(24 * 60 * 60)
-        object Days2 : AutoArchiveAfterPlaying(2 * 24 * 60 * 60)
-        object Weeks1 : AutoArchiveAfterPlaying(7 * 24 * 60 * 60)
-
-        fun toIndex(): Int = options.indexOf(this)
     }
 
     sealed class MediaNotificationControls(@StringRes val controlName: Int, @DrawableRes val iconRes: Int, val key: String) {
@@ -445,7 +413,7 @@ interface Settings {
     fun getAutoArchiveExcludedPodcasts(): List<String>
     fun setAutoArchiveExcludedPodcasts(excluded: List<String>)
     fun getAutoArchiveIncludeStarred(): Boolean
-    fun getAutoArchiveAfterPlaying(): AutoArchiveAfterPlaying
+    val autoArchiveAfterPlaying: UserSetting<AutoArchiveAfterPlayingSetting>
     fun getAutoArchiveInactive(): AutoArchiveInactive
 
     fun selectedFilter(): String?

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -379,7 +379,7 @@ interface Settings {
 
     fun getAutoArchiveExcludedPodcasts(): List<String>
     fun setAutoArchiveExcludedPodcasts(excluded: List<String>)
-    fun getAutoArchiveIncludeStarred(): Boolean
+    val autoArchiveIncludeStarred: UserSetting<Boolean>
     val autoArchiveAfterPlaying: UserSetting<AutoArchiveAfterPlayingSetting>
     val autoArchiveInactive: UserSetting<AutoArchiveInactiveSetting>
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -963,9 +963,11 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override fun getAutoArchiveIncludeStarred(): Boolean {
-        return getBoolean(Settings.AUTO_ARCHIVE_INCLUDE_STARRED, false)
-    }
+    override val autoArchiveIncludeStarred = UserSetting.BoolPref(
+        sharedPrefKey = Settings.AUTO_ARCHIVE_INCLUDE_STARRED,
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
 
     override val autoArchiveAfterPlaying = UserSetting.PrefFromInt(
         sharedPrefKey = "autoArchivePlayedEpisodesIndex",

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -25,6 +25,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.di.PrivateSharedPreferences
 import au.com.shiftyjelly.pocketcasts.preferences.di.PublicSharedPreferences
 import au.com.shiftyjelly.pocketcasts.preferences.model.AppIconSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveInactiveSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.NewEpisodeNotificationActionSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.NotificationVibrateSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
@@ -967,21 +968,26 @@ class SettingsImpl @Inject constructor(
     }
 
     override val autoArchiveAfterPlaying = UserSetting.PrefFromInt(
-        sharedPrefKey = "autoArchivePlayedEpisodesSeconds",
-        defaultValue =
-        // First, check for the old String setting. Only fall back to default if that doesn't exist.
-        getString("autoArchivePlayedEpisodes", null)?.let {
+        sharedPrefKey = "autoArchivePlayedEpisodesIndex",
+        defaultValue = getString("autoArchivePlayedEpisodes")?.let {
+            // Use the old String setting if it exists before falling back to the default value
             AutoArchiveAfterPlayingSetting.fromString(it, context)
         } ?: AutoArchiveAfterPlayingSetting.defaultValue(context),
         sharedPrefs = sharedPreferences,
-        fromInt = { AutoArchiveAfterPlayingSetting.fromSeconds(it, context) },
-        toInt = { it.timeSeconds },
+        fromInt = { AutoArchiveAfterPlayingSetting.fromIndex(it) },
+        toInt = { it.toIndex() },
     )
 
-    override fun getAutoArchiveInactive(): Settings.AutoArchiveInactive {
-        val value = getString(Settings.AUTO_ARCHIVE_INACTIVE, null)
-        return Settings.AutoArchiveInactive.fromString(context, value)
-    }
+    override val autoArchiveInactive = UserSetting.PrefFromInt(
+        sharedPrefKey = "autoArchiveInactiveIndex",
+        defaultValue = getString("autoArchiveInactiveEpisodes")?.let {
+            // Use the old String setting if it exists before falling back to the default value
+            AutoArchiveInactiveSetting.fromString(it, context)
+        } ?: AutoArchiveInactiveSetting.default,
+        sharedPrefs = sharedPreferences,
+        fromInt = { AutoArchiveInactiveSetting.fromIndex(it) },
+        toInt = { it.toIndex() },
+    )
 
     override fun getCustomStorageLimitGb(): Long {
         return getRemoteConfigLong(FirebaseConfig.CLOUD_STORAGE_LIMIT)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -24,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationCont
 import au.com.shiftyjelly.pocketcasts.preferences.di.PrivateSharedPreferences
 import au.com.shiftyjelly.pocketcasts.preferences.di.PublicSharedPreferences
 import au.com.shiftyjelly.pocketcasts.preferences.model.AppIconSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.NewEpisodeNotificationActionSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.NotificationVibrateSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
@@ -965,10 +966,17 @@ class SettingsImpl @Inject constructor(
         return getBoolean(Settings.AUTO_ARCHIVE_INCLUDE_STARRED, false)
     }
 
-    override fun getAutoArchiveAfterPlaying(): Settings.AutoArchiveAfterPlaying {
-        val value = getString(Settings.AUTO_ARCHIVE_PLAYED_EPISODES_AFTER, null)
-        return Settings.AutoArchiveAfterPlaying.fromString(context, value)
-    }
+    override val autoArchiveAfterPlaying = UserSetting.PrefFromInt(
+        sharedPrefKey = "autoArchivePlayedEpisodesSeconds",
+        defaultValue =
+        // First, check for the old String setting. Only fall back to default if that doesn't exist.
+        getString("autoArchivePlayedEpisodes", null)?.let {
+            AutoArchiveAfterPlayingSetting.fromString(it, context)
+        } ?: AutoArchiveAfterPlayingSetting.defaultValue(context),
+        sharedPrefs = sharedPreferences,
+        fromInt = { AutoArchiveAfterPlayingSetting.fromSeconds(it, context) },
+        toInt = { it.timeSeconds },
+    )
 
     override fun getAutoArchiveInactive(): Settings.AutoArchiveInactive {
         val value = getString(Settings.AUTO_ARCHIVE_INACTIVE, null)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoArchiveAfterPlayingSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoArchiveAfterPlayingSetting.kt
@@ -1,0 +1,43 @@
+package au.com.shiftyjelly.pocketcasts.preferences.model
+
+import android.content.Context
+import au.com.shiftyjelly.pocketcasts.localization.R
+import au.com.shiftyjelly.pocketcasts.utils.Util
+
+sealed class AutoArchiveAfterPlayingSetting(val timeSeconds: Int, val analyticsValue: String) {
+    companion object {
+        fun defaultValue(context: Context) = if (Util.isAutomotive(context)) Never else AfterPlaying
+
+        fun fromSeconds(seconds: Int, context: Context) = when (seconds) {
+            Never.timeSeconds -> Never
+            AfterPlaying.timeSeconds -> AfterPlaying
+            Hours24.timeSeconds -> Hours24
+            Days2.timeSeconds -> Days2
+            Weeks1.timeSeconds -> Weeks1
+            else -> defaultValue(context)
+        }
+
+        fun fromString(value: String?, context: Context): AutoArchiveAfterPlayingSetting =
+            when (value) {
+                context.getString(R.string.settings_auto_archive_played_never) -> Never
+                context.getString(R.string.settings_auto_archive_played_after_playing) -> AfterPlaying
+                context.getString(R.string.settings_auto_archive_played_after_24_hours) -> Hours24
+                context.getString(R.string.settings_auto_archive_played_after_2_days) -> Days2
+                context.getString(R.string.settings_auto_archive_played_after_1_week) -> Weeks1
+                else -> defaultValue(context)
+            }
+
+        val options
+            get() = listOf(Never, AfterPlaying, Hours24, Days2, Weeks1)
+
+        fun fromIndex(index: Int) = options[index]
+    }
+
+    object Never : AutoArchiveAfterPlayingSetting(-1, "never")
+    object AfterPlaying : AutoArchiveAfterPlayingSetting(0, "after_playing")
+    object Hours24 : AutoArchiveAfterPlayingSetting(24 * 60 * 60, "after_24_hours")
+    object Days2 : AutoArchiveAfterPlayingSetting(2 * 24 * 60 * 60, "after_2_days")
+    object Weeks1 : AutoArchiveAfterPlayingSetting(7 * 24 * 60 * 60, "after_1_week")
+
+    fun toIndex(): Int = options.indexOf(this)
+}

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoArchiveAfterPlayingSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoArchiveAfterPlayingSetting.kt
@@ -8,15 +8,6 @@ sealed class AutoArchiveAfterPlayingSetting(val timeSeconds: Int, val analyticsV
     companion object {
         fun defaultValue(context: Context) = if (Util.isAutomotive(context)) Never else AfterPlaying
 
-        fun fromSeconds(seconds: Int, context: Context) = when (seconds) {
-            Never.timeSeconds -> Never
-            AfterPlaying.timeSeconds -> AfterPlaying
-            Hours24.timeSeconds -> Hours24
-            Days2.timeSeconds -> Days2
-            Weeks1.timeSeconds -> Weeks1
-            else -> defaultValue(context)
-        }
-
         fun fromString(value: String?, context: Context): AutoArchiveAfterPlayingSetting =
             when (value) {
                 context.getString(R.string.settings_auto_archive_played_never) -> Never

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoArchiveInactiveSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoArchiveInactiveSetting.kt
@@ -1,0 +1,39 @@
+package au.com.shiftyjelly.pocketcasts.preferences.model
+
+import android.content.Context
+import au.com.shiftyjelly.pocketcasts.localization.R
+
+sealed class AutoArchiveInactiveSetting(val timeSeconds: Int, val analyticsValue: String) {
+    object Never : AutoArchiveInactiveSetting(-1, "never")
+    object Hours24 : AutoArchiveInactiveSetting(24 * 60 * 60, "after_24_hours")
+    object Days2 : AutoArchiveInactiveSetting(2 * 24 * 60 * 60, "after_2_days")
+    object Weeks1 : AutoArchiveInactiveSetting(7 * 24 * 60 * 60, "after_1_week")
+    object Weeks2 : AutoArchiveInactiveSetting(14 * 24 * 60 * 60, "after_2_weeks")
+    object Days30 : AutoArchiveInactiveSetting(30 * 24 * 60 * 60, "after_30_days")
+    object Days90 : AutoArchiveInactiveSetting(90 * 24 * 60 * 60, "after_3_months")
+
+    companion object {
+
+        val default = Never
+
+        fun fromString(value: String?, context: Context): AutoArchiveInactiveSetting {
+            return when (value) {
+                context.getString(R.string.settings_auto_archive_inactive_never) -> Never
+                context.getString(R.string.settings_auto_archive_inactive_24_hours) -> Hours24
+                context.getString(R.string.settings_auto_archive_inactive_2_days) -> Days2
+                context.getString(R.string.settings_auto_archive_inactive_1_week) -> Weeks1
+                context.getString(R.string.settings_auto_archive_inactive_2_weeks) -> Weeks2
+                context.getString(R.string.settings_auto_archive_inactive_30_days) -> Days30
+                context.getString(R.string.settings_auto_archive_inactive_3_months) -> Days90
+                else -> default
+            }
+        }
+
+        val options
+            get() = listOf(Never, Hours24, Days2, Weeks1, Weeks2, Days30, Days90)
+
+        fun fromIndex(index: Int) = options[index]
+    }
+
+    fun toIndex(): Int = options.indexOf(this)
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -27,6 +27,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.models.type.UserEpisodeServerStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.UpdateEpisodeDetailsTask
@@ -657,7 +658,7 @@ class EpisodeManagerImpl @Inject constructor(
             // check if we are meant to archive after episode is played
             val podcast = podcastManager.findPodcastByUuid(episode.podcastUuid) ?: return@launch
             val podcastOverrideSettings = podcast.overrideGlobalArchive
-            val podcastArchiveAfterPlaying = Settings.AutoArchiveAfterPlaying.fromIndex(podcast.autoArchiveAfterPlaying)
+            val podcastArchiveAfterPlaying = AutoArchiveAfterPlayingSetting.fromIndex(podcast.autoArchiveAfterPlaying)
 
             val shouldArchiveBasedOnSettings = shouldArchiveBasedOnSettings(podcastOverrideSettings, podcastArchiveAfterPlaying)
 
@@ -676,10 +677,10 @@ class EpisodeManagerImpl @Inject constructor(
         }
     }
 
-    private fun shouldArchiveBasedOnSettings(podcastOverrideSettings: Boolean, podcastArchiveAfterPlaying: Settings.AutoArchiveAfterPlaying) =
+    private fun shouldArchiveBasedOnSettings(podcastOverrideSettings: Boolean, podcastArchiveAfterPlaying: AutoArchiveAfterPlayingSetting) =
         (
-            (!podcastOverrideSettings && settings.getAutoArchiveAfterPlaying() == Settings.AutoArchiveAfterPlaying.AfterPlaying) ||
-                (podcastArchiveAfterPlaying == Settings.AutoArchiveAfterPlaying.AfterPlaying)
+            (!podcastOverrideSettings && settings.autoArchiveAfterPlaying.flow.value == AutoArchiveAfterPlayingSetting.AfterPlaying) ||
+                (podcastArchiveAfterPlaying == AutoArchiveAfterPlayingSetting.AfterPlaying)
             )
 
     @Suppress("NAME_SHADOWING")
@@ -691,7 +692,7 @@ class EpisodeManagerImpl @Inject constructor(
 
         for ((podcastUuid, episodes) in episodesByPodcast) {
             val podcast = podcastManager.findPodcastByUuid(podcastUuid) ?: continue
-            val podcastArchiveAfterPlaying = Settings.AutoArchiveAfterPlaying.fromIndex(podcast.autoArchiveAfterPlaying)
+            val podcastArchiveAfterPlaying = AutoArchiveAfterPlayingSetting.fromIndex(podcast.autoArchiveAfterPlaying)
             val shouldArchiveBasedOnSettings = shouldArchiveBasedOnSettings(podcast.overrideGlobalSettings, podcastArchiveAfterPlaying)
 
             if (shouldArchiveBasedOnSettings) {
@@ -986,8 +987,8 @@ class EpisodeManagerImpl @Inject constructor(
     override fun checkPodcastForAutoArchive(podcast: Podcast, playbackManager: PlaybackManager?) {
         val now = Date()
 
-        val podcastArchivePlaying = Settings.AutoArchiveAfterPlaying.fromIndex(podcast.autoArchiveAfterPlaying)
-        val autoArchiveSetting = if (podcast.overrideGlobalArchive) podcastArchivePlaying else settings.getAutoArchiveAfterPlaying()
+        val podcastArchivePlaying = AutoArchiveAfterPlayingSetting.fromIndex(podcast.autoArchiveAfterPlaying)
+        val autoArchiveSetting = if (podcast.overrideGlobalArchive) podcastArchivePlaying else settings.autoArchiveAfterPlaying.flow.value
         val autoArchiveAfterPlayingTime = autoArchiveSetting.timeSeconds * 1000L
 
         if (autoArchiveAfterPlayingTime > 0) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -28,6 +28,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.models.type.UserEpisodeServerStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveInactiveSetting
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.UpdateEpisodeDetailsTask
@@ -1003,8 +1004,8 @@ class EpisodeManagerImpl @Inject constructor(
             }
         }
 
-        val podcastInactiveSetting = Settings.AutoArchiveInactive.fromIndex(podcast.autoArchiveInactive)
-        val inactiveSetting = if (podcast.overrideGlobalArchive) podcastInactiveSetting else settings.getAutoArchiveInactive()
+        val podcastInactiveSetting = AutoArchiveInactiveSetting.fromIndex(podcast.autoArchiveInactive)
+        val inactiveSetting = if (podcast.overrideGlobalArchive) podcastInactiveSetting else settings.autoArchiveInactive.flow.value
 
         val inactiveTime = inactiveSetting.timeSeconds * 1000L
         if (inactiveTime > 0) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -313,11 +313,10 @@ class Support @Inject constructor(
                 Timber.e(e)
             }
 
-            val afterPlaying = context.resources.getStringArray(R.array.settings_auto_archive_played_values)
             val inactive = context.resources.getStringArray(R.array.settings_auto_archive_inactive_values)
             output.append(eol)
             output.append("Auto archive settings").append(eol)
-            output.append("Auto archive played episodes after: " + afterPlaying[settings.getAutoArchiveAfterPlaying().toIndex()]).append(eol)
+            output.append("Auto archive played episodes after: " + settings.autoArchiveAfterPlaying.flow.value.analyticsValue).append(eol)
             output.append("Auto archive inactive episodes after: " + inactive[settings.getAutoArchiveInactive().toIndex()]).append(eol)
             output.append("Auto archive starred episodes: " + settings.getAutoArchiveIncludeStarred().toString()).append(eol)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -313,11 +313,10 @@ class Support @Inject constructor(
                 Timber.e(e)
             }
 
-            val inactive = context.resources.getStringArray(R.array.settings_auto_archive_inactive_values)
             output.append(eol)
             output.append("Auto archive settings").append(eol)
             output.append("Auto archive played episodes after: " + settings.autoArchiveAfterPlaying.flow.value.analyticsValue).append(eol)
-            output.append("Auto archive inactive episodes after: " + inactive[settings.getAutoArchiveInactive().toIndex()]).append(eol)
+            output.append("Auto archive inactive episodes after: " + settings.autoArchiveInactive.flow.value.analyticsValue).append(eol)
             output.append("Auto archive starred episodes: " + settings.getAutoArchiveIncludeStarred().toString()).append(eol)
 
             output.append(eol)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -315,9 +315,9 @@ class Support @Inject constructor(
 
             output.append(eol)
             output.append("Auto archive settings").append(eol)
-            output.append("Auto archive played episodes after: " + settings.autoArchiveAfterPlaying.flow.value.analyticsValue).append(eol)
-            output.append("Auto archive inactive episodes after: " + settings.autoArchiveInactive.flow.value.analyticsValue).append(eol)
-            output.append("Auto archive starred episodes: " + settings.getAutoArchiveIncludeStarred().toString()).append(eol)
+            output.append("Auto archive played episodes after: ${settings.autoArchiveAfterPlaying.flow.value.analyticsValue}").append(eol)
+            output.append("Auto archive inactive episodes after: ${settings.autoArchiveInactive.flow.value.analyticsValue}").append(eol)
+            output.append("Auto archive starred episodes: ${settings.autoArchiveIncludeStarred.flow.value}").append(eol)
 
             output.append(eol)
             output.append("Auto downloads").append(eol)


### PR DESCRIPTION
## Description
This updates the archive settings to be user settings.

In doing this, I found that we were persisting some of the archive settings as localized strings. Not surprisingly, this can cause [some issues](https://github.com/Automattic/pocket-casts-android/issues/741#issuecomment-1663067646) when a user changes the language on their phone. This PR fixes this by migrating the settings to a new key in shared preferences that is no longer tied to the app's language.

I also updated our support logs so that the auto archive settings are no longer displayed with a localized string.

## Testing Instructions

### 1. General refactor testing
For each setting in the "Auto Archive" section:

1. Fresh install the app
2. Verify that the setting has the same default value that it had before
3. Change the setting to a new value
4. Force close the app
5. Verify that the setting has retained the new value
6. Verify that the app's behavior reflects the updated setting value.

### 2. Language change bug fix
1. Fresh install the app
2. Go the Auto Archive settings
3. Change the "Archive played episodes" and "Archive inactive episodes" settings to a non-default value
4. Change the language of your phone to French
5. Return to the Pocket Casts app
6. Wait for the Pocket Casts app to update to the new language
7. Confirm that the non-default settings are still visible on the Auto Archive settings screen (without this PR fix, the previously set settings [would disappear](https://github.com/Automattic/pocket-casts-android/issues/741#issuecomment-1663067646)).

### 3. Migration of archive settings
1. Fresh install a build from `main`
2. Change the "Archive played episodes" and "Archive inactive episodes" settings to a non-default value
3. Install a build from this PR
4. Verify that your updates to those settings are retained

### 4. Support logs no longer use localized strings for archive settings
1. Change your phone's language to French
5. View the app logs (Profile → "Help & feedback" → logs icon in the toolbar)
6. Verify that the values for "Auto archive played episodes after" and "Auto archive inactive episodes after" are not in French.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews