### PR TITLE
Bookmarks - Link edit action

### DIFF
--- a/modules/features/player/src/main/AndroidManifest.xml
+++ b/modules/features/player/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
             tools:ignore="UnusedAttribute" />
         <activity
             android:name=".view.bookmark.BookmarkActivity"
+            android:launchMode="singleTask"
             android:windowSoftInputMode="adjustResize"
             android:configChanges="orientation|layoutDirection|screenSize" />
     </application>

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkPage.kt
@@ -86,8 +86,9 @@ private fun Content(isNewBookmark: Boolean, title: TextFieldValue, tintColor: Co
             .verticalScroll(rememberScrollState())
             .padding(16.dp)
     ) {
+        val titleRes = if (isNewBookmark) R.string.add_bookmark_title_hint else R.string.change_bookmark_title_hint
         TextP40(
-            text = stringResource(R.string.add_bookmark_title_hint),
+            text = stringResource(titleRes),
             color = Color.White.copy(alpha = 0.5f),
             textAlign = TextAlign.Center,
             modifier = Modifier.widthIn(100.dp, 240.dp)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
@@ -99,6 +99,7 @@ class BookmarksFragment : BaseFragment() {
                             textColor = requireNotNull(textColor(listData)),
                             sourceView = sourceView,
                             bookmarksViewModel = bookmarksViewModel,
+                            multiSelectHelper = multiSelectHelper,
                             onRowLongPressed = { bookmark ->
                                 multiSelectHelper.defaultLongPress(
                                     multiSelectable = bookmark,
@@ -106,6 +107,7 @@ class BookmarksFragment : BaseFragment() {
                                     forceDarkTheme = sourceView == SourceView.PLAYER,
                                 )
                             },
+                            onEditBookmarkClick = ::onEditBookmarkClick,
                             showOptionsDialog = { showOptionsDialog(it) }
                         )
                     }
@@ -162,6 +164,12 @@ class BookmarksFragment : BaseFragment() {
                         )
                     }
                 ).show(it, "bookmarks_options_dialog")
+        }
+    }
+
+    private fun onEditBookmarkClick() {
+        bookmarksViewModel.buildBookmarkArguments { arguments ->
+            startActivity(arguments.getIntent(requireContext()))
         }
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
@@ -30,6 +30,7 @@ import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.PlusUpsell
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import java.util.Date
 import java.util.UUID
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -41,7 +42,9 @@ fun BookmarksPage(
     textColor: Color,
     sourceView: SourceView,
     bookmarksViewModel: BookmarksViewModel,
+    multiSelectHelper: MultiSelectBookmarksHelper,
     onRowLongPressed: (Bookmark) -> Unit,
+    onEditBookmarkClick: () -> Unit,
     showOptionsDialog: (Int) -> Unit,
 ) {
     val context = LocalContext.current
@@ -70,6 +73,13 @@ fun BookmarksPage(
         bookmarksViewModel.showOptionsDialog
             .collect { selectedValue ->
                 showOptionsDialog(selectedValue)
+            }
+    }
+
+    LaunchedEffect(context) {
+        multiSelectHelper.showEditBookmarkPage
+            .collect { show ->
+                if (show) onEditBookmarkClick()
             }
     }
 }

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
@@ -7,8 +7,10 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
@@ -39,6 +41,9 @@ class BookmarksViewModelTest {
     private lateinit var episodeManager: EpisodeManager
 
     @Mock
+    private lateinit var podcastManager: PodcastManager
+
+    @Mock
     private lateinit var userManager: UserManager
 
     @Mock
@@ -56,6 +61,9 @@ class BookmarksViewModelTest {
     @Mock
     private lateinit var playbackManager: PlaybackManager
 
+    @Mock
+    private lateinit var theme: Theme
+
     private lateinit var bookmarksViewModel: BookmarksViewModel
     private val episodeUuid = UUID.randomUUID().toString()
 
@@ -69,10 +77,12 @@ class BookmarksViewModelTest {
         bookmarksViewModel = BookmarksViewModel(
             bookmarkManager = bookmarkManager,
             episodeManager = episodeManager,
+            podcastManager = podcastManager,
             userManager = userManager,
             multiSelectHelper = multiSelectHelper,
             settings = settings,
             playbackManager = playbackManager,
+            theme = theme,
             ioDispatcher = UnconfinedTestDispatcher()
         )
     }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="bookmark_added">Bookmark \"%s\" added</string>
     <string name="change_title">Change title</string>
     <string name="add_bookmark_title_hint">Add an optional title to identify this bookmark</string>
+    <string name="change_bookmark_title_hint">Change the title that identifies this bookmark</string>
     <string name="save_bookmark">Save bookmark</string>
     <string name="playing_bookmark">Playing \"%s\"</string>
     <string name="skipping_to">Skipping to %s</string>

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
@@ -10,6 +10,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.views.R
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -22,6 +24,9 @@ class MultiSelectBookmarksHelper @Inject constructor(
     private val bookmarkManager: BookmarkManager,
 ) : MultiSelectHelper<Bookmark>() {
     override val maxToolbarIcons = 2
+
+    private val _showEditBookmarkPage = MutableSharedFlow<Boolean>()
+    val showEditBookmarkPage = _showEditBookmarkPage.asSharedFlow()
 
     override val toolbarActions: LiveData<List<MultiSelectAction>> = _selectedListLive
         .map {
@@ -45,7 +50,7 @@ class MultiSelectBookmarksHelper @Inject constructor(
         return when (itemId) {
 
             UR.id.menu_edit -> {
-                // TODO: Bookmark - Add edit action
+                edit()
                 true
             }
 
@@ -61,6 +66,10 @@ class MultiSelectBookmarksHelper @Inject constructor(
 
             else -> false
         }
+    }
+
+    private fun edit() {
+        launch { _showEditBookmarkPage.emit(true) }
     }
 
     fun delete(resources: Resources, fragmentManager: FragmentManager) {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
@@ -68,6 +68,19 @@ class MultiSelectBookmarksHelper @Inject constructor(
         }
     }
 
+    override fun deselect(multiSelectable: Bookmark) {
+        if (isSelected(multiSelectable)) {
+            val selectedItem = selectedList.firstOrNull { it.uuid == multiSelectable.uuid }
+            selectedItem?.let { selectedList.remove(it) }
+        }
+
+        _selectedListLive.value = selectedList
+
+        if (selectedList.isEmpty()) {
+            closeMultiSelect()
+        }
+    }
+
     private fun edit() {
         launch { _showEditBookmarkPage.emit(true) }
     }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -143,6 +143,19 @@ class MultiSelectEpisodesHelper @Inject constructor(
         }
     }
 
+    override fun deselect(multiSelectable: BaseEpisode) {
+        if (isSelected(multiSelectable)) {
+            val selectedItem = selectedList.firstOrNull { it.uuid == multiSelectable.uuid }
+            selectedItem?.let { selectedList.remove(it) }
+        }
+
+        _selectedListLive.value = selectedList
+
+        if (selectedList.isEmpty()) {
+            closeMultiSelect()
+        }
+    }
+
     fun markAsPlayed(shownWarning: Boolean = false, resources: Resources, fragmentManager: FragmentManager) {
         if (selectedList.isEmpty()) {
             closeMultiSelect()

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -179,7 +179,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
         }
     }
 
-    fun markAsUnplayed(resources: Resources) {
+    private fun markAsUnplayed(resources: Resources) {
         if (selectedList.isEmpty()) {
             closeMultiSelect()
             return
@@ -221,7 +221,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
         }
     }
 
-    fun unarchive(resources: Resources) {
+    private fun unarchive(resources: Resources) {
         if (selectedList.isEmpty()) {
             closeMultiSelect()
             return
@@ -258,7 +258,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
         }
     }
 
-    fun unstar(resources: Resources) {
+    private fun unstar(resources: Resources) {
         if (selectedList.isEmpty()) {
             closeMultiSelect()
             return
@@ -287,7 +287,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
             .show(fragmentManager, "confirm_played_all_")
     }
 
-    fun archiveWarning(count: Int, resources: Resources, fragmentManager: FragmentManager) {
+    private fun archiveWarning(count: Int, resources: Resources, fragmentManager: FragmentManager) {
         val buttonString = resources.getStringPlural(count = count, singular = LR.string.archive_episodes_singular, plural = LR.string.archive_episodes_plural)
 
         ConfirmationDialog()
@@ -318,7 +318,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
         }?.show(fragmentManager, "multiselect_download")
     }
 
-    fun deleteDownload() {
+    private fun deleteDownload() {
         if (selectedList.isEmpty()) {
             closeMultiSelect()
             return
@@ -346,7 +346,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
         }
     }
 
-    fun playNext(resources: Resources) {
+    private fun playNext(resources: Resources) {
         if (selectedList.isEmpty()) {
             closeMultiSelect()
             return
@@ -364,7 +364,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
         }
     }
 
-    fun playLast(resources: Resources) {
+    private fun playLast(resources: Resources) {
         if (selectedList.isEmpty()) {
             closeMultiSelect()
             return
@@ -440,7 +440,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
         closeMultiSelect()
     }
 
-    fun removeFromUpNext(resources: Resources) {
+    private fun removeFromUpNext(resources: Resources) {
         val list = selectedList.toList()
         launch {
             list.forEach {
@@ -456,13 +456,13 @@ class MultiSelectEpisodesHelper @Inject constructor(
         closeMultiSelect()
     }
 
-    fun moveToTop() {
+    private fun moveToTop() {
         val list = selectedList.toList()
         playbackManager.playEpisodesNext(episodes = list, source = source)
         closeMultiSelect()
     }
 
-    fun moveToBottom() {
+    private fun moveToBottom() {
         val list = selectedList.toList()
         playbackManager.playEpisodesLast(episodes = list, source = source)
         closeMultiSelect()

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectHelper.kt
@@ -60,6 +60,7 @@ abstract class MultiSelectHelper<T> : CoroutineScope {
         resources: Resources,
         fragmentManager: FragmentManager,
     ): Boolean
+    abstract fun deselect(multiSelectable: T)
 
     fun defaultLongPress(
         multiSelectable: T,
@@ -117,18 +118,6 @@ abstract class MultiSelectHelper<T> : CoroutineScope {
             selectedList.add(multiSelectable)
         }
         _selectedListLive.value = selectedList
-    }
-
-    fun deselect(multiSelectable: T) {
-        if (isSelected(multiSelectable)) {
-            selectedList.remove(multiSelectable)
-        }
-
-        _selectedListLive.value = selectedList
-
-        if (selectedList.isEmpty()) {
-            closeMultiSelect()
-        }
     }
 
     fun selectAll() {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectHelper.kt
@@ -46,6 +46,7 @@ abstract class MultiSelectHelper<T> : CoroutineScope {
             field = value
             _isMultiSelectingLive.value = value
             selectedList.clear()
+            _selectedListLive.value = emptyList()
         }
 
     var coordinatorLayout: View? = null


### PR DESCRIPTION
## Description

This links multi-select toolbar edit action for bookmarks.


## Testing Instructions
- Add a few bookmarks to an episode
- Open bookmarks view 
- Long press a bookmark
- Tap edit icon on the multi-select toolbar
- ✅ Notice that the change title view is displayed
- Change the title and click save
- ✅ Notice that you're returned to the bookmarks view and the title is changed

** Repeat above for bookmarks on Episode Details, Player, Podcast Details, and User Episodes(Cloud Files) 

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/093e8fe1-418b-4188-bae2-8a1fc801ef3a

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
