### PR TITLE
Revert "Use transaction when archiving multiple episodes (#1327)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@
          ([#1280](https://github.com/Automattic/pocket-casts-android/pull/1280))
     *    Improved upgrade flow when signing in with Google account
          ([#1275](https://github.com/Automattic/pocket-casts-android/pull/1275))
-    *    Improved performance when archiving multiple episodes
-         ([1327](https://github.com/Automattic/pocket-casts-android/pull/1327))
 
 7.45.1
 -----

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -149,7 +149,7 @@ project.ext {
             browserHelper: 'com.google.androidbrowserhelper:androidbrowserhelper:2.3.0',
             flexbox: 'com.google.android.flexbox:flexbox:3.0.0',
             androidTestCore: "androidx.test:core:$versionTest",
-            room: "androidx.room:room-ktx:$versionRoom",
+            room: "androidx.room:room-runtime:$versionRoom",
             roomRx: "androidx.room:room-rxjava2:$versionRoom",
             roomKtx: "androidx.room:room-ktx:$versionRoom",
             roomCompile: "androidx.room:room-compiler:$versionRoom",

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -17,11 +17,11 @@ import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.MessageVie
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.NoBookmarksViewColors
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
-import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.ui.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModel.kt
@@ -6,9 +6,9 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
-import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.ui.di.IoDispatcher
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/di/DispatcherModule.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/di/DispatcherModule.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.repositories.di
+package au.com.shiftyjelly.pocketcasts.ui.di
 
 import dagger.Module
 import dagger.Provides


### PR DESCRIPTION
This reverts commit f5a948a943cf760d8e4ce69d865c22c0da31ba18 because the changes from that PR have made the tests flaky.