### PR TITLE
Remove the FiltersFragment runBlocking code

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -22,8 +22,6 @@ import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.None
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -132,10 +130,9 @@ class FiltersFragment : BaseFragment(), CoroutineScope, Toolbar.OnMenuItemClickL
     private fun checkForSavedFilter() {
         val shouldOpenSavedFilter = settings.selectedFilter() != null && lastFilterUuidShown != settings.selectedFilter()
         if (shouldOpenSavedFilter) {
-            runBlocking {
-                val playlistUUID = settings.selectedFilter() ?: return@runBlocking
-                lastFilterUuidShown = playlistUUID
-                val playlist = withContext(Dispatchers.Default) { playlistManager.findByUuid(playlistUUID) } ?: return@runBlocking
+            val playlistUuid = settings.selectedFilter() ?: return
+            lastFilterUuidShown = playlistUuid
+            viewModel.findPlaylistByUuid(playlistUuid) { playlist ->
                 openPlaylist(playlist, isNewFilter = false)
             }
         } else if (!viewModel.isFragmentChangingConfigurations) {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.filters
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
+import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
@@ -12,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.util.Collections
 import javax.inject.Inject
@@ -78,5 +80,12 @@ class FiltersFragmentViewModel @Inject constructor(
     fun trackFilterListShown(filterCount: Int) {
         val properties = mapOf(FILTER_COUNT_KEY to filterCount)
         analyticsTracker.track(AnalyticsEvent.FILTER_LIST_SHOWN, properties)
+    }
+
+    fun findPlaylistByUuid(playlistUuid: String, onSuccess: (Playlist) -> Unit) {
+        viewModelScope.launch {
+            val playlist = playlistManager.findByUuid(playlistUuid) ?: return@launch
+            onSuccess(playlist)
+        }
     }
 }


### PR DESCRIPTION
## Description

The top ANR in Sentry is the following:

<img width="589" alt="Screenshot 2023-09-18 at 4 02 59 pm" src="https://github.com/Automattic/pocket-casts-android/assets/308331/a9ddc8a8-9a4d-4a38-bc67-a1f73e5504a9">

The issue appears at FiltersFragment.checkForSavedFilter() on the `runBlocking` line. This change ahs removed this and switched to Coroutines.

## Testing Instructions
1. Tap on the Filters tab
2. If the list of filters is showing, tap on a filter.
3. Tap on the Podcasts tab
4. Tap on the Filters tab
5. ✅ Verify the filter list of episodes are shown