### PR TITLE
Settings Sync - Make promo code acknowlegement a UserSetting

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/PromoCodeFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/PromoCodeFragment.kt
@@ -64,8 +64,7 @@ class PromoCodeFragment : BaseFragment() {
                         binding.loadedGroup.isVisible = false
                         // We need to set this to true here so we know not to show the gift dialog.
                         // There is no way to know what type of gift the upgrade came via the API
-                        settings.setFreeGiftAcknowledged(true)
-                        settings.setFreeGiftAcknowledgedNeedsSync(true)
+                        settings.freeGiftAcknowledged.set(true, needsSync = true)
 
                         val result = Intent()
                         result.putExtra(AccountActivity.PROMO_CODE_RETURN_DESCRIPTION, it.response.description)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -73,8 +73,6 @@ interface Settings {
 
         const val PREFERENCE_MARKETING_OPT_IN = "marketingOptIn"
         const val PREFERENCE_MARKETING_OPT_IN_NEEDS_SYNC = "marketingOptInNeedsSync"
-        const val PREFERENCE_FREE_GIFT_ACKNOWLEDGED = "freeGiftAck"
-        const val PREFERENCE_FREE_GIFT_ACKNOWLEDGED_NEEDS_SYNC = "freeGiftAckNeedsSync"
 
         const val PREFERENCE_STORAGE_CHOICE = "storageChoice"
         const val PREFERENCE_STORAGE_CHOICE_NAME = "storageChoiceName"
@@ -379,10 +377,7 @@ interface Settings {
     fun getMarketingOptInNeedsSync(): Boolean
     fun setMarketingOptInNeedsSync(value: Boolean)
 
-    fun getFreeGiftAcknowledged(): Boolean
-    fun setFreeGiftAcknowledged(value: Boolean)
-    fun getFreeGiftAcknowledgedNeedsSync(): Boolean
-    fun setFreeGiftAcknowledgedNeedsSync(value: Boolean)
+    val freeGiftAcknowledged: UserSetting<Boolean>
 
     fun setCloudSortOrder(sortOrder: CloudSortOrder)
     fun getCloudSortOrder(): CloudSortOrder

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -171,21 +171,11 @@ class SettingsImpl @Inject constructor(
         setBoolean(Settings.PREFERENCE_MARKETING_OPT_IN_NEEDS_SYNC, value)
     }
 
-    override fun getFreeGiftAcknowledged(): Boolean {
-        return getBoolean(Settings.PREFERENCE_FREE_GIFT_ACKNOWLEDGED, false)
-    }
-
-    override fun setFreeGiftAcknowledged(value: Boolean) {
-        setBoolean(Settings.PREFERENCE_FREE_GIFT_ACKNOWLEDGED, value)
-    }
-
-    override fun getFreeGiftAcknowledgedNeedsSync(): Boolean {
-        return getBoolean(Settings.PREFERENCE_FREE_GIFT_ACKNOWLEDGED_NEEDS_SYNC, false)
-    }
-
-    override fun setFreeGiftAcknowledgedNeedsSync(value: Boolean) {
-        setBoolean(Settings.PREFERENCE_FREE_GIFT_ACKNOWLEDGED_NEEDS_SYNC, value)
-    }
+    override val freeGiftAcknowledged = UserSetting.BoolPref(
+        sharedPrefKey = "freeGiftAck",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun getCancelledAcknowledged(): Boolean {
         return getBoolean("cancelled_acknowledged", false)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -17,7 +17,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         skipForward = settings.skipForwardInSecs.getSyncValue(),
                         skipBack = settings.skipBackInSecs.getSyncValue(),
                         marketingOptIn = if (settings.getMarketingOptInNeedsSync()) settings.getMarketingOptIn() else null,
-                        freeGiftAcknowledged = if (settings.getFreeGiftAcknowledgedNeedsSync()) settings.getFreeGiftAcknowledged() else null,
+                        freeGiftAcknowledged = settings.freeGiftAcknowledged.getSyncValue(),
                         gridOrder = settings.podcastsSortType.getSyncValue()?.serverId,
                     )
                 )
@@ -39,7 +39,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         } else if (value.value is Boolean) {
                             when (key) {
                                 "marketingOptIn" -> settings.setMarketingOptIn(value.value)
-                                "freeGiftAcknowledgement" -> settings.setFreeGiftAcknowledged(value.value)
+                                "freeGiftAcknowledgement" -> settings.freeGiftAcknowledged.set(value.value)
                             }
                         }
                     } else {
@@ -52,6 +52,8 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
             }
 
             listOf(
+                settings.freeGiftAcknowledged,
+                settings.podcastsSortType,
                 settings.skipBackInSecs,
                 settings.skipForwardInSecs,
                 settings.podcastsSortType,
@@ -59,8 +61,6 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 it.hasBeenSynced()
             }
             settings.setMarketingOptInNeedsSync(false)
-            settings.setFreeGiftAcknowledgedNeedsSync(false)
-
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Settings synced")
 
             return Result.success()

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -56,7 +56,6 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 settings.podcastsSortType,
                 settings.skipBackInSecs,
                 settings.skipForwardInSecs,
-                settings.podcastsSortType,
             ).forEach {
                 it.hasBeenSynced()
             }


### PR DESCRIPTION
## Description
This makes the free gift acknowledgement a UserSetting.

I separated this setting out into its own PR because I think the code changes are simple enough to be reviewed on their own since this is just reusing the same settings infrastructure that I've migrated the other Settings to. I don't know a good way to test this without making a lot of code changes, so I wanted to make the code as easy to review as possible.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews