### PR TITLE
Convert privacy settings into UserSettings

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -114,12 +114,12 @@ class PocketCastsApplication : Application(), Configuration.Provider {
         }
 
         SentryAndroid.init(this) { options ->
-            options.dsn = if (settings.getSendCrashReports()) settings.getSentryDsn() else ""
+            options.dsn = if (settings.sendCrashReports.flow.value) settings.getSentryDsn() else ""
             options.setTag(SentryHelper.GLOBAL_TAG_APP_PLATFORM, AppPlatform.MOBILE.value)
         }
 
         // Link email to Sentry crash reports only if the user has opted in
-        if (settings.getLinkCrashReportsToUser()) {
+        if (settings.linkCrashReportsToUser.flow.value) {
             syncManager.getEmail()?.let { syncEmail ->
                 val user = User().apply { email = syncEmail }
                 Sentry.setUser(user)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/PrivacyViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/PrivacyViewModel.kt
@@ -33,8 +33,8 @@ class PrivacyViewModel @Inject constructor(
     private val mutableUiState = MutableStateFlow<UiState>(
         UiState.Loaded(
             analytics = analyticsTracker.getSendUsageStats(),
-            crashReports = settings.getSendCrashReports(),
-            linkAccount = settings.getLinkCrashReportsToUser(),
+            crashReports = settings.sendCrashReports.flow.value,
+            linkAccount = settings.linkCrashReportsToUser.flow.value,
             getUserEmail = { syncManager.getEmail() }
         )
     )

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
@@ -34,13 +34,13 @@ class UserAnalyticsSettings @Inject constructor(
         } else {
             SentryAndroid.init(context) { it.dsn = "" }
         }
-        settings.setSendCrashReports(enabled)
+        settings.sendCrashReports.set(enabled)
     }
 
     fun updateLinkAccountSetting(enabled: Boolean) {
         val user = if (enabled) User().apply { email = syncManager.getEmail() } else null
         Sentry.setUser(user)
 
-        settings.setLinkCrashReportsToUser(enabled)
+        settings.linkCrashReportsToUser.set(enabled)
     }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTracker.kt
@@ -35,12 +35,12 @@ object AnalyticsTracker {
 
     fun setSendUsageStats(send: Boolean) {
         if (send != getSendUsageStats()) {
-            settings.setSendUsageStats(send)
+            settings.collectAnalytics.set(send)
             if (!send) {
                 trackers.forEach { it.clearAllData() }
             }
         }
     }
 
-    fun getSendUsageStats() = settings.getSendUsageStats()
+    fun getSendUsageStats() = settings.collectAnalytics.flow.value
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/FirebaseAnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/FirebaseAnalyticsTracker.kt
@@ -261,7 +261,7 @@ object FirebaseAnalyticsTracker {
     }
 
     private fun logEvent(name: String, bundle: Bundle? = Bundle()) {
-        if (settings.getSendUsageStats()) {
+        if (settings.collectAnalytics.flow.value) {
             firebaseAnalytics.logEvent(name, bundle)
 
             Timber.d("Analytic event $name $bundle")

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -475,16 +475,11 @@ interface Settings {
     fun setTimesToShowBatteryWarning(value: Int)
     fun getTimesToShowBatteryWarning(): Int
 
-    // Only the AnalyticsTracker object should update or retrieve SendUsageState directly. Everything else
-    // should update/access this setting through the AnalyticsTracker.
-    fun setSendUsageStats(value: Boolean)
-    fun getSendUsageStats(): Boolean
-
-    fun setSendCrashReports(value: Boolean)
-    fun getSendCrashReports(): Boolean
-
-    fun setLinkCrashReportsToUser(value: Boolean)
-    fun getLinkCrashReportsToUser(): Boolean
+    // Only the AnalyticsTracker object should update SendUsageState directly. Everything else
+    // should update this setting through the AnalyticsTracker.
+    val collectAnalytics: UserSetting<Boolean>
+    val sendCrashReports: UserSetting<Boolean>
+    val linkCrashReportsToUser: UserSetting<Boolean>
 
     fun setEndOfYearShowBadge2022(value: Boolean)
     fun getEndOfYearShowBadge2022(): Boolean

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -65,9 +65,6 @@ class SettingsImpl @Inject constructor(
     companion object {
         private const val DEVICE_ID_KEY = "DeviceIdKey"
         private const val SHOWN_BATTERY_WARNING_KEY = "ShownBetteryWarningKey"
-        private const val SEND_USAGE_STATS_KEY = "SendUsageStatsKey"
-        private const val SEND_CRASH_REPORTS_KEY = "SendCrashReportsKey"
-        private const val LINK_CRASH_REPORTS_TO_USER_KEY = "LinkCrashReportsToUserKey"
         private const val END_OF_YEAR_SHOW_BADGE_2022_KEY = "EndOfYearShowBadge2022Key"
         private const val END_OF_YEAR_MODAL_HAS_BEEN_SHOWN_KEY = "EndOfYearModalHasBeenShownKey"
         private const val DONE_INITIAL_ONBOARDING_KEY = "CompletedOnboardingKey"
@@ -1310,26 +1307,23 @@ class SettingsImpl @Inject constructor(
     override fun getTimesToShowBatteryWarning(): Int =
         getInt(SHOWN_BATTERY_WARNING_KEY, 4)
 
-    override fun setSendUsageStats(value: Boolean) {
-        setBoolean(SEND_USAGE_STATS_KEY, value)
-    }
+    override val collectAnalytics = UserSetting.BoolPref(
+        sharedPrefKey = "SendUsageStatsKey",
+        defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
 
-    override fun getSendUsageStats(): Boolean =
-        getBoolean(SEND_USAGE_STATS_KEY, true)
+    override val sendCrashReports = UserSetting.BoolPref(
+        sharedPrefKey = "SendCrashReportsKey",
+        defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
 
-    override fun setSendCrashReports(value: Boolean) {
-        setBoolean(SEND_CRASH_REPORTS_KEY, value)
-    }
-
-    override fun getSendCrashReports(): Boolean =
-        getBoolean(SEND_CRASH_REPORTS_KEY, true)
-
-    override fun setLinkCrashReportsToUser(value: Boolean) {
-        setBoolean(LINK_CRASH_REPORTS_TO_USER_KEY, value)
-    }
-
-    override fun getLinkCrashReportsToUser(): Boolean =
-        getBoolean(LINK_CRASH_REPORTS_TO_USER_KEY, false)
+    override val linkCrashReportsToUser = UserSetting.BoolPref(
+        sharedPrefKey = "LinkCrashReportsToUserKey",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun setEndOfYearShowBadge2022(value: Boolean) {
         setBoolean(END_OF_YEAR_SHOW_BADGE_2022_KEY, value)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -68,12 +68,12 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
 
     private fun setupSentry() {
         SentryAndroid.init(this) { options ->
-            options.dsn = if (settings.getSendCrashReports()) settings.getSentryDsn() else ""
+            options.dsn = if (settings.sendCrashReports.flow.value) settings.getSentryDsn() else ""
             options.setTag(SentryHelper.GLOBAL_TAG_APP_PLATFORM, AppPlatform.WEAR.value)
         }
 
         // Link email to Sentry crash reports only if the user has opted in
-        if (settings.getLinkCrashReportsToUser()) {
+        if (settings.linkCrashReportsToUser.flow.value) {
             syncManager.getEmail()?.let { syncEmail ->
                 val user = User().apply { email = syncEmail }
                 Sentry.setUser(user)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/PrivacySettingsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/PrivacySettingsViewModel.kt
@@ -23,9 +23,9 @@ class PrivacySettingsViewModel @Inject constructor(
 
     private val _state = MutableStateFlow(
         State(
-            sendAnalytics = settings.getSendUsageStats(),
-            sendCrashReports = settings.getSendCrashReports(),
-            linkCrashReportsToUser = settings.getLinkCrashReportsToUser(),
+            sendAnalytics = settings.collectAnalytics.flow.value,
+            sendCrashReports = settings.sendCrashReports.flow.value,
+            linkCrashReportsToUser = settings.linkCrashReportsToUser.flow.value,
         )
     )
     val state = _state.asStateFlow()


### PR DESCRIPTION
## Description
Updating the privacy settings to be UserSettings

## Testing Instructions

### 1. Tracks
1.  Verify that "Analytics" toggle in the Privacy settings defaults to on
2. Verify that tracks come through when the "Analytics" toggle is on, and that they do not come through when it is off.

### 2. Crash Reports
1. Make a change to the app so you can trigger a recognizable crash by tapping some button
2. Freshly install a release build
3. Log into an account
4. Verify that in the privacy setting for "Crash reports" defaults to off
5. Turn this toggle "on"
6. Leave "Link your account to crashes" to be "off"
7. Trigger a crash
8. Toggle "Link your account to crashes" to be "on"
9. Trigger a crash
10. Toggle "Crash reports" to off
11. Trigger a crash
12. Reopen the app
13. Check Sentry and confirm that you there are only two matching crash events: the first one should not have the email linked, and the second one should have the email linked

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
