### PR TITLE
Avoid multiselect ANRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 7.46
 -----
 
+7.45.1
+-----
+*   Bug Fixes:
+    *   Fixed issue where that could cause app freeze when using multiselect
+        ([#1315](https://github.com/Automattic/pocket-casts-android/pull/1315))
 
 7.45
 -----

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -463,7 +463,7 @@ class FilterEpisodeListFragment : BaseFragment() {
             override fun multiSelectSelectNone() {
                 val episodes = viewModel.episodesList.value
                 if (episodes != null) {
-                    episodes.forEach { multiSelectHelper.deselect(it) }
+                    multiSelectHelper.deselectAllInList(episodes)
                     adapter.notifyDataSetChanged()
                 }
             }
@@ -488,7 +488,7 @@ class FilterEpisodeListFragment : BaseFragment() {
                     val startIndex = episodes.indexOf(multiSelectable)
                     if (startIndex > -1) {
                         val episodesBelow = episodes.subList(startIndex, episodes.size)
-                        episodesBelow.forEach { multiSelectHelper.deselect(it) }
+                        multiSelectHelper.deselectAllInList(episodesBelow)
                         adapter.notifyDataSetChanged()
                     }
                 }
@@ -501,7 +501,7 @@ class FilterEpisodeListFragment : BaseFragment() {
                     val startIndex = episodes.indexOf(multiSelectable)
                     if (startIndex > -1) {
                         val episodesAbove = episodes.subList(0, startIndex + 1)
-                        episodesAbove.forEach { multiSelectHelper.deselect(it) }
+                        multiSelectHelper.deselectAllInList(episodesAbove)
                         adapter.notifyDataSetChanged()
                     }
                 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -245,20 +245,21 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
         multiSelectHelper.listener = object : MultiSelectHelper.Listener<BaseEpisode> {
             override fun multiSelectSelectAll() {
                 trackUpNextEvent(AnalyticsEvent.UP_NEXT_SELECT_ALL_TAPPED, mapOf(SELECT_ALL_KEY to true))
-                upNextEpisodes.forEach { multiSelectHelper.select(it) }
+                multiSelectHelper.selectAllInList(upNextEpisodes)
                 adapter.notifyDataSetChanged()
             }
 
             override fun multiSelectSelectNone() {
                 trackUpNextEvent(AnalyticsEvent.UP_NEXT_SELECT_ALL_TAPPED, mapOf(SELECT_ALL_KEY to false))
-                upNextEpisodes.forEach { multiSelectHelper.deselect(it) }
+                multiSelectHelper.deselectAllInList(upNextEpisodes)
                 adapter.notifyDataSetChanged()
             }
 
             override fun multiSelectSelectAllUp(multiSelectable: BaseEpisode) {
                 val startIndex = upNextEpisodes.indexOf(multiSelectable)
                 if (startIndex > -1) {
-                    upNextEpisodes.subList(0, startIndex + 1).forEach { multiSelectHelper.select(it) }
+                    val episodesAbove = upNextEpisodes.subList(0, startIndex + 1)
+                    multiSelectHelper.selectAllInList(episodesAbove)
                 }
 
                 adapter.notifyDataSetChanged()
@@ -267,7 +268,8 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
             override fun multiSelectSelectAllDown(multiSelectable: BaseEpisode) {
                 val startIndex = upNextEpisodes.indexOf(multiSelectable)
                 if (startIndex > -1) {
-                    upNextEpisodes.subList(startIndex, upNextEpisodes.size).forEach { multiSelectHelper.select(it) }
+                    val episodesBelow = upNextEpisodes.subList(startIndex, upNextEpisodes.size)
+                    multiSelectHelper.selectAllInList(episodesBelow)
                 }
 
                 adapter.notifyDataSetChanged()
@@ -276,7 +278,8 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
             override fun multiDeselectAllBelow(multiSelectable: BaseEpisode) {
                 val startIndex = upNextEpisodes.indexOf(multiSelectable)
                 if (startIndex > -1) {
-                    upNextEpisodes.subList(startIndex, upNextEpisodes.size).forEach { multiSelectHelper.deselect(it) }
+                    val episodesBelow = upNextEpisodes.subList(startIndex, upNextEpisodes.size)
+                    multiSelectHelper.deselectAllInList(episodesBelow)
                 }
                 adapter.notifyDataSetChanged()
             }
@@ -284,7 +287,8 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
             override fun multiDeselectAllAbove(multiSelectable: BaseEpisode) {
                 val startIndex = upNextEpisodes.indexOf(multiSelectable)
                 if (startIndex > -1) {
-                    upNextEpisodes.subList(0, startIndex + 1).forEach { multiSelectHelper.deselect(it) }
+                    val episdesAbove = upNextEpisodes.subList(0, startIndex + 1)
+                    multiSelectHelper.deselectAllInList(episdesAbove)
                 }
                 adapter.notifyDataSetChanged()
             }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -110,7 +110,7 @@ class BookmarksViewModel
 
             override fun multiSelectSelectNone() {
                 (_uiState.value as? UiState.Loaded)?.bookmarks?.let { bookmarks ->
-                    bookmarks.forEach { multiSelectHelper.deselect(it) }
+                    multiSelectHelper.deselectAllInList(bookmarks)
                 }
             }
 
@@ -128,8 +128,8 @@ class BookmarksViewModel
                 (_uiState.value as? UiState.Loaded)?.bookmarks?.let { bookmarks ->
                     val startIndex = bookmarks.indexOf(multiSelectable)
                     if (startIndex > -1) {
-                        bookmarks.subList(startIndex, bookmarks.size)
-                            .forEach { multiSelectHelper.deselect(it) }
+                        val bookmarksBelow = bookmarks.subList(startIndex, bookmarks.size)
+                        multiSelectHelper.deselectAllInList(bookmarksBelow)
                     }
                 }
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -252,7 +252,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             override fun multiSelectSelectNone() {
                 val episodes = viewModel.episodeList.value
                 if (episodes != null) {
-                    episodes.forEach { multiSelectHelper.deselect(it) }
+                    multiSelectHelper.deselectAllInList(episodes)
                     adapter.notifyDataSetChanged()
                     trackSelectAll(false)
                 }
@@ -289,7 +289,8 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
                 if (episodes != null) {
                     val startIndex = episodes.indexOf(multiSelectable)
                     if (startIndex > -1) {
-                        episodes.subList(startIndex, episodes.size).forEach { multiSelectHelper.deselect(it) }
+                        val episodesBelow = episodes.subList(startIndex, episodes.size)
+                        multiSelectHelper.deselectAllInList(episodesBelow)
                         adapter.notifyDataSetChanged()
                     }
                 }
@@ -300,7 +301,8 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
                 if (episodes != null) {
                     val startIndex = episodes.indexOf(multiSelectable)
                     if (startIndex > -1) {
-                        episodes.subList(0, startIndex + 1).forEach { multiSelectHelper.deselect(it) }
+                        val episodesAbove = episodes.subList(0, startIndex + 1)
+                        multiSelectHelper.deselectAllInList(episodesAbove)
                         adapter.notifyDataSetChanged()
                     }
                 }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -253,7 +253,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             override fun multiSelectSelectNone() {
                 val episodes = viewModel.cloudFilesList.value
                 if (episodes != null) {
-                    episodes.forEach { multiSelectHelper.deselect(it) }
+                    multiSelectHelper.deselectAllInList(episodes)
                     adapter.notifyDataSetChanged()
                     analyticsTracker.track(AnalyticsEvent.UPLOADED_FILES_SELECT_ALL_TAPPED, mapOf(SELECT_ALL_KEY to false))
                 }


### PR DESCRIPTION
## Description
With the 7.45 release we've seen a significant increase in ANRs: https://github.com/Automattic/pocket-casts-android/issues/1314. This PR avoids the ANRs by addressing part of the underlying issue. 

Note that this PR is targeting a new `7.45.1` hotfix branch because I think this should be a hotfix since it is causing thousands of ANRs a day. For that reason, I am keeping this PR small and lean (basically the simplest changes that address the ANRs), and I will open a separate PR that builds on this for a betafix release (https://github.com/Automattic/pocket-casts-android/pull/1316).

This fix is basically just to make sure that we avoid iterating through the multiselect items when we select or deselect all of the multiselect items.

## Testing Instructions
1. Make sure you have a bunch of episodes in your Up Next queue
2. Go to a filter with a lot of episodes
3. Enter multiselection
4. Select all
5. Tap the miniplayer and then swipe up to get your Up Next queue (don't close the filters screen)
6. Enter multiselect mode
7. Select all
8. Select None
9. Observe the app locks up for a while

| Before | After |
| --- | --- |
| This video just shows a freeze, not a full ANR, but I've seen these steps result in ANRs on my device multiple times
<video src="https://github.com/Automattic/pocket-casts-android/assets/4656348/4381d489-6e53-47d1-86ff-9b2c692a2acc"/> | <video src="https://github.com/Automattic/pocket-casts-android/assets/4656348/6e1d1ec4-ef85-4017-82fc-76472469fd69"/> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews