### PR TITLE
Settings Sync - Make podcast display settings into UserSettings

### DIFF
--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -84,10 +84,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
         preferenceSkipForward?.setOnPreferenceChangeListener { _, newValue ->
             val value = newValue.toString().toIntOrNull() ?: 0
             if (value > 0) {
-                settings.skipForwardInSecs.run {
-                    set(value)
-                    needsSync = true
-                }
+                settings.skipForwardInSecs.set(value, needsSync = true)
                 changeSkipTitles()
                 true
             } else {
@@ -98,10 +95,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
         preferenceSkipBackward?.setOnPreferenceChangeListener { _, newValue ->
             val value = newValue.toString().toIntOrNull() ?: 0
             if (value > 0) {
-                settings.skipBackInSecs.run {
-                    set(value)
-                    needsSync = true
-                }
+                settings.skipBackInSecs.set(value, needsSync = true)
                 changeSkipTitles()
                 true
             } else {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditColorPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditColorPage.kt
@@ -30,7 +30,7 @@ import au.com.shiftyjelly.pocketcasts.compose.folder.FolderImage
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcasts.FolderListRow
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.PodcastGridLayoutType
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -121,10 +121,10 @@ private fun FolderEditColorForm(
 }
 
 @Composable
-private fun FolderPreview(layout: Int, name: String, colorId: Int, gridImageWidthDp: Int, podcastUuids: List<String>, modifier: Modifier = Modifier) {
+private fun FolderPreview(layout: PodcastGridLayoutType, name: String, colorId: Int, gridImageWidthDp: Int, podcastUuids: List<String>, modifier: Modifier = Modifier) {
     val backgroundColor = MaterialTheme.theme.colors.getFolderColor(colorId)
     when (layout) {
-        Settings.PodcastGridLayoutType.LIST_VIEW.id -> {
+        PodcastGridLayoutType.LIST_VIEW -> {
             FolderListRow(
                 color = backgroundColor,
                 name = name,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModel.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastFolder
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.PodcastGridLayoutType
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
@@ -48,7 +49,7 @@ class FolderEditViewModel
         val selectedUuids: List<String> = emptyList(),
         val searchText: String = "",
         val folder: Folder? = null,
-        val layout: Int = Settings.PodcastGridLayoutType.LARGE_ARTWORK.id
+        val layout: PodcastGridLayoutType = PodcastGridLayoutType.LARGE_ARTWORK
     ) {
         fun isSelected(podcast: Podcast): Boolean {
             return selectedUuids.contains(podcast.uuid)
@@ -130,7 +131,7 @@ class FolderEditViewModel
                     searchText = searchText,
                     folders = folders,
                     folder = folder,
-                    layout = settings.getPodcastsLayout()
+                    layout = settings.podcastGridLayout.flow.value
                 )
             }.collect {
                 mutableState.value = it
@@ -263,8 +264,8 @@ class FolderEditViewModel
         }
     }
 
-    fun getGridImageWidthDp(layout: Int, context: Context): Int {
-        return UiUtil.getGridImageWidthPx(smallArtwork = layout == Settings.PodcastGridLayoutType.SMALL_ARTWORK.id, context = context).pxToDp(context).toInt()
+    fun getGridImageWidthDp(layout: PodcastGridLayoutType, context: Context): Int {
+        return UiUtil.getGridImageWidthPx(smallArtwork = layout == PodcastGridLayoutType.SMALL_ARTWORK, context = context).pxToDp(context).toInt()
     }
 
     fun movePodcastToFolder(podcastUuid: String, folder: Folder) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderAdapter.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.podcasts.R
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
 import au.com.shiftyjelly.pocketcasts.repositories.colors.ColorManager
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImageLoader
 import au.com.shiftyjelly.pocketcasts.repositories.images.into
@@ -41,7 +42,7 @@ class FolderAdapter(
     val theme: Theme
 ) : ListAdapter<FolderItem, RecyclerView.ViewHolder>(FolderItemDiffCallback()) {
 
-    var badgeType = Settings.BadgeType.OFF
+    var badgeType = BadgeType.OFF
 
     private val imageLoader: PodcastImageLoaderThemed = PodcastImageLoaderThemed(context)
     private var podcastUuidToBadge: Map<String, Int> = emptyMap()
@@ -159,16 +160,16 @@ class FolderAdapter(
         val countTextMarginLarge: Int = 4.dpToPx(view.resources.displayMetrics)
         val isListLayout: Boolean = layout == Settings.PodcastGridLayoutType.LIST_VIEW.id
 
-        fun bind(podcast: Podcast, badgeType: Settings.BadgeType, podcastUuidToBadge: Map<String, Int>, clickListener: ClickListener) {
+        fun bind(podcast: Podcast, badgeType: BadgeType, podcastUuidToBadge: Map<String, Int>, clickListener: ClickListener) {
             button.setOnClickListener { clickListener.onPodcastClick(podcast, itemView) }
             podcastTitle.text = podcast.title
             podcastTitle.show()
             author?.text = podcast.author
             val unplayedEpisodeCount = podcastUuidToBadge[podcast.uuid] ?: 0
             val badgeCount = when (badgeType) {
-                Settings.BadgeType.OFF -> 0
-                Settings.BadgeType.ALL_UNFINISHED -> unplayedEpisodeCount
-                Settings.BadgeType.LATEST_EPISODE -> min(1, unplayedEpisodeCount)
+                BadgeType.OFF -> 0
+                BadgeType.ALL_UNFINISHED -> unplayedEpisodeCount
+                BadgeType.LATEST_EPISODE -> min(1, unplayedEpisodeCount)
             }
             setTextViewCount(unplayedBackground, unplayedText, badgeCount, badgeType)
 
@@ -176,21 +177,21 @@ class FolderAdapter(
                 UiUtil.setBackgroundColor(podcastTitle, ColorManager.getBackgroundColor(podcast))
                 unplayedText.setTextColor(unplayedText.context.getThemeColor(UR.attr.contrast_01))
             } else {
-                if (badgeType == Settings.BadgeType.LATEST_EPISODE) {
+                if (badgeType == BadgeType.LATEST_EPISODE) {
                     unplayedText.setTextColor(unplayedText.context.getThemeColor(UR.attr.support_05))
                 } else {
                     unplayedText.setTextColor(unplayedText.context.getThemeColor(UR.attr.primary_text_02))
                 }
             }
 
-            val badgeCountMessage = if (badgeType == Settings.BadgeType.OFF) "" else "$unplayedEpisodeCount new episodes. "
+            val badgeCountMessage = if (badgeType == BadgeType.OFF) "" else "$unplayedEpisodeCount new episodes. "
             button.contentDescription = "${podcast.title}. $badgeCountMessage Open podcast."
 
             imageLoader.loadCoil(podcast.uuid, placeholder = false) { if (!isListLayout) podcastTitle.hide() }.into(podcastThumbnail)
         }
 
         @Suppress("NAME_SHADOWING")
-        private fun setTextViewCount(image: ImageView?, text: TextView, count: Int, badgeType: Settings.BadgeType) {
+        private fun setTextViewCount(image: ImageView?, text: TextView, count: Int, badgeType: BadgeType) {
             var count = count
             if (count == 0) {
                 text.hide()
@@ -206,7 +207,7 @@ class FolderAdapter(
                     (text.layoutParams as ViewGroup.MarginLayoutParams).setMargins(0, 0, if (count > 9) countTextMarginSmall else countTextMarginLarge, 0)
                 }
 
-                if (badgeType != Settings.BadgeType.LATEST_EPISODE) {
+                if (badgeType != BadgeType.LATEST_EPISODE) {
                     text.text = count.toString()
                 } else {
                     text.text = "●"

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderListRow.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderListRow.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.folder.FolderImageSmall
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -29,7 +29,7 @@ fun FolderListRow(
     podcastUuids: List<String>,
     modifier: Modifier = Modifier,
     badgeCount: Int = 0,
-    badgeType: Settings.BadgeType = Settings.BadgeType.OFF,
+    badgeType: BadgeType = BadgeType.OFF,
     onClick: (() -> Unit)?
 ) {
     Row(
@@ -70,11 +70,11 @@ fun FolderListRow(
                 modifier = Modifier.padding(top = 2.dp)
             )
         }
-        if (badgeType != Settings.BadgeType.OFF) {
+        if (badgeType != BadgeType.OFF) {
             Text(
-                text = if (badgeType != Settings.BadgeType.LATEST_EPISODE) badgeCount.toString() else "●",
+                text = if (badgeType != BadgeType.LATEST_EPISODE) badgeCount.toString() else "●",
                 fontSize = 14.sp,
-                color = if (badgeType == Settings.BadgeType.LATEST_EPISODE) MaterialTheme.theme.colors.support05 else MaterialTheme.theme.colors.primaryText02
+                color = if (badgeType == BadgeType.LATEST_EPISODE) MaterialTheme.theme.colors.support05 else MaterialTheme.theme.colors.primaryText02
             )
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderViewHolder.kt
@@ -16,8 +16,8 @@ import au.com.shiftyjelly.pocketcasts.compose.folder.FolderImage
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
+import au.com.shiftyjelly.pocketcasts.preferences.model.PodcastGridLayoutType
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import kotlin.math.min
 
@@ -25,7 +25,7 @@ class FolderViewHolder(
     val composeView: ComposeView,
     val theme: Theme,
     val gridWidthDp: Int,
-    val podcastsLayout: Int,
+    val podcastsLayout: PodcastGridLayoutType,
     val onFolderClick: (Folder) -> Unit
 ) : RecyclerView.ViewHolder(composeView) {
 
@@ -37,7 +37,7 @@ class FolderViewHolder(
                 val color = MaterialTheme.theme.colors.getFolderColor(folder.color)
                 val podcastUuids = podcasts.map { it.uuid }
                 when (podcastsLayout) {
-                    Settings.PodcastGridLayoutType.LIST_VIEW.id -> {
+                    PodcastGridLayoutType.LIST_VIEW -> {
                         FolderListAdapter(
                             color = color,
                             name = folder.name,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderViewHolder.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import kotlin.math.min
 
@@ -28,7 +29,7 @@ class FolderViewHolder(
     val onFolderClick: (Folder) -> Unit
 ) : RecyclerView.ViewHolder(composeView) {
 
-    fun bind(folder: Folder, podcasts: List<Podcast>, badgeType: Settings.BadgeType, podcastUuidToBadge: Map<String, Int>) {
+    fun bind(folder: Folder, podcasts: List<Podcast>, badgeType: BadgeType, podcastUuidToBadge: Map<String, Int>) {
         val badgeCount = calculateFolderBadge(podcasts, badgeType, podcastUuidToBadge)
 
         composeView.setContent {
@@ -62,21 +63,21 @@ class FolderViewHolder(
         }
     }
 
-    private fun calculateFolderBadge(podcasts: List<Podcast>, badgeType: Settings.BadgeType, podcastUuidToBadge: Map<String, Int>): Int {
-        if (badgeType == Settings.BadgeType.OFF) {
+    private fun calculateFolderBadge(podcasts: List<Podcast>, badgeType: BadgeType, podcastUuidToBadge: Map<String, Int>): Int {
+        if (badgeType == BadgeType.OFF) {
             return 0
         }
         val episodeCount = podcasts.sumOf { podcast -> podcastUuidToBadge[podcast.uuid] ?: 0 }
         return when (badgeType) {
-            Settings.BadgeType.OFF -> 0
-            Settings.BadgeType.ALL_UNFINISHED -> min(99, episodeCount)
-            Settings.BadgeType.LATEST_EPISODE -> min(1, episodeCount)
+            BadgeType.OFF -> 0
+            BadgeType.ALL_UNFINISHED -> min(99, episodeCount)
+            BadgeType.LATEST_EPISODE -> min(1, episodeCount)
         }
     }
 }
 
 @Composable
-private fun FolderGridAdapter(color: Color, name: String, podcastUuids: List<String>, badgeCount: Int, badgeType: Settings.BadgeType, modifier: Modifier = Modifier, onClick: () -> Unit) {
+private fun FolderGridAdapter(color: Color, name: String, podcastUuids: List<String>, badgeCount: Int, badgeType: BadgeType, modifier: Modifier = Modifier, onClick: () -> Unit) {
     FolderImage(
         name = name,
         color = color,
@@ -88,7 +89,7 @@ private fun FolderGridAdapter(color: Color, name: String, podcastUuids: List<Str
 }
 
 @Composable
-private fun FolderListAdapter(color: Color, name: String, podcastUuids: List<String>, badgeCount: Int, badgeType: Settings.BadgeType, modifier: Modifier = Modifier, onClick: () -> Unit) {
+private fun FolderListAdapter(color: Color, name: String, podcastUuids: List<String>, badgeCount: Int, badgeType: BadgeType, modifier: Modifier = Modifier, onClick: () -> Unit) {
     Column {
         FolderListRow(
             color = color,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -30,6 +30,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderEditPodcastsFr
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastsViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.PodcastGridLayoutType
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.search.SearchFragment
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
@@ -320,10 +321,10 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
     }
 
     private fun setupGridView(savedInstanceState: Parcelable? = listState) {
-        val layoutManager = when (settings.getPodcastsLayout()) {
-            Settings.PodcastGridLayoutType.LARGE_ARTWORK.id -> GridLayoutManager(activity, UiUtil.getGridColumnCount(false, context))
-            Settings.PodcastGridLayoutType.SMALL_ARTWORK.id -> GridLayoutManager(activity, UiUtil.getGridColumnCount(true, context))
-            else -> LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
+        val layoutManager = when (settings.podcastGridLayout.flow.value) {
+            PodcastGridLayoutType.LARGE_ARTWORK -> GridLayoutManager(activity, UiUtil.getGridColumnCount(false, context))
+            PodcastGridLayoutType.SMALL_ARTWORK -> GridLayoutManager(activity, UiUtil.getGridColumnCount(true, context))
+            PodcastGridLayoutType.LIST_VIEW -> LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         }
         val badgeType = settings.podcastBadgeType.flow.value
         val currentLayoutManager = realBinding?.recyclerView?.layoutManager

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -153,7 +153,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         }
 
         viewModel.podcastUuidToBadge.observe(viewLifecycleOwner) { podcastUuidToBadge ->
-            adapter?.badgeType = settings.getPodcastBadgeType()
+            adapter?.badgeType = settings.podcastBadgeType.flow.value
             adapter?.setBadges(podcastUuidToBadge)
         }
 
@@ -325,7 +325,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
             Settings.PodcastGridLayoutType.SMALL_ARTWORK.id -> GridLayoutManager(activity, UiUtil.getGridColumnCount(true, context))
             else -> LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         }
-        val badgeType = settings.getPodcastBadgeType()
+        val badgeType = settings.podcastBadgeType.flow.value
         val currentLayoutManager = realBinding?.recyclerView?.layoutManager
 
         // We only want to reset the adapter if something actually changed, or else it will flash

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.R
 import au.com.shiftyjelly.pocketcasts.podcasts.view.share.ShareListCreateActivity
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
+import au.com.shiftyjelly.pocketcasts.preferences.model.PodcastGridLayoutType
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -43,31 +44,31 @@ class PodcastsOptionsDialog(
                 ToggleButtonOption(
                     imageId = R.drawable.ic_largegrid,
                     descriptionId = LR.string.podcasts_layout_large_grid,
-                    isOn = { settings.getPodcastsLayout() == Settings.PodcastGridLayoutType.LARGE_ARTWORK.id },
+                    isOn = { settings.podcastGridLayout.flow.value == PodcastGridLayoutType.LARGE_ARTWORK },
                     click = {
-                        settings.setPodcastsLayout(Settings.PodcastGridLayoutType.LARGE_ARTWORK.id)
+                        settings.podcastGridLayout.set(PodcastGridLayoutType.LARGE_ARTWORK)
                         trackTapOnModalOption(ModalOption.LAYOUT)
-                        trackLayoutChanged(Settings.PodcastGridLayoutType.LARGE_ARTWORK)
+                        trackLayoutChanged(PodcastGridLayoutType.LARGE_ARTWORK)
                     }
                 ),
                 ToggleButtonOption(
                     imageId = R.drawable.ic_smallgrid,
                     descriptionId = LR.string.podcasts_layout_small_grid,
-                    isOn = { settings.getPodcastsLayout() == Settings.PodcastGridLayoutType.SMALL_ARTWORK.id },
+                    isOn = { settings.podcastGridLayout.flow.value == PodcastGridLayoutType.SMALL_ARTWORK },
                     click = {
-                        settings.setPodcastsLayout(Settings.PodcastGridLayoutType.SMALL_ARTWORK.id)
+                        settings.podcastGridLayout.set(PodcastGridLayoutType.SMALL_ARTWORK)
                         trackTapOnModalOption(ModalOption.LAYOUT)
-                        trackLayoutChanged(Settings.PodcastGridLayoutType.SMALL_ARTWORK)
+                        trackLayoutChanged(PodcastGridLayoutType.SMALL_ARTWORK)
                     }
                 ),
                 ToggleButtonOption(
                     imageId = R.drawable.ic_list,
                     descriptionId = LR.string.podcasts_layout_list_view,
-                    isOn = { settings.getPodcastsLayout() == Settings.PodcastGridLayoutType.LIST_VIEW.id },
+                    isOn = { settings.podcastGridLayout.flow.value == PodcastGridLayoutType.LIST_VIEW },
                     click = {
-                        settings.setPodcastsLayout(Settings.PodcastGridLayoutType.LIST_VIEW.id)
+                        settings.podcastGridLayout.set(PodcastGridLayoutType.LIST_VIEW)
                         trackTapOnModalOption(ModalOption.LAYOUT)
-                        trackLayoutChanged(Settings.PodcastGridLayoutType.LIST_VIEW)
+                        trackLayoutChanged(PodcastGridLayoutType.LIST_VIEW)
                     }
                 )
             )
@@ -171,7 +172,7 @@ class PodcastsOptionsDialog(
         analyticsTracker.track(AnalyticsEvent.PODCASTS_LIST_SORT_ORDER_CHANGED, mapOf(SORT_BY_KEY to order.analyticsValue))
     }
 
-    private fun trackLayoutChanged(layoutType: Settings.PodcastGridLayoutType) {
+    private fun trackLayoutChanged(layoutType: PodcastGridLayoutType) {
         analyticsTracker.track(AnalyticsEvent.PODCASTS_LIST_LAYOUT_CHANGED, mapOf(LAYOUT_KEY to layoutType.analyticsValue))
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
@@ -32,7 +32,7 @@ class PodcastsOptionsDialog(
             .addTextOption(
                 titleId = LR.string.podcasts_menu_sort_by,
                 imageId = IR.drawable.ic_sort,
-                valueId = settings.getPodcastsSortType().labelId,
+                valueId = settings.podcastsSortType.flow.value.labelId,
                 click = {
                     openSortOptions()
                     trackTapOnModalOption(ModalOption.SORT_BY)
@@ -101,7 +101,7 @@ class PodcastsOptionsDialog(
     }
 
     private fun openSortOptions() {
-        val sortOrder = settings.getPodcastsSortType()
+        val sortOrder = settings.podcastsSortType.flow.value
         val title = fragment.getString(LR.string.sort_by)
         val dialog = OptionsDialog().setTitle(title)
         for (order in PodcastsSortType.values()) {
@@ -109,7 +109,7 @@ class PodcastsOptionsDialog(
                 titleId = order.labelId,
                 checked = order.clientId == sortOrder.clientId,
                 click = {
-                    settings.setPodcastsSortType(sortType = order, sync = true)
+                    settings.podcastsSortType.set(order, needsSync = true)
                     trackSortByChanged(order)
                 }
             )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.podcasts.R
 import au.com.shiftyjelly.pocketcasts.podcasts.view.share.ShareListCreateActivity
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -73,7 +74,7 @@ class PodcastsOptionsDialog(
             .addTextOption(
                 titleId = LR.string.podcasts_menu_badges,
                 imageId = R.drawable.ic_badge,
-                valueId = settings.getPodcastBadgeType().labelId,
+                valueId = settings.podcastBadgeType.flow.value.labelId,
                 click = {
                     openBadgeOptions()
                     trackTapOnModalOption(ModalOption.BADGE)
@@ -119,34 +120,34 @@ class PodcastsOptionsDialog(
     }
 
     private fun openBadgeOptions() {
-        val badgeType: Settings.BadgeType = settings.getPodcastBadgeType()
+        val badgeType: BadgeType = settings.podcastBadgeType.flow.value
         val title = fragment.getString(LR.string.podcasts_menu_badges)
         val dialog = OptionsDialog()
             .setTitle(title)
             .addCheckedOption(
                 titleId = LR.string.podcasts_badges_off,
-                checked = badgeType == Settings.BadgeType.OFF,
+                checked = badgeType == BadgeType.OFF,
                 click = {
-                    val newBadgeType = Settings.BadgeType.OFF
-                    settings.setPodcastBadgeType(newBadgeType)
+                    val newBadgeType = BadgeType.OFF
+                    settings.podcastBadgeType.set(newBadgeType)
                     trackBadgeChanged(newBadgeType)
                 }
             )
             .addCheckedOption(
                 titleId = LR.string.podcasts_badges_all_unfinished,
-                checked = badgeType == Settings.BadgeType.ALL_UNFINISHED,
+                checked = badgeType == BadgeType.ALL_UNFINISHED,
                 click = {
-                    val newBadgeType = Settings.BadgeType.ALL_UNFINISHED
-                    settings.setPodcastBadgeType(newBadgeType)
+                    val newBadgeType = BadgeType.ALL_UNFINISHED
+                    settings.podcastBadgeType.set(newBadgeType)
                     trackBadgeChanged(newBadgeType)
                 }
             )
             .addCheckedOption(
                 titleId = LR.string.podcasts_badges_only_latest_episode,
-                checked = badgeType == Settings.BadgeType.LATEST_EPISODE,
+                checked = badgeType == BadgeType.LATEST_EPISODE,
                 click = {
-                    val newBadgeType = Settings.BadgeType.LATEST_EPISODE
-                    settings.setPodcastBadgeType(newBadgeType)
+                    val newBadgeType = BadgeType.LATEST_EPISODE
+                    settings.podcastBadgeType.set(newBadgeType)
                     trackBadgeChanged(newBadgeType)
                 }
             )
@@ -174,7 +175,7 @@ class PodcastsOptionsDialog(
         analyticsTracker.track(AnalyticsEvent.PODCASTS_LIST_LAYOUT_CHANGED, mapOf(LAYOUT_KEY to layoutType.analyticsValue))
     }
 
-    private fun trackBadgeChanged(badgeType: Settings.BadgeType) {
+    private fun trackBadgeChanged(badgeType: BadgeType) {
         analyticsTracker.track(AnalyticsEvent.PODCASTS_LIST_BADGES_CHANGED, mapOf(TYPE_KEY to badgeType.analyticsValue))
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -25,7 +25,6 @@ import io.reactivex.Flowable.combineLatest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.combineLatest
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asObservable
@@ -87,7 +86,7 @@ class PodcastsViewModel
         // monitor the folder uuid
         folderUuidObservable.toFlowable(BackpressureStrategy.LATEST),
         // monitor the home folder sort order
-        settings.podcastSortTypeObservable.toFlowable(BackpressureStrategy.LATEST),
+        settings.podcastsSortType.flow.asObservable(coroutineContext).toFlowable(BackpressureStrategy.LATEST),
         // show folders for Plus users
         userManager.getSignInState()
     ) { podcasts, folders, folderUuidOptional, podcastSortOrder, signInState ->
@@ -245,7 +244,7 @@ class PodcastsViewModel
 
         val folder = folder
         if (folder == null) {
-            settings.setPodcastsSortType(sortType = PodcastsSortType.DRAG_DROP, sync = true)
+            settings.podcastsSortType.set(PodcastsSortType.DRAG_DROP, needsSync = true)
         } else {
             folderManager.updateSortType(folderUuid = folder.uuid, podcastsSortType = PodcastsSortType.DRAG_DROP)
         }
@@ -268,7 +267,7 @@ class PodcastsViewModel
             properties[NUMBER_OF_PODCASTS_KEY] = podcastManager.countSubscribed()
             properties[BADGE_TYPE_KEY] = settings.podcastBadgeType.flow.value.analyticsValue
             properties[LAYOUT_KEY] = settings.podcastGridLayout.flow.value.analyticsValue
-            properties[SORT_ORDER_KEY] = settings.getPodcastsSortType().analyticsValue
+            properties[SORT_ORDER_KEY] = settings.podcastsSortType.flow.value.analyticsValue
             analyticsTracker.track(AnalyticsEvent.PODCASTS_LIST_SHOWN, properties)
         }
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -229,10 +229,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                 AnalyticsEvent.SETTINGS_GENERAL_SKIP_FORWARD_CHANGED,
                                 mapOf("value" to it)
                             )
-                            settings.skipForwardInSecs.run {
-                                set(it)
-                                needsSync = true
-                            }
+                            settings.skipForwardInSecs.set(it, needsSync = true)
                         }
                     )
 
@@ -245,10 +242,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                 AnalyticsEvent.SETTINGS_GENERAL_SKIP_BACK_CHANGED,
                                 mapOf("value" to it)
                             )
-                            settings.skipBackInSecs.run {
-                                set(it)
-                                needsSync = true
-                            }
+                            settings.skipBackInSecs.set(it, needsSync = true)
                         }
                     )
 

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
@@ -90,7 +90,7 @@ class AppLifecycleObserverTest {
 
         verify(appLifecycleAnalytics).onNewApplicationInstall()
 
-        verify(autoPlayNextEpisodeSetting, never()).set(any(), any())
+        verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any())
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
     }
 
@@ -105,7 +105,7 @@ class AppLifecycleObserverTest {
 
         verify(appLifecycleAnalytics).onNewApplicationInstall()
 
-        verify(autoPlayNextEpisodeSetting, never()).set(any(), any())
+        verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any())
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
     }
 
@@ -121,6 +121,6 @@ class AppLifecycleObserverTest {
         verify(appLifecycleAnalytics).onApplicationUpgrade(VERSION_CODE_AFTER_FIRST_INSTALL)
 
         verify(appLifecycleAnalytics, never()).onNewApplicationInstall()
-        verify(autoPlayNextEpisodeSetting, never()).set(any(), any())
+        verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any())
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImage.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 
@@ -57,7 +57,7 @@ fun FolderImage(
     modifier: Modifier = Modifier,
     fontSize: TextUnit = 11.sp,
     badgeCount: Int = 0,
-    badgeType: Settings.BadgeType = Settings.BadgeType.OFF
+    badgeType: BadgeType = BadgeType.OFF
 ) {
     BoxWithConstraints(
         contentAlignment = Alignment.Center,
@@ -148,7 +148,7 @@ fun FolderImage(
 }
 
 @Composable
-private fun PodcastBadge(modifier: Modifier = Modifier, count: Int, badgeType: Settings.BadgeType) {
+private fun PodcastBadge(modifier: Modifier = Modifier, count: Int, badgeType: BadgeType) {
     if (count == 0) {
         return
     }
@@ -166,7 +166,7 @@ private fun PodcastBadge(modifier: Modifier = Modifier, count: Int, badgeType: S
         )
     }
     Text(
-        text = if (badgeType != Settings.BadgeType.LATEST_EPISODE) count.toString() else "●",
+        text = if (badgeType != BadgeType.LATEST_EPISODE) count.toString() else "●",
         fontSize = if (count > 9) 12.sp else 14.sp,
         fontWeight = FontWeight.Bold,
         color = Color.White,
@@ -244,7 +244,7 @@ private fun FolderImagePreview() {
         color = Color.Blue,
         podcastUuids = emptyList(),
         badgeCount = 1,
-        badgeType = Settings.BadgeType.ALL_UNFINISHED,
+        badgeType = BadgeType.ALL_UNFINISHED,
         modifier = Modifier.size(100.dp)
     )
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/PodcastsSortType.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/PodcastsSortType.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.models.type
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
@@ -56,9 +57,25 @@ enum class PodcastsSortType(
     );
 
     companion object {
-        fun fromServerId(id: Int?): PodcastsSortType {
-            id ?: return DATE_ADDED_OLDEST_TO_NEWEST
-            return values().firstOrNull { it.serverId == id } ?: DATE_ADDED_OLDEST_TO_NEWEST
+        val default = DATE_ADDED_OLDEST_TO_NEWEST
+
+        fun fromServerId(serverId: Int?): PodcastsSortType {
+            val sortType = values().firstOrNull { it.serverId == serverId }
+            if (sortType == null) {
+                LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Invalid server ${PodcastsSortType::class.java.simpleName}: $serverId")
+                return default
+            }
+            return sortType
+        }
+
+        fun fromClientIdString(clientIdString: String): PodcastsSortType {
+            val clientId = clientIdString.toIntOrNull()
+            val sortType = PodcastsSortType.values().firstOrNull { it.clientId == clientId }
+            if (sortType == null) {
+                LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Invalid client ${PodcastsSortType::class.java.simpleName}: $clientIdString")
+                return default
+            }
+            return sortType
         }
 
         fun cleanStringForSort(value: String): String {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -79,8 +79,6 @@ interface Settings {
         const val PREFERENCE_STORAGE_CHOICE = "storageChoice"
         const val PREFERENCE_STORAGE_CHOICE_NAME = "storageChoiceName"
         const val PREFERENCE_STORAGE_CUSTOM_FOLDER = "storageCustomFolder"
-        const val PREFERENCE_PODCAST_LIBRARY_SORT = "podcastLibrarySort"
-        const val PREFERENCE_PODCAST_LIBRARY_SORT_NEEDS_SYNC = "podcastLibrarySortNeedsSync"
         const val PREFERENCE_SELECT_PODCAST_LIBRARY_SORT = "selectPodcastLibrarySort"
         const val PREFERENCE_WARN_WHEN_NOT_ON_WIFI = "warnWhenNotOnWifi"
         const val PREFERENCE_SYNC_ON_METERED = "SyncWhenOnMetered"
@@ -197,7 +195,6 @@ interface Settings {
         object Star : MediaNotificationControls(LR.string.star, IR.drawable.ic_star, STAR_KEY)
     }
 
-    val podcastSortTypeObservable: Observable<PodcastsSortType>
     val selectPodcastSortTypeObservable: Observable<PodcastsSortType>
     val playbackEffectsObservable: Observable<PlaybackEffects>
     val refreshStateObservable: Observable<RefreshState>
@@ -232,10 +229,7 @@ interface Settings {
     fun getWorkManagerNetworkTypeConstraint(): NetworkType
     fun refreshPodcastsOnResume(isUnmetered: Boolean): Boolean
     val backgroundRefreshPodcasts: UserSetting<Boolean>
-    fun setPodcastsSortType(sortType: PodcastsSortType, sync: Boolean)
-    fun setPodcastsSortTypeNeedsSync(value: Boolean)
-    fun getPodcastsSortTypeNeedsSync(): Boolean
-    fun getPodcastsSortType(): PodcastsSortType
+    val podcastsSortType: UserSetting<PodcastsSortType>
 
     fun setSelectPodcastsSortType(sortType: PodcastsSortType)
     fun getSelectPodcastsSortType(): PodcastsSortType

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.AppIconSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoAddUpNextLimitBehaviour
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveInactiveSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
 import au.com.shiftyjelly.pocketcasts.preferences.model.NewEpisodeNotificationActionSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.NotificationVibrateSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
@@ -142,12 +143,6 @@ interface Settings {
         SIGN_IN_ERROR(21483649),
     }
 
-    enum class BadgeType(val labelId: Int, val analyticsValue: String) {
-        OFF(labelId = LR.string.podcasts_badges_off, analyticsValue = "off"),
-        LATEST_EPISODE(labelId = LR.string.podcasts_badges_only_latest_episode, analyticsValue = "only_latest_episode"),
-        ALL_UNFINISHED(labelId = LR.string.podcasts_badges_all_unfinished, analyticsValue = "unfinished_episodes")
-    }
-
     enum class PodcastGridLayoutType(val id: Int, val analyticsValue: String) {
         LARGE_ARTWORK(id = 0, analyticsValue = "large_artwork"),
         SMALL_ARTWORK(id = 1, analyticsValue = "small_artwork"),
@@ -212,7 +207,6 @@ interface Settings {
     }
 
     val podcastLayoutObservable: Observable<Int>
-    val podcastBadgeTypeObservable: Observable<BadgeType>
     val podcastSortTypeObservable: Observable<PodcastsSortType>
     val selectPodcastSortTypeObservable: Observable<PodcastsSortType>
     val playbackEffectsObservable: Observable<PlaybackEffects>
@@ -337,8 +331,7 @@ interface Settings {
 
     fun setMigratedVersionCode(versionCode: Int)
 
-    fun getPodcastBadgeType(): BadgeType
-    fun setPodcastBadgeType(badgeType: BadgeType)
+    val podcastBadgeType: UserSetting<BadgeType>
     fun setPodcastsLayout(layout: Int)
     fun getPodcastsLayout(): Int
     fun isPodcastsLayoutListView(): Boolean

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -21,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
 import au.com.shiftyjelly.pocketcasts.preferences.model.NewEpisodeNotificationActionSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.NotificationVibrateSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.PodcastGridLayoutType
 import au.com.shiftyjelly.pocketcasts.preferences.model.ThemeSetting
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.StateFlow
@@ -143,16 +144,6 @@ interface Settings {
         SIGN_IN_ERROR(21483649),
     }
 
-    enum class PodcastGridLayoutType(val id: Int, val analyticsValue: String) {
-        LARGE_ARTWORK(id = 0, analyticsValue = "large_artwork"),
-        SMALL_ARTWORK(id = 1, analyticsValue = "small_artwork"),
-        LIST_VIEW(id = 2, analyticsValue = "list");
-        companion object {
-            fun fromLayoutId(id: Int) =
-                PodcastGridLayoutType.values().find { it.id == id } ?: LARGE_ARTWORK
-        }
-    }
-
     enum class UpNextAction {
         PLAY_NEXT,
         PLAY_LAST
@@ -206,7 +197,6 @@ interface Settings {
         object Star : MediaNotificationControls(LR.string.star, IR.drawable.ic_star, STAR_KEY)
     }
 
-    val podcastLayoutObservable: Observable<Int>
     val podcastSortTypeObservable: Observable<PodcastsSortType>
     val selectPodcastSortTypeObservable: Observable<PodcastsSortType>
     val playbackEffectsObservable: Observable<PlaybackEffects>
@@ -332,9 +322,7 @@ interface Settings {
     fun setMigratedVersionCode(versionCode: Int)
 
     val podcastBadgeType: UserSetting<BadgeType>
-    fun setPodcastsLayout(layout: Int)
-    fun getPodcastsLayout(): Int
-    fun isPodcastsLayoutListView(): Boolean
+    val podcastGridLayout: UserSetting<PodcastGridLayoutType>
 
     fun getNotificationLastSeen(): Date?
     fun setNotificationLastSeen(lastSeen: Date?)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -28,6 +28,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.AppIconSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoAddUpNextLimitBehaviour
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveInactiveSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
 import au.com.shiftyjelly.pocketcasts.preferences.model.NewEpisodeNotificationActionSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.NotificationVibrateSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
@@ -77,7 +78,6 @@ class SettingsImpl @Inject constructor(
     private var languageCode: String? = null
 
     override val podcastLayoutObservable = BehaviorRelay.create<Int>().apply { accept(getPodcastsLayout()) }
-    override val podcastBadgeTypeObservable = BehaviorRelay.create<Settings.BadgeType>().apply { accept(getPodcastBadgeType()) }
     override val podcastSortTypeObservable = BehaviorRelay.create<PodcastsSortType>().apply { accept(getPodcastsSortType()) }
     override val selectPodcastSortTypeObservable = BehaviorRelay.create<PodcastsSortType>().apply { accept(getSelectPodcastsSortType()) }
     override val playbackEffectsObservable = BehaviorRelay.create<PlaybackEffects>().apply { accept(getGlobalPlaybackEffects()) }
@@ -694,14 +694,13 @@ class SettingsImpl @Inject constructor(
         setInt("MIGRATED_VERSION_CODE", versionCode)
     }
 
-    override fun getPodcastBadgeType(): Settings.BadgeType {
-        return Settings.BadgeType.values()[getInt("PODCAST_BADGE_TYPE", Settings.BadgeType.OFF.ordinal)]
-    }
-
-    override fun setPodcastBadgeType(badgeType: Settings.BadgeType) {
-        setInt("PODCAST_BADGE_TYPE", badgeType.ordinal)
-        podcastBadgeTypeObservable.accept(badgeType)
-    }
+    override val podcastBadgeType = UserSetting.PrefFromInt<BadgeType>(
+        sharedPrefKey = "PODCAST_BADGE_TYPE",
+        defaultValue = BadgeType.defaultValue,
+        sharedPrefs = sharedPreferences,
+        fromInt = { BadgeType.fromPersistedInt(it) },
+        toInt = { it.persistedInt }
+    )
 
     override fun setPodcastsLayout(layout: Int) {
         setInt("PODCAST_GRID_LAYOUT", layout)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -78,7 +78,6 @@ class SettingsImpl @Inject constructor(
 
     private var languageCode: String? = null
 
-    override val podcastSortTypeObservable = BehaviorRelay.create<PodcastsSortType>().apply { accept(getPodcastsSortType()) }
     override val selectPodcastSortTypeObservable = BehaviorRelay.create<PodcastsSortType>().apply { accept(getSelectPodcastsSortType()) }
     override val playbackEffectsObservable = BehaviorRelay.create<PlaybackEffects>().apply { accept(getGlobalPlaybackEffects()) }
     override val marketingOptObservable = BehaviorRelay.create<Boolean>().apply { accept(getMarketingOptIn()) }
@@ -230,33 +229,13 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override fun setPodcastsSortType(sortType: PodcastsSortType, sync: Boolean) {
-        if (getPodcastsSortType() == sortType) {
-            return
-        }
-        val editor = sharedPreferences.edit()
-        editor.putString(Settings.PREFERENCE_PODCAST_LIBRARY_SORT, sortType.clientId.toString())
-        editor.apply()
-        podcastSortTypeObservable.accept(sortType)
-        if (sync) {
-            setPodcastsSortTypeNeedsSync(true)
-        }
-    }
-
-    override fun setPodcastsSortTypeNeedsSync(value: Boolean) {
-        setBoolean(Settings.PREFERENCE_PODCAST_LIBRARY_SORT_NEEDS_SYNC, value)
-    }
-
-    override fun getPodcastsSortTypeNeedsSync(): Boolean {
-        return getBoolean(Settings.PREFERENCE_PODCAST_LIBRARY_SORT_NEEDS_SYNC, false)
-    }
-
-    override fun getPodcastsSortType(): PodcastsSortType {
-        val default = PodcastsSortType.DATE_ADDED_OLDEST_TO_NEWEST
-        val defaultId = default.clientId.toString()
-        val sortOrderId = Integer.parseInt(getString(Settings.PREFERENCE_PODCAST_LIBRARY_SORT, defaultId) ?: defaultId)
-        return PodcastsSortType.values().find { it.clientId == sortOrderId } ?: default
-    }
+    override val podcastsSortType = UserSetting.PrefFromString(
+        sharedPrefKey = "podcastLibrarySort",
+        defaultValue = PodcastsSortType.default,
+        sharedPrefs = sharedPreferences,
+        fromString = { PodcastsSortType.fromClientIdString(it) },
+        toString = { it.clientId.toString() },
+    )
 
     override fun setSelectPodcastsSortType(sortType: PodcastsSortType) {
         sharedPreferences.edit().apply {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -32,6 +32,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
 import au.com.shiftyjelly.pocketcasts.preferences.model.NewEpisodeNotificationActionSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.NotificationVibrateSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.PodcastGridLayoutType
 import au.com.shiftyjelly.pocketcasts.preferences.model.ThemeSetting
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Util
@@ -77,7 +78,6 @@ class SettingsImpl @Inject constructor(
 
     private var languageCode: String? = null
 
-    override val podcastLayoutObservable = BehaviorRelay.create<Int>().apply { accept(getPodcastsLayout()) }
     override val podcastSortTypeObservable = BehaviorRelay.create<PodcastsSortType>().apply { accept(getPodcastsSortType()) }
     override val selectPodcastSortTypeObservable = BehaviorRelay.create<PodcastsSortType>().apply { accept(getSelectPodcastsSortType()) }
     override val playbackEffectsObservable = BehaviorRelay.create<PlaybackEffects>().apply { accept(getGlobalPlaybackEffects()) }
@@ -702,10 +702,13 @@ class SettingsImpl @Inject constructor(
         toInt = { it.persistedInt }
     )
 
-    override fun setPodcastsLayout(layout: Int) {
-        setInt("PODCAST_GRID_LAYOUT", layout)
-        podcastLayoutObservable.accept(layout)
-    }
+    override val podcastGridLayout = UserSetting.PrefFromInt<PodcastGridLayoutType>(
+        sharedPrefKey = "PODCAST_GRID_LAYOUT",
+        defaultValue = PodcastGridLayoutType.default,
+        sharedPrefs = sharedPreferences,
+        fromInt = { PodcastGridLayoutType.fromLayoutId(it) },
+        toInt = { it.id }
+    )
 
     override fun getNotificationLastSeen(): Date? {
         return getDate("NOTIFICATION_LAST_SEEN")
@@ -930,14 +933,6 @@ class SettingsImpl @Inject constructor(
             }
         },
     )
-
-    override fun getPodcastsLayout(): Int {
-        return getInt("PODCAST_GRID_LAYOUT", Settings.PodcastGridLayoutType.LARGE_ARTWORK.id)
-    }
-
-    override fun isPodcastsLayoutListView(): Boolean {
-        return getPodcastsLayout() == Settings.PodcastGridLayoutType.LIST_VIEW.id
-    }
 
     override fun getAutoArchiveExcludedPodcasts(): List<String> {
         return sharedPreferences.getStringSet(Settings.AUTO_ARCHIVE_EXCLUDED_PODCASTS, null)?.toList() ?: emptyList()

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/BadgeType.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/BadgeType.kt
@@ -1,0 +1,40 @@
+package au.com.shiftyjelly.pocketcasts.preferences.model
+
+import androidx.annotation.StringRes
+import au.com.shiftyjelly.pocketcasts.localization.R
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+
+enum class BadgeType(
+    internal val persistedInt: Int,
+    @StringRes val labelId: Int,
+    val analyticsValue: String,
+) {
+    OFF(
+        persistedInt = 0,
+        labelId = R.string.podcasts_badges_off,
+        analyticsValue = "off",
+    ),
+
+    LATEST_EPISODE(
+        persistedInt = 1,
+        labelId = R.string.podcasts_badges_only_latest_episode,
+        analyticsValue = "only_latest_episode",
+    ),
+
+    ALL_UNFINISHED(
+        persistedInt = 2,
+        labelId = R.string.podcasts_badges_all_unfinished,
+        analyticsValue = "unfinished_episodes",
+    );
+
+    companion object {
+        val defaultValue = OFF
+
+        fun fromPersistedInt(value: Int): BadgeType =
+            BadgeType.values().find { it.persistedInt == value }
+                ?: run {
+                    LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Unknown persisted int for badge type: $value")
+                    defaultValue
+                }
+    }
+}

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/PodcastGridLayoutType.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/PodcastGridLayoutType.kt
@@ -1,0 +1,13 @@
+package au.com.shiftyjelly.pocketcasts.preferences.model
+
+enum class PodcastGridLayoutType(val id: Int, val analyticsValue: String) {
+    LARGE_ARTWORK(id = 0, analyticsValue = "large_artwork"),
+    SMALL_ARTWORK(id = 1, analyticsValue = "small_artwork"),
+    LIST_VIEW(id = 2, analyticsValue = "list");
+
+    companion object {
+        val default = LARGE_ARTWORK
+        fun fromLayoutId(id: Int) =
+            PodcastGridLayoutType.values().find { it.id == id } ?: default
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
@@ -171,7 +171,7 @@ class FolderManagerImpl @Inject constructor(
     }
 
     override suspend fun getHomeFolder(): List<FolderItem> {
-        val sortType = settings.getPodcastsSortType()
+        val sortType = settings.podcastsSortType.flow.value
 
         val podcasts = if (sortType == EPISODE_DATE_NEWEST_TO_OLDEST) {
             podcastManager.findPodcastsOrderByLatestEpisode(orderAsc = false)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -396,7 +396,7 @@ class PodcastManagerImpl @Inject constructor(
     }
 
     override suspend fun findSubscribedSorted(): List<Podcast> {
-        val sortType = settings.getPodcastsSortType()
+        val sortType = settings.podcastsSortType.flow.value
         // use a query to get the podcasts ordered by episode release date
         if (sortType == PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST) {
             return findPodcastsOrderByLatestEpisode(orderAsc = false)


### PR DESCRIPTION
## Description
This converts the podcasts display settings to be UserSettings.

In addition, I made some minor changes to how we track whether a setting needs to be synced.

## Testing Instructions

### 1. Verify settings work
1. On a fresh install of the app
2. Subscribe to some podcasts
3. go to the podcasts screen and tap the three dot overflow menu
4. verify the following defaults:
    1. Sort by: Date added
    2. Layout: large grid
    3. badges: off
1. On the podcasts tab, change the sort order, layout, and badges setting
5. Kill the app
6. Restart the app
7. verify that the settings persisted and are reflected in the UI

### 2. Check for sync regressions

Because I did some minor refactoring to how syncing is done, it would be good to retest that syncing setting to an account still works:

1. Fresh install the app
2. Log into an account
3. Change the skip forward and skip backward settings to new values
4. Sync the app
5. uninstall the app
6. reinstall the app and log into the account
7. Once the account has synced, verify that the updated setting values are shown


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews