### PR TITLE
Make star method a suspended function

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -48,6 +49,7 @@ class AutoArchiveTest {
     val downloadManager = mock<DownloadManager> {}
     val podcastCacheServerManager = mock<PodcastCacheServerManager> {}
     val userEpisodeManager = mock<UserEpisodeManager> {}
+    val episodeAnalytics = EpisodeAnalytics(mock())
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private val testDispatcher = UnconfinedTestDispatcher()
@@ -76,7 +78,17 @@ class AutoArchiveTest {
             on { autoArchiveAfterPlaying } doReturn UserSetting.Mock(played, mock())
             on { autoArchiveIncludeStarred } doReturn UserSetting.Mock(includeStarred, mock())
         }
-        return EpisodeManagerImpl(settings, fileStorage, downloadManager, context, db, podcastCacheServerManager, userEpisodeManager, testDispatcher)
+        return EpisodeManagerImpl(
+            settings = settings,
+            fileStorage = fileStorage,
+            downloadManager = downloadManager,
+            context = context,
+            appDatabase = db,
+            podcastCacheServerManager = podcastCacheServerManager,
+            userEpisodeManager = userEpisodeManager,
+            ioDispatcher = testDispatcher,
+            episodeAnalytics = episodeAnalytics,
+        )
     }
 
     private fun podcastManagerThatReturns(podcast: Podcast): PodcastManager {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
+import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
@@ -569,9 +570,9 @@ class PlayerViewModel @Inject constructor(
     fun starToggle() {
         playbackManager.upNextQueue.currentEpisode?.let {
             if (it is PodcastEpisode) {
-                episodeManager.toggleStarEpisodeAsync(episode = it)
-                val event = if (it.isStarred) AnalyticsEvent.EPISODE_UNSTARRED else AnalyticsEvent.EPISODE_STARRED
-                episodeAnalytics.trackEvent(event, source, it.uuid)
+                viewModelScope.launch {
+                    episodeManager.toggleStarEpisode(episode = it, source)
+                }
             }
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.map
 import androidx.lifecycle.toLiveData
+import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
@@ -277,9 +278,9 @@ class EpisodeFragmentViewModel @Inject constructor(
 
     fun starClicked() {
         episode?.let { episode ->
-            episodeManager.toggleStarEpisodeAsync(episode)
-            val event = if (episode.isStarred) AnalyticsEvent.EPISODE_UNSTARRED else AnalyticsEvent.EPISODE_STARRED
-            episodeAnalytics.trackEvent(event, source, episode.uuid)
+            viewModelScope.launch {
+                episodeManager.toggleStarEpisode(episode, source)
+            }
         }
     }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -262,7 +262,7 @@ abstract class EpisodeDao {
     abstract fun findLatestEpisodeToPlay(): PodcastEpisode?
 
     @Query("UPDATE podcast_episodes SET starred = :starred, starred_modified = :modified WHERE uuid = :uuid")
-    abstract fun updateStarred(starred: Boolean, modified: Long, uuid: String)
+    abstract suspend fun updateStarred(starred: Boolean, modified: Long, uuid: String)
 
     @Query("UPDATE podcast_episodes SET starred = :starred, starred_modified = :modified WHERE uuid IN (:episodesUUIDs)")
     abstract suspend fun updateAllStarred(episodesUUIDs: List<String>, starred: Boolean, modified: Long)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -662,8 +662,7 @@ class MediaSessionManager(
             playbackManager.getCurrentEpisode()?.let {
                 if (it is PodcastEpisode) {
                     it.isStarred = true
-                    episodeManager.starEpisode(it, true)
-                    episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_STARRED, source, it.uuid)
+                    episodeManager.starEpisode(episode = it, starred = true, sourceView = source)
                 }
             }
         }
@@ -674,8 +673,7 @@ class MediaSessionManager(
             playbackManager.getCurrentEpisode()?.let {
                 if (it is PodcastEpisode) {
                     it.isStarred = false
-                    episodeManager.starEpisode(it, false)
-                    episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_UNSTARRED, source, it.uuid)
+                    episodeManager.starEpisode(episode = it, starred = false, sourceView = source)
                 }
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import androidx.lifecycle.LiveData
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.db.helper.LongestEpisode
@@ -99,9 +100,9 @@ interface EpisodeManager {
     fun rxMarkAsPlayed(episode: PodcastEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager): Completable
     fun markAsPlaybackError(episode: BaseEpisode?, errorMessage: String?)
     fun markAsPlaybackError(episode: BaseEpisode?, event: PlayerEvent.PlayerError, isPlaybackRemote: Boolean)
-    fun starEpisode(episode: PodcastEpisode, starred: Boolean)
+    suspend fun starEpisode(episode: PodcastEpisode, starred: Boolean, sourceView: SourceView)
     suspend fun updateAllStarred(episodes: List<PodcastEpisode>, starred: Boolean)
-    fun toggleStarEpisodeAsync(episode: PodcastEpisode)
+    suspend fun toggleStarEpisode(episode: PodcastEpisode, sourceView: SourceView)
     fun clearPlaybackError(episode: BaseEpisode?)
     fun clearDownloadError(episode: PodcastEpisode?)
     fun archive(episode: PodcastEpisode, playbackManager: PlaybackManager, sync: Boolean = true)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -447,7 +447,6 @@ class EpisodeManagerImpl @Inject constructor(
     }
 
     override suspend fun starEpisode(episode: PodcastEpisode, starred: Boolean, sourceView: SourceView) {
-        episode.isStarred = starred
         episodeDao.updateStarred(starred, System.currentTimeMillis(), episode.uuid)
         val event =
             if (starred) AnalyticsEvent.EPISODE_UNSTARRED

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -433,10 +433,9 @@ class EpisodeViewModel @Inject constructor(
                 return
             }
 
-            episodeManager.toggleStarEpisodeAsync(episode)
-            val event =
-                if (episode.isStarred) AnalyticsEvent.EPISODE_UNSTARRED else AnalyticsEvent.EPISODE_STARRED
-            episodeAnalytics.trackEvent(event, sourceView, episode.uuid)
+            viewModelScope.launch {
+                episodeManager.toggleStarEpisode(episode, sourceView)
+            }
         }
     }
 


### PR DESCRIPTION
## Description
This updates the star methods to be suspended functions. This avoids us needing to launch new coroutines within the `EpisodeManager`.

As part of this, I moved the tracks event logic into the `EpisodeManagerImpl` to avoid duplicating in all the view models where we update an episode's starred status.

## Testing Instructions
Test starring/unstarring episodes
1. From the media notification
2. From the episode details screen
3. From multiselect on the podcast screen
4. From the now playing screen
5. From the watch app

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
