### PR TITLE
Give `debug` and `debugProd` buildTypes different icons

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,9 @@ android {
 
         debugProd {
             initWith debug
+            manifestPlaceholders += [
+                    appIcon: "@mipmap/ic_launcher_3",
+            ]
         }
 
         release {


### PR DESCRIPTION
## Description
Doing this to make it more obvious when we're using a build of the app that is hitting the staging server.

## Testing Instructions
Verify the app uses the following icons

| debug | debugProd | release |
| --- | --- | --- |
| The `debug` icon has not changed. | | The `release` icon has not changed |
| ![image](https://github.com/Automattic/pocket-casts-android/assets/4656348/17aeae75-47a6-4677-8ec4-69d7b6ae699d) |  ![image](https://github.com/Automattic/pocket-casts-android/assets/4656348/a1c8b66f-f24c-437d-8111-3024cd226759) | ![image](https://github.com/Automattic/pocket-casts-android/assets/4656348/c280cf08-dfa4-4729-862b-b3902cfc89ff) |

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack
