### PR TITLE
Hide ratings if the podcast doesn't have any.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Bug Fixes:
     *   Added audio ducking as an option when playing over notifications
         ([#1009](https://github.com/Automattic/pocket-casts-android/pull/1009))
+    *   Fixed the podcast ratings stars showing if there isn't a rating
+        ([#1237](https://github.com/Automattic/pocket-casts-android/pull/1237))
     *   Fixed swiping to open Up Next queue in landscape and on foldables
         ([#1209](https://github.com/Automattic/pocket-casts-android/pull/1209))
     *   Fixed upgrade flow when signing in with Google account

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/StarRatingView.kt
@@ -55,6 +55,9 @@ private fun Content(
     state: RatingState.Loaded,
     onClick: () -> Unit
 ) {
+    if (state.noRatings) {
+        return
+    }
     Row(
         modifier = Modifier
             .padding(horizontal = 14.dp, vertical = 4.dp)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
@@ -98,7 +98,10 @@ class PodcastRatingsViewModel
             val podcastUuid: String,
             val stars: List<Star>,
             val total: Int?,
-        ) : RatingState()
+        ) : RatingState() {
+            val noRatings: Boolean
+                get() = total == null || total == 0
+        }
 
         object Error : RatingState()
     }


### PR DESCRIPTION
## Description

When a podcast doesn't have any ratings it looks like they have zero stars. This change hides the star if there are no ratings.

## Testing Instructions
1. Tap the Discover tab
2. Tap search
3. Paste in the staging share URL https://pcast.pocketcasts.net/51phk3pk
4. ✅ Verify no stars are visible
5. Go back to search and find The Daily
6. ✅ Verify the stars are visible

## Screenshots

| Before | After |
| --- | --- |
| ![Screenshot_20230804_140129](https://github.com/Automattic/pocket-casts-android/assets/308331/e858ea23-d563-4b2c-8726-e34b4174a3f8) | ![Screenshot_20230804_135933](https://github.com/Automattic/pocket-casts-android/assets/308331/c9a4dd77-c1b6-4364-ba23-439980b1c270) |
