### PR TITLE
Make findFirstBySearchQuery a suspended function

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -60,7 +60,7 @@ abstract class EpisodeDao {
     abstract fun findByUuids(uuids: List<String>): List<PodcastEpisode>
 
     @Query("SELECT * FROM podcast_episodes WHERE UPPER(title) = UPPER(:query) LIMIT 1")
-    abstract fun findFirstBySearchQuery(query: String): PodcastEpisode?
+    abstract suspend fun findFirstBySearchQuery(query: String): PodcastEpisode?
 
     @Query("SELECT * FROM podcast_episodes WHERE last_playback_interaction_sync_status <> 1 AND last_playback_interaction_date IS NOT NULL ORDER BY last_playback_interaction_date DESC LIMIT 1000")
     abstract fun findEpisodesForHistorySync(): List<PodcastEpisode>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -30,7 +30,7 @@ interface EpisodeManager {
     fun observeByUuid(uuid: String): Flow<PodcastEpisode>
     fun observeEpisodeByUuidRx(uuid: String): Flowable<BaseEpisode>
     fun observeEpisodeByUuid(uuid: String): Flow<BaseEpisode>
-    fun findFirstBySearchQuery(query: String): PodcastEpisode?
+    suspend fun findFirstBySearchQuery(query: String): PodcastEpisode?
 
     fun findAll(rowParser: (PodcastEpisode) -> Boolean)
     fun findEpisodesWhere(queryAfterWhere: String, forSubscribedPodcastsOnly: Boolean = true): List<PodcastEpisode>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -125,9 +125,8 @@ class EpisodeManagerImpl @Inject constructor(
             userEpisodeManager.observeEpisode(uuid) // if it is a UserEpisode
         ).filterNotNull() // because it is not going to be both a PodcastEpisode and a UserEpisode
 
-    override fun findFirstBySearchQuery(query: String): PodcastEpisode? {
-        return episodeDao.findFirstBySearchQuery(query)
-    }
+    override suspend fun findFirstBySearchQuery(query: String): PodcastEpisode? =
+        episodeDao.findFirstBySearchQuery(query)
 
     @Suppress("DEPRECATION")
     override fun findAll(rowParser: (PodcastEpisode) -> Boolean) {


### PR DESCRIPTION
One small step toward making sure we use coroutines when hitting the database. This didn't require any changes [at the callsite](https://github.com/Automattic/pocket-casts-android/blob/c46d2c44fa9cd37c1669b4df310976a0e2b4e8cd/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt#L776) since that was already running a coroutine.

## Testing Instructions
1. Fresh install the app
2. Subscribe to "The Big Flop"
3. Run the following command: `adb shell am start -a android.media.action.MEDIA_PLAY_FROM_SEARCH -p au.com.shiftyjelly.pocketcasts.debug --es query "Introducing:\ The\ Big\ Flop"`
4. Observe that the episode with that name starts playing.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews