### PR TITLE
Avoid crash when accessing and dismissing episode details from up next queue

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -190,7 +190,7 @@ class EpisodeFragment : BaseFragment() {
         super.onDestroyView()
         if (!viewModel.isFragmentChangingConfigurations) {
             analyticsTracker.track(AnalyticsEvent.EPISODE_DETAIL_DISMISSED, mapOf(AnalyticsProp.Key.SOURCE to episodeViewSource.value))
-            podcastAndEpisodeDetailsCoordinator.onEpisodeDetailsDismissed()
+            podcastAndEpisodeDetailsCoordinator.onEpisodeDetailsDismissed?.invoke()
         }
         webView.cleanup()
         webView = null

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastAndEpisodeDetailsCoordinator.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastAndEpisodeDetailsCoordinator.kt
@@ -5,5 +5,5 @@ import javax.inject.Singleton
 
 @Singleton
 class PodcastAndEpisodeDetailsCoordinator @Inject constructor() {
-    lateinit var onEpisodeDetailsDismissed: () -> Unit
+    var onEpisodeDetailsDismissed: (() -> Unit)? = null
 }


### PR DESCRIPTION
## Description
This avoids a crash that can occur when dismissing the episode details view.

This issue was introduced in https://github.com/Automattic/pocket-casts-android/pull/1282.

## Testing Instructions
1. Make sure you have the "General" setting for playing episodes when you tap them in your up next queue turned off (we need it to open the episode details screen).
2. Open the up next queue without opening a podcast screen (if you go to a podcast screen first the crash doesn't happen)
3. Tap on an episode to open the episode details view
4. Dismiss the episode details view
5. Observe that the app doesn't crash

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md (no changelog because this is a regression since the last release)
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews