### PR TITLE
Cherry pick #1383 to 7.47

### DIFF
--- a/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackServiceTest.kt
+++ b/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackServiceTest.kt
@@ -102,7 +102,7 @@ class AutoPlaybackServiceTest {
             val podcast = Podcast(UUID.randomUUID().toString(), title = "Test podcast")
             val episode = PodcastEpisode(UUID.randomUUID().toString(), title = "Test episode", publishedDate = Date())
 
-            service.playlistManager = mock { on { findByUuid(any()) }.doReturn(null) }
+            service.playlistManager = mock { on { findByUuidSync(any()) }.doReturn(null) }
             service.podcastManager = mock { on { runBlocking { findPodcastByUuidSuspend(any()) } }.doReturn(podcast) }
             service.episodeManager = mock { on { findEpisodesByPodcastOrdered(any()) }.doReturn(listOf(episode)) }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/DurationOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/DurationOptionsFragment.kt
@@ -102,7 +102,7 @@ class DurationOptionsFragment : BaseFragment() {
         val btnClose = binding.btnClose
 
         launch {
-            val playlist = withContext(Dispatchers.Default) { playlistManager.findByUuid(requireArguments().getString(ARG_PLAYLIST_UUID)!!) } ?: return@launch
+            val playlist = withContext(Dispatchers.Default) { playlistManager.findByUuidSync(requireArguments().getString(ARG_PLAYLIST_UUID)!!) } ?: return@launch
             this@DurationOptionsFragment.playlist = playlist
 
             enableDurations(playlist.filterDuration)

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/EpisodeOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/EpisodeOptionsFragment.kt
@@ -75,7 +75,7 @@ class EpisodeOptionsFragment : BaseFragment(), CoroutineScope {
             val playlist = withContext(Dispatchers.Default) {
                 val uuid = requireArguments().getString(ARG_PLAYLIST_UUID)!!
                 Timber.d("Loading playlist $uuid")
-                playlistManager.findByUuid(uuid)
+                playlistManager.findByUuidSync(uuid)
             } ?: return@launch
             this@EpisodeOptionsFragment.playlist = playlist
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -93,7 +93,7 @@ class FilterEpisodeListViewModel @Inject constructor(
 
     fun deletePlaylist() {
         launch {
-            withContext(Dispatchers.Default) { playlistManager.findByUuid(playlistUUID) }?.let { playlist ->
+            withContext(Dispatchers.Default) { playlistManager.findByUuidSync(playlistUUID) }?.let { playlist ->
                 playlistManager.delete(playlist)
                 analyticsTracker.track(AnalyticsEvent.FILTER_DELETED)
             }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -135,7 +135,7 @@ class FiltersFragment : BaseFragment(), CoroutineScope, Toolbar.OnMenuItemClickL
             runBlocking {
                 val playlistUUID = settings.selectedFilter() ?: return@runBlocking
                 lastFilterUuidShown = playlistUUID
-                val playlist = withContext(Dispatchers.Default) { playlistManager.findByUuid(playlistUUID) } ?: return@runBlocking
+                val playlist = withContext(Dispatchers.Default) { playlistManager.findByUuidSync(playlistUUID) } ?: return@runBlocking
                 openPlaylist(playlist, isNewFilter = false)
             }
         } else if (!viewModel.isFragmentChangingConfigurations) {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -22,8 +22,6 @@ import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.None
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -132,10 +130,9 @@ class FiltersFragment : BaseFragment(), CoroutineScope, Toolbar.OnMenuItemClickL
     private fun checkForSavedFilter() {
         val shouldOpenSavedFilter = settings.selectedFilter() != null && lastFilterUuidShown != settings.selectedFilter()
         if (shouldOpenSavedFilter) {
-            runBlocking {
-                val playlistUUID = settings.selectedFilter() ?: return@runBlocking
-                lastFilterUuidShown = playlistUUID
-                val playlist = withContext(Dispatchers.Default) { playlistManager.findByUuidSync(playlistUUID) } ?: return@runBlocking
+            val playlistUuid = settings.selectedFilter() ?: return
+            lastFilterUuidShown = playlistUuid
+            viewModel.findPlaylistByUuid(playlistUuid) { playlist ->
                 openPlaylist(playlist, isNewFilter = false)
             }
         } else if (!viewModel.isFragmentChangingConfigurations) {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.filters
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
+import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
@@ -12,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.util.Collections
 import javax.inject.Inject
@@ -78,5 +80,12 @@ class FiltersFragmentViewModel @Inject constructor(
     fun trackFilterListShown(filterCount: Int) {
         val properties = mapOf(FILTER_COUNT_KEY to filterCount)
         analyticsTracker.track(AnalyticsEvent.FILTER_LIST_SHOWN, properties)
+    }
+
+    fun findPlaylistByUuid(playlistUuid: String, onSuccess: (Playlist) -> Unit) {
+        viewModelScope.launch {
+            val playlist = playlistManager.findByUuid(playlistUuid) ?: return@launch
+            onSuccess(playlist)
+        }
     }
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
@@ -79,7 +79,7 @@ class PodcastOptionsFragment : BaseFragment(), PodcastSelectFragment.Listener, C
 
         launch {
             val subscribedPodcasts = withContext(Dispatchers.Default) { podcastManager.findSubscribed() }.map { it.uuid }
-            val playlist = withContext(Dispatchers.Default) { playlistManager.findByUuid(requireArguments().getString(ARG_PLAYLIST_UUID)!!) }!!
+            val playlist = withContext(Dispatchers.Default) { playlistManager.findByUuidSync(requireArguments().getString(ARG_PLAYLIST_UUID)!!) }!!
             this@PodcastOptionsFragment.playlist = playlist
 
             val color = playlist.getColor(context)

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/TimeOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/TimeOptionsFragment.kt
@@ -175,7 +175,7 @@ class TimeOptionsFragment : BaseFragment(), CoroutineScope {
         val recyclerView = binding.recyclerView
 
         launch {
-            val playlist = async(Dispatchers.Default) { playlistManager.findByUuid(requireArguments().getString(ARG_PLAYLIST_UUID)!!) }.await()!!
+            val playlist = async(Dispatchers.Default) { playlistManager.findByUuidSync(requireArguments().getString(ARG_PLAYLIST_UUID)!!) }.await()!!
             this@TimeOptionsFragment.playlist = playlist
 
             selectedPosition = when (optionType) {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -34,6 +34,9 @@ abstract class PlaylistDao {
     abstract fun findByUuidSync(uuid: String): Playlist?
 
     @Query("SELECT * FROM filters WHERE uuid = :uuid LIMIT 1")
+    abstract suspend fun findByUuid(uuid: String): Playlist?
+
+    @Query("SELECT * FROM filters WHERE uuid = :uuid LIMIT 1")
     abstract fun findByUUIDRx(uuid: String): Maybe<Playlist>
 
     @Query("SELECT * FROM filters WHERE uuid = :uuid LIMIT 1")

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -31,7 +31,7 @@ abstract class PlaylistDao {
     abstract fun observeAll(): Flowable<List<Playlist>>
 
     @Query("SELECT * FROM filters WHERE uuid = :uuid LIMIT 1")
-    abstract fun findByUUID(uuid: String): Playlist?
+    abstract fun findByUuidSync(uuid: String): Playlist?
 
     @Query("SELECT * FROM filters WHERE uuid = :uuid LIMIT 1")
     abstract fun findByUUIDRx(uuid: String): Maybe<Playlist>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1185,7 +1185,7 @@ open class PlaybackManager @Inject constructor(
             // First check if it is a podcast uuid, then check if it is from a filter
             else -> podcastManager.findPodcastByUuid(lastPodcastOrFilterUuid)?.let { podcast ->
                 autoPlayOrderForPodcastEpisodes(podcast)
-            } ?: playlistManager.findByUuid(lastPodcastOrFilterUuid)?.let { playlist ->
+            } ?: playlistManager.findByUuidSync(lastPodcastOrFilterUuid)?.let { playlist ->
                 playlistManager.findEpisodes(playlist, episodeManager, this)
             }
         } ?: emptyList()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -506,7 +506,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
         // user tapped on a playlist or podcast, show the episodes
         val episodeItems = ArrayList<MediaBrowserCompat.MediaItem>()
 
-        val playlist = if (DOWNLOADS_ROOT == parentId) playlistManager.getSystemDownloadsFilter() else playlistManager.findByUuid(parentId)
+        val playlist = if (DOWNLOADS_ROOT == parentId) playlistManager.getSystemDownloadsFilter() else playlistManager.findByUuidSync(parentId)
         if (playlist != null) {
             val episodeList = if (DOWNLOADS_ROOT == parentId) episodeManager.observeDownloadedEpisodes().blockingFirst() else playlistManager.findEpisodes(playlist, episodeManager, playbackManager)
             val topEpisodes = episodeList.take(EPISODE_LIMIT)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
@@ -15,7 +15,7 @@ interface PlaylistManager {
     fun observeAll(): Flowable<List<Playlist>>
 
     fun findById(id: Long): Playlist?
-    fun findByUuid(playlistUuid: String): Playlist?
+    fun findByUuidSync(playlistUuid: String): Playlist?
     fun findByUuidRx(playlistUuid: String): Maybe<Playlist>
     fun observeByUuid(playlistUuid: String): Flowable<Playlist>
     fun observeByUuidAsList(playlistUuid: String): Flowable<List<Playlist>>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
@@ -15,6 +15,7 @@ interface PlaylistManager {
     fun observeAll(): Flowable<List<Playlist>>
 
     fun findById(id: Long): Playlist?
+    suspend fun findByUuid(playlistUuid: String): Playlist?
     fun findByUuidSync(playlistUuid: String): Playlist?
     fun findByUuidRx(playlistUuid: String): Maybe<Playlist>
     fun observeByUuid(playlistUuid: String): Flowable<Playlist>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -127,6 +127,10 @@ class PlaylistManagerImpl @Inject constructor(
         return playlistDao.findByUuidSync(playlistUuid)
     }
 
+    override suspend fun findByUuid(playlistUuid: String): Playlist? {
+        return playlistDao.findByUuid(playlistUuid)
+    }
+
     override fun findByUuidRx(playlistUuid: String): Maybe<Playlist> {
         return playlistDao.findByUUIDRx(playlistUuid)
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -54,7 +54,7 @@ class PlaylistManagerImpl @Inject constructor(
         get() = Dispatchers.Default
 
     private fun setupDefaultPlaylists() {
-        val existingNewRelease = playlistDao.findByUUID(NEWRELEASE_UUID)
+        val existingNewRelease = playlistDao.findByUuidSync(NEWRELEASE_UUID)
         if (existingNewRelease == null) {
             val newRelease = Playlist()
             newRelease.apply {
@@ -77,7 +77,7 @@ class PlaylistManagerImpl @Inject constructor(
             playlistDao.update(existingNewRelease)
         }
 
-        val existingInProgress = playlistDao.findByUUID(INPROGRESS_UUID)
+        val existingInProgress = playlistDao.findByUuidSync(INPROGRESS_UUID)
         if (existingInProgress == null) {
             val inProgress = Playlist()
             inProgress.apply {
@@ -124,7 +124,7 @@ class PlaylistManagerImpl @Inject constructor(
     }
 
     override fun findByUuidSync(playlistUuid: String): Playlist? {
-        return playlistDao.findByUUID(playlistUuid)
+        return playlistDao.findByUuidSync(playlistUuid)
     }
 
     override fun findByUuidRx(playlistUuid: String): Maybe<Playlist> {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -123,7 +123,7 @@ class PlaylistManagerImpl @Inject constructor(
         return playlistDao.observeAll()
     }
 
-    override fun findByUuid(playlistUuid: String): Playlist? {
+    override fun findByUuidSync(playlistUuid: String): Playlist? {
         return playlistDao.findByUUID(playlistUuid)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -669,7 +669,7 @@ class PodcastSyncProcess(
                 return@fromCallable null
             }
 
-            var playlist = playlistManager.findByUuid(uuid)
+            var playlist = playlistManager.findByUuidSync(uuid)
             if (sync.deleted) {
                 playlist?.let { playlistManager.deleteSynced(it) }
                 return@fromCallable null


### PR DESCRIPTION
## Description

This cherry picks #1383 from `main` branch to `release/7.47`

In order to properly cherry-pick #1383  to `release/7.47`, I also picked `suspend fun findByUuid(...)` methods from `PlaylistManager` and `PlaylistDao` added in #1362 after renaming existing methods to `findByUuidSync(..)`.

I did not pick the entire  #1362 to get minimum required changes to the release branch at this time.

## Testing Instructions
Refer to testing instruction in #1383

1. Tap on the Filters tab
2. If the list of filters is showing, tap on a filter.
3. Tap on the Podcasts tab
4. Tap on the Filters tab
5. :white_check_mark: Verify the filter list of episodes are shown