### PR TITLE
Updating bookmark tabs design

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkHeaderViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkHeaderViewHolder.kt
@@ -57,12 +57,10 @@ class BookmarkHeaderViewHolder(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth()
+                .padding(start = 16.dp, top = 4.dp, bottom = 12.dp)
         ) {
             Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(start = 16.dp)
-                    .padding(vertical = 16.dp)
+                modifier = Modifier.weight(1f)
             ) {
                 SearchView(
                     bookmarkHeader = bookmarkHeader,
@@ -113,7 +111,7 @@ class BookmarkHeaderViewHolder(
             color = MaterialTheme.theme.colors.primaryText02,
             modifier = Modifier
                 .padding(start = 16.dp)
-                .padding(vertical = 16.dp)
+                .padding(vertical = 14.dp)
         )
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/TabsViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/TabsViewHolder.kt
@@ -1,19 +1,16 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.adapter
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.ScrollableTabRow
-import androidx.compose.material.Tab
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.buttons.ButtonTab
+import au.com.shiftyjelly.pocketcasts.compose.buttons.ButtonTabs
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastAdapter.TabsHeader
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastViewModel.PodcastTab
@@ -24,47 +21,24 @@ class TabsViewHolder(
     private val theme: Theme,
 ) : RecyclerView.ViewHolder(composeView) {
     fun bind(tabsHeader: TabsHeader) {
+        val tabs = PodcastTab.values().map {
+            ButtonTab(
+                labelResId = it.labelResId,
+                onClick = { tabsHeader.onTabClicked(it) }
+            )
+        }
         composeView.setContent {
             AppTheme(theme.activeTheme) {
-                TabsRow(tabsHeader)
-            }
-        }
-    }
-}
+                ButtonTabs(
+                    tabs = tabs,
+                    selectedTab = tabs[tabsHeader.selectedTab.ordinal],
+                    modifier = Modifier
+                        .background(color = MaterialTheme.theme.colors.primaryUi02)
+                        .padding(start = 16.dp)
+                        .fillMaxWidth()
 
-@Composable
-private fun TabsRow(
-    tabsHeader: TabsHeader,
-) {
-    val selectedTabIndex = tabsHeader.selectedTab.ordinal
-    ScrollableTabRow(
-        selectedTabIndex = selectedTabIndex,
-        backgroundColor = MaterialTheme.theme.colors.primaryUi02,
-        contentColor = MaterialTheme.theme.colors.primaryText01,
-        edgePadding = 0.dp,
-        divider = {},
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        PodcastTab.values().toList()
-            .map { stringResource(it.labelResId) }
-            .forEachIndexed { i, text ->
-                Tab(
-                    selected = selectedTabIndex == i,
-                    onClick = { tabsHeader.onTabClicked(PodcastTab.values()[i]) },
-                    text = { au.com.shiftyjelly.pocketcasts.compose.components.TextH40(text = text) },
                 )
             }
-    }
-}
-
-@Preview
-@Composable
-private fun TabsRowPreview(
-    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
-) {
-    AppTheme(themeType) {
-        TabsRow(
-            tabsHeader = TabsHeader(PodcastTab.EPISODES) {},
-        )
+        }
     }
 }

--- a/modules/features/podcasts/src/main/res/layout/adapter_episode_header.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_episode_header.xml
@@ -8,7 +8,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/primary_ui_02"
-        android:paddingTop="16dp">
+        android:paddingTop="8dp">
 
         <au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.EpisodeSearchView
             android:id="@+id/episodeSearchView"

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
@@ -47,7 +47,7 @@
             android:id="@+id/artworkContainer"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:layout_marginStart="20dp"
+            android:layout_marginStart="16dp"
             android:clipToPadding="false"
             android:elevation="8dp"
             android:importantForAccessibility="noHideDescendants"

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkRow.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkRow.kt
@@ -86,7 +86,7 @@ sealed class BookmarkRowColors {
             return if (isMultiSelecting() && isSelected) {
                 MaterialTheme.theme.colors.primaryUi02Selected
             } else {
-                MaterialTheme.theme.colors.primaryUi01
+                MaterialTheme.theme.colors.primaryUi02
             }
         }
         @Composable

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/ButtonTabs.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/ButtonTabs.kt
@@ -1,0 +1,123 @@
+package au.com.shiftyjelly.pocketcasts.compose.buttons
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.SnackbarDefaults.backgroundColor
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+private val ButtonHorizontalPadding = 12.dp
+private val ButtonVerticalPadding = 8.dp
+
+private val ButtonPaddingValues = PaddingValues(
+    start = ButtonHorizontalPadding,
+    top = ButtonVerticalPadding,
+    end = ButtonHorizontalPadding,
+    bottom = ButtonVerticalPadding
+)
+
+data class ButtonTab(
+    @StringRes val labelResId: Int,
+    val onClick: () -> Unit,
+)
+
+@Composable
+fun ButtonTabs(
+    tabs: List<ButtonTab>,
+    selectedTab: ButtonTab,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier) {
+        for (tab in tabs) {
+            val interactionSource = remember { MutableInteractionSource() }
+            val pressed by interactionSource.collectIsPressedAsState()
+            val focused by interactionSource.collectIsFocusedAsState()
+            val selected = selectedTab == tab
+            val backgroundColor = if (selected) {
+                // make the button background the same color as the text, black on the light theme and white on the dark theme
+                MaterialTheme.theme.colors.primaryText01
+            } else {
+                if (pressed || focused) {
+                    // the press and focus state is a lighter version of the button background color
+                    MaterialTheme.theme.colors.primaryText01.copy(alpha = 0.1f)
+                } else {
+                    // the unselected button is the same color as the layout background
+                    MaterialTheme.theme.colors.primaryUi02
+                }
+            }
+            val textColor = if (selected) MaterialTheme.theme.colors.primaryUi02 else MaterialTheme.theme.colors.primaryText02
+            Button(
+                onClick = { tab.onClick() },
+                shape = RoundedCornerShape(8.dp),
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = backgroundColor
+                ),
+                contentPadding = ButtonPaddingValues,
+                elevation = ButtonDefaults.elevation(
+                    defaultElevation = 0.dp,
+                    pressedElevation = 0.dp,
+                    focusedElevation = 0.dp
+                ),
+                interactionSource = interactionSource,
+                modifier = Modifier.padding(end = 6.dp)
+            ) {
+                Text(
+                    text = stringResource(tab.labelResId),
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight(500),
+                    letterSpacing = 0.5.sp,
+                    color = textColor
+                )
+            }
+        }
+    }
+}
+
+@ShowkaseComposable(name = "ButtonTabs", group = "Button", styleName = "Light", defaultStyle = true)
+@Preview(name = "Light")
+@Composable
+fun ButtonTabsLightPreview() {
+    ButtonTabsPreview(Theme.ThemeType.LIGHT)
+}
+
+@ShowkaseComposable(name = "ButtonTabs", group = "Button", styleName = "Dark")
+@Preview(name = "Dark")
+@Composable
+fun ButtonTabsDarkPreview() {
+    ButtonTabsPreview(Theme.ThemeType.DARK)
+}
+
+@Composable
+private fun ButtonTabsPreview(themeType: Theme.ThemeType) {
+    AppThemeWithBackground(themeType) {
+        val episodesTab = ButtonTab(labelResId = LR.string.episodes, onClick = {})
+        val bookmarksTab = ButtonTab(labelResId = LR.string.bookmarks, onClick = {})
+        ButtonTabs(
+            tabs = listOf(episodesTab, bookmarksTab),
+            selectedTab = episodesTab,
+            modifier = Modifier.padding(horizontal = 8.dp)
+        )
+    }
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/ButtonTabs.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/ButtonTabs.kt
@@ -6,12 +6,13 @@ import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.SnackbarDefaults.backgroundColor
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -80,8 +81,7 @@ fun ButtonTabs(
                     pressedElevation = 0.dp,
                     focusedElevation = 0.dp
                 ),
-                interactionSource = interactionSource,
-                modifier = Modifier.padding(end = 6.dp)
+                interactionSource = interactionSource
             ) {
                 Text(
                     text = stringResource(tab.labelResId),
@@ -91,6 +91,7 @@ fun ButtonTabs(
                     color = textColor
                 )
             }
+            Spacer(Modifier.width(6.dp))
         }
     }
 }


### PR DESCRIPTION
## Description

This updates the podcast page bookmark tabs to match the design.

## Testing Instructions
1. Make sure you are signed into an account with a Plus subscription
2. Go to the 'Podcasts' tab
3. Tap on a podcast artwork
4. ✅ Verify the tabs work correctly

## Screenshots 

| Light | Dark | Indigo |
| --- | --- | --- |
| ![Screenshot_20230811_084315](https://github.com/Automattic/pocket-casts-android/assets/308331/4d0cb3cc-3020-447d-94b3-7e9fce387171) | ![Screenshot_20230811_084356](https://github.com/Automattic/pocket-casts-android/assets/308331/b2bd3082-aec9-440c-93c5-0c677334b831) | ![Screenshot_20230811_084417](https://github.com/Automattic/pocket-casts-android/assets/308331/1990bd2a-1a5b-4d32-a04c-9e04ef8c71e1) |
