### PR TITLE
Update multi select toolbars setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 -----
 
 
+7.46.1
+------
+*   Bug Fixes:
+    *   Improved multi-select toolbars setup
+        ([#1338](https://github.com/Automattic/pocket-casts-android/pull/1338))
+
 7.46
 -----
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -21,6 +21,8 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
@@ -73,6 +75,7 @@ import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectHelper
+import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -637,17 +640,32 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
 
         binding.episodesRecyclerView.requestFocus()
 
-        multiSelectEpisodesHelper.setUp()
-        multiSelectBookmarksHelper.setUp()
-
         return binding.root
     }
 
-    fun <T> MultiSelectHelper<T>.setUp() {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding?.setupMultiSelect()
+    }
+
+    private fun FragmentPodcastBinding.setupMultiSelect() {
+        multiSelectEpisodesHelper.setUp(multiSelectEpisodesToolbar)
+        if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+            multiSelectBookmarksHelper.setUp(multiSelectBookmarksToolbar)
+        }
+    }
+
+    fun <T> MultiSelectHelper<T>.setUp(multiSelectToolbar: MultiSelectToolbar) {
+        multiSelectToolbar.setup(
+            lifecycleOwner = viewLifecycleOwner,
+            multiSelectHelper = this,
+            menuRes = null,
+            fragmentManager = parentFragmentManager,
+        )
         isMultiSelectingLive.observe(viewLifecycleOwner) {
             val episodeContainerFragment = parentFragmentManager.findFragmentByTag(EPISODE_CARD)
             if (episodeContainerFragment != null) return@observe
-            binding?.multiSelectToolbar?.isVisible = it
+            multiSelectToolbar.isVisible = it
             binding?.toolbar?.isVisible = !it
             adapter?.notifyDataSetChanged()
         }
@@ -740,13 +758,6 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                     addPaddingForEpisodeSearch(state.episodes)
                     when (state.showTab) {
                         PodcastTab.EPISODES -> {
-                            binding?.multiSelectToolbar?.setup(
-                                lifecycleOwner = viewLifecycleOwner,
-                                multiSelectHelper = multiSelectEpisodesHelper,
-                                menuRes = null,
-                                fragmentManager = parentFragmentManager,
-                            )
-
                             adapter?.setEpisodes(
                                 episodes = state.episodes,
                                 showingArchived = state.showingArchived,
@@ -760,13 +771,6 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener, Corouti
                             )
                         }
                         PodcastTab.BOOKMARKS -> {
-                            binding?.multiSelectToolbar?.setup(
-                                lifecycleOwner = viewLifecycleOwner,
-                                multiSelectHelper = multiSelectBookmarksHelper,
-                                menuRes = null,
-                                fragmentManager = parentFragmentManager,
-                            )
-
                             adapter?.setBookmarks(
                                 bookmarks = state.bookmarks,
                                 searchTerm = state.searchBookmarkTerm,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -193,6 +193,10 @@ class PodcastViewModel
     }
 
     fun onTabClicked(tab: PodcastTab) {
+        when (tab) {
+            PodcastTab.EPISODES -> multiSelectBookmarksHelper.closeMultiSelect()
+            PodcastTab.BOOKMARKS -> multiSelectEpisodesHelper.closeMultiSelect()
+        }
         analyticsTracker.track(AnalyticsEvent.PODCASTS_SCREEN_TAB_TAPPED, mapOf("value" to tab.analyticsValue))
         _uiState.value = (uiState.value as? UiState.Loaded)?.copy(showTab = tab)
     }

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
@@ -35,7 +35,15 @@
             app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
 
         <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
-            android:id="@+id/multiSelectToolbar"
+            android:id="@+id/multiSelectEpisodesToolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="?android:attr/actionBarSize"
+            app:navigationIcon="?attr/homeAsUpIndicator"
+            android:visibility="gone"/>
+
+        <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
+            android:id="@+id/multiSelectBookmarksToolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:minHeight="?android:attr/actionBarSize"


### PR DESCRIPTION
## Description
This cherry-picks updates to multi-select toolbar setup from `main` into release 7.46.1.
Slack discussion p1693977647570579/1693648601.805499-slack-C028JAG44VD

> **warning**
> Targets 7.46.1

## Testing Instructions
The changes were already tested as part of https://github.com/Automattic/pocket-casts-android/pull/1338. Smoke test that episode multi-select works on podcast details screen.

## Screenshots or Screencast 


https://github.com/Automattic/pocket-casts-android/assets/1405144/b3c1abf1-23a2-460f-a146-9942c6a2a673



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack