### PR TITLE
Make log for successful remote flag fetch not an error log

### DIFF
--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/FirebaseRemoteFeatureProvider.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/FirebaseRemoteFeatureProvider.kt
@@ -23,7 +23,7 @@ class FirebaseRemoteFeatureProvider @Inject constructor(
         firebaseRemoteConfig.fetch().addOnCompleteListener {
             if (it.isSuccessful) {
                 firebaseRemoteConfig.activate()
-                Timber.e("Firebase feature flag refreshed")
+                Timber.i("Firebase feature flag refreshed")
             } else {
                 Timber.e("Could not fetch remote config: ${it.exception?.message ?: "Unknown error"}")
             }


### PR DESCRIPTION
## Description
We're getting [a bunch of events in Sentry](https://a8c.sentry.io/issues/4416441119/events/aa089a13322f4045a1c7c54c0c2205df/) for firebase successfully fetching a remove flag. I'm guessing these are showing up because we're logging this as an error (`Timber.e`). I didn't actually know that error logs got sent to Sentry, so today-i-learned. 

This doesn't really seem like an error, and I don't think we need these in Sentry, so this PR is just changing this to be an `info` log.

## Checklist
- X ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews