### PR TITLE
Add scrollbar to Up Next screen on watch for 7.46.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 7.47
 -----
 
+7.46.3
+------
+*   Updates:
+    *   Added scrollbar to Watch app's Up Next screen
+        ([#1365](https://github.com/Automattic/pocket-casts-android/pull/1365))
+
 7.46.2
 ------
 *   Updates:

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 # Version Information for Vanilla / Release builds
-versionName=7.46.2
-versionCode=9140
+versionName=7.46.3
+versionCode=9142

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.PositionIndicator
+import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Text
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.EpisodeChip
@@ -50,21 +52,25 @@ fun UpNextScreen(
             if (list.isEmpty()) {
                 EmptyQueueState()
             } else {
-                ScalingLazyColumn(
-                    columnState = columnState,
-                    modifier = modifier.fillMaxWidth(),
+                Scaffold(
+                    positionIndicator = { PositionIndicator(scalingLazyListState = columnState.state) }
                 ) {
+                    ScalingLazyColumn(
+                        columnState = columnState,
+                        modifier = modifier.fillMaxWidth(),
+                    ) {
 
-                    item { ScreenHeaderChip(LR.string.up_next) }
+                        item { ScreenHeaderChip(LR.string.up_next) }
 
-                    items(list) { episode ->
-                        EpisodeChip(
-                            episode = episode,
-                            useUpNextIcon = false,
-                            onClick = {
-                                navigateToEpisode(episode.uuid)
-                            },
-                        )
+                        items(list) { episode ->
+                            EpisodeChip(
+                                episode = episode,
+                                useUpNextIcon = false,
+                                onClick = {
+                                    navigateToEpisode(episode.uuid)
+                                },
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This brings the change from #1363 for a `7.46.3` release. Refer to that PR for more information and testing instructions.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
