### PR TITLE
Stop episodes being removed from the Up Next when clearing downloads.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
     *   Added a support section to the Automotive app
         ([#1277](https://github.com/Automattic/pocket-casts-android/pull/1277))
 *   Bug Fixes:
+    *    Fixed episodes being removed from the Up Next when clearing downloads
+         ([#1280](https://github.com/Automattic/pocket-casts-android/pull/1280))
     *    Improved upgrade flow when signing in with Google account
          ([#1275](https://github.com/Automattic/pocket-casts-android/pull/1275))
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModel.kt
@@ -120,7 +120,11 @@ class ManualCleanupViewModel
         if (episodesToDelete.isNotEmpty()) {
             trackCleanupCompleted()
             viewModelScope.launch {
-                episodeManager.deleteEpisodeFiles(episodesToDelete, playbackManager)
+                episodeManager.deleteEpisodeFiles(
+                    episodes = episodesToDelete,
+                    playbackManager = playbackManager,
+                    removeFromUpNext = false
+                )
                 _snackbarMessage.emit(LR.string.settings_manage_downloads_deleting)
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -139,7 +139,7 @@ interface EpisodeManager {
     fun setDownloadFailed(episode: BaseEpisode, errorMessage: String)
     fun observeEpisodeCount(queryAfterWhere: String): Flowable<Int>
     suspend fun updatePlaybackInteractionDate(episode: BaseEpisode?)
-    suspend fun deleteEpisodeFiles(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager)
+    suspend fun deleteEpisodeFiles(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager, removeFromUpNext: Boolean = true)
     suspend fun findStaleDownloads(): List<PodcastEpisode>
     suspend fun calculateListeningTime(fromEpochMs: Long, toEpochMs: Long): Long?
     suspend fun findListenedCategories(fromEpochMs: Long, toEpochMs: Long): List<ListenedCategory>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -839,9 +839,9 @@ class EpisodeManagerImpl @Inject constructor(
         }
     }
 
-    override suspend fun deleteEpisodeFiles(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager) = withContext(Dispatchers.IO) {
+    override suspend fun deleteEpisodeFiles(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager, removeFromUpNext: Boolean) = withContext(Dispatchers.IO) {
         episodes.toList().forEach {
-            deleteEpisodeFile(it, playbackManager, removeFromUpNext = true, disableAutoDownload = false)
+            deleteEpisodeFile(it, playbackManager, removeFromUpNext = removeFromUpNext, disableAutoDownload = false)
         }
     }
 


### PR DESCRIPTION
## Description

This change fixes the issue that if any episodes in the Up Next are downloaded when the downloads are cleared in the settings area they are removed from the Up Next. 

## Testing Instructions
1. Tap on the 'Profile' tab
2. Tap on the settings cog
3. Tap on 'Auto download'
4. Turn on 'Episodes added to Up Next'
5. Add multiple episodes to the Up Next
6. Open the Up Next
7. ✅ Verify the downloaded icon is on the episode rows
8. Go back to the settings section
9. Tap on 'Storage & data use'
10. Tap on 'Downloaded files'
11. Tick all the checkboxes and tap 'Clean up'
12. ✅ Verify the Up Next episodes haven't been removed

## Screencast 

https://github.com/Automattic/pocket-casts-android/assets/308331/6396fe63-b5b8-4f2b-a332-de6458a49c00
