### PR TITLE
Fix Protocol Buffers in the release build

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -185,3 +185,6 @@
 # R8 full mode strips generic signatures from return types if not kept.
 -if interface * { @retrofit2.http.* public *** *(...); }
 -keep,allowoptimization,allowshrinking,allowobfuscation class <3>
+
+# Protocol Buffers - keep the field names
+-keep class * extends com.google.protobuf.GeneratedMessageLite { *; }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.StatsBundle
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
+import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
@@ -856,7 +857,7 @@ class PodcastSyncProcess(
         if (bookmark.deleted) {
             bookmarkManager.deleteSynced(bookmark.uuid)
         } else {
-            bookmarkManager.upsertSynced(bookmark)
+            bookmarkManager.upsertSynced(bookmark.copy(syncStatus = SyncStatus.SYNCED))
         }
     }
 }


### PR DESCRIPTION
## Description

This change fixes two issues.

1. The new Protocol Buffers don't work after Proguard has run.

<img  width="500" src="https://github.com/Automattic/pocket-casts-android/assets/308331/216c01bd-317b-4839-a54c-ba41c07361ec" />

2. After your first login if it downloaded any bookmarks they are uploaded to the server again.

## Testing Instructions

### Test Proguard
1. In `Feature.kt` set the default value for bookmarks to true.
2. Build a release version of the app `./gradlew app:assembleRelease`
4. Install the build
5. Login to a Pocket Casts Plus account
6. Add a bookmark
7. On the 'Profile' tab manually refresh
8. ✅ Verify the refresh is successful

### Test first login
1. Add some bookmarks to a Pocket Casts account
2. Sign out and clear the app storage (or reinstall)
3. Open the App Inspection window
4. Open the Network Inspector
5. Tap Refresh Now
6. ✅ Verify the https://api.pocketcasts.net/sync/update call doesn't send any changes to the server. `"changes":[]`