### PR TITLE
Add recommendations to Automotive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 7.48
 -----
 
+*   New Feature:
+    *   Suggest episodes to play in Automotive
+        ([#1362](https://github.com/Automattic/pocket-casts-android/pull/1362)).
+
 7.47
 -----
 

--- a/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackServiceTest.kt
+++ b/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackServiceTest.kt
@@ -102,7 +102,7 @@ class AutoPlaybackServiceTest {
             val podcast = Podcast(UUID.randomUUID().toString(), title = "Test podcast")
             val episode = PodcastEpisode(UUID.randomUUID().toString(), title = "Test episode", publishedDate = Date())
 
-            service.playlistManager = mock { on { findByUuid(any()) }.doReturn(null) }
+            service.playlistManager = mock { on { findByUuidSync(any()) }.doReturn(null) }
             service.podcastManager = mock { on { runBlocking { findPodcastByUuidSuspend(any()) } }.doReturn(podcast) }
             service.episodeManager = mock { on { findEpisodesByPodcastOrdered(any()) }.doReturn(listOf(episode)) }
 

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
@@ -21,6 +21,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.FOLDER_ROOT_PREFIX
 import au.com.shiftyjelly.pocketcasts.repositories.playback.MEDIA_ID_ROOT
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PODCASTS_ROOT
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackService
+import au.com.shiftyjelly.pocketcasts.repositories.playback.RECENT_ROOT
+import au.com.shiftyjelly.pocketcasts.repositories.playback.SUGGESTED_ROOT
 import au.com.shiftyjelly.pocketcasts.repositories.playback.auto.AutoConverter
 import au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsTask
 import au.com.shiftyjelly.pocketcasts.servers.model.Discover
@@ -77,6 +79,8 @@ class AutoPlaybackService : PlaybackService() {
                     PROFILE_FILES -> loadFilesChildren()
                     PROFILE_LISTENING_HISTORY -> loadListeningHistoryChildren()
                     PROFILE_STARRED -> loadStarredChildren()
+                    RECENT_ROOT -> loadRecentChildren()
+                    SUGGESTED_ROOT -> loadSuggestedChildren()
                     else -> {
                         if (parentId.startsWith(FOLDER_ROOT_PREFIX)) {
                             loadFolderPodcastsChildren(folderUuid = parentId.substring(FOLDER_ROOT_PREFIX.length))

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/DurationOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/DurationOptionsFragment.kt
@@ -21,7 +21,6 @@ import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -102,7 +101,7 @@ class DurationOptionsFragment : BaseFragment() {
         val btnClose = binding.btnClose
 
         launch {
-            val playlist = withContext(Dispatchers.Default) { playlistManager.findByUuid(requireArguments().getString(ARG_PLAYLIST_UUID)!!) } ?: return@launch
+            val playlist = playlistManager.findByUuid(requireArguments().getString(ARG_PLAYLIST_UUID)!!) ?: return@launch
             this@DurationOptionsFragment.playlist = playlist
 
             enableDurations(playlist.filterDuration)

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/EpisodeOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/EpisodeOptionsFragment.kt
@@ -21,7 +21,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -72,11 +71,10 @@ class EpisodeOptionsFragment : BaseFragment(), CoroutineScope {
         val recyclerView = binding.recyclerView
 
         launch {
-            val playlist = withContext(Dispatchers.Default) {
-                val uuid = requireArguments().getString(ARG_PLAYLIST_UUID)!!
-                Timber.d("Loading playlist $uuid")
-                playlistManager.findByUuid(uuid)
-            } ?: return@launch
+            val uuid = requireArguments().getString(ARG_PLAYLIST_UUID)!!
+            Timber.d("Loading playlist $uuid")
+            val playlist = playlistManager.findByUuid(uuid) ?: return@launch
+
             this@EpisodeOptionsFragment.playlist = playlist
 
             val unplayedOption = FilterOption(LR.string.unplayed, playlist.unplayed, { v, _ ->

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asObservable
-import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -93,7 +92,7 @@ class FilterEpisodeListViewModel @Inject constructor(
 
     fun deletePlaylist() {
         launch {
-            withContext(Dispatchers.Default) { playlistManager.findByUuid(playlistUUID) }?.let { playlist ->
+            playlistManager.findByUuid(playlistUUID)?.let { playlist ->
                 playlistManager.delete(playlist)
                 analyticsTracker.track(AnalyticsEvent.FILTER_DELETED)
             }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
@@ -79,7 +79,8 @@ class PodcastOptionsFragment : BaseFragment(), PodcastSelectFragment.Listener, C
 
         launch {
             val subscribedPodcasts = withContext(Dispatchers.Default) { podcastManager.findSubscribed() }.map { it.uuid }
-            val playlist = withContext(Dispatchers.Default) { playlistManager.findByUuid(requireArguments().getString(ARG_PLAYLIST_UUID)!!) }!!
+            val playlistUuid = requireArguments().getString(ARG_PLAYLIST_UUID) ?: return@launch
+            val playlist = playlistManager.findByUuid(playlistUuid) ?: return@launch
             this@PodcastOptionsFragment.playlist = playlist
 
             val color = playlist.getColor(context)

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/TimeOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/TimeOptionsFragment.kt
@@ -21,7 +21,6 @@ import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -175,7 +174,7 @@ class TimeOptionsFragment : BaseFragment(), CoroutineScope {
         val recyclerView = binding.recyclerView
 
         launch {
-            val playlist = async(Dispatchers.Default) { playlistManager.findByUuid(requireArguments().getString(ARG_PLAYLIST_UUID)!!) }.await()!!
+            val playlist = playlistManager.findByUuid(requireArguments().getString(ARG_PLAYLIST_UUID)!!) ?: return@launch
             this@TimeOptionsFragment.playlist = playlist
 
             selectedPosition = when (optionType) {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -31,7 +31,10 @@ abstract class PlaylistDao {
     abstract fun observeAll(): Flowable<List<Playlist>>
 
     @Query("SELECT * FROM filters WHERE uuid = :uuid LIMIT 1")
-    abstract fun findByUUID(uuid: String): Playlist?
+    abstract fun findByUuidSync(uuid: String): Playlist?
+
+    @Query("SELECT * FROM filters WHERE uuid = :uuid LIMIT 1")
+    abstract suspend fun findByUuid(uuid: String): Playlist?
 
     @Query("SELECT * FROM filters WHERE uuid = :uuid LIMIT 1")
     abstract fun findByUUIDRx(uuid: String): Maybe<Playlist>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -19,12 +19,14 @@ import androidx.media.MediaBrowserServiceCompat
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.localization.BuildConfig
 import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationControls.Companion.items
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.id
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationDrawer
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
@@ -39,6 +41,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.servers.ServerManager
+import au.com.shiftyjelly.pocketcasts.servers.list.ListServerManager
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
 import au.com.shiftyjelly.pocketcasts.utils.IS_RUNNING_UNDER_TEST
 import au.com.shiftyjelly.pocketcasts.utils.SchedulerProvider
 import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
@@ -105,6 +109,8 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
     @Inject lateinit var serverManager: ServerManager
     @Inject lateinit var notificationHelper: NotificationHelper
     @Inject lateinit var subscriptionManager: SubscriptionManager
+    @Inject lateinit var listServerManager: ListServerManager
+    @Inject lateinit var podcastCacheServerManager: PodcastCacheServerManager
 
     var mediaController: MediaControllerCompat? = null
         set(value) {
@@ -396,44 +402,57 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
     }
 
     private val NUM_SUGGESTED_ITEMS = 8
-    private suspend fun loadSuggestedChildren(): ArrayList<MediaBrowserCompat.MediaItem> {
-        Timber.d("Loading sugggested children")
-        val upNext = listOfNotNull(playbackManager.getCurrentEpisode()) + playbackManager.upNextQueue.queueEpisodes
-        val mediaUpNext = upNext.take(NUM_SUGGESTED_ITEMS).mapNotNull { playable ->
-            val filesPodcast = Podcast(uuid = UserEpisodePodcastSubstitute.substituteUuid, title = UserEpisodePodcastSubstitute.substituteTitle)
-            val parentPodcast = (if (playable is PodcastEpisode) podcastManager.findPodcastByUuid(playable.podcastUuid) else filesPodcast) ?: return@mapNotNull null
-            AutoConverter.convertEpisodeToMediaItem(this, playable, parentPodcast)
+    suspend fun loadSuggestedChildren(): List<MediaBrowserCompat.MediaItem> {
+        Timber.d("Loading suggested children")
+        val episodes = mutableListOf<BaseEpisode>()
+        // add episodes from the Up Next
+        val currentEpisode = upNextQueue.currentEpisode
+        if (currentEpisode != null) {
+            episodes.add(currentEpisode)
         }
-
-        if (mediaUpNext.size == NUM_SUGGESTED_ITEMS) {
-            return ArrayList(mediaUpNext)
+        episodes.addAll(upNextQueue.queueEpisodes.take(NUM_SUGGESTED_ITEMS - 1))
+        // add episodes from the top filter
+        if (episodes.size < NUM_SUGGESTED_ITEMS) {
+            val topFilter = playlistManager.findAllSuspend().firstOrNull()
+            if (topFilter != null) {
+                val filterEpisodes = playlistManager.findEpisodes(topFilter, episodeManager, playbackManager)
+                for (filterEpisode in filterEpisodes) {
+                    if (episodes.size >= NUM_SUGGESTED_ITEMS) {
+                        break
+                    }
+                    if (episodes.none { it.uuid == filterEpisode.uuid }) {
+                        episodes.add(filterEpisode)
+                    }
+                }
+            }
         }
-
-        Timber.d("Up next length was ${mediaUpNext.size}. Trying top filter.")
-        // If we don't have enough items in up next, try the top filter
-        val topPlaylist = playlistManager.findAll().firstOrNull()
-        if (topPlaylist == null) {
-            Timber.d("Could not find top filter.")
-            return ArrayList(mediaUpNext)
+        // add the latest episode
+        if (episodes.size < NUM_SUGGESTED_ITEMS) {
+            val latestEpisode = episodeManager.findLatestEpisodeToPlay()
+            if (latestEpisode != null && episodes.none { it.uuid == latestEpisode.uuid }) {
+                episodes.add(latestEpisode)
+            }
         }
-
-        Timber.d("Loading suggestions from ${topPlaylist.title}")
-        val playlistItems = loadEpisodeChildren(topPlaylist.uuid).take(NUM_SUGGESTED_ITEMS - mediaUpNext.size)
-        Timber.d("Got ${playlistItems.size} from playlist.")
-
-        val retList = mediaUpNext + playlistItems
-        Timber.d("Returning ${retList.size} suggestions. $retList")
-        return ArrayList(retList)
+        return convertEpisodesToMediaItems(episodes)
     }
 
-    private fun loadRecentChildren(): ArrayList<MediaBrowserCompat.MediaItem> {
+    suspend fun loadRecentChildren(): List<MediaBrowserCompat.MediaItem> {
         Timber.d("Loading recent children")
-        val upNext = playbackManager.getCurrentEpisode() ?: return arrayListOf()
-        val filesPodcast = Podcast(uuid = UserEpisodePodcastSubstitute.substituteUuid, title = UserEpisodePodcastSubstitute.substituteTitle)
-        val parentPodcast = (if (upNext is PodcastEpisode) podcastManager.findPodcastByUuid(upNext.podcastUuid) else filesPodcast) ?: return arrayListOf()
+        val episodes = listOfNotNull(upNextQueue.currentEpisode)
+        return convertEpisodesToMediaItems(episodes)
+    }
 
-        Timber.d("Recent item ${upNext.title}")
-        return arrayListOf(AutoConverter.convertEpisodeToMediaItem(this, upNext, parentPodcast))
+    private suspend fun convertEpisodesToMediaItems(episodes: List<BaseEpisode>): List<MediaBrowserCompat.MediaItem> {
+        return episodes.mapNotNull { episode ->
+            // find the podcast
+            val podcast = if (episode is PodcastEpisode) {
+                podcastManager.findPodcastByUuidSuspend(episode.podcastUuid)
+            } else {
+                Podcast(uuid = UserEpisodePodcastSubstitute.substituteUuid, title = UserEpisodePodcastSubstitute.substituteTitle)
+            }
+            // convert to a media item
+            if (podcast == null) null else AutoConverter.convertEpisodeToMediaItem(context = this, episode = episode, parentPodcast = podcast)
+        }
     }
 
     open suspend fun loadRootChildren(): List<MediaBrowserCompat.MediaItem> {
@@ -504,7 +523,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
 
     suspend fun loadEpisodeChildren(parentId: String): List<MediaBrowserCompat.MediaItem> {
         // user tapped on a playlist or podcast, show the episodes
-        val episodeItems = ArrayList<MediaBrowserCompat.MediaItem>()
+        val episodeItems = mutableListOf<MediaBrowserCompat.MediaItem>()
 
         val playlist = if (DOWNLOADS_ROOT == parentId) playlistManager.getSystemDownloadsFilter() else playlistManager.findByUuid(parentId)
         if (playlist != null) {
@@ -512,7 +531,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
             val topEpisodes = episodeList.take(EPISODE_LIMIT)
             if (topEpisodes.isNotEmpty()) {
                 for (episode in topEpisodes) {
-                    podcastManager.findPodcastByUuid(episode.podcastUuid)?.let { parentPodcast ->
+                    podcastManager.findPodcastByUuidSuspend(episode.podcastUuid)?.let { parentPodcast ->
                         episodeItems.add(AutoConverter.convertEpisodeToMediaItem(this, episode, parentPodcast, sourceId = playlist.uuid))
                     }
                 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
@@ -15,7 +15,8 @@ interface PlaylistManager {
     fun observeAll(): Flowable<List<Playlist>>
 
     fun findById(id: Long): Playlist?
-    fun findByUuid(playlistUuid: String): Playlist?
+    suspend fun findByUuid(playlistUuid: String): Playlist?
+    fun findByUuidSync(playlistUuid: String): Playlist?
     fun findByUuidRx(playlistUuid: String): Maybe<Playlist>
     fun observeByUuid(playlistUuid: String): Flowable<Playlist>
     fun observeByUuidAsList(playlistUuid: String): Flowable<List<Playlist>>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -54,7 +54,7 @@ class PlaylistManagerImpl @Inject constructor(
         get() = Dispatchers.Default
 
     private fun setupDefaultPlaylists() {
-        val existingNewRelease = playlistDao.findByUUID(NEWRELEASE_UUID)
+        val existingNewRelease = playlistDao.findByUuidSync(NEWRELEASE_UUID)
         if (existingNewRelease == null) {
             val newRelease = Playlist()
             newRelease.apply {
@@ -77,7 +77,7 @@ class PlaylistManagerImpl @Inject constructor(
             playlistDao.update(existingNewRelease)
         }
 
-        val existingInProgress = playlistDao.findByUUID(INPROGRESS_UUID)
+        val existingInProgress = playlistDao.findByUuidSync(INPROGRESS_UUID)
         if (existingInProgress == null) {
             val inProgress = Playlist()
             inProgress.apply {
@@ -123,8 +123,12 @@ class PlaylistManagerImpl @Inject constructor(
         return playlistDao.observeAll()
     }
 
-    override fun findByUuid(playlistUuid: String): Playlist? {
-        return playlistDao.findByUUID(playlistUuid)
+    override fun findByUuidSync(playlistUuid: String): Playlist? {
+        return playlistDao.findByUuidSync(playlistUuid)
+    }
+
+    override suspend fun findByUuid(playlistUuid: String): Playlist? {
+        return playlistDao.findByUuid(playlistUuid)
     }
 
     override fun findByUuidRx(playlistUuid: String): Maybe<Playlist> {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -670,7 +670,7 @@ class PodcastSyncProcess(
                 return@fromCallable null
             }
 
-            var playlist = playlistManager.findByUuid(uuid)
+            var playlist = playlistManager.findByUuidSync(uuid)
             if (sync.deleted) {
                 playlist?.let { playlistManager.deleteSynced(it) }
                 return@fromCallable null


### PR DESCRIPTION
## Description

This change adds the recommendations to Automotive. This feature is already available for Android Auto. I made some code changes and added a test to ensure it still worked correctly. There was a bug that you could have the same episode in the list from the Up Next queue and the top filter.

It's hard to test it from the Automotive emulator as I don't know how to trigger it. The code changes to the suggestion method can be tested using Android Auto in Google Maps.

## Testing Instructions
1. Deploy to a physical device
2. Start playing an episode
3. Add another episode to your Up Next
4. Open Google Maps
5. Setup navigation to a location
6. The Pocket Casts mini player should appear
7. Tap on the mini player in Google Maps
8. Tap "Browse Pocket Debug"
9. ✅ Verify your current episode is first, followed by your Up Next, and then episode from your top filter.

I changed some other methods over to using the same new Coroutine version, to test these do the following.
1. Open a filter
2. Tap on the title to expand the filter option
3. Tap on "Episode Status"
4. Change the setting
5. Tap "Update filter"
6. Tap on "Episode Status" again
7. ✅ Verify the options have persisted
8. Do the same for the filter setting "Duration" and "Download Status"

## Screenshots

<img  width="300" src="https://github.com/Automattic/pocket-casts-android/assets/308331/0b384e3e-fc74-4fe1-9b78-c0f44c0f8323" />
