### PR TITLE
Disable in app review prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@
 *   Updates:
     *   Enable copying logs from in-app logs viewer
         ([#1298](https://github.com/Automattic/pocket-casts-android/pull/1298))
-    *   Present app review prompt 
-        ([#1305](https://github.com/Automattic/pocket-casts-android/pull/1305))
     *   Updated storage limit title
         ([#1342](https://github.com/Automattic/pocket-casts-android/pull/1342))
 *   Bug Fixes:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,6 +92,7 @@ dependencies {
     // services
     implementation project(':modules:services:analytics')
     implementation project(':modules:services:compose')
+    implementation project(':modules:services:featureflag')
     implementation project(':modules:services:localization')
     implementation project(':modules:services:model')
     implementation project(':modules:services:preferences')

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModel.kt
@@ -5,6 +5,8 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlagWrapper
 import au.com.shiftyjelly.pocketcasts.models.to.StatsBundle
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
@@ -35,6 +37,7 @@ class StatsViewModel @Inject constructor(
     val application: Application,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val inAppReviewHelper: InAppReviewHelper,
+    private val featureFlag: FeatureFlagWrapper,
 ) : ViewModel() {
 
     sealed class State {
@@ -88,8 +91,10 @@ class StatsViewModel @Inject constructor(
                     funnyText = funnyText,
                     startedAt = serverStats?.startedAt
                 )
-                withContext(ioDispatcher) {
-                    serverStats?.startedAt?.let { showAppReviewDialogIfPossible(it) }
+                if (featureFlag.isEnabled(Feature.IN_APP_REVIEW_ENABLED)) {
+                    withContext(ioDispatcher) {
+                        serverStats?.startedAt?.let { showAppReviewDialogIfPossible(it) }
+                    }
                 }
             } catch (e: Exception) {
                 Timber.e(e)

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/Feature.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/Feature.kt
@@ -25,4 +25,9 @@ enum class Feature(
         title = "Bookmarks",
         defaultValue = BuildConfig.DEBUG
     ),
+    IN_APP_REVIEW_ENABLED(
+        key = "in_app_review_enabled",
+        title = "In App Review",
+        defaultValue = BuildConfig.DEBUG
+    ),
 }

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/FeatureFlagWrapper.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/FeatureFlagWrapper.kt
@@ -2,6 +2,6 @@ package au.com.shiftyjelly.pocketcasts.featureflag
 
 import javax.inject.Inject
 
-class FeatureFlagWrapper @Inject constructor() {
-    fun isEnabled(feature: Feature) = FeatureFlag.isEnabled(feature)
+open class FeatureFlagWrapper @Inject constructor() {
+    open fun isEnabled(feature: Feature) = FeatureFlag.isEnabled(feature)
 }

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/FeatureFlagWrapper.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/FeatureFlagWrapper.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.featureflag
+
+import javax.inject.Inject
+
+class FeatureFlagWrapper @Inject constructor() {
+    fun isEnabled(feature: Feature) = FeatureFlag.isEnabled(feature)
+}

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/DefaultReleaseFeatureProvider.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/DefaultReleaseFeatureProvider.kt
@@ -23,5 +23,6 @@ class DefaultReleaseFeatureProvider @Inject constructor() : FeatureProvider {
             Feature.SHOW_RATINGS_ENABLED -> Feature.SHOW_RATINGS_ENABLED.defaultValue
             Feature.ADD_PATRON_ENABLED -> Feature.ADD_PATRON_ENABLED.defaultValue
             Feature.BOOKMARKS_ENABLED -> Feature.BOOKMARKS_ENABLED.defaultValue
+            Feature.IN_APP_REVIEW_ENABLED -> Feature.IN_APP_REVIEW_ENABLED.defaultValue
         }
 }

--- a/modules/services/views/build.gradle
+++ b/modules/services/views/build.gradle
@@ -16,6 +16,7 @@ android {
 dependencies {
     implementation project(':modules:services:analytics')
     implementation project(':modules:services:compose')
+    implementation project(':modules:services:featureflag')
     implementation project(':modules:services:images')
     implementation project(':modules:services:localization')
     implementation project(':modules:services:model')

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/review/InAppReviewHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/review/InAppReviewHelper.kt
@@ -4,6 +4,8 @@ import androidx.appcompat.app.AppCompatActivity
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlagWrapper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import com.google.android.play.core.review.ReviewManager
@@ -17,6 +19,7 @@ class InAppReviewHelper @Inject constructor(
     private val settings: Settings,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val reviewManager: ReviewManager,
+    private val featureFlag: FeatureFlagWrapper,
 ) {
     /* Request in-app review from the user
        Right now, this method only allow requesting it once per user */
@@ -25,7 +28,9 @@ class InAppReviewHelper @Inject constructor(
         delayInMs: Long,
         sourceView: SourceView,
     ) {
-        if (settings.getReviewRequestedDates().isNotEmpty()) return
+        if (!featureFlag.isEnabled(Feature.IN_APP_REVIEW_ENABLED) ||
+            settings.getReviewRequestedDates().isNotEmpty()
+        ) return
         delay(delayInMs)
         try {
             val flow = reviewManager.requestReviewFlow()


### PR DESCRIPTION
## Description

This puts the in-app-review dialog behind a feature flag and enables it only for a debug build..

> **Warning**
> Targets 7.47

## Testing Instructions

- Make sure that tests run fine and CI is green.
- Optionally, test that the in-app review dialog is not shown for the testing steps in https://github.com/Automattic/pocket-casts-android/pull/1305

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` N/A
- Any jetpack compose components I added or changed are covered by compose previews N/A
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- with different themes N/A
- with a landscape orientation N/A
- with the device set to have a large display and font size N/A
- for accessibility with TalkBack N/A
