### PR TITLE
Fixing Sentry issues

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -142,7 +142,6 @@ class DiscoverViewModel @Inject constructor(
             .map { sponsoredPodcast ->
                 loadPodcastList(sponsoredPodcast.source as String)
                     .filter {
-                        Timber.e("Invalid sponsored podcast list found.")
                         it.podcasts.isNotEmpty() && it.listId != null
                     }
                     .map {


### PR DESCRIPTION
## Description

### Issue 1. Remove invalid sponsored error message

Since Sentry reports Timber exceptions, there is an issue "Invalid sponsored podcast list found.". I don't believe this is an invalid sponsor and it should say valid sponsor. We don't need this log so I have removed it.

### Issue 2. 

## Testing Instructions

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
