### PR TITLE
Settings Sync - Make refresh and stream warning into UserSettings

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.models.db
 
 import android.content.Context
-import android.content.SharedPreferences
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -66,9 +65,9 @@ class AutoArchiveTest {
         excludedPodcasts: List<String> = emptyList()
     ): EpisodeManager {
         val settings = mock<Settings> {
-            on { autoArchiveInactive } doReturn MockUserSetting(inactive)
-            on { autoArchiveAfterPlaying } doReturn MockUserSetting(played)
-            on { autoArchiveIncludeStarred } doReturn MockUserSetting(includeStarred)
+            on { autoArchiveInactive } doReturn UserSetting.Mock(inactive, mock())
+            on { autoArchiveAfterPlaying } doReturn UserSetting.Mock(played, mock())
+            on { autoArchiveIncludeStarred } doReturn UserSetting.Mock(includeStarred, mock())
             on { getAutoArchiveExcludedPodcasts() } doReturn excludedPodcasts
         }
         return EpisodeManagerImpl(settings, fileStorage, downloadManager, context, db, podcastCacheServerManager, userEpisodeManager)
@@ -83,7 +82,7 @@ class AutoArchiveTest {
 
     private fun upNextQueueFor(db: AppDatabase, episodeManager: EpisodeManager): UpNextQueue {
         val settings = mock<Settings>() {
-            on { autoDownloadUpNext } doReturn MockUserSetting(false)
+            on { autoDownloadUpNext } doReturn UserSetting.Mock(false, mock())
         }
         val context = mock<Context>()
         val syncManager = mock<SyncManager>()
@@ -550,19 +549,5 @@ class AutoArchiveTest {
 
         val updatedNewEpisodeInUpNextAfterInactive = episodeDao.findByUuid(newUUID)!!
         assertTrue("Episode should not be archived as it was added to up next after being inactive", !updatedNewEpisodeInUpNextAfterInactive.isArchived)
-    }
-
-    // This manual mock is needed to avoid problems when accessing a lazily initialized UserSetting::flow
-    // from a mocked Settings class
-    private class MockUserSetting<T>(
-        private val initialValue: T,
-        sharedPrefKey: String = "a_shared_pref_key",
-        sharedPrefs: SharedPreferences = mock(),
-    ) : UserSetting<T>(
-        sharedPrefKey = sharedPrefKey,
-        sharedPrefs = sharedPrefs,
-    ) {
-        override fun get(): T = initialValue
-        override fun persist(value: T, commit: Boolean) {}
     }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.models.db
 
-import android.content.SharedPreferences
 import androidx.room.Room
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
@@ -47,8 +46,8 @@ class PodcastManagerTest {
         val playlistManager = mock<PlaylistManager>()
 
         val settings = mock<Settings> {
-            on { podcastGroupingDefault } doReturn MockUserSetting(PodcastGrouping.None)
-            on { showArchivedDefault } doReturn MockUserSetting(false)
+            on { podcastGroupingDefault } doReturn UserSetting.Mock(PodcastGrouping.None, mock())
+            on { showArchivedDefault } doReturn UserSetting.Mock(false, mock())
         }
 
         val syncManagerSignedOut = mock<SyncManager> {
@@ -111,19 +110,5 @@ class PodcastManagerTest {
         podcastManagerSignedIn.unsubscribe(uuid, playbackManager)
         val daoPodcast = podcastDao.findByUuid(uuid)
         assertTrue("Podcast should be unsubscribed", daoPodcast?.isSubscribed == false)
-    }
-
-    // This manual mock is needed to avoid problems when accessing a lazily initialized UserSetting::flow
-    // from a mocked Settings class
-    private class MockUserSetting<T>(
-        private val initialValue: T,
-        sharedPrefKey: String = "a_shared_pref_key",
-        sharedPrefs: SharedPreferences = mock(),
-    ) : UserSetting<T>(
-        sharedPrefKey = sharedPrefKey,
-        sharedPrefs = sharedPrefs,
-    ) {
-        override fun get(): T = initialValue
-        override fun persist(value: T, commit: Boolean) {}
     }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UpNextQueueTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UpNextQueueTest.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.models.db
 
-import android.content.SharedPreferences
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -36,7 +35,7 @@ class UpNextQueueTest {
         downloadManager = mock {}
         val episodeManager = mock<EpisodeManager> {}
         val settings = mock<Settings> {
-            on { autoDownloadUpNext } doReturn MockUserSetting(true)
+            on { autoDownloadUpNext } doReturn UserSetting.Mock(true, mock())
         }
         val syncManager = mock<SyncManager> {}
 
@@ -242,19 +241,5 @@ class UpNextQueueTest {
         val currentEpisode = upNextQueue.currentEpisode
         assertTrue("Current episode should still be first", currentEpisode?.uuid == uuids.first())
         assertTrue("Queue should be empty", upNextQueue.queueEpisodes.isEmpty())
-    }
-
-    // This manual mock is needed to avoid problems when accessing a lazily initialized UserSetting::flow
-    // from a mocked Settings class
-    private class MockUserSetting<T>(
-        private val initialValue: T,
-        sharedPrefKey: String = "a_shared_pref_key",
-        sharedPrefs: SharedPreferences = mock(),
-    ) : UserSetting<T>(
-        sharedPrefKey = sharedPrefKey,
-        sharedPrefs = sharedPrefs,
-    ) {
-        override fun get(): T = initialValue
-        override fun persist(value: T, commit: Boolean) {}
     }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/settings/advanced/AdvancedSettingsTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/settings/advanced/AdvancedSettingsTest.kt
@@ -29,11 +29,11 @@ class AdvancedSettingsTest {
         )
 
         // Non-advanced settings
-        assertEquals(false, settings.warnOnMeteredNetwork())
+        assertEquals(false, settings.warnOnMeteredNetwork.flow.value)
         assertEquals(true, settings.autoDownloadUnmeteredOnly.flow.value)
         assertEquals(false, settings.autoDownloadOnlyWhenCharging.flow.value)
         assertEquals(false, settings.autoDownloadUpNext.flow.value)
-        assertEquals(true, settings.refreshPodcastsAutomatically())
+        assertEquals(true, settings.backgroundRefreshPodcasts.flow.value)
 
         // Advanced settings
         assertEquals(true, settings.syncOnMeteredNetwork())

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
@@ -91,11 +91,11 @@ class PlayButtonListener @Inject constructor(
     }
 
     override fun onDownload(episodeUuid: String) {
-        if (settings.warnOnMeteredNetwork() && !Network.isUnmeteredConnection(activity) && activity is AppCompatActivity) {
+        if (settings.warnOnMeteredNetwork.flow.value && !Network.isUnmeteredConnection(activity) && activity is AppCompatActivity) {
             warningsHelper.downloadWarning(episodeUuid, "play button")
                 .show(activity.supportFragmentManager, "download warning")
         } else {
-            download(episodeUuid, waitForWifi = settings.warnOnMeteredNetwork())
+            download(episodeUuid, waitForWifi = settings.warnOnMeteredNetwork.flow.value)
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -441,7 +441,7 @@ class EpisodeFragment : BaseFragment() {
                 }
             } else {
                 context?.let { context ->
-                    if (settings.warnOnMeteredNetwork() && !Network.isUnmeteredConnection(context) && viewModel.shouldDownload()) {
+                    if (settings.warnOnMeteredNetwork.flow.value && !Network.isUnmeteredConnection(context) && viewModel.shouldDownload()) {
                         warningsHelper.downloadWarning(episodeUUID!!, "episode card")
                             .show(parentFragmentManager, "download warning")
                     } else {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -246,7 +246,7 @@ class EpisodeFragmentViewModel @Inject constructor(
     }
 
     fun shouldShowStreamingWarning(context: Context): Boolean {
-        return isPlaying.value == false && episode?.isDownloaded == false && settings.warnOnMeteredNetwork() && !Network.isUnmeteredConnection(context)
+        return isPlaying.value == false && episode?.isDownloaded == false && settings.warnOnMeteredNetwork.flow.value && !Network.isUnmeteredConnection(context)
     }
 
     fun playClickedGetShouldClose(

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheet.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheet.kt
@@ -335,7 +335,7 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
 
     fun download(episode: UserEpisode, isOnWifi: Boolean) {
         viewModel.trackOptionTapped(DOWNLOAD)
-        if (settings.warnOnMeteredNetwork() && !isOnWifi) {
+        if (settings.warnOnMeteredNetwork.flow.value && !isOnWifi) {
             warningsHelper.downloadWarning(episodeUUID, "user episode sheet")
                 .show(parentFragmentManager, "download_warning")
         } else {
@@ -345,7 +345,7 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
 
     private fun upload(episode: UserEpisode, isOnWifi: Boolean) {
         viewModel.trackOptionTapped(UPLOAD)
-        if (settings.warnOnMeteredNetwork() && !isOnWifi) {
+        if (settings.warnOnMeteredNetwork.flow.value && !isOnWifi) {
             warningsHelper.uploadWarning(episodeUUID, source = SourceView.FILES)
                 .show(parentFragmentManager, "upload_warning")
         } else {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModel.kt
@@ -25,11 +25,11 @@ class AdvancedSettingsViewModel
     private fun initState() = State(
         backgroundSyncOnMeteredState = State.BackgroundSyncOnMeteredState(
             isChecked = settings.syncOnMeteredNetwork(),
-            isEnabled = settings.refreshPodcastsAutomatically(),
+            isEnabled = settings.backgroundRefreshPodcasts.flow.value,
             onCheckedChange = {
                 // isEnabled controls the grey out of the function but not if it's actually called
                 // here we disable the functionality
-                if (settings.refreshPodcastsAutomatically()) {
+                if (settings.backgroundRefreshPodcasts.flow.value) {
                     onSyncOnMeteredCheckedChange(it)
                     analyticsTracker.track(
                         AnalyticsEvent.SETTINGS_ADVANCED_SYNC_ON_METERED,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
@@ -136,7 +136,7 @@ class StorageSettingsViewModel
             }
         ),
         storageDataWarningState = State.StorageDataWarningState(
-            isChecked = settings.warnOnMeteredNetwork(),
+            isChecked = settings.warnOnMeteredNetwork.flow.value,
             onCheckedChange = {
                 onStorageDataWarningCheckedChange(it)
                 analyticsTracker.track(
@@ -161,14 +161,14 @@ class StorageSettingsViewModel
     }
 
     private fun onStorageDataWarningCheckedChange(isChecked: Boolean) {
-        settings.setWarnOnMeteredNetwork(isChecked)
+        settings.warnOnMeteredNetwork.set(isChecked)
         updateMobileDataWarningState()
     }
 
     private fun updateMobileDataWarningState() {
         mutableState.value = mutableState.value.copy(
             storageDataWarningState = mutableState.value.storageDataWarningState.copy(
-                isChecked = settings.warnOnMeteredNetwork(),
+                isChecked = settings.warnOnMeteredNetwork.flow.value,
             )
         )
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
@@ -58,7 +58,7 @@ class StorageSettingsViewModel
     val permissionRequest = mutablePermissionRequest.asSharedFlow()
 
     private val backgroundRefreshSummary: Int
-        get() = if (settings.refreshPodcastsAutomatically()) {
+        get() = if (settings.backgroundRefreshPodcasts.flow.value) {
             LR.string.settings_storage_background_refresh_on
         } else {
             LR.string.settings_storage_background_refresh_off
@@ -126,7 +126,7 @@ class StorageSettingsViewModel
         ),
         backgroundRefreshState = State.BackgroundRefreshState(
             summary = backgroundRefreshSummary,
-            isChecked = settings.refreshPodcastsAutomatically(),
+            isChecked = settings.backgroundRefreshPodcasts.flow.value,
             onCheckedChange = {
                 onBackgroundRefreshCheckedChange(it)
                 analyticsTracker.track(
@@ -174,14 +174,14 @@ class StorageSettingsViewModel
     }
 
     private fun onBackgroundRefreshCheckedChange(isChecked: Boolean) {
-        settings.setRefreshPodcastsAutomatically(isChecked)
+        settings.backgroundRefreshPodcasts.set(isChecked)
         updateBackgroundRefreshState()
     }
 
     private fun updateBackgroundRefreshState() {
         mutableState.value = mutableState.value.copy(
             backgroundRefreshState = mutableState.value.backgroundRefreshState.copy(
-                isChecked = settings.refreshPodcastsAutomatically(),
+                isChecked = settings.backgroundRefreshPodcasts.flow.value,
                 summary = backgroundRefreshSummary
             )
         )

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModelTest.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.settings.viewmodel
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import dagger.hilt.android.qualifiers.ApplicationContext
 import junit.framework.TestCase
@@ -13,6 +14,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 @RunWith(MockitoJUnitRunner::class)
@@ -35,6 +37,7 @@ class AdvancedSettingsViewModelTest {
     @Before
     fun setUp() {
         whenever(settings.syncOnMeteredNetwork()).thenReturn(false)
+        whenever(settings.backgroundRefreshPodcasts).thenReturn(UserSetting.Mock(true, mock()))
         viewModel = AdvancedSettingsViewModel(
             settings,
             analyticsTracker,

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModelTest.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.settings.viewmodel
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
 import au.com.shiftyjelly.pocketcasts.repositories.file.FolderLocation
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -27,6 +28,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.io.File
@@ -73,6 +75,8 @@ class StorageSettingsViewModelTest {
         whenever(context.getString(any())).thenReturn("")
         whenever(context.getString(any(), any())).thenReturn("")
         whenever(settings.getStorageChoiceName()).thenReturn("")
+        whenever(settings.backgroundRefreshPodcasts).thenReturn(UserSetting.Mock(true, mock()))
+        whenever(settings.warnOnMeteredNetwork).thenReturn(UserSetting.Mock(true, mock()))
         whenever(episodeManager.observeDownloadedEpisodes()).thenReturn(Flowable.empty())
         viewModel = StorageSettingsViewModel(
             podcastManager,

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -247,8 +247,7 @@ interface Settings {
     fun setSyncOnMeteredNetwork(shouldSyncOnMetered: Boolean)
     fun getWorkManagerNetworkTypeConstraint(): NetworkType
     fun refreshPodcastsOnResume(isUnmetered: Boolean): Boolean
-    fun refreshPodcastsAutomatically(): Boolean
-    fun setRefreshPodcastsAutomatically(shouldRefresh: Boolean)
+    val backgroundRefreshPodcasts: UserSetting<Boolean>
     fun setPodcastsSortType(sortType: PodcastsSortType, sync: Boolean)
     fun setPodcastsSortTypeNeedsSync(value: Boolean)
     fun getPodcastsSortTypeNeedsSync(): Boolean

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -285,8 +285,7 @@ interface Settings {
     fun getDiscoveryCountryCode(): String
     fun setDiscoveryCountryCode(code: String)
 
-    fun warnOnMeteredNetwork(): Boolean
-    fun setWarnOnMeteredNetwork(warn: Boolean)
+    val warnOnMeteredNetwork: UserSetting<Boolean>
 
     fun getPopularPodcastCountryCode(): String
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -227,14 +227,11 @@ class SettingsImpl @Inject constructor(
     override fun refreshPodcastsOnResume(isUnmetered: Boolean): Boolean =
         syncOnMeteredNetwork() || isUnmetered
 
-    override fun refreshPodcastsAutomatically(): Boolean {
-        val isWear = Util.isWearOs(context)
-        return getBoolean("backgroundRefresh", !isWear)
-    }
-
-    override fun setRefreshPodcastsAutomatically(shouldRefresh: Boolean) {
-        return setBoolean("backgroundRefresh", shouldRefresh)
-    }
+    override val backgroundRefreshPodcasts = UserSetting.BoolPref(
+        sharedPrefKey = "backgroundRefresh",
+        defaultValue = !Util.isWearOs(context),
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun setPodcastsSortType(sortType: PodcastsSortType, sync: Boolean) {
         if (getPodcastsSortType() == sortType) {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -426,13 +426,11 @@ class SettingsImpl @Inject constructor(
         editor.apply()
     }
 
-    override fun warnOnMeteredNetwork(): Boolean {
-        return sharedPreferences.getBoolean(Settings.PREFERENCE_WARN_WHEN_NOT_ON_WIFI, false)
-    }
-
-    override fun setWarnOnMeteredNetwork(warn: Boolean) {
-        setBoolean(Settings.PREFERENCE_WARN_WHEN_NOT_ON_WIFI, warn)
-    }
+    override val warnOnMeteredNetwork = UserSetting.BoolPref(
+        sharedPrefKey = Settings.PREFERENCE_WARN_WHEN_NOT_ON_WIFI,
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun getPopularPodcastCountryCode(): String {
         return sharedPreferences.getString(Settings.PREFERENCE_POPULAR_PODCAST_COUNTRY_CODE, "") ?: ""

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -209,4 +209,17 @@ abstract class UserSetting<T>(
             intValue.toString()
         }
     )
+
+    // This manual mock is needed to avoid problems when accessing a lazily initialized UserSetting::flow
+    // from a mocked Settings class
+    class Mock<T>(
+        private val initialValue: T,
+        sharedPrefs: SharedPreferences,
+    ) : UserSetting<T>(
+        sharedPrefKey = "a_shared_pref_key",
+        sharedPrefs = sharedPrefs,
+    ) {
+        override fun get(): T = initialValue
+        override fun persist(value: T, commit: Boolean) {}
+    }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
@@ -472,7 +472,7 @@ class DownloadManagerImpl @Inject constructor(
         // user has tapped download
         if (!episode.isAutoDownloaded) {
             // user said yes to warning dialog
-            return if (episode.isManualDownloadOverridingWifiSettings || !settings.warnOnMeteredNetwork()) {
+            return if (episode.isManualDownloadOverridingWifiSettings || !settings.warnOnMeteredNetwork.flow.value) {
                 NetworkRequirements.runImmediately()
             } else NetworkRequirements.needsUnmetered()
         } else if (episode is UserEpisode) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -351,7 +351,7 @@ open class PlaybackManager @Inject constructor(
     }
 
     fun shouldWarnAboutPlayback(episodeUUID: String? = upNextQueue.currentEpisode?.uuid): Boolean {
-        return settings.warnOnMeteredNetwork() && !Network.isUnmeteredConnection(application) && lastWarnedPlayedEpisodeUuid != episodeUUID
+        return settings.warnOnMeteredNetwork.flow.value && !Network.isUnmeteredConnection(application) && lastWarnedPlayedEpisodeUuid != episodeUUID
     }
 
     fun getPlaybackSpeed(): Double {
@@ -1495,7 +1495,7 @@ open class PlaybackManager @Inject constructor(
         if (!episode.isDownloaded) {
             if (!Util.isCarUiMode(application) &&
                 !Util.isWearOs(application) && // The watch handles these warnings before this is called
-                settings.warnOnMeteredNetwork() &&
+                settings.warnOnMeteredNetwork.flow.value &&
                 !Network.isUnmeteredConnection(application) &&
                 !forceStream &&
                 play

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsTask.kt
@@ -54,7 +54,7 @@ class RefreshPodcastsTask @AssistedInject constructor(
         fun scheduleOrCancel(context: Context, settings: Settings) {
             val workManager = WorkManager.getInstance(context)
 
-            if (!settings.refreshPodcastsAutomatically()) {
+            if (!settings.backgroundRefreshPodcasts.flow.value) {
                 workManager.cancelAllWorkByTag(TAG_REFRESH_TASK)
                 return
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsTask.kt
@@ -66,10 +66,10 @@ class RefreshPodcastsTask @AssistedInject constructor(
                 .setRequiresBatteryNotLow(true)
                 .build()
 
-            val request = PeriodicWorkRequestBuilder<RefreshPodcastsTask>(REFRESH_EVERY_HOURS, TimeUnit.HOURS)
+            val request = PeriodicWorkRequestBuilder<RefreshPodcastsTask>(20, TimeUnit.SECONDS)
                 .addTag(TAG_REFRESH_TASK)
                 .setConstraints(constraints)
-                .setInitialDelay(REFRESH_EVERY_HOURS, TimeUnit.HOURS)
+                .setInitialDelay(20, TimeUnit.SECONDS)
                 .build()
 
             workManager.enqueueUniquePeriodicWork(TAG_REFRESH_TASK, ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE, request)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -263,7 +263,7 @@ class Support @Inject constructor(
             output.append("Android version: ").append(Build.VERSION.RELEASE).append(" SDK ").append(Build.VERSION.SDK_INT).append(eol)
             output.append(eol)
 
-            output.append("Background refresh: ").append(settings.refreshPodcastsAutomatically()).append(eol)
+            output.append("Background refresh: ").append(settings.backgroundRefreshPodcasts.flow.value).append(eol)
             output.append("Battery restriction: ${systemBatteryRestrictions.status}")
             output.append(eol)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -333,7 +333,7 @@ class Support @Inject constructor(
             output.append("  Restrict Background Status: ").append(Network.getRestrictBackgroundStatusString(context)).append(eol)
             output.append(eol)
 
-            output.append("Warning when not on Wifi? ").append(yesNoString(settings.warnOnMeteredNetwork())).append(eol)
+            output.append("Warning when not on Wifi? ").append(yesNoString(settings.warnOnMeteredNetwork.flow.value)).append(eol)
             output.append(eol)
 
             output.append("Work Manager Tasks").append(eol)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsViewModel.kt
@@ -38,7 +38,7 @@ class SettingsViewModel @Inject constructor(
             refreshState = null,
             signInState = userManager.getSignInState().blockingFirst(),
             showDataWarning = settings.warnOnMeteredNetwork.flow.value,
-            refreshInBackground = settings.refreshPodcastsAutomatically(),
+            refreshInBackground = settings.backgroundRefreshPodcasts.flow.value,
         )
     )
     val state = _state.asStateFlow()
@@ -67,7 +67,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun setRefreshPodcastsInBackground(isChecked: Boolean) {
-        settings.setRefreshPodcastsAutomatically(isChecked)
+        settings.backgroundRefreshPodcasts.set(isChecked)
         _state.update { it.copy(refreshInBackground = isChecked) }
     }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsViewModel.kt
@@ -37,7 +37,7 @@ class SettingsViewModel @Inject constructor(
         State(
             refreshState = null,
             signInState = userManager.getSignInState().blockingFirst(),
-            showDataWarning = settings.warnOnMeteredNetwork(),
+            showDataWarning = settings.warnOnMeteredNetwork.flow.value,
             refreshInBackground = settings.refreshPodcastsAutomatically(),
         )
     )
@@ -62,7 +62,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun setWarnOnMeteredNetwork(warnOnMeteredNetwork: Boolean) {
-        settings.setWarnOnMeteredNetwork(warnOnMeteredNetwork)
+        settings.warnOnMeteredNetwork.set(warnOnMeteredNetwork)
         _state.update { it.copy(showDataWarning = warnOnMeteredNetwork) }
     }
 


### PR DESCRIPTION
## Description
This makes the stream warning and background refresh settings into UserSettings.

I also moved the MockUserSetting class out of the separate test classes and instead into the UserSetting class itself. Ideally, we would only include this as a test artifact, and I could do that, but I don't see any way to accomplish that without quite a bit of boilerplate, and I just didn't think it was worth it to avoid bundling this small mock class in the app. Let me know if you disagree or have a better idea how to handle this mock class.

## Testing Instructions

1. Fresh install of the app
2. Go to "Profile" → ⚙️ → "Storage & data use"
3. Verify that "Background refresh" is defaulted to on (on the watch this defaults to off) and "Warn before using data" is defaulted to off
4. Toggle the warning before using data to be on
5. Switch your network to be metered
6. Begin streaming an episode
7. Observe the stream warning is presented
8. Switch your network to be unmetered
9. Begin streaming an episode and observe the stream warning is NOT presented
10. Monitor the app logs to observe background refresh is occurring. I triggered this to occur more often [by updating the refresh to occur every 20 seconds](https://gist.github.com/mchowning/eb2e5f8af81e0efff6e869215be5d323). Also filtering the logs for "BgTask" helps.
11. Toggle the background refresh to be off
12. Monitor the app logs and observe background refresh is NOT occurring

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews