### PR TITLE
Address flaky tests by updating episode manager coroutine handling for archiveAllFilesInList

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -201,7 +201,7 @@ abstract class EpisodeDao {
     abstract fun updateDownloadedFilePath(downloadedFilePath: String, uuid: String)
 
     @Query("UPDATE podcast_episodes SET auto_download_status = :autoDownloadStatus WHERE uuid = :uuid")
-    abstract fun updateAutoDownloadStatus(autoDownloadStatus: Int, uuid: String)
+    abstract suspend fun updateAutoDownloadStatus(autoDownloadStatus: Int, uuid: String)
 
     @Query("UPDATE podcast_episodes SET thumbnail_status = :thumbnailStatus WHERE uuid = :uuid")
     abstract fun updateThumbnailStatus(thumbnailStatus: Int, uuid: String)
@@ -213,7 +213,7 @@ abstract class EpisodeDao {
     abstract fun updateDownloadErrorDetails(downloadErrorDetails: String?, uuid: String)
 
     @Query("UPDATE podcast_episodes SET episode_status = :episodeStatus WHERE uuid = :uuid")
-    abstract fun updateEpisodeStatus(episodeStatus: EpisodeStatusEnum, uuid: String)
+    abstract suspend fun updateEpisodeStatus(episodeStatus: EpisodeStatusEnum, uuid: String)
 
     @Query("UPDATE podcast_episodes SET episode_status = :episodeStatus")
     abstract fun updateAllEpisodeStatus(episodeStatus: EpisodeStatusEnum)
@@ -304,7 +304,7 @@ abstract class EpisodeDao {
     abstract fun findInactiveEpisodes(podcastUuid: String, inactiveDate: Date, inactiveTime: Long = inactiveDate.time): List<PodcastEpisode>
 
     @Query("UPDATE podcast_episodes SET archived = 1, archived_modified = :modified, last_archive_interaction_date = :modified WHERE uuid IN (:episodesUUIDs)")
-    abstract fun archiveAllInList(episodesUUIDs: List<String>, modified: Long)
+    abstract suspend fun archiveAllInList(episodesUUIDs: List<String>, modified: Long)
 
     @Query("UPDATE podcast_episodes SET archived = 0, archived_modified = :modified, last_archive_interaction_date = :modified WHERE uuid IN (:episodesUUIDs)")
     abstract fun unarchiveAllInList(episodesUUIDs: List<String>, modified: Long)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadHelper.kt
@@ -7,6 +7,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
 import au.com.shiftyjelly.pocketcasts.repositories.file.StorageException
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import kotlinx.coroutines.runBlocking
 
 object DownloadHelper {
 
@@ -15,7 +16,9 @@ object DownloadHelper {
             return
         }
 
-        episodeManager.updateAutoDownloadStatus(episode, PodcastEpisode.AUTO_DOWNLOAD_STATUS_MANUALLY_DOWNLOADED)
+        runBlocking {
+            episodeManager.updateAutoDownloadStatus(episode, PodcastEpisode.AUTO_DOWNLOAD_STATUS_MANUALLY_DOWNLOADED)
+        }
         downloadManager.addEpisodeToQueue(episode, from, true)
     }
 
@@ -27,15 +30,9 @@ object DownloadHelper {
             return
         }
         LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Adding ${episode.title} to auto download from $from")
-        episodeManager.updateAutoDownloadStatus(episode, PodcastEpisode.AUTO_DOWNLOAD_STATUS_AUTO_DOWNLOADED)
-        downloadManager.addEpisodeToQueue(episode, from, true)
-    }
-
-    fun addEpisodeToQueueOverridingWifiWarning(episode: PodcastEpisode, from: String, downloadManager: DownloadManager, episodeManager: EpisodeManager) {
-        if (episode.isDownloaded) {
-            return
+        runBlocking {
+            episodeManager.updateAutoDownloadStatus(episode, PodcastEpisode.AUTO_DOWNLOAD_STATUS_AUTO_DOWNLOADED)
         }
-        episodeManager.updateAutoDownloadStatus(episode, PodcastEpisode.AUTO_DOWNLOAD_STATUS_MANUAL_OVERRIDE_WIFI)
         downloadManager.addEpisodeToQueue(episode, from, true)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
@@ -140,7 +140,9 @@ class DownloadEpisodeTask @AssistedInject constructor(
                 setForegroundAsync(createForegroundInfo())
             }
 
-            episodeManager.updateEpisodeStatus(episode, EpisodeStatusEnum.DOWNLOADING)
+            runBlocking {
+                episodeManager.updateEpisodeStatus(episode, EpisodeStatusEnum.DOWNLOADING)
+            }
 
             download()
                 .doOnNext { updateProgress(it) }
@@ -150,7 +152,9 @@ class DownloadEpisodeTask @AssistedInject constructor(
             if (!isStopped) {
                 pathToSaveTo?.let {
                     episodeManager.updateDownloadFilePath(episode, it, false)
-                    episodeManager.updateEpisodeStatus(episode, EpisodeStatusEnum.DOWNLOADED)
+                    runBlocking {
+                        episodeManager.updateEpisodeStatus(episode, EpisodeStatusEnum.DOWNLOADED)
+                    }
                 }
 
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Downloaded episode ${episode.title} ${episode.uuid}")
@@ -201,7 +205,9 @@ class DownloadEpisodeTask @AssistedInject constructor(
             .putString(OUTPUT_EPISODE_UUID, episode.uuid)
             .build()
 
-        episodeManager.updateEpisodeStatus(episode, EpisodeStatusEnum.DOWNLOAD_FAILED)
+        runBlocking {
+            episodeManager.updateEpisodeStatus(episode, EpisodeStatusEnum.DOWNLOAD_FAILED)
+        }
         val message = if (downloadMessage.isNullOrBlank()) "Download Failed" else downloadMessage
         episodeManager.updateDownloadErrorDetails(episode, message)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -71,8 +71,8 @@ interface EpisodeManager {
     fun updatePlayedUpTo(episode: BaseEpisode?, playedUpTo: Double, forceUpdate: Boolean)
     fun updateDuration(episode: BaseEpisode?, durationInSecs: Double, syncChanges: Boolean)
     fun updatePlayingStatus(episode: BaseEpisode?, status: EpisodePlayingStatus)
-    fun updateEpisodeStatus(episode: BaseEpisode?, status: EpisodeStatusEnum)
-    fun updateAutoDownloadStatus(episode: BaseEpisode?, autoDownloadStatus: Int)
+    suspend fun updateEpisodeStatus(episode: BaseEpisode?, status: EpisodeStatusEnum)
+    suspend fun updateAutoDownloadStatus(episode: BaseEpisode?, autoDownloadStatus: Int)
     fun updateDownloadFilePath(episode: BaseEpisode?, filePath: String, markAsDownloaded: Boolean)
     fun updateFileType(episode: BaseEpisode?, fileType: String)
     fun updateSizeInBytes(episode: BaseEpisode?, sizeInBytes: Long)
@@ -101,7 +101,7 @@ interface EpisodeManager {
     fun archive(episode: PodcastEpisode, playbackManager: PlaybackManager, sync: Boolean = true)
     fun archivePlayedEpisode(episode: BaseEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager, sync: Boolean)
     fun unarchive(episode: BaseEpisode)
-    fun archiveAllInList(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager?)
+    suspend fun archiveAllInList(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager?)
     fun checkForEpisodesToAutoArchive(playbackManager: PlaybackManager?, podcastManager: PodcastManager)
     fun userHasInteractedWithEpisode(episode: PodcastEpisode, playbackManager: PlaybackManager): Boolean
     fun clearEpisodePlaybackInteractionDatesBefore(lastCleared: Date)
@@ -115,7 +115,7 @@ interface EpisodeManager {
     fun deleteEpisodesWithoutSync(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager)
 
     fun deleteEpisodeWithoutSync(episode: PodcastEpisode?, playbackManager: PlaybackManager)
-    fun deleteEpisodeFile(episode: BaseEpisode?, playbackManager: PlaybackManager?, disableAutoDownload: Boolean, updateDatabase: Boolean = true, removeFromUpNext: Boolean = true)
+    suspend fun deleteEpisodeFile(episode: BaseEpisode?, playbackManager: PlaybackManager?, disableAutoDownload: Boolean, updateDatabase: Boolean = true, removeFromUpNext: Boolean = true)
     fun deleteCustomFolderEpisode(episode: PodcastEpisode?, playbackManager: PlaybackManager)
     fun deleteFinishedEpisodes(playbackManager: PlaybackManager)
     fun deleteDownloadedEpisodeFiles()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -355,14 +355,14 @@ class EpisodeManagerImpl @Inject constructor(
         }
     }
 
-    override fun updateEpisodeStatus(episode: BaseEpisode?, status: EpisodeStatusEnum) {
+    override suspend fun updateEpisodeStatus(episode: BaseEpisode?, status: EpisodeStatusEnum) {
         episode ?: return
         episode.episodeStatus = status
 
         if (episode is PodcastEpisode) {
             episodeDao.updateEpisodeStatus(status, episode.uuid)
         } else if (episode is UserEpisode) {
-            runBlocking { userEpisodeManager.updateEpisodeStatus(episode, status) }
+            userEpisodeManager.updateEpisodeStatus(episode, status)
         }
     }
 
@@ -370,7 +370,7 @@ class EpisodeManagerImpl @Inject constructor(
         episodeDao.updateAllEpisodeStatus(episodeStatus)
     }
 
-    override fun updateAutoDownloadStatus(episode: BaseEpisode?, autoDownloadStatus: Int) {
+    override suspend fun updateAutoDownloadStatus(episode: BaseEpisode?, autoDownloadStatus: Int) {
         episode ?: return
         episode.autoDownloadStatus = autoDownloadStatus
 
@@ -391,7 +391,9 @@ class EpisodeManagerImpl @Inject constructor(
         }
 
         if (markAsDownloaded) {
-            updateEpisodeStatus(episode, EpisodeStatusEnum.DOWNLOADED)
+            runBlocking {
+                updateEpisodeStatus(episode, EpisodeStatusEnum.DOWNLOADED)
+            }
         }
     }
 
@@ -536,8 +538,10 @@ class EpisodeManagerImpl @Inject constructor(
         if (episodes.isEmpty()) {
             return
         }
-        for (episode in episodes) {
-            deleteEpisodeFile(episode, playbackManager, disableAutoDownload = false, updateDatabase = false)
+        runBlocking {
+            for (episode in episodes) {
+                deleteEpisodeFile(episode, playbackManager, disableAutoDownload = false, updateDatabase = false)
+            }
         }
         episodeDao.deleteAll(episodes)
     }
@@ -545,12 +549,14 @@ class EpisodeManagerImpl @Inject constructor(
     override fun deleteEpisodeWithoutSync(episode: PodcastEpisode?, playbackManager: PlaybackManager) {
         episode ?: return
 
-        deleteEpisodeFile(episode, playbackManager, false, false)
+        runBlocking {
+            deleteEpisodeFile(episode, playbackManager, false, false)
+        }
 
         episodeDao.delete(episode)
     }
 
-    override fun deleteEpisodeFile(episode: BaseEpisode?, playbackManager: PlaybackManager?, disableAutoDownload: Boolean, updateDatabase: Boolean, removeFromUpNext: Boolean) {
+    override suspend fun deleteEpisodeFile(episode: BaseEpisode?, playbackManager: PlaybackManager?, disableAutoDownload: Boolean, updateDatabase: Boolean, removeFromUpNext: Boolean) {
         episode ?: return
 
         Timber.d("Deleting episode file ${episode.title}")
@@ -650,7 +656,9 @@ class EpisodeManagerImpl @Inject constructor(
     override fun clearDownloadError(episode: PodcastEpisode?) {
         episode ?: return
         episodeDao.updateDownloadErrorDetails(null, episode.uuid)
-        updateEpisodeStatus(episode, EpisodeStatusEnum.NOT_DOWNLOADED)
+        runBlocking {
+            updateEpisodeStatus(episode, EpisodeStatusEnum.NOT_DOWNLOADED)
+        }
         episode.episodeStatus = EpisodeStatusEnum.NOT_DOWNLOADED
         episode.downloadErrorDetails = null
     }
@@ -711,11 +719,13 @@ class EpisodeManagerImpl @Inject constructor(
             episodeDao.updateArchivedNoSync(true, System.currentTimeMillis(), episode.uuid)
         }
         episode.isArchived = true
-        cleanUpEpisode(episode, playbackManager)
+        runBlocking {
+            cleanUpEpisode(episode, playbackManager)
+        }
     }
 
     @Suppress("NAME_SHADOWING")
-    private fun cleanUpEpisode(episode: BaseEpisode, playbackManager: PlaybackManager?) {
+    private suspend fun cleanUpEpisode(episode: BaseEpisode, playbackManager: PlaybackManager?) {
         val playbackManager = playbackManager ?: return
         if (episode.isDownloaded || episode.isDownloading || episode.downloadTaskId != null) {
             downloadManager.removeEpisodeFromQueue(episode, "episode manager")
@@ -810,8 +820,10 @@ class EpisodeManagerImpl @Inject constructor(
         val episodes = findEpisodesWhere("episode_status = " + EpisodeStatusEnum.DOWNLOADED.ordinal + " AND playing_status = " + EpisodePlayingStatus.COMPLETED.ordinal)
         if (episodes.isEmpty()) return
 
-        for (episode in episodes) {
-            deleteEpisodeFile(episode, playbackManager, true, true)
+        runBlocking {
+            for (episode in episodes) {
+                deleteEpisodeFile(episode, playbackManager, true, true)
+            }
         }
     }
 
@@ -832,7 +844,9 @@ class EpisodeManagerImpl @Inject constructor(
         if (episodes.isEmpty()) return
 
         for (episode in episodes) {
-            updateEpisodeStatus(episode, EpisodeStatusEnum.NOT_DOWNLOADED)
+            runBlocking {
+                updateEpisodeStatus(episode, EpisodeStatusEnum.NOT_DOWNLOADED)
+            }
         }
     }
 
@@ -958,11 +972,11 @@ class EpisodeManagerImpl @Inject constructor(
 
     // Playback manager is only optional for UI tests. Should never be optional in the app but can't work out
     // another way without mocking a lot of stuff.
-    override fun archiveAllInList(
+    override suspend fun archiveAllInList(
         episodes: List<PodcastEpisode>,
         playbackManager: PlaybackManager?
     ) {
-        launch(ioDispatcher) {
+        withContext(ioDispatcher) {
             appDatabase.withTransaction {
                 episodes.filter { !it.isArchived }.chunked(500).forEach { chunked ->
                     episodeDao.archiveAllInList(chunked.map { it.uuid }, System.currentTimeMillis())
@@ -1006,9 +1020,13 @@ class EpisodeManagerImpl @Inject constructor(
                 .filter { (settings.getAutoArchiveIncludeStarred() && it.isStarred) || !it.isStarred }
                 .filter { it.lastPlaybackInteractionDate != null && now.time - it.lastPlaybackInteractionDate!!.time > autoArchiveAfterPlayingTime }
 
-            archiveAllInList(playedEpisodes, playbackManager)
+            runBlocking {
+                archiveAllInList(playedEpisodes, playbackManager)
+            }
             playedEpisodes.forEach {
-                cleanUpEpisode(it, playbackManager)
+                runBlocking {
+                    cleanUpEpisode(it, playbackManager)
+                }
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Auto archiving played episode ${it.title}")
             }
         }
@@ -1021,9 +1039,13 @@ class EpisodeManagerImpl @Inject constructor(
             val inactiveEpisodes = episodeDao.findInactiveEpisodes(podcast.uuid, Date(now.time - inactiveTime))
                 .filter { settings.getAutoArchiveIncludeStarred() || !it.isStarred }
             if (inactiveEpisodes.isNotEmpty()) {
-                archiveAllInList(inactiveEpisodes, playbackManager)
+                runBlocking {
+                    archiveAllInList(inactiveEpisodes, playbackManager)
+                }
                 inactiveEpisodes.forEach {
-                    cleanUpEpisode(it, playbackManager)
+                    runBlocking {
+                        cleanUpEpisode(it, playbackManager)
+                    }
                     LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Auto archiving inactive episode ${it.title}")
                 }
             }
@@ -1045,9 +1067,13 @@ class EpisodeManagerImpl @Inject constructor(
                     .filter { (settings.getAutoArchiveIncludeStarred() && it.isStarred) || !it.isStarred }
                     .filter { playbackManager?.getCurrentEpisode()?.uuid != it.uuid }
                 if (episodesToRemove.isNotEmpty()) {
-                    archiveAllInList(episodesToRemove, playbackManager)
+                    runBlocking {
+                        archiveAllInList(episodesToRemove, playbackManager)
+                    }
                     episodesToRemove.forEach {
-                        cleanUpEpisode(it, playbackManager)
+                        runBlocking {
+                            cleanUpEpisode(it, playbackManager)
+                        }
                         LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Auto archiving episode over limit $episodeLimit ${it.title}")
                     }
                 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -728,9 +728,12 @@ class EpisodeManagerImpl @Inject constructor(
     private suspend fun cleanUpEpisode(episode: BaseEpisode, playbackManager: PlaybackManager?) {
         val playbackManager = playbackManager ?: return
         if (episode.isDownloaded || episode.isDownloading || episode.downloadTaskId != null) {
+            // FIXME doesn't seem this is necessary since it is handled by deleteEpisodeFile
             downloadManager.removeEpisodeFromQueue(episode, "episode manager")
         }
         deleteEpisodeFile(episode, playbackManager, disableAutoDownload = true, updateDatabase = true, removeFromUpNext = true)
+
+        // FIXME doesn't seem this is necessary since it is handled by deleteEpisodeFile
         playbackManager.removeEpisode(episode, source = SourceView.UNKNOWN, userInitiated = false)
     }
 


### PR DESCRIPTION
## Description
This is fixing some recent test flakiness we've seen in the `AutoArchiveTest` class due to the recent change that started launching a coroutine from the `EpisodeManagerImpl::archiveAllInList` method (https://github.com/Automattic/pocket-casts-android/pull/1327).

> **Warning**
> This PR is currently targetting the `release/7.46` branch.

I've been wanting to convert more of our manager classes to use properly suspending functions instead of having regular functions that launch coroutines (which then call other regular functions that launch new coroutines, etc.). Making this kind of change will make help us avoid hard to reproduce/fix race conditions due to the order the coroutines run. 

The recent test flakiness we had due to the `archiveAllInList` method change seemed like another example of how this is hurting us, so I'm taking this opportunity to do this as a bit of a small POC/first-step toward the changes I would like to make. In particular, this PR focuses on making the `archiveAllInList` method a proper suspended function and, conveniently enough, the tests don't seem to be flaky anymore (I'm scared that me saying that is basically guaranteeing that they will fail the next time CI runs 🤞 ).

I intentionally limited the changes to the minimum ones necessary to make `archiveAllInList` a proper suspended function, which is why everywhere else I just changed the new suspend function calls to be called in a `runBlocking {...}` block. If I were doing this as a broader refactor, I would remove those as well, but since we might want to merge this change to a release branch I didn't want to do that in this PR.

I've got this currently targetng the `release/7.46` branch since that is where we have the test flakiness, but I think I'm probably leaning toward just merging this to `main` instead to minimize the risk of breakages on the release branch. In fact, I'm kind of thinking we should perhaps revert `https://github.com/Automattic/pocket-casts-android/pull/1327` on the `release/7.46` branch, and merge that, along with these changes, to `main`. That way, if everything goes according to plan, neither branch will be flaky.

Anyway, take a look, and let me know what you think both about this general approach (since I'm currently planning to do more of this next week), and about how we should approach the flakiness on `release/7.46`.

## Testing Instructions
1. Go to a podcast screen
2. Tap the three dot overflow menu
3. Tap archive all
4. Confirm you want to archive all
5. Observe that all the episodes are archived.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews