### PR TITLE
Make markPlayed and Unplayed suspend functions

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -614,7 +614,8 @@ class MainActivity :
             episodeManager = episodeManager,
             fragmentManager = supportFragmentManager,
             analyticsTracker = analyticsTracker,
-            episodeAnalytics = episodeAnalytics
+            episodeAnalytics = episodeAnalytics,
+            coroutineScope = this,
         ).show(this)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -648,11 +648,10 @@ class MediaSessionManager(
     }
 
     private fun markAsPlayed() {
-        launch {
-            val episode = playbackManager.getCurrentEpisode()
-            episodeManager.markAsPlayed(episode, playbackManager, podcastManager)
-            episode?.let {
-                episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_MARKED_AS_PLAYED, source, it.uuid)
+        playbackManager.getCurrentEpisode()?.let { episode ->
+            launch {
+                episodeManager.markAsPlayed(episode, playbackManager, podcastManager)
+                episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_MARKED_AS_PLAYED, source, episode.uuid)
             }
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1112,7 +1112,12 @@ open class PlaybackManager @Inject constructor(
 
             // auto archive after playing
             if (episode is PodcastEpisode) {
-                episodeManager.archivePlayedEpisode(episode, this, podcastManager, sync = true)
+                episodeManager.archivePlayedEpisode(
+                    episode = episode,
+                    playbackManager = this,
+                    podcastManager = podcastManager,
+                    sync = true,
+                )
             } else if (episode is UserEpisode) {
                 userEpisodeManager.deletePlayedEpisodeIfReq(episode, this)
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -12,7 +12,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayerEvent
-import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Maybe
 import io.reactivex.Single
@@ -94,10 +93,8 @@ interface EpisodeManager {
     fun markAsNotPlayed(episode: BaseEpisode?)
     fun markAsNotPlayedRx(episode: PodcastEpisode): Single<PodcastEpisode>
     suspend fun markAllAsPlayed(episodes: List<BaseEpisode>, playbackManager: PlaybackManager, podcastManager: PodcastManager)
-    fun markedAsPlayedExternally(episode: PodcastEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager)
-    fun markAsPlayedAsync(episode: BaseEpisode?, playbackManager: PlaybackManager, podcastManager: PodcastManager)
-    fun markAsPlayed(episode: BaseEpisode?, playbackManager: PlaybackManager, podcastManager: PodcastManager)
-    fun rxMarkAsPlayed(episode: PodcastEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager): Completable
+    suspend fun markedAsPlayedExternally(episode: PodcastEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager)
+    suspend fun markAsPlayed(episode: BaseEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager)
     fun markAsPlaybackError(episode: BaseEpisode?, errorMessage: String?)
     fun markAsPlaybackError(episode: BaseEpisode?, event: PlayerEvent.PlayerError, isPlaybackRemote: Boolean)
     suspend fun starEpisode(episode: PodcastEpisode, starred: Boolean, sourceView: SourceView)
@@ -106,7 +103,7 @@ interface EpisodeManager {
     fun clearPlaybackError(episode: BaseEpisode?)
     fun clearDownloadError(episode: PodcastEpisode?)
     fun archive(episode: PodcastEpisode, playbackManager: PlaybackManager, sync: Boolean = true)
-    fun archivePlayedEpisode(episode: BaseEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager, sync: Boolean)
+    suspend fun archivePlayedEpisode(episode: BaseEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager, sync: Boolean)
     fun unarchive(episode: BaseEpisode)
     suspend fun archiveAllInList(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager?)
     fun checkForEpisodesToAutoArchive(playbackManager: PlaybackManager?, podcastManager: PodcastManager)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -93,8 +93,12 @@ interface EpisodeManager {
     fun markAsNotPlayed(episode: BaseEpisode?)
     fun markAsNotPlayedRx(episode: PodcastEpisode): Single<PodcastEpisode>
     suspend fun markAllAsPlayed(episodes: List<BaseEpisode>, playbackManager: PlaybackManager, podcastManager: PodcastManager)
-    suspend fun markedAsPlayedExternally(episode: PodcastEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager)
-    suspend fun markAsPlayed(episode: BaseEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager)
+    suspend fun markAsPlayed(
+        episode: BaseEpisode,
+        playbackManager: PlaybackManager,
+        podcastManager: PodcastManager,
+        fromExternalSource: Boolean = false,
+    )
     fun markAsPlaybackError(episode: BaseEpisode?, errorMessage: String?)
     fun markAsPlaybackError(episode: BaseEpisode?, event: PlayerEvent.PlayerError, isPlaybackRemote: Boolean)
     suspend fun starEpisode(episode: PodcastEpisode, starred: Boolean, sourceView: SourceView)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -139,7 +139,7 @@ interface EpisodeManager {
     fun checkPodcastForEpisodeLimit(podcast: Podcast, playbackManager: PlaybackManager?)
     fun checkPodcastForAutoArchive(podcast: Podcast, playbackManager: PlaybackManager?)
     fun episodeCanBeCleanedUp(episode: PodcastEpisode, playbackManager: PlaybackManager): Boolean
-    fun markAsUnplayed(episodes: List<BaseEpisode>)
+    suspend fun markAsUnplayed(episodes: List<BaseEpisode>)
     fun unarchiveAllInListAsync(episodes: List<PodcastEpisode>)
     suspend fun findEpisodeByUuid(uuid: String): BaseEpisode?
     fun observeDownloadingEpisodesRx(): Flowable<List<BaseEpisode>>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -499,17 +499,15 @@ class EpisodeManagerImpl @Inject constructor(
         userEpisodeManager.markAllAsPlayed(episodes.filterIsInstance<UserEpisode>(), playbackManager)
     }
 
-    override fun markAsUnplayed(episodes: List<BaseEpisode>) {
-        launch {
-            val justEpisodes = episodes.filterIsInstance<PodcastEpisode>()
-            justEpisodes.chunked(500).forEach {
-                episodeDao.markAllUnplayed(it.map { it.uuid }, System.currentTimeMillis())
-            }
-            unarchiveAllInList(justEpisodes)
-
-            val justUserEpisodes = episodes.filterIsInstance<UserEpisode>()
-            userEpisodeManager.markAllAsUnplayed(justUserEpisodes)
+    override suspend fun markAsUnplayed(episodes: List<BaseEpisode>) {
+        val justEpisodes = episodes.filterIsInstance<PodcastEpisode>()
+        justEpisodes.chunked(500).forEach {
+            episodeDao.markAllUnplayed(it.map { it.uuid }, System.currentTimeMillis())
         }
+        unarchiveAllInList(justEpisodes)
+
+        val justUserEpisodes = episodes.filterIsInstance<UserEpisode>()
+        userEpisodeManager.markAllAsUnplayed(justUserEpisodes)
     }
 
     override fun markedAsPlayedExternally(episode: PodcastEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -509,28 +509,23 @@ class EpisodeManagerImpl @Inject constructor(
         userEpisodeManager.markAllAsUnplayed(justUserEpisodes)
     }
 
-    override suspend fun markedAsPlayedExternally(episode: PodcastEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager) {
+    override suspend fun markAsPlayed(
+        episode: BaseEpisode,
+        playbackManager: PlaybackManager,
+        podcastManager: PodcastManager,
+        fromExternalSource: Boolean,
+    ) {
         playbackManager.removeEpisode(episode, source = SourceView.UNKNOWN, userInitiated = false)
+
+        if (!fromExternalSource) {
+            episode.playingStatus = EpisodePlayingStatus.COMPLETED
+            updatePlayingStatus(episode, EpisodePlayingStatus.COMPLETED)
+        }
 
         // Auto archive after playing if the episode isn't already archived
         if (!episode.isArchived) {
             archivePlayedEpisode(episode, playbackManager, podcastManager, sync = true)
         }
-    }
-
-    override suspend fun markAsPlayed(
-        episode: BaseEpisode,
-        playbackManager: PlaybackManager,
-        podcastManager: PodcastManager,
-    ) {
-        playbackManager.removeEpisode(episode, source = SourceView.UNKNOWN, userInitiated = false)
-
-        episode.playingStatus = EpisodePlayingStatus.COMPLETED
-
-        updatePlayingStatus(episode, EpisodePlayingStatus.COMPLETED)
-
-        // Auto archive after playing
-        archivePlayedEpisode(episode, playbackManager, podcastManager, sync = true)
     }
 
     override fun deleteEpisodesWithoutSync(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -828,7 +828,9 @@ class PodcastSyncProcess(
                     episode.playingStatusModified = null
                     episode.playingStatus = newPlayingStatus
                     if (episode.isFinished) {
-                        episodeManager.markedAsPlayedExternally(episode, playbackManager, podcastManager)
+                        runBlocking {
+                            episodeManager.markedAsPlayedExternally(episode, playbackManager, podcastManager)
+                        }
                     }
                 }
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -829,7 +829,7 @@ class PodcastSyncProcess(
                     episode.playingStatus = newPlayingStatus
                     if (episode.isFinished) {
                         runBlocking {
-                            episodeManager.markedAsPlayedExternally(episode, playbackManager, podcastManager)
+                            episodeManager.markAsPlayed(episode, playbackManager, podcastManager, fromExternalSource = true)
                         }
                     }
                 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -190,7 +190,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
 
             episodeManager.markAsUnplayed(list)
             episodeAnalytics.trackBulkEvent(AnalyticsEvent.EPISODE_BULK_MARKED_AS_UNPLAYED, source, list.size)
-            launch(Dispatchers.Main) {
+            withContext(Dispatchers.Main) {
                 val snackText = resources.getStringPlural(selectedList.size, LR.string.marked_as_unplayed_singular, LR.string.marked_as_unplayed_plural)
                 showSnackBar(snackText)
                 closeMultiSelect()


### PR DESCRIPTION
## Description
This reduces how often the episodeManager launches new coroutines.

## Testing Instructions

### 1. markAllAsUnplayed
1. Use multiselect to select a bunch of played episodes
2. Observe that marking them all as unplayed by selecting the mark as unplayed option in the multiselect toolbar still works as expected.

### 2. markAsPlayed
Archive an episode from within the app:
* Now Playing bottom sheet
* Episode details screen

### 3. markAsPlayed from external source
1. Log into an account on your phone
2. Start playing an episode
3. Pause the episode
4. Sync the app
5. Log into the same account on the web
6. Finish playing the episode
7. On your phone, sync the app again
8. Verify that the episode you completed on the web is now archived

### 4. archivePlayedEpisode
1. Start playing an episode
2. Complete playing the episode
3. Verify that the episode is archived

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews