### PR TITLE
Adding logs to Automotive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.46
 -----
-
+*   New Feature:
+    *   Added a support section to the Automotive app
+        ([#1277](https://github.com/Automattic/pocket-casts-android/pull/1277))
 
 7.45
 -----

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveAboutFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveAboutFragment.kt
@@ -35,11 +35,12 @@ import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.extensions.openUrl
 import au.com.shiftyjelly.pocketcasts.localization.BuildConfig
-import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.settings.LogsFragment
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeDrawable
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import dagger.hilt.android.AndroidEntryPoint
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @AndroidEntryPoint
@@ -51,6 +52,7 @@ class AutomotiveAboutFragment : Fragment() {
                 AutomotiveTheme {
                     AboutPage(
                         onOpenLicenses = { openLicenses() },
+                        onOpenLogs = { onOpenLogs() },
                         onOpenUrl = { openUrl(it) }
                     )
                 }
@@ -61,10 +63,18 @@ class AutomotiveAboutFragment : Fragment() {
     private fun openLicenses() {
         (activity as? FragmentHostListener)?.addFragment(AutomotiveLicensesFragment())
     }
+
+    private fun onOpenLogs() {
+        (activity as? FragmentHostListener)?.addFragment(LogsFragment())
+    }
 }
 
 @Composable
-private fun AboutPage(onOpenLicenses: () -> Unit, onOpenUrl: (String) -> Unit) {
+private fun AboutPage(
+    onOpenLicenses: () -> Unit,
+    onOpenLogs: () -> Unit,
+    onOpenUrl: (String) -> Unit
+) {
     val context = LocalContext.current
     val scrollState = rememberScrollState()
     Column(
@@ -73,13 +83,13 @@ private fun AboutPage(onOpenLicenses: () -> Unit, onOpenUrl: (String) -> Unit) {
     ) {
         Image(
             painter = painterResource(context.getThemeDrawable(UR.attr.logo_title_vertical)),
-            contentDescription = stringResource(R.string.settings_app_icon),
+            contentDescription = stringResource(LR.string.settings_app_icon),
             modifier = Modifier
                 .padding(top = 56.dp)
                 .size(width = 220.dp, height = 132.dp)
         )
         Text(
-            text = stringResource(R.string.settings_version, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE.toString()),
+            text = stringResource(LR.string.settings_version, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE.toString()),
             fontSize = 24.sp,
             modifier = Modifier.padding(top = 16.dp),
             color = MaterialTheme.theme.colors.primaryText02
@@ -87,28 +97,44 @@ private fun AboutPage(onOpenLicenses: () -> Unit, onOpenUrl: (String) -> Unit) {
         HorizontalDivider(
             modifier = Modifier.padding(top = 56.dp, bottom = 16.dp)
         )
-        Text(
-            text = stringResource(R.string.settings_about_legal),
-            fontSize = 24.sp,
-            fontWeight = FontWeight(500),
-            letterSpacing = 0.25.sp,
-            color = MaterialTheme.theme.colors.primaryInteractive01,
-            modifier = Modifier.align(Alignment.Start).padding(horizontal = 48.dp, vertical = 16.dp)
-        )
+        SubTitle(stringResource(LR.string.settings_about_legal))
         TextLinkButton(
-            text = stringResource(R.string.settings_about_terms_of_serivce),
+            text = stringResource(LR.string.settings_about_terms_of_serivce),
             onClick = { onOpenUrl(Settings.INFO_TOS_URL) }
         )
         TextLinkButton(
-            text = stringResource(R.string.settings_about_privacy_policy),
+            text = stringResource(LR.string.settings_about_privacy_policy),
             onClick = { onOpenUrl(Settings.INFO_PRIVACY_URL) }
         )
         TextLinkButton(
-            text = stringResource(R.string.settings_about_acknowledgements),
+            text = stringResource(LR.string.settings_about_acknowledgements),
             onClick = { onOpenLicenses() }
+        )
+        SubTitle(stringResource(LR.string.support))
+        TextLinkButton(
+            text = stringResource(LR.string.settings_title_help),
+            onClick = { onOpenUrl(Settings.INFO_FAQ_URL) }
+        )
+        TextLinkButton(
+            text = stringResource(LR.string.settings_logs),
+            onClick = { onOpenLogs() }
         )
         Spacer(Modifier.height(15.dp))
     }
+}
+
+@Composable
+private fun SubTitle(title: String, modifier: Modifier = Modifier) {
+    Text(
+        text = title,
+        fontSize = 24.sp,
+        fontWeight = FontWeight(500),
+        letterSpacing = 0.25.sp,
+        color = MaterialTheme.theme.colors.primaryInteractive01,
+        modifier = modifier
+            .padding(horizontal = 48.dp, vertical = 16.dp)
+            .fillMaxWidth()
+    )
 }
 
 @Composable
@@ -131,5 +157,5 @@ private fun TextLinkButton(text: String, onClick: () -> Unit, modifier: Modifier
 @Composable
 @Preview
 private fun AboutPageRow() {
-    AboutPage(onOpenLicenses = {}, onOpenUrl = {})
+    AboutPage(onOpenLicenses = {}, onOpenLogs = {}, onOpenUrl = {})
 }

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
@@ -21,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import au.com.shiftyjelly.pocketcasts.utils.SentryHelper.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.log.RxJavaUncaughtExceptionHandling
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
@@ -31,6 +32,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+import java.io.File
 import java.util.concurrent.Executors
 import javax.inject.Inject
 
@@ -112,10 +114,10 @@ class AutomotiveApplication : Application(), Configuration.Provider {
     }
 
     private fun setupLogging() {
-        // TODO uncomment this after we have playback issues resolved
-        // if (BuildConfig.DEBUG) {
-        Timber.plant(TimberDebugTree())
-        // }
+        LogBuffer.setup(File(filesDir, "logs").absolutePath)
+        if (BuildConfig.DEBUG) {
+            Timber.plant(TimberDebugTree())
+        }
     }
 
     private fun setupAnalytics() {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
@@ -98,7 +98,7 @@ class HelpFragment : Fragment(), HasBackstack, Toolbar.OnMenuItemClickListener {
 
         webView = (view.findViewById<View>(VR.id.webview) as WebView).apply {
             webViewClient = SupportWebViewClient()
-            loadUrl(loadedUrl ?: "https://support.pocketcasts.com/android/?device=android")
+            loadUrl(loadedUrl ?: Settings.INFO_FAQ_URL)
             settings.javaScriptEnabled = true
             settings.textZoom = 100
         }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LogsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LogsFragment.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CopyAll
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -23,14 +24,19 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
+import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.LogsViewModel
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -64,53 +70,110 @@ private fun LogsPage(
     val clipboardManager = LocalClipboardManager.current
     val context = LocalContext.current
 
+    LogsContent(
+        onBackPressed = onBackPressed,
+        onCopyToClipboard = { logs?.let { clipboardManager.setText(AnnotatedString(it)) } },
+        onShareLogs = { viewModel.shareLogs(context) },
+        includeAppBar = !Util.isAutomotive(context),
+        logs = logs
+    )
+}
+
+@Composable
+private fun LogsContent(
+    onBackPressed: () -> Unit,
+    onCopyToClipboard: () -> Unit,
+    onShareLogs: () -> Unit,
+    logs: String?,
+    includeAppBar: Boolean
+) {
+    val logScrollState = rememberScrollState(0)
     Column {
-
-        ThemedTopAppBar(
-            title = stringResource(LR.string.settings_logs),
-            onNavigationClick = onBackPressed,
-            actions = {
-                IconButton(
-                    onClick = {
-                        logs?.let {
-                            clipboardManager.setText(AnnotatedString(it))
-                        }
-                    },
-                    enabled = logs != null
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.CopyAll,
-                        contentDescription = stringResource(LR.string.share)
-                    )
-                }
-
-                IconButton(
-                    onClick = { viewModel.shareLogs(context) },
-                    enabled = logs != null
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Share,
-                        contentDescription = stringResource(LR.string.share)
-                    )
-                }
-            }
-        )
-
+        if (includeAppBar) {
+            AppBarWithShare(
+                onBackPressed = onBackPressed,
+                onCopyToClipboard = onCopyToClipboard,
+                onShareLogs = onShareLogs,
+                logsAvailable = logs != null
+            )
+        }
         Column(
             modifier = Modifier
-                .verticalScroll(rememberScrollState())
+                .verticalScroll(logScrollState)
                 .padding(16.dp)
                 .fillMaxWidth()
         ) {
-
             if (logs == null) {
-                TextH30(
-                    text = stringResource(LR.string.loading),
-                    modifier = Modifier.padding(vertical = 24.dp)
-                )
+                LoadingView()
             } else {
                 TextP60(logs)
             }
         }
+    }
+    // scroll to the end to show the latest logs
+    LaunchedEffect(logs) {
+        logScrollState.scrollTo(logScrollState.maxValue)
+    }
+}
+
+@Composable
+private fun AppBarWithShare(
+    onBackPressed: () -> Unit,
+    onCopyToClipboard: () -> Unit,
+    onShareLogs: () -> Unit,
+    logsAvailable: Boolean,
+    modifier: Modifier = Modifier
+) {
+    ThemedTopAppBar(
+        title = stringResource(LR.string.settings_logs),
+        onNavigationClick = onBackPressed,
+        actions = {
+            IconButton(
+                onClick = onCopyToClipboard,
+                enabled = logsAvailable
+            ) {
+                Icon(
+                    imageVector = Icons.Default.CopyAll,
+                    contentDescription = stringResource(LR.string.share)
+                )
+            }
+            IconButton(
+                onClick = onShareLogs,
+                enabled = logsAvailable
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Share,
+                    contentDescription = stringResource(LR.string.share)
+                )
+            }
+        },
+        modifier = modifier
+    )
+}
+
+@Composable
+@Preview
+private fun LogsContentPreview(@PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType) {
+    AppThemeWithBackground(themeType) {
+        LogsContent(
+            onBackPressed = {},
+            onCopyToClipboard = {},
+            onShareLogs = {},
+            logs = "This is a preview",
+            includeAppBar = true
+        )
+    }
+}
+@Composable
+@Preview
+private fun LogsContentLoadingPreview(@PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType) {
+    AppThemeWithBackground(themeType) {
+        LogsContent(
+            onBackPressed = {},
+            onCopyToClipboard = {},
+            onShareLogs = {},
+            logs = null,
+            includeAppBar = true
+        )
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -148,6 +148,7 @@
     <string name="please_try_again">Please try again</string>
     <string name="next">Next</string>
     <string name="select_podcasts">Select podcasts</string>
+    <string name="support">Support</string>
 
     <string name="multiselect_actions_shown">Shortcut in toolbar</string>
     <string name="multiselect_actions_hidden">In overflow</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -44,6 +44,7 @@ interface Settings {
         const val INFO_TOS_URL = "https://support.pocketcasts.com/article/terms-of-use-overview/"
         const val INFO_PRIVACY_URL = "https://support.pocketcasts.com/article/privacy-policy/"
         const val INFO_CANCEL_URL = "https://support.pocketcasts.com/article/subscription-info/"
+        const val INFO_FAQ_URL = "https://support.pocketcasts.com/android/?device=android"
 
         const val USER_AGENT_POCKETCASTS_SERVER = "Pocket Casts/Android/" + BuildConfig.VERSION_NAME
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -372,20 +372,28 @@ class Support @Inject constructor(
                 output.append("Screen: ").append(width).append("x").append(height).append(", dpi: ").append(metrics.densityDpi).append(", density: ").append(metrics.density).append(eol)
             }
 
-            val storageFolder = fileStorage.storageDirectory.absolutePath
-            output.append("Storage: ").append(if (settings.usingCustomFolderStorage()) "Custom Folder" else settings.getStorageChoiceName()).append(", ").append(storageFolder).append(eol)
-            output.append("Storage options:").append(eol)
-            val storageOptions = StorageOptions()
-            for (folderLocation in storageOptions.getFolderLocations(context)) {
-                if (storageFolder == folderLocation.filePath) {
-                    continue
+            try {
+                val storageFolder = fileStorage.storageDirectory.absolutePath
+                output.append("Storage: ").append(if (settings.usingCustomFolderStorage()) "Custom Folder" else settings.getStorageChoiceName()).append(", ").append(storageFolder).append(eol)
+                output.append("Storage options:").append(eol)
+                val storageOptions = StorageOptions()
+                for (folderLocation in storageOptions.getFolderLocations(context)) {
+                    if (storageFolder == folderLocation.filePath) {
+                        continue
+                    }
+                    output.append(folderLocation.label).append(", ").append(folderLocation.filePath).append(eol)
                 }
-                output.append(folderLocation.label).append(", ").append(folderLocation.filePath).append(eol)
+            } catch (e: Exception) {
+                Timber.e(e)
             }
             output.append("Database: " + Util.formattedBytes(context.getDatabasePath("pocketcasts").length(), context = context)).append(eol)
-            output.append("Temp directory: " + Util.formattedBytes(FileUtil.folderSize(fileStorage.tempPodcastDirectory), context = context)).append(eol)
-            output.append("Podcast directory: " + Util.formattedBytes(FileUtil.folderSize(fileStorage.podcastDirectory), context = context)).append(eol)
-            output.append("Network image directory: " + Util.formattedBytes(FileUtil.folderSize(fileStorage.networkImageDirectory), context = context)).append(eol)
+            try {
+                output.append("Temp directory: " + Util.formattedBytes(FileUtil.folderSize(fileStorage.tempPodcastDirectory), context = context)).append(eol)
+                output.append("Podcast directory: " + Util.formattedBytes(FileUtil.folderSize(fileStorage.podcastDirectory), context = context)).append(eol)
+                output.append("Network image directory: " + Util.formattedBytes(FileUtil.folderSize(fileStorage.networkImageDirectory), context = context)).append(eol)
+            } catch (e: Exception) {
+                Timber.e(e)
+            }
 
             if (!html) {
                 output.append(eol)
@@ -456,6 +464,7 @@ class Support @Inject constructor(
                 }
             }
         } catch (e: Exception) {
+            Timber.e(e)
             output.append("Unable to report all user debug info due to an exception. ").append(e.message)
         }
 


### PR DESCRIPTION
## Description

This change adds the logs to the Automotive version of the app to help us debug issues one of our Automotive partners is having. 

Thanks @ashiagr, this uses the log viewer from your PR. I didn't include the encrypted upload in this version and instead will ask for a screenshot. To help with this I have scrolled to the bottom of the logs as this is where the latest logs are. 

I also added a link to our "Help & Feedback" section.

## Testing Instructions
1. Tap the settings cog
2. Scroll to the bottom of the page and tap "About"
3. Scroll to the bottom of the page and tap "Help & Feedback"
4. ✅ Verify it shows a link to the support website
5. Tap the back arrow
6. Tap "Logs"
7. ✅ Verify the logs are shown

## Screenshots and Screencast 

![Screenshot_20230814_101928](https://github.com/Automattic/pocket-casts-android/assets/308331/a848a361-b8d9-4da5-a66c-779712986eb7)

https://github.com/Automattic/pocket-casts-android/assets/308331/0823cb36-8fd3-4ec7-a264-e2ef1d3989a3
