### PR TITLE
Remove Sentry NDK

### DIFF
--- a/base.gradle
+++ b/base.gradle
@@ -241,7 +241,7 @@ dependencies {
     implementation libs.accompanistFlowLayout
     implementation libs.accompanistSystemUiController
     implementation platform(libs.sentryBom)
-    implementation libs.sentry
+    implementation libs.sentryAndroidCore
     implementation libs.sentryFragment
     implementation libs.sentryTimber
     implementation libs.media3Cast
@@ -308,4 +308,9 @@ dependencies {
             because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
         }
     }
+}
+
+// Exclude the NDK from the Sentry Android SDK as we don't use it and Tracks includes it.
+configurations.configureEach {
+    exclude group: "io.sentry", module: "sentry-android-ndk"
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -297,8 +297,8 @@ project.ext {
             // Automattic Tracks
             automatticTracks: "com.automattic:Automattic-Tracks-Android:$versionTracks",
             // Sentry
-            sentryBom: 'io.sentry:sentry-bom:6.4.2',
-            sentry: 'io.sentry:sentry-android',
+            sentryBom: 'io.sentry:sentry-bom:6.28.0',
+            sentryAndroidCore: 'io.sentry:sentry-android-core',
             sentryFragment: 'io.sentry:sentry-android-fragment',
             sentryTimber: 'io.sentry:sentry-android-timber',
             // AboutLibraries - https://github.com/mikepenz/AboutLibraries

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperPage.kt
@@ -3,9 +3,11 @@ package au.com.shiftyjelly.pocketcasts.settings.developer
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.outlined.BugReport
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.HomeRepairService
 import androidx.compose.material.icons.outlined.Notifications
@@ -19,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRow
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import io.sentry.Sentry
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -38,6 +41,7 @@ fun DeveloperPage(
         )
         ShowkaseSetting(onClick = onShowkaseClick)
         ForceRefreshSetting(onClick = onForceRefreshClick)
+        SendCrashSetting()
         TriggerNotificationSetting(onClick = onTriggerNotificationClick)
         DeleteFirstEpisodeSetting(onClick = onDeleteFirstEpisodeClick)
     }
@@ -66,6 +70,20 @@ private fun ForceRefreshSetting(
         secondaryText = "Refresh podcasts and sync data",
         icon = rememberVectorPainter(Icons.Default.Refresh),
         modifier = modifier.clickable { onClick() }
+    )
+}
+
+@Composable
+private fun SendCrashSetting(
+    modifier: Modifier = Modifier,
+) {
+    SettingRow(
+        primaryText = "Report a crash",
+        secondaryText = "Send an exception to Sentry",
+        icon = rememberVectorPainter(Icons.Outlined.BugReport),
+        modifier = modifier.clickable {
+            Sentry.captureException(Exception("Test crash"))
+        }
     )
 }
 


### PR DESCRIPTION
## Description

As we don't use the NDK we don't need to include `sentry-android-ndk`. Removing these libraries reduces the APK from 28.4MB to 23.8MB. 

We have also been contacted by an Automotive partner as these libraries include old C functions which it recommends not using. I thought we could have tried just the library upgrade but if we don't need these anyway maybe it's best to remove them.

Here is the [Sentry documentation](https://docs.sentry.io/platforms/android/configuration/using-ndk/#using-the-sdk-without-the-ndk).

## Testing Instructions
1. Change `modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragmentPage.kt` so the developer menu is visible in a release build.
2. Install a release build
3. Go to 'Profile' tab -> settings cog -> Developer
4. Tap 'Report a crash'
5. ✅ Verify in Sentry the exception has the same information as previous reports
