### PR TITLE
Enable selecting text in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+7.47
+-----
+
+*   Updates:
+    *   Enable copying logs from in-app logs viewer
+        ([#1298](https://github.com/Automattic/pocket-casts-android/pull/1298))
+
 7.46
 -----
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LogsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LogsFragment.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -121,7 +122,9 @@ private fun LogsContent(
             if (logs == null) {
                 LoadingView()
             } else {
-                TextP60(logs)
+                SelectionContainer {
+                    TextP60(logs)
+                }
             }
         }
     }


### PR DESCRIPTION
## Description
Makes it possible to select text and copy it from the in-app logs viewer.

## Testing Instructions
1. Go to the in-app logs viewer ("Profile" → ⚙️ → "Help & feedback" → logs icon on the top of the screen)
2. Long press somewhere in the logs to start selecting text

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/4656348/f1607b27-19ce-4e4c-b1ba-098540fc6eb1

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews