### PR TITLE
Settings Sync - convert remaining settings to UserSettings

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UpNextQueueTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UpNextQueueTest.kt
@@ -7,6 +7,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.LastPlayedList
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueueImpl
@@ -36,6 +37,7 @@ class UpNextQueueTest {
         val episodeManager = mock<EpisodeManager> {}
         val settings = mock<Settings> {
             on { autoDownloadUpNext } doReturn UserSetting.Mock(true, mock())
+            on { lastLoadedFromPodcastOrFilterUuid } doReturn UserSetting.Mock(LastPlayedList.None, mock())
         }
         val syncManager = mock<SyncManager> {}
 

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
@@ -55,7 +55,6 @@ class AutomotiveApplication : Application(), Configuration.Provider {
         setupSentry()
         setupLogging()
         setupAnalytics()
-        setupAutomotiveDefaults()
         setupApp()
     }
 
@@ -94,14 +93,6 @@ class AutomotiveApplication : Application(), Configuration.Provider {
     override fun onTerminate() {
         super.onTerminate()
         Log.d(Settings.LOG_TAG_AUTO, "Terminate")
-    }
-
-    private fun setupAutomotiveDefaults() {
-        // We don't want these to default to true in the main app so we set them up here.
-
-        if (!settings.contains(Settings.PREFERENCE_AUTO_SUBSCRIBE_ON_PLAY)) {
-            settings.setBooleanForKey(Settings.PREFERENCE_AUTO_SUBSCRIBE_ON_PLAY, true)
-        }
     }
 
     private fun setupSentry() {

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -31,6 +31,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
     @Inject lateinit var settings: Settings
     @Inject lateinit var podcastManager: PodcastManager
 
+    private lateinit var preferenceAutoPlay: SwitchPreference
     private lateinit var preferenceAutoSubscribeToPlayed: SwitchPreference
     private lateinit var preferenceAutoShowPlayed: SwitchPreference
     private var preferenceRefreshNow: Preference? = null
@@ -41,8 +42,9 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.preferences_auto)
 
-        preferenceAutoSubscribeToPlayed = preferenceManager.findPreference<SwitchPreference>("autoSubscribeToPlayed")!!
-        preferenceAutoShowPlayed = preferenceManager.findPreference<SwitchPreference>("autoShowPlayed")!!
+        preferenceAutoPlay = preferenceManager.findPreference("autoUpNextEmpty")!!
+        preferenceAutoSubscribeToPlayed = preferenceManager.findPreference("autoSubscribeToPlayed")!!
+        preferenceAutoShowPlayed = preferenceManager.findPreference("autoShowPlayed")!!
 
         preferenceSkipForward = preferenceManager.findPreference<EditTextPreference>(Settings.PREFERENCE_SKIP_FORWARD)?.apply {
             setInputAsSeconds()
@@ -58,6 +60,14 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
 
     override fun onResume() {
         super.onResume()
+        preferenceAutoPlay.apply {
+            isChecked = settings.autoPlayNextEpisodeOnEmpty.value
+            setOnPreferenceChangeListener { _, newValue ->
+                settings.autoPlayNextEpisodeOnEmpty.set(newValue as Boolean)
+                true
+            }
+        }
+
         preferenceAutoSubscribeToPlayed.apply {
             isChecked = settings.autoSubscribeToPlayed.value
             setOnPreferenceChangeListener { _, newValue ->

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -31,6 +31,8 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
     @Inject lateinit var settings: Settings
     @Inject lateinit var podcastManager: PodcastManager
 
+    private lateinit var preferenceAutoSubscribeToPlayed: SwitchPreference
+    private lateinit var preferenceAutoShowPlayed: SwitchPreference
     private var preferenceRefreshNow: Preference? = null
     private var preferenceSkipForward: EditTextPreference? = null
     private var preferenceSkipBackward: EditTextPreference? = null
@@ -39,13 +41,8 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.preferences_auto)
 
-        preferenceManager.findPreference<SwitchPreference>("autoSubscribeToPlayed")?.apply {
-            isChecked = settings.autoSubscribeToPlayed.value
-            setOnPreferenceChangeListener { _, newValue ->
-                settings.autoSubscribeToPlayed.set(newValue as Boolean)
-                true
-            }
-        }
+        preferenceAutoSubscribeToPlayed = preferenceManager.findPreference<SwitchPreference>("autoSubscribeToPlayed")!!
+        preferenceAutoShowPlayed = preferenceManager.findPreference<SwitchPreference>("autoShowPlayed")!!
 
         preferenceSkipForward = preferenceManager.findPreference<EditTextPreference>(Settings.PREFERENCE_SKIP_FORWARD)?.apply {
             setInputAsSeconds()
@@ -57,6 +54,25 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
         changeSkipTitles()
         setupRefreshNow()
         setupAbout()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        preferenceAutoSubscribeToPlayed.apply {
+            isChecked = settings.autoSubscribeToPlayed.value
+            setOnPreferenceChangeListener { _, newValue ->
+                settings.autoSubscribeToPlayed.set(newValue as Boolean)
+                true
+            }
+        }
+
+        preferenceAutoShowPlayed.apply {
+            isChecked = settings.autoShowPlayed.value
+            setOnPreferenceChangeListener { _, newValue ->
+                settings.autoShowPlayed.set(newValue as Boolean)
+                true
+            }
+        }
     }
 
     private fun setupAbout() {

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.toLiveData
 import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreference
 import au.com.shiftyjelly.pocketcasts.localization.BuildConfig
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralSeconds
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralSecondsMinutesHoursDaysOrYears
@@ -37,6 +38,14 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.preferences_auto)
+
+        preferenceManager.findPreference<SwitchPreference>("autoSubscribeToPlayed")?.apply {
+            isChecked = settings.autoSubscribeToPlayed.value
+            setOnPreferenceChangeListener { _, newValue ->
+                settings.autoSubscribeToPlayed.set(newValue as Boolean)
+                true
+            }
+        }
 
         preferenceSkipForward = preferenceManager.findPreference<EditTextPreference>(Settings.PREFERENCE_SKIP_FORWARD)?.apply {
             setInputAsSeconds()

--- a/automotive/src/main/res/xml/preferences_auto.xml
+++ b/automotive/src/main/res/xml/preferences_auto.xml
@@ -5,19 +5,16 @@
         <SwitchPreference
             android:key="autoUpNextEmpty"
             android:title="@string/settings_auto_play"
-            app:defaultValue="true"
             android:summary="@string/settings_auto_play_summary" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_title_playback">
         <SwitchPreference
             android:key="autoSubscribeToPlayed"
             android:title="@string/settings_subscribe_to_played"
-            android:defaultValue="true"
             android:summary="@string/settings_subscribe_to_played_summary" />
         <SwitchPreference
             android:key="autoShowPlayed"
             android:title="@string/settings_show_played"
-            android:defaultValue="false"
             android:summary="@string/settings_show_played_summary" />
     </PreferenceCategory>
     <EditTextPreference

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -82,7 +82,6 @@ interface Settings {
         const val PREFERENCE_UPNEXT_EXPANDED = "upnextExpanded"
         const val INTELLIGENT_PLAYBACK_RESUMPTION = "intelligentPlaybackResumption"
 
-        const val PREFERENCE_AUTO_SUBSCRIBE_ON_PLAY = "autoSubscribeToPlayed"
         const val PREFERENCE_AUTO_SHOW_PLAYED = "autoShowPlayed"
 
         const val STORAGE_ON_CUSTOM_FOLDER = "custom_folder"
@@ -348,7 +347,7 @@ interface Settings {
     fun getSeenUpNextTour(): Boolean
     fun setTrialFinishedSeen(seen: Boolean)
     fun getTrialFinishedSeen(): Boolean
-    fun getAutoSubscribeToPlayed(): Boolean
+    val autoSubscribeToPlayed: UserSetting<Boolean>
     fun getAutoShowPlayed(): Boolean
     val autoPlayNextEpisodeOnEmpty: UserSetting<Boolean>
     val showArchivedDefault: UserSetting<Boolean>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.AutoAddUpNextLimitBehavi
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveInactiveSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
+import au.com.shiftyjelly.pocketcasts.preferences.model.LastPlayedList
 import au.com.shiftyjelly.pocketcasts.preferences.model.NewEpisodeNotificationActionSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.NotificationVibrateSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
@@ -402,8 +403,7 @@ interface Settings {
     fun setFullySignedOut(boolean: Boolean)
     fun getFullySignedOut(): Boolean
 
-    fun getlastLoadedFromPodcastOrFilterUuid(): String?
-    fun setlastLoadedFromPodcastOrFilterUuid(uuid: String?)
+    val lastLoadedFromPodcastOrFilterUuid: UserSetting<LastPlayedList>
 
     // It would be better to have this be a UserSetting<ThemeType>, but that
     // is not easy due to the way our modules are structured.

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -82,8 +82,6 @@ interface Settings {
         const val PREFERENCE_UPNEXT_EXPANDED = "upnextExpanded"
         const val INTELLIGENT_PLAYBACK_RESUMPTION = "intelligentPlaybackResumption"
 
-        const val PREFERENCE_AUTO_SHOW_PLAYED = "autoShowPlayed"
-
         const val STORAGE_ON_CUSTOM_FOLDER = "custom_folder"
 
         const val PREFERENCE_BOOKMARKS_SORT_TYPE_FOR_PLAYER = "bookmarksSortTypeForPlayer"
@@ -348,7 +346,7 @@ interface Settings {
     fun setTrialFinishedSeen(seen: Boolean)
     fun getTrialFinishedSeen(): Boolean
     val autoSubscribeToPlayed: UserSetting<Boolean>
-    fun getAutoShowPlayed(): Boolean
+    val autoShowPlayed: UserSetting<Boolean>
     val autoPlayNextEpisodeOnEmpty: UserSetting<Boolean>
     val showArchivedDefault: UserSetting<Boolean>
     val mediaControlItems: UserSetting<List<MediaNotificationControls>>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -337,9 +337,11 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override fun getAutoSubscribeToPlayed(): Boolean {
-        return getBoolean(Settings.PREFERENCE_AUTO_SUBSCRIBE_ON_PLAY, false)
-    }
+    override val autoSubscribeToPlayed = UserSetting.BoolPref(
+        sharedPrefKey = "autoSubscribeToPlayed",
+        defaultValue = Util.isAutomotive(context),
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun getAutoShowPlayed(): Boolean {
         return getBoolean(Settings.PREFERENCE_AUTO_SHOW_PLAYED, false)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -343,9 +343,11 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override fun getAutoShowPlayed(): Boolean {
-        return getBoolean(Settings.PREFERENCE_AUTO_SHOW_PLAYED, false)
-    }
+    override val autoShowPlayed = UserSetting.BoolPref(
+        sharedPrefKey = "autoShowPlayed",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
 
     override val playOverNotification = UserSetting.PrefFromString<PlayOverNotificationSetting>(
         sharedPrefKey = "overrideNotificationAudio",

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -29,6 +29,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.AutoAddUpNextLimitBehavi
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveInactiveSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
+import au.com.shiftyjelly.pocketcasts.preferences.model.LastPlayedList
 import au.com.shiftyjelly.pocketcasts.preferences.model.NewEpisodeNotificationActionSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.NotificationVibrateSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
@@ -72,7 +73,6 @@ class SettingsImpl @Inject constructor(
         private const val LAST_SELECTED_SUBSCRIPTION_TIER_KEY = "LastSelectedSubscriptionTierKey"
         private const val LAST_SELECTED_SUBSCRIPTION_FREQUENCY_KEY = "LastSelectedSubscriptionFrequencyKey"
         private const val PROCESSED_SIGNOUT_KEY = "ProcessedSignout"
-        private const val LAST_SELECTED_PODCAST_OR_FILTER_UUID = "LastSelectedPodcastOrFilterUuid"
     }
 
     private var languageCode: String? = null
@@ -1216,12 +1216,24 @@ class SettingsImpl @Inject constructor(
     override fun getFullySignedOut(): Boolean =
         getBoolean(PROCESSED_SIGNOUT_KEY, true)
 
-    override fun setlastLoadedFromPodcastOrFilterUuid(uuid: String?) {
-        setString(LAST_SELECTED_PODCAST_OR_FILTER_UUID, uuid)
-    }
-
-    override fun getlastLoadedFromPodcastOrFilterUuid(): String? =
-        getString(LAST_SELECTED_PODCAST_OR_FILTER_UUID)
+    override val lastLoadedFromPodcastOrFilterUuid = UserSetting.PrefFromString(
+        sharedPrefKey = "LastSelectedPodcastOrFilterUuid",
+        defaultValue = LastPlayedList.default,
+        sharedPrefs = sharedPreferences,
+        fromString = {
+            if (it.isEmpty()) {
+                LastPlayedList.default
+            } else {
+                LastPlayedList.Uuid(it)
+            }
+        },
+        toString = {
+            when (it) {
+                LastPlayedList.None -> ""
+                is LastPlayedList.Uuid -> it.uuid
+            }
+        }
+    )
 
     override val theme = ThemeSetting.UserSettingPref(
         sharedPrefKey = "pocketCastsTheme",

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -37,6 +37,9 @@ abstract class UserSetting<T>(
     // better, use the flow to observe changes.
     protected abstract fun get(): T
 
+    val value: T
+        get() = flow.value
+
     protected abstract fun persist(value: T, commit: Boolean)
 
     fun set(value: T, commit: Boolean = false, needsSync: Boolean = false) {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/LastPlayedList.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/LastPlayedList.kt
@@ -1,0 +1,17 @@
+package au.com.shiftyjelly.pocketcasts.preferences.model
+
+sealed class LastPlayedList(open val uuid: String?) {
+    class Uuid(override val uuid: String) : LastPlayedList(uuid)
+    object None : LastPlayedList(null)
+
+    companion object {
+        val default = None
+
+        fun fromString(uuid: String?): LastPlayedList =
+            if (uuid == null) {
+                None
+            } else {
+                Uuid(uuid)
+            }
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -25,6 +25,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationControls
+import au.com.shiftyjelly.pocketcasts.preferences.model.LastPlayedList
 import au.com.shiftyjelly.pocketcasts.repositories.playback.auto.AutoConverter
 import au.com.shiftyjelly.pocketcasts.repositories.playback.auto.AutoMediaId
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -570,7 +571,9 @@ class MediaSessionManager(
                 val episodeId = autoMediaId.episodeId
                 episodeManager.findEpisodeByUuid(episodeId)?.let { episode ->
                     playbackManager.playNow(episode, sourceView = source)
-                    settings.setlastLoadedFromPodcastOrFilterUuid(autoMediaId.sourceId)
+                    LastPlayedList.fromString(autoMediaId.sourceId).let { lastPlayedList ->
+                        settings.lastLoadedFromPodcastOrFilterUuid.set(lastPlayedList)
+                    }
                 }
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1564,7 +1564,7 @@ open class PlaybackManager @Inject constructor(
         // podcast start from
         if (episode is PodcastEpisode) {
             // Auto subscribe to played podcasts (used in Automotive)
-            if (podcast != null && settings.getAutoSubscribeToPlayed() && !podcast.isSubscribed && episode.episodeType !is PodcastEpisode.EpisodeType.Trailer) {
+            if (podcast != null && settings.autoSubscribeToPlayed.value && !podcast.isSubscribed && episode.episodeType !is PodcastEpisode.EpisodeType.Trailer) {
                 podcastManager.subscribeToPodcast(podcast.uuid, sync = true)
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1151,7 +1151,7 @@ open class PlaybackManager @Inject constructor(
     }
 
     private suspend fun autoSelectNextEpisode(): BaseEpisode? {
-        val lastPodcastOrFilterUuid = settings.getlastLoadedFromPodcastOrFilterUuid()
+        val lastPodcastOrFilterUuid = settings.lastLoadedFromPodcastOrFilterUuid.value.uuid
         val lastEpisodeUuid = lastPlayedEpisodeUuid
         if (lastEpisodeUuid == null || lastPodcastOrFilterUuid == null) {
             return null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -521,7 +521,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
             val podcastFound = podcastManager.findPodcastByUuidSuspend(parentId) ?: podcastManager.findOrDownloadPodcastRx(parentId).toMaybe().onErrorComplete().awaitSingleOrNull()
             podcastFound?.let { podcast ->
 
-                val showPlayed = settings.getAutoShowPlayed()
+                val showPlayed = settings.autoShowPlayed.value
                 val episodes = episodeManager
                     .findEpisodesByPodcastOrdered(podcast)
                     .filterNot { !showPlayed && (it.isFinished || it.isArchived) }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
@@ -8,6 +8,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UpNextChange
 import au.com.shiftyjelly.pocketcasts.models.entity.toUpNextEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.LastPlayedList
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -163,7 +164,9 @@ class UpNextQueueImpl @Inject constructor(
         if (queueEpisodes.isEmpty()) {
             // when the upNextQueue is empty, save the source for auto playing the next episode
             automaticUpNextSource?.let {
-                settings.setlastLoadedFromPodcastOrFilterUuid(it.uuid)
+                LastPlayedList.fromString(it.uuid).let { lastPlayedList ->
+                    settings.lastLoadedFromPodcastOrFilterUuid.set(lastPlayedList)
+                }
             }
             saveChanges(UpNextAction.ClearAll)
         }
@@ -307,7 +310,7 @@ class UpNextQueueImpl @Inject constructor(
         // clear last loaded uuid if anything gets added to the up next queue
         val hasQueuedItems = currentEpisode != null
         if (hasQueuedItems) {
-            settings.setlastLoadedFromPodcastOrFilterUuid(null)
+            settings.lastLoadedFromPodcastOrFilterUuid.set(LastPlayedList.None)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -496,7 +496,7 @@ class PlaylistManagerImpl @Inject constructor(
         where.append("archived = 0")
 
         val playingEpisode = playbackManager?.getCurrentEpisode()?.uuid
-        val lastLoadedFromPodcastOrFilterUuid = settings.getlastLoadedFromPodcastOrFilterUuid()
+        val lastLoadedFromPodcastOrFilterUuid = settings.lastLoadedFromPodcastOrFilterUuid.value.uuid
         if (playingEpisode != null && lastLoadedFromPodcastOrFilterUuid == playlist.uuid) {
             where.insert(0, "(podcast_episodes.uuid = '$playingEpisode' OR (")
             where.append("))")


### PR DESCRIPTION
## Description
This makes the automotive settings for subscribing to played podcasts, showing played podcasts, and the setting for the last played list into UserSettings. 

In addition, this fixes a bug whereby auto play on automotive was not updating the autoPlay user setting. It was just updating the persisted setting directly, which meant the UserSetting's flow was not updated and would not reflect the new value until the app was restarted. I introduced this bug when I refactored the auto play setting to be a `UserSetting` (https://github.com/Automattic/pocket-casts-android/pull/1213), so it never got released.

## Testing Instructions

### 1. Subscribing to played podcasts
On the automotive app, ensure that toggling the subscribe to played podcast setting 
- is defaulted to true
- controls whether played podcasts get automatically subscribed to
- is persisted between restarts of the app

### 2. Showing played podcasts
On the automotive app, ensure that togglign the show played episodes setting
- is defaulted to false
- controls whether played episodes are shown when viewing a podcast
- is persisted between restarts of the app

### 3. Auto play (implicitly testing the last-played-list setting)
On both the automotive and phone apps, ensure that when playing a podcast episode with remaining unplayed episodes, completing that episode will:
- if the auto play setting is on, continue playing episodes from that podcast
- if the auto play setting is off, stop playing episodes from that podcast

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews