### PR TITLE
Disable bookmarks menu

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheet.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheet.kt
@@ -317,7 +317,7 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
                         if (signInState.subscriptionStatus is SubscriptionStatus.Paid) {
                             layoutCloud.isVisible = true
                             layoutLockedCloud.isVisible = false
-                            layoutBookmark.isVisible = true
+                            layoutBookmark.isVisible = FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)
                         } else {
                             layoutCloud.isVisible = false
                             layoutLockedCloud.isVisible = true


### PR DESCRIPTION
## Description

This disables the bookmarks menu on `Files` screen

> **Warning**
> Targets 7.47

## Testing Instructions

1. Open `Profile` -> `Files` 
2. Add a file
3. Tap on a file row
4. Notice that the file details bottom sheet doesn't have a "Bookmarks" menu

<img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/cd792bd7-842a-4d41-b7d7-918a959bebb9"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
