### PR TITLE
Fix episode detail theme

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -137,13 +137,16 @@ class EpisodeFragment : BaseFragment() {
         get() = if (forceDarkTheme && theme.isLightTheme) Theme.ThemeType.DARK else theme.activeTheme
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        binding = FragmentEpisodeBinding.inflate(inflater, container, false)
-        showNotesFormatter = if (!forceDarkTheme || theme.isDarkTheme) {
-            createShowNotesFormatter(requireContext())
+        val themeResId = if (!forceDarkTheme || theme.isDarkTheme) {
+            activeTheme.resourceId
         } else {
-            val context = ContextThemeWrapper(requireContext(), R.style.ThemeDark)
-            createShowNotesFormatter(context)
+            R.style.ThemeDark
         }
+        val contextThemeWrapper = ContextThemeWrapper(requireContext(), themeResId)
+        val localInflater = inflater.cloneInContext(contextThemeWrapper)
+        binding = FragmentEpisodeBinding.inflate(localInflater, container, false)
+
+        showNotesFormatter = createShowNotesFormatter(contextThemeWrapper)
 
         statusBarColor = StatusBarColor.Custom(
             context?.getThemeColor(R.attr.primary_ui_01) ?: Color.WHITE, theme.isDarkTheme


### PR DESCRIPTION
## Description

This fixes episode details screen theming when dark theme is forced.

## Testing Instructions
1. Switch to rose theme
2. Add a few episode to `Up Next` queue
3. Go to `Up Next` screen which is always in dark theme
4. Tap on an episode from `Up Next` screen
5. Notice that `Episode Details` screen has a dark theme
6. Tap on podcast name on the `Episode Details` screen
7. Tap on an episode from the `Podcast Details` screen
8. Notice that the `Episode Details` screen has rose theme

## Screenshots or Screencast 

Rose Theme | Dark Theme 
----| -----
![1](https://github.com/Automattic/pocket-casts-android/assets/1405144/697c63a0-6f32-4482-8c9a-2f95cddbbbb1) |  ![2](https://github.com/Automattic/pocket-casts-android/assets/1405144/ec39bf60-27c7-46ae-9e38-b37a8e5a9e07)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
