### PR TITLE
Update headphone control to be UserSettings

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/CancelConfirmationViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/CancelConfirmationViewModel.kt
@@ -17,7 +17,7 @@ class CancelConfirmationViewModel
 ) : ViewModel() {
     var expirationDate: String? = null
     private val paidSubscription: SubscriptionStatus.Paid?
-        get() = settings.getCachedSubscription() as? SubscriptionStatus.Paid
+        get() = settings.cachedSubscriptionStatus.value as? SubscriptionStatus.Paid
 
     init {
         onViewShown()

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsFragment.kt
@@ -56,7 +56,7 @@ class HeadphoneControlsSettingsFragment : BaseFragment() {
 
     private val isAddBookmarkEnabled: Boolean
         get() = FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) &&
-            (settings.getCachedSubscription() as? SubscriptionStatus.Paid)?.tier == SubscriptionTier.PATRON
+            (settings.cachedSubscriptionStatus.value as? SubscriptionStatus.Paid)?.tier == SubscriptionTier.PATRON
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsFragment.kt
@@ -36,7 +36,7 @@ import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.preferences.Settings.HeadphoneAction
+import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
@@ -66,10 +66,9 @@ class HeadphoneControlsSettingsFragment : BaseFragment() {
         setContent {
             AppThemeWithBackground(theme.activeTheme) {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                val previousAction = settings.headphonePreviousActionFlow.collectAsState().value
-                val nextAction = settings.headphoneNextActionFlow.collectAsState().value
-                val confirmationSound =
-                    settings.headphonePlayBookmarkConfirmationSoundFlow.collectAsState().value
+                val previousAction = settings.headphoneControlsPreviousAction.flow.collectAsState().value
+                val nextAction = settings.headphoneControlsNextAction.flow.collectAsState().value
+                val confirmationSound = settings.headphoneControlsPlayBookmarkConfirmationSound.flow.collectAsState().value
 
                 val viewModel = hiltViewModel<HeadphoneControlsSettingsPageViewModel>()
 
@@ -81,20 +80,20 @@ class HeadphoneControlsSettingsFragment : BaseFragment() {
                     previousAction = previousAction,
                     nextAction = nextAction,
                     onNextActionSave = {
-                        settings.setHeadphoneControlsNextAction(it)
+                        settings.headphoneControlsNextAction.set(it)
                         viewModel.onNextActionChanged(it)
                     },
                     onPreviousActionSave = {
-                        settings.setHeadphoneControlsPreviousAction(it)
+                        settings.headphoneControlsPreviousAction.set(it)
                         viewModel.onPreviousActionChanged(it)
                     },
                     confirmationSound = confirmationSound,
-                    onConfirmationSoundSave = {
-                        settings.setHeadphoneControlsPlayBookmarkConfirmationSound(it)
-                        if (settings.getHeadphoneControlsPlayBookmarkConfirmationSound()) {
+                    onConfirmationSoundSave = { newValue ->
+                        settings.headphoneControlsPlayBookmarkConfirmationSound.set(newValue)
+                        if (newValue) {
                             playbackManager.playTone()
                         }
-                        viewModel.onConfirmationSoundChanged(it)
+                        viewModel.onConfirmationSoundChanged(newValue)
                     },
                     onBackPressed = {
                         @Suppress("DEPRECATION")

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.settings
 import androidx.lifecycle.ViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -23,15 +23,15 @@ class HeadphoneControlsSettingsPageViewModel @Inject constructor(
         )
     }
 
-    fun onNextActionChanged(action: Settings.HeadphoneAction) {
+    fun onNextActionChanged(action: HeadphoneAction) {
         trackHeadphoneAction(action, AnalyticsEvent.SETTINGS_HEADPHONE_CONTROLS_NEXT_CHANGED)
     }
 
-    fun onPreviousActionChanged(action: Settings.HeadphoneAction) {
+    fun onPreviousActionChanged(action: HeadphoneAction) {
         trackHeadphoneAction(action, AnalyticsEvent.SETTINGS_HEADPHONE_CONTROLS_PREVIOUS_CHANGED)
     }
 
-    private fun trackHeadphoneAction(action: Settings.HeadphoneAction, event: AnalyticsEvent) {
+    private fun trackHeadphoneAction(action: HeadphoneAction, event: AnalyticsEvent) {
         analyticsTracker.track(event, mapOf("value" to action.analyticsValue))
     }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/TracksAnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/TracksAnalyticsTracker.kt
@@ -24,7 +24,7 @@ class TracksAnalyticsTracker @Inject constructor(
     private val tracksClient: TracksClient? = TracksClient.getClient(appContext)
     override val anonIdPrefKey: String = TRACKS_ANON_ID
     private val paidSubscription: SubscriptionStatus.Paid?
-        get() = settings.getCachedSubscription() as? SubscriptionStatus.Paid
+        get() = settings.cachedSubscriptionStatus.value as? SubscriptionStatus.Paid
 
     private val predefinedEventProperties: Map<String, Any>
         get() {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.AutoAddUpNextLimitBehavi
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveInactiveSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
+import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
 import au.com.shiftyjelly.pocketcasts.preferences.model.LastPlayedList
 import au.com.shiftyjelly.pocketcasts.preferences.model.NewEpisodeNotificationActionSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.NotificationVibrateSetting
@@ -143,14 +144,6 @@ interface Settings {
         LONG_SHORT
     }
 
-    enum class HeadphoneAction(val analyticsValue: String) {
-        ADD_BOOKMARK("add_bookmark"),
-        SKIP_BACK("skip_back"),
-        SKIP_FORWARD("skip_forward"),
-        NEXT_CHAPTER("next_chapter"),
-        PREVIOUS_CHAPTER("previous_chapter"),
-    }
-
     sealed class MediaNotificationControls(@StringRes val controlName: Int, @DrawableRes val iconRes: Int, val key: String) {
 
         companion object {
@@ -187,9 +180,6 @@ interface Settings {
     val shelfItemsObservable: Observable<List<String>>
     val multiSelectItemsObservable: Observable<List<Int>>
 
-    val headphonePreviousActionFlow: StateFlow<HeadphoneAction>
-    val headphoneNextActionFlow: StateFlow<HeadphoneAction>
-    val headphonePlayBookmarkConfirmationSoundFlow: StateFlow<Boolean>
     val bookmarkSortTypeForPlayerFlow: StateFlow<BookmarksSortTypeForPlayer>
     val bookmarkSortTypeForPodcastFlow: StateFlow<BookmarksSortTypeForPodcast>
 
@@ -306,12 +296,9 @@ interface Settings {
     val upNextSwipe: UserSetting<UpNextAction>
     val tapOnUpNextShouldPlay: UserSetting<Boolean>
 
-    fun getHeadphoneControlsNextAction(): HeadphoneAction
-    fun setHeadphoneControlsNextAction(action: HeadphoneAction)
-    fun getHeadphoneControlsPreviousAction(): HeadphoneAction
-    fun setHeadphoneControlsPreviousAction(action: HeadphoneAction)
-    fun getHeadphoneControlsPlayBookmarkConfirmationSound(): Boolean
-    fun setHeadphoneControlsPlayBookmarkConfirmationSound(value: Boolean)
+    val headphoneControlsNextAction: UserSetting<HeadphoneAction>
+    val headphoneControlsPreviousAction: UserSetting<HeadphoneAction>
+    val headphoneControlsPlayBookmarkConfirmationSound: UserSetting<Boolean>
 
     // Firebase remote config
     fun getPeriodicSaveTimeMs(): Long

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -318,8 +318,7 @@ interface Settings {
     val cloudAutoUpload: UserSetting<Boolean>
     val cloudAutoDownload: UserSetting<Boolean>
     val cloudDownloadOnlyOnWifi: UserSetting<Boolean>
-    fun getCachedSubscription(): SubscriptionStatus?
-    fun setCachedSubscription(subscriptionStatus: SubscriptionStatus?)
+    val cachedSubscriptionStatus: UserSetting<SubscriptionStatus?>
 
     fun setUpgradeClosedProfile(value: Boolean)
     fun getUpgradeClosedProfile(): Boolean

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -8,8 +8,6 @@ import android.content.pm.PackageManager.NameNotFoundException
 import android.os.Build
 import android.util.Base64
 import androidx.work.NetworkType
-import au.com.shiftyjelly.pocketcasts.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
@@ -19,7 +17,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.BookmarksSortTypeForPodcast
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
-import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.DEFAULT_MAX_AUTO_ADD_LIMIT
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.NOTIFICATIONS_DISABLED_MESSAGE_SHOWN
@@ -32,6 +29,8 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.AutoAddUpNextLimitBehavi
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveInactiveSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
+import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
+import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneActionUserSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.LastPlayedList
 import au.com.shiftyjelly.pocketcasts.preferences.model.NewEpisodeNotificationActionSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.NotificationVibrateSetting
@@ -84,9 +83,6 @@ class SettingsImpl @Inject constructor(
     override val shelfItemsObservable = BehaviorRelay.create<List<String>>().apply { accept(getShelfItems()) }
     override val multiSelectItemsObservable = BehaviorRelay.create<List<Int>>().apply { accept(getMultiSelectItems()) }
 
-    override val headphonePreviousActionFlow = MutableStateFlow(getHeadphoneControlsPreviousAction())
-    override val headphoneNextActionFlow = MutableStateFlow(getHeadphoneControlsNextAction())
-    override val headphonePlayBookmarkConfirmationSoundFlow = MutableStateFlow(getHeadphoneControlsPlayBookmarkConfirmationSound())
     override val bookmarkSortTypeForPlayerFlow = MutableStateFlow(getBookmarksSortTypeForPlayer())
     override val bookmarkSortTypeForPodcastFlow = MutableStateFlow(getBookmarksSortTypeForPodcast())
 
@@ -877,60 +873,25 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override fun getHeadphoneControlsNextAction(): Settings.HeadphoneAction {
-        val isAddBookmarkEnabled =
-            FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) && (getCachedSubscription() as? SubscriptionStatus.Paid)?.tier == SubscriptionTier.PATRON
+    override val headphoneControlsNextAction = HeadphoneActionUserSetting(
+        sharedPrefKey = "headphone_controls_next_action",
+        defaultAction = HeadphoneAction.SKIP_FORWARD,
+        sharedPrefs = sharedPreferences,
+        subscriptionStatus = { getCachedSubscription() },
+    )
 
-        val defaultAction = Settings.HeadphoneAction.SKIP_FORWARD
-        val nextAction = Settings.HeadphoneAction.values()[
-            getInt(
-                "headphone_controls_next_action",
-                defaultAction.ordinal
-            )
-        ]
-        return if (nextAction == Settings.HeadphoneAction.ADD_BOOKMARK && !isAddBookmarkEnabled) {
-            defaultAction
-        } else {
-            nextAction
-        }
-    }
+    override val headphoneControlsPreviousAction = HeadphoneActionUserSetting(
+        sharedPrefKey = "headphone_controls_previous_action",
+        defaultAction = HeadphoneAction.SKIP_BACK,
+        sharedPrefs = sharedPreferences,
+        subscriptionStatus = { getCachedSubscription() },
+    )
 
-    override fun setHeadphoneControlsNextAction(action: Settings.HeadphoneAction) {
-        setInt("headphone_controls_next_action", action.ordinal)
-        headphoneNextActionFlow.update { action }
-    }
-
-    override fun getHeadphoneControlsPreviousAction(): Settings.HeadphoneAction {
-        val isAddBookmarkEnabled =
-            FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) && (getCachedSubscription() as? SubscriptionStatus.Paid)?.tier == SubscriptionTier.PATRON
-
-        val defaultAction = Settings.HeadphoneAction.SKIP_BACK
-        val previousAction = Settings.HeadphoneAction.values()[
-            getInt(
-                "headphone_controls_previous_action",
-                defaultAction.ordinal
-            )
-        ]
-        return if (previousAction == Settings.HeadphoneAction.ADD_BOOKMARK && !isAddBookmarkEnabled) {
-            defaultAction
-        } else {
-            previousAction
-        }
-    }
-
-    override fun setHeadphoneControlsPreviousAction(action: Settings.HeadphoneAction) {
-        setInt("headphone_controls_previous_action", action.ordinal)
-        headphonePreviousActionFlow.update { action }
-    }
-
-    override fun getHeadphoneControlsPlayBookmarkConfirmationSound(): Boolean {
-        return getBoolean("headphone_controls_play_bookmark_confirmation_sound", true)
-    }
-
-    override fun setHeadphoneControlsPlayBookmarkConfirmationSound(value: Boolean) {
-        setBoolean("headphone_controls_play_bookmark_confirmation_sound", value)
-        headphonePlayBookmarkConfirmationSoundFlow.update { value }
-    }
+    override val headphoneControlsPlayBookmarkConfirmationSound = UserSetting.BoolPref(
+        sharedPrefKey = "headphone_controls_play_bookmark_confirmation_sound",
+        defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
 
     override val showArchivedDefault = UserSetting.BoolPref(
         sharedPrefKey = "default_show_archived",

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -30,7 +30,7 @@ abstract class UserSetting<T>(
     // These are lazy because (1) the class needs to initialize before calling get() and
     // (2) we don't want to get the current value from SharedPreferences for every
     // setting immediately on app startup.
-    private val _flow by lazy { MutableStateFlow(get()) }
+    protected val _flow by lazy { MutableStateFlow(get()) }
     val flow: StateFlow<T> by lazy { _flow }
 
     // External callers should use [value] to get the current value if they can't

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/HeadphoneAction.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/HeadphoneAction.kt
@@ -6,6 +6,11 @@ import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 
 enum class HeadphoneAction(val analyticsValue: String) {
     ADD_BOOKMARK("add_bookmark"),
@@ -19,14 +24,14 @@ class HeadphoneActionUserSetting(
     sharedPrefKey: String,
     defaultAction: HeadphoneAction,
     sharedPrefs: SharedPreferences,
-    subscriptionStatus: () -> SubscriptionStatus?
+    subscriptionStatusFlow: StateFlow<SubscriptionStatus?>,
 ) : UserSetting.PrefFromInt<HeadphoneAction>(
     sharedPrefKey = sharedPrefKey,
     defaultValue = defaultAction,
     sharedPrefs = sharedPrefs,
     fromInt = {
         val isAddBookmarkEnabled =
-            FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) && (subscriptionStatus() as? SubscriptionStatus.Paid)?.tier == SubscriptionTier.PATRON
+            FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) && (subscriptionStatusFlow.value as? SubscriptionStatus.Paid)?.tier == SubscriptionTier.PATRON
         val nextAction = HeadphoneAction.values()[it]
         if (nextAction == HeadphoneAction.ADD_BOOKMARK && !isAddBookmarkEnabled) {
             defaultAction
@@ -35,4 +40,25 @@ class HeadphoneActionUserSetting(
         }
     },
     toInt = { it.ordinal }
-)
+) {
+
+    // Even though this coroutine scope never gets cancelled explicitly, it should
+    // get cancelled if/when the HeadphoneActionUserSetting is garbage collected.
+    private val coroutineScope = CoroutineScope(Dispatchers.Default + Job())
+
+    init {
+        // We're never cancelling this coroutine, but that should be fine
+        // since it is doing so little work (also, we don't have a relevant lifecycle
+        // to let us know when to cancel it).
+        coroutineScope.launch {
+            subscriptionStatusFlow.collect { _ ->
+                // Update the flow value because the subscription status has changed, so
+                // some actions (like bookmarks) might now be/not-be valid. We're using
+                // _flow.value here instead of set() because we don't want to persist a
+                // new value to shared prefs unless the user explicitly changes the
+                // setting.
+                _flow.value = get()
+            }
+        }
+    }
+}

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/HeadphoneAction.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/HeadphoneAction.kt
@@ -1,0 +1,38 @@
+package au.com.shiftyjelly.pocketcasts.preferences.model
+
+import android.content.SharedPreferences
+import au.com.shiftyjelly.pocketcasts.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+
+enum class HeadphoneAction(val analyticsValue: String) {
+    ADD_BOOKMARK("add_bookmark"),
+    SKIP_BACK("skip_back"),
+    SKIP_FORWARD("skip_forward"),
+    NEXT_CHAPTER("next_chapter"),
+    PREVIOUS_CHAPTER("previous_chapter"),
+}
+
+class HeadphoneActionUserSetting(
+    sharedPrefKey: String,
+    defaultAction: HeadphoneAction,
+    sharedPrefs: SharedPreferences,
+    subscriptionStatus: () -> SubscriptionStatus?
+) : UserSetting.PrefFromInt<HeadphoneAction>(
+    sharedPrefKey = sharedPrefKey,
+    defaultValue = defaultAction,
+    sharedPrefs = sharedPrefs,
+    fromInt = {
+        val isAddBookmarkEnabled =
+            FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) && (subscriptionStatus() as? SubscriptionStatus.Paid)?.tier == SubscriptionTier.PATRON
+        val nextAction = HeadphoneAction.values()[it]
+        if (nextAction == HeadphoneAction.ADD_BOOKMARK && !isAddBookmarkEnabled) {
+            defaultAction
+        } else {
+            nextAction
+        }
+    },
+    toInt = { it.ordinal }
+)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkHelper.kt
@@ -73,7 +73,7 @@ class BookmarkHelper @Inject constructor(
     }
 
     private fun shouldAllowAddBookmark(): Boolean {
-        return settings.getCachedSubscription()?.let { subscriptionStatus ->
+        return settings.cachedSubscriptionStatus.value?.let { subscriptionStatus ->
             (subscriptionStatus as? SubscriptionStatus.Paid)?.tier == SubscriptionTier.PATRON
         } ?: false
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkHelper.kt
@@ -63,7 +63,7 @@ class BookmarkHelper @Inject constructor(
                     )
                 }
 
-                if (settings.getHeadphoneControlsPlayBookmarkConfirmationSound()) {
+                if (settings.headphoneControlsPlayBookmarkConfirmationSound.value) {
                     playbackManager.playTone()
                 }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -25,6 +25,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationControls
+import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
 import au.com.shiftyjelly.pocketcasts.preferences.model.LastPlayedList
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkHelper
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
@@ -521,20 +522,20 @@ class MediaSessionManager(
         }
 
         private fun handleMediaButtonDoubleTap() {
-            handleMediaButtonAction(settings.headphoneNextActionFlow.value)
+            handleMediaButtonAction(settings.headphoneControlsNextAction.value)
         }
 
         private fun handleMediaButtonTripleTap() {
-            handleMediaButtonAction(settings.headphonePreviousActionFlow.value)
+            handleMediaButtonAction(settings.headphoneControlsPreviousAction.value)
         }
 
-        private fun handleMediaButtonAction(action: Settings.HeadphoneAction) {
+        private fun handleMediaButtonAction(action: HeadphoneAction) {
             when (action) {
-                Settings.HeadphoneAction.ADD_BOOKMARK -> onAddBookmark()
-                Settings.HeadphoneAction.SKIP_FORWARD -> onSkipToNext()
-                Settings.HeadphoneAction.SKIP_BACK -> onSkipToPrevious()
-                Settings.HeadphoneAction.NEXT_CHAPTER,
-                Settings.HeadphoneAction.PREVIOUS_CHAPTER -> Timber.e(ACTION_NOT_SUPPORTED)
+                HeadphoneAction.ADD_BOOKMARK -> onAddBookmark()
+                HeadphoneAction.SKIP_FORWARD -> onSkipToNext()
+                HeadphoneAction.SKIP_BACK -> onSkipToPrevious()
+                HeadphoneAction.NEXT_CHAPTER,
+                HeadphoneAction.PREVIOUS_CHAPTER -> Timber.e(ACTION_NOT_SUPPORTED)
             }
         }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -63,8 +63,8 @@ class SubscriptionManagerImpl @Inject constructor(
     AcknowledgePurchaseResponseListener {
 
     private var cachedSubscriptionStatus: SubscriptionStatus?
-        get() = settings.getCachedSubscription()
-        set(value) = settings.setCachedSubscription(value)
+        get() = settings.cachedSubscriptionStatus.value
+        set(value) = settings.cachedSubscriptionStatus.set(value)
 
     private var subscriptionStatus = BehaviorRelay.create<Optional<SubscriptionStatus>>().apply {
         val cachedStatus = cachedSubscriptionStatus
@@ -349,7 +349,7 @@ class SubscriptionManagerImpl @Inject constructor(
                 BillingFlowParams.newBuilder()
                     .setProductDetailsParamsList(productDetailsParamsList)
 
-            settings.getCachedSubscription()?.let { subscriptionStatus ->
+            settings.cachedSubscriptionStatus.value?.let { subscriptionStatus ->
                 if (
                     shouldAllowUpgradePlan(
                         subscribedPlanStatus = subscriptionStatus,


### PR DESCRIPTION
## Description
This updates the headphone controls to be UserSettings and also makes the headphone control settings react to changes in the user subscription to insure it is always up-to-date (see discussion in https://github.com/Automattic/pocket-casts-android/pull/1284#pullrequestreview-1583549610).

This PR is targeting the `feature/sync-settings-refactor` branch (which currently has a PR open to merge to `main`)

## Testing Instructions
1. Make sure the headphone controls update and work as expected.
2. When logged into a Patron account, set the headphone controls to "Add bookmark"
3. Log out of your account
4. Note that the headphone controls are no longer "Add bookmark"
5. Log back into your Patron account
6. Note that the headphone controls have returns to be "Add bookmark" if they were that before (and assuming you didn't update the headphone control setting when you were logged out). Let me know if you think we should overwrite the persisted headphone control when a user logs out automatically. I thought it was better to leave it so someone that logs out and logs right back in doesn't lose their setting, but I don't think there's a clear correct answer here.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews