### PR TITLE
Settings Sync - Make file settings into UserSettings

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
@@ -103,7 +103,7 @@ class CloudSettingsFragment : BaseFragment() {
             }
         }
         with(binding.swtAutoUploadToCloud) {
-            isChecked = settings.getCloudAutoUpload()
+            isChecked = settings.cloudAutoUpload.flow.value
             setOnCheckedChangeListener { _, isChecked ->
                 viewModel.setCloudAutoUpload(isChecked)
             }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
@@ -115,7 +115,7 @@ class CloudSettingsFragment : BaseFragment() {
             }
         }
         with(binding.swtCloudOnlyOnWiFi) {
-            isChecked = settings.getCloudOnlyWifi()
+            isChecked = settings.cloudDownloadOnlyOnWifi.flow.value
             setOnCheckedChangeListener { _, isChecked ->
                 viewModel.setCloudOnlyWifi(isChecked)
             }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
@@ -85,7 +85,7 @@ class CloudSettingsFragment : BaseFragment() {
         }
 
         with(binding.swtAutoAddToUpNext) {
-            isChecked = settings.getCloudAddToUpNext()
+            isChecked = settings.cloudAddToUpNext.flow.value
             setOnCheckedChangeListener { _, isChecked ->
                 viewModel.setAddToUpNext(isChecked)
             }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
@@ -109,7 +109,7 @@ class CloudSettingsFragment : BaseFragment() {
             }
         }
         with(binding.swtAutoDownloadFromCloud) {
-            isChecked = settings.getCloudAutoDownload()
+            isChecked = settings.cloudAutoDownload.flow.value
             setOnCheckedChangeListener { _, isChecked ->
                 viewModel.setCloudAutoDownload(isChecked)
             }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
@@ -91,13 +91,13 @@ class CloudSettingsFragment : BaseFragment() {
             }
         }
         with(binding.swtDeleteLocalFileAfterPlaying) {
-            isChecked = settings.getDeleteLocalFileAfterPlaying()
+            isChecked = settings.deleteLocalFileAfterPlaying.flow.value
             setOnCheckedChangeListener { _, isChecked ->
                 viewModel.setDeleteLocalFileAfterPlaying(isChecked)
             }
         }
         with(binding.swtDeleteCloudFileAfterPlaying) {
-            isChecked = settings.getDeleteCloudFileAfterPlaying()
+            isChecked = settings.deleteCloudFileAfterPlaying.flow.value
             setOnCheckedChangeListener { _, isChecked ->
                 viewModel.setDeleteCloudFileAfterPlaying(isChecked)
             }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
@@ -41,7 +41,7 @@ class CloudSettingsViewModel @Inject constructor(
     }
 
     fun setDeleteLocalFileAfterPlaying(enabled: Boolean) {
-        settings.setDeleteLocalFileAfterPlaying(enabled)
+        settings.deleteLocalFileAfterPlaying.set(enabled)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_FILES_DELETE_LOCAL_FILE_AFTER_PLAYING_TOGGLED,
             mapOf("enabled" to enabled)
@@ -49,7 +49,7 @@ class CloudSettingsViewModel @Inject constructor(
     }
 
     fun setDeleteCloudFileAfterPlaying(enabled: Boolean) {
-        settings.setDeleteCloudFileAfterPlaying(enabled)
+        settings.deleteCloudFileAfterPlaying.set(enabled)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_FILES_DELETE_CLOUD_FILE_AFTER_PLAYING_TOGGLED,
             mapOf("enabled" to enabled)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
@@ -73,7 +73,7 @@ class CloudSettingsViewModel @Inject constructor(
     }
 
     fun setCloudOnlyWifi(enabled: Boolean) {
-        settings.setCloudOnlyWifi(enabled)
+        settings.cloudDownloadOnlyOnWifi.set(enabled)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_FILES_ONLY_ON_WIFI_TOGGLED,
             mapOf("enabled" to enabled)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
@@ -33,7 +33,7 @@ class CloudSettingsViewModel @Inject constructor(
     }
 
     fun setAddToUpNext(enabled: Boolean) {
-        settings.setCloudAddToUpNext(enabled)
+        settings.cloudAddToUpNext.set(enabled)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_FILES_AUTO_ADD_UP_NEXT_TOGGLED,
             mapOf("enabled" to enabled)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
@@ -65,7 +65,7 @@ class CloudSettingsViewModel @Inject constructor(
     }
 
     fun setCloudAutoDownload(enabled: Boolean) {
-        settings.setCloudAutoDownload(enabled)
+        settings.cloudAutoDownload.set(enabled)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_FILES_AUTO_DOWNLOAD_FROM_CLOUD_TOGGLED,
             mapOf("enabled" to enabled)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
@@ -57,7 +57,7 @@ class CloudSettingsViewModel @Inject constructor(
     }
 
     fun setCloudAutoUpload(enabled: Boolean) {
-        settings.setCloudAutoUpload(enabled)
+        settings.cloudAutoUpload.set(enabled)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_FILES_AUTO_UPLOAD_TO_CLOUD_TOGGLED,
             mapOf("enabled" to enabled)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -418,10 +418,9 @@ interface Settings {
     val deleteCloudFileAfterPlaying: UserSetting<Boolean>
     val cloudAutoUpload: UserSetting<Boolean>
     val cloudAutoDownload: UserSetting<Boolean>
+    val cloudDownloadOnlyOnWifi: UserSetting<Boolean>
     fun getCachedSubscription(): SubscriptionStatus?
     fun setCachedSubscription(subscriptionStatus: SubscriptionStatus?)
-    fun getCloudOnlyWifi(): Boolean
-    fun setCloudOnlyWifi(value: Boolean)
     fun getAppIconId(): String?
     fun setAppIconId(value: String)
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -413,8 +413,7 @@ interface Settings {
 
     fun setCloudSortOrder(sortOrder: CloudSortOrder)
     fun getCloudSortOrder(): CloudSortOrder
-    fun getCloudAddToUpNext(): Boolean
-    fun setCloudAddToUpNext(value: Boolean)
+    val cloudAddToUpNext: UserSetting<Boolean>
     fun getDeleteLocalFileAfterPlaying(): Boolean
     fun setDeleteLocalFileAfterPlaying(value: Boolean)
     fun getDeleteCloudFileAfterPlaying(): Boolean

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -416,8 +416,7 @@ interface Settings {
     val cloudAddToUpNext: UserSetting<Boolean>
     val deleteLocalFileAfterPlaying: UserSetting<Boolean>
     val deleteCloudFileAfterPlaying: UserSetting<Boolean>
-    fun getCloudAutoUpload(): Boolean
-    fun setCloudAutoUpload(value: Boolean)
+    val cloudAutoUpload: UserSetting<Boolean>
     fun getCloudAutoDownload(): Boolean
     fun setCloudAutoDownload(value: Boolean)
     fun getCachedSubscription(): SubscriptionStatus?

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -414,10 +414,8 @@ interface Settings {
     fun setCloudSortOrder(sortOrder: CloudSortOrder)
     fun getCloudSortOrder(): CloudSortOrder
     val cloudAddToUpNext: UserSetting<Boolean>
-    fun getDeleteLocalFileAfterPlaying(): Boolean
-    fun setDeleteLocalFileAfterPlaying(value: Boolean)
-    fun getDeleteCloudFileAfterPlaying(): Boolean
-    fun setDeleteCloudFileAfterPlaying(value: Boolean)
+    val deleteLocalFileAfterPlaying: UserSetting<Boolean>
+    val deleteCloudFileAfterPlaying: UserSetting<Boolean>
     fun getCloudAutoUpload(): Boolean
     fun setCloudAutoUpload(value: Boolean)
     fun getCloudAutoDownload(): Boolean

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -417,8 +417,7 @@ interface Settings {
     val deleteLocalFileAfterPlaying: UserSetting<Boolean>
     val deleteCloudFileAfterPlaying: UserSetting<Boolean>
     val cloudAutoUpload: UserSetting<Boolean>
-    fun getCloudAutoDownload(): Boolean
-    fun setCloudAutoDownload(value: Boolean)
+    val cloudAutoDownload: UserSetting<Boolean>
     fun getCachedSubscription(): SubscriptionStatus?
     fun setCachedSubscription(subscriptionStatus: SubscriptionStatus?)
     fun getCloudOnlyWifi(): Boolean

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -562,7 +562,7 @@ class SettingsImpl @Inject constructor(
 
     override fun clearPlusPreferences() {
         deleteCloudFileAfterPlaying.set(false)
-        setCloudAutoUpload(false)
+        cloudAutoUpload.set(false)
         setCloudAutoDownload(false)
         setCloudOnlyWifi(false)
         setCancelledAcknowledged(false)
@@ -1112,13 +1112,11 @@ class SettingsImpl @Inject constructor(
 
     )
 
-    override fun getCloudAutoUpload(): Boolean {
-        return getBoolean("cloudAutoUpload", false)
-    }
-
-    override fun setCloudAutoUpload(value: Boolean) {
-        setBoolean("cloudAutoUpload", value)
-    }
+    override val cloudAutoUpload = UserSetting.BoolPref(
+        sharedPrefKey = "cloudAutoUpload",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun getCloudAutoDownload(): Boolean {
         return getBoolean("cloudAutoDownload", false)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -563,7 +563,7 @@ class SettingsImpl @Inject constructor(
     override fun clearPlusPreferences() {
         deleteCloudFileAfterPlaying.set(false)
         cloudAutoUpload.set(false)
-        setCloudAutoDownload(false)
+        cloudAutoDownload.set(false)
         setCloudOnlyWifi(false)
         setCancelledAcknowledged(false)
     }
@@ -1118,13 +1118,11 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override fun getCloudAutoDownload(): Boolean {
-        return getBoolean("cloudAutoDownload", false)
-    }
-
-    override fun setCloudAutoDownload(value: Boolean) {
-        setBoolean("cloudAutoDownload", value)
-    }
+    override val cloudAutoDownload = UserSetting.BoolPref(
+        sharedPrefKey = "cloudAutoDownload",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun getCloudOnlyWifi(): Boolean {
         return getBoolean("cloudOnlyWifi", true)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -564,7 +564,7 @@ class SettingsImpl @Inject constructor(
         deleteCloudFileAfterPlaying.set(false)
         cloudAutoUpload.set(false)
         cloudAutoDownload.set(false)
-        setCloudOnlyWifi(false)
+        cloudDownloadOnlyOnWifi.set(false)
         setCancelledAcknowledged(false)
     }
 
@@ -1124,13 +1124,11 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override fun getCloudOnlyWifi(): Boolean {
-        return getBoolean("cloudOnlyWifi", true)
-    }
-
-    override fun setCloudOnlyWifi(value: Boolean) {
-        setBoolean("cloudOnlyWifi", value)
-    }
+    override val cloudDownloadOnlyOnWifi = UserSetting.BoolPref(
+        sharedPrefKey = "cloudOnlyWifi",
+        defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun getAppIconId(): String? {
         return getString("appIconId", "Default")

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1089,13 +1089,11 @@ class SettingsImpl @Inject constructor(
         return Settings.CloudSortOrder.values().getOrNull(getInt("cloud_sort_order", 0)) ?: Settings.CloudSortOrder.NEWEST_OLDEST
     }
 
-    override fun getCloudAddToUpNext(): Boolean {
-        return getBoolean("cloudUpNext", false)
-    }
-
-    override fun setCloudAddToUpNext(value: Boolean) {
-        setBoolean("cloudUpNext", value)
-    }
+    override val cloudAddToUpNext = UserSetting.BoolPref(
+        sharedPrefKey = "cloudUpNext",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun getDeleteLocalFileAfterPlaying(): Boolean {
         return getBoolean("cloudDeleteAfterPlaying", false)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -561,7 +561,7 @@ class SettingsImpl @Inject constructor(
     }
 
     override fun clearPlusPreferences() {
-        setDeleteCloudFileAfterPlaying(false)
+        deleteCloudFileAfterPlaying.set(false)
         setCloudAutoUpload(false)
         setCloudAutoDownload(false)
         setCloudOnlyWifi(false)
@@ -1095,21 +1095,22 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override fun getDeleteLocalFileAfterPlaying(): Boolean {
-        return getBoolean("cloudDeleteAfterPlaying", false)
-    }
+    override val deleteLocalFileAfterPlaying = UserSetting.BoolPref(
+        sharedPrefKey = "deleteLocalFileAfterPlaying",
+        defaultValue =
+        // Use value stored under previous key if it exists
+        getBoolean("cloudDeleteAfterPlaying", false),
+        sharedPrefs = sharedPreferences,
+    )
 
-    override fun setDeleteLocalFileAfterPlaying(value: Boolean) {
-        setBoolean("cloudDeleteAfterPlaying", value)
-    }
+    override val deleteCloudFileAfterPlaying = UserSetting.BoolPref(
+        sharedPrefKey = "deleteCloudFileAfterPlaying",
+        defaultValue =
+        // Use value stored under previous key if it exists
+        sharedPreferences.getBoolean("cloudDeleteCloudAfterPlaying", false),
+        sharedPrefs = sharedPreferences,
 
-    override fun getDeleteCloudFileAfterPlaying(): Boolean {
-        return getBoolean("cloudDeleteCloudAfterPlaying", false)
-    }
-
-    override fun setDeleteCloudFileAfterPlaying(value: Boolean) {
-        setBoolean("cloudDeleteCloudAfterPlaying", value)
-    }
+    )
 
     override fun getCloudAutoUpload(): Boolean {
         return getBoolean("cloudAutoUpload", false)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
@@ -477,7 +477,7 @@ class DownloadManagerImpl @Inject constructor(
             } else NetworkRequirements.needsUnmetered()
         } else if (episode is UserEpisode) {
             // UserEpisodes have their own auto download setting
-            return if (settings.getCloudOnlyWifi()) {
+            return if (settings.cloudDownloadOnlyOnWifi.flow.value) {
                 NetworkRequirements.needsUnmetered()
             } else {
                 NetworkRequirements.runImmediately()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -173,7 +173,7 @@ class UserEpisodeManagerImpl @Inject constructor(
     override suspend fun add(episode: UserEpisode, playbackManager: PlaybackManager) {
         userEpisodeDao.insert(episode)
 
-        if (settings.getCloudAddToUpNext()) {
+        if (settings.cloudAddToUpNext.flow.value) {
             playbackManager.playLast(episode = episode, source = SourceView.FILES)
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -551,7 +551,7 @@ class UserEpisodeManagerImpl @Inject constructor(
     }
 
     override suspend fun deletePlayedEpisodeIfReq(episode: UserEpisode, playbackManager: PlaybackManager) {
-        if (settings.getDeleteLocalFileAfterPlaying()) {
+        if (settings.deleteLocalFileAfterPlaying.flow.value) {
             deleteFilesForEpisode(episode)
             userEpisodeDao.updateEpisodeStatus(episode.uuid, EpisodeStatusEnum.NOT_DOWNLOADED)
 
@@ -560,7 +560,7 @@ class UserEpisodeManagerImpl @Inject constructor(
             }
         }
 
-        if (settings.getDeleteCloudFileAfterPlaying() && episode.serverStatus == UserEpisodeServerStatus.UPLOADED) {
+        if (settings.deleteCloudFileAfterPlaying.flow.value && episode.serverStatus == UserEpisodeServerStatus.UPLOADED) {
             removeFromCloud(episode)
             if (!episode.isDownloaded) {
                 delete(episode, playbackManager)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -569,7 +569,7 @@ class UserEpisodeManagerImpl @Inject constructor(
     }
 
     override fun autoUploadToCloudIfReq(episode: UserEpisode) {
-        if (settings.getCloudAutoUpload() && subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid) {
+        if (settings.cloudAutoUpload.flow.value && subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid) {
             uploadToServer(episode, settings.getCloudOnlyWifi())
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -385,7 +385,7 @@ class UserEpisodeManagerImpl @Inject constructor(
                 val newEpisode = it.toUserEpisode()
                 add(newEpisode, playbackManager)
 
-                if (settings.getCloudAutoDownload() && subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid) {
+                if (settings.cloudAutoDownload.flow.value && subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid) {
                     userEpisodeDao.updateAutoDownloadStatus(PodcastEpisode.AUTO_DOWNLOAD_STATUS_AUTO_DOWNLOADED, newEpisode.uuid)
                     newEpisode.autoDownloadStatus = PodcastEpisode.AUTO_DOWNLOAD_STATUS_AUTO_DOWNLOADED
                     downloadManager.addEpisodeToQueue(newEpisode, "cloud files sync", false)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -570,7 +570,7 @@ class UserEpisodeManagerImpl @Inject constructor(
 
     override fun autoUploadToCloudIfReq(episode: UserEpisode) {
         if (settings.cloudAutoUpload.flow.value && subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid) {
-            uploadToServer(episode, settings.getCloudOnlyWifi())
+            uploadToServer(episode, settings.cloudDownloadOnlyOnWifi.flow.value)
         }
     }
 


### PR DESCRIPTION
## Description
This converts the file settings to be UserSettings.

## Testing Instructions

### 1. Check defaults
1. Fresh install of build from this PR
2. Log into a Plus account
3. Go to "Profile" tab → "Files" → three-dot-overflow-menu → "Files Settings"
4. Verify that the only setting that defaults to being on is "Only on WiFi". All other settings should be turned off.

### 2. Settings are migrated
1. Fresh install of app built from `main`
2. Log into a Plus account
3. Go to "Profile" tab → "Files" → three-dot-overflow-menu → "Files Settings"
4. Update all the settings to not be their default (so you want them all turned on except "Only on WiFi")
5. Install a build of the app from this PR
6. Verify that all the settings have their updated values

### 3. Settings work as they did before
Verify that toggling each setting still works.
- The automatic deletion settings only appear to work when skipping to the end of an episode, they [do not work when marking an episode as played](https://github.com/Automattic/pocket-casts-android/issues/1248).
- The "Only on WiFi" setting is really only checking for an unmetered network connection, so this can be tested by switching your wifi network to be metered/unmetered.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews