### PR TITLE
Ensure upgrade flow continues after signing into account with google sign in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 7.46
 -----
 
+*   Bug Fixes:
+    *    Improved upgrade flow when signing in with Google account
+         ([#1275](https://github.com/Automattic/pocket-casts-android/pull/1275))
 
 7.45
 -----

--- a/TESTING-CHECKLIST.md
+++ b/TESTING-CHECKLIST.md
@@ -2,7 +2,7 @@ Note: (A) means Automated Test. If automated UI tests were executed for the app,
 
 ## Manual Tests
 
-#### Account
+### Account
 
 - [ ] Create an account.
 - [ ] Change email.
@@ -12,7 +12,36 @@ Note: (A) means Automated Test. If automated UI tests were executed for the app,
 - [ ] Login to account.
 - [ ] Purchase Pocket Casts Plus.
 
-#### Podcasts
+### Onboarding
+
+#### Onboarding: Create Account
+- [ ] With username/password
+- [ ] With Google
+
+#### Onboarding: Log into existing account
+- [ ] With username/password
+- [ ] With Google
+
+#### Onboarding: Upgrade
+Test the following routes into the upgrade screen:
+
+- [ ] Folder icon on Podcasts tab
+- [ ] Upsell prompt on Profile tab
+- [ ] Upsell prompt on Account screen
+- [ ] Bookmarks (accessible from podcast screen, episode screen, and now playing screen)
+- [ ] Settings: Pocket Casts Plus section
+- [ ] Settings: Appearance
+- [ ] Files: bottom of add file screen prompt
+- [ ] Files: Upload to cloud button
+
+For each of the following setups:
+1. not logged in—making sure you are prompted to log in during the onboarding flow and logging in
+   1. With a Google account
+   2. With username/password
+2. when logged in to a free account
+3. when logged in to a Plus account (will not see upgrade prompts for Plus features)
+
+### Podcasts
 
 - [ ] Subscribe to a new podcast in discover.
 - [ ] Stream an episode.
@@ -31,9 +60,9 @@ Note: (A) means Automated Test. If automated UI tests were executed for the app,
 - [ ] Swipe an episode row to add to Up Next in first position.
 - [ ] Swipe an episode row to add to Up Next in last position.
 
-#### Folders
+### Folders
 
-##### Folders: Create
+#### Folders: Create
 
 - [ ] When creating a folder the search should filter the list of podcasts to add.
 - [ ] When creating a folder check the sort works for ‘name’, ‘episode release date’ and ‘date added’.
@@ -42,7 +71,7 @@ Note: (A) means Automated Test. If automated UI tests were executed for the app,
 - [ ] After creating a folder you should be taken to the created folder page and not the root folder.
 - [ ] The new folder’s sort type should default to the same as the home folder’s.
 
-##### Folders: Edit
+#### Folders: Edit
 
 - [ ] Edit the folder name and colour.
 - [ ] Make sure the folder name can't be empty.  
@@ -51,7 +80,7 @@ Note: (A) means Automated Test. If automated UI tests were executed for the app,
 - [ ] When in drag and drop mode, added podcasts should appear at the end of the folder.
 - [ ] When the home folder is in drag and drop mode, removed podcasts should appear at the end of the home folder.
 
-##### Folders: Podcasts Tab
+#### Folders: Podcasts Tab
 
 - [ ] The folder artwork should show the podcasts in the sort order in the folder.
 - [ ] When the home folder is sorted by drag & drop a created folder should be added to the top of the list.
@@ -65,7 +94,7 @@ Note: (A) means Automated Test. If automated UI tests were executed for the app,
 - [ ] The podcast search should include a folder if the name matches. Tapping the folder should open the folder podcasts page.
 - [ ] If the user doesn't have Pocket Casts Plus the folder shouldn't appear in the search results.
 
-##### Folders: Open Folder Page
+#### Folders: Open Folder Page
 
 - [ ] The create folder icon only appears on the root folder page.
 - [ ] The podcast search only appears on the root folder page.
@@ -74,21 +103,21 @@ Note: (A) means Automated Test. If automated UI tests were executed for the app,
 - [ ] The sort in the folder should be separate from the home folder. Also different folders can have their own sort orders.
 - [ ] Podcasts in folders should be able to be sorted by ‘Name’, ‘Episode Release Date’, ‘Date Added’, and ‘Drag and Drop’.
 
-##### Folders: Podcast Page
+#### Folders: Podcast Page
 
 - [ ] On the podcast page there should be a folder icon so the podcast can be added to a folder, or moved if it is already in a folder.
 - [ ] Pocket Casts Plus
 - [ ] You will only see folders if you are signed in to an account with a Pocket Casts Plus subscription.
 - [ ] You will still see the create folder icon if you aren’t paying for a Plus subscription, tapping it will show an upgrade page.
 
-#### Mini Player
+### Mini Player
 - [ ] Play and pause an episode.
 - [ ] Skip forward and back.
 - [ ] Tap the Up Next icon to open the Up Next.
 - [ ] Tap near the artwork to open the full screen player.
 - [ ] Swipe down to close the full screen player.
 
-#### Full Screen Player
+### Full Screen Player
 
 - [ ] Play / pause an episode.
 - [ ] Skip forward / backward.
@@ -106,13 +135,13 @@ Note: (A) means Automated Test. If automated UI tests were executed for the app,
 - [ ] Tap the video picture in picture button
 - [ ] With picture in picture check the play, pause, skip and close buttons work.
 
-#### Chromecast
+### Chromecast
 
 - [ ] Play and pause episode through Chromecast.
 - [ ] Skip forward / backward.
 - [ ] Check when an episode finishes the next starts playing.
 
-#### Up Next
+### Up Next
 
 - [ ] Rearrange Up Next episodes.
 - [ ] Remove an episode.
@@ -121,13 +150,13 @@ Note: (A) means Automated Test. If automated UI tests were executed for the app,
 - [ ] Sign in to your account, add episodes to your Up Next, sign out of your account, change the Up Next, sign back in and your local Up Next shouldn't change.
 - [ ] Sign in to your account, add episodes to your Up Next, sign out of your account, clear your Up Next, sign back in and your server Up Next should be seen on your device.
 
-#### Search
+### Search
 
 - [ ] Search for a podcast and subscribe to it.
 - [ ] The podcasts tab search should return your subscribed local podcasts first. The subscribed podcasts should be sorted A to Z. After these should be the server search results.  
 - [ ] The discover tab search should not return your local podcasts first.
 
-#### Podcast Grid
+### Podcast Grid
 
 - [ ] Turn badges on and off.
 - [ ] Change the layout.
@@ -135,17 +164,17 @@ Note: (A) means Automated Test. If automated UI tests were executed for the app,
 - [ ] Drag and drop podcasts to a new position.
 - [ ] Share a podcast list.
 
-#### Podcast shares
+### Podcast shares
 
 - [ ] Open a podcast share list.
 
-#### Discover
+### Discover
 
 - [ ] Tap show all on a list.
 - [ ] Open a category list.
 - [ ] Change your region.
 
-#### Profile
+### Profile
 
 - [ ] Open Stats.
 - [ ] Open Downloads.
@@ -153,26 +182,26 @@ Note: (A) means Automated Test. If automated UI tests were executed for the app,
 - [ ] Open Starred.
 - [ ] Open Listening History.
 
-#### Settings
+### Settings
 
 - [ ] Open up every section.
 - [ ] Opml export / import.
 
-#### Android Auto
+### Android Auto
 
 - [ ] Press all the buttons.
 
-#### Android Automotive
+### Android Automotive
 
 - [ ] Try the app in the Polestar emulator.
 - [ ] Try the app in a landscape emulator.
 
-#### Playback Notification
+### Playback Notification
 
 - [ ] Test the player controls work.
 - [ ] Test the seek bar works.
 
-#### Sonos
+### Sonos
 
 - [ ] Make sure you can link an account.
 - [ ] Check your podcasts and filters lists.

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/OnboardingFlowComposableTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/OnboardingFlowComposableTest.kt
@@ -1,0 +1,121 @@
+package au.com.shiftyjelly.pocketcasts
+
+import androidx.activity.compose.setContent
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.testing.TestNavHostController
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivity
+import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingFlowComposable
+import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingNavRoute
+import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import junit.framework.TestCase.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+
+/**
+ * This test class is in the app component so Hilt can access the application for injection.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class OnboardingFlowComposableTest {
+
+    @get:Rule val composeTestRule = createAndroidComposeRule<OnboardingActivity>()
+    lateinit var navController: TestNavHostController
+
+    fun setupAppNavHost(
+        flow: OnboardingFlow,
+        signInState: SignInState = mock(),
+        exitOnboarding: () -> Unit = {},
+        completeOnboardingToDiscover: () -> Unit = {},
+    ) {
+        composeTestRule.activity.setContent {
+            navController = TestNavHostController(LocalContext.current).apply {
+                navigatorProvider.addNavigator(ComposeNavigator())
+            }
+            OnboardingFlowComposable(
+                theme = Theme.ThemeType.LIGHT,
+                flow = flow,
+                exitOnboarding = exitOnboarding,
+                completeOnboardingToDiscover = completeOnboardingToDiscover,
+                signInState = signInState,
+                navController = navController,
+            )
+        }
+
+        // Make sure lateinit navController field is initialized before proceeding
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun startDestination_LoggedOut() {
+        assertStartDestinationForFlow(
+            startDestination = OnboardingNavRoute.logInOrSignUp,
+            flow = OnboardingFlow.LoggedOut,
+        )
+    }
+
+    @Test
+    fun startDestination_PlusAccountUpgradeNeedsLogin() {
+        assertStartDestinationForFlow(
+            startDestination = OnboardingNavRoute.logInOrSignUp,
+            flow = OnboardingFlow.PlusAccountUpgradeNeedsLogin,
+        )
+    }
+
+    @Test
+    fun startDestination_InitialOnboarding() {
+        assertStartDestinationForFlow(
+            startDestination = OnboardingNavRoute.logInOrSignUp,
+            flow = OnboardingFlow.InitialOnboarding,
+        )
+    }
+
+    @Test
+    fun startDestination_PlusAccountUpgrade() {
+        assertStartDestinationForFlow(
+            startDestination = OnboardingNavRoute.PlusUpgrade.route,
+            flow = OnboardingFlow.PlusAccountUpgrade(OnboardingUpgradeSource.ACCOUNT_DETAILS),
+        )
+    }
+
+    @Test
+    fun startDestination_PlusFlow_PlusAccountUpgrade() {
+        assertStartDestinationForFlow(
+            startDestination = OnboardingNavRoute.PlusUpgrade.route,
+            flow = OnboardingFlow.PlusAccountUpgrade(OnboardingUpgradeSource.ACCOUNT_DETAILS),
+        )
+    }
+
+    @Test
+    fun startDestination_PlusFlow_PlusUpsell() {
+        assertStartDestinationForFlow(
+            startDestination = OnboardingNavRoute.PlusUpgrade.route,
+            flow = OnboardingFlow.PlusUpsell(OnboardingUpgradeSource.ACCOUNT_DETAILS),
+        )
+    }
+
+    @Test
+    fun startDestination_PlusFlow_PatronAccountUpgrade() {
+        assertStartDestinationForFlow(
+            startDestination = OnboardingNavRoute.PlusUpgrade.route,
+            flow = OnboardingFlow.PatronAccountUpgrade(OnboardingUpgradeSource.ACCOUNT_DETAILS),
+        )
+    }
+
+    private fun assertStartDestinationForFlow(
+        startDestination: String,
+        flow: OnboardingFlow,
+    ) {
+        setupAppNavHost(flow)
+        val route = navController.currentBackStackEntry?.destination?.route
+        assertEquals(startDestination, route)
+    }
+}

--- a/base.gradle
+++ b/base.gradle
@@ -281,6 +281,7 @@ dependencies {
     androidTestImplementation androidLibs.androidTestCore
     androidTestImplementation androidLibs.roomTest
     androidTestImplementation androidLibs.annotations
+    androidTestImplementation androidLibs.navigationTest
     androidTestImplementation androidLibs.testRunner
     androidTestImplementation androidLibs.testRules
     androidTestImplementation androidLibs.testEspressoCore

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -170,6 +170,7 @@ project.ext {
             workManagerTest: "androidx.work:work-testing:$versionWork",
             navigationFragment: "androidx.navigation:navigation-fragment-ktx:$versionNavigation",
             navigationUi: "androidx.navigation:navigation-ui-ktx:$versionNavigation",
+            navigationTest: "androidx.navigation:navigation-testing:$versionNavigation",
             viewPager: "androidx.viewpager2:viewpager2:1.0.0",
             composeActivity: "androidx.activity:activity-compose:1.5.1",
             composeAnimation: "androidx.compose.animation:animation:$versionCompose",

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -25,7 +26,8 @@ fun OnboardingFlowComposable(
     flow: OnboardingFlow,
     exitOnboarding: () -> Unit,
     completeOnboardingToDiscover: () -> Unit,
-    signInState: SignInState
+    signInState: SignInState,
+    navController: NavHostController = rememberNavController(),
 ) {
     if (flow is OnboardingFlow.PlusAccountUpgrade) {
         Content(
@@ -33,7 +35,8 @@ fun OnboardingFlowComposable(
             flow = flow,
             exitOnboarding = exitOnboarding,
             completeOnboardingToDiscover = completeOnboardingToDiscover,
-            signInState = signInState
+            signInState = signInState,
+            navController = navController,
         )
     } else {
         AppThemeWithBackground(theme) {
@@ -42,7 +45,8 @@ fun OnboardingFlowComposable(
                 flow = flow,
                 exitOnboarding = exitOnboarding,
                 completeOnboardingToDiscover = completeOnboardingToDiscover,
-                signInState = signInState
+                signInState = signInState,
+                navController = navController,
             )
         }
     }
@@ -54,10 +58,9 @@ private fun Content(
     flow: OnboardingFlow,
     exitOnboarding: () -> Unit,
     completeOnboardingToDiscover: () -> Unit,
-    signInState: SignInState
+    signInState: SignInState,
+    navController: NavHostController,
 ) {
-    val navController = rememberNavController()
-
     val startDestination = when (flow) {
         OnboardingFlow.LoggedOut,
         is OnboardingFlow.PlusAccountUpgradeNeedsLogin,
@@ -263,7 +266,8 @@ private fun onLoginToExistingAccount(
     }
 }
 
-private object OnboardingNavRoute {
+@VisibleForTesting
+object OnboardingNavRoute {
 
     const val createFreeAccount = "create_free_account"
     const val forgotPassword = "forgot_password"

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding
 
 import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -125,21 +126,7 @@ private fun Content(
                     if (state.isNewAccount) {
                         onAccountCreated()
                     } else {
-                        when (flow) {
-                            OnboardingFlow.InitialOnboarding,
-                            OnboardingFlow.LoggedOut,
-                            is OnboardingFlow.PlusAccountUpgrade,
-                            is OnboardingFlow.PlusUpsell -> exitOnboarding()
-
-                            is OnboardingFlow.PatronAccountUpgrade,
-                            OnboardingFlow.PlusAccountUpgradeNeedsLogin ->
-                                navController.navigate(
-                                    OnboardingNavRoute.PlusUpgrade.routeWithSource(OnboardingUpgradeSource.LOGIN)
-                                ) {
-                                    // clear backstack after successful login
-                                    popUpTo(OnboardingNavRoute.logInOrSignUp) { inclusive = true }
-                                }
-                        }
+                        onLoginToExistingAccount(flow, exitOnboarding, navController)
                     }
                 },
             )
@@ -158,20 +145,7 @@ private fun Content(
                 theme = theme,
                 onBackPressed = { navController.popBackStack() },
                 onLoginComplete = {
-                    when (flow) {
-                        OnboardingFlow.InitialOnboarding,
-                        OnboardingFlow.LoggedOut -> exitOnboarding()
-
-                        is OnboardingFlow.PlusAccountUpgrade,
-                        is OnboardingFlow.PatronAccountUpgrade,
-                        OnboardingFlow.PlusAccountUpgradeNeedsLogin,
-                        is OnboardingFlow.PlusUpsell -> navController.navigate(
-                            OnboardingNavRoute.PlusUpgrade.routeWithSource(OnboardingUpgradeSource.LOGIN)
-                        ) {
-                            // clear backstack after successful login
-                            popUpTo(OnboardingNavRoute.logInOrSignUp) { inclusive = true }
-                        }
-                    }
+                    onLoginToExistingAccount(flow, exitOnboarding, navController)
                 },
                 onForgotPasswordTapped = { navController.navigate(OnboardingNavRoute.forgotPassword) },
             )
@@ -264,6 +238,27 @@ private fun Content(
                     }
                 },
             )
+        }
+    }
+}
+
+private fun onLoginToExistingAccount(
+    flow: OnboardingFlow,
+    exitOnboarding: () -> Unit,
+    navController: NavHostController
+) {
+    when (flow) {
+        OnboardingFlow.InitialOnboarding,
+        OnboardingFlow.LoggedOut -> exitOnboarding()
+
+        is OnboardingFlow.PlusAccountUpgrade,
+        is OnboardingFlow.PatronAccountUpgrade,
+        OnboardingFlow.PlusAccountUpgradeNeedsLogin,
+        is OnboardingFlow.PlusUpsell -> navController.navigate(
+            OnboardingNavRoute.PlusUpgrade.routeWithSource(OnboardingUpgradeSource.LOGIN)
+        ) {
+            // clear backstack after successful login
+            popUpTo(OnboardingNavRoute.logInOrSignUp) { inclusive = true }
         }
     }
 }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -47,7 +47,7 @@ class SearchHandler @Inject constructor(
     private val onlySearchRemoteObservable = BehaviorRelay.create<Boolean>().apply {
         accept(false)
     }
-    private val signInStateObservable = userManager.getSignInState().startWith(SignInState.SignedOut()).toObservable()
+    private val signInStateObservable = userManager.getSignInState().startWith(SignInState.SignedOut).toObservable()
 
     private val localPodcastsResults = Observable
         .combineLatest(searchQuery, onlySearchRemoteObservable, signInStateObservable) { searchQuery, onlySearchRemoteObservable, signInState ->

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragmentPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragmentPage.kt
@@ -288,7 +288,7 @@ private fun rowModifier(onClick: () -> Unit) =
 private fun SettingsPagePreview(@PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType) {
     AppThemeWithBackground(themeType) {
         SettingsFragmentPage(
-            signInState = SignInState.SignedOut(),
+            signInState = SignInState.SignedOut,
             isDebug = true,
             isUnrestrictedBattery = false,
             onBackPressed = {},

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SignInState.kt
@@ -12,7 +12,7 @@ private val paidSubscriptionPlatforms = listOf(SubscriptionPlatform.ANDROID, Sub
 
 sealed class SignInState {
     data class SignedIn(val email: String, val subscriptionStatus: SubscriptionStatus) : SignInState()
-    class SignedOut : SignInState()
+    object SignedOut : SignInState()
 
     val isSignedIn: Boolean
         get() = this is SignedIn

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -98,7 +98,7 @@ class UserManagerImpl @Inject constructor(
                             SignInState.SignedIn(syncManager.getEmail() ?: "", SubscriptionStatus.Free())
                         }
                 } else {
-                    Flowable.just(SignInState.SignedOut())
+                    Flowable.just(SignInState.SignedOut)
                 }
             }
     }


### PR DESCRIPTION
## Description

This addressses an issue where the upgrade flow for logged-out users would exit after the user signed in with a google account. Basically, it's a follow-up to https://github.com/Automattic/pocket-casts-android/pull/1204 that further improves the flow.

As part of this I added test scenarios for the onboarding flow to our testing checklist. I also created a very basic first step toward testing the onboarding flow's navigation. All it does now is test the start destination though because this ended up taking a bit to get working and I ran out of time. I suspect we may be better off moving as much of the navigation logic as we can into a view model and testing that in isolation. If you think it's not worth adding the integration test here since it's not doing much yet, just let me know and I can remove that commit.

Fixes # <!-- issue number, if applicable -->

## Testing Instructions
1. When not signed into an account
2. Tap on an upgrade prompt like the folder icon on the Podcasts tab
3. Sign in with a google account
4. After sign in you should proceed through the upgrade flow (before this change you would be returned to the screen from which you tapped on the upgrade prompt).

Also test a few of the onboarding flows I've added to the testing-checklist to make sure there aren't any regressions.


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 