### PR TITLE
Settings Sync - Make global playback effects into UserSettings

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
@@ -47,7 +47,7 @@ class PodcastEffectsViewModel
         launch {
             podcastManager.updateOverrideGlobalEffects(podcast, override)
             if (shouldUpdatePlaybackManager()) {
-                val effects = if (override) podcast.playbackEffects else settings.getGlobalPlaybackEffects()
+                val effects = if (override) podcast.playbackEffects else settings.globalPlaybackEffects.flow.value
                 playbackManager.updatePlayerEffects(effects)
             }
         }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
-import au.com.shiftyjelly.pocketcasts.repositories.extensions.saveToGlobalSettings
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.playbackManager
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.podcastManager
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.settings
@@ -83,13 +82,13 @@ class ActionRunnerControlPlayback : TaskerPluginRunnerActionNoOutput<InputContro
         val playbackEffects: PlaybackEffects = if (overrideGlobalEffects) {
             currentPodcast.playbackEffects
         } else {
-            settings.getGlobalPlaybackEffects()
+            settings.globalPlaybackEffects.flow.value
         }
         playbackEffects.updater()
         if (overrideGlobalEffects) {
             podcastManager.updateEffects(currentPodcast, playbackEffects)
         } else {
-            playbackEffects.saveToGlobalSettings(settings)
+            settings.globalPlaybackEffects.set(playbackEffects)
         }
         playbackManager.updatePlayerEffects(playbackEffects)
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -12,7 +12,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.BookmarksSortTypeForPodcast
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
-import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.model.AppIconSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoAddUpNextLimitBehaviour
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
@@ -196,7 +195,6 @@ interface Settings {
     }
 
     val selectPodcastSortTypeObservable: Observable<PodcastsSortType>
-    val playbackEffectsObservable: Observable<PlaybackEffects>
     val refreshStateObservable: Observable<RefreshState>
     val marketingOptObservable: Observable<Boolean>
     val isFirstSyncRunObservable: Observable<Boolean>
@@ -298,12 +296,7 @@ interface Settings {
 
     val useEmbeddedArtwork: UserSetting<Boolean>
 
-    fun getGlobalPlaybackEffects(): PlaybackEffects
-    fun getGlobalPlaybackSpeed(): Double
-    fun getGlobalAudioEffectRemoveSilence(): TrimMode
-    fun getGlobalAudioEffectVolumeBoost(): Boolean
-
-    fun setGlobalAudioEffects(playbackSpeed: Double, trimMode: TrimMode, isVolumeBoosted: Boolean)
+    val globalPlaybackEffects: UserSetting<PlaybackEffects>
 
     fun allowOtherAppsAccessToEpisodes(): Boolean
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -129,10 +129,40 @@ abstract class UserSetting<T>(
         }
     }
 
+    // This persists the parameterized object as a Float in shared preferences.
+    open class PrefFromFloat<T>(
+        sharedPrefKey: String,
+        private val defaultValue: T,
+        sharedPrefs: SharedPreferences,
+        private val fromFloat: (Float) -> T,
+        private val toFloat: (T) -> Float,
+    ) : UserSetting<T>(
+        sharedPrefKey = sharedPrefKey,
+        sharedPrefs = sharedPrefs,
+    ) {
+        override fun get(): T {
+            val persistedInt = sharedPrefs.getFloat(sharedPrefKey, toFloat(defaultValue))
+            return fromFloat(persistedInt)
+        }
+
+        @SuppressLint("ApplySharedPref")
+        override fun persist(value: T, commit: Boolean) {
+            val floatValue = toFloat(value)
+            sharedPrefs.edit().run {
+                putFloat(sharedPrefKey, floatValue)
+                if (commit) {
+                    commit()
+                } else {
+                    apply()
+                }
+            }
+        }
+    }
+
     // This persists the parameterized object as a String in shared preferences.
     open class PrefFromString<T>(
         sharedPrefKey: String,
-        private val defaultValue: T,
+        defaultValue: T,
         sharedPrefs: SharedPreferences,
         private val fromString: (String) -> T,
         private val toString: (T) -> String,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/extensions/PlaybackEffects.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/extensions/PlaybackEffects.kt
@@ -1,8 +1,0 @@
-package au.com.shiftyjelly.pocketcasts.repositories.extensions
-
-import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
-
-fun PlaybackEffects.saveToGlobalSettings(settings: Settings) {
-    settings.setGlobalAudioEffects(playbackSpeed, trimMode, isVolumeBoosted)
-}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -25,7 +25,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationControls
-import au.com.shiftyjelly.pocketcasts.repositories.extensions.saveToGlobalSettings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.auto.AutoConverter
 import au.com.shiftyjelly.pocketcasts.repositories.playback.auto.AutoMediaId
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -668,9 +667,9 @@ class MediaSessionManager(
                 }
             }
             // update global playback speed
-            val effects = settings.getGlobalPlaybackEffects()
+            val effects = settings.globalPlaybackEffects.flow.value
             effects.playbackSpeed = newSpeed
-            effects.saveToGlobalSettings(settings)
+            settings.globalPlaybackEffects.set(effects)
             playbackManager.updatePlayerEffects(effects = effects)
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1586,7 +1586,11 @@ open class PlaybackManager @Inject constructor(
         player?.setPodcast(podcast)
         player?.setEpisode(episode)
 
-        val playbackEffects = if (podcast != null && podcast.overrideGlobalEffects) podcast.playbackEffects else settings.getGlobalPlaybackEffects()
+        val playbackEffects = if (podcast != null && podcast.overrideGlobalEffects) {
+            podcast.playbackEffects
+        } else {
+            settings.globalPlaybackEffects.flow.value
+        }
 
         val previousPlaybackState = playbackStateRelay.blockingFirst()
         val playbackState = PlaybackState(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -408,7 +408,7 @@ class Support @Inject constructor(
                 output.append("Hide notification on pause? ").append(if (settings.hideNotificationOnPause.flow.value) "yes" else "no").append(eol)
                 output.append(eol)
 
-                val effects = settings.getGlobalPlaybackEffects()
+                val effects = settings.globalPlaybackEffects.flow.value
                 output.append("Effects").append(eol)
                 output.append("Global Audio effects: ")
                     .append(" Playback speed: ").append(effects.playbackSpeed).append(eol)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.extensions.saveToGlobalSettings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.utils.extensions.clipToRange
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -29,7 +28,7 @@ class EffectsViewModel
         playbackManager.playbackStateRelay
             .asFlow()
             .map {
-                State.Loaded(settings.getGlobalPlaybackEffects())
+                State.Loaded(settings.globalPlaybackEffects.flow.value)
             }
             .stateIn(
                 scope = viewModelScope,
@@ -74,7 +73,7 @@ class EffectsViewModel
     private fun saveEffects(effects: PlaybackEffects) {
         viewModelScope.launch {
             playbackManager.updatePlayerEffects(effects)
-            effects.saveToGlobalSettings(settings)
+            settings.globalPlaybackEffects.set(effects)
         }
     }
 


### PR DESCRIPTION
## Description
This refactors the global playback efffets settings to use the UserSettings structure. I really liked how it was easy to just create a UserSetting for the `PlaybackEffects` that delegated to UserSettings for the speed, trim silence, and volume boost settings.

## Testing Instructions

### 1. Settings from previous versions get picked up
1. Install a build from the `feature/sync-settings-refactor` branch
2. Start playing an episode and update all the playback effects (speed, trim silence, volume boost)
3. Install a build from this PR
4. Verfiy that all the updated settings are carried over

### 2. Settings have proper defaults
1. Do a fresh install from this branch
2. Check that the speed value is defaulted to 1.0
3. Check that the trim silence setting is defaulted to off
4. Check that the volume boost setting is defaulted to off

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 