### PR TITLE
Fix delete icon visibility on podcast detail screen

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
@@ -76,7 +76,11 @@ class EpisodeListAdapter(
                 playbackStateUpdates = playbackManager.playbackStateRelay,
                 upNextChangesObservable = upNextQueue.changesObservable,
                 imageLoader = imageLoader,
-                swipeButtonLayoutFactory = swipeButtonLayoutFactory
+                swipeButtonLayoutFactory = swipeButtonLayoutFactory,
+                userBookmarksObservable = bookmarkManager.findPodcastBookmarksFlow(
+                    podcastUuid = fromListUuid ?: "",
+                    sortType = settings.getBookmarksSortTypeForPodcast()
+                ).asObservable()
             )
             R.layout.adapter_user_episode -> UserEpisodeViewHolder(
                 binding = AdapterUserEpisodeBinding.inflate(inflater, parent, false),

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
@@ -54,8 +54,6 @@ class EpisodeListAdapter(
     val swipeButtonLayoutFactory: SwipeButtonLayoutFactory,
 ) : ListAdapter<BaseEpisode, RecyclerView.ViewHolder>(PLAYBACK_DIFF) {
 
-    private lateinit var podcastEpisode: PodcastEpisode
-
     val disposables = CompositeDisposable()
 
     init {
@@ -78,11 +76,7 @@ class EpisodeListAdapter(
                 playbackStateUpdates = playbackManager.playbackStateRelay,
                 upNextChangesObservable = upNextQueue.changesObservable,
                 imageLoader = imageLoader,
-                swipeButtonLayoutFactory = swipeButtonLayoutFactory,
-                podcastBookmarksObservable = bookmarkManager.findPodcastBookmarksFlow(
-                    podcastUuid = podcastEpisode.podcastUuid,
-                    sortType = settings.getBookmarksSortTypeForPodcast()
-                ).asObservable()
+                swipeButtonLayoutFactory = swipeButtonLayoutFactory
             )
             R.layout.adapter_user_episode -> UserEpisodeViewHolder(
                 binding = AdapterUserEpisodeBinding.inflate(inflater, parent, false),
@@ -118,7 +112,11 @@ class EpisodeListAdapter(
             upNextAction = settings.upNextSwipe.value,
             multiSelectEnabled = multiSelectHelper.isMultiSelecting,
             isSelected = multiSelectHelper.isSelected(episode),
-            disposables = disposables
+            disposables = disposables,
+            podcastBookmarksObservable = bookmarkManager.findPodcastBookmarksFlow(
+                podcastUuid = episode.podcastUuid,
+                sortType = settings.getBookmarksSortTypeForPodcast()
+            ).asObservable()
         )
         holder.episodeRow.setOnClickListener {
             if (multiSelectHelper.isMultiSelecting) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
@@ -54,6 +54,8 @@ class EpisodeListAdapter(
     val swipeButtonLayoutFactory: SwipeButtonLayoutFactory,
 ) : ListAdapter<BaseEpisode, RecyclerView.ViewHolder>(PLAYBACK_DIFF) {
 
+    private lateinit var podcastEpisode: PodcastEpisode
+
     val disposables = CompositeDisposable()
 
     init {
@@ -77,8 +79,8 @@ class EpisodeListAdapter(
                 upNextChangesObservable = upNextQueue.changesObservable,
                 imageLoader = imageLoader,
                 swipeButtonLayoutFactory = swipeButtonLayoutFactory,
-                userBookmarksObservable = bookmarkManager.findPodcastBookmarksFlow(
-                    podcastUuid = fromListUuid ?: "",
+                podcastBookmarksObservable = bookmarkManager.findPodcastBookmarksFlow(
+                    podcastUuid = podcastEpisode.podcastUuid,
                     sortType = settings.getBookmarksSortTypeForPodcast()
                 ).asObservable()
             )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
@@ -17,6 +17,7 @@ import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
@@ -58,6 +59,7 @@ class EpisodeViewHolder constructor(
     val playbackStateUpdates: Observable<PlaybackState>,
     val upNextChangesObservable: Observable<UpNextQueue.State>,
     val imageLoader: PodcastImageLoader? = null,
+    private val userBookmarksObservable: Observable<List<Bookmark>>,
     private val swipeButtonLayoutFactory: SwipeButtonLayoutFactory,
 ) : RecyclerView.ViewHolder(binding.root), RowSwipeable {
     override val episodeRow: ViewGroup
@@ -166,6 +168,13 @@ class EpisodeViewHolder constructor(
             .startWith(emptyState) // Pre load with a blank state so it doesn't wait for the first update
             .map { if (it.episodeUuid == episode.uuid) it else emptyState } // When another episode is playing return an empty state to clear fields like the buffering status
 
+        data class CombinedData(
+            val downloadProgress: Int,
+            val playbackState: PlaybackState,
+            val isInUpNext: Boolean,
+            val userBookmarks: List<Bookmark>,
+        )
+
         val imgIcon = binding.imgIcon
         val progressBar = binding.progressBar
         val progressCircle = binding.progressCircle
@@ -176,23 +185,30 @@ class EpisodeViewHolder constructor(
         val date = binding.date
 
         disposable?.dispose()
-        disposable = Observables.combineLatest(downloadUpdates, playbackStateForThisEpisode, isInUpNextObservable)
+        disposable = Observables.combineLatest(
+            downloadUpdates,
+            playbackStateForThisEpisode,
+            isInUpNextObservable,
+            userBookmarksObservable
+        ) { downloadProgress, playbackState, isInUpNext, userBookmarks ->
+            CombinedData(downloadProgress, playbackState, isInUpNext, userBookmarks)
+        }
             .distinctUntilChanged()
             .toFlowable(BackpressureStrategy.LATEST)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
-            .doOnNext { (downloadProgress, playbackState, isInUpNext) ->
-                episode.playing = playbackState.isPlaying && playbackState.episodeUuid == episode.uuid
+            .doOnNext { combinedData ->
+                episode.playing = combinedData.playbackState.isPlaying && combinedData.playbackState.episodeUuid == episode.uuid
                 val playButtonType = PlayButton.calculateButtonType(episode, streamByDefault)
                 binding.playButton.setButtonType(episode, playButtonType, tintColor, fromListUuid)
-                binding.inUpNext = isInUpNext
+                binding.inUpNext = combinedData.isInUpNext
                 binding.hasBookmarks = episode.hasBookmark
 
                 imgIcon.isVisible = false
                 progressCircle.isVisible = false
                 progressBar.isVisible = false
                 imgIcon.alpha = 1.0f
-                if (playbackState.episodeUuid == episode.uuid && playbackState.isBuffering) {
+                if (combinedData.playbackState.episodeUuid == episode.uuid && combinedData.playbackState.isBuffering) {
                     progressBar.isVisible = true
                     lblStatus.text = context.getString(LR.string.episode_row_buffering)
                 } else if (episode.episodeStatus == EpisodeStatusEnum.DOWNLOADED) {
@@ -202,8 +218,8 @@ class EpisodeViewHolder constructor(
                     ImageViewCompat.setImageTintList(imgIcon, ColorStateList.valueOf(context.getThemeColor(UR.attr.support_02)))
                 } else if (episode.episodeStatus == EpisodeStatusEnum.DOWNLOADING) {
                     progressCircle.isVisible = true
-                    lblStatus.text = context.getString(LR.string.episode_row_downloading, downloadProgress)
-                    progressCircle.setPercent(downloadProgress / 100.0f)
+                    lblStatus.text = context.getString(LR.string.episode_row_downloading, combinedData.downloadProgress)
+                    progressCircle.setPercent(combinedData.downloadProgress / 100.0f)
                 } else if (episode.episodeStatus == EpisodeStatusEnum.DOWNLOAD_FAILED) {
                     imgIcon.isVisible = true
                     imgIcon.setImageResource(IR.drawable.ic_download_failed_row)
@@ -240,7 +256,7 @@ class EpisodeViewHolder constructor(
                 } else {
                     updateTimeLeft(textView = lblStatus, episode = episode)
                 }
-                updateRowText(episode, captionColor, tintColor, date, title, lblStatus, isInUpNext)
+                updateRowText(episode, captionColor, tintColor, date, title, lblStatus, combinedData.isInUpNext)
 
                 val episodeGreyedOut = episode.playingStatus == EpisodePlayingStatus.COMPLETED || episode.isArchived
                 imgArtwork.alpha = if (episodeGreyedOut) 0.5f else 1f

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
@@ -59,7 +59,6 @@ class EpisodeViewHolder constructor(
     val playbackStateUpdates: Observable<PlaybackState>,
     val upNextChangesObservable: Observable<UpNextQueue.State>,
     val imageLoader: PodcastImageLoader? = null,
-    private val podcastBookmarksObservable: Observable<List<Bookmark>>,
     private val swipeButtonLayoutFactory: SwipeButtonLayoutFactory,
 ) : RecyclerView.ViewHolder(binding.root), RowSwipeable {
     override val episodeRow: ViewGroup
@@ -134,7 +133,7 @@ class EpisodeViewHolder constructor(
             return listOf(archiveItem, shareItem)
         }
 
-    fun setup(episode: PodcastEpisode, fromListUuid: String?, tintColor: Int, playButtonListener: PlayButton.OnClickListener, streamByDefault: Boolean, upNextAction: Settings.UpNextAction, multiSelectEnabled: Boolean = false, isSelected: Boolean = false, disposables: CompositeDisposable) {
+    fun setup(episode: PodcastEpisode, fromListUuid: String?, tintColor: Int, playButtonListener: PlayButton.OnClickListener, streamByDefault: Boolean, upNextAction: Settings.UpNextAction, multiSelectEnabled: Boolean = false, isSelected: Boolean = false, disposables: CompositeDisposable, podcastBookmarksObservable: Observable<List<Bookmark>>) {
         this.upNextAction = upNextAction
         this.isMultiSelecting = multiSelectEnabled
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
@@ -59,7 +59,7 @@ class EpisodeViewHolder constructor(
     val playbackStateUpdates: Observable<PlaybackState>,
     val upNextChangesObservable: Observable<UpNextQueue.State>,
     val imageLoader: PodcastImageLoader? = null,
-    private val userBookmarksObservable: Observable<List<Bookmark>>,
+    private val podcastBookmarksObservable: Observable<List<Bookmark>>,
     private val swipeButtonLayoutFactory: SwipeButtonLayoutFactory,
 ) : RecyclerView.ViewHolder(binding.root), RowSwipeable {
     override val episodeRow: ViewGroup
@@ -172,7 +172,7 @@ class EpisodeViewHolder constructor(
             val downloadProgress: Int,
             val playbackState: PlaybackState,
             val isInUpNext: Boolean,
-            val userBookmarks: List<Bookmark>,
+            val podcastBookmarks: List<Bookmark>,
         )
 
         val imgIcon = binding.imgIcon
@@ -189,9 +189,9 @@ class EpisodeViewHolder constructor(
             downloadUpdates,
             playbackStateForThisEpisode,
             isInUpNextObservable,
-            userBookmarksObservable
-        ) { downloadProgress, playbackState, isInUpNext, userBookmarks ->
-            CombinedData(downloadProgress, playbackState, isInUpNext, userBookmarks)
+            podcastBookmarksObservable
+        ) { downloadProgress, playbackState, isInUpNext, podcastBookmarks ->
+            CombinedData(downloadProgress, playbackState, isInUpNext, podcastBookmarks)
         }
             .distinctUntilChanged()
             .toFlowable(BackpressureStrategy.LATEST)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -215,7 +215,6 @@ class PodcastAdapter(
                 playbackStateUpdates = playbackManager.playbackStateRelay,
                 upNextChangesObservable = upNextQueue.changesObservable,
                 swipeButtonLayoutFactory = swipeButtonLayoutFactory,
-                podcastBookmarksObservable = podcastBookmarksObservable
             )
         }
     }
@@ -315,7 +314,8 @@ class PodcastAdapter(
             upNextAction = settings.upNextSwipe.value,
             multiSelectEnabled = multiSelectEpisodesHelper.isMultiSelecting,
             isSelected = multiSelectEpisodesHelper.isSelected(episode),
-            disposables = disposables
+            disposables = disposables,
+            podcastBookmarksObservable = podcastBookmarksObservable
         )
         holder.episodeRow.setOnClickListener {
             if (multiSelectEpisodesHelper.isMultiSelecting) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -66,6 +66,7 @@ import au.com.shiftyjelly.pocketcasts.views.helper.AnimatorUtil
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
+import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -112,6 +113,7 @@ class PodcastAdapter(
     val settings: Settings,
     val theme: Theme,
     var fromListUuid: String?,
+    private val userBookmarksObservable: Observable<List<Bookmark>>,
     private val onHeaderSummaryToggled: (Boolean, Boolean) -> Unit,
     private val onSubscribeClicked: () -> Unit,
     private val onUnsubscribeClicked: (successCallback: () -> Unit) -> Unit,
@@ -213,6 +215,7 @@ class PodcastAdapter(
                 playbackStateUpdates = playbackManager.playbackStateRelay,
                 upNextChangesObservable = upNextQueue.changesObservable,
                 swipeButtonLayoutFactory = swipeButtonLayoutFactory,
+                userBookmarksObservable = userBookmarksObservable
             )
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -113,7 +113,7 @@ class PodcastAdapter(
     val settings: Settings,
     val theme: Theme,
     var fromListUuid: String?,
-    private val userBookmarksObservable: Observable<List<Bookmark>>,
+    private val podcastBookmarksObservable: Observable<List<Bookmark>>,
     private val onHeaderSummaryToggled: (Boolean, Boolean) -> Unit,
     private val onSubscribeClicked: () -> Unit,
     private val onUnsubscribeClicked: (successCallback: () -> Unit) -> Unit,
@@ -215,7 +215,7 @@ class PodcastAdapter(
                 playbackStateUpdates = playbackManager.playbackStateRelay,
                 upNextChangesObservable = upNextQueue.changesObservable,
                 swipeButtonLayoutFactory = swipeButtonLayoutFactory,
-                userBookmarksObservable = userBookmarksObservable
+                podcastBookmarksObservable = podcastBookmarksObservable
             )
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -618,7 +618,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                 ),
                 onHeadsetSettingsClicked = ::onHeadsetSettingsClicked,
                 sourceView = SourceView.PODCAST_SCREEN,
-                userBookmarksObservable = bookmarkManager.findPodcastBookmarksFlow(
+                podcastBookmarksObservable = bookmarkManager.findPodcastBookmarksFlow(
                     podcastUuid = podcastUuid,
                     sortType = settings.getBookmarksSortTypeForPodcast()
                 ).asObservable()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -42,6 +42,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastRatingsViewModel
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastViewModel
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastViewModel.PodcastTab
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.AutomaticUpNextSource
@@ -77,6 +78,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.rx2.asObservable
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -123,6 +125,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
     @Inject lateinit var playButtonListener: PlayButton.OnClickListener
     @Inject lateinit var castManager: CastManager
     @Inject lateinit var upNextQueue: UpNextQueue
+    @Inject lateinit var bookmarkManager: BookmarkManager
     @Inject lateinit var multiSelectEpisodesHelper: MultiSelectEpisodesHelper
     @Inject lateinit var multiSelectBookmarksHelper: MultiSelectBookmarksHelper
     @Inject lateinit var coilManager: CoilManager
@@ -615,6 +618,10 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                 ),
                 onHeadsetSettingsClicked = ::onHeadsetSettingsClicked,
                 sourceView = SourceView.PODCAST_SCREEN,
+                userBookmarksObservable = bookmarkManager.findPodcastBookmarksFlow(
+                    podcastUuid = podcastUuid,
+                    sortType = settings.getBookmarksSortTypeForPodcast()
+                ).asObservable()
             )
         }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR fixes the bookmark icon visibility on the Podcast detail screen as discussed [here](https://github.com/Automattic/pocket-casts-android/pull/1276#issuecomment-1689321629)
The UserEpisodes was resolved on [1276](https://github.com/Automattic/pocket-casts-android/pull/1276)


Fixes # <!-- issue number, if applicable -->[1273](https://github.com/Automattic/pocket-casts-android/issues/1273)
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Login using Paid account and sign as Patron
2. Go to Podcast 
3. Play one episode 
4. Add Bookmark 
5. Go to the the Podcast episode list and check the bookmark is added 
6. Delete bookmark. 
7. Observe the Bookmark icon is deleted 

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
