### PR TITLE
Moving the user files podcast substitute.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -304,8 +304,8 @@ project.ext {
             sentryFragment: 'io.sentry:sentry-android-fragment',
             sentryTimber: 'io.sentry:sentry-android-timber',
             // AboutLibraries - https://github.com/mikepenz/AboutLibraries
-            aboutLibrariesCore: 'com.mikepenz:aboutlibraries-core:10.8.3',
-            aboutLibrariesCompose: 'com.mikepenz:aboutlibraries-compose:10.8.3',
+            aboutLibrariesCore: 'com.mikepenz:aboutlibraries-core:10.5.0',
+            aboutLibrariesCompose: 'com.mikepenz:aboutlibraries-compose:10.5.0',
             // Showkase
             showkase: 'com.airbnb.android:showkase:1.0.0-beta18',
             showkaseProcessor: 'com.airbnb.android:showkase-processor:1.0.0-beta18',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -304,8 +304,8 @@ project.ext {
             sentryFragment: 'io.sentry:sentry-android-fragment',
             sentryTimber: 'io.sentry:sentry-android-timber',
             // AboutLibraries - https://github.com/mikepenz/AboutLibraries
-            aboutLibrariesCore: 'com.mikepenz:aboutlibraries-core:10.5.0',
-            aboutLibrariesCompose: 'com.mikepenz:aboutlibraries-compose:10.5.0',
+            aboutLibrariesCore: 'com.mikepenz:aboutlibraries-core:10.8.3',
+            aboutLibrariesCompose: 'com.mikepenz:aboutlibraries-compose:10.8.3',
             // Showkase
             showkase: 'com.airbnb.android:showkase:1.0.0-beta18',
             showkaseProcessor: 'com.airbnb.android:showkase-processor:1.0.0-beta18',

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -11,7 +11,6 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -274,7 +273,7 @@ class PlayerViewModel @Inject constructor(
             if (it is PodcastEpisode) {
                 podcastManager.observePodcastByUuid(it.podcastUuid)
             } else {
-                Flowable.just(Podcast(uuid = UserEpisodePodcastSubstitute.substituteUuid, title = UserEpisodePodcastSubstitute.substituteTitle, overrideGlobalEffects = false))
+                Flowable.just(Podcast.userPodcast.copy(overrideGlobalEffects = false))
             }
         }
         .map { PodcastEffectsPair(it, if (it.overrideGlobalEffects) it.playbackEffects else settings.globalPlaybackEffects.value) }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/UserEpisodePodcastSubstitute.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/UserEpisodePodcastSubstitute.kt
@@ -1,9 +1,0 @@
-package au.com.shiftyjelly.pocketcasts.models.db.helper
-
-// A holder of podcast substitutes when needed for UserEpisodes
-// I thought about making this an actual Podcast but then there
-// is nothing stopping it getting passed in to a podcast manager function.
-object UserEpisodePodcastSubstitute {
-    const val substituteUuid = "da7aba5e-f11e-f11e-f11e-da7aba5ef11e"
-    const val substituteTitle = "Custom Episode"
-}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.models.entity
 
-import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import java.util.Date
@@ -95,7 +94,7 @@ sealed interface BaseEpisode {
         get() = autoDownloadStatus == PodcastEpisode.AUTO_DOWNLOAD_STATUS_IGNORE
 
     val podcastOrSubstituteUuid: String
-        get() = if (this is PodcastEpisode) this.podcastUuid else UserEpisodePodcastSubstitute.substituteUuid
+        get() = if (this is PodcastEpisode) this.podcastUuid else Podcast.userPodcast.uuid
 
     // fall back to something that most podcasts are
     fun getFileExtension(): String {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
@@ -94,6 +94,11 @@ data class Podcast(
     }
 
     companion object {
+        // A holder of podcast substitutes when needed for UserEpisodes
+        val userPodcast = Podcast(
+            uuid = "da7aba5e-f11e-f11e-f11e-da7aba5ef11e",
+            title = "Custom Episode"
+        )
 
         const val SYNC_STATUS_NOT_SYNCED = 0
         const val SYNC_STATUS_SYNCED = 1

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/UserEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/UserEpisode.kt
@@ -5,7 +5,6 @@ import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.Index
 import androidx.room.PrimaryKey
-import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.models.type.UserEpisodeServerStatus
@@ -56,7 +55,7 @@ data class UserEpisode(
     var hasBookmark: Boolean = false
 
     override fun displaySubtitle(podcast: Podcast?): String {
-        return UserEpisodePodcastSubstitute.substituteTitle
+        return Podcast.userPodcast.title
     }
 
     val isUploading: Boolean

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/extensions/Podcast.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/extensions/Podcast.kt
@@ -1,16 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.repositories.extensions
 
-import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 
-val Podcast.largeArtworkUrl: String
-    get() = getArtworkUrl(960)
-
 fun Podcast.getArtworkUrl(size: Int): String {
-    return if (uuid == UserEpisodePodcastSubstitute.substituteUuid) thumbnailUrl ?: "" else PodcastImage.getArtworkUrl(size, uuid)
-}
-
-fun Podcast.getArtworkJpgUrl(size: Int): String {
-    return if (uuid == UserEpisodePodcastSubstitute.substituteUuid) thumbnailUrl ?: "" else PodcastImage.getArtworkJpgUrl(size, uuid)
+    return if (uuid == Podcast.userPodcast.uuid) thumbnailUrl ?: "" else PodcastImage.getArtworkUrl(size, uuid)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
@@ -13,7 +13,6 @@ import android.support.v4.media.session.PlaybackStateCompat.ACTION_STOP
 import androidx.core.app.NotificationCompat
 import androidx.media.app.NotificationCompat.MediaStyle
 import androidx.media.session.MediaButtonReceiver
-import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -103,7 +102,7 @@ class NotificationDrawerImpl @Inject constructor(
         }
 
         val bitmap = if (podcast != null) loadArtwork(podcast) else if (episode is UserEpisode) loadUserEpisodeArtwork(episode) else null
-        val podcastTitle = (if (episode is PodcastEpisode) podcast?.title else UserEpisodePodcastSubstitute.substituteTitle) ?: ""
+        val podcastTitle = (if (episode is PodcastEpisode) podcast?.title else Podcast.userPodcast.title) ?: ""
 
         val data = NotificationData(
             episodeUuid = episodeUuid,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -18,7 +18,6 @@ import android.support.v4.media.session.PlaybackStateCompat
 import androidx.media.MediaBrowserServiceCompat
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.localization.BuildConfig
-import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -445,11 +444,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
     private suspend fun convertEpisodesToMediaItems(episodes: List<BaseEpisode>): List<MediaBrowserCompat.MediaItem> {
         return episodes.mapNotNull { episode ->
             // find the podcast
-            val podcast = if (episode is PodcastEpisode) {
-                podcastManager.findPodcastByUuidSuspend(episode.podcastUuid)
-            } else {
-                Podcast(uuid = UserEpisodePodcastSubstitute.substituteUuid, title = UserEpisodePodcastSubstitute.substituteTitle)
-            }
+            val podcast = if (episode is PodcastEpisode) podcastManager.findPodcastByUuidSuspend(episode.podcastUuid) else Podcast.userPodcast
             // convert to a media item
             if (podcast == null) null else AutoConverter.convertEpisodeToMediaItem(context = this, episode = episode, parentPodcast = podcast)
         }
@@ -560,8 +555,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
 
     protected suspend fun loadFilesChildren(): List<MediaBrowserCompat.MediaItem> {
         return userEpisodeManager.findUserEpisodes().map {
-            val podcast = Podcast(uuid = UserEpisodePodcastSubstitute.substituteUuid, title = UserEpisodePodcastSubstitute.substituteTitle, thumbnailUrl = it.artworkUrl)
-            AutoConverter.convertEpisodeToMediaItem(this, it, podcast)
+            AutoConverter.convertEpisodeToMediaItem(this, it, Podcast.userPodcast)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -20,7 +20,6 @@ import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.db.helper.LongestEpisode
 import au.com.shiftyjelly.pocketcasts.models.db.helper.QueryHelper
-import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -1124,7 +1123,7 @@ class EpisodeManagerImpl @Inject constructor(
     override fun downloadMissingEpisode(episodeUuid: String, podcastUuid: String, skeletonEpisode: PodcastEpisode, podcastManager: PodcastManager, downloadMetaData: Boolean): Maybe<BaseEpisode> {
         return episodeDao.existsRx(episodeUuid)
             .flatMapMaybe { episodeExists ->
-                if (episodeExists || podcastUuid == UserEpisodePodcastSubstitute.substituteUuid) {
+                if (episodeExists || podcastUuid == Podcast.userPodcast.uuid) {
                     observeEpisodeByUuidRx(episodeUuid).firstElement()
                 } else {
                     podcastCacheServerManager.getPodcastAndEpisode(podcastUuid, episodeUuid).flatMapMaybe { response ->

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
-import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -747,11 +746,7 @@ class PodcastManagerImpl @Inject constructor(
     }
 
     override fun buildUserEpisodePodcast(episode: UserEpisode): Podcast {
-        return Podcast(
-            uuid = UserEpisodePodcastSubstitute.substituteUuid,
-            title = UserEpisodePodcastSubstitute.substituteTitle,
-            thumbnailUrl = episode.getUrlForArtwork()
-        )
+        return Podcast.userPodcast.copy(thumbnailUrl = episode.getUrlForArtwork())
     }
 
     override fun observeAutoAddToUpNextPodcasts(): Flowable<List<Podcast>> {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
@@ -9,7 +9,6 @@ import android.view.View
 import android.widget.RemoteViews
 import androidx.media.session.MediaButtonReceiver
 import au.com.shiftyjelly.pocketcasts.core.ui.widget.PodcastWidget
-import au.com.shiftyjelly.pocketcasts.models.db.helper.UserEpisodePodcastSubstitute
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -147,7 +146,7 @@ class WidgetManagerImpl @Inject constructor(
             return
         }
 
-        val podcastTitle = podcast?.title ?: UserEpisodePodcastSubstitute.substituteTitle
+        val podcastTitle = podcast?.title ?: Podcast.userPodcast.title
         views.setContentDescription(R.id.widget_artwork, "$podcastTitle. Open Pocket Casts")
         views.setImageViewResource(R.id.widget_artwork, IR.drawable.defaultartwork_small_dark)
 


### PR DESCRIPTION
## Description

This was an excellent suggestion made in another [PR review](https://github.com/Automattic/pocket-casts-android/pull/1362#discussion_r1319970327). As we often use the user file podcast as a Podcast object, this PR creates one for us. It looks much cleaner and stops the repeating code.

## Testing Instructions
There are lots of changes which are simple enough to just look through but it might be worth testing sync.
1. Sign in to a Plus Pocket Casts account
2. Go to Profile -> Files
3. Add a new file
4. Tap the file row
5. Tap "Upload to Cloud"
6. Tap the file row again
7. Tap "Add to Up Next"
8. Go back to the Profile tab and manually refresh
9. Go to another app and confirm the file is in the Up Next.
