### PR TITLE
Bookmarks - Update Add bookmark visibility

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
@@ -110,7 +110,7 @@ class ShelfBottomSheet : BaseDialogFragment() {
                 playerViewModel.archiveCurrentlyPlaying(resources)?.show(parentFragmentManager, "archive")
             }
             is ShelfItem.Bookmark -> {
-                (parentFragment as? PlayerHeaderFragment)?.onAddBookmarkClick()
+                (parentFragment as? PlayerHeaderFragment)?.onAddBookmarkClick(item)
             }
             ShelfItem.Download -> {
                 Timber.e("Unexpected click on ShelfItem.Download")

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfItem.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfItem.kt
@@ -23,7 +23,7 @@ object ShelfItems {
         add(ShelfItem.Cast)
         add(ShelfItem.Played)
         if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-            add(ShelfItem.Bookmark)
+            add(ShelfItem.Bookmark())
         }
         add(ShelfItem.Archive)
     }
@@ -40,6 +40,7 @@ sealed class ShelfItem(
     var iconRes: (BaseEpisode?) -> Int,
     val shownWhen: Shown,
     val tier: SubscriptionTier = SubscriptionTier.NONE,
+    open val isUnlocked: Boolean = true,
     val analyticsValue: String,
     @StringRes val subtitle: Int? = null
 ) {
@@ -107,7 +108,9 @@ sealed class ShelfItem(
         analyticsValue = "mark_as_played"
     )
 
-    object Bookmark : ShelfItem(
+    data class Bookmark(
+        override val isUnlocked: Boolean = false
+    ) : ShelfItem(
         id = "bookmark",
         title = { LR.string.add_bookmark },
         iconRes = { IR.drawable.ic_bookmark },

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -19,7 +19,6 @@ import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.models.to.Chapters
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
-import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.player.view.ShelfItem
 import au.com.shiftyjelly.pocketcasts.player.view.ShelfItems
@@ -209,12 +208,12 @@ class PlayerViewModel @Inject constructor(
     }
         .toFlowable(BackpressureStrategy.LATEST)
         .combineLatest(userManager.getSignInState()).map { (shelfItems, signInState) ->
-            shelfItems.filter { item ->
-                when (item.tier) {
-                    SubscriptionTier.NONE -> true
-                    SubscriptionTier.PLUS -> signInState.isSignedInAsPlusOrPatron
-                    SubscriptionTier.PATRON -> signInState.isSignedInAsPatron
+            shelfItems.map { item ->
+                var updatedItem = item
+                if (item is ShelfItem.Bookmark) {
+                    updatedItem = item.copy(isUnlocked = signInState.isSignedInAsPatron)
                 }
+                updatedItem
             }
         }
 


### PR DESCRIPTION
## Description

This displays the Add Bookmark option even if bookmarks are not unlocked, tapping it triggers the upsell.

Part of https://github.com/Automattic/pocket-casts-android/issues/1307

## Testing Instructions
1. Open the app as a free user
2. Play an episode
3. Open the full-screen player 
4. Tap on more options from the bottom shelf 
5. ✅  Notice that `Add bookmark` is present on the shelf bottom sheet
6. Tap on `Add bookmark` from the shelf bottom sheet
7. ✅ Notice that Upsell flow is triggered
8. Dismiss the flow
9. Bring the `Add bookmark` to the visible shelf items on the Now Playing screen
10. Tap on `Add bookmark` from the  visible shelf items on the Now Playing screen
11. ✅ Notice that Upsell flow is triggered

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
