### PR TITLE
Prefer suspended method for finding podcast by uuid

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -48,6 +49,7 @@ class AutoArchiveTest {
     val downloadManager = mock<DownloadManager> {}
     val podcastCacheServerManager = mock<PodcastCacheServerManager> {}
     val userEpisodeManager = mock<UserEpisodeManager> {}
+    val episodeAnalytics = EpisodeAnalytics(mock())
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private val testDispatcher = UnconfinedTestDispatcher()
@@ -76,7 +78,17 @@ class AutoArchiveTest {
             on { autoArchiveAfterPlaying } doReturn UserSetting.Mock(played, mock())
             on { autoArchiveIncludeStarred } doReturn UserSetting.Mock(includeStarred, mock())
         }
-        return EpisodeManagerImpl(settings, fileStorage, downloadManager, context, db, podcastCacheServerManager, userEpisodeManager, testDispatcher)
+        return EpisodeManagerImpl(
+            settings = settings,
+            fileStorage = fileStorage,
+            downloadManager = downloadManager,
+            context = context,
+            appDatabase = db,
+            podcastCacheServerManager = podcastCacheServerManager,
+            userEpisodeManager = userEpisodeManager,
+            ioDispatcher = testDispatcher,
+            episodeAnalytics = episodeAnalytics,
+        )
     }
 
     private fun podcastManagerThatReturns(podcast: Podcast): PodcastManager {

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -95,7 +96,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun testNever() {
+    fun testNever() = runTest {
         val uuid = UUID.randomUUID().toString()
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.Never, AutoArchiveInactiveSetting.Never, testDispatcher = testDispatcher)
         val podcast = Podcast(UUID.randomUUID().toString())
@@ -110,7 +111,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun testInactive30Days() {
+    fun testInactive30Days() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.Never, AutoArchiveInactiveSetting.Days30, testDispatcher = testDispatcher)
         val podcastUUID = UUID.randomUUID().toString()
         val podcast = Podcast(uuid = podcastUUID, isSubscribed = true)
@@ -136,7 +137,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun testPlayedRecently() {
+    fun testPlayedRecently() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.Never, AutoArchiveInactiveSetting.Days30, testDispatcher = testDispatcher)
         val podcastUUID = UUID.randomUUID().toString()
         val podcast = Podcast(uuid = podcastUUID, isSubscribed = true)
@@ -157,7 +158,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun testDownloadedRecently() {
+    fun testDownloadedRecently() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.Never, AutoArchiveInactiveSetting.Days30, testDispatcher = testDispatcher)
         val podcastUUID = UUID.randomUUID().toString()
         val podcast = Podcast(uuid = podcastUUID, isSubscribed = true)
@@ -178,7 +179,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun testPlayed24Hours() {
+    fun testPlayed24Hours() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.Hours24, AutoArchiveInactiveSetting.Never, testDispatcher = testDispatcher)
         val podcast = Podcast(UUID.randomUUID().toString())
         val podcastManager = podcastManagerThatReturns(podcast)
@@ -203,7 +204,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun testPlayedNotIncludeStarred() {
+    fun testPlayedNotIncludeStarred() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.Hours24, AutoArchiveInactiveSetting.Never, testDispatcher = testDispatcher)
         val podcast = Podcast(UUID.randomUUID().toString())
         val podcastManager = podcastManagerThatReturns(podcast)
@@ -228,7 +229,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun testPlayedIncludeStarred() {
+    fun testPlayedIncludeStarred() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.Hours24, AutoArchiveInactiveSetting.Never, includeStarred = true, testDispatcher = testDispatcher)
         val podcast = Podcast(UUID.randomUUID().toString())
         val podcastManager = podcastManagerThatReturns(podcast)
@@ -253,7 +254,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun inactiveNotIncludeStarred() {
+    fun inactiveNotIncludeStarred() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.Never, AutoArchiveInactiveSetting.Days30, testDispatcher = testDispatcher)
         val podcastUUID = UUID.randomUUID().toString()
         val podcast = Podcast(uuid = podcastUUID, isSubscribed = true)
@@ -279,7 +280,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun inactiveIncludeStarred() {
+    fun inactiveIncludeStarred() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.Never, AutoArchiveInactiveSetting.Days30, includeStarred = true, testDispatcher = testDispatcher)
         val podcastUUID = UUID.randomUUID().toString()
 
@@ -306,7 +307,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun inactiveArchiveModified() {
+    fun inactiveArchiveModified() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.Never, AutoArchiveInactiveSetting.Weeks1, includeStarred = true, testDispatcher = testDispatcher)
         val podcastUUID = UUID.randomUUID().toString()
 
@@ -343,7 +344,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun testPlayed24HoursPodcastOverride() {
+    fun testPlayed24HoursPodcastOverride() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.Never, AutoArchiveInactiveSetting.Never, testDispatcher = testDispatcher)
         val podcast = Podcast(UUID.randomUUID().toString(), overrideGlobalArchive = true, autoArchiveAfterPlaying = AutoArchiveAfterPlayingSetting.Hours24.toIndex())
         val podcastManager = podcastManagerThatReturns(podcast)
@@ -368,7 +369,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun testInactive30DaysPodcastOverride() {
+    fun testInactive30DaysPodcastOverride() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.Never, AutoArchiveInactiveSetting.Never, testDispatcher = testDispatcher)
         val podcastUUID = UUID.randomUUID().toString()
         val podcast = Podcast(uuid = podcastUUID, isSubscribed = true, overrideGlobalArchive = true, autoArchiveInactive = AutoArchiveInactiveSetting.Days30.toIndex())
@@ -394,7 +395,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun testInactive24HoursAddedRecentlyPodcastOverride() {
+    fun testInactive24HoursAddedRecentlyPodcastOverride() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.Never, AutoArchiveInactiveSetting.Never, testDispatcher = testDispatcher)
         val podcastUUID = UUID.randomUUID().toString()
         val podcast = Podcast(uuid = podcastUUID, isSubscribed = true, overrideGlobalArchive = true, autoArchiveInactive = AutoArchiveInactiveSetting.Hours24.toIndex())
@@ -420,7 +421,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun testInactive2DaysAndAfterPlayingPodcastOverride() {
+    fun testInactive2DaysAndAfterPlayingPodcastOverride() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.AfterPlaying, AutoArchiveInactiveSetting.Weeks2, testDispatcher = testDispatcher)
         val podcastUUID = UUID.randomUUID().toString()
         val podcast = Podcast(uuid = podcastUUID, isSubscribed = true, overrideGlobalArchive = true, autoArchiveInactive = AutoArchiveInactiveSetting.Days2.toIndex(), autoArchiveAfterPlaying = AutoArchiveAfterPlayingSetting.AfterPlaying.toIndex())
@@ -446,7 +447,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun testEpisodeLimit() {
+    fun testEpisodeLimit() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.Never, AutoArchiveInactiveSetting.Never, testDispatcher = testDispatcher)
         val podcast = Podcast(UUID.randomUUID().toString(), autoArchiveEpisodeLimit = 1, overrideGlobalArchive = true)
         val podcastManager = podcastManagerThatReturns(podcast)
@@ -471,7 +472,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun testEpisodeLimitIgnoresManualUnarchiveInCount() {
+    fun testEpisodeLimitIgnoresManualUnarchiveInCount() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.Never, AutoArchiveInactiveSetting.Never, testDispatcher = testDispatcher)
         val podcast = Podcast(UUID.randomUUID().toString(), autoArchiveEpisodeLimit = 0, overrideGlobalArchive = true)
         val podcastManager = podcastManagerThatReturns(podcast)
@@ -496,7 +497,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun testEpisodeLimitRespectsIgnoreGlobal() {
+    fun testEpisodeLimitRespectsIgnoreGlobal() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.Never, AutoArchiveInactiveSetting.Never, testDispatcher = testDispatcher)
         val podcast = Podcast(UUID.randomUUID().toString(), autoArchiveEpisodeLimit = 0, overrideGlobalArchive = false)
         val podcastManager = podcastManagerThatReturns(podcast)
@@ -516,7 +517,7 @@ class AutoArchiveTest {
     }
 
     @Test
-    fun testAddingInactiveEpisodeToUpNext() {
+    fun testAddingInactiveEpisodeToUpNext() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlayingSetting.Never, AutoArchiveInactiveSetting.Weeks1, includeStarred = true, testDispatcher = testDispatcher)
         val upNext = upNextQueueFor(testDb, episodeManager)
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTest.kt
@@ -55,7 +55,9 @@ class UpdateEpisodeDetailsTest {
         server.enqueue(finalResponse)
 
         val episode = PodcastEpisode(uuid = UUID.randomUUID().toString(), publishedDate = Date(), downloadUrl = firstUrl.toString())
-        val episodeManager = mock<EpisodeManager> { on { findByUuid(episode.uuid) }.doReturn(episode) }
+        val episodeManager = mock<EpisodeManager> {
+            onBlocking { findByUuid(episode.uuid) }.doReturn(episode)
+        }
 
         val episodeUuids = listOf(episode.uuid).toTypedArray()
         val data = Data.Builder().putStringArray(UpdateEpisodeDetailsTask.INPUT_EPISODE_UUIDS, episodeUuids).build()

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -214,7 +214,10 @@ class DiscoverViewModel @Inject constructor(
 
     fun findOrDownloadEpisode(discoverEpisode: DiscoverEpisode, success: (episode: PodcastEpisode) -> Unit) {
         podcastManager.findOrDownloadPodcastRx(discoverEpisode.podcast_uuid)
-            .flatMapMaybe { episodeManager.findByUuidRx(discoverEpisode.uuid) }
+            .flatMapMaybe {
+                @Suppress("DEPRECATION")
+                episodeManager.findByUuidRx(discoverEpisode.uuid)
+            }
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeBy(

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/PodcastListViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/PodcastListViewModel.kt
@@ -23,6 +23,7 @@ import io.reactivex.rxkotlin.addTo
 import io.reactivex.rxkotlin.combineLatest
 import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.rx2.rxMaybe
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -135,8 +136,9 @@ class PodcastListViewModel @Inject constructor(
     fun findOrDownloadEpisode(discoverEpisode: DiscoverEpisode, success: (episode: PodcastEpisode) -> Unit) {
         podcastManager.findOrDownloadPodcastRx(discoverEpisode.podcast_uuid)
             .flatMapMaybe {
-                @Suppress("DEPRECATION")
-                episodeManager.findByUuidRx(discoverEpisode.uuid)
+                rxMaybe {
+                    episodeManager.findByUuid(discoverEpisode.uuid)
+                }
             }
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/PodcastListViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/PodcastListViewModel.kt
@@ -134,7 +134,10 @@ class PodcastListViewModel @Inject constructor(
 
     fun findOrDownloadEpisode(discoverEpisode: DiscoverEpisode, success: (episode: PodcastEpisode) -> Unit) {
         podcastManager.findOrDownloadPodcastRx(discoverEpisode.podcast_uuid)
-            .flatMapMaybe { episodeManager.findByUuidRx(discoverEpisode.uuid) }
+            .flatMapMaybe {
+                @Suppress("DEPRECATION")
+                episodeManager.findByUuidRx(discoverEpisode.uuid)
+            }
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeBy(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkViewModel.kt
@@ -93,7 +93,7 @@ class BookmarkViewModel
                 val episodeUuid = arguments.episodeUuid
                 val isExistingBookmark = bookmarkUuid != null
                 val bookmark = if (bookmarkUuid == null) {
-                    val episode = episodeManager.findByUuidSuspend(episodeUuid)
+                    val episode = episodeManager.findByUuid(episodeUuid)
                         ?: userEpisodeManager.findEpisodeByUuid(episodeUuid)
                         ?: return@launch
                     bookmarkManager.add(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
+import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
@@ -569,9 +570,9 @@ class PlayerViewModel @Inject constructor(
     fun starToggle() {
         playbackManager.upNextQueue.currentEpisode?.let {
             if (it is PodcastEpisode) {
-                episodeManager.toggleStarEpisodeAsync(episode = it)
-                val event = if (it.isStarred) AnalyticsEvent.EPISODE_UNSTARRED else AnalyticsEvent.EPISODE_STARRED
-                episodeAnalytics.trackEvent(event, source, it.uuid)
+                viewModelScope.launch {
+                    episodeManager.toggleStarEpisode(episode = it, source)
+                }
             }
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.map
 import androidx.lifecycle.toLiveData
+import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
@@ -277,9 +278,9 @@ class EpisodeFragmentViewModel @Inject constructor(
 
     fun starClicked() {
         episode?.let { episode ->
-            episodeManager.toggleStarEpisodeAsync(episode)
-            val event = if (episode.isStarred) AnalyticsEvent.EPISODE_UNSTARRED else AnalyticsEvent.EPISODE_STARRED
-            episodeAnalytics.trackEvent(event, source, episode.uuid)
+            viewModelScope.launch {
+                episodeManager.toggleStarEpisode(episode, source)
+            }
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -100,7 +100,10 @@ class EpisodeFragmentViewModel @Inject constructor(
             Maybe.empty()
         }
 
-        val stateObservable: Flowable<EpisodeFragmentState> = episodeManager.findByUuidRx(episodeUuid)
+        @Suppress("DEPRECATION")
+        val maybeEpisode = episodeManager.findByUuidRx(episodeUuid)
+
+        val stateObservable: Flowable<EpisodeFragmentState> = maybeEpisode
             .switchIfEmpty(onEmptyHandler)
             .flatMapPublisher { episode ->
                 val zipper: Function4<PodcastEpisode, Podcast, ShowNotesState, Float, EpisodeFragmentState> = Function4 { episodeLoaded: PodcastEpisode, podcast: Podcast, showNotesState: ShowNotesState, downloadProgress: Float ->

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/addtoupnext/ActionRunnerAddToUpNext.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/addtoupnext/ActionRunnerAddToUpNext.kt
@@ -10,6 +10,7 @@ import com.joaomgcd.taskerpluginlibrary.input.TaskerInput
 import com.joaomgcd.taskerpluginlibrary.runner.TaskerPluginResult
 import com.joaomgcd.taskerpluginlibrary.runner.TaskerPluginResultError
 import com.joaomgcd.taskerpluginlibrary.runner.TaskerPluginResultSucess
+import kotlinx.coroutines.runBlocking
 
 private const val ERROR_NO_EPISODE_IDS_PROVIDED = 1
 private const val ERROR_NO_EPISODES_FOUND = 2
@@ -21,7 +22,11 @@ class ActionRunnerAddToUpNext : TaskerPluginRunnerActionNoOutput<InputAddToUpNex
         val episodeIds = regularInput.episodeIds
         val episodeIdsSplit = episodeIds?.split(",") ?: return TaskerPluginResultError(ERROR_NO_EPISODE_IDS_PROVIDED, context.getString(R.string.no_episode_ids_provided))
 
-        val episodesFromInput = episodeIdsSplit.mapNotNull { context.episodeManager.findByUuid(it) }
+        val episodesFromInput = episodeIdsSplit.mapNotNull {
+            runBlocking {
+                context.episodeManager.findByUuid(it)
+            }
+        }
         if (episodesFromInput.isEmpty()) return TaskerPluginResultError(ERROR_NO_EPISODES_FOUND, context.getString(R.string.no_episodes_found_for_episode_ids_x, episodeIds))
 
         val playbackManager = context.playbackManager

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -39,10 +39,10 @@ abstract class EpisodeDao {
     abstract fun observeCount(query: SupportSQLiteQuery): Flowable<Int>
 
     @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")
-    abstract fun findByUuid(uuid: String): PodcastEpisode?
+    abstract fun findByUuidSync(uuid: String): PodcastEpisode?
 
     @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")
-    abstract suspend fun findByUuidSuspend(uuid: String): PodcastEpisode?
+    abstract suspend fun findByUuid(uuid: String): PodcastEpisode?
 
     @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")
     abstract fun findByUuidRx(uuid: String): Maybe<PodcastEpisode>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -262,7 +262,7 @@ abstract class EpisodeDao {
     abstract fun findLatestEpisodeToPlay(): PodcastEpisode?
 
     @Query("UPDATE podcast_episodes SET starred = :starred, starred_modified = :modified WHERE uuid = :uuid")
-    abstract fun updateStarred(starred: Boolean, modified: Long, uuid: String)
+    abstract suspend fun updateStarred(starred: Boolean, modified: Long, uuid: String)
 
     @Query("UPDATE podcast_episodes SET starred = :starred, starred_modified = :modified WHERE uuid IN (:episodesUUIDs)")
     abstract suspend fun updateAllStarred(episodesUUIDs: List<String>, starred: Boolean, modified: Long)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.await
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -45,7 +46,9 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
             Timber.i("Downloading Meta Data for ${episodeUuids.size} episodes")
 
             for (episodeUuid in episodeUuids) {
-                val episode = episodeManager.findByUuid(episodeUuid) ?: continue
+                val episode = runBlocking {
+                    episodeManager.findByUuid(episodeUuid)
+                } ?: continue
                 val downloadUrl = episode.downloadUrl?.toHttpUrlOrNull() ?: continue
 
                 val client = OkHttpClient()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -11,7 +11,6 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.await
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -46,9 +45,7 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
             Timber.i("Downloading Meta Data for ${episodeUuids.size} episodes")
 
             for (episodeUuid in episodeUuids) {
-                val episode = runBlocking {
-                    episodeManager.findByUuid(episodeUuid)
-                } ?: continue
+                val episode = episodeManager.findByUuid(episodeUuid) ?: continue
                 val downloadUrl = episode.downloadUrl?.toHttpUrlOrNull() ?: continue
 
                 val client = OkHttpClient()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateEpisodeTask.kt
@@ -41,7 +41,7 @@ class UpdateEpisodeTask(val context: Context, val params: WorkerParameters) : Wo
             val appDatabase = AppDatabase.getInstance(context)
             val episodeDao = appDatabase.episodeDao()
 
-            val episode = episodeDao.findByUuid(episodeUUID)
+            val episode = episodeDao.findByUuidSync(episodeUUID)
             val serverEpisodeUrl = serverPodcast.episodes.firstOrNull()?.downloadUrl
             if (episode != null &&
                 serverEpisodeUrl != null &&

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.java
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.java
@@ -322,7 +322,8 @@ public class FileStorage {
 							if (fileName.length() < 36) {
 								continue;
 							}
-							PodcastEpisode episode = episodeManager.findByUuid(fileName);
+							//noinspection deprecation
+							PodcastEpisode episode = episodeManager.findByUuidSync(fileName);
 							if (episode != null) {
 								// Delete the original file if it is already there
 								if (!StringUtil.isBlank(episode.getDownloadedFilePath())) {
@@ -438,7 +439,8 @@ public class FileStorage {
 					if (uuid.length() != 36) {
 						continue;
 					}
-					PodcastEpisode episode = episodeManager.findByUuid(uuid);
+					//noinspection deprecation
+					PodcastEpisode episode = episodeManager.findByUuidSync(uuid);
 					if (episode != null) {
 						if (episode.getDownloadedFilePath() != null && new File(episode.getDownloadedFilePath()).exists() && episode.isDownloaded()) {
 							// skip as the episode download already exists

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -662,8 +662,7 @@ class MediaSessionManager(
             playbackManager.getCurrentEpisode()?.let {
                 if (it is PodcastEpisode) {
                     it.isStarred = true
-                    episodeManager.starEpisode(it, true)
-                    episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_STARRED, source, it.uuid)
+                    episodeManager.starEpisode(episode = it, starred = true, sourceView = source)
                 }
             }
         }
@@ -674,8 +673,7 @@ class MediaSessionManager(
             playbackManager.getCurrentEpisode()?.let {
                 if (it is PodcastEpisode) {
                     it.isStarred = false
-                    episodeManager.starEpisode(it, false)
-                    episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_UNSTARRED, source, it.uuid)
+                    episodeManager.starEpisode(episode = it, starred = false, sourceView = source)
                 }
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -24,9 +24,15 @@ interface EpisodeManager {
     fun getPodcastUuidToBadgeLatest(): Flowable<Map<String, Int>>
 
     /** Find methods  */
-    fun findByUuid(uuid: String): PodcastEpisode?
-    suspend fun findByUuidSuspend(uuid: String): PodcastEpisode?
+
+    suspend fun findByUuid(uuid: String): PodcastEpisode?
+
+    @Deprecated("Use findByUuid suspended function instead")
+    fun findByUuidSync(uuid: String): PodcastEpisode?
+
+    @Deprecated("Use findByUuid suspended function instead")
     fun findByUuidRx(uuid: String): Maybe<PodcastEpisode>
+
     fun observeByUuid(uuid: String): Flow<PodcastEpisode>
     fun observeEpisodeByUuidRx(uuid: String): Flowable<BaseEpisode>
     fun observeEpisodeByUuid(uuid: String): Flow<BaseEpisode>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import androidx.lifecycle.LiveData
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.db.helper.LongestEpisode
@@ -99,9 +100,9 @@ interface EpisodeManager {
     fun rxMarkAsPlayed(episode: PodcastEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager): Completable
     fun markAsPlaybackError(episode: BaseEpisode?, errorMessage: String?)
     fun markAsPlaybackError(episode: BaseEpisode?, event: PlayerEvent.PlayerError, isPlaybackRemote: Boolean)
-    fun starEpisode(episode: PodcastEpisode, starred: Boolean)
+    suspend fun starEpisode(episode: PodcastEpisode, starred: Boolean, sourceView: SourceView)
     suspend fun updateAllStarred(episodes: List<PodcastEpisode>, starred: Boolean)
-    fun toggleStarEpisodeAsync(episode: PodcastEpisode)
+    suspend fun toggleStarEpisode(episode: PodcastEpisode, sourceView: SourceView)
     fun clearPlaybackError(episode: BaseEpisode?)
     fun clearDownloadError(episode: PodcastEpisode?)
     fun archive(episode: PodcastEpisode, playbackManager: PlaybackManager, sync: Boolean = true)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -12,6 +12,8 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
@@ -52,9 +54,7 @@ import io.reactivex.Single
 import io.reactivex.rxkotlin.zipWith
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.merge
@@ -80,6 +80,7 @@ class EpisodeManagerImpl @Inject constructor(
     private val podcastCacheServerManager: PodcastCacheServerManager,
     private val userEpisodeManager: UserEpisodeManager,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    private val episodeAnalytics: EpisodeAnalytics,
 ) : EpisodeManager, CoroutineScope {
 
     override val coroutineContext: CoroutineContext
@@ -445,9 +446,12 @@ class EpisodeManagerImpl @Inject constructor(
         }
     }
 
-    override fun starEpisode(episode: PodcastEpisode, starred: Boolean) {
-        episode.isStarred = starred
+    override suspend fun starEpisode(episode: PodcastEpisode, starred: Boolean, sourceView: SourceView) {
         episodeDao.updateStarred(starred, System.currentTimeMillis(), episode.uuid)
+        val event =
+            if (starred) AnalyticsEvent.EPISODE_UNSTARRED
+            else AnalyticsEvent.EPISODE_STARRED
+        episodeAnalytics.trackEvent(event, sourceView, episode.uuid)
     }
 
     override suspend fun updateAllStarred(episodes: List<PodcastEpisode>, starred: Boolean) {
@@ -456,12 +460,10 @@ class EpisodeManagerImpl @Inject constructor(
         }
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
-    override fun toggleStarEpisodeAsync(episode: PodcastEpisode) {
-        GlobalScope.launch {
-            findByUuid(episode.uuid)?.let {
-                starEpisode(episode, !it.isStarred)
-            }
+    override suspend fun toggleStarEpisode(episode: PodcastEpisode, sourceView: SourceView) {
+        // Retrieve the episode to make sure we have the latest starred status
+        findByUuid(episode.uuid)?.let {
+            starEpisode(episode, !it.isStarred, sourceView)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 import java.util.Calendar
 import java.util.Date
@@ -681,7 +682,9 @@ class PodcastManagerImpl @Inject constructor(
 
         val uuidToAdded = HashMap<String, Boolean>()
         for (episodeUuid in episodeUuidsAdded) {
-            val episode = episodeManager.findByUuid(episodeUuid) ?: continue
+            val episode = runBlocking {
+                episodeManager.findByUuid(episodeUuid)
+            } ?: continue
             val autoDownload = podcastUuidToAutoDownload[episode.podcastUuid]
             Timber.i(
                 "Auto download " + episode.title +

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -45,6 +45,7 @@ import io.reactivex.schedulers.Schedulers
 import io.sentry.Sentry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxCompletable
 import org.json.JSONArray
 import org.json.JSONException
@@ -771,7 +772,9 @@ class PodcastSyncProcess(
         val uuid = episodeSync.uuid ?: return Maybe.empty()
 
         // check if the episode already exists
-        val episode = episodeManager.findByUuid(uuid)
+        val episode = runBlocking {
+            episodeManager.findByUuid(uuid)
+        }
         return if (episode == null) {
             Maybe.empty()
         } else {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -433,10 +433,9 @@ class EpisodeViewModel @Inject constructor(
                 return
             }
 
-            episodeManager.toggleStarEpisodeAsync(episode)
-            val event =
-                if (episode.isStarred) AnalyticsEvent.EPISODE_UNSTARRED else AnalyticsEvent.EPISODE_STARRED
-            episodeAnalytics.trackEvent(event, sourceView, episode.uuid)
+            viewModelScope.launch {
+                episodeManager.toggleStarEpisode(episode, sourceView)
+            }
         }
     }
 


### PR DESCRIPTION
## Description
This PR makes the suspended function for finding podcasts by id the preferred method by deprecating the other methods and removing the usages of the other methods where it is easy to do so. I did not remove all usages of the other methods because I wanted to keep this PR reviewable and reduce the risk of regressions. My thinking is that we'll be better off trying to remove the big RxJava chains when we are actually making changes to them because we'll be more familiar with what they're doing then and there will already be a risk of regression at that point since we'll be making changes.

I'm planning to make some more changes similar to this, so let me know if you think any other approach to this makes more sense.

## Testing Instructions
Smoke test interacting with a few podcasts in different ways (playing episodes, queueing episodes, filters, subscribing to podcasts, etc.).

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews