### PR TITLE
Bookmarks - Update Add Bookmark Headphone Control

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -198,7 +198,8 @@ private fun Content(
                 OnboardingUpgradeSource.PROFILE,
                 OnboardingUpgradeSource.ACCOUNT_DETAILS,
                 OnboardingUpgradeSource.SETTINGS,
-                OnboardingUpgradeSource.BOOKMARKS -> false
+                OnboardingUpgradeSource.BOOKMARKS,
+                OnboardingUpgradeSource.HEADPHONE_CONTROLS_SETTINGS -> false
 
                 OnboardingUpgradeSource.RECOMMENDATIONS -> true
             }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsFragment.kt
@@ -135,13 +135,13 @@ class HeadphoneControlsSettingsFragment : BaseFragment() {
                     color = MaterialTheme.theme.colors.primaryText02,
                     modifier = Modifier.padding(16.dp)
                 )
-                NextActionRow(
-                    saved = nextAction,
-                    onSave = onNextActionSave
-                )
                 PreviousActionRow(
                     saved = previousAction,
                     onSave = onPreviousActionSave
+                )
+                NextActionRow(
+                    saved = nextAction,
+                    onSave = onNextActionSave
                 )
                 if (previousAction == HeadphoneAction.ADD_BOOKMARK || nextAction == HeadphoneAction.ADD_BOOKMARK) {
                     ConfirmationSoundRow(

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
@@ -1,16 +1,62 @@
 package au.com.shiftyjelly.pocketcasts.settings
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.reactive.asFlow
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class HeadphoneControlsSettingsPageViewModel @Inject constructor(
-    private val analyticsTracker: AnalyticsTrackerWrapper
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val userManager: UserManager,
+    private val settings: Settings,
 ) : ViewModel() {
+
+    private val _state: MutableStateFlow<UiState> = MutableStateFlow(UiState())
+    val state: StateFlow<UiState> = _state
+
+    init {
+        viewModelScope.launch {
+            userManager.getSignInState().asFlow()
+                .stateIn(viewModelScope)
+                .collect {
+                    val isAddBookmarkEnabled =
+                        FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) && it.isSignedInAsPatron
+
+                    _state.update { state -> state.copy(isAddBookmarkEnabled = isAddBookmarkEnabled) }
+
+                    _state.value.startUpsellFromSource?.let { upsellFrom ->
+                        onUpsellComplete(upsellFrom)
+                    }
+                }
+        }
+    }
+
+    private fun onUpsellComplete(
+        upsellSourceAction: UpsellSourceAction,
+    ) {
+        if (state.value.isAddBookmarkEnabled) {
+            when (upsellSourceAction) {
+                UpsellSourceAction.PREVIOUS -> onPreviousActionSave(HeadphoneAction.ADD_BOOKMARK)
+                UpsellSourceAction.NEXT -> onNextActionSave(HeadphoneAction.ADD_BOOKMARK)
+            }
+            resetUpsellSourceAction()
+        }
+    }
 
     fun onShown() {
         analyticsTracker.track(AnalyticsEvent.SETTINGS_HEADPHONE_CONTROLS_SHOWN)
@@ -23,15 +69,56 @@ class HeadphoneControlsSettingsPageViewModel @Inject constructor(
         )
     }
 
-    fun onNextActionChanged(action: HeadphoneAction) {
-        trackHeadphoneAction(action, AnalyticsEvent.SETTINGS_HEADPHONE_CONTROLS_NEXT_CHANGED)
+    fun onNextActionSave(action: HeadphoneAction) {
+        if (action.canSave()) {
+            settings.headphoneControlsNextAction.set(action)
+            trackHeadphoneAction(action, AnalyticsEvent.SETTINGS_HEADPHONE_CONTROLS_NEXT_CHANGED)
+        } else {
+            _state.update { it.copy(startUpsellFromSource = UpsellSourceAction.NEXT) }
+        }
     }
 
-    fun onPreviousActionChanged(action: HeadphoneAction) {
-        trackHeadphoneAction(action, AnalyticsEvent.SETTINGS_HEADPHONE_CONTROLS_PREVIOUS_CHANGED)
+    fun onPreviousActionSave(action: HeadphoneAction) {
+        if (action.canSave()) {
+            settings.headphoneControlsPreviousAction.set(action)
+            trackHeadphoneAction(action, AnalyticsEvent.SETTINGS_HEADPHONE_CONTROLS_PREVIOUS_CHANGED)
+        } else {
+            _state.update { it.copy(startUpsellFromSource = UpsellSourceAction.PREVIOUS) }
+        }
+    }
+
+    fun onOptionsDialogShown() {
+        /* Upsell source action is reset here so that upsell can be re-triggered
+           from the options dialog if the previous upsell flow was not complete. */
+        resetUpsellSourceAction()
+    }
+
+    private fun resetUpsellSourceAction() {
+        _state.update { it.copy(startUpsellFromSource = null) }
     }
 
     private fun trackHeadphoneAction(action: HeadphoneAction, event: AnalyticsEvent) {
         analyticsTracker.track(event, mapOf("value" to action.analyticsValue))
+    }
+
+    private fun HeadphoneAction.canSave() = when (this) {
+        HeadphoneAction.SKIP_BACK,
+        HeadphoneAction.SKIP_FORWARD, -> true
+        HeadphoneAction.ADD_BOOKMARK -> state.value.isAddBookmarkEnabled
+        HeadphoneAction.NEXT_CHAPTER,
+        HeadphoneAction.PREVIOUS_CHAPTER -> {
+            Timber.e("Headphone action not supported")
+            false
+        }
+    }
+
+    data class UiState(
+        val isAddBookmarkEnabled: Boolean = false,
+        val startUpsellFromSource: UpsellSourceAction? = null,
+    )
+
+    enum class UpsellSourceAction {
+        PREVIOUS,
+        NEXT,
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
@@ -11,4 +11,5 @@ enum class OnboardingUpgradeSource(val analyticsValue: String) {
     RECOMMENDATIONS("recommendations"),
     SETTINGS("settings"),
     BOOKMARKS("bookmarks"),
+    HEADPHONE_CONTROLS_SETTINGS("headphone_controls_settings"),
 }


### PR DESCRIPTION
## Description
This displays the Add Bookmark option if the user does not have bookmarks unlocked

Part of https://github.com/Automattic/pocket-casts-android/issues/1307

## Testing Instructions

Prerequisites
- Release build
- License test account
- Patron and Bookmarks features enabled

1. Install release build without being logged in
2. Go to `Profile` -> `Settings` -> `Headphone controls`
3. Notice that `Previous` Action is displayed above `Next` action.
4. Tap on `Previous action` or `Next action`
5. ✅ Notice that `Add bookmark` is shown in options
6. Tap on `Add bookmark`
7. ✅ Notice that Upsell flow is shown
8. Dismiss Upsell flow 
9. ✅ Notice that previous value is retained for the action started in step 4 
10. Tap on `Add bookmark` again
11. Complete Upsell flow
12. ✅ Notice that `Add bookmark` option is selected for action started in step 4 


## Screenshots or Screencast 

Before Unlock | After Unlock
----|---
<img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/6347b031-fa1c-4f9d-b12d-5186711cf72d"/> | <img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/de4c5f23-61d9-4b48-9b69-0f41de21d590"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
