### PR TITLE
Specify android agent in Buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,6 +4,9 @@ common_params:
   - &common_plugins
     - automattic/bash-cache#2.11.0
 
+agents:
+  queue: "android"
+
 steps:
   - label: "Gradle Wrapper Validation"
     command: |


### PR DESCRIPTION
We are already using `android` agent for this pipeline, but having it specified in the `.buildkite/pipeline.yml` file will make it easier to programmatically change it.

I am working on a small bash script that will make it easier to test `android-staging` changes such as [this one](https://github.com/wordpress-mobile/WordPress-Android/pull/18773) and this change will help keep that script simple.