### PR TITLE
Log and notify users when episode duration changes unexpectedly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 *   Updates:
     *   Enable copying logs from in-app logs viewer
         ([#1298](https://github.com/Automattic/pocket-casts-android/pull/1298))
+    *   Present toast notification when duration of an in-progress episode changes
+        ([#1312](https://github.com/Automattic/pocket-casts-android/pull/1312))
 *   Bug Fixes:
     *   Fixed auto archive settings getting lost when switching languages
         ([#1234](https://github.com/Automattic/pocket-casts-android/pull/1234))
@@ -11,7 +13,6 @@
         ([#1264](https://github.com/Automattic/pocket-casts-android/pull/1264))
     *    Fixed the artwork not appearing on the onboarding page
         ([#1299](https://github.com/Automattic/pocket-casts-android/pull/1299))
-
 
 7.46
 -----

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -251,6 +251,7 @@ enum class AnalyticsEvent(val key: String) {
     PLAYBACK_STOP("playback_stop"),
     PLAYBACK_SEEK("playback_seek"),
     PLAYBACK_EPISODE_AUTOPLAYED("playback_episode_autoplayed"),
+    PLAYBACK_EPISODE_DURATION_CHANGED("playback_episode_duration_changed"),
 
     /* Privacy */
     PRIVACY_SETTINGS_SHOWN("privacy_settings_shown"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -151,6 +151,7 @@
     <string name="support">Support</string>
     <string name="go_to_top">Go to top</string>
     <string name="go_to_bottom">Go to bottom</string>
+    <string name="episode_duration_change">"This episode's duration has changed by %d seconds"</string>
 
     <string name="multiselect_actions_shown">Shortcut in toolbar</string>
     <string name="multiselect_actions_hidden">In overflow</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -95,6 +95,7 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
+import kotlin.math.abs
 import kotlin.math.min
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -1288,6 +1289,15 @@ open class PlaybackManager @Inject constructor(
         val durationMs = player?.durationMs() ?: 0
         if (durationMs <= 0) {
             return
+        }
+
+        val durationDiffSeconds = (durationMs - episode.durationMs) / 1000
+        if (abs(durationDiffSeconds) > 30) {
+            LogBuffer.e(LogBuffer.TAG_PLAYBACK, "The total episode duration has changed significantly ($durationDiffSeconds seconds)")
+            launch(Dispatchers.Main) {
+                val message = application.getString(LR.string.episode_duration_change, durationDiffSeconds)
+                Toast.makeText(application, message, Toast.LENGTH_LONG).show()
+            }
         }
 
         withContext(Dispatchers.Main) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1292,12 +1292,27 @@ open class PlaybackManager @Inject constructor(
         }
 
         val durationDiffSeconds = (durationMs - episode.durationMs) / 1000
-        if (abs(durationDiffSeconds) > 30) {
-            LogBuffer.e(LogBuffer.TAG_PLAYBACK, "The total episode duration has changed significantly ($durationDiffSeconds seconds)")
-            launch(Dispatchers.Main) {
-                val message = application.getString(LR.string.episode_duration_change, durationDiffSeconds)
-                Toast.makeText(application, message, Toast.LENGTH_LONG).show()
+        if (abs(durationDiffSeconds) > 0) {
+            val notifyUser = abs(durationDiffSeconds) > 30
+            if (notifyUser) {
+                LogBuffer.e(LogBuffer.TAG_PLAYBACK, "The total episode duration has changed significantly ($durationDiffSeconds seconds)")
+                launch(Dispatchers.Main) {
+                    val message = application.getString(LR.string.episode_duration_change, durationDiffSeconds)
+                    Toast.makeText(application, message, Toast.LENGTH_LONG).show()
+                }
             }
+            analyticsTracker.track(
+                AnalyticsEvent.PLAYBACK_EPISODE_DURATION_CHANGED,
+                mapOf(
+                    "duration_change" to durationDiffSeconds,
+                    "duration" to durationMs / 1000,
+                    "notified_user" to notifyUser,
+                    "is_user_file" to (episode is UserEpisode),
+                    "is_downloaded" to episode.isDownloaded,
+                    "episode_uuid" to episode.uuid,
+                    "podcast_uuid" to episode.podcastOrSubstituteUuid,
+                )
+            )
         }
 
         withContext(Dispatchers.Main) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1310,13 +1310,7 @@ open class PlaybackManager @Inject constructor(
         }
 
         val playerDurationSecs = durationMs.toDouble() / 1000.0
-
-        val currentDurationMs = episode.durationMs
-        if (currentDurationMs < 10000) {
-            episodeManager.updateDuration(episode, playerDurationSecs, true)
-        } else {
-            episodeManager.updateDuration(episode, playerDurationSecs, true)
-        }
+        episodeManager.updateDuration(episode, playerDurationSecs, true)
     }
 
     suspend fun onSeekComplete(positionMs: Int) {


### PR DESCRIPTION
## Description
We have many complaints about playback skipping to different positions in an episode unexpectedly (https://github.com/Automattic/pocket-casts-android/issues/157). I think that at least the majority of the times this is happening is because the podcast provider is changing the dynamic ads in the episode. If those ads are of a different length, then our playback position value will end up representing a different part of the episode.

I do not see any straightforward ways to address this, so this PR is attempting to mitigate the issue a bit by checking if the duration of a podcast episode has changed by more than 30 seconds and
1. Presenting a toast message to the user advising them that the duration of the podcast has changed. I figured that this at least gives the listener a clue that something has changed and, if they notice a jump in the playback position, the reason why.
2. Adding logs so that support can see this if the user reaches out to support 
3. Adding a tracks event so that we can get more specific data about when/how-often this issue is occurring. Let me know if you can think of any other event properties it would be good to include.

Adding the logs and tracks event feel like pretty clear wins to me, but I'm slightly less confident about presenting a notification to the user since I'm not sure how many users will see it and I wouldn't want a bug to cause it to get presented too often (the tracks will let us check how often its getting shown at least). 

I toyed with only showing the toast if the duration change was more than a minute instead of the 30 seconds that I arrived at in order to show it less often.  Let me know if you think requiring a minute (or longer) duration would be better than 30 seconds.

## Testing Instructions

In addition to the following test, it would be good to just generally smoke-test different playback scenarios to make sure the toast isn't getting shown when it shouldn't be shown.

1. Create a podcast where you can insert/remove dynamic ads.
2. Load an episode of the podcast you created and start playing it.
4. Make sure the episode is streaming and is not being downloaded.
5. Skip to somewhere at least 5 minutes into the podcast.
6. Pause the podcast
7. Swipe the Pocket Casts app away
8. Update the dynamic ads in the episode of the podcast that you were listening to so that the duration of episode changes by at least 30 seconds.
9. Clear the cache of Pocket Casts via the Android App settings options
10. Reopen the Pocket Casts app
11. Resume playing the podcast where you left off
12. Note that
    1. the duration of the podcast has changed,
    2. the audio jumps to a different place,
    3. there is a toast message presented notifying you that the duration of the episode has changed, and
    4. There is a `playback_episode_duration_changed` tracks event sent off with the appropriate values set for "duration_change", "duration", "notified_user", "is_user_file", "is_downloaded", "episode_uuid", and "podcast_uuid"

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/4656348/354b334e-c176-4d52-87ee-20d61f0928c0

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews