### PR TITLE
Disable Save Bookmark Button when bookmark title is blank

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkPage.kt
@@ -126,10 +126,11 @@ private fun Content(isNewBookmark: Boolean, title: TextFieldValue, tintColor: Co
         }
 
         Spacer(Modifier.weight(1f))
-
+        val isTitleEnable = title.text.isBlank()
         RowButton(
             text = stringResource(if (isNewBookmark) R.string.save_bookmark else R.string.change_title),
             colors = ButtonDefaults.buttonColors(backgroundColor = buttonColor),
+            enabled = !isTitleEnable,
             // if the tint color is too light use the background color for the text
             textColor = if (buttonColor.luminance() > 0.5) backgroundColor else Color.White,
             includePadding = false,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkPage.kt
@@ -126,11 +126,11 @@ private fun Content(isNewBookmark: Boolean, title: TextFieldValue, tintColor: Co
         }
 
         Spacer(Modifier.weight(1f))
-        val isTitleEnable = title.text.isBlank()
+        val isTitleBlank = title.text.isBlank()
         RowButton(
             text = stringResource(if (isNewBookmark) R.string.save_bookmark else R.string.change_title),
             colors = ButtonDefaults.buttonColors(backgroundColor = buttonColor),
-            enabled = !isTitleEnable,
+            enabled = !isTitleBlank,
             // if the tint color is too light use the background color for the text
             textColor = if (buttonColor.luminance() > 0.5) backgroundColor else Color.White,
             includePadding = false,


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR disables the save bookmark button when the title is blank.
Fixes # <!-- issue number, if applicable -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open player
2. Add bookmark 
3. Delete the default title, 
4. Observe the save bookmark icon is disabled 

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
