### PR TITLE
Add scrollbar to Up Next screen on watch

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.PositionIndicator
+import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.EpisodeChip
@@ -50,21 +52,25 @@ fun UpNextScreen(
             if (list.isEmpty()) {
                 EmptyQueueState()
             } else {
-                ScalingLazyColumn(
-                    columnState = columnState,
-                    modifier = modifier.fillMaxWidth(),
+                Scaffold(
+                    positionIndicator = { PositionIndicator(scalingLazyListState = columnState.state) }
                 ) {
+                    ScalingLazyColumn(
+                        columnState = columnState,
+                        modifier = modifier.fillMaxWidth(),
+                    ) {
 
-                    item { ScreenHeaderChip(LR.string.up_next) }
+                        item { ScreenHeaderChip(LR.string.up_next) }
 
-                    items(list) { episode ->
-                        EpisodeChip(
-                            episode = episode,
-                            useUpNextIcon = false,
-                            onClick = {
-                                navigateToEpisode(episode.uuid)
-                            },
-                        )
+                        items(list) { episode ->
+                            EpisodeChip(
+                                episode = episode,
+                                useUpNextIcon = false,
+                                onClick = {
+                                    navigateToEpisode(episode.uuid)
+                                },
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Description
Google rejected our latest app update because the Up Next screen on the watch did not have a scroll bar. This fixes that.

What I'm doing in this PR is a bit weird because I'm adding a Scaffold around the Up Next screen (to get the scrollbar), but this is already inside of a view pager, which itself is inside a `WearNavScaffold`, which is basically the horologist library's superpowered `Scaffold` (it actually uses `Scaffold` under the hood). So we are ending up with a `Scaffold` inside of a `Scaffold` here. I didn't observe any adverse side effects here, but I do think it merits some extra testing (i.e., making sure that scrolling on the first page of the view pager, which uses the top-level scaffold, does not adversely affect scroll on the up next `Scaffold`).

> **Note**
> I've got this PR targeting 7.47 because my thinking is that (assuming the phone app's 7.46.2 apk gets approved) we won't submit any more `7.46.x` watch updates. If we do have to submit more `7.46.x` watch updates, then we'll have to include this change there too.

## Testing Instructions
1. Log into the watch
2. Add some episodes to your up next queue if it is empty
3. Swipe to the third screen in the view pager
4. Verify that scrolling the up next queue shows a scrollbar on the right
5. Verify that using the watch's rotary input scrolls the up next view

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/4656348/de8a25e6-4f24-4c7a-b96e-9d66a3556eb9

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews