### PR TITLE
Improve handling of notification enabled setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Unknown
 *   Bug Fixes:
     *   Fixed auto archive settings getting lost when switching languages
         ([#1234](https://github.com/Automattic/pocket-casts-android/pull/1234))
+    *   Improved handling of enabling/disabling new episode notifications
+        ([#1264](https://github.com/Automattic/pocket-casts-android/pull/1264))
 
 7.46
 -----

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.widget.Toolbar
+import androidx.lifecycle.lifecycleScope
 import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
@@ -34,15 +35,12 @@ import com.afollestad.materialdialogs.list.MultiChoiceListener
 import com.afollestad.materialdialogs.list.listItemsMultiChoice
 import com.afollestad.materialdialogs.list.updateListItemsMultiChoice
 import dagger.hilt.android.AndroidEntryPoint
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -170,7 +168,7 @@ class NotificationsSettingsFragment :
             podcastManager.findSubscribed().forEach {
                 podcastManager.updateShowNotifications(it, newSelection.contains(it.uuid))
             }
-            launch(Dispatchers.Main) { changePodcastsSummary() }
+            changePodcastsSummary()
         }
     }
 
@@ -338,22 +336,19 @@ class NotificationsSettingsFragment :
         }
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
-    private fun changePodcastsSummary() {
-        GlobalScope.launch(Dispatchers.Default) {
-            val podcasts = podcastManager.findSubscribed()
-            val podcastCount = podcasts.size
-            val notificationCount = podcasts.count { it.isShowNotifications }
-
-            val summary = when {
-                notificationCount == 0 -> resources.getString(LR.string.settings_podcasts_selected_zero)
-                notificationCount == 1 -> resources.getString(LR.string.settings_podcasts_selected_one)
-                notificationCount >= podcastCount -> resources.getString(LR.string.settings_podcasts_selected_all)
-                else -> resources.getString(LR.string.settings_podcasts_selected_x, notificationCount)
-            }
-            launch(Dispatchers.Main) {
-                notificationPodcasts?.summary = summary
-            }
+    private suspend fun changePodcastsSummary() {
+        val podcasts = withContext(Dispatchers.IO) {
+            podcastManager.findSubscribed()
+        }
+        val notificationCount = podcasts.count { it.isShowNotifications }
+        val summary = when {
+            notificationCount == 0 -> resources.getString(LR.string.settings_podcasts_selected_zero)
+            notificationCount == 1 -> resources.getString(LR.string.settings_podcasts_selected_one)
+            notificationCount >= podcasts.size -> resources.getString(LR.string.settings_podcasts_selected_all)
+            else -> resources.getString(LR.string.settings_podcasts_selected_x, notificationCount)
+        }
+        withContext(Dispatchers.Main) {
+            notificationPodcasts?.summary = summary
         }
     }
 
@@ -362,7 +357,9 @@ class NotificationsSettingsFragment :
         setupEnabledNotifications()
         setupNotificationVibrate()
         setupPlayOverNotifications()
-        changePodcastsSummary()
+        launch {
+            changePodcastsSummary()
+        }
         setupHidePlaybackNotifications()
     }
 
@@ -419,13 +416,14 @@ class NotificationsSettingsFragment :
                         mapOf("enabled" to checked)
                     )
 
-                    podcastManager.updateAllShowNotificationsRx(checked)
-                        .observeOn(AndroidSchedulers.mainThread())
-                        .subscribeOn(Schedulers.io()).onErrorComplete().subscribe()
+                    lifecycleScope.launch {
+                        podcastManager.updateAllShowNotifications(checked)
+                        // Don't change the podcasts summary until after the podcasts have been updated
+                        changePodcastsSummary()
+                    }
                     if (checked) {
                         settings.setNotificationLastSeenToNow()
                     }
-                    changePodcastsSummary()
                     enabledPreferences(checked)
 
                     true

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
@@ -160,8 +160,7 @@ class NotificationsSettingsFragment :
 
     private fun updateNotificationsEnabled() {
         launch(Dispatchers.Default) {
-            val notificationCount = podcastManager.countNotificationsOn()
-            val enabled = notificationCount > 0
+            val enabled = settings.notifyRefreshPodcast.flow.value
 
             launch(Dispatchers.Main) {
                 enabledPreference?.isChecked = enabled
@@ -169,6 +168,7 @@ class NotificationsSettingsFragment :
 
                 enabledPreference?.setOnPreferenceChangeListener { _, newValue ->
                     val checked = newValue as Boolean
+                    settings.notifyRefreshPodcast.set(checked)
 
                     analyticsTracker.track(
                         AnalyticsEvent.SETTINGS_NOTIFICATIONS_NEW_EPISODES_TOGGLED,
@@ -403,6 +403,7 @@ class NotificationsSettingsFragment :
 
     override fun onResume() {
         super.onResume()
+        setupEnabledNotifications()
         setupNotificationVibrate()
         setupPlayOverNotifications()
         changePodcastsSummary()
@@ -443,6 +444,10 @@ class NotificationsSettingsFragment :
                 it.summary = getRingtoneValue(notificationSoundPath)
             }
         }
+    }
+
+    private fun setupEnabledNotifications() {
+        enabledPreference?.isChecked = settings.notifyRefreshPodcast.flow.value
     }
 
     private fun setupNotificationVibrate() {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -332,7 +332,7 @@ abstract class PodcastDao {
     abstract fun updateAllAutoDownloadStatus(autoDownloadStatus: Int)
 
     @Query("UPDATE podcasts SET show_notifications = :showNotifications")
-    abstract fun updateAllShowNotifications(showNotifications: Boolean)
+    abstract suspend fun updateAllShowNotifications(showNotifications: Boolean)
 
     @Query("UPDATE podcasts SET auto_download_status = :autoDownloadStatus WHERE uuid = :uuid")
     abstract fun updateAutoDownloadStatus(autoDownloadStatus: Int, uuid: String)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -12,7 +12,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Maybe
 import io.reactivex.Single
@@ -68,8 +67,7 @@ interface PodcastManager {
     fun updatePodcast(podcast: Podcast)
 
     fun updateAllAutoDownloadStatus(autoDownloadStatus: Int)
-    fun updateAllShowNotifications(showNotifications: Boolean)
-    fun updateAllShowNotificationsRx(showNotifications: Boolean): Completable
+    suspend fun updateAllShowNotifications(showNotifications: Boolean)
     fun updateAutoDownloadStatus(podcast: Podcast, autoDownloadStatus: Int)
     suspend fun updateAutoAddToUpNext(podcast: Podcast, autoAddToUpNext: Podcast.AutoAddUpNext)
     suspend fun updateAutoAddToUpNexts(podcastUuids: List<String>, autoAddToUpNext: Podcast.AutoAddUpNext)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -32,7 +32,6 @@ import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.jakewharton.rxrelay2.PublishRelay
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.BackpressureStrategy
-import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Maybe
 import io.reactivex.Single
@@ -560,12 +559,8 @@ class PodcastManagerImpl @Inject constructor(
         podcastDao.updateAllAutoDownloadStatus(autoDownloadStatus)
     }
 
-    override fun updateAllShowNotifications(showNotifications: Boolean) {
+    override suspend fun updateAllShowNotifications(showNotifications: Boolean) {
         podcastDao.updateAllShowNotifications(showNotifications)
-    }
-
-    override fun updateAllShowNotificationsRx(showNotifications: Boolean): Completable {
-        return Completable.fromAction { updateAllShowNotifications(showNotifications) }
     }
 
     override fun updateAutoDownloadStatus(podcast: Podcast, autoDownloadStatus: Int) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -627,6 +627,9 @@ class PodcastManagerImpl @Inject constructor(
     }
 
     override fun updateShowNotifications(podcast: Podcast, show: Boolean) {
+        if (show) {
+            settings.notifyRefreshPodcast.set(true)
+        }
         podcastDao.updateShowNotifications(show, podcast.uuid)
     }
 


### PR DESCRIPTION
## Description
This PR addresses an issue where we were not using the notifications enabled setting to determine the state of the notifications enabled toggle. Instead we were checking whether any podcasts had notifications enabled. This PR updates this and makes the behavior consistent with iOS.

This issue exists on `main` and is not a result of the recent Settings refactorings.

This change feels a bit tricky, so let me know if you can think of any undesireable behavior that these changes might introduce.

I am targeting the settings sync refactor branch with this change because it is easier to just include this with the other settings changes, and I anticipate that I'll be merging this branch to `main` pretty soon. 

## Testing Instructions

1. Go to the notification settings
2. Change the notification setting
3. Exit the screen and return to the screen
4. Note that the new setting value persists
5. Update the setting to be turned on, but with no podcasts selected
6. Exit the screen and return to the screen
7. Note that notifications are still enabled (previously, notifications would have been turned off because we were just checking if any podcasts had notifications enabled).
8. Turn off notifications
9. Tap on the podcasts tab (do not back out of the notifications screen), and open a subscribed podcast
10. Tap the notification bell to turn on notifications
11. Tap on the profile tab to return to the notifications screen
12. Note that notifications are now on (previously, notifications would have been turned on, but the UI would have shown that notifications were off because the UI was out of date).

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews