### PR TITLE
In-app review

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/views/review/InAppReviewHelperTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/views/review/InAppReviewHelperTest.kt
@@ -15,8 +15,8 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import java.util.Date
 
@@ -50,8 +50,7 @@ class InAppReviewHelperTest {
         launchReviewDialog()
         launchReviewDialog()
 
-        verify(reviewManager).requestReviewFlow()
-        verifyNoMoreInteractions(reviewManager)
+        verify(reviewManager, times(1)).requestReviewFlow()
     }
 
     private fun launchReviewDialog() = runTest() {

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/views/review/InAppReviewHelperTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/views/review/InAppReviewHelperTest.kt
@@ -1,0 +1,72 @@
+package au.com.shiftyjelly.pocketcasts.views.review
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import com.google.android.play.core.review.ReviewManager
+import com.google.android.play.core.review.testing.FakeReviewManager
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+class InAppReviewHelperTest {
+
+    @Mock
+    private lateinit var settings: Settings
+
+    @Mock
+    private lateinit var analyticsTracker: AnalyticsTrackerWrapper
+
+    private lateinit var inAppReviewHelper: InAppReviewHelper
+
+    private lateinit var reviewManager: ReviewManager
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        reviewManager = spy(FakeReviewManager(appContext))
+    }
+
+    @Test
+    fun testInAppReviewFlowRequestedOnlyOnce() = runTest {
+        whenever(settings.getReviewRequestedDates())
+            .thenReturn(emptyList())
+            .thenReturn(listOf(Date().toString()))
+        initInAppReviewHelper()
+
+        launchReviewDialog()
+        launchReviewDialog()
+
+        verify(reviewManager).requestReviewFlow()
+        verifyNoMoreInteractions(reviewManager)
+    }
+
+    private fun launchReviewDialog() = runTest() {
+        inAppReviewHelper.launchReviewDialog(
+            activity = mock(),
+            delayInMs = 100,
+            sourceView = SourceView.UNKNOWN
+        )
+    }
+
+    private fun initInAppReviewHelper() {
+        inAppReviewHelper = InAppReviewHelper(
+            settings = settings,
+            analyticsTracker = analyticsTracker,
+            reviewManager = reviewManager
+        )
+    }
+}

--- a/base.gradle
+++ b/base.gradle
@@ -180,6 +180,7 @@ dependencies {
     implementation androidLibs.lifecycleProcess
     implementation androidLibs.paging
     implementation androidLibs.pagingRx
+    implementation androidLibs.playReview
     implementation androidLibs.workManager
     implementation androidLibs.workManagerRx
     implementation androidLibs.navigationFragment

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -214,7 +214,9 @@ project.ext {
             media3DatasourceOkhttp: "androidx.media3:media3-datasource-okhttp:$versionMedia3",
 
             // Fixes instrumentation tests, see: https://github.com/android/android-test/issues/861#issuecomment-1180219978
-            accessibilityTestFramework: "com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:$versionAccessibilityTestFramework"
+            accessibilityTestFramework: "com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:$versionAccessibilityTestFramework",
+            // In-app reviews
+            playReview: 'com.google.android.play:review-ktx:2.0.1',
     ]
 
     libs = [

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModelTest.kt
@@ -23,6 +23,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.util.Date
@@ -106,6 +107,16 @@ class StatsViewModelTest {
     fun `given stats started equal to 7 days, when stats are loaded, then app review dialog is not shown`() =
         runTest {
             initViewModel(statsStartedAt = LocalDateTime.now().minusDays(7.toLong()))
+
+            viewModel.loadStats()
+
+            assertFalse((viewModel.state.value as StatsViewModel.State.Loaded).showAppReviewDialog)
+        }
+
+    @Test
+    fun `given stats started at unix epoch, when stats are loaded, then app review dialog is not shown`() =
+        runTest {
+            initViewModel(statsStartedAt = LocalDateTime.ofInstant(Instant.EPOCH, ZoneId.systemDefault()))
 
             viewModel.loadStats()
 

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModelTest.kt
@@ -1,0 +1,141 @@
+package au.com.shiftyjelly.pocketcasts.settings.stats
+
+import android.app.Application
+import android.content.res.Resources
+import au.com.shiftyjelly.pocketcasts.models.to.StatsBundle
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.views.review.InAppReviewHelper
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.Date
+import java.util.concurrent.TimeUnit
+
+@RunWith(MockitoJUnitRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class StatsViewModelTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    @Mock
+    private lateinit var settings: Settings
+
+    @Mock
+    private lateinit var statsManager: StatsManager
+
+    @Mock
+    private lateinit var episodeManager: EpisodeManager
+
+    @Mock
+    private lateinit var syncManager: SyncManager
+
+    @Mock
+    private lateinit var application: Application
+
+    @Mock
+    private lateinit var inAppReviewHelper: InAppReviewHelper
+
+    private lateinit var viewModel: StatsViewModel
+
+    @Before
+    fun setUp() {
+        val mockResources = mock<Resources>()
+        whenever(mockResources.getString(anyInt())).thenReturn("")
+        whenever(application.resources).thenReturn(mockResources)
+        whenever(syncManager.isLoggedIn()).thenReturn(true)
+    }
+
+    @Test
+    fun `given last 7 days played upto sum more than 2_5 hrs, when stats are loaded, then app review dialog is shown`() =
+        runTest {
+            initViewModel(playedUpToSumInHours = 3.0)
+
+            viewModel.loadStats()
+
+            assertTrue((viewModel.state.value as StatsViewModel.State.Loaded).showAppReviewDialog)
+        }
+
+    @Test
+    fun `given last 7 days played upto sum less than 2_5 hrs, when stats are loaded, then app review dialog  is not shown`() =
+        runTest {
+            initViewModel(playedUpToSumInHours = 2.0)
+
+            viewModel.loadStats()
+
+            assertFalse((viewModel.state.value as StatsViewModel.State.Loaded).showAppReviewDialog)
+        }
+
+    @Test
+    fun `given stats started more than 7 days, when stats are loaded, then app review dialog is shown`() =
+        runTest {
+            initViewModel(statsStartedAt = LocalDateTime.now().minusDays(8.toLong()))
+
+            viewModel.loadStats()
+
+            assertTrue((viewModel.state.value as StatsViewModel.State.Loaded).showAppReviewDialog)
+        }
+
+    @Test
+    fun `given stats started less than 7 days, when stats are loaded, then app review dialog is not shown`() =
+        runTest {
+            initViewModel(statsStartedAt = LocalDateTime.now().minusDays(6.toLong()))
+
+            viewModel.loadStats()
+
+            assertFalse((viewModel.state.value as StatsViewModel.State.Loaded).showAppReviewDialog)
+        }
+
+    @Test
+    fun `given stats started equal to 7 days, when stats are loaded, then app review dialog is not shown`() =
+        runTest {
+            initViewModel(statsStartedAt = LocalDateTime.now().minusDays(7.toLong()))
+
+            viewModel.loadStats()
+
+            assertFalse((viewModel.state.value as StatsViewModel.State.Loaded).showAppReviewDialog)
+        }
+
+    private suspend fun initViewModel(
+        statsStartedAt: LocalDateTime = LocalDateTime.now().minusDays(8.toLong()),
+        playedUpToSumInHours: Double = 3.0,
+    ) {
+        whenever(statsManager.getServerStats()).thenReturn(
+            StatsBundle(
+                values = emptyMap(),
+                startedAt = Date.from(statsStartedAt.atZone(ZoneId.systemDefault()).toInstant())
+            )
+        )
+
+        whenever(episodeManager.calculatePlayedUptoSumInSecsWithinDays(7))
+            .thenReturn(
+                TimeUnit.HOURS.toSeconds(playedUpToSumInHours.toLong()).toDouble()
+            )
+
+        viewModel = StatsViewModel(
+            statsManager = statsManager,
+            episodeManager = episodeManager,
+            settings = settings,
+            syncManager = syncManager,
+            application = application,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            inAppReviewHelper = inAppReviewHelper,
+        )
+    }
+}

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -588,4 +588,7 @@ enum class AnalyticsEvent(val key: String) {
     WHATSNEW_SHOWN("whatsnew_shown"),
     WHATSNEW_DISMISSED("whatsnew_dismissed"),
     WHATSNEW_CONFIRM_BUTTON_TAPPED("whatsnew_confirm_button_tapped"),
+
+    /* App Store Review */
+    APP_STORE_REVIEW_REQUESTED("app_store_review_requested"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
@@ -31,7 +31,8 @@ enum class SourceView(val analyticsValue: String) {
     UNKNOWN("unknown"),
     TASKER("tasker"),
     EPISODE_SWIPE_ACTION("episode_swipe_action"),
-    MULTI_SELECT("multi_select");
+    MULTI_SELECT("multi_select"),
+    STATS("stats");
 
     fun skipTracking() = this in listOf(AUTO_PLAY, AUTO_PAUSE)
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -143,6 +143,8 @@ interface Settings {
         const val LOG_TAG_AUTO = "PocketCastsAuto"
 
         const val NOTIFICATIONS_DISABLED_MESSAGE_SHOWN = "notificationsDisabledMessageShown"
+
+        const val APP_REVIEW_REQUESTED_DATES = "in_app_review_requested_dates"
     }
 
     enum class NotificationChannel(val id: String) {
@@ -659,4 +661,7 @@ interface Settings {
     fun <T> setBookmarksSortType(sortType: T)
     fun getBookmarksSortTypeForPlayer(): BookmarksSortTypeForPlayer
     fun getBookmarksSortTypeForPodcast(): BookmarksSortTypeForPodcast
+
+    fun addReviewRequestedDate()
+    fun getReviewRequestedDates(): List<String>
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1515,4 +1515,13 @@ class SettingsImpl @Inject constructor(
                 BookmarksSortTypeForPlayer.DATE_ADDED_NEWEST_TO_OLDEST.key
             )
         ) ?: BookmarksSortTypeForPodcast.DATE_ADDED_NEWEST_TO_OLDEST
+
+    override fun addReviewRequestedDate() {
+        val dates = getReviewRequestedDates().toMutableList()
+        dates.add(Date().toString())
+        sharedPreferences.edit().putStringSet(Settings.APP_REVIEW_REQUESTED_DATES, dates.toSet()).apply()
+    }
+    override fun getReviewRequestedDates(): List<String> {
+        return sharedPreferences.getStringSet(Settings.APP_REVIEW_REQUESTED_DATES, emptySet())?.toList() ?: emptyList()
+    }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -456,6 +456,7 @@ open class PlaybackManager @Inject constructor(
             SourceView.TASKER,
             SourceView.UNKNOWN,
             SourceView.UP_NEXT,
+            SourceView.STATS,
             -> null
 
             SourceView.MEDIA_BUTTON_BROADCAST_SEARCH_ACTION,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -148,4 +148,5 @@ interface EpisodeManager {
     suspend fun countEpisodesPlayedUpto(fromEpochMs: Long, toEpochMs: Long, playedUpToInSecs: Long): Int
     suspend fun findEpisodeInteractedBefore(fromEpochMs: Long): PodcastEpisode?
     suspend fun countEpisodesInListeningHistory(fromEpochMs: Long, toEpochMs: Long): Int
+    suspend fun calculatePlayedUptoSumInSecsWithinDays(days: Int): Double
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -33,7 +33,7 @@ interface EpisodeManager {
     fun findFirstBySearchQuery(query: String): PodcastEpisode?
 
     fun findAll(rowParser: (PodcastEpisode) -> Boolean)
-    fun findEpisodesWhere(queryAfterWhere: String): List<PodcastEpisode>
+    fun findEpisodesWhere(queryAfterWhere: String, forSubscribedPodcastsOnly: Boolean = true): List<PodcastEpisode>
     fun findEpisodesByUuids(uuids: Array<String>, ordered: Boolean): List<PodcastEpisode>
     fun findEpisodesByPodcast(podcast: Podcast): Single<List<PodcastEpisode>>
     fun findEpisodesByPodcastOrdered(podcast: Podcast): List<PodcastEpisode>

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/di/ReviewModule.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/di/ReviewModule.kt
@@ -1,0 +1,21 @@
+package au.com.shiftyjelly.pocketcasts.views.di
+
+import android.content.Context
+import com.google.android.play.core.review.ReviewManager
+import com.google.android.play.core.review.ReviewManagerFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class ReviewModule {
+    @Provides
+    @Singleton
+    internal fun provideReviewManager(@ApplicationContext context: Context): ReviewManager {
+        return ReviewManagerFactory.create(context)
+    }
+}

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/review/InAppReviewHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/review/InAppReviewHelper.kt
@@ -1,0 +1,53 @@
+package au.com.shiftyjelly.pocketcasts.views.review
+
+import androidx.appcompat.app.AppCompatActivity
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
+import com.google.android.play.core.review.ReviewManager
+import kotlinx.coroutines.delay
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class InAppReviewHelper @Inject constructor(
+    private val settings: Settings,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val reviewManager: ReviewManager,
+) {
+    /* Request in-app review from the user
+       Right now, this method only allow requesting it once per user */
+    suspend fun launchReviewDialog(
+        activity: AppCompatActivity,
+        delayInMs: Long,
+        sourceView: SourceView,
+    ) {
+        if (settings.getReviewRequestedDates().isNotEmpty()) return
+        delay(delayInMs)
+        try {
+            val flow = reviewManager.requestReviewFlow()
+            flow.addOnCompleteListener { request ->
+                if (request.isSuccessful) {
+                    analyticsTracker.track(
+                        AnalyticsEvent.APP_STORE_REVIEW_REQUESTED,
+                        AnalyticsProp.addSource(sourceView)
+                    )
+                    settings.addReviewRequestedDate()
+                    reviewManager.launchReviewFlow(activity, request.result)
+                }
+            }
+        } catch (e: Exception) {
+            Timber.e("Could not launch review dialog.")
+            SentryHelper.recordException(e)
+        }
+    }
+
+    private object AnalyticsProp {
+        private const val source = "source"
+        fun addSource(sourceView: SourceView) =
+            mapOf(source to sourceView.analyticsValue)
+    }
+}


### PR DESCRIPTION
## Description

This matches iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/240 and requests in-app review if:
- The user checks Stats and stays there for more than a second after the information appears
- The user has been using the app for more than a week
- The user has a total of playedUpTo in the last 7 days bigger than 2.5 hours
- The request hasn't been made to this user before

Logic to display the review dialog only once and saving review request date matches iOS logic for consistency and future extensibility.

## Testing Instructions

Prerequisites: 

[Optional]
1. Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/12428599/in-app-review.patch) (that reduces playedUpto duration check from 2.5 hours to mins)
2. Build apk and upload to [internal app sharing](https://play.google.com/console/internal-app-sharing/)
3. Open the uploaded apk url on device and fresh install the app

[Or]

Install already uploaded apk with this patch from [this url](https://play.google.com/apps/test/RQyLMLSAri8/ahAO29uNQSXaVkDTTiNZnDfwX5J9-NsL863dS6oYkI7esWzYkxFQvZWiu7o6bOl7Ifu7vAARS7KgzJeqIcuDGG6M61
)

> Important: When using an app installed with internal app sharing, reviews can't be submitted. To emphasize this difference, the button is disabled in the UI.


### Account with more than a week
1. Open the app and login to an account that you created more than a week ago and with 
2. Go to Stats
3. Wait a few seconds
5. ✅ Make sure the request review appears
6. ✅ Make sure that `Tracked: app_store_review_requested ["source": "stats"]` is logged
7. Tap any star or dismiss it
8. Close the app and reopen it again
9. Go to Stats
10. Wait a few seconds
11. ✅ You should not see the review dialog

### Account with less than a week

Put a breakpoint on lines `112` and `117` of `StatsViewModel`

1. Signout and clear app storage
2. Create an account
3. Listen to a podcast for more than the time you specified on `StatsViewModel` line `110` 
4. Go to Profile > Refresh Now
5. Open Stats
6. ✅ Check that the breakpoint `112` is hit
7. Continue execution
8. ✅ Check that breakpoint `117` is not hit because your account is less than a week old

## Screenshots or Screencast 

<img width=320 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/77696959-eaa8-4b73-8c82-cae864438fef"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
