### PR TITLE
Add Sentry breadcrumbs when toolbar actions change

### DIFF
--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.views.R
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
+import io.sentry.Sentry
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -35,6 +36,7 @@ class MultiSelectBookmarksHelper @Inject constructor(
 
     override val toolbarActions: LiveData<List<MultiSelectAction>> = _selectedListLive
         .map {
+            Sentry.addBreadcrumb("MultiSelectBookmarksHelper toolbarActions updated, ${it.size} bookmarks from $source")
             listOf(
                 MultiSelectBookmarkAction.EditBookmark(isVisible = it.count() == 1),
                 MultiSelectBookmarkAction.DeleteBookmark,

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -28,6 +28,7 @@ import au.com.shiftyjelly.pocketcasts.views.dialog.ShareDialog
 import au.com.shiftyjelly.pocketcasts.views.helper.CloudDeleteHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.DeleteState
 import io.reactivex.BackpressureStrategy
+import io.sentry.Sentry
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -59,6 +60,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
         .toLiveData()
         .combineLatest(_selectedListLive)
         .map { (actions, selectedEpisodes) ->
+            Sentry.addBreadcrumb("MultiSelectEpisodesHelper toolbarActions updated (${actions.size}): ${actions.map { it::class.java.simpleName }}, ${selectedEpisodes.size} selectedEpisodes from $source")
             actions.mapNotNull {
                 MultiSelectEpisodeAction.actionForGroup(it.groupId, selectedEpisodes)
             }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectToolbar.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectToolbar.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.views.R
 import au.com.shiftyjelly.pocketcasts.views.extensions.tintIcons
 import dagger.hilt.android.AndroidEntryPoint
+import io.sentry.Sentry
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -44,6 +45,9 @@ class MultiSelectToolbar @JvmOverloads constructor(
         } else {
             multiSelectHelper.toolbarActions.removeObservers(lifecycleOwner)
             multiSelectHelper.toolbarActions.observe(lifecycleOwner) {
+
+                Sentry.addBreadcrumb("MultiSelectToolbar setup observed toolbarActionChange,$it from ${multiSelectHelper.source}")
+
                 menu.clear()
 
                 val maxIcons = multiSelectHelper.maxToolbarIcons


### PR DESCRIPTION
## Description
Although the number of ANRs is lower with `7.46`, they [are still happening](https://a8c.sentry.io/discover/results/?field=title&field=release&field=environment&field=user.display&field=timestamp&name=ApplicationNotResponding%3A+Background+ANR&project=6711064&query=issue%3APOCKET-CASTS-ANDROID-MR3+release.version%3A7.46&sort=-timestamp&statsPeriod=90d&yAxis=count%28%29), and I haven't been able to reproduce them. With this PR, I'm proposing adding some Sentry breadcrumbs around the `toolbarActions` changes to see if/how those may be contributing to the ANRs.

Based on the stacktraces in Sentry, it seems pretty likely that extra updates to the list of `toolbarActions` are causing the problem, but it's hard to be 100% sure. This will either disprove that theory, or (🤞) give us more information about what is causing the toolbar actions to change. My thinking is that we'll probably just revert this PR before we do the final `7.47` release since we will most likely be able to get the data we need from the beta releases.

My expectation is that we'll see a ton of these breadcrumbs when the ANRs happen, and they won't really show anything changing. If that happens, this won't point out the problem, but it will rule out a fair number of possible causes, which is still pretty useful.

This is just a proposal. Let me know what you think.

> **Note**
> This PR is targeting the `release/7.47` branch.

## Testing Instructions
Really shouldn't need to do any testing, but I guess you could smoke test multi-select to make sure there aren't any regresions.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes