### PR TITLE
Remove previous toolbar action observers when adding a new one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
          ([#1275](https://github.com/Automattic/pocket-casts-android/pull/1275))
     *    Improved performance when archiving multiple episodes
          ([1327](https://github.com/Automattic/pocket-casts-android/pull/1327))
+    *    Avoided adding multiple toolbar observers, which was causing the app to lag and freeze
+         ([#1333](https://github.com/Automattic/pocket-casts-android/pull/1333))
 
 7.45.1
 -----

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectToolbar.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectToolbar.kt
@@ -42,6 +42,7 @@ class MultiSelectToolbar @JvmOverloads constructor(
         if (menuRes != null) {
             inflateMenu(menuRes)
         } else {
+            multiSelectHelper.toolbarActions.removeObservers(lifecycleOwner)
             multiSelectHelper.toolbarActions.observe(lifecycleOwner) {
                 menu.clear()
 


### PR DESCRIPTION
## Description
This avoids some significant ANRs caused by us adding multiple observers for the same lifecycle owner. This feels like a bit of a band-aid, but I'm not seeing that this introduces any new issues and any other way I see to address the ANRs (such as avoiding us trying to add an observer multiple times) feels much riskier, so I'd rather not try them this close to the `7.46` release and instead stick with this simple fix to address the ANRs.

> **Note**
> This PR is targeting to `release/7.46` branch which is due to be released pretty much immediately.

My thinking is that we can work on a fuller fix in https://github.com/Automattic/pocket-casts-android/pull/1316 for the `7.37` release.

Thanks to @emilylaguna for coming up with the steps to reproduce and proposed fix for this. 🤩 

## Testing Instructions
1. Launch the app
1. Go to a podcast detail page, it's easier to trigger when the podcast has lots of episodes
2. Tap on an episode to view the details page
3. Tap the mark as played/unplayed at least 10-20 times
4. Dismiss the episode details
5. Tap and hold the enter multi select
6. Select/deselect some episodes
7. Observe that the app is not starting to lag

In addition to those test steps, also do some smoke-testing of multi-select across multiple screens to make sure we aren't introducing any _new_ issues.

## Screenshots or Screencast 

| Before | After |
| --- | --- | 
| <video src="https://github.com/Automattic/pocket-casts-android/assets/4656348/71f071e0-f610-42f2-a844-c33390472926"/> | <video src="https://github.com/Automattic/pocket-casts-android/assets/4656348/370c389a-dc03-4ba7-aa48-c49df0df11be"/> |

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack
