### PR TITLE
Replace UserSetting.flow.value with UserSetting.flow

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/CastOptionsProvider.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/CastOptionsProvider.kt
@@ -22,7 +22,7 @@ class CastOptionsProvider : OptionsProvider {
         val compatButtonActionsIndices = intArrayOf(0, 1, 2)
         val notificationOptions = NotificationOptions.Builder()
             .setActions(buttonActions, compatButtonActionsIndices)
-            .setSkipStepMs(application.settings.skipForwardInSecs.flow.value * 1000L)
+            .setSkipStepMs(application.settings.skipForwardInSecs.value * 1000L)
             .setTargetActivityClassName(MainActivity::class.java.name)
             .build()
         val mediaOptions = CastMediaOptions.Builder()

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -114,12 +114,12 @@ class PocketCastsApplication : Application(), Configuration.Provider {
         }
 
         SentryAndroid.init(this) { options ->
-            options.dsn = if (settings.sendCrashReports.flow.value) settings.getSentryDsn() else ""
+            options.dsn = if (settings.sendCrashReports.value) settings.getSentryDsn() else ""
             options.setTag(SentryHelper.GLOBAL_TAG_APP_PLATFORM, AppPlatform.MOBILE.value)
         }
 
         // Link email to Sentry crash reports only if the user has opted in
-        if (settings.linkCrashReportsToUser.flow.value) {
+        if (settings.linkCrashReportsToUser.value) {
             syncManager.getEmail()?.let { syncEmail ->
                 val user = User().apply { email = syncEmail }
                 Sentry.setUser(user)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -684,7 +684,7 @@ class MainActivity :
                     viewModel.lastPlaybackState?.episodeUuid != state.episodeUuid ||
                         (viewModel.lastPlaybackState?.isPlaying == false && state.isPlaying)
                     ) &&
-                settings.openPlayerAutomatically.flow.value
+                settings.openPlayerAutomatically.value
             ) {
                 binding.playerBottomSheet.openPlayer()
             }
@@ -798,7 +798,7 @@ class MainActivity :
     private fun updatePlaybackState(state: PlaybackState) {
         binding.playerBottomSheet.setPlaybackState(state)
 
-        if ((state.isPlaying || state.isBuffering) && settings.keepScreenAwake.flow.value) {
+        if ((state.isPlaying || state.isBuffering) && settings.keepScreenAwake.value) {
             window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         } else {
             window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -130,9 +130,9 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
     }
 
     private fun changeSkipTitles() {
-        val skipForwardSummary = resources.getStringPluralSeconds(settings.skipForwardInSecs.flow.value)
+        val skipForwardSummary = resources.getStringPluralSeconds(settings.skipForwardInSecs.value)
         preferenceSkipForward?.summary = skipForwardSummary
-        val skipBackwardSummary = resources.getStringPluralSeconds(settings.skipBackInSecs.flow.value)
+        val skipBackwardSummary = resources.getStringPluralSeconds(settings.skipBackInSecs.value)
         preferenceSkipBackward?.summary = skipBackwardSummary
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
@@ -135,7 +135,7 @@ class OnboardingRecommendationsStartPageViewModel @Inject constructor(
                 return@launch
             }
 
-            val regionCode = settings.discoverCountryCode.flow.value
+            val regionCode = settings.discoverCountryCode.value
             val region = feed.regions[regionCode]
                 ?: feed.regions[feed.defaultRegionCode]
                     .let {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -49,7 +49,7 @@ class DiscoverViewModel @Inject constructor(
     private val disposables = CompositeDisposable()
     private val sourceView = SourceView.DISCOVER
     val state = MutableLiveData<DiscoverState>().apply { value = DiscoverState.Loading }
-    var currentRegionCode: String? = settings.discoverCountryCode.flow.value
+    var currentRegionCode: String? = settings.discoverCountryCode.value
     var replacements = emptyMap<String, String>()
     private var isFragmentChangingConfigurations: Boolean = false
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -109,7 +109,7 @@ class FilterEpisodeListFragment : BaseFragment() {
             swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                 swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
                 onItemUpdated = this::lazyNotifyAdapterChanged,
-                defaultUpNextSwipeAction = { settings.upNextSwipe.flow.value },
+                defaultUpNextSwipeAction = { settings.upNextSwipe.value },
                 context = requireContext(),
                 fragmentManager = parentFragmentManager,
                 swipeSource = EpisodeItemTouchHelper.SwipeSource.FILTERS,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -106,7 +106,7 @@ class UpNextAdapter(
                 holder.binding.checkbox.isChecked = multiSelectHelper.toggle(episode)
             } else {
                 val podcastUuid = (episode as? PodcastEpisode)?.podcastUuid
-                val playOnTap = settings.tapOnUpNextShouldPlay.flow.value
+                val playOnTap = settings.tapOnUpNextShouldPlay.value
                 trackUpNextEvent(AnalyticsEvent.UP_NEXT_QUEUE_EPISODE_TAPPED, mapOf(WILL_PLAY_KEY to playOnTap))
                 listener.onEpisodeActionsClick(episodeUuid = episode.uuid, podcastUuid = podcastUuid)
             }
@@ -116,7 +116,7 @@ class UpNextAdapter(
                 multiSelectHelper.defaultLongPress(multiSelectable = episode, fragmentManager = fragmentManager)
             } else {
                 val podcastUuid = (episode as? PodcastEpisode)?.podcastUuid
-                val playOnLongPress = !settings.tapOnUpNextShouldPlay.flow.value
+                val playOnLongPress = !settings.tapOnUpNextShouldPlay.value
                 trackUpNextEvent(AnalyticsEvent.UP_NEXT_QUEUE_EPISODE_LONG_PRESSED, mapOf(WILL_PLAY_KEY to playOnLongPress))
                 listener.onEpisodeActionsLongPress(episodeUuid = episode.uuid, podcastUuid = podcastUuid)
             }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -143,7 +143,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
             swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                 swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
                 onItemUpdated = this::clearViewAtPosition,
-                defaultUpNextSwipeAction = { settings.upNextSwipe.flow.value },
+                defaultUpNextSwipeAction = { settings.upNextSwipe.value },
                 context = context,
                 fragmentManager = parentFragmentManager,
                 swipeSource = SwipeSource.UP_NEXT,
@@ -348,7 +348,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
     }
 
     override fun onEpisodeActionsClick(episodeUuid: String, podcastUuid: String?) {
-        if (settings.tapOnUpNextShouldPlay.flow.value) {
+        if (settings.tapOnUpNextShouldPlay.value) {
             playerViewModel.playEpisode(uuid = episodeUuid, sourceView = sourceView)
         } else {
             (activity as? FragmentHostListener)?.openEpisodeDialog(
@@ -361,7 +361,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
     }
 
     override fun onEpisodeActionsLongPress(episodeUuid: String, podcastUuid: String?) {
-        if (settings.tapOnUpNextShouldPlay.flow.value) {
+        if (settings.tapOnUpNextShouldPlay.value) {
             (activity as? FragmentHostListener)?.openEpisodeDialog(
                 episodeUuid = episodeUuid,
                 source = EpisodeViewSource.UP_NEXT,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
@@ -69,8 +69,8 @@ class VideoFragment : Fragment(), PlayerSeekBar.OnUserSeekListener {
         binding.seekBar.changeListener = this
         binding.toolbar.setNavigationOnClickListener { activity?.finish() }
 
-        binding.skipBackwardInSecs = "${settings.skipBackInSecs.flow.value}"
-        binding.skipForwardInSecs = "${settings.skipForwardInSecs.flow.value}"
+        binding.skipBackwardInSecs = "${settings.skipBackInSecs.value}"
+        binding.skipForwardInSecs = "${settings.skipForwardInSecs.value}"
 
         binding.playButton.setCircleTintColor(ContextCompat.getColor(context, UR.color.transparent))
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -271,7 +271,7 @@ class PlayerViewModel @Inject constructor(
                 Flowable.just(Podcast(uuid = UserEpisodePodcastSubstitute.substituteUuid, title = UserEpisodePodcastSubstitute.substituteTitle, overrideGlobalEffects = false))
             }
         }
-        .map { PodcastEffectsPair(it, if (it.overrideGlobalEffects) it.playbackEffects else settings.globalPlaybackEffects.flow.value) }
+        .map { PodcastEffectsPair(it, if (it.overrideGlobalEffects) it.playbackEffects else settings.globalPlaybackEffects.value) }
         .doOnNext { Timber.i("Effects: Podcast: ${it.podcast.overrideGlobalEffects} ${it.effects}") }
         .observeOn(AndroidSchedulers.mainThread())
     val effectsLive = effectsObservable.toLiveData()
@@ -587,7 +587,7 @@ class PlayerViewModel @Inject constructor(
     fun clearPodcastEffects(podcast: Podcast) {
         launch {
             podcastManager.updateOverrideGlobalEffects(podcast, false)
-            playbackManager.updatePlayerEffects(settings.globalPlaybackEffects.flow.value)
+            playbackManager.updatePlayerEffects(settings.globalPlaybackEffects.value)
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
@@ -91,11 +91,11 @@ class PlayButtonListener @Inject constructor(
     }
 
     override fun onDownload(episodeUuid: String) {
-        if (settings.warnOnMeteredNetwork.flow.value && !Network.isUnmeteredConnection(activity) && activity is AppCompatActivity) {
+        if (settings.warnOnMeteredNetwork.value && !Network.isUnmeteredConnection(activity) && activity is AppCompatActivity) {
             warningsHelper.downloadWarning(episodeUuid, "play button")
                 .show(activity.supportFragmentManager, "download warning")
         } else {
-            download(episodeUuid, waitForWifi = settings.warnOnMeteredNetwork.flow.value)
+            download(episodeUuid, waitForWifi = settings.warnOnMeteredNetwork.value)
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -129,7 +129,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                 swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
                 onItemUpdated = ::lazyNotifyItemChanged,
-                defaultUpNextSwipeAction = { settings.upNextSwipe.flow.value },
+                defaultUpNextSwipeAction = { settings.upNextSwipe.value },
                 context = requireContext(),
                 fragmentManager = parentFragmentManager,
                 swipeSource = when (mode) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -441,7 +441,7 @@ class EpisodeFragment : BaseFragment() {
                 }
             } else {
                 context?.let { context ->
-                    if (settings.warnOnMeteredNetwork.flow.value && !Network.isUnmeteredConnection(context) && viewModel.shouldDownload()) {
+                    if (settings.warnOnMeteredNetwork.value && !Network.isUnmeteredConnection(context) && viewModel.shouldDownload()) {
                         warningsHelper.downloadWarning(episodeUUID!!, "episode card")
                             .show(parentFragmentManager, "download warning")
                     } else {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -246,7 +246,7 @@ class EpisodeFragmentViewModel @Inject constructor(
     }
 
     fun shouldShowStreamingWarning(context: Context): Boolean {
-        return isPlaying.value == false && episode?.isDownloaded == false && settings.warnOnMeteredNetwork.flow.value && !Network.isUnmeteredConnection(context)
+        return isPlaying.value == false && episode?.isDownloaded == false && settings.warnOnMeteredNetwork.value && !Network.isUnmeteredConnection(context)
     }
 
     fun playClickedGetShouldClose(

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModel.kt
@@ -134,7 +134,7 @@ class FolderEditViewModel
                     searchText = searchText,
                     folders = folders,
                     folder = folder,
-                    layout = settings.podcastGridLayout.flow.value
+                    layout = settings.podcastGridLayout.value
                 )
             }.collect {
                 mutableState.value = it
@@ -149,7 +149,7 @@ class FolderEditViewModel
 
     private fun sortPodcasts(podcastsSortedByReleaseDate: List<Podcast>): List<Podcast> {
         val podcasts = podcastsSortedByReleaseDate
-        return when (settings.podcastsSortType.flow.value) {
+        return when (settings.podcastsSortType.value) {
             PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST -> podcastsSortedByReleaseDate
             PodcastsSortType.DATE_ADDED_OLDEST_TO_NEWEST -> podcasts.sortedWith(compareBy { it.addedDate })
             PodcastsSortType.DRAG_DROP -> podcasts.sortedWith(compareBy { it.sortPosition })
@@ -229,7 +229,7 @@ class FolderEditViewModel
                 val newFolder = folderManager.create(
                     name = name,
                     color = colorId.value,
-                    podcastsSortType = settings.podcastsSortType.flow.value,
+                    podcastsSortType = settings.podcastsSortType.value,
                     podcastUuids = podcastUuids
                 )
                 onComplete(newFolder)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
@@ -104,8 +104,8 @@ class EpisodeListAdapter(
             fromListUuid = fromListUuid,
             tintColor = tintColor,
             playButtonListener = playButtonListener,
-            streamByDefault = settings.streamingMode.flow.value,
-            upNextAction = settings.upNextSwipe.flow.value,
+            streamByDefault = settings.streamingMode.value,
+            upNextAction = settings.upNextSwipe.value,
             multiSelectEnabled = multiSelectHelper.isMultiSelecting,
             isSelected = multiSelectHelper.isSelected(episode),
             disposables = disposables
@@ -131,8 +131,8 @@ class EpisodeListAdapter(
             episode = userEpisode,
             tintColor = tintColor,
             playButtonListener = playButtonListener,
-            streamByDefault = settings.streamingMode.flow.value,
-            upNextAction = settings.upNextSwipe.flow.value,
+            streamByDefault = settings.streamingMode.value,
+            upNextAction = settings.upNextSwipe.value,
             multiSelectEnabled = multiSelectHelper.isMultiSelecting,
             isSelected = multiSelectHelper.isSelected(userEpisode)
         )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -294,8 +294,8 @@ class PodcastAdapter(
             fromListUuid = fromListUuid,
             tintColor = ThemeColor.podcastIcon02(theme.activeTheme, tintColor),
             playButtonListener = playButtonListener,
-            streamByDefault = settings.streamingMode.flow.value || castConnected,
-            upNextAction = settings.upNextSwipe.flow.value,
+            streamByDefault = settings.streamingMode.value || castConnected,
+            upNextAction = settings.upNextSwipe.value,
             multiSelectEnabled = multiSelectEpisodesHelper.isMultiSelecting,
             isSelected = multiSelectEpisodesHelper.isSelected(episode),
             disposables = disposables

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveViewModel.kt
@@ -39,8 +39,8 @@ class PodcastAutoArchiveViewModel @Inject constructor(
         launch {
             val podcast = podcast.value ?: return@launch
             podcast.overrideGlobalArchive = checked
-            podcast.autoArchiveAfterPlaying = settings.autoArchiveAfterPlaying.flow.value.toIndex()
-            podcast.autoArchiveInactive = settings.autoArchiveInactive.flow.value.toIndex()
+            podcast.autoArchiveAfterPlaying = settings.autoArchiveAfterPlaying.value.toIndex()
+            podcast.autoArchiveInactive = settings.autoArchiveInactive.value.toIndex()
             podcastManager.updatePodcast(podcast)
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -596,7 +596,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                 swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                     swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
                     onItemUpdated = ::notifyItemChanged,
-                    defaultUpNextSwipeAction = { settings.upNextSwipe.flow.value },
+                    defaultUpNextSwipeAction = { settings.upNextSwipe.value },
                     context = context,
                     fragmentManager = parentFragmentManager,
                     swipeSource = EpisodeItemTouchHelper.SwipeSource.PODCAST_DETAILS,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderAdapter.kt
@@ -66,15 +66,15 @@ class FolderAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (viewType) {
             FolderItem.Podcast.viewTypeId -> {
-                val isLayoutListView = settings.podcastGridLayout.flow.value == PodcastGridLayoutType.LIST_VIEW
+                val isLayoutListView = settings.podcastGridLayout.value == PodcastGridLayoutType.LIST_VIEW
                 val layoutId = if (isLayoutListView) R.layout.adapter_podcast_list else R.layout.adapter_podcast_grid
                 imageLoader.radiusPx = if (isLayoutListView) 4.dpToPx(context) else 0
                 val view = parent.inflate(layoutId, attachToThis = false)
-                val podcastGridLayout = settings.podcastGridLayout.flow.value
+                val podcastGridLayout = settings.podcastGridLayout.value
                 PodcastViewHolder(view, imageLoader, podcastGridLayout, theme)
             }
             FolderItem.Folder.viewTypeId -> {
-                val podcastsLayout = settings.podcastGridLayout.flow.value
+                val podcastsLayout = settings.podcastGridLayout.value
                 val gridWidthDp = UiUtil.getGridImageWidthPx(smallArtwork = podcastsLayout == PodcastGridLayoutType.SMALL_ARTWORK, context = context).pxToDp(parent.context).toInt()
                 FolderViewHolder(
                     composeView = ComposeView(parent.context),

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -154,7 +154,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         }
 
         viewModel.podcastUuidToBadge.observe(viewLifecycleOwner) { podcastUuidToBadge ->
-            adapter?.badgeType = settings.podcastBadgeType.flow.value
+            adapter?.badgeType = settings.podcastBadgeType.value
             adapter?.setBadges(podcastUuidToBadge)
         }
 
@@ -321,12 +321,12 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
     }
 
     private fun setupGridView(savedInstanceState: Parcelable? = listState) {
-        val layoutManager = when (settings.podcastGridLayout.flow.value) {
+        val layoutManager = when (settings.podcastGridLayout.value) {
             PodcastGridLayoutType.LARGE_ARTWORK -> GridLayoutManager(activity, UiUtil.getGridColumnCount(false, context))
             PodcastGridLayoutType.SMALL_ARTWORK -> GridLayoutManager(activity, UiUtil.getGridColumnCount(true, context))
             PodcastGridLayoutType.LIST_VIEW -> LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         }
-        val badgeType = settings.podcastBadgeType.flow.value
+        val badgeType = settings.podcastBadgeType.value
         val currentLayoutManager = realBinding?.recyclerView?.layoutManager
 
         // We only want to reset the adapter if something actually changed, or else it will flash

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
@@ -32,7 +32,7 @@ class PodcastsOptionsDialog(
             .addTextOption(
                 titleId = LR.string.podcasts_menu_sort_by,
                 imageId = IR.drawable.ic_sort,
-                valueId = settings.podcastsSortType.flow.value.labelId,
+                valueId = settings.podcastsSortType.value.labelId,
                 click = {
                     openSortOptions()
                     trackTapOnModalOption(ModalOption.SORT_BY)
@@ -44,7 +44,7 @@ class PodcastsOptionsDialog(
                 ToggleButtonOption(
                     imageId = R.drawable.ic_largegrid,
                     descriptionId = LR.string.podcasts_layout_large_grid,
-                    isOn = { settings.podcastGridLayout.flow.value == PodcastGridLayoutType.LARGE_ARTWORK },
+                    isOn = { settings.podcastGridLayout.value == PodcastGridLayoutType.LARGE_ARTWORK },
                     click = {
                         settings.podcastGridLayout.set(PodcastGridLayoutType.LARGE_ARTWORK)
                         trackTapOnModalOption(ModalOption.LAYOUT)
@@ -54,7 +54,7 @@ class PodcastsOptionsDialog(
                 ToggleButtonOption(
                     imageId = R.drawable.ic_smallgrid,
                     descriptionId = LR.string.podcasts_layout_small_grid,
-                    isOn = { settings.podcastGridLayout.flow.value == PodcastGridLayoutType.SMALL_ARTWORK },
+                    isOn = { settings.podcastGridLayout.value == PodcastGridLayoutType.SMALL_ARTWORK },
                     click = {
                         settings.podcastGridLayout.set(PodcastGridLayoutType.SMALL_ARTWORK)
                         trackTapOnModalOption(ModalOption.LAYOUT)
@@ -64,7 +64,7 @@ class PodcastsOptionsDialog(
                 ToggleButtonOption(
                     imageId = R.drawable.ic_list,
                     descriptionId = LR.string.podcasts_layout_list_view,
-                    isOn = { settings.podcastGridLayout.flow.value == PodcastGridLayoutType.LIST_VIEW },
+                    isOn = { settings.podcastGridLayout.value == PodcastGridLayoutType.LIST_VIEW },
                     click = {
                         settings.podcastGridLayout.set(PodcastGridLayoutType.LIST_VIEW)
                         trackTapOnModalOption(ModalOption.LAYOUT)
@@ -75,7 +75,7 @@ class PodcastsOptionsDialog(
             .addTextOption(
                 titleId = LR.string.podcasts_menu_badges,
                 imageId = R.drawable.ic_badge,
-                valueId = settings.podcastBadgeType.flow.value.labelId,
+                valueId = settings.podcastBadgeType.value.labelId,
                 click = {
                     openBadgeOptions()
                     trackTapOnModalOption(ModalOption.BADGE)
@@ -101,7 +101,7 @@ class PodcastsOptionsDialog(
     }
 
     private fun openSortOptions() {
-        val sortOrder = settings.podcastsSortType.flow.value
+        val sortOrder = settings.podcastsSortType.value
         val title = fragment.getString(LR.string.sort_by)
         val dialog = OptionsDialog().setTitle(title)
         for (order in PodcastsSortType.values()) {
@@ -121,7 +121,7 @@ class PodcastsOptionsDialog(
     }
 
     private fun openBadgeOptions() {
-        val badgeType: BadgeType = settings.podcastBadgeType.flow.value
+        val badgeType: BadgeType = settings.podcastBadgeType.value
         val title = fragment.getString(LR.string.podcasts_menu_badges)
         val dialog = OptionsDialog()
             .setTitle(title)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
@@ -47,7 +47,7 @@ class PodcastEffectsViewModel
         launch {
             podcastManager.updateOverrideGlobalEffects(podcast, override)
             if (shouldUpdatePlaybackManager()) {
-                val effects = if (override) podcast.playbackEffects else settings.globalPlaybackEffects.flow.value
+                val effects = if (override) podcast.playbackEffects else settings.globalPlaybackEffects.value
                 playbackManager.updatePlayerEffects(effects)
             }
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -265,9 +265,9 @@ class PodcastsViewModel
             val properties = HashMap<String, Any>()
             properties[NUMBER_OF_FOLDERS_KEY] = folderManager.countFolders()
             properties[NUMBER_OF_PODCASTS_KEY] = podcastManager.countSubscribed()
-            properties[BADGE_TYPE_KEY] = settings.podcastBadgeType.flow.value.analyticsValue
-            properties[LAYOUT_KEY] = settings.podcastGridLayout.flow.value.analyticsValue
-            properties[SORT_ORDER_KEY] = settings.podcastsSortType.flow.value.analyticsValue
+            properties[BADGE_TYPE_KEY] = settings.podcastBadgeType.value.analyticsValue
+            properties[LAYOUT_KEY] = settings.podcastGridLayout.value.analyticsValue
+            properties[SORT_ORDER_KEY] = settings.podcastsSortType.value.analyticsValue
             analyticsTracker.track(AnalyticsEvent.PODCASTS_LIST_SHOWN, properties)
         }
     }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheet.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheet.kt
@@ -335,7 +335,7 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
 
     fun download(episode: UserEpisode, isOnWifi: Boolean) {
         viewModel.trackOptionTapped(DOWNLOAD)
-        if (settings.warnOnMeteredNetwork.flow.value && !isOnWifi) {
+        if (settings.warnOnMeteredNetwork.value && !isOnWifi) {
             warningsHelper.downloadWarning(episodeUUID, "user episode sheet")
                 .show(parentFragmentManager, "download_warning")
         } else {
@@ -345,7 +345,7 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
 
     private fun upload(episode: UserEpisode, isOnWifi: Boolean) {
         viewModel.trackOptionTapped(UPLOAD)
-        if (settings.warnOnMeteredNetwork.flow.value && !isOnWifi) {
+        if (settings.warnOnMeteredNetwork.value && !isOnWifi) {
             warningsHelper.uploadWarning(episodeUUID, source = SourceView.FILES)
                 .show(parentFragmentManager, "upload_warning")
         } else {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -83,7 +83,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             swipeButtonLayoutFactory = SwipeButtonLayoutFactory(
                 swipeButtonLayoutViewModel = swipeButtonLayoutViewModel,
                 onItemUpdated = ::lazyNotifyItemChanged,
-                defaultUpNextSwipeAction = { settings.upNextSwipe.flow.value },
+                defaultUpNextSwipeAction = { settings.upNextSwipe.value },
                 context = requireContext(),
                 fragmentManager = parentFragmentManager,
                 swipeSource = EpisodeItemTouchHelper.SwipeSource.FILES,

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
@@ -85,37 +85,37 @@ class CloudSettingsFragment : BaseFragment() {
         }
 
         with(binding.swtAutoAddToUpNext) {
-            isChecked = settings.cloudAddToUpNext.flow.value
+            isChecked = settings.cloudAddToUpNext.value
             setOnCheckedChangeListener { _, isChecked ->
                 viewModel.setAddToUpNext(isChecked)
             }
         }
         with(binding.swtDeleteLocalFileAfterPlaying) {
-            isChecked = settings.deleteLocalFileAfterPlaying.flow.value
+            isChecked = settings.deleteLocalFileAfterPlaying.value
             setOnCheckedChangeListener { _, isChecked ->
                 viewModel.setDeleteLocalFileAfterPlaying(isChecked)
             }
         }
         with(binding.swtDeleteCloudFileAfterPlaying) {
-            isChecked = settings.deleteCloudFileAfterPlaying.flow.value
+            isChecked = settings.deleteCloudFileAfterPlaying.value
             setOnCheckedChangeListener { _, isChecked ->
                 viewModel.setDeleteCloudFileAfterPlaying(isChecked)
             }
         }
         with(binding.swtAutoUploadToCloud) {
-            isChecked = settings.cloudAutoUpload.flow.value
+            isChecked = settings.cloudAutoUpload.value
             setOnCheckedChangeListener { _, isChecked ->
                 viewModel.setCloudAutoUpload(isChecked)
             }
         }
         with(binding.swtAutoDownloadFromCloud) {
-            isChecked = settings.cloudAutoDownload.flow.value
+            isChecked = settings.cloudAutoDownload.value
             setOnCheckedChangeListener { _, isChecked ->
                 viewModel.setCloudAutoDownload(isChecked)
             }
         }
         with(binding.swtCloudOnlyOnWiFi) {
-            isChecked = settings.cloudDownloadOnlyOnWifi.flow.value
+            isChecked = settings.cloudDownloadOnlyOnWifi.value
             setOnCheckedChangeListener { _, isChecked ->
                 viewModel.setCloudOnlyWifi(isChecked)
             }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoAddSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoAddSettingsFragment.kt
@@ -93,10 +93,10 @@ class AutoAddSettingsFragment : BaseFragment(), PodcastSelectFragment.Listener {
                     LR.string.settings_auto_up_next_limit
                 ),
                 getString(
-                    LR.string.episodes_plural, settings.autoAddUpNextLimit.flow.value
+                    LR.string.episodes_plural, settings.autoAddUpNextLimit.value
                 )
             ) {
-                val currentLimit = settings.autoAddUpNextLimit.flow.value
+                val currentLimit = settings.autoAddUpNextLimit.value
                 OptionsDialog()
                     .setTitle(getString(LR.string.settings_auto_up_next_limit))
                     .addCheckedOption(titleString = getString(LR.string.episodes_plural, 10), checked = currentLimit == 10) { viewModel.autoAddUpNextLimitChanged(10) }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoArchiveFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoArchiveFragment.kt
@@ -78,7 +78,7 @@ class AutoArchiveFragment : PreferenceFragmentCompat(), HasBackstack {
     }
 
     private fun updateStarredSummary() {
-        val starredSummary = getString(if (settings.autoArchiveIncludeStarred.flow.value) LR.string.settings_auto_archive_starred_summary else LR.string.settings_auto_archive_no_starred_summary)
+        val starredSummary = getString(if (settings.autoArchiveIncludeStarred.value) LR.string.settings_auto_archive_starred_summary else LR.string.settings_auto_archive_no_starred_summary)
         autoArchiveIncludeStarred.summary = starredSummary
     }
 
@@ -98,15 +98,15 @@ class AutoArchiveFragment : PreferenceFragmentCompat(), HasBackstack {
 
     private fun setupAutoArchiveAfterPlaying() {
         val stringArray = resources.getStringArray(LR.array.settings_auto_archive_played_values)
-        autoArchivePlayedEpisodes.value = stringArray[settings.autoArchiveAfterPlaying.flow.value.toIndex()]
+        autoArchivePlayedEpisodes.value = stringArray[settings.autoArchiveAfterPlaying.value.toIndex()]
     }
 
     private fun setupAutoArchiveInactive() {
         val stringArray = resources.getStringArray(LR.array.settings_auto_archive_inactive_values)
-        autoArchiveInactiveEpisodes.value = stringArray[settings.autoArchiveInactive.flow.value.toIndex()]
+        autoArchiveInactiveEpisodes.value = stringArray[settings.autoArchiveInactive.value.toIndex()]
     }
 
     private fun setupIncludeStarred() {
-        autoArchiveIncludeStarred.isChecked = settings.autoArchiveIncludeStarred.flow.value
+        autoArchiveIncludeStarred.isChecked = settings.autoArchiveIncludeStarred.value
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/MediaNotificationControlsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/MediaNotificationControlsFragment.kt
@@ -112,7 +112,7 @@ class MediaNotificationControlsFragment : BaseFragment(), MediaActionTouchCallba
         recyclerView.adapter = adapter
         (recyclerView.itemAnimator as? SimpleItemAnimator)?.supportsChangeAnimations = false
         (recyclerView.itemAnimator as? SimpleItemAnimator)?.changeDuration = 0
-        updateMediaActionsVisibility(settings.customMediaActionsVisibility.flow.value)
+        updateMediaActionsVisibility(settings.customMediaActionsVisibility.value)
 
         val callback = MediaActionTouchCallback(listener = this)
         itemTouchHelper = ItemTouchHelper(callback)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
@@ -247,7 +247,7 @@ class NotificationsSettingsFragment :
             intent.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_SILENT, true)
             intent.putExtra(RingtoneManager.EXTRA_RINGTONE_DEFAULT_URI, android.provider.Settings.System.DEFAULT_NOTIFICATION_URI)
 
-            val existingValue = settings.notificationSound.flow.value.path
+            val existingValue = settings.notificationSound.value.path
             // Select "Silent" if empty
             intent.putExtra(RingtoneManager.EXTRA_RINGTONE_EXISTING_URI, if (existingValue.isEmpty()) null else Uri.parse(existingValue))
 
@@ -410,7 +410,7 @@ class NotificationsSettingsFragment :
     }
 
     private fun changeVibrateSummary() {
-        vibratePreference?.summary = getString(settings.notificationVibrate.flow.value.summary)
+        vibratePreference?.summary = getString(settings.notificationVibrate.value.summary)
     }
 
     private fun getRingtoneValue(ringtonePath: String): String {
@@ -438,7 +438,7 @@ class NotificationsSettingsFragment :
                 preference.summary = getRingtoneValue(newValue as String)
                 true
             }
-            settings.notificationSound.flow.value.path.let { notificationSoundPath ->
+            settings.notificationSound.value.path.let { notificationSoundPath ->
                 it.setDefaultValue(notificationSoundPath)
                 it.summary = getRingtoneValue(notificationSoundPath)
             }
@@ -458,12 +458,12 @@ class NotificationsSettingsFragment :
             it.entryValues = options.map {
                 it.intValue.toString()
             }.toTypedArray()
-            it.value = settings.notificationVibrate.flow.value.intValue.toString()
+            it.value = settings.notificationVibrate.value.intValue.toString()
         }
     }
 
     private fun setupHidePlaybackNotifications() {
-        hidePlaybackNotificationsPreference?.isChecked = settings.hideNotificationOnPause.flow.value
+        hidePlaybackNotificationsPreference?.isChecked = settings.hideNotificationOnPause.value
     }
 
     private fun setupPlayOverNotifications() {
@@ -475,13 +475,13 @@ class NotificationsSettingsFragment :
             )
             entries = options.map { getString(it.titleRes) }.toTypedArray()
             entryValues = options.map { it.preferenceInt.toString() }.toTypedArray()
-            value = settings.playOverNotification.flow.value.preferenceInt.toString()
+            value = settings.playOverNotification.value.preferenceInt.toString()
         }
         changePlayOverNotificationSummary()
     }
 
     private fun changePlayOverNotificationSummary() {
-        playOverNotificationPreference?.summary = getString(settings.playOverNotification.flow.value.titleRes)
+        playOverNotificationPreference?.summary = getString(settings.playOverNotification.value.titleRes)
     }
 
     override fun getBackstackCount(): Int {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/PrivacyViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/PrivacyViewModel.kt
@@ -33,8 +33,8 @@ class PrivacyViewModel @Inject constructor(
     private val mutableUiState = MutableStateFlow<UiState>(
         UiState.Loaded(
             analytics = analyticsTracker.getSendUsageStats(),
-            crashReports = settings.sendCrashReports.flow.value,
-            linkAccount = settings.linkCrashReportsToUser.flow.value,
+            crashReports = settings.sendCrashReports.value,
+            linkAccount = settings.linkCrashReportsToUser.value,
             getUserEmail = { syncManager.getEmail() }
         )
     )

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModel.kt
@@ -25,11 +25,11 @@ class AdvancedSettingsViewModel
     private fun initState() = State(
         backgroundSyncOnMeteredState = State.BackgroundSyncOnMeteredState(
             isChecked = settings.syncOnMeteredNetwork(),
-            isEnabled = settings.backgroundRefreshPodcasts.flow.value,
+            isEnabled = settings.backgroundRefreshPodcasts.value,
             onCheckedChange = {
                 // isEnabled controls the grey out of the function but not if it's actually called
                 // here we disable the functionality
-                if (settings.backgroundRefreshPodcasts.flow.value) {
+                if (settings.backgroundRefreshPodcasts.value) {
                     onSyncOnMeteredCheckedChange(it)
                     analyticsTracker.track(
                         AnalyticsEvent.SETTINGS_ADVANCED_SYNC_ON_METERED,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -41,7 +41,7 @@ class AutoDownloadSettingsViewModel @Inject constructor(
         )
     }
 
-    fun getAutoDownloadUpNext() = settings.autoDownloadUpNext.flow.value
+    fun getAutoDownloadUpNext() = settings.autoDownloadUpNext.value
 
     fun onNewEpisodesChange(newValue: Boolean) {
         analyticsTracker.track(
@@ -70,7 +70,7 @@ class AutoDownloadSettingsViewModel @Inject constructor(
         )
     }
 
-    fun getAutoDownloadUnmeteredOnly() = settings.autoDownloadUnmeteredOnly.flow.value
+    fun getAutoDownloadUnmeteredOnly() = settings.autoDownloadUnmeteredOnly.value
 
     fun onDownloadOnlyWhenChargingChange(enabled: Boolean) {
         settings.autoDownloadOnlyWhenCharging.set(enabled)
@@ -80,5 +80,5 @@ class AutoDownloadSettingsViewModel @Inject constructor(
         )
     }
 
-    fun getAutoDownloadOnlyWhenCharging() = settings.autoDownloadOnlyWhenCharging.flow.value
+    fun getAutoDownloadOnlyWhenCharging() = settings.autoDownloadOnlyWhenCharging.value
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
@@ -58,7 +58,7 @@ class StorageSettingsViewModel
     val permissionRequest = mutablePermissionRequest.asSharedFlow()
 
     private val backgroundRefreshSummary: Int
-        get() = if (settings.backgroundRefreshPodcasts.flow.value) {
+        get() = if (settings.backgroundRefreshPodcasts.value) {
             LR.string.settings_storage_background_refresh_on
         } else {
             LR.string.settings_storage_background_refresh_off
@@ -126,7 +126,7 @@ class StorageSettingsViewModel
         ),
         backgroundRefreshState = State.BackgroundRefreshState(
             summary = backgroundRefreshSummary,
-            isChecked = settings.backgroundRefreshPodcasts.flow.value,
+            isChecked = settings.backgroundRefreshPodcasts.value,
             onCheckedChange = {
                 onBackgroundRefreshCheckedChange(it)
                 analyticsTracker.track(
@@ -136,7 +136,7 @@ class StorageSettingsViewModel
             }
         ),
         storageDataWarningState = State.StorageDataWarningState(
-            isChecked = settings.warnOnMeteredNetwork.flow.value,
+            isChecked = settings.warnOnMeteredNetwork.value,
             onCheckedChange = {
                 onStorageDataWarningCheckedChange(it)
                 analyticsTracker.track(
@@ -168,7 +168,7 @@ class StorageSettingsViewModel
     private fun updateMobileDataWarningState() {
         mutableState.value = mutableState.value.copy(
             storageDataWarningState = mutableState.value.storageDataWarningState.copy(
-                isChecked = settings.warnOnMeteredNetwork.flow.value,
+                isChecked = settings.warnOnMeteredNetwork.value,
             )
         )
     }
@@ -181,7 +181,7 @@ class StorageSettingsViewModel
     private fun updateBackgroundRefreshState() {
         mutableState.value = mutableState.value.copy(
             backgroundRefreshState = mutableState.value.backgroundRefreshState.copy(
-                isChecked = settings.backgroundRefreshPodcasts.flow.value,
+                isChecked = settings.backgroundRefreshPodcasts.value,
                 summary = backgroundRefreshSummary
             )
         )

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
@@ -82,7 +82,7 @@ class ActionRunnerControlPlayback : TaskerPluginRunnerActionNoOutput<InputContro
         val playbackEffects: PlaybackEffects = if (overrideGlobalEffects) {
             currentPodcast.playbackEffects
         } else {
-            settings.globalPlaybackEffects.flow.value
+            settings.globalPlaybackEffects.value
         }
         playbackEffects.updater()
         if (overrideGlobalEffects) {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTracker.kt
@@ -42,5 +42,5 @@ object AnalyticsTracker {
         }
     }
 
-    fun getSendUsageStats() = settings.collectAnalytics.flow.value
+    fun getSendUsageStats() = settings.collectAnalytics.value
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/FirebaseAnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/FirebaseAnalyticsTracker.kt
@@ -261,7 +261,7 @@ object FirebaseAnalyticsTracker {
     }
 
     private fun logEvent(name: String, bundle: Bundle? = Bundle()) {
-        if (settings.collectAnalytics.flow.value) {
+        if (settings.collectAnalytics.value) {
             firebaseAnalytics.logEvent(name, bundle)
 
             Timber.d("Analytic event $name $bundle")

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -529,9 +529,9 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     ) {
         override fun get(): PlaybackEffects = PlaybackEffects().apply {
-            playbackSpeed = globalPlaybackSpeed.flow.value
-            trimMode = globalAudioEffectRemoveSilence.flow.value
-            isVolumeBoosted = globalAudioEffectVolumeBoost.flow.value
+            playbackSpeed = globalPlaybackSpeed.value
+            trimMode = globalAudioEffectRemoveSilence.value
+            isVolumeBoosted = globalAudioEffectVolumeBoost.value
         }
 
         override fun persist(value: PlaybackEffects, commit: Boolean) {
@@ -1086,7 +1086,7 @@ class SettingsImpl @Inject constructor(
     }
 
     override fun getMaxUpNextEpisodes(): Int {
-        return max(DEFAULT_MAX_AUTO_ADD_LIMIT, autoAddUpNextLimit.flow.value)
+        return max(DEFAULT_MAX_AUTO_ADD_LIMIT, autoAddUpNextLimit.value)
     }
 
     private fun setStringList(key: String, array: List<String>) {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -24,7 +24,7 @@ abstract class UserSetting<T>(
     // Returns the value to sync if sync is needed. Returns null if sync is not needed.
     fun getSyncValue(): T? {
         val needsSync = sharedPrefs.getBoolean(needsSyncKey, false)
-        return if (needsSync) flow.value else null
+        return if (needsSync) value else null
     }
 
     // These are lazy because (1) the class needs to initialize before calling get() and
@@ -33,9 +33,13 @@ abstract class UserSetting<T>(
     private val _flow by lazy { MutableStateFlow(get()) }
     val flow: StateFlow<T> by lazy { _flow }
 
-    // external callers should use the flow.value to get the current value or, even
-    // better, use the flow to observe changes.
+    // External callers should use [value] to get the current value if they can't
+    // listen to the flow for changes. This method is solely to be used to intitialize
+    // the flow.
     protected abstract fun get(): T
+
+    val value: T
+        get() = flow.value
 
     protected abstract fun persist(value: T, commit: Boolean)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
@@ -472,12 +472,12 @@ class DownloadManagerImpl @Inject constructor(
         // user has tapped download
         if (!episode.isAutoDownloaded) {
             // user said yes to warning dialog
-            return if (episode.isManualDownloadOverridingWifiSettings || !settings.warnOnMeteredNetwork.flow.value) {
+            return if (episode.isManualDownloadOverridingWifiSettings || !settings.warnOnMeteredNetwork.value) {
                 NetworkRequirements.runImmediately()
             } else NetworkRequirements.needsUnmetered()
         } else if (episode is UserEpisode) {
             // UserEpisodes have their own auto download setting
-            return if (settings.cloudDownloadOnlyOnWifi.flow.value) {
+            return if (settings.cloudDownloadOnlyOnWifi.value) {
                 NetworkRequirements.needsUnmetered()
             } else {
                 NetworkRequirements.runImmediately()
@@ -486,8 +486,8 @@ class DownloadManagerImpl @Inject constructor(
 
         val networkRequirements = NetworkRequirements.mostStringent()
 
-        networkRequirements.requiresUnmetered = settings.autoDownloadUnmeteredOnly.flow.value
-        networkRequirements.requiresPower = settings.autoDownloadOnlyWhenCharging.flow.value
+        networkRequirements.requiresUnmetered = settings.autoDownloadUnmeteredOnly.value
+        networkRequirements.requiresPower = settings.autoDownloadOnlyWhenCharging.value
 
         return networkRequirements
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
@@ -181,12 +181,12 @@ class VersionMigrationsJob : JobService() {
 
     private fun performV7Migration() {
         // We want v6 users to keep defaulting to download, new users should get the new stream default
-        val currentStreamingPreference = if (settings.contains(Settings.PREFERENCE_GLOBAL_STREAMING_MODE)) settings.streamingMode.flow.value else false
+        val currentStreamingPreference = if (settings.contains(Settings.PREFERENCE_GLOBAL_STREAMING_MODE)) settings.streamingMode.value else false
         settings.streamingMode.set(currentStreamingPreference)
     }
 
     private fun addUpNextAutoDownload() {
-        settings.autoDownloadUpNext.set(!settings.streamingMode.flow.value)
+        settings.autoDownloadUpNext.set(!settings.streamingMode.value)
     }
 
     private fun deletePodcastImages() {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NewEpisodeNotificationAction.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NewEpisodeNotificationAction.kt
@@ -72,7 +72,7 @@ enum class NewEpisodeNotificationAction(
         }
 
         fun loadFromSettings(settings: Settings): List<NewEpisodeNotificationAction> {
-            val setting = settings.newEpisodeNotificationActions.flow.value
+            val setting = settings.newEpisodeNotificationActions.value
             return when (setting) {
                 NewEpisodeNotificationActionSetting.Default -> DEFAULT_ACTIONS
                 is NewEpisodeNotificationActionSetting.ValueOf -> actionsFromString(setting.value)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
@@ -39,8 +39,8 @@ class NotificationDrawerImpl @Inject constructor(
 
     private val playAction = NotificationCompat.Action(IR.drawable.notification_play, context.getString(LR.string.play), MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PLAY))
     private val pauseAction = NotificationCompat.Action(IR.drawable.notification_pause, context.getString(LR.string.pause), MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PAUSE))
-    private val skipBackAction = NotificationCompat.Action(IR.drawable.notification_skipbackwards, context.getString(LR.string.player_notification_skip_back, settings.skipBackInSecs.flow.value), MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_SKIP_TO_PREVIOUS))
-    private val skipForwardAction = NotificationCompat.Action(IR.drawable.notification_skipforward, context.getString(LR.string.player_notification_skip_forward, settings.skipForwardInSecs.flow.value), MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_SKIP_TO_NEXT))
+    private val skipBackAction = NotificationCompat.Action(IR.drawable.notification_skipbackwards, context.getString(LR.string.player_notification_skip_back, settings.skipBackInSecs.value), MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_SKIP_TO_PREVIOUS))
+    private val skipForwardAction = NotificationCompat.Action(IR.drawable.notification_skipforward, context.getString(LR.string.player_notification_skip_forward, settings.skipForwardInSecs.value), MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_SKIP_TO_NEXT))
     private val stopPendingIntent = MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_STOP)
 
     private var notificationData: NotificationData? = null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeFileMetadata.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeFileMetadata.kt
@@ -39,7 +39,7 @@ class EpisodeFileMetadata(val filenamePrefix: String? = null) {
 
     @UnstableApi
     fun read(tracks: Tracks?, settings: Settings, context: Context) {
-        return read(tracks, settings.useEmbeddedArtwork.flow.value, context)
+        return read(tracks, settings.useEmbeddedArtwork.value, context)
     }
 
     @UnstableApi

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FocusManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FocusManager.kt
@@ -153,7 +153,7 @@ open class FocusManager(private val settings: Settings, context: Context?) : Aud
 
     private fun canDuck(): PlayOverNotificationSetting {
         if (audioFocus != AUDIO_NO_FOCUS_CAN_DUCK_TRANSIENT) return PlayOverNotificationSetting.NEVER
-        return settings.playOverNotification.flow.value
+        return settings.playOverNotification.value
     }
 
     interface FocusChangeListener {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -352,7 +352,7 @@ class MediaSessionManager(
         Timber.i("MediaSession metadata. Episode: ${episode.uuid} ${episode.title} Duration: ${episode.durationMs.toLong()}")
         mediaSession.setMetadata(nowPlaying)
 
-        if (settings.showArtworkOnLockScreen.flow.value) {
+        if (settings.showArtworkOnLockScreen.value) {
             if (Util.isAutomotive(context)) {
                 val bitmapUri = AutoConverter.getBitmapUriForPodcast(podcast, episode, context)?.toString()
                 nowPlayingBuilder = nowPlayingBuilder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM_ART_URI, bitmapUri)
@@ -374,8 +374,8 @@ class MediaSessionManager(
             addCustomAction(stateBuilder, APP_ACTION_SKIP_FWD, "Skip forward", IR.drawable.auto_skipforward)
         }
 
-        val visibleCount = if (settings.customMediaActionsVisibility.flow.value) MediaNotificationControls.MAX_VISIBLE_OPTIONS else 0
-        settings.mediaControlItems.flow.value.take(visibleCount).forEach { mediaControl ->
+        val visibleCount = if (settings.customMediaActionsVisibility.value) MediaNotificationControls.MAX_VISIBLE_OPTIONS else 0
+        settings.mediaControlItems.value.take(visibleCount).forEach { mediaControl ->
             when (mediaControl) {
                 MediaNotificationControls.Archive -> addCustomAction(stateBuilder, APP_ACTION_ARCHIVE, "Archive", IR.drawable.ic_archive)
                 MediaNotificationControls.MarkAsPlayed -> addCustomAction(stateBuilder, APP_ACTION_MARK_AS_PLAYED, "Mark as played", IR.drawable.auto_markasplayed)
@@ -667,7 +667,7 @@ class MediaSessionManager(
                 }
             }
             // update global playback speed
-            val effects = settings.globalPlaybackEffects.flow.value
+            val effects = settings.globalPlaybackEffects.value
             effects.playbackSpeed = newSpeed
             settings.globalPlaybackEffects.set(effects)
             playbackManager.updatePlayerEffects(effects = effects)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -229,7 +229,7 @@ open class PlaybackManager @Inject constructor(
             return nextEpisode
         }
 
-        if (!settings.autoPlayNextEpisodeOnEmpty.flow.value) {
+        if (!settings.autoPlayNextEpisodeOnEmpty.value) {
             return null
         }
 
@@ -351,7 +351,7 @@ open class PlaybackManager @Inject constructor(
     }
 
     fun shouldWarnAboutPlayback(episodeUUID: String? = upNextQueue.currentEpisode?.uuid): Boolean {
-        return settings.warnOnMeteredNetwork.flow.value && !Network.isUnmeteredConnection(application) && lastWarnedPlayedEpisodeUuid != episodeUUID
+        return settings.warnOnMeteredNetwork.value && !Network.isUnmeteredConnection(application) && lastWarnedPlayedEpisodeUuid != episodeUUID
     }
 
     fun getPlaybackSpeed(): Double {
@@ -715,7 +715,7 @@ open class PlaybackManager @Inject constructor(
 
     fun skipForward(
         sourceView: SourceView = SourceView.UNKNOWN,
-        jumpAmountSeconds: Int = settings.skipForwardInSecs.flow.value,
+        jumpAmountSeconds: Int = settings.skipForwardInSecs.value,
     ) {
         launch {
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Skip forward tapped")
@@ -740,7 +740,7 @@ open class PlaybackManager @Inject constructor(
         trackPlayback(AnalyticsEvent.PLAYBACK_SKIP_FORWARD, sourceView)
     }
 
-    fun skipBackward(sourceView: SourceView = SourceView.UNKNOWN, jumpAmountSeconds: Int = settings.skipBackInSecs.flow.value) {
+    fun skipBackward(sourceView: SourceView = SourceView.UNKNOWN, jumpAmountSeconds: Int = settings.skipBackInSecs.value) {
         launch {
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Skip backward tapped")
 
@@ -1495,7 +1495,7 @@ open class PlaybackManager @Inject constructor(
         if (!episode.isDownloaded) {
             if (!Util.isCarUiMode(application) &&
                 !Util.isWearOs(application) && // The watch handles these warnings before this is called
-                settings.warnOnMeteredNetwork.flow.value &&
+                settings.warnOnMeteredNetwork.value &&
                 !Network.isUnmeteredConnection(application) &&
                 !forceStream &&
                 play
@@ -1589,7 +1589,7 @@ open class PlaybackManager @Inject constructor(
         val playbackEffects = if (podcast != null && podcast.overrideGlobalEffects) {
             podcast.playbackEffects
         } else {
-            settings.globalPlaybackEffects.flow.value
+            settings.globalPlaybackEffects.value
         }
 
         val previousPlaybackState = playbackStateRelay.blockingFirst()
@@ -1709,7 +1709,7 @@ open class PlaybackManager @Inject constructor(
         val notification = builder.build()
 
         // Add sound and vibrations
-        val sound = settings.notificationSound.flow.value.uri
+        val sound = settings.notificationSound.value.uri
         if (sound != null) {
             notification.sound = sound
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -268,7 +268,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
                 PlaybackStateCompat.STATE_STOPPED,
                 PlaybackStateCompat.STATE_PAUSED,
                 PlaybackStateCompat.STATE_ERROR -> {
-                    val removeNotification = state != PlaybackStateCompat.STATE_PAUSED || settings.hideNotificationOnPause.flow.value
+                    val removeNotification = state != PlaybackStateCompat.STATE_PAUSED || settings.hideNotificationOnPause.value
                     // We have to be careful here to only call notify when moving from PLAY to PAUSE once
                     // or else the notification will come back after being swiped away
                     if (removeNotification || isForegroundService) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ResumptionHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ResumptionHelper.kt
@@ -13,7 +13,7 @@ class ResumptionHelper(val settings: Settings) {
     private var lastPauseTime: Date? = settings.getLastPauseTime()
 
     fun adjustedStartTimeMsFor(episode: BaseEpisode): Int {
-        if (!settings.intelligentPlaybackResumption.flow.value ||
+        if (!settings.intelligentPlaybackResumption.value ||
             settings.getLastPausedUUID() != episode.uuid ||
             (settings.getLastPausedAt() ?: 0) != episode.playedUpToMs
         ) return episode.playedUpToMs

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -191,8 +191,8 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
         val player = ExoPlayer.Builder(context, renderer)
             .setTrackSelector(trackSelector)
             .setLoadControl(loadControl)
-            .setSeekForwardIncrementMs(settings.skipForwardInSecs.flow.value * 1000L)
-            .setSeekBackIncrementMs(settings.skipBackInSecs.flow.value * 1000L)
+            .setSeekForwardIncrementMs(settings.skipForwardInSecs.value * 1000L)
+            .setSeekBackIncrementMs(settings.skipBackInSecs.value * 1000L)
             .build()
 
         renderer.onAudioSessionId(player.audioSessionId)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
@@ -312,7 +312,7 @@ class UpNextQueueImpl @Inject constructor(
     }
 
     private fun downloadIfPossible(episode: BaseEpisode, downloadManager: DownloadManager) {
-        if (settings.autoDownloadUpNext.flow.value) {
+        if (settings.autoDownloadUpNext.value) {
             DownloadHelper.addAutoDownloadedEpisodeToQueue(episode, "up next auto download", downloadManager, episodeManager)
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
@@ -171,7 +171,7 @@ class FolderManagerImpl @Inject constructor(
     }
 
     override suspend fun getHomeFolder(): List<FolderItem> {
-        val sortType = settings.podcastsSortType.flow.value
+        val sortType = settings.podcastsSortType.value
 
         val podcasts = if (sortType == EPISODE_DATE_NEWEST_TO_OLDEST) {
             podcastManager.findPodcastsOrderByLatestEpisode(orderAsc = false)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -396,7 +396,7 @@ class PodcastManagerImpl @Inject constructor(
     }
 
     override suspend fun findSubscribedSorted(): List<Podcast> {
-        val sortType = settings.podcastsSortType.flow.value
+        val sortType = settings.podcastsSortType.value
         // use a query to get the podcasts ordered by episode release date
         if (sortType == PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST) {
             return findPodcastsOrderByLatestEpisode(orderAsc = false)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -129,8 +129,8 @@ class SubscribeManager @Inject constructor(
         // set subscribed to true and update the sync status
         val updateObservable = podcastDao.updateSubscribedRx(subscribed = true, uuid = podcastUuid)
             .andThen(podcastDao.updateSyncStatusRx(syncStatus = if (sync) Podcast.SYNC_STATUS_NOT_SYNCED else Podcast.SYNC_STATUS_SYNCED, uuid = podcastUuid))
-            .andThen(Completable.fromAction { podcastDao.updateGrouping(PodcastGrouping.All.indexOf(settings.podcastGroupingDefault.flow.value), podcastUuid) })
-            .andThen(rxCompletable { podcastDao.updateShowArchived(podcastUuid, settings.showArchivedDefault.flow.value) })
+            .andThen(Completable.fromAction { podcastDao.updateGrouping(PodcastGrouping.All.indexOf(settings.podcastGroupingDefault.value), podcastUuid) })
+            .andThen(rxCompletable { podcastDao.updateShowArchived(podcastUuid, settings.showArchivedDefault.value) })
         // return the final podcast
         val findObservable = podcastDao.findByUuidRx(podcastUuid)
         return updateObservable.andThen(findObservable.toSingle())
@@ -143,8 +143,8 @@ class SubscribeManager @Inject constructor(
                 // mark sync status
                 podcast.syncStatus = if (sync) Podcast.SYNC_STATUS_NOT_SYNCED else Podcast.SYNC_STATUS_SYNCED
                 podcast.isSubscribed = subscribed
-                podcast.grouping = PodcastGrouping.All.indexOf(settings.podcastGroupingDefault.flow.value)
-                podcast.showArchived = settings.showArchivedDefault.flow.value
+                podcast.grouping = PodcastGrouping.All.indexOf(settings.podcastGroupingDefault.value)
+                podcast.showArchived = settings.showArchivedDefault.value
             }
         // add the podcast
         val insertPodcastObservable = podcastObservable.flatMap { podcast ->

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -173,7 +173,7 @@ class UserEpisodeManagerImpl @Inject constructor(
     override suspend fun add(episode: UserEpisode, playbackManager: PlaybackManager) {
         userEpisodeDao.insert(episode)
 
-        if (settings.cloudAddToUpNext.flow.value) {
+        if (settings.cloudAddToUpNext.value) {
             playbackManager.playLast(episode = episode, source = SourceView.FILES)
         }
     }
@@ -385,7 +385,7 @@ class UserEpisodeManagerImpl @Inject constructor(
                 val newEpisode = it.toUserEpisode()
                 add(newEpisode, playbackManager)
 
-                if (settings.cloudAutoDownload.flow.value && subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid) {
+                if (settings.cloudAutoDownload.value && subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid) {
                     userEpisodeDao.updateAutoDownloadStatus(PodcastEpisode.AUTO_DOWNLOAD_STATUS_AUTO_DOWNLOADED, newEpisode.uuid)
                     newEpisode.autoDownloadStatus = PodcastEpisode.AUTO_DOWNLOAD_STATUS_AUTO_DOWNLOADED
                     downloadManager.addEpisodeToQueue(newEpisode, "cloud files sync", false)
@@ -551,7 +551,7 @@ class UserEpisodeManagerImpl @Inject constructor(
     }
 
     override suspend fun deletePlayedEpisodeIfReq(episode: UserEpisode, playbackManager: PlaybackManager) {
-        if (settings.deleteLocalFileAfterPlaying.flow.value) {
+        if (settings.deleteLocalFileAfterPlaying.value) {
             deleteFilesForEpisode(episode)
             userEpisodeDao.updateEpisodeStatus(episode.uuid, EpisodeStatusEnum.NOT_DOWNLOADED)
 
@@ -560,7 +560,7 @@ class UserEpisodeManagerImpl @Inject constructor(
             }
         }
 
-        if (settings.deleteCloudFileAfterPlaying.flow.value && episode.serverStatus == UserEpisodeServerStatus.UPLOADED) {
+        if (settings.deleteCloudFileAfterPlaying.value && episode.serverStatus == UserEpisodeServerStatus.UPLOADED) {
             removeFromCloud(episode)
             if (!episode.isDownloaded) {
                 delete(episode, playbackManager)
@@ -569,8 +569,8 @@ class UserEpisodeManagerImpl @Inject constructor(
     }
 
     override fun autoUploadToCloudIfReq(episode: UserEpisode) {
-        if (settings.cloudAutoUpload.flow.value && subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid) {
-            uploadToServer(episode, settings.cloudDownloadOnlyOnWifi.flow.value)
+        if (settings.cloudAutoUpload.value && subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid) {
+            uploadToServer(episode, settings.cloudDownloadOnlyOnWifi.value)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsTask.kt
@@ -54,7 +54,7 @@ class RefreshPodcastsTask @AssistedInject constructor(
         fun scheduleOrCancel(context: Context, settings: Settings) {
             val workManager = WorkManager.getInstance(context)
 
-            if (!settings.backgroundRefreshPodcasts.flow.value) {
+            if (!settings.backgroundRefreshPodcasts.value) {
                 workManager.cancelAllWorkByTag(TAG_REFRESH_TASK)
                 return
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -329,7 +329,7 @@ class RefreshPodcastsThread(
         // and run through them one by one sorted by their publish date. They are added to up next as if the action
         // was run right as they were published magically
         runBlocking {
-            val upNextLimit = settings.autoAddUpNextLimit.flow.value
+            val upNextLimit = settings.autoAddUpNextLimit.value
             episodesToAddToUpNext.sortBy { it.second.publishedDate }
             episodesToAddToUpNext.forEach {
                 if (playbackManager.upNextQueue.queueEpisodes.size < upNextLimit) {
@@ -338,7 +338,7 @@ class RefreshPodcastsThread(
                         AddToUpNext.Last -> playbackManager.playLast(it.second, source = SourceView.UNKNOWN, userInitiated = false)
                     }
                 } else if (playbackManager.upNextQueue.queueEpisodes.size >= upNextLimit &&
-                    settings.autoAddUpNextLimitBehaviour.flow.value == AutoAddUpNextLimitBehaviour.ONLY_ADD_TO_TOP &&
+                    settings.autoAddUpNextLimitBehaviour.value == AutoAddUpNextLimitBehaviour.ONLY_ADD_TO_TOP &&
                     it.first == AddToUpNext.Next
                 ) {
                     playbackManager.playNext(it.second, source = SourceView.UNKNOWN, userInitiated = false)
@@ -537,11 +537,11 @@ class RefreshPodcastsThread(
 
             // Add sound and vibrations
             if (!isGroupNotification) {
-                val sound = settings.notificationSound.flow.value.uri
+                val sound = settings.notificationSound.value.uri
                 if (sound != null) {
                     notification.sound = sound
                 }
-                val isVibrateOn = settings.notificationVibrate.flow.value.isNotificationVibrateOn(context)
+                val isVibrateOn = settings.notificationVibrate.value.isNotificationVibrateOn(context)
                 if (isVibrateOn) {
                     notification.defaults = notification.defaults or Notification.DEFAULT_VIBRATE
                 }
@@ -627,11 +627,11 @@ class RefreshPodcastsThread(
             val summaryNotification = summaryBuilder.build()
 
             // Add sound and vibrations
-            val sound = settings.notificationSound.flow.value.uri
+            val sound = settings.notificationSound.value.uri
             if (sound != null) {
                 summaryNotification.sound = sound
             }
-            val isVibrateOn = settings.notificationVibrate.flow.value.isNotificationVibrateOn(context)
+            val isVibrateOn = settings.notificationVibrate.value.isNotificationVibrateOn(context)
             if (isVibrateOn) {
                 summaryNotification.defaults = summaryNotification.defaults or Notification.DEFAULT_VIBRATE
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -263,7 +263,7 @@ class Support @Inject constructor(
             output.append("Android version: ").append(Build.VERSION.RELEASE).append(" SDK ").append(Build.VERSION.SDK_INT).append(eol)
             output.append(eol)
 
-            output.append("Background refresh: ").append(settings.backgroundRefreshPodcasts.flow.value).append(eol)
+            output.append("Background refresh: ").append(settings.backgroundRefreshPodcasts.value).append(eol)
             output.append("Battery restriction: ${systemBatteryRestrictions.status}")
             output.append(eol)
 
@@ -315,16 +315,16 @@ class Support @Inject constructor(
 
             output.append(eol)
             output.append("Auto archive settings").append(eol)
-            output.append("Auto archive played episodes after: ${settings.autoArchiveAfterPlaying.flow.value.analyticsValue}").append(eol)
-            output.append("Auto archive inactive episodes after: ${settings.autoArchiveInactive.flow.value.analyticsValue}").append(eol)
-            output.append("Auto archive starred episodes: ${settings.autoArchiveIncludeStarred.flow.value}").append(eol)
+            output.append("Auto archive played episodes after: ${settings.autoArchiveAfterPlaying.value.analyticsValue}").append(eol)
+            output.append("Auto archive inactive episodes after: ${settings.autoArchiveInactive.value.analyticsValue}").append(eol)
+            output.append("Auto archive starred episodes: ${settings.autoArchiveIncludeStarred.value}").append(eol)
 
             output.append(eol)
             output.append("Auto downloads").append(eol)
             output.append("  Any podcast? ").append(yesNoString(autoDownloadOn[0])).append(eol)
-            output.append("  Up Next? ").append(yesNoString(settings.autoDownloadUpNext.flow.value)).append(eol)
-            output.append("  Only on unmetered WiFi? ").append(yesNoString(settings.autoDownloadUnmeteredOnly.flow.value)).append(eol)
-            output.append("  Only when charging? ").append(yesNoString(settings.autoDownloadOnlyWhenCharging.flow.value)).append(eol)
+            output.append("  Up Next? ").append(yesNoString(settings.autoDownloadUpNext.value)).append(eol)
+            output.append("  Only on unmetered WiFi? ").append(yesNoString(settings.autoDownloadUnmeteredOnly.value)).append(eol)
+            output.append("  Only when charging? ").append(yesNoString(settings.autoDownloadOnlyWhenCharging.value)).append(eol)
             output.append(eol)
 
             output.append("Current connection").append(eol)
@@ -333,7 +333,7 @@ class Support @Inject constructor(
             output.append("  Restrict Background Status: ").append(Network.getRestrictBackgroundStatusString(context)).append(eol)
             output.append(eol)
 
-            output.append("Warning when not on Wifi? ").append(yesNoString(settings.warnOnMeteredNetwork.flow.value)).append(eol)
+            output.append("Warning when not on Wifi? ").append(yesNoString(settings.warnOnMeteredNetwork.value)).append(eol)
             output.append(eol)
 
             output.append("Work Manager Tasks").append(eol)
@@ -404,11 +404,11 @@ class Support @Inject constructor(
                 output.append(eol)
 
                 output.append("Notifications").append(eol)
-                output.append("Play over notifications? ").append(settings.playOverNotification.flow.value.analyticsString).append(eol)
-                output.append("Hide notification on pause? ").append(if (settings.hideNotificationOnPause.flow.value) "yes" else "no").append(eol)
+                output.append("Play over notifications? ").append(settings.playOverNotification.value.analyticsString).append(eol)
+                output.append("Hide notification on pause? ").append(if (settings.hideNotificationOnPause.value) "yes" else "no").append(eol)
                 output.append(eol)
 
-                val effects = settings.globalPlaybackEffects.flow.value
+                val effects = settings.globalPlaybackEffects.value
                 output.append("Effects").append(eol)
                 output.append("Global Audio effects: ")
                     .append(" Playback speed: ").append(effects.playbackSpeed).append(eol)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
@@ -131,8 +131,8 @@ class WidgetManagerImpl @Inject constructor(
     }
 
     private fun updateSkipAmounts(views: RemoteViews, settings: Settings) {
-        val jumpFwdAmount = settings.skipForwardInSecs.flow.value
-        val jumpBackAmount = settings.skipBackInSecs.flow.value
+        val jumpFwdAmount = settings.skipForwardInSecs.value
+        val jumpBackAmount = settings.skipBackInSecs.value
 
         views.setTextViewText(R.id.widget_skip_back_text, "$jumpBackAmount")
         views.setContentDescription(R.id.widget_skip_back_text, "Skip back $jumpBackAmount seconds")

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/AppIcon.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/AppIcon.kt
@@ -209,7 +209,7 @@ class AppIcon @Inject constructor(
         }
     }
 
-    var activeAppIcon: AppIconType = AppIconType.fromSetting(settings.appIcon.flow.value)
+    var activeAppIcon: AppIconType = AppIconType.fromSetting(settings.appIcon.value)
         set(value) {
             field = value
             settings.appIcon.set(value.setting)

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
@@ -267,17 +267,17 @@ class Theme @Inject constructor(private val settings: Settings) {
     }
 
     private fun getThemeFromPreferences(): ThemeType =
-        ThemeType.fromThemeSetting(settings.theme.flow.value)
+        ThemeType.fromThemeSetting(settings.theme.value)
 
     private fun setThemeToPreferences(theme: ThemeType) {
         settings.theme.set(theme.themeSetting)
     }
 
     private fun getPreferredDarkThemeFromPreferences(): ThemeType =
-        ThemeType.fromThemeSetting(settings.darkThemePreference.flow.value)
+        ThemeType.fromThemeSetting(settings.darkThemePreference.value)
 
     private fun getPreferredLightFromPreferences(): ThemeType =
-        ThemeType.fromThemeSetting(settings.lightThemePreference.flow.value)
+        ThemeType.fromThemeSetting(settings.lightThemePreference.value)
 
     private fun setPreferredDarkThemeToPreferences(theme: ThemeType) {
         settings.darkThemePreference.set(theme.themeSetting)
@@ -295,7 +295,7 @@ class Theme @Inject constructor(private val settings: Settings) {
         }
     }
 
-    fun getUseSystemTheme(): Boolean = settings.useSystemTheme.flow.value
+    fun getUseSystemTheme(): Boolean = settings.useSystemTheme.value
 
     fun getPodcastTintColor(podcast: Podcast): Int {
         return podcast.getTintColor(isDarkTheme)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -68,12 +68,12 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
 
     private fun setupSentry() {
         SentryAndroid.init(this) { options ->
-            options.dsn = if (settings.sendCrashReports.flow.value) settings.getSentryDsn() else ""
+            options.dsn = if (settings.sendCrashReports.value) settings.getSentryDsn() else ""
             options.setTag(SentryHelper.GLOBAL_TAG_APP_PLATFORM, AppPlatform.WEAR.value)
         }
 
         // Link email to Sentry crash reports only if the user has opted in
-        if (settings.linkCrashReportsToUser.flow.value) {
+        if (settings.linkCrashReportsToUser.value) {
             syncManager.getEmail()?.let { syncEmail ->
                 val user = User().apply { email = syncEmail }
                 Sentry.setUser(user)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsViewModel.kt
@@ -28,7 +28,7 @@ class EffectsViewModel
         playbackManager.playbackStateRelay
             .asFlow()
             .map {
-                State.Loaded(settings.globalPlaybackEffects.flow.value)
+                State.Loaded(settings.globalPlaybackEffects.value)
             }
             .stateIn(
                 scope = viewModelScope,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/PrivacySettingsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/PrivacySettingsViewModel.kt
@@ -23,9 +23,9 @@ class PrivacySettingsViewModel @Inject constructor(
 
     private val _state = MutableStateFlow(
         State(
-            sendAnalytics = settings.collectAnalytics.flow.value,
-            sendCrashReports = settings.sendCrashReports.flow.value,
-            linkCrashReportsToUser = settings.linkCrashReportsToUser.flow.value,
+            sendAnalytics = settings.collectAnalytics.value,
+            sendCrashReports = settings.sendCrashReports.value,
+            linkCrashReportsToUser = settings.linkCrashReportsToUser.value,
         )
     )
     val state = _state.asStateFlow()

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsViewModel.kt
@@ -37,8 +37,8 @@ class SettingsViewModel @Inject constructor(
         State(
             refreshState = null,
             signInState = userManager.getSignInState().blockingFirst(),
-            showDataWarning = settings.warnOnMeteredNetwork.flow.value,
-            refreshInBackground = settings.backgroundRefreshPodcasts.flow.value,
+            showDataWarning = settings.warnOnMeteredNetwork.value,
+            refreshInBackground = settings.backgroundRefreshPodcasts.value,
         )
     )
     val state = _state.asStateFlow()


### PR DESCRIPTION
## Description
This gives the `UserSetting` object a `value` field to access `flow.value`. The other changes are just replacing calls to `.flow.value` with `.value` as suggested in [this comment](https://github.com/Automattic/pocket-casts-android/pull/1264#discussion_r1289708778).

This PR is targeting the settings-refactor feature branch.

## Testing Instructions
If CI is happy, then we should be good.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews