### PR TITLE
Bookmarks - Update tabs display

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -394,7 +394,7 @@ class PodcastAdapter(
         }
         val content = mutableListOf<Any>().apply {
             add(Podcast())
-            if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+            if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) && signInState.isSignedInAsPatron) {
                 add(TabsHeader(PodcastTab.EPISODES, onTabClicked))
             }
             add(
@@ -429,7 +429,7 @@ class PodcastAdapter(
         searchTerm: String,
     ) {
         val content = mutableListOf<Any>().apply {
-            if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+            if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) && signInState.isSignedInAsPatron) {
                 add(Podcast())
                 add(TabsHeader(PodcastTab.BOOKMARKS, onTabClicked))
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheet.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheet.kt
@@ -17,11 +17,10 @@ import androidx.lifecycle.Observer
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.UserEpisodeServerStatus
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarksContainerFragment
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -211,7 +210,6 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
                 }
 
                 val layoutBookmark = binding.layoutBookmark
-                layoutBookmark.isVisible = FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)
                 layoutBookmark.setOnClickListener {
                     dialog?.dismiss()
                     BookmarksContainerFragment.newInstance(
@@ -303,14 +301,13 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
                 val layoutBookmark = binding.layoutBookmark
                 when (signInState) {
                     is SignInState.SignedIn -> {
+                        layoutBookmark.isVisible = (signInState.subscriptionStatus as? SubscriptionStatus.Paid)?.tier == SubscriptionTier.PATRON
                         if (signInState.subscriptionStatus is SubscriptionStatus.Paid) {
                             layoutCloud.isVisible = true
                             layoutLockedCloud.isVisible = false
-                            layoutBookmark.isVisible = true
                         } else {
                             layoutCloud.isVisible = false
                             layoutLockedCloud.isVisible = true
-                            layoutBookmark.isVisible = false
                         }
                     }
                     else -> {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -11,6 +11,8 @@ import android.os.Build
 import android.util.Base64
 import androidx.core.content.edit
 import androidx.work.NetworkType
+import au.com.shiftyjelly.pocketcasts.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
@@ -20,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.BookmarksSortTypeForPodcast
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.DEFAULT_MAX_AUTO_ADD_LIMIT
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.NOTIFICATIONS_DISABLED_MESSAGE_SHOWN
@@ -1082,7 +1085,21 @@ class SettingsImpl @Inject constructor(
     }
 
     override fun getHeadphoneControlsNextAction(): Settings.HeadphoneAction {
-        return Settings.HeadphoneAction.values()[getInt("headphone_controls_next_action", Settings.HeadphoneAction.SKIP_FORWARD.ordinal)]
+        val isAddBookmarkEnabled =
+            FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) && (getCachedSubscription() as? SubscriptionStatus.Paid)?.tier == SubscriptionTier.PATRON
+
+        val defaultAction = Settings.HeadphoneAction.SKIP_FORWARD
+        val nextAction = Settings.HeadphoneAction.values()[
+            getInt(
+                "headphone_controls_next_action",
+                defaultAction.ordinal
+            )
+        ]
+        return if (nextAction == Settings.HeadphoneAction.ADD_BOOKMARK && !isAddBookmarkEnabled) {
+            defaultAction
+        } else {
+            nextAction
+        }
     }
 
     override fun setHeadphoneControlsNextAction(action: Settings.HeadphoneAction) {
@@ -1091,7 +1108,21 @@ class SettingsImpl @Inject constructor(
     }
 
     override fun getHeadphoneControlsPreviousAction(): Settings.HeadphoneAction {
-        return Settings.HeadphoneAction.values()[getInt("headphone_controls_previous_action", Settings.HeadphoneAction.SKIP_BACK.ordinal)]
+        val isAddBookmarkEnabled =
+            FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) && (getCachedSubscription() as? SubscriptionStatus.Paid)?.tier == SubscriptionTier.PATRON
+
+        val defaultAction = Settings.HeadphoneAction.SKIP_BACK
+        val previousAction = Settings.HeadphoneAction.values()[
+            getInt(
+                "headphone_controls_previous_action",
+                defaultAction.ordinal
+            )
+        ]
+        return if (previousAction == Settings.HeadphoneAction.ADD_BOOKMARK && !isAddBookmarkEnabled) {
+            defaultAction
+        } else {
+            previousAction
+        }
     }
 
     override fun setHeadphoneControlsPreviousAction(action: Settings.HeadphoneAction) {


### PR DESCRIPTION
## Description
This updates bookmarks tabs display based on this discussion: p1692263371047309/1692162285.498199-slack-C055BDMU095 and fixes `Bookmarks` option display for user episode.

## Testing Instructions

1. Login as Plus or Free account
2. Notice that you do not see `Bookmarks` tabs on
    - Full screen player
    - Episode details
    - Podcast details 
3. Go to `Profile` -> `Files`
4. Add a file
5. Tap on the file row to open the bottom sheet
6. Notice that `Bookmarks` option is not present in the bottom sheet


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack