### PR TITLE
Add podcast/podcastEpisode title and thumbnail to android share sheet…

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
@@ -57,6 +57,16 @@ open class PodcastImageLoader(
         }
     }
 
+    suspend fun getBitmapSuspend(podcast: Podcast, size: Int): Bitmap? {
+        return try {
+            val request = load(podcast).size(size, size).build()
+            context.imageLoader.execute(request).drawable!!.toBitmap()
+        } catch (e: Exception) {
+            val request = loadNoPodcastCoil().size(size, size).build()
+            context.imageLoader.execute(request).drawable?.toBitmap()
+        }
+    }
+
     fun loadForTarget(podcast: Podcast, size: Int, bitmapListener: coil.target.Target) {
         val request = load(podcast).size(size, size).target(bitmapListener).build()
         context.imageLoader.enqueue(request)


### PR DESCRIPTION

## Description
This PR adds a rich share sheet preview when sharing podcasts and podcast episodes. The share sheet now includes the title and a thumbnail (or placeholder) of the podcast  

Fixes #1281

## Testing Instructions
1. Tap on a podcast or episode
2. Tap on the share icon
3. In the share dialog, choose share episode or share current position
4. The Android share sheet shows up with a thumbnail of the podcast and the podcast/ episode title

## Screenshots or Screencast 
<img src="https://github.com/Automattic/pocket-casts-android/assets/20142549/a6647b8e-2c2d-4cf1-ae4c-ffb91a19b5c5" width="300">

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
