### PR TITLE
Temporary fix for notification permission checker

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1726,7 +1726,9 @@ open class PlaybackManager @Inject constructor(
                     manager.notify(notificationTag, NotificationBroadcastReceiver.NOTIFICATION_ID, notification)
                 }
             } ?: run {
-                LogBuffer.e(LogBuffer.TAG_PLAYBACK, "notificationPermissionChecker was null (this should never happen)")
+                val message = "notificationPermissionChecker was null (this should never happen)"
+                LogBuffer.e(LogBuffer.TAG_PLAYBACK, message)
+                Sentry.addBreadcrumb(message)
                 manager.notify(notificationTag, NotificationBroadcastReceiver.NOTIFICATION_ID, notification)
             }
         } catch (e: Exception) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1720,9 +1720,15 @@ open class PlaybackManager @Inject constructor(
         }
 
         try {
-            notificationPermissionChecker?.checkNotificationPermission {
+            notificationPermissionChecker?.let {
+                Timber.i("Checking notification permission")
+                it.checkNotificationPermission {
+                    manager.notify(notificationTag, NotificationBroadcastReceiver.NOTIFICATION_ID, notification)
+                }
+            } ?: run {
+                LogBuffer.e(LogBuffer.TAG_PLAYBACK, "notificationPermissionChecker was null (this should never happen)")
                 manager.notify(notificationTag, NotificationBroadcastReceiver.NOTIFICATION_ID, notification)
-            } ?: manager.notify(notificationTag, NotificationBroadcastReceiver.NOTIFICATION_ID, notification)
+            }
         } catch (e: Exception) {
             val message = "Could not post notification ${e.message}"
             LogBuffer.e(LogBuffer.TAG_PLAYBACK, message)


### PR DESCRIPTION
## Description

This includes a temporary fix for https://a8c.sentry.io/share/issue/a00791f201394715be1cdffda7814fda/ 

> **Warning**
> Targets release/7.46

## Testing Instructions

I have not been able to reproduce the issue. I have converted `notificationPermissionChecker` to be nullable, and attempted `notify(...)` even when `notificationPermissionChecker`  is null to bring back the original implementation. I have also added logs to `Sentry` and `LogBuffer` if it still fails.