### PR TITLE
Add scroll to top/bottom to logs screen

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LogsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LogsFragment.kt
@@ -14,10 +14,13 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CopyAll
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.VerticalAlignBottom
+import androidx.compose.material.icons.filled.VerticalAlignTop
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalClipboardManager
@@ -39,6 +42,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @AndroidEntryPoint
@@ -90,11 +94,22 @@ private fun LogsContent(
     val logScrollState = rememberScrollState(0)
     Column {
         if (includeAppBar) {
+            val coroutineScope = rememberCoroutineScope()
             AppBarWithShare(
                 onBackPressed = onBackPressed,
                 onCopyToClipboard = onCopyToClipboard,
                 onShareLogs = onShareLogs,
-                logsAvailable = logs != null
+                onScrollToTop = {
+                    coroutineScope.launch {
+                        logScrollState.animateScrollTo(0)
+                    }
+                },
+                onScrollToBottom = {
+                    coroutineScope.launch {
+                        logScrollState.animateScrollTo(Int.MAX_VALUE)
+                    }
+                },
+                logsAvailable = logs != null,
             )
         }
         Column(
@@ -121,6 +136,8 @@ private fun AppBarWithShare(
     onBackPressed: () -> Unit,
     onCopyToClipboard: () -> Unit,
     onShareLogs: () -> Unit,
+    onScrollToTop: () -> Unit,
+    onScrollToBottom: () -> Unit,
     logsAvailable: Boolean,
     modifier: Modifier = Modifier
 ) {
@@ -128,6 +145,24 @@ private fun AppBarWithShare(
         title = stringResource(LR.string.settings_logs),
         onNavigationClick = onBackPressed,
         actions = {
+            IconButton(
+                onClick = onScrollToTop,
+                enabled = logsAvailable,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.VerticalAlignTop,
+                    contentDescription = stringResource(LR.string.go_to_top)
+                )
+            }
+            IconButton(
+                onClick = onScrollToBottom,
+                enabled = logsAvailable,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.VerticalAlignBottom,
+                    contentDescription = stringResource(LR.string.go_to_bottom)
+                )
+            }
             IconButton(
                 onClick = onCopyToClipboard,
                 enabled = logsAvailable

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -149,6 +149,8 @@
     <string name="next">Next</string>
     <string name="select_podcasts">Select podcasts</string>
     <string name="support">Support</string>
+    <string name="go_to_top">Go to top</string>
+    <string name="go_to_bottom">Go to bottom</string>
 
     <string name="multiselect_actions_shown">Shortcut in toolbar</string>
     <string name="multiselect_actions_hidden">In overflow</string>


### PR DESCRIPTION
## Description
This adds buttons to make it easy to get to the top or bottom of the logs screen (it can get very long).

## Testing Instructions
1. Go to logs screen (Profile tab → ⚙️ → "Help & feedback" → logs button on toolbar)
2. Verify that the toolbar has scroll to top and scroll to bottom buttons and they work as expected

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/4656348/a1eb092f-8848-420f-9556-ff19d241cb74


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
