### PR TITLE
Bookmarks - Update upsell view based on tier

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
@@ -102,7 +102,6 @@ class BookmarksFragment : BaseFragment() {
                     if (episodeUuid != null) {
                         BookmarksPage(
                             episodeUuid = episodeUuid,
-                            activeTheme = overrideTheme,
                             backgroundColor = requireNotNull(backgroundColor(listData)),
                             textColor = requireNotNull(textColor(listData)),
                             sourceView = sourceView,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
@@ -44,7 +44,6 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 fun BookmarksPage(
     episodeUuid: String,
-    activeTheme: Theme.ThemeType,
     backgroundColor: Color,
     textColor: Color,
     sourceView: SourceView,
@@ -62,7 +61,6 @@ fun BookmarksPage(
     Content(
         state = state,
         sourceView = sourceView,
-        activeTheme = activeTheme,
         backgroundColor = backgroundColor,
         textColor = textColor,
         onRowLongPressed = onRowLongPressed,
@@ -101,7 +99,6 @@ fun BookmarksPage(
 private fun Content(
     state: UiState,
     sourceView: SourceView,
-    activeTheme: Theme.ThemeType,
     backgroundColor: Color,
     textColor: Color,
     onRowLongPressed: (Bookmark) -> Unit,
@@ -135,7 +132,6 @@ private fun Content(
             )
             is UiState.Upsell -> UpsellView(
                 style = state.colors,
-                activeTheme = activeTheme,
                 onClick = onUpgradeClicked,
                 sourceView = sourceView,
                 modifier = Modifier
@@ -224,7 +220,6 @@ private fun BookmarksPreview(
                 sourceView = SourceView.PLAYER
             ),
             sourceView = SourceView.PLAYER,
-            activeTheme = theme,
             backgroundColor = Color.Black,
             textColor = Color.Black,
             onPlayClick = {},

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/MessageView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/MessageView.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.player.view.bookmark.components
 
-import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -14,18 +13,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun MessageView(
     titleView: @Composable () -> Unit,
-    @StringRes buttonTitleRes: Int,
+    message: String,
+    buttonTitle: String,
     buttonAction: () -> Unit,
     style: MessageViewColors,
     modifier: Modifier = Modifier
@@ -49,13 +47,13 @@ fun MessageView(
             ) {
                 titleView()
                 TextP40(
-                    text = stringResource(LR.string.bookmarks_create_instructions),
+                    text = message,
                     color = style.textColor(),
                     textAlign = TextAlign.Center,
                     modifier = Modifier.padding(top = 12.dp)
                 )
                 TextButton(
-                    buttonTitleRes = buttonTitleRes,
+                    buttonTitle = buttonTitle,
                     buttonAction = buttonAction,
                     modifier = Modifier.padding(top = 4.dp),
                     style = style
@@ -67,7 +65,7 @@ fun MessageView(
 
 @Composable
 private fun TextButton(
-    @StringRes buttonTitleRes: Int,
+    buttonTitle: String,
     buttonAction: () -> Unit = {},
     modifier: Modifier,
     style: MessageViewColors
@@ -79,7 +77,7 @@ private fun TextButton(
             .clickable { buttonAction() }
     ) {
         TextH40(
-            text = stringResource(buttonTitleRes),
+            text = buttonTitle,
             color = style.buttonTextColor(),
             textAlign = TextAlign.Center,
             modifier = Modifier.padding(8.dp)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/NoBookmarksView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/NoBookmarksView.kt
@@ -49,7 +49,8 @@ private fun Content(
                 color = style.textColor(),
             )
         },
-        buttonTitleRes = LR.string.bookmarks_headphone_settings,
+        message = stringResource(LR.string.bookmarks_create_instructions),
+        buttonTitle = stringResource(LR.string.bookmarks_headphone_settings),
         buttonAction = onClick,
         style = style.toMessageViewColors(),
         modifier = modifier,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/PlusUpsellViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/PlusUpsellViewModel.kt
@@ -1,21 +1,87 @@
 package au.com.shiftyjelly.pocketcasts.player.view.bookmark.components
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.reactive.asFlow
 import javax.inject.Inject
 
 @HiltViewModel
 class PlusUpsellViewModel @Inject constructor(
-    private val analyticsTracker: AnalyticsTrackerWrapper
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val subscriptionManager: SubscriptionManager,
 ) : ViewModel() {
+
+    private val _state: MutableStateFlow<UiState> = MutableStateFlow(UiState.Loading)
+    val state: StateFlow<UiState> = _state
+
+    init {
+        viewModelScope.launch {
+            subscriptionManager
+                .observeProductDetails()
+                .asFlow()
+                .stateIn(viewModelScope)
+                .collect { productDetails ->
+                    val subscriptions = when (productDetails) {
+                        is ProductDetailsState.Error -> null
+                        is ProductDetailsState.Loaded -> productDetails.productDetails.mapNotNull { productDetailsState ->
+                            Subscription.fromProductDetails(
+                                productDetails = productDetailsState,
+                                isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(
+                                    SubscriptionMapper.mapProductIdToTier(productDetailsState.productId)
+                                )
+                            )
+                        }
+                    } ?: emptyList()
+                    updateState(subscriptions)
+                }
+        }
+    }
+
+    private fun updateState(
+        subscriptions: List<Subscription>,
+    ) {
+        val subscriptionTier = SubscriptionTier.PATRON
+        val updatedSubscriptions = subscriptions.filter { it.tier == subscriptionTier }
+
+        val selectedSubscription = subscriptionManager.getDefaultSubscription(
+            tier = subscriptionTier,
+            subscriptions = updatedSubscriptions,
+        )
+
+        _state.update {
+            UiState.Loaded(
+                tier = subscriptionTier,
+                hasFreeTrial = selectedSubscription?.trialPricingPhase != null,
+            )
+        }
+    }
 
     fun onClick(sourceView: SourceView) {
         analyticsTracker.track(
             AnalyticsEvent.BOOKMARKS_UPGRADE_BUTTON_TAPPED,
             mapOf("source" to sourceView.analyticsValue)
         )
+    }
+
+    sealed class UiState {
+        object Loading : UiState()
+        data class Loaded(
+            val tier: SubscriptionTier,
+            val hasFreeTrial: Boolean,
+        ) : UiState()
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellView.kt
@@ -17,8 +17,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.images.DisplayMode
 import au.com.shiftyjelly.pocketcasts.compose.images.HorizontalLogoText
+import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeDisplayMode
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
@@ -70,7 +70,7 @@ private fun UpsellViewContent(
                 Spacer(modifier = Modifier.width(8.dp))
                 SubscriptionBadgeForTier(
                     tier = state.tier,
-                    displayMode = DisplayMode.Colored
+                    displayMode = SubscriptionBadgeDisplayMode.Colored
                 )
             }
         },

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellView.kt
@@ -1,16 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.player.view.bookmark.components
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
@@ -20,42 +17,48 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
+import au.com.shiftyjelly.pocketcasts.compose.images.DisplayMode
+import au.com.shiftyjelly.pocketcasts.compose.images.HorizontalLogoText
+import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.UpsellViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
-import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @Composable
 fun UpsellView(
     style: MessageViewColors,
-    activeTheme: Theme.ThemeType,
     onClick: () -> Unit,
     sourceView: SourceView,
     modifier: Modifier = Modifier,
 ) {
     val viewModel = hiltViewModel<UpsellViewModel>()
-    Content(
-        style = style,
-        activeTheme = activeTheme,
-        onClick = {
-            viewModel.onClick(sourceView)
-            onClick()
-        },
-        modifier = modifier,
-    )
+    val state by viewModel.state.collectAsState()
+    when (state) {
+        UiState.Loading -> Unit
+        is UiState.Loaded -> {
+            UpsellViewContent(
+                style = style,
+                state = state as UiState.Loaded,
+                onClick = {
+                    viewModel.onClick(sourceView)
+                    onClick()
+                },
+                modifier = modifier,
+            )
+        }
+    }
 }
 
 @Composable
-private fun Content(
+private fun UpsellViewContent(
     style: MessageViewColors,
-    activeTheme: Theme.ThemeType,
+    state: UiState.Loaded,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val logoColor = if (activeTheme.darkTheme) Color.White else Color.Black
-    val description = stringResource(LR.string.pocket_casts_patron)
+    val description = stringResource(state.tier.getContentDescription())
     MessageView(
         titleView = {
             Row(
@@ -63,25 +66,42 @@ private fun Content(
                 modifier = Modifier
                     .clearAndSetSemantics { contentDescription = description }
             ) {
-                Image(
-                    painter = painterResource(IR.drawable.logo_pocket_casts),
-                    contentDescription = null,
-                    colorFilter = ColorFilter.tint(logoColor),
-                )
+                HorizontalLogoText()
                 Spacer(modifier = Modifier.width(8.dp))
-                SubscriptionBadge(
-                    iconRes = IR.drawable.ic_patron,
-                    shortNameRes = LR.string.pocket_casts_patron_short,
-                    iconColor = Color.White,
-                    textColor = Color.White,
-                    backgroundColor = colorResource(UR.color.patron_purple),
+                SubscriptionBadgeForTier(
+                    tier = state.tier,
+                    displayMode = DisplayMode.Colored
                 )
             }
         },
-        buttonTitleRes = LR.string.subscribe, // TODO: Bookmarks update upsell button title based on subscription status
+        message = stringResource(LR.string.bookmarks_create_instructions),
+        buttonTitle = getButtonTitle(state.tier, state.hasFreeTrial),
         buttonAction = onClick,
         style = style,
         modifier = modifier,
+    )
+}
+
+private fun SubscriptionTier.getContentDescription() = when (this) {
+    SubscriptionTier.PATRON -> LR.string.pocket_casts_patron
+    SubscriptionTier.PLUS -> LR.string.pocket_casts_plus
+    SubscriptionTier.UNKNOWN -> throw IllegalStateException("Unknown subscription tier")
+}
+
+@Composable
+private fun getButtonTitle(
+    tier: SubscriptionTier,
+    hasFreeTrial: Boolean
+) = if (hasFreeTrial) {
+    stringResource(LR.string.profile_start_free_trial)
+} else {
+    stringResource(
+        LR.string.upgrade_to,
+        when (tier) {
+            SubscriptionTier.PATRON -> stringResource(LR.string.pocket_casts_patron_short)
+            SubscriptionTier.PLUS -> stringResource(LR.string.pocket_casts_plus_short)
+            SubscriptionTier.UNKNOWN -> throw IllegalStateException("Unknown subscription tier")
+        }
     )
 }
 
@@ -91,9 +111,9 @@ private fun UpsellPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppTheme(themeType) {
-        Content(
+        UpsellViewContent(
             style = MessageViewColors.Default,
-            activeTheme = themeType,
+            state = UiState.Loaded(tier = SubscriptionTier.PATRON, hasFreeTrial = false),
             onClick = {},
         )
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellView.kt
@@ -32,8 +32,8 @@ fun UpsellView(
     onClick: () -> Unit,
     sourceView: SourceView,
     modifier: Modifier = Modifier,
+    viewModel: UpsellViewModel = hiltViewModel(),
 ) {
-    val viewModel = hiltViewModel<UpsellViewModel>()
     val state by viewModel.state.collectAsState()
     when (state) {
         UiState.Loading -> Unit

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellView.kt
@@ -35,7 +35,7 @@ fun UpsellView(
     sourceView: SourceView,
     modifier: Modifier = Modifier,
 ) {
-    val viewModel = hiltViewModel<PlusUpsellViewModel>()
+    val viewModel = hiltViewModel<UpsellViewModel>()
     Content(
         style = style,
         activeTheme = activeTheme,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellViewModel.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.reactive.asFlow
 import javax.inject.Inject
 
 @HiltViewModel
-class PlusUpsellViewModel @Inject constructor(
+class UpsellViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val subscriptionManager: SubscriptionManager,
 ) : ViewModel() {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellViewModel.kt
@@ -57,6 +57,7 @@ class UpsellViewModel @Inject constructor(
         val subscriptionTier = SubscriptionTier.PATRON
         val updatedSubscriptions = subscriptions.filter { it.tier == subscriptionTier }
 
+        // Check the server subscriptions to see if the Patron tier has a free trial
         val selectedSubscription = subscriptionManager.getDefaultSubscription(
             tier = subscriptionTier,
             subscriptions = updatedSubscriptions,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkUpsellViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkUpsellViewHolder.kt
@@ -24,7 +24,6 @@ class BookmarkUpsellViewHolder(
                 val context = LocalContext.current
                 UpsellView(
                     style = MessageViewColors.Default,
-                    activeTheme = theme.activeTheme,
                     sourceView = sourceView,
                     onClick = {
                         val source = OnboardingUpgradeSource.BOOKMARKS

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkUpsellViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkUpsellViewHolder.kt
@@ -1,10 +1,14 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.adapter
 
+import androidx.compose.foundation.background
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.MessageViewColors
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.UpsellView
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
@@ -29,7 +33,9 @@ class BookmarkUpsellViewHolder(
                         val source = OnboardingUpgradeSource.BOOKMARKS
                         val onboardingFlow = OnboardingFlow.Upsell(source, true)
                         OnboardingLauncher.openOnboardingFlow(context.getActivity(), onboardingFlow)
-                    }
+                    },
+                    modifier = Modifier
+                        .background(color = MaterialTheme.theme.colors.primaryUi02),
                 )
             }
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/NoBookmarkViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/NoBookmarkViewHolder.kt
@@ -1,9 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.adapter
 
+import androidx.compose.foundation.background
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.NoBookmarksView
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.NoBookmarksViewColors
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -20,6 +24,8 @@ class NoBookmarkViewHolder(
                     style = NoBookmarksViewColors.Default,
                     sourceView = SourceView.PODCAST_SCREEN,
                     openFragment = { onHeadsetSettingsClicked() },
+                    modifier = Modifier
+                        .background(color = MaterialTheme.theme.colors.primaryUi02),
                 )
             }
         }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/HorizontalLogoText.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/HorizontalLogoText.kt
@@ -1,0 +1,47 @@
+package au.com.shiftyjelly.pocketcasts.compose.images
+
+import androidx.compose.foundation.Image
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+
+@Composable
+fun HorizontalLogoText(
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+) {
+    val logoColor = if (MaterialTheme.theme.isLight) Color.Black else Color.White
+    Image(
+        painter = painterResource(IR.drawable.logo_pocket_casts),
+        contentDescription = contentDescription,
+        colorFilter = ColorFilter.tint(logoColor),
+        modifier = modifier
+    )
+}
+
+@ShowkaseComposable(name = "Logo", group = "Images", styleName = "HorizontalLogoText - Dark", defaultStyle = true)
+@Preview(name = "Dark")
+@Composable
+fun HorizontalLogoTextDarkPreview() {
+    AppThemeWithBackground(Theme.ThemeType.LIGHT) {
+        HorizontalLogoText()
+    }
+}
+
+@ShowkaseComposable(name = "Logo", group = "Images", styleName = "HorizontalLogoText - Light")
+@Preview(name = "Light")
+@Composable
+fun HorizontalLogoTextLightPreview() {
+    AppThemeWithBackground(Theme.ThemeType.DARK) {
+        HorizontalLogoText()
+    }
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
@@ -27,7 +26,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
-import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 private val pillCornerRadiusInDp = 800.dp
 
@@ -85,15 +83,15 @@ fun SubscriptionBadgeForTier(
             iconRes = IR.drawable.ic_plus,
             shortNameRes = LR.string.pocket_casts_plus_short,
             iconColor = when (displayMode) {
-                SubscriptionBadgeDisplayMode.Black -> colorResource(UR.color.plus_gold)
+                SubscriptionBadgeDisplayMode.Black -> SubscriptionTierColor.plusGold
                 SubscriptionBadgeDisplayMode.Colored -> Color.White
             },
             backgroundColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.Black
-                SubscriptionBadgeDisplayMode.Colored -> colorResource(UR.color.plus_gold)
+                SubscriptionBadgeDisplayMode.Colored -> SubscriptionTierColor.plusGold
             },
             textColor = when (displayMode) {
-                SubscriptionBadgeDisplayMode.Black -> colorResource(UR.color.plus_gold)
+                SubscriptionBadgeDisplayMode.Black -> SubscriptionTierColor.plusGold
                 SubscriptionBadgeDisplayMode.Colored -> Color.White
             },
         )
@@ -101,12 +99,12 @@ fun SubscriptionBadgeForTier(
             iconRes = IR.drawable.ic_patron,
             shortNameRes = LR.string.pocket_casts_patron_short,
             iconColor = when (displayMode) {
-                SubscriptionBadgeDisplayMode.Black -> colorResource(UR.color.patron_purple_light)
+                SubscriptionBadgeDisplayMode.Black -> SubscriptionTierColor.patronPurpleLight
                 SubscriptionBadgeDisplayMode.Colored -> Color.White
             },
             backgroundColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.Black
-                SubscriptionBadgeDisplayMode.Colored -> colorResource(UR.color.patron_purple)
+                SubscriptionBadgeDisplayMode.Colored -> SubscriptionTierColor.patronPurple
             },
             textColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.White
@@ -120,6 +118,12 @@ fun SubscriptionBadgeForTier(
 enum class SubscriptionBadgeDisplayMode {
     Black,
     Colored,
+}
+
+object SubscriptionTierColor {
+    val plusGold = Color(0xFFFFD846)
+    val patronPurple = Color(0xFF6046F5)
+    val patronPurpleLight = Color(0xFFAFA2FA)
 }
 
 @ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored", defaultStyle = true)

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -78,46 +78,46 @@ fun SubscriptionBadge(
 @Composable
 fun SubscriptionBadgeForTier(
     tier: SubscriptionTier,
-    displayMode: DisplayMode,
+    displayMode: SubscriptionBadgeDisplayMode,
 ) {
     when (tier) {
         SubscriptionTier.PLUS -> SubscriptionBadge(
             iconRes = IR.drawable.ic_plus,
             shortNameRes = LR.string.pocket_casts_plus_short,
             iconColor = when (displayMode) {
-                DisplayMode.Black -> colorResource(UR.color.plus_gold)
-                DisplayMode.Colored -> Color.White
+                SubscriptionBadgeDisplayMode.Black -> colorResource(UR.color.plus_gold)
+                SubscriptionBadgeDisplayMode.Colored -> Color.White
             },
             backgroundColor = when (displayMode) {
-                DisplayMode.Black -> Color.Black
-                DisplayMode.Colored -> colorResource(UR.color.plus_gold)
+                SubscriptionBadgeDisplayMode.Black -> Color.Black
+                SubscriptionBadgeDisplayMode.Colored -> colorResource(UR.color.plus_gold)
             },
             textColor = when (displayMode) {
-                DisplayMode.Black -> colorResource(UR.color.plus_gold)
-                DisplayMode.Colored -> Color.White
+                SubscriptionBadgeDisplayMode.Black -> colorResource(UR.color.plus_gold)
+                SubscriptionBadgeDisplayMode.Colored -> Color.White
             },
         )
         SubscriptionTier.PATRON -> SubscriptionBadge(
             iconRes = IR.drawable.ic_patron,
             shortNameRes = LR.string.pocket_casts_patron_short,
             iconColor = when (displayMode) {
-                DisplayMode.Black -> colorResource(UR.color.patron_purple_light)
-                DisplayMode.Colored -> Color.White
+                SubscriptionBadgeDisplayMode.Black -> colorResource(UR.color.patron_purple_light)
+                SubscriptionBadgeDisplayMode.Colored -> Color.White
             },
             backgroundColor = when (displayMode) {
-                DisplayMode.Black -> Color.Black
-                DisplayMode.Colored -> colorResource(UR.color.patron_purple)
+                SubscriptionBadgeDisplayMode.Black -> Color.Black
+                SubscriptionBadgeDisplayMode.Colored -> colorResource(UR.color.patron_purple)
             },
             textColor = when (displayMode) {
-                DisplayMode.Black -> Color.White
-                DisplayMode.Colored -> Color.White
+                SubscriptionBadgeDisplayMode.Black -> Color.White
+                SubscriptionBadgeDisplayMode.Colored -> Color.White
             },
         )
         SubscriptionTier.UNKNOWN -> throw IllegalStateException("Unknown subscription tier")
     }
 }
 
-enum class DisplayMode {
+enum class SubscriptionBadgeDisplayMode {
     Black,
     Colored,
 }
@@ -128,7 +128,7 @@ enum class DisplayMode {
 fun SubscriptionBadgePlusColoredPreview() {
     SubscriptionBadgeForTier(
         tier = SubscriptionTier.PLUS,
-        displayMode = DisplayMode.Colored
+        displayMode = SubscriptionBadgeDisplayMode.Colored
     )
 }
 
@@ -138,7 +138,7 @@ fun SubscriptionBadgePlusColoredPreview() {
 fun SubscriptionBadgePlusBlackPreview() {
     SubscriptionBadgeForTier(
         tier = SubscriptionTier.PLUS,
-        displayMode = DisplayMode.Black
+        displayMode = SubscriptionBadgeDisplayMode.Black
     )
 }
 
@@ -148,7 +148,7 @@ fun SubscriptionBadgePlusBlackPreview() {
 fun SubscriptionBadgePatronColoredPreview() {
     SubscriptionBadgeForTier(
         tier = SubscriptionTier.PATRON,
-        displayMode = DisplayMode.Colored
+        displayMode = SubscriptionBadgeDisplayMode.Colored
     )
 }
 
@@ -158,6 +158,6 @@ fun SubscriptionBadgePatronColoredPreview() {
 fun SubscriptionBadgePatronBlackPreview() {
     SubscriptionBadgeForTier(
         tier = SubscriptionTier.PATRON,
-        displayMode = DisplayMode.Black
+        displayMode = SubscriptionBadgeDisplayMode.Black
     )
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
@@ -22,8 +23,11 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
-import au.com.shiftyjelly.pocketcasts.images.R
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
+import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 private val pillCornerRadiusInDp = 800.dp
 
@@ -71,12 +75,89 @@ fun SubscriptionBadge(
     }
 }
 
-@Preview
 @Composable
-private fun SubscriptionBadgePreview() {
-    SubscriptionBadge(
-        iconRes = R.drawable.ic_patron,
-        shortNameRes = LR.string.pocket_casts_patron_short,
-        backgroundColor = Color.Black,
+fun SubscriptionBadgeForTier(
+    tier: SubscriptionTier,
+    displayMode: DisplayMode,
+) {
+    when (tier) {
+        SubscriptionTier.PLUS -> SubscriptionBadge(
+            iconRes = IR.drawable.ic_plus,
+            shortNameRes = LR.string.pocket_casts_plus_short,
+            iconColor = when (displayMode) {
+                DisplayMode.Black -> colorResource(UR.color.plus_gold)
+                DisplayMode.Colored -> Color.White
+            },
+            backgroundColor = when (displayMode) {
+                DisplayMode.Black -> Color.Black
+                DisplayMode.Colored -> colorResource(UR.color.plus_gold)
+            },
+            textColor = when (displayMode) {
+                DisplayMode.Black -> colorResource(UR.color.plus_gold)
+                DisplayMode.Colored -> Color.White
+            },
+        )
+        SubscriptionTier.PATRON -> SubscriptionBadge(
+            iconRes = IR.drawable.ic_patron,
+            shortNameRes = LR.string.pocket_casts_patron_short,
+            iconColor = when (displayMode) {
+                DisplayMode.Black -> colorResource(UR.color.patron_purple_light)
+                DisplayMode.Colored -> Color.White
+            },
+            backgroundColor = when (displayMode) {
+                DisplayMode.Black -> Color.Black
+                DisplayMode.Colored -> colorResource(UR.color.patron_purple)
+            },
+            textColor = when (displayMode) {
+                DisplayMode.Black -> Color.White
+                DisplayMode.Colored -> Color.White
+            },
+        )
+        SubscriptionTier.UNKNOWN -> throw IllegalStateException("Unknown subscription tier")
+    }
+}
+
+enum class DisplayMode {
+    Black,
+    Colored,
+}
+
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored", defaultStyle = true)
+@Preview(name = "Colored")
+@Composable
+fun SubscriptionBadgePlusColoredPreview() {
+    SubscriptionBadgeForTier(
+        tier = SubscriptionTier.PLUS,
+        displayMode = DisplayMode.Colored
+    )
+}
+
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Black")
+@Preview(name = "Black")
+@Composable
+fun SubscriptionBadgePlusBlackPreview() {
+    SubscriptionBadgeForTier(
+        tier = SubscriptionTier.PLUS,
+        displayMode = DisplayMode.Black
+    )
+}
+
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored")
+@Preview(name = "Colored")
+@Composable
+fun SubscriptionBadgePatronColoredPreview() {
+    SubscriptionBadgeForTier(
+        tier = SubscriptionTier.PATRON,
+        displayMode = DisplayMode.Colored
+    )
+}
+
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Black")
+@Preview(name = "Black")
+@Composable
+fun SubscriptionBadgePatronBlackPreview() {
+    SubscriptionBadgeForTier(
+        tier = SubscriptionTier.PATRON,
+        displayMode = DisplayMode.Black
     )
 }


### PR DESCRIPTION
## Description

This updates upsell view to display content based on the tier passed to it. It also updates the upgrade button title to display text based on free trial info. 

Part of https://github.com/Automattic/pocket-casts-android/issues/1307

## Testing Instructions

Prerequisites:
- Release build
- Feature flag enabled for Patron and Bookmarks
- License test account

1. Open the app without login
2. Go to bookmarks upsell view
3. ✅ Notice that upsell view is shown for Patron
4. ✅ Notice that upgrade button title is set to "Upgrade to Patron"


I also tested for `Plus`, and included the screenshot. You may skip it as it will be updated based on the Feature tier in the following PR where it will need to be tested again.

## Screenshots or Screencast 
Plus | Patron
-----|---
<img width= 200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/d14d4645-536f-428b-a8b8-bfb70463e353"/>|<img width= 200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/38958fbb-cdd6-42e7-babc-9b2c7c40de9e"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
