### PR TITLE
Update multi select toolbars setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
         ([#1298](https://github.com/Automattic/pocket-casts-android/pull/1298))
     *   Present toast notification when duration of an in-progress episode changes
         ([#1312](https://github.com/Automattic/pocket-casts-android/pull/1312))
+    *   Present app review prompt 
+        ([#1305](https://github.com/Automattic/pocket-casts-android/pull/1305))
 *   Bug Fixes:
     *   Fixed auto archive settings getting lost when switching languages
         ([#1234](https://github.com/Automattic/pocket-casts-android/pull/1234))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@
         ([#1234](https://github.com/Automattic/pocket-casts-android/pull/1234))
     *   Improved handling of enabling/disabling new episode notifications
         ([#1264](https://github.com/Automattic/pocket-casts-android/pull/1264))
-    *    Fixed the artwork not appearing on the onboarding page
+    *   Fixed the artwork not appearing on the onboarding page
         ([#1299](https://github.com/Automattic/pocket-casts-android/pull/1299))
+    *   Improved multi-select toolbars setup 
+        ([#1338](https://github.com/Automattic/pocket-casts-android/pull/1338))
 
 7.46
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
@@ -181,7 +181,7 @@ private fun BookmarksView(
                 isSelected = state.isSelected,
                 onPlayClick = onPlayClick,
                 modifier = Modifier
-                    .pointerInput(state.isSelected(bookmark)) {
+                    .pointerInput(bookmark.adapterId) {
                         detectTapGestures(
                             onLongPress = { onRowLongPressed(bookmark) },
                             onTap = { state.onRowClick(bookmark) }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -21,6 +21,8 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
@@ -74,6 +76,7 @@ import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectHelper
+import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -644,17 +647,32 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
 
         binding.episodesRecyclerView.requestFocus()
 
-        multiSelectEpisodesHelper.setUp()
-        multiSelectBookmarksHelper.setUp()
-
         return binding.root
     }
 
-    fun <T> MultiSelectHelper<T>.setUp() {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding?.setupMultiSelect()
+    }
+
+    private fun FragmentPodcastBinding.setupMultiSelect() {
+        multiSelectEpisodesHelper.setUp(multiSelectEpisodesToolbar)
+        if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+            multiSelectBookmarksHelper.setUp(multiSelectBookmarksToolbar)
+        }
+    }
+
+    fun <T> MultiSelectHelper<T>.setUp(multiSelectToolbar: MultiSelectToolbar) {
+        multiSelectToolbar.setup(
+            lifecycleOwner = viewLifecycleOwner,
+            multiSelectHelper = this,
+            menuRes = null,
+            fragmentManager = parentFragmentManager,
+        )
         isMultiSelectingLive.observe(viewLifecycleOwner) {
             val episodeContainerFragment = parentFragmentManager.findFragmentByTag(EPISODE_CARD)
             if (episodeContainerFragment != null) return@observe
-            binding?.multiSelectToolbar?.isVisible = it
+            multiSelectToolbar.isVisible = it
             binding?.toolbar?.isVisible = !it
             adapter?.notifyDataSetChanged()
         }
@@ -747,13 +765,6 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                     addPaddingForEpisodeSearch(state.episodes)
                     when (state.showTab) {
                         PodcastTab.EPISODES -> {
-                            binding?.multiSelectToolbar?.setup(
-                                lifecycleOwner = viewLifecycleOwner,
-                                multiSelectHelper = multiSelectEpisodesHelper,
-                                menuRes = null,
-                                fragmentManager = parentFragmentManager,
-                            )
-
                             adapter?.setEpisodes(
                                 episodes = state.episodes,
                                 showingArchived = state.showingArchived,
@@ -767,13 +778,6 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                             )
                         }
                         PodcastTab.BOOKMARKS -> {
-                            binding?.multiSelectToolbar?.setup(
-                                lifecycleOwner = viewLifecycleOwner,
-                                multiSelectHelper = multiSelectBookmarksHelper,
-                                menuRes = null,
-                                fragmentManager = parentFragmentManager,
-                            )
-
                             adapter?.setBookmarks(
                                 bookmarks = state.bookmarks,
                                 searchTerm = state.searchBookmarkTerm,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkViewHolder.kt
@@ -27,7 +27,7 @@ class BookmarkViewHolder(
                     isSelected = data.isSelected,
                     onPlayClick = { data.onBookmarkPlayClicked(it) },
                     modifier = Modifier
-                        .pointerInput(data.isSelected(data.bookmark)) {
+                        .pointerInput(data.bookmark.adapterId) {
                             detectTapGestures(
                                 onLongPress = { data.onBookmarkRowLongPress(data.bookmark) },
                                 onTap = { data.onBookmarkRowClick(data.bookmark, bindingAdapterPosition) }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -193,6 +193,10 @@ class PodcastViewModel
     }
 
     fun onTabClicked(tab: PodcastTab) {
+        when (tab) {
+            PodcastTab.EPISODES -> multiSelectBookmarksHelper.closeMultiSelect()
+            PodcastTab.BOOKMARKS -> multiSelectEpisodesHelper.closeMultiSelect()
+        }
         analyticsTracker.track(AnalyticsEvent.PODCASTS_SCREEN_TAB_TAPPED, mapOf("value" to tab.analyticsValue))
         _uiState.value = (uiState.value as? UiState.Loaded)?.copy(showTab = tab)
     }

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
@@ -35,7 +35,15 @@
             app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
 
         <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
-            android:id="@+id/multiSelectToolbar"
+            android:id="@+id/multiSelectEpisodesToolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="?android:attr/actionBarSize"
+            app:navigationIcon="?attr/homeAsUpIndicator"
+            android:visibility="gone"/>
+
+        <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
+            android:id="@+id/multiSelectBookmarksToolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:minHeight="?android:attr/actionBarSize"

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModel.kt
@@ -7,11 +7,11 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.to.StatsBundle
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.settings.util.FunnyTimeConverter
-import au.com.shiftyjelly.pocketcasts.ui.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.utils.timeIntervalSinceNow
 import au.com.shiftyjelly.pocketcasts.views.review.InAppReviewHelper
 import dagger.hilt.android.lifecycle.HiltViewModel


### PR DESCRIPTION
## Description

This sets up separate multi-select toolbars for episodes and bookmarks instead of reusing the same toolbar and setting it up based on the selected tab on the podcast details screen.

4ef7ddd5c8eff81858bfc00acf2cccf8008bc38a is a cherry pick from an unmerged PR to help with testing.

## Testing Instructions

#### Bookmarks enabled

0. Enable the `Patron` and `Bookmarks` feature
1. Login with a `Patron` account
2. Open a podcast
3. Long press on an episode row
4. ✅ Notice that the episode multi-select toolbar is shown
5. Select a few episodes
6. ✅ Notice that correct episodes are selected
7. Tap on the `Bookmarks` tab
8. Notice that 
    - Episodes multi-select toolbar is closed
    - Bookmarks multi-select toolbar is shown
9. Select a few bookmarks
10. ✅ Notice that correct bookmarks are selected
11. Tap on the `Episodes` tab
12. ✅ Notice that 
    - Bookmarks multi-select toolbar is closed
    - Episodes multi-select toolbar is shown

#### Bookmarks disabled

0. Disable the `Bookmarks` feature
1. Open a podcast
2. Long press on an episode row
3. ✅ Notice that the episode multi-select toolbar is shown
4. Select a few episodes
5. ✅ Notice that correct episodes are selected


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
