### PR TITLE
Bookmarks - Update headphone controls options display

### DIFF
--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -11,6 +11,8 @@ import android.os.Build
 import android.util.Base64
 import androidx.core.content.edit
 import androidx.work.NetworkType
+import au.com.shiftyjelly.pocketcasts.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
@@ -20,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.BookmarksSortTypeForPodcast
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.DEFAULT_MAX_AUTO_ADD_LIMIT
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.NOTIFICATIONS_DISABLED_MESSAGE_SHOWN
@@ -1082,7 +1085,21 @@ class SettingsImpl @Inject constructor(
     }
 
     override fun getHeadphoneControlsNextAction(): Settings.HeadphoneAction {
-        return Settings.HeadphoneAction.values()[getInt("headphone_controls_next_action", Settings.HeadphoneAction.SKIP_FORWARD.ordinal)]
+        val isAddBookmarkEnabled =
+            FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) && (getCachedSubscription() as? SubscriptionStatus.Paid)?.tier == SubscriptionTier.PATRON
+
+        val defaultAction = Settings.HeadphoneAction.SKIP_FORWARD
+        val nextAction = Settings.HeadphoneAction.values()[
+            getInt(
+                "headphone_controls_next_action",
+                defaultAction.ordinal
+            )
+        ]
+        return if (nextAction == Settings.HeadphoneAction.ADD_BOOKMARK && !isAddBookmarkEnabled) {
+            defaultAction
+        } else {
+            nextAction
+        }
     }
 
     override fun setHeadphoneControlsNextAction(action: Settings.HeadphoneAction) {
@@ -1091,7 +1108,21 @@ class SettingsImpl @Inject constructor(
     }
 
     override fun getHeadphoneControlsPreviousAction(): Settings.HeadphoneAction {
-        return Settings.HeadphoneAction.values()[getInt("headphone_controls_previous_action", Settings.HeadphoneAction.SKIP_BACK.ordinal)]
+        val isAddBookmarkEnabled =
+            FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) && (getCachedSubscription() as? SubscriptionStatus.Paid)?.tier == SubscriptionTier.PATRON
+
+        val defaultAction = Settings.HeadphoneAction.SKIP_BACK
+        val previousAction = Settings.HeadphoneAction.values()[
+            getInt(
+                "headphone_controls_previous_action",
+                defaultAction.ordinal
+            )
+        ]
+        return if (previousAction == Settings.HeadphoneAction.ADD_BOOKMARK && !isAddBookmarkEnabled) {
+            defaultAction
+        } else {
+            previousAction
+        }
     }
 
     override fun setHeadphoneControlsPreviousAction(action: Settings.HeadphoneAction) {


### PR DESCRIPTION
## Description

This
- Updates headphone controls options layout from `SettingRadioDialogRow` to `OptionsDialog`
- Displays "Add bookmark" option only if the user is eligible for `Bookmarks` feature
- Returns default values for headphone controls if the previous value is "Add bookmark" and the user is not eligible for the `Bookmarks` feature

Slack discussion p1692252268904039/1692162285.498199-slack-C055BDMU095

P.S: Since Android didn't have a skip chapters option for headphone controls, we only focussed on adding skip actions and "Add bookmark" in this PR. Other options will be added as part of a separate PR.

## Testing Instructions

Prerequisites:

- Release build
- Patron + Bookmarks features enabled in `Feature` class
- License test account

1. Upgrade to `Patron` plan
2. Go to `Profile` -> `Settings`
3. Notice that "Headphone controls" menu is present
4. Tap on "Headphone settings" menu 
5. Tap on "Previous" or "Next" action
6. Notice that the options layout is changed to use`OptionsDialog`
7. Notice that options have "Add bookmark" option
8. Select "Add bookmark" options for both previous and next actions
9. Downgrade to `Plus` or `Free` plan
10. Go to `Profile` -> `Settings` 
11. Notice that "Headphone controls" menu is present
12. Tap on "Headphone controls" menu 
13. Notice that "Previous" and "Next" actions do not have "Add bookmark" option and have been set to default values. 

## Screenshots or Screencast 

Before | Now
----| ----
<img width="300" alt="Screenshot 2023-08-17 at 12 55 07 PM" src="https://github.com/Automattic/pocket-casts-android/assets/1405144/16e0ccda-9667-40ba-b437-a89a76be9508"> |  <img width="300" src="https://github.com/Automattic/pocket-casts-android/assets/1405144/002b2218-3542-4945-b78a-c59d62df9625"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack