### PR TITLE
Update cloud storage limit title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
         ([#1312](https://github.com/Automattic/pocket-casts-android/pull/1312))
     *   Present app review prompt 
         ([#1305](https://github.com/Automattic/pocket-casts-android/pull/1305))
+    *   Updated storage limit title
+        ([#1342](https://github.com/Automattic/pocket-casts-android/pull/1342))
 *   Bug Fixes:
     *   Fixed auto archive settings getting lost when switching languages
         ([#1234](https://github.com/Automattic/pocket-casts-android/pull/1234))

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1655,7 +1655,7 @@
     <string name="onboarding_plus_feature_desktop_apps_text">Listen in more places with our Windows, macOS, and Web apps.</string>
     <string name="onboarding_plus_feature_folders_title">Folders</string>
     <string name="onboarding_plus_feature_folders_text">Organize your podcasts in folders and keep them in sync across all your devices.</string>
-    <string name="onboarding_plus_feature_cloud_storage_title">10GB Cloud Storage</string>
+    <string name="onboarding_plus_feature_cloud_storage_title">20GB Cloud Storage</string>
     <string name="onboarding_plus_feature_cloud_storage_text">Upload your files to cloud storage and have them available everywhere.</string>
     <string name="onboarding_plus_feature_watch_playback">Watch Playback</string>
     <string name="onboarding_plus_feature_extra_themes_icons_title">Extra Themes &amp; App Icons</string>


### PR DESCRIPTION
## Description

This updates cloud storage string title from 10GB to 20GB.

> This targets v7.47 beta branch.

##### We should probably add a task to update this title dynamically from the remote config. 

## Testing Instructions
It should be sufficient to just check the strings file. 

## Screenshots or Screencast 

Old| New
---|---
<img wiidth=200  src="https://github.com/Automattic/pocket-casts-android/assets/1405144/fd6473fe-86cf-4d80-bc4a-7d2d6bd5a445"/>|<img  wiidth=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/f35a7f06-d5c2-4829-9abc-ee0ec49c49d0"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
