### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Reporting Security Issues
+
+If you find a security vulnerability, please let us know at https://hackerone.com/automattic and allow us to respond before disclosing the issue publicly.


### PR DESCRIPTION
## Description
This adds our hackerone security issue reporting link to the `SECURITY.md` file [that GitHub uses](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository).

This will make this policy available in GitHub under the `Security` tab and (I believe) within the issue types when reporting an issue (you can see an example of this in the [Gutenberg repo](https://github.com/WordPress/gutenberg/issues/new/choose)).

<details><summary>Screenshot of issue form on the Gutenberg repo</summary>

![Screenshot 2023-08-16 at 9 45 25 AM](https://github.com/Automattic/pocket-casts-android/assets/4656348/fc03ac84-800e-4481-98fc-a7bfa2e605ec)

</details>

I think that with this change we could remove the reference to our security policy from the [README](https://github.com/Automattic/pocket-casts-android/blob/main/README.md), but I'll hold off on that until we're sure this works like we want.

## Testing Instructions
I don't think we'll know if this is working like we expect until we merge it to `main`.