### PR TITLE
Remove no longer used settings from Settings class

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
@@ -62,13 +62,11 @@ class AutoArchiveTest {
         played: AutoArchiveAfterPlayingSetting,
         inactive: AutoArchiveInactiveSetting,
         includeStarred: Boolean = false,
-        excludedPodcasts: List<String> = emptyList()
     ): EpisodeManager {
         val settings = mock<Settings> {
             on { autoArchiveInactive } doReturn UserSetting.Mock(inactive, mock())
             on { autoArchiveAfterPlaying } doReturn UserSetting.Mock(played, mock())
             on { autoArchiveIncludeStarred } doReturn UserSetting.Mock(includeStarred, mock())
-            on { getAutoArchiveExcludedPodcasts() } doReturn excludedPodcasts
         }
         return EpisodeManagerImpl(settings, fileStorage, downloadManager, context, db, podcastCacheServerManager, userEpisodeManager)
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/NotesViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/NotesViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.servers.ServerShowNotesManager
@@ -31,12 +30,11 @@ class NotesViewModel
     private val podcastManager: PodcastManager,
     private val playbackManager: PlaybackManager,
     private val serverShowNotesManager: ServerShowNotesManager,
-    settings: Settings,
     @ApplicationContext context: Context
 ) : ViewModel() {
 
     private val disposables = CompositeDisposable()
-    private val showNotesFormatter = ShowNotesFormatter(settings, context).apply {
+    private val showNotesFormatter = ShowNotesFormatter(context).apply {
         backgroundColor = "#FFFFFF"
         textColor = "#FFFFFF"
         linkColor = "#FFFFFF"

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -152,7 +152,7 @@ class EpisodeFragment : BaseFragment() {
     }
 
     private fun createShowNotesFormatter(context: Context): ShowNotesFormatter {
-        val showNotesFormatter = ShowNotesFormatter(settings, context)
+        val showNotesFormatter = ShowNotesFormatter(context)
         showNotesFormatter.apply {
             setBackgroundThemeColor(UR.attr.primary_ui_01)
             setTextThemeColor(UR.attr.primary_text_01)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -103,7 +103,6 @@ interface Settings {
         const val LEGACY_STORAGE_ON_PHONE = "phone"
         const val LEGACY_STORAGE_ON_SD_CARD = "external"
 
-        const val AUTO_ARCHIVE_EXCLUDED_PODCASTS = "autoArchiveExcludedPodcasts"
         const val AUTO_ARCHIVE_INCLUDE_STARRED = "autoArchiveIncludeStarred"
 
         const val INTENT_OPEN_APP_NEW_EPISODES = "INTENT_OPEN_APP_NEW_EPISODES"
@@ -301,8 +300,6 @@ interface Settings {
     val showArtworkOnLockScreen: UserSetting<Boolean>
     val newEpisodeNotificationActions: UserSetting<NewEpisodeNotificationActionSetting>
 
-    fun getAutoArchiveExcludedPodcasts(): List<String>
-    fun setAutoArchiveExcludedPodcasts(excluded: List<String>)
     val autoArchiveIncludeStarred: UserSetting<Boolean>
     val autoArchiveAfterPlaying: UserSetting<AutoArchiveAfterPlayingSetting>
     val autoArchiveInactive: UserSetting<AutoArchiveInactiveSetting>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -250,9 +250,6 @@ interface Settings {
 
     val playOverNotification: UserSetting<PlayOverNotificationSetting>
 
-    fun hasBlockAlreadyRun(label: String): Boolean
-    fun setBlockAlreadyRun(label: String, hasRun: Boolean)
-
     fun setLastModified(lastModified: String?)
     fun getLastModified(): String?
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -84,7 +84,6 @@ interface Settings {
         const val PREFERENCE_FIRST_SYNC_RUN = "firstSyncRun"
         const val PREFERENCE_GLOBAL_STREAMING_MODE = "globalStreamingMode"
         const val PREFERENCE_ALLOW_OTHER_APPS_ACCESS = "allowOtherAppsAccess"
-        const val PREFERENCE_HIDE_SYNC_SETUP_MENU = "hideSyncSetupMenu"
         const val PREFERENCE_SHOW_NOTE_IMAGES_ON = "showNotesImagesOn"
         const val PREFERENCE_SELECTED_FILTER = "selectedFilter"
         const val PREFERENCE_CHAPTERS_EXPANDED = "chaptersExpanded"
@@ -278,10 +277,6 @@ interface Settings {
     val globalPlaybackEffects: UserSetting<PlaybackEffects>
 
     fun allowOtherAppsAccessToEpisodes(): Boolean
-
-    fun setHideSyncSetupMenu(hide: Boolean)
-
-    fun isSyncSetupMenuHidden(): Boolean
 
     fun getMigratedVersionCode(): Int
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -295,9 +295,6 @@ interface Settings {
     fun setSleepTimerCustomMins(minutes: Int)
     fun getSleepTimerCustomMins(): Int
 
-    fun getImageSignature(): String
-    fun changeImageSignature(): String
-
     fun setShowPlayedEpisodes(show: Boolean)
     fun showPlayedEpisodes(): Boolean
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -383,7 +383,6 @@ interface Settings {
     val showArchivedDefault: UserSetting<Boolean>
     val mediaControlItems: UserSetting<List<MediaNotificationControls>>
     fun setMultiSelectItems(items: List<Int>)
-    fun getMultiSelectItems(): List<Int>
     fun setLastPauseTime(date: Date)
     fun getLastPauseTime(): Date?
     fun setLastPausedUUID(uuid: String)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -96,7 +96,6 @@ interface Settings {
         const val PREFERENCE_AUTO_SHOW_PLAYED = "autoShowPlayed"
 
         const val PREFERENCE_DISCOVERY_COUNTRY_CODE = "discovery_country_code"
-        const val PREFERENCE_POPULAR_PODCAST_COUNTRY_CODE = "popular_podcast_country_code"
         const val STORAGE_ON_CUSTOM_FOLDER = "custom_folder"
 
         const val PREFERENCE_BOOKMARKS_SORT_TYPE_FOR_PLAYER = "bookmarksSortTypeForPlayer"
@@ -261,10 +260,6 @@ interface Settings {
     fun setDiscoveryCountryCode(code: String)
 
     val warnOnMeteredNetwork: UserSetting<Boolean>
-
-    fun getPopularPodcastCountryCode(): String
-
-    fun setPopularPodcastCountryCode(code: String)
 
     val playOverNotification: UserSetting<PlayOverNotificationSetting>
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -356,8 +356,6 @@ interface Settings {
     val cloudDownloadOnlyOnWifi: UserSetting<Boolean>
     fun getCachedSubscription(): SubscriptionStatus?
     fun setCachedSubscription(subscriptionStatus: SubscriptionStatus?)
-    fun getAppIconId(): String?
-    fun setAppIconId(value: String)
 
     fun setUpgradeClosedProfile(value: Boolean)
     fun getUpgradeClosedProfile(): Boolean

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -326,11 +326,8 @@ interface Settings {
     val upNextSwipe: UserSetting<UpNextAction>
     val tapOnUpNextShouldPlay: UserSetting<Boolean>
 
-    fun getHeadphoneControlsNextAction(): HeadphoneAction
     fun setHeadphoneControlsNextAction(action: HeadphoneAction)
-    fun getHeadphoneControlsPreviousAction(): HeadphoneAction
     fun setHeadphoneControlsPreviousAction(action: HeadphoneAction)
-    fun getHeadphoneControlsPlayBookmarkConfirmationSound(): Boolean
     fun setHeadphoneControlsPlayBookmarkConfirmationSound(value: Boolean)
 
     // Firebase remote config

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -370,7 +370,6 @@ interface Settings {
     fun getCustomStorageLimitGb(): Long
     fun getCancelledAcknowledged(): Boolean
     fun setCancelledAcknowledged(value: Boolean)
-    fun getShelfItems(): List<String>
     fun setShelfItems(items: List<String>)
     fun getSeenPlayerTour(): Boolean
     fun setSeenPlayerTour(value: Boolean)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -196,7 +196,6 @@ interface Settings {
     val selectPodcastSortTypeObservable: Observable<PodcastsSortType>
     val refreshStateObservable: Observable<RefreshState>
     val marketingOptObservable: Observable<Boolean>
-    val isFirstSyncRunObservable: Observable<Boolean>
     val shelfItemsObservable: Observable<List<String>>
     val multiSelectItemsObservable: Observable<List<Int>>
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -83,7 +83,6 @@ interface Settings {
         const val PREFERENCE_LAST_MODIFIED = "lastModified"
         const val PREFERENCE_FIRST_SYNC_RUN = "firstSyncRun"
         const val PREFERENCE_GLOBAL_STREAMING_MODE = "globalStreamingMode"
-        const val PREFERENCE_ALLOW_OTHER_APPS_ACCESS = "allowOtherAppsAccess"
         const val PREFERENCE_SHOW_NOTE_IMAGES_ON = "showNotesImagesOn"
         const val PREFERENCE_SELECTED_FILTER = "selectedFilter"
         const val PREFERENCE_CHAPTERS_EXPANDED = "chaptersExpanded"
@@ -275,8 +274,6 @@ interface Settings {
     val useEmbeddedArtwork: UserSetting<Boolean>
 
     val globalPlaybackEffects: UserSetting<PlaybackEffects>
-
-    fun allowOtherAppsAccessToEpisodes(): Boolean
 
     fun getMigratedVersionCode(): Int
     fun setMigratedVersionCode(versionCode: Int)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -210,8 +210,6 @@ interface Settings {
 
     fun getSentryDsn(): String
 
-    fun isScreenReaderOn(): Boolean
-
     val skipForwardInSecs: UserSetting<Int>
     val skipBackInSecs: UserSetting<Int>
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -66,7 +66,6 @@ interface Settings {
         const val SYNC_HISTORY_VERSION = 1
         const val SYNC_API_MODEL = "mobile"
         const val LAST_UPDATE_TIME = "LastUpdateTime"
-        const val LAST_SYNC_TIME = "LastSyncTime"
         const val PREFERENCE_SKIP_FORWARD = "skipForward"
         const val PREFERENCE_SKIP_BACKWARD = "skipBack"
 
@@ -235,8 +234,6 @@ interface Settings {
 
     fun getLastRefreshTime(): Long
     fun getLastRefreshDate(): Date?
-    fun setLastSyncTime(lastSyncTime: Long)
-    fun getLastSyncTime(): Long
     fun setRefreshState(refreshState: RefreshState)
     fun getRefreshState(): RefreshState?
     fun getLastSuccessRefreshState(): RefreshState?

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -208,8 +208,6 @@ interface Settings {
     fun getVersion(): String
     fun getVersionCode(): Int
 
-    fun getGitHash(): String?
-
     fun getSentryDsn(): String
 
     fun isScreenReaderOn(): Boolean

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -279,7 +279,6 @@ interface Settings {
     fun allowOtherAppsAccessToEpisodes(): Boolean
 
     fun getMigratedVersionCode(): Int
-
     fun setMigratedVersionCode(versionCode: Int)
 
     val podcastBadgeType: UserSetting<BadgeType>
@@ -323,7 +322,6 @@ interface Settings {
     fun setSelectedTab(selected: Int?)
 
     fun contains(key: String): Boolean
-    fun getLastRefreshError(): String?
 
     val upNextSwipe: UserSetting<UpNextAction>
     val tapOnUpNextShouldPlay: UserSetting<Boolean>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -83,7 +83,6 @@ interface Settings {
         const val PREFERENCE_LAST_MODIFIED = "lastModified"
         const val PREFERENCE_FIRST_SYNC_RUN = "firstSyncRun"
         const val PREFERENCE_GLOBAL_STREAMING_MODE = "globalStreamingMode"
-        const val PREFERENCE_SHOW_NOTE_IMAGES_ON = "showNotesImagesOn"
         const val PREFERENCE_SELECTED_FILTER = "selectedFilter"
         const val PREFERENCE_CHAPTERS_EXPANDED = "chaptersExpanded"
         const val PREFERENCE_UPNEXT_EXPANDED = "upnextExpanded"
@@ -284,8 +283,6 @@ interface Settings {
     fun getNotificationLastSeen(): Date?
     fun setNotificationLastSeen(lastSeen: Date?)
     fun setNotificationLastSeenToNow()
-
-    fun isShowNotesImagesOn(): Boolean
 
     fun setUpNextServerModified(timeMs: Long)
     fun getUpNextServerModified(): Long

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -107,8 +107,6 @@ interface Settings {
         const val LEGACY_STORAGE_ON_PHONE = "phone"
         const val LEGACY_STORAGE_ON_SD_CARD = "external"
 
-        const val LAST_MAIN_NAV_SCREEN_OPENED = "last_main_screen"
-
         const val AUTO_ARCHIVE_EXCLUDED_PODCASTS = "autoArchiveExcludedPodcasts"
         const val AUTO_ARCHIVE_INCLUDE_STARRED = "autoArchiveIncludeStarred"
 
@@ -212,9 +210,6 @@ interface Settings {
 
     val skipForwardInSecs: UserSetting<Int>
     val skipBackInSecs: UserSetting<Int>
-
-    fun getLastScreenOpened(): String?
-    fun setLastScreenOpened(screenId: String)
 
     fun syncOnMeteredNetwork(): Boolean
     fun setSyncOnMeteredNetwork(shouldSyncOnMetered: Boolean)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -598,16 +598,6 @@ class SettingsImpl @Inject constructor(
         return sharedPreferences.getBoolean(Settings.PREFERENCE_ALLOW_OTHER_APPS_ACCESS, false)
     }
 
-    override fun setHideSyncSetupMenu(hide: Boolean) {
-        val editor = sharedPreferences.edit()
-        editor.putBoolean(Settings.PREFERENCE_HIDE_SYNC_SETUP_MENU, hide)
-        editor.apply()
-    }
-
-    override fun isSyncSetupMenuHidden(): Boolean {
-        return sharedPreferences.getBoolean(Settings.PREFERENCE_HIDE_SYNC_SETUP_MENU, false)
-    }
-
     override fun getMigratedVersionCode(): Int {
         return getInt("MIGRATED_VERSION_CODE", 0)
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -37,7 +37,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.ThemeSetting
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.config.FirebaseConfig
-import au.com.shiftyjelly.pocketcasts.utils.extensions.isScreenReaderOn
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.jakewharton.rxrelay2.BehaviorRelay
 import com.squareup.moshi.Moshi
@@ -120,10 +119,6 @@ class SettingsImpl @Inject constructor(
         } catch (e: NameNotFoundException) {
             ""
         }
-    }
-
-    override fun isScreenReaderOn(): Boolean {
-        return context.isScreenReaderOn()
     }
 
     override val skipBackInSecs = UserSetting.SkipAmountPref(

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -404,16 +404,6 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override fun getPopularPodcastCountryCode(): String {
-        return sharedPreferences.getString(Settings.PREFERENCE_POPULAR_PODCAST_COUNTRY_CODE, "") ?: ""
-    }
-
-    override fun setPopularPodcastCountryCode(code: String) {
-        val editor = sharedPreferences.edit()
-        editor.putString(Settings.PREFERENCE_POPULAR_PODCAST_COUNTRY_CODE, code)
-        editor.apply()
-    }
-
     override fun getAutoSubscribeToPlayed(): Boolean {
         return getBoolean(Settings.PREFERENCE_AUTO_SUBSCRIBE_ON_PLAY, false)
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -666,20 +666,6 @@ class SettingsImpl @Inject constructor(
         return getInt("sleepTimerCustomMins", 5)
     }
 
-    override fun getImageSignature(): String {
-        var signature = getString("imageSignature", null)
-        if (signature == null) {
-            signature = changeImageSignature()
-        }
-        return signature
-    }
-
-    override fun changeImageSignature(): String {
-        val signature = System.currentTimeMillis().toString()
-        setString("imageSignature", signature)
-        return signature
-    }
-
     override fun setShowPlayedEpisodes(show: Boolean) {
         setBoolean("showPlayedEpisodes", show)
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -108,20 +108,6 @@ class SettingsImpl @Inject constructor(
         return BuildConfig.VERSION_CODE
     }
 
-    override fun getGitHash(): String? {
-        try {
-            val applicationInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                context.packageManager.getApplicationInfo(context.packageName, PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA.toLong()))
-            } else {
-                @Suppress("DEPRECATION")
-                context.packageManager.getApplicationInfo(context.packageName, PackageManager.GET_META_DATA)
-            }
-            return applicationInfo.metaData.getString("au.com.shiftyjelly.pocketcasts.gitHash")
-        } catch (e: NameNotFoundException) {
-            return null
-        }
-    }
-
     override fun getSentryDsn(): String {
         return try {
             val applicationInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -385,16 +385,6 @@ class SettingsImpl @Inject constructor(
         toString = { it.preferenceInt.toString() }
     )
 
-    override fun hasBlockAlreadyRun(label: String): Boolean {
-        return sharedPreferences.getBoolean("blockAlreadyRun$label", false)
-    }
-
-    override fun setBlockAlreadyRun(label: String, hasRun: Boolean) {
-        val editor = sharedPreferences.edit()
-        editor.putBoolean("blockAlreadyRun$label", hasRun)
-        editor.apply()
-    }
-
     override fun setLastModified(lastModified: String?) {
         val editor = sharedPreferences.edit()
         editor.putString(Settings.PREFERENCE_LAST_MODIFIED, lastModified)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1097,7 +1097,7 @@ class SettingsImpl @Inject constructor(
         shelfItemsObservable.accept(items)
     }
 
-    override fun getMultiSelectItems(): List<Int> {
+    private fun getMultiSelectItems(): List<Int> {
         return getStringList("multi_select_items").map { it.toInt() }
     }
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -824,14 +824,6 @@ class SettingsImpl @Inject constructor(
         },
     )
 
-    override fun getAutoArchiveExcludedPodcasts(): List<String> {
-        return sharedPreferences.getStringSet(Settings.AUTO_ARCHIVE_EXCLUDED_PODCASTS, null)?.toList() ?: emptyList()
-    }
-
-    override fun setAutoArchiveExcludedPodcasts(excluded: List<String>) {
-        sharedPreferences.edit().putStringSet(Settings.AUTO_ARCHIVE_EXCLUDED_PODCASTS, excluded.toSet()).apply()
-    }
-
     override val autoPlayNextEpisodeOnEmpty = UserSetting.BoolPref(
         sharedPrefKey = "autoUpNextEmpty",
         defaultValue = when (Util.getAppPlatform(context)) {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -80,7 +80,6 @@ class SettingsImpl @Inject constructor(
 
     override val selectPodcastSortTypeObservable = BehaviorRelay.create<PodcastsSortType>().apply { accept(getSelectPodcastsSortType()) }
     override val marketingOptObservable = BehaviorRelay.create<Boolean>().apply { accept(getMarketingOptIn()) }
-    override val isFirstSyncRunObservable = BehaviorRelay.create<Boolean>().apply { accept(isFirstSyncRun()) }
     override val shelfItemsObservable = BehaviorRelay.create<List<String>>().apply { accept(getShelfItems()) }
     override val multiSelectItemsObservable = BehaviorRelay.create<List<Int>>().apply { accept(getMultiSelectItems()) }
 
@@ -453,7 +452,6 @@ class SettingsImpl @Inject constructor(
         val editor = sharedPreferences.edit()
         editor.putBoolean(Settings.PREFERENCE_FIRST_SYNC_RUN, firstRun)
         editor.apply()
-        isFirstSyncRunObservable.accept(firstRun)
     }
 
     override fun isRestoreFromBackup(): Boolean {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -927,7 +927,7 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override fun getHeadphoneControlsNextAction(): Settings.HeadphoneAction {
+    private fun getHeadphoneControlsNextAction(): Settings.HeadphoneAction {
         return Settings.HeadphoneAction.values()[getInt("headphone_controls_next_action", Settings.HeadphoneAction.SKIP_FORWARD.ordinal)]
     }
 
@@ -936,7 +936,7 @@ class SettingsImpl @Inject constructor(
         headphoneNextActionFlow.update { action }
     }
 
-    override fun getHeadphoneControlsPreviousAction(): Settings.HeadphoneAction {
+    private fun getHeadphoneControlsPreviousAction(): Settings.HeadphoneAction {
         return Settings.HeadphoneAction.values()[getInt("headphone_controls_previous_action", Settings.HeadphoneAction.SKIP_BACK.ordinal)]
     }
 
@@ -945,7 +945,7 @@ class SettingsImpl @Inject constructor(
         headphonePreviousActionFlow.update { action }
     }
 
-    override fun getHeadphoneControlsPlayBookmarkConfirmationSound(): Boolean {
+    private fun getHeadphoneControlsPlayBookmarkConfirmationSound(): Boolean {
         return getBoolean("headphone_controls_play_bookmark_confirmation_sound", true)
     }
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -174,16 +174,6 @@ class SettingsImpl @Inject constructor(
         setBoolean("cancelled_acknowledged", value)
     }
 
-    override fun getLastScreenOpened(): String? {
-        return sharedPreferences.getString(Settings.LAST_MAIN_NAV_SCREEN_OPENED, null)
-    }
-
-    override fun setLastScreenOpened(screenId: String) {
-        val editor = sharedPreferences.edit()
-        editor.putString(Settings.LAST_MAIN_NAV_SCREEN_OPENED, screenId)
-        editor.apply()
-    }
-
     override fun syncOnMeteredNetwork(): Boolean {
         return getBoolean(Settings.PREFERENCE_SYNC_ON_METERED, true)
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1028,14 +1028,6 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override fun getAppIconId(): String? {
-        return getString("appIconId", "Default")
-    }
-
-    override fun setAppIconId(value: String) {
-        setString("appIconId", value)
-    }
-
     override fun getUpgradeClosedProfile(): Boolean {
         return getBoolean("upgradeClosedProfile", false)
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -594,10 +594,6 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override fun allowOtherAppsAccessToEpisodes(): Boolean {
-        return sharedPreferences.getBoolean(Settings.PREFERENCE_ALLOW_OTHER_APPS_ACCESS, false)
-    }
-
     override fun getMigratedVersionCode(): Int {
         return getInt("MIGRATED_VERSION_CODE", 0)
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -327,16 +327,6 @@ class SettingsImpl @Inject constructor(
         setString("last_refresh_error", error, true)
     }
 
-    override fun setLastSyncTime(lastSyncTime: Long) {
-        val editor = sharedPreferences.edit()
-        editor.putLong(Settings.LAST_SYNC_TIME, lastSyncTime)
-        editor.apply()
-    }
-
-    override fun getLastSyncTime(): Long {
-        return sharedPreferences.getLong(Settings.LAST_SYNC_TIME, 0)
-    }
-
     override fun getLongForKey(key: String, defaultValue: Long): Long {
         return sharedPreferences.getLong(key, defaultValue)
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1088,7 +1088,7 @@ class SettingsImpl @Inject constructor(
         }
     }
 
-    override fun getShelfItems(): List<String> {
+    private fun getShelfItems(): List<String> {
         return getStringList("shelfItems")
     }
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -630,10 +630,6 @@ class SettingsImpl @Inject constructor(
         setNotificationLastSeen(Date())
     }
 
-    override fun isShowNotesImagesOn(): Boolean {
-        return getBoolean(Settings.PREFERENCE_SHOW_NOTE_IMAGES_ON, true)
-    }
-
     override fun setUpNextServerModified(timeMs: Long) {
         setLong("upNextModified", timeMs)
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -319,7 +319,7 @@ class SettingsImpl @Inject constructor(
         return getLastRefreshDate()?.let { RefreshState.Success(it) }
     }
 
-    override fun getLastRefreshError(): String? {
+    private fun getLastRefreshError(): String? {
         return getString("last_refresh_error", null)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.java
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.java
@@ -166,7 +166,7 @@ public class FileStorage {
 	}
 	
 	private final static void addNoMediaFile(File folder, Settings settings) {
-		if (folder == null || !folder.exists() || settings.allowOtherAppsAccessToEpisodes()) {
+		if (folder == null || !folder.exists()) {
 			return;
 		}
 		File file = new File(folder, ".nomedia");

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -664,7 +664,6 @@ class EpisodeManagerImpl @Inject constructor(
             val shouldArchiveBasedOnSettings = shouldArchiveBasedOnSettings(podcastOverrideSettings, podcastArchiveAfterPlaying)
 
             if (shouldArchiveBasedOnSettings &&
-                !settings.getAutoArchiveExcludedPodcasts().contains(episode.podcastUuid) &&
                 (settings.autoArchiveIncludeStarred.flow.value || !episode.isStarred)
             ) {
                 if (sync) {
@@ -688,8 +687,6 @@ class EpisodeManagerImpl @Inject constructor(
     private suspend fun archiveAllPlayedEpisodes(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager, podcastManager: PodcastManager) {
         val episodesWithoutStarred = if (!settings.autoArchiveIncludeStarred.flow.value) episodes.filter { !it.isStarred } else episodes // Remove starred episodes if we have to
         val episodesByPodcast = episodesWithoutStarred.groupBy { it.podcastUuid }.toMutableMap() // Sort in to podcasts
-        val excludedPodcasts = settings.getAutoArchiveExcludedPodcasts()
-        excludedPodcasts.forEach { episodesByPodcast.remove(it) } // Remove all excluded podcasts
 
         for ((podcastUuid, episodes) in episodesByPodcast) {
             val podcast = podcastManager.findPodcastByUuid(podcastUuid) ?: continue

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -597,7 +597,6 @@ class PodcastSyncProcess(
     private fun updateSettings(response: SyncUpdateResponse): Completable {
         return Completable.fromAction {
             settings.setLastModified(response.lastModified)
-            settings.setLastSyncTime(System.currentTimeMillis())
         }
     }
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ShowNotesFormatter.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ShowNotesFormatter.kt
@@ -1,16 +1,14 @@
 package au.com.shiftyjelly.pocketcasts.views.helper
 
 import android.content.Context
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import timber.log.Timber
 import java.text.Bidi
 import java.util.*
 import java.util.regex.Pattern
 
-class ShowNotesFormatter(settings: Settings?, private val context: Context) {
+class ShowNotesFormatter(private val context: Context) {
 
-    private val showImages: Boolean = settings != null && settings.isShowNotesImagesOn()
     private var padding = "0px"
     private var convertTimesToLinks: Boolean = false
 
@@ -102,12 +100,7 @@ class ShowNotesFormatter(settings: Settings?, private val context: Context) {
         html.append(".separator { padding: 0 2px; color: #D8D8D8; } \n")
         html.append("p { margin: 4px 0 8px 0; } \n")
         html.append("a, .pageHeader { color:").append(linkColor).append("; font-weight: 400; } \n")
-        if (showImages) {
-            html.append("img { width: auto !important; height: auto !important; max-width:100%; max-height: auto; padding-bottom: 10px; padding-top: 10px; display: block; }\nimg[src*='coverart'], img[src*='CoverArt'], img[src*='COVERART'], img[src*='feeds.feedburner.com'] { display: none; } \n")
-        } else {
-            html.append("img { display: none; } \n")
-        }
-
+        html.append("img { width: auto !important; height: auto !important; max-width:100%; max-height: auto; padding-bottom: 10px; padding-top: 10px; display: block; }\nimg[src*='coverart'], img[src*='CoverArt'], img[src*='COVERART'], img[src*='feeds.feedburner.com'] { display: none; } \n")
         html.append("</style></head>\n")
     }
 }


### PR DESCRIPTION
## Description
This PR is removing mthods from the Settings class where either the setting is never getting read/used or the setting is never getting set (meaning that only the default value ever gets used, which means we don't need the setting). The goal of this is to clean out unused code and to reduce the quite large public interface of our Settings class.

There are a lot of changes here. I considered breaking this out into multiple PRs, but putting each setting in its own PR would lead to a LOT of PRs. Instead, I made each setting that got removed its own commit. In reviewing this, I would go through each commit instead of trying to look at all the changes at once.

One effect this will have is that for settings that are used but never set, it is possible that a user could have set the setting when they had a version of the app that still allowed that, and they've just been upgrading the app ever since, so the setting is still there in their shared preferences and getting read. I still think it's better to go ahead and remove the setting because the user can't change the setting anymore, so although they might like the setting, they also might not like it, and there's nothing they can do about it (and presumably we removed the setting for a good reason). 

Note that I am making these changes on top of the other settings refactorings that I've been doing recently, and I'm merging this first to the feature branch.

This does feel like a bit of a risky PR to me. I think it's worth it to get some overdue cleanup in, but if you disagree let me know.

## Testing Instructions

If CI is happy, we're probably fine on these. One thing that CI could miss would be if we have one of the Preference views that is keyed to a hardcoded string matching a setting that was removed. I was pretty careful about doing string searches to avoid this, but I wanted to mention it as a possible risk.

If you can think of any other ways that this could introduce issues that CI might miss, let me know because I'd like to test those as well.

Since CI might not catch everything, it would be good to do a bit of smoketesting of the app with these changes.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews