### PR TITLE
Add podcast uuid to support logs when playing episode

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1823,7 +1823,7 @@ open class PlaybackManager @Inject constructor(
             episode.isAudio,
             episode.downloadUrl ?: "_",
             episode.uuid,
-            (episode as? PodcastEpisode)?.podcastUuid ?: "_",
+            (episode as? PodcastEpisode)?.podcastUuid ?: "User File",
         )
 
         player?.play(currentTimeMs)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1814,10 +1814,16 @@ open class PlaybackManager @Inject constructor(
 
         val currentTimeMs = resumptionHelper.adjustedStartTimeMsFor(episode)
         LogBuffer.i(
-            LogBuffer.TAG_PLAYBACK, "Play %.3f %s Player. %s Downloaded: %b Downloading: %b Audio: %b File: %s Uuid: %s", currentTimeMs / 1000f,
-            player?.name
-                ?: "",
-            episode.title, episode.isDownloaded, episode.isDownloading, episode.isAudio, episode.downloadUrl ?: "", episode.uuid
+            LogBuffer.TAG_PLAYBACK, "Play %.3f %s Player. %s Downloaded: %b, Downloading: %b, Audio: %b, File: %s, EpisodeUuid: %s, PodcastUuid: %s",
+            currentTimeMs / 1000f,
+            player?.name ?: "_",
+            episode.title,
+            episode.isDownloaded,
+            episode.isDownloading,
+            episode.isAudio,
+            episode.downloadUrl ?: "_",
+            episode.uuid,
+            (episode as? PodcastEpisode)?.podcastUuid ?: "_",
         )
 
         player?.play(currentTimeMs)


### PR DESCRIPTION
## Description
This adds the podcast uuid to the support logs when an episode is played because our support team has told us that sometimes it isn't obvious from the logs what podcast an episode comes from. internal ref: pdzxoO-fr-p2#comment-352

I also used "_" as the placeholder for missing values instead of the empty string because I thought that would make it easier to see in the support logs that a value is missing. Let me know if you disagree though.

## Testing Instructions
1. Play an episode
2. Verify that the relevant support log line starting with "Playback: Play" includes the podcast uuid at the end of the line.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews