### PR TITLE
Fix the artwork not loading on the onboarding page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 *   Updates:
     *   Enable copying logs from in-app logs viewer
         ([#1298](https://github.com/Automattic/pocket-casts-android/pull/1298))
+*   Bug Fixes:
+    *    Fixed the artwork not appearing on the onboarding page
+        ([#1299](https://github.com/Automattic/pocket-casts-android/pull/1299))
 
 7.46
 -----

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
@@ -5,6 +5,7 @@ import android.content.res.Configuration.ORIENTATION_LANDSCAPE
 import androidx.activity.compose.BackHandler
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -29,11 +30,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.coerceAtMost
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -59,8 +60,8 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
+import au.com.shiftyjelly.pocketcasts.ui.extensions.inLandscape
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -126,82 +127,91 @@ private fun Content(
     onSignUpClicked: () -> Unit,
     onLoginClicked: () -> Unit,
     onContinueWithGoogleComplete: (GoogleSignInState) -> Unit,
+    modifier: Modifier = Modifier
 ) {
-    Column(
-        Modifier
-            .fillMaxHeight()
-            .verticalScroll(rememberScrollState())
-    ) {
-
-        Spacer(Modifier.windowInsetsPadding(WindowInsets.statusBars))
-
-        Row(
+    BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+        val width = maxWidth
+        val height = maxHeight
+        Column(
             Modifier
-                .padding(vertical = 12.dp, horizontal = 16.dp)
-                .fillMaxWidth()
+                .fillMaxHeight()
+                .verticalScroll(rememberScrollState())
         ) {
-            Box(Modifier.weight(1f)) {
-                NavigationIconButton(
-                    iconColor = MaterialTheme.theme.colors.primaryText01,
-                    navigationButton = NavigationButton.Close,
-                    onNavigationClick = onNavigationClick
+
+            Spacer(Modifier.windowInsetsPadding(WindowInsets.statusBars))
+
+            Row(
+                Modifier
+                    .padding(vertical = 12.dp, horizontal = 16.dp)
+                    .fillMaxWidth()
+            ) {
+                Box(Modifier.weight(1f)) {
+                    NavigationIconButton(
+                        iconColor = MaterialTheme.theme.colors.primaryText01,
+                        navigationButton = NavigationButton.Close,
+                        onNavigationClick = onNavigationClick
+                    )
+                }
+
+                HorizontalLogo(
+                    modifier = Modifier
+                        .align(Alignment.CenterVertically)
+                        .height(28.dp)
+                )
+
+                Spacer(Modifier.weight(1f))
+            }
+
+            Spacer(Modifier.height(32.dp))
+
+            if (state is UiState.Loaded) {
+                val context = LocalContext.current
+                Artwork(
+                    googleSignInShown = GoogleSignInButtonViewModel.showContinueWithGoogleButton(
+                        context
+                    ),
+                    podcasts = state.randomPodcasts,
+                    viewWidth = width,
+                    viewHeight = height
                 )
             }
 
-            HorizontalLogo(
+            Spacer(Modifier.weight(1f))
+
+            TextH10(
+                text = stringResource(LR.string.onboarding_discover_your_next_favorite_podcast),
                 modifier = Modifier
-                    .align(Alignment.CenterVertically)
-                    .height(28.dp)
+                    .padding(horizontal = 24.dp)
+                    .fillMaxWidth(),
+                textAlign = TextAlign.Center,
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            TextH40(
+                text = stringResource(LR.string.onboarding_create_an_account_to),
+                modifier = Modifier
+                    .padding(horizontal = 24.dp)
+                    .fillMaxWidth(),
+                textAlign = TextAlign.Center
             )
 
             Spacer(Modifier.weight(1f))
+
+            if (showContinueWithGoogleButton) {
+                Spacer(Modifier.height(8.dp))
+                ContinueWithGoogleButton(
+                    flow = flow,
+                    onComplete = onContinueWithGoogleComplete
+                )
+            } else {
+                Spacer(Modifier.height(8.dp))
+            }
+
+            SignUpButton(onClick = onSignUpClicked)
+            LogInButton(onClick = onLoginClicked)
+            Spacer(Modifier.windowInsetsPadding(WindowInsets.navigationBars))
         }
-
-        Spacer(Modifier.height(32.dp))
-
-        if (state is UiState.Loaded) {
-            val context = LocalContext.current
-            Artwork(
-                googleSignInShown = GoogleSignInButtonViewModel.showContinueWithGoogleButton(context),
-                podcasts = state.randomPodcasts
-            )
-        }
-
-        Spacer(Modifier.weight(1f))
-
-        TextH10(
-            text = stringResource(LR.string.onboarding_discover_your_next_favorite_podcast),
-            modifier = Modifier
-                .padding(horizontal = 24.dp)
-                .fillMaxWidth(),
-            textAlign = TextAlign.Center,
-        )
-
-        Spacer(Modifier.height(8.dp))
-
-        TextH40(
-            text = stringResource(LR.string.onboarding_create_an_account_to),
-            modifier = Modifier
-                .padding(horizontal = 24.dp)
-                .fillMaxWidth(),
-            textAlign = TextAlign.Center
-        )
-
-        Spacer(Modifier.weight(1f))
-
-        if (showContinueWithGoogleButton) {
-            Spacer(Modifier.height(8.dp))
-            ContinueWithGoogleButton(
-                flow = flow,
-                onComplete = onContinueWithGoogleComplete
-            )
-        } else {
-            Spacer(Modifier.height(8.dp))
-        }
-
-        SignUpButton(onClick = onSignUpClicked)
-        LogInButton(onClick = onLoginClicked)
-        Spacer(Modifier.windowInsetsPadding(WindowInsets.navigationBars))
     }
 }
 
@@ -209,13 +219,13 @@ private fun Content(
 private fun Artwork(
     googleSignInShown: Boolean,
     podcasts: List<Podcast>,
+    viewWidth: Dp,
+    viewHeight: Dp
 ) {
-    val context = LocalContext.current
-    val localView = LocalView.current
     val configuration = LocalConfiguration.current
-
-    val viewWidth = localView.width.pxToDp(context).dp
-    val viewHeight = localView.height.pxToDp(context).dp
+    if (configuration.inLandscape()) {
+        return
+    }
 
     val artworkWidth = viewWidth * Artwork.getScaleFactor(googleSignInShown)
     val maxY = Artwork.coverModels.maxOf { it.y }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLoginOrSignUpViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLoginOrSignUpViewModel.kt
@@ -14,7 +14,8 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.isGooglePlayServicesAvail
 import com.google.android.gms.common.GoogleApiAvailability
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -31,12 +32,19 @@ class OnboardingLoginOrSignUpViewModel @Inject constructor(
         Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID.isNotEmpty() &&
             GoogleApiAvailability.getInstance().isGooglePlayServicesAvailableSuccess(context)
 
-    val randomPodcasts = mutableListOf<Podcast>()
+    private val _uiState = MutableStateFlow<UiState>(UiState.Loading)
+    val uiState: StateFlow<UiState> = _uiState
+
+    sealed class UiState {
+        object Loading : UiState()
+        data class Loaded(val randomPodcasts: List<Podcast>) : UiState()
+    }
 
     init {
-        viewModelScope.launch(Dispatchers.IO) {
-            randomPodcasts.clear()
-            randomPodcasts.addAll(podcastManager.findRandomPodcasts(limit = 6))
+        viewModelScope.launch {
+            _uiState.value = UiState.Loading
+            val randomPodcasts = podcastManager.findRandomPodcasts(limit = 6)
+            _uiState.value = UiState.Loaded(randomPodcasts = randomPodcasts)
         }
     }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -366,5 +366,5 @@ abstract class PodcastDao {
     abstract suspend fun findTopPodcasts(fromEpochMs: Long, toEpochMs: Long, limit: Int): List<TopPodcast>
 
     @Query("SELECT * FROM podcasts ORDER BY random() LIMIT :limit")
-    abstract fun findRandomPodcasts(limit: Int): List<Podcast>
+    abstract suspend fun findRandomPodcasts(limit: Int): List<Podcast>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -144,5 +144,5 @@ interface PodcastManager {
 
     suspend fun findTopPodcasts(fromEpochMs: Long, toEpochMs: Long, limit: Int): List<TopPodcast>
 
-    fun findRandomPodcasts(limit: Int): List<Podcast>
+    suspend fun findRandomPodcasts(limit: Int): List<Podcast>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -768,7 +768,7 @@ class PodcastManagerImpl @Inject constructor(
     override suspend fun findTopPodcasts(fromEpochMs: Long, toEpochMs: Long, limit: Int): List<TopPodcast> =
         podcastDao.findTopPodcasts(fromEpochMs, toEpochMs, limit)
 
-    override fun findRandomPodcasts(limit: Int): List<Podcast> {
+    override suspend fun findRandomPodcasts(limit: Int): List<Podcast> {
         return podcastDao.findRandomPodcasts(limit)
     }
 }


### PR DESCRIPTION
## Description

The issue is that the `LocalView.current` returns a view with zero width and height. To fix this I have replaced this logic with a `BoxWithConstraints`. 

Before I found the issue I thought it was related to the podcasts in the ViewModel being a list and not a state variable. Whilst these changes didn't fix it I believe they are still worth making. Let me know what you think, I will remove them if you don't agree.

Fixes https://github.com/Automattic/pocket-casts-android/issues/1295

## Testing Instructions

1. Do a refresh install of the app
2. ✅ Verify you are shown the podcast artwork when the app launches
3. Don't sign in and close the dialog
4. Subscribe to a few podcasts
5. Tap on the 'Profile' tab
6. Tap "Set Up Account'
7. ✅ Verify the subscribed podcasts are included in the artwork

## Screencast 

https://github.com/Automattic/pocket-casts-android/assets/308331/deaddbd0-3a31-47de-ac3a-da4af77be6cb
