### PR TITLE
Remove toast message when episode duration diff changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@
 *   Updates:
     *   Enable copying logs from in-app logs viewer
         ([#1298](https://github.com/Automattic/pocket-casts-android/pull/1298))
-    *   Present toast notification when duration of an in-progress episode changes
-        ([#1312](https://github.com/Automattic/pocket-casts-android/pull/1312))
     *   Present app review prompt 
         ([#1305](https://github.com/Automattic/pocket-casts-android/pull/1305))
     *   Updated storage limit title

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -152,7 +152,6 @@
     <string name="support">Support</string>
     <string name="go_to_top">Go to top</string>
     <string name="go_to_bottom">Go to bottom</string>
-    <string name="episode_duration_change">"This episode's duration has changed by %d seconds"</string>
 
     <string name="multiselect_actions_shown">Shortcut in toolbar</string>
     <string name="multiselect_actions_hidden">In overflow</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1294,20 +1294,12 @@ open class PlaybackManager @Inject constructor(
 
         val durationDiffSeconds = (durationMs - episode.durationMs) / 1000
         if (abs(durationDiffSeconds) > 0) {
-            val notifyUser = abs(durationDiffSeconds) > 30
-            if (notifyUser) {
-                LogBuffer.e(LogBuffer.TAG_PLAYBACK, "The total episode duration has changed significantly ($durationDiffSeconds seconds)")
-                launch(Dispatchers.Main) {
-                    val message = application.getString(LR.string.episode_duration_change, durationDiffSeconds)
-                    Toast.makeText(application, message, Toast.LENGTH_LONG).show()
-                }
-            }
+            LogBuffer.i(LogBuffer.TAG_PLAYBACK, "The total episode duration has changed by $durationDiffSeconds seconds")
             analyticsTracker.track(
                 AnalyticsEvent.PLAYBACK_EPISODE_DURATION_CHANGED,
                 mapOf(
                     "duration_change" to durationDiffSeconds,
                     "duration" to durationMs / 1000,
-                    "notified_user" to notifyUser,
                     "is_user_file" to (episode is UserEpisode),
                     "is_downloaded" to episode.isDownloaded,
                     "episode_uuid" to episode.uuid,


### PR DESCRIPTION
## Description
It looks like the episode duration diff toast might get shown more than I anticipated, so let's remove it for the time being.

> **Note**
> This PR is targeting `release/7.47`, but I don't think we need to rush out a new beta for this.

## Testing Instructions
1. Play "Monday Morning Podcast 9-4-23" from Bill Burr's Monday Morning Podcast
2. Observe that the logs contain a message about the episode duration changing when you start playing the episode
3. Observe that there is _not_ a toast message shown to the user

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
