### PR TITLE
Watch app: Remove login by email and password screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 7.48
 -----
 
+*   Updates:
+    *   Removed login by email and password on WearOS app
+        ([#1356](https://github.com/Automattic/pocket-casts-android/pull/1356))
 
 7.47
 -----

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -334,9 +334,6 @@ fun WearApp(
 
         authenticationNavGraph(
             navController = navController,
-            onEmailSignInSuccess = {
-                navController.navigate(LoggingInScreen.route)
-            },
             googleSignInSuccessScreen = { googleSignInAccount ->
                 LoggingInScreen(
                     avatarUrl = googleSignInAccount?.photoUrl?.toString(),

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
@@ -5,7 +5,6 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.navigation
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
-import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
 import com.google.android.horologist.compose.navscaffold.composable
 import com.google.android.horologist.compose.navscaffold.scrollable
 
@@ -15,12 +14,10 @@ private object AuthenticationNavRoutes {
     const val loginScreen = "login_screen"
     const val loginWithGoogle = "login_with_google"
     const val loginWithPhone = "login_with_phone"
-    const val loginWithEmail = "login_with_email"
 }
 
 fun NavGraphBuilder.authenticationNavGraph(
     navController: NavController,
-    onEmailSignInSuccess: () -> Unit,
     googleSignInSuccessScreen: @Composable (GoogleSignInAccount?) -> Unit,
 ) {
     navigation(startDestination = AuthenticationNavRoutes.loginScreen, route = authenticationSubGraph) {
@@ -34,16 +31,6 @@ fun NavGraphBuilder.authenticationNavGraph(
                 onLoginWithPhoneClick = {
                     navController.navigate(AuthenticationNavRoutes.loginWithPhone)
                 },
-                onLoginWithEmailClick = {
-                    navController.navigate(AuthenticationNavRoutes.loginWithEmail)
-                },
-            )
-        }
-
-        composable(AuthenticationNavRoutes.loginWithEmail) {
-            it.viewModel.timeTextMode = NavScaffoldViewModel.TimeTextMode.Off
-            LoginWithEmailScreen(
-                onSignInSuccess = onEmailSignInSuccess
             )
         }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginScreen.kt
@@ -15,7 +15,6 @@ fun LoginScreen(
     columnState: ScalingLazyColumnState,
     onLoginWithGoogleClick: () -> Unit,
     onLoginWithPhoneClick: () -> Unit,
-    onLoginWithEmailClick: () -> Unit,
 ) {
 
     val viewModel = hiltViewModel<LoginViewModel>()
@@ -47,18 +46,6 @@ fun LoginScreen(
                 onClick = {
                     viewModel.onPhoneLoginClicked()
                     onLoginWithPhoneClick()
-                },
-            )
-        }
-
-        item {
-            Chip(
-                labelId = LR.string.log_in_with_email,
-                colors = ChipDefaults.secondaryChipColors(),
-                icon = IR.drawable.ic_email_white_24dp,
-                onClick = {
-                    viewModel.onEmailLoginClicked()
-                    onLoginWithEmailClick()
                 },
             )
         }


### PR DESCRIPTION
## Description
This removes login by email and password in the watch app to meet [WO-P6](https://developer.android.com/docs/quality-guidelines/wear-app-quality#:~:text=Identity,Wear%20OS%20device.) guideline.

> Your app must not ask the user to input a username or password directly on the Wear OS device.

The following login methods will continue to exist:
- Log in on phone (or pass tokens using the data layer)
- Google Sign-In

which complies with the [requirement](https://developer.android.com/training/wearables/apps/auth-wear#auth-methods:~:text=Your%20Wear%20app%20must,with%20an%20iOS%20device.) to have one other login method in addition to the pass token method.

## Testing Instructions

- Install watch app
- Tap "Log in"
- ✅  Notice that there is no "Log in with email" options in the login options screen

#### Regression

Make sure that "Log in with Google" and "Log in on phone" work as before.

## Screenshots or Screencast 
<img src="https://github.com/Automattic/pocket-casts-android/assets/1405144/559eab20-2dc5-493e-bb5e-71aeb072cc9f"/>

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- I have considered whether it makes sense to add tests for my changes
- All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- with different themes
- with a landscape orientation
- with the device set to have a large display and font size
- for accessibility with TalkBack
