### PR TITLE
Fix/issue 1192 toolbar disappear on add file screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
         ([#1204](https://github.com/Automattic/pocket-casts-android/pull/1204))
     *   Fixed watch background refresh description to not reference auto downloads
         ([#1212](https://github.com/Automattic/pocket-casts-android/pull/1212))
+    *   Fixed bug where the Add File toolbar would disappear on orientation change
+        ([#1235](https://github.com/Automattic/pocket-casts-android/pull/1235))
 
 7.44
 -----

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -291,6 +291,12 @@ class AddFileActivity :
                 updateColorItems()
             }
         }
+
+        @Suppress("DEPRECATION")
+        if (savedInstanceState != null) {
+            dataUri = savedInstanceState.getParcelable(STATE_DATAURI)
+            setupForNewFile(dataUri)
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -83,7 +83,7 @@ private const val ACTION_PICK_FILE = 2
 private const val EXTRA_EXISTING_EPISODE_UUID = "fileUUID"
 private const val EXTRA_FILE_CHOOSER = "filechooser"
 private const val STATE_LAUNCHED_FILE_CHOOSER = "LAUNCHED_FILE_CHOOSER"
-private const val STATE_DATAURI = "null"
+private const val STATE_DATAURI = "DATAURI"
 
 @AndroidEntryPoint
 class AddFileActivity :

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -83,6 +83,7 @@ private const val ACTION_PICK_FILE = 2
 private const val EXTRA_EXISTING_EPISODE_UUID = "fileUUID"
 private const val EXTRA_FILE_CHOOSER = "filechooser"
 private const val STATE_LAUNCHED_FILE_CHOOSER = "LAUNCHED_FILE_CHOOSER"
+private const val STATE_DATAURI = "null"
 
 @AndroidEntryPoint
 class AddFileActivity :
@@ -295,6 +296,7 @@ class AddFileActivity :
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putBoolean(STATE_LAUNCHED_FILE_CHOOSER, launchedFileChooser)
+        outState.putParcelable(STATE_DATAURI, dataUri)
     }
 
     private fun openOnboardingFlow() {


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR is to fix a bug on the *Add File* Activity/Screen where when a user has a file selected for upload and changes the screen orientation the Toolbar does not load and the file art disappears. When this occurs, the save and back navigation buttons within the Toolbar also do not work as they are not loaded.

Fixes #1192

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->
1. Go to the user account page.
2. Click on the Files button.
3. Click the Add button (Floating Action Button).
4. Select a file to upload.
5. You will automatically be taken to the Add File screen.
6. Change the orientation of the screen/phone and the Toolbar + file art should reappear when the Activity is recreated.

## Screenshots or Screencast 
<!-- if applicable -->
#### Before:
Check the original issue for a Before screen cap of the issue.
#### After:
https://github.com/Automattic/pocket-casts-android/assets/68164093/ea22d2e1-d867-4eae-baad-ffd8ac3e77b0

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
	- No strings added.
- [ ] Any jetpack compose components I added or changed are covered by compose previews
	- No Jetpack compose components added or changed.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
	- This was a bug fix to bring back a missing UI element

#### Notes:
`savedInstanceState.getParcelable(key: String)` is deprecated. I did have a solution to fix this, which involves using `savedInstanceState.getParcelable(key: String, clazz: Class<T>)`, but it requires Android version 33 and the minimum SDK version is 23. So for the time being, I suppressed the deprecation warning because I saw the same suppression used elsewhere in the `AddFileActivity.kt` file (where my changes take place).
![image](https://github.com/Automattic/pocket-casts-android/assets/68164093/18f9d707-c192-4a41-a271-b14272aeac71)
