### PR TITLE
Remove security section from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,6 @@ The hierarchy of the modules in the project are reflected in [this diagram](docs
 
 Read our [Contributing Guide](CONTRIBUTING.md) to learn about reporting issues, contributing code, and more ways to contribute.
 
-## Security
-
-If you happen to find a security vulnerability, please let us know at https://hackerone.com/automattic and allow us to respond before disclosing the issue publicly.
-
 ## Documentation
 
 - [Coding Style](docs/coding-style.md) - guidelines and validation and auto-formatting tools


### PR DESCRIPTION
## Description

This removes the security section from our readme because we now have a security policy set up on GitHub (https://github.com/Automattic/pocket-casts-android/pull/1283) with the same information.

This is what the security tab looks like:

![image](https://github.com/Automattic/pocket-casts-android/assets/4656348/227a8cba-0d96-4569-a2c6-beefae216036)

And there is also a security policy link if someone goes to open a new issue:

![image](https://github.com/Automattic/pocket-casts-android/assets/4656348/52cbca86-4fea-471e-ac8b-7fa99e30eee5)

So it feels like having this in the readme as well is just duplication, and that it would be better for the `SECURITY.md` file to be the source of truth here.