### PR TITLE
Settings Sync - Make newsletter settings a UserSetting

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
@@ -178,8 +178,7 @@ class CreateAccountViewModel
         )
         newsletter.value = isChecked
         newsletter.value?.let {
-            settings.setMarketingOptIn(it)
-            settings.setMarketingOptInNeedsSync(true)
+            settings.marketingOptIn.set(it, needsSync = true)
         }
     }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingWelcomeViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingWelcomeViewModel.kt
@@ -34,8 +34,7 @@ class OnboardingWelcomeViewModel @Inject constructor(
             )
         )
 
-        settings.setMarketingOptIn(newsletter)
-        settings.setMarketingOptInNeedsSync(true)
+        settings.marketingOptIn.set(newsletter, needsSync = true)
     }
 
     fun onShown(flow: OnboardingFlow) {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -71,8 +71,6 @@ interface Settings {
         const val PREFERENCE_SKIP_FORWARD = "skipForward"
         const val PREFERENCE_SKIP_BACKWARD = "skipBack"
 
-        const val PREFERENCE_MARKETING_OPT_IN = "marketingOptIn"
-        const val PREFERENCE_MARKETING_OPT_IN_NEEDS_SYNC = "marketingOptInNeedsSync"
         const val PREFERENCE_FREE_GIFT_ACKNOWLEDGED = "freeGiftAck"
         const val PREFERENCE_FREE_GIFT_ACKNOWLEDGED_NEEDS_SYNC = "freeGiftAckNeedsSync"
 
@@ -198,7 +196,6 @@ interface Settings {
     val selectPodcastSortTypeObservable: Observable<PodcastsSortType>
     val playbackEffectsObservable: Observable<PlaybackEffects>
     val refreshStateObservable: Observable<RefreshState>
-    val marketingOptObservable: Observable<Boolean>
     val isFirstSyncRunObservable: Observable<Boolean>
     val shelfItemsObservable: Observable<List<String>>
     val multiSelectItemsObservable: Observable<List<Int>>
@@ -374,10 +371,7 @@ interface Settings {
     fun getEpisodeSearchDebounceMs(): Long
     val podcastGroupingDefault: UserSetting<PodcastGrouping>
 
-    fun getMarketingOptIn(): Boolean
-    fun setMarketingOptIn(value: Boolean)
-    fun getMarketingOptInNeedsSync(): Boolean
-    fun setMarketingOptInNeedsSync(value: Boolean)
+    val marketingOptIn: UserSetting<Boolean>
 
     fun getFreeGiftAcknowledged(): Boolean
     fun setFreeGiftAcknowledged(value: Boolean)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -80,7 +80,6 @@ class SettingsImpl @Inject constructor(
 
     override val selectPodcastSortTypeObservable = BehaviorRelay.create<PodcastsSortType>().apply { accept(getSelectPodcastsSortType()) }
     override val playbackEffectsObservable = BehaviorRelay.create<PlaybackEffects>().apply { accept(getGlobalPlaybackEffects()) }
-    override val marketingOptObservable = BehaviorRelay.create<Boolean>().apply { accept(getMarketingOptIn()) }
     override val isFirstSyncRunObservable = BehaviorRelay.create<Boolean>().apply { accept(isFirstSyncRun()) }
     override val shelfItemsObservable = BehaviorRelay.create<List<String>>().apply { accept(getShelfItems()) }
     override val multiSelectItemsObservable = BehaviorRelay.create<List<Int>>().apply { accept(getMultiSelectItems()) }
@@ -154,22 +153,11 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override fun getMarketingOptIn(): Boolean {
-        return getBoolean(Settings.PREFERENCE_MARKETING_OPT_IN, false)
-    }
-
-    override fun setMarketingOptIn(value: Boolean) {
-        setBoolean(Settings.PREFERENCE_MARKETING_OPT_IN, value)
-        marketingOptObservable.accept(value)
-    }
-
-    override fun getMarketingOptInNeedsSync(): Boolean {
-        return getBoolean(Settings.PREFERENCE_MARKETING_OPT_IN_NEEDS_SYNC, false)
-    }
-
-    override fun setMarketingOptInNeedsSync(value: Boolean) {
-        setBoolean(Settings.PREFERENCE_MARKETING_OPT_IN_NEEDS_SYNC, value)
-    }
+    override val marketingOptIn = UserSetting.BoolPref(
+        sharedPrefKey = "marketingOptIn",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun getFreeGiftAcknowledged(): Boolean {
         return getBoolean(Settings.PREFERENCE_FREE_GIFT_ACKNOWLEDGED, false)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -114,8 +114,8 @@ class UserManagerImpl @Inject constructor(
                     userEpisodeManager.removeCloudStatusFromFiles(playbackManager)
                 }
 
-                settings.setMarketingOptIn(false)
-                settings.setMarketingOptInNeedsSync(false)
+                settings.marketingOptIn.set(false)
+                settings.marketingOptIn.needsSync = false
                 settings.setEndOfYearModalHasBeenShown(false)
 
                 analyticsTracker.track(

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -16,7 +16,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     settings = NamedSettingsSettings(
                         skipForward = settings.skipForwardInSecs.getSyncValue(),
                         skipBack = settings.skipBackInSecs.getSyncValue(),
-                        marketingOptIn = if (settings.getMarketingOptInNeedsSync()) settings.getMarketingOptIn() else null,
+                        marketingOptIn = settings.marketingOptIn.getSyncValue(),
                         freeGiftAcknowledged = if (settings.getFreeGiftAcknowledgedNeedsSync()) settings.getFreeGiftAcknowledged() else null,
                         gridOrder = settings.podcastsSortType.getSyncValue()?.serverId,
                     )
@@ -38,7 +38,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                             }
                         } else if (value.value is Boolean) {
                             when (key) {
-                                "marketingOptIn" -> settings.setMarketingOptIn(value.value)
+                                "marketingOptIn" -> settings.marketingOptIn.set(value.value)
                                 "freeGiftAcknowledgement" -> settings.setFreeGiftAcknowledged(value.value)
                             }
                         }
@@ -52,13 +52,13 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
             }
 
             listOf(
+                settings.marketingOptIn,
+                settings.podcastsSortType,
                 settings.skipBackInSecs,
                 settings.skipForwardInSecs,
-                settings.podcastsSortType,
             ).forEach {
-                it.hasBeenSynced()
+                it.needsSync = false
             }
-            settings.setMarketingOptInNeedsSync(false)
             settings.setFreeGiftAcknowledgedNeedsSync(false)
 
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Settings synced")


### PR DESCRIPTION
## Description
This makes the newsletter preference into a `UserSetting`. I also did a slight tweak to how we indicate whether a setting needs to be synced, but the actual behavior is unchanged.

## Testing Instructions
1. Veriify the newsletter setting value for a PC account
2. Log into that account on a clean install of the app
3. Verify that the account screen reflects the proper newsletter setting value
4. Change the newsletter setting value
5. Sync the app
6. Uninstall and reinstall the app
7. Verify that the new newsletter setting is picked up

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews