### PR TITLE
Use transaction when archiving multiple episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
          ([#1280](https://github.com/Automattic/pocket-casts-android/pull/1280))
     *    Improved upgrade flow when signing in with Google account
          ([#1275](https://github.com/Automattic/pocket-casts-android/pull/1275))
+    *    Improved performance when archiving multiple episodes
+         ([1327](https://github.com/Automattic/pocket-casts-android/pull/1327))
 
 7.45.1
 -----

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -149,7 +149,7 @@ project.ext {
             browserHelper: 'com.google.androidbrowserhelper:androidbrowserhelper:2.3.0',
             flexbox: 'com.google.android.flexbox:flexbox:3.0.0',
             androidTestCore: "androidx.test:core:$versionTest",
-            room: "androidx.room:room-runtime:$versionRoom",
+            room: "androidx.room:room-ktx:$versionRoom",
             roomRx: "androidx.room:room-rxjava2:$versionRoom",
             roomKtx: "androidx.room:room-ktx:$versionRoom",
             roomCompile: "androidx.room:room-compiler:$versionRoom",

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -17,11 +17,11 @@ import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.MessageVie
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.NoBookmarksViewColors
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
+import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
-import au.com.shiftyjelly.pocketcasts.ui.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModel.kt
@@ -6,9 +6,9 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
+import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
-import au.com.shiftyjelly.pocketcasts.ui.di.IoDispatcher
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/DispatcherModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/DispatcherModule.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.ui.di
+package au.com.shiftyjelly.pocketcasts.repositories.di
 
 import dagger.Module
 import dagger.Provides

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -28,6 +28,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.models.type.UserEpisodeServerStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.UpdateEpisodeDetailsTask
@@ -46,6 +47,7 @@ import io.reactivex.Flowable
 import io.reactivex.Maybe
 import io.reactivex.Single
 import io.reactivex.rxkotlin.zipWith
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
@@ -73,6 +75,7 @@ class EpisodeManagerImpl @Inject constructor(
     private val appDatabase: AppDatabase,
     private val podcastCacheServerManager: PodcastCacheServerManager,
     private val userEpisodeManager: UserEpisodeManager,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : EpisodeManager, CoroutineScope {
 
     override val coroutineContext: CoroutineContext
@@ -959,7 +962,7 @@ class EpisodeManagerImpl @Inject constructor(
         episodes: List<PodcastEpisode>,
         playbackManager: PlaybackManager?
     ) {
-        launch(Dispatchers.IO) {
+        launch(ioDispatcher) {
             appDatabase.withTransaction {
                 episodes.filter { !it.isArchived }.chunked(500).forEach { chunked ->
                     episodeDao.archiveAllInList(chunked.map { it.uuid }, System.currentTimeMillis())


### PR DESCRIPTION
## Description
This avoids ANRs when archiving multiple episodes by wrapping all the db calls into a single transaction.

> **Note**
> Note that this change is targeting the beta branch. Let me know if you think that's not the right call this late in the beta period.

There are a lot of other places where we should consider creating transactions like this, but this is the most significant performance issue I'm seeing so far (by a wide margin), so I kept this PR small (and hopefully safe).

## Testing Instructions
1. Fresh install of the app
2. Open the Tim Ferriss Show podcast page
3. Tap the three dots
4. Tap Archive All and confirm
5. Observe that the UI locks for <1 second (without this change it would lock the UI on my device for ~30 seconds)

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews