### PR TITLE
Settings sync - make discover country a User Setting

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
@@ -135,7 +135,7 @@ class OnboardingRecommendationsStartPageViewModel @Inject constructor(
                 return@launch
             }
 
-            val regionCode = settings.getDiscoveryCountryCode()
+            val regionCode = settings.discoverCountryCode.flow.value
             val region = feed.regions[regionCode]
                 ?: feed.regions[feed.defaultRegionCode]
                     .let {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -49,7 +49,7 @@ class DiscoverViewModel @Inject constructor(
     private val disposables = CompositeDisposable()
     private val sourceView = SourceView.DISCOVER
     val state = MutableLiveData<DiscoverState>().apply { value = DiscoverState.Loading }
-    var currentRegionCode: String? = settings.getDiscoveryCountryCode()
+    var currentRegionCode: String? = settings.discoverCountryCode.flow.value
     var replacements = emptyMap<String, String>()
     private var isFragmentChangingConfigurations: Boolean = false
 
@@ -100,7 +100,7 @@ class DiscoverViewModel @Inject constructor(
     }
 
     fun changeRegion(region: DiscoverRegion, resources: Resources) {
-        settings.setDiscoveryCountryCode(region.code)
+        settings.discoverCountryCode.set(region.code)
         currentRegionCode = region.code
         loadData(resources)
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -95,7 +95,6 @@ interface Settings {
         const val PREFERENCE_AUTO_SUBSCRIBE_ON_PLAY = "autoSubscribeToPlayed"
         const val PREFERENCE_AUTO_SHOW_PLAYED = "autoShowPlayed"
 
-        const val PREFERENCE_DISCOVERY_COUNTRY_CODE = "discovery_country_code"
         const val PREFERENCE_POPULAR_PODCAST_COUNTRY_CODE = "popular_podcast_country_code"
         const val STORAGE_ON_CUSTOM_FOLDER = "custom_folder"
 
@@ -257,8 +256,7 @@ interface Settings {
     fun getBooleanForKey(key: String, defaultValue: Boolean): Boolean
     fun setBooleanForKey(key: String, value: Boolean)
 
-    fun getDiscoveryCountryCode(): String
-    fun setDiscoveryCountryCode(code: String)
+    val discoverCountryCode: UserSetting<String>
 
     val warnOnMeteredNetwork: UserSetting<Boolean>
 
@@ -281,8 +279,6 @@ interface Settings {
     fun setRestoreFromBackupEnded()
 
     fun clearPlusPreferences()
-
-    fun getLanguageCode(): String
 
     val hideNotificationOnPause: UserSetting<Boolean>
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -387,16 +387,11 @@ class SettingsImpl @Inject constructor(
         editor.apply()
     }
 
-    override fun getDiscoveryCountryCode(): String {
-        val countryCode = sharedPreferences.getString(Settings.PREFERENCE_DISCOVERY_COUNTRY_CODE, null)
-        return countryCode ?: getLanguageCode()
-    }
-
-    override fun setDiscoveryCountryCode(code: String) {
-        val editor = sharedPreferences.edit()
-        editor.putString(Settings.PREFERENCE_DISCOVERY_COUNTRY_CODE, code)
-        editor.apply()
-    }
+    override val discoverCountryCode = UserSetting.StringPref(
+        sharedPrefKey = "discovery_country_code",
+        defaultValue = getDefaultCountryCode(),
+        sharedPrefs = sharedPreferences,
+    )
 
     override val warnOnMeteredNetwork = UserSetting.BoolPref(
         sharedPrefKey = Settings.PREFERENCE_WARN_WHEN_NOT_ON_WIFI,
@@ -538,7 +533,7 @@ class SettingsImpl @Inject constructor(
         setCancelledAcknowledged(false)
     }
 
-    override fun getLanguageCode(): String {
+    private fun getDefaultCountryCode(): String {
         val languageCode = languageCode
         if (languageCode != null) {
             return languageCode


### PR DESCRIPTION
## Description
Yet another PR migrating a setting to be a UserSetting (because apparently I like resolving merge conflicts 😅  ). 

## Testing Instructions

### 1. Persists country selection
1. Install a build from the `feature/sync-settings-refactor` branch
2. Change the country selection on the bottom of the discover page
3. Install a build from this PR
4. Verify that you still have your updated country selection
5. Change to a new country selection
6. Force close the app
7. Reopen the app and verify that your new country selection was persisted

### 2. Has appropriate default country selection
1. Do a clean install from their PR
2. Verify that you have the correct default country selection for your discover feed

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews