### PR TITLE
Improve the worker with updates the episode file size and content type

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperFragment.kt
@@ -32,7 +32,8 @@ class DeveloperFragment : BaseFragment() {
                         onShowkaseClick = ::onShowkaseClick,
                         onForceRefreshClick = viewModel::forceRefresh,
                         onTriggerNotificationClick = viewModel::triggerNotification,
-                        onDeleteFirstEpisodeClick = viewModel::deleteFirstEpisode
+                        onDeleteFirstEpisodeClick = viewModel::deleteFirstEpisode,
+                        onTriggerUpdateEpisodeDetails = viewModel::triggerUpdateEpisodeDetails
                     )
                 }
             }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperPage.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.outlined.BugReport
 import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Downloading
 import androidx.compose.material.icons.outlined.HomeRepairService
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.Refresh
@@ -31,7 +32,8 @@ fun DeveloperPage(
     onShowkaseClick: () -> Unit,
     onForceRefreshClick: () -> Unit,
     onTriggerNotificationClick: () -> Unit,
-    onDeleteFirstEpisodeClick: () -> Unit
+    onDeleteFirstEpisodeClick: () -> Unit,
+    onTriggerUpdateEpisodeDetails: () -> Unit
 ) {
 
     Column(modifier = modifier) {
@@ -44,6 +46,7 @@ fun DeveloperPage(
         SendCrashSetting()
         TriggerNotificationSetting(onClick = onTriggerNotificationClick)
         DeleteFirstEpisodeSetting(onClick = onDeleteFirstEpisodeClick)
+        TriggerUpdateEpisodeDetails(onClick = onTriggerUpdateEpisodeDetails)
     }
 }
 
@@ -113,6 +116,19 @@ private fun DeleteFirstEpisodeSetting(
     )
 }
 
+@Composable
+private fun TriggerUpdateEpisodeDetails(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SettingRow(
+        primaryText = "Trigger update episode details",
+        secondaryText = "Test the update episode details task with 5 random episodes",
+        icon = rememberVectorPainter(Icons.Outlined.Downloading),
+        modifier = modifier.clickable { onClick() }
+    )
+}
+
 @Preview(name = "Light")
 @Composable
 private fun DeveloperPageLightPreview() {
@@ -136,6 +152,7 @@ private fun DeveloperPagePreview() {
         onShowkaseClick = {},
         onForceRefreshClick = {},
         onTriggerNotificationClick = {},
-        onDeleteFirstEpisodeClick = {}
+        onDeleteFirstEpisodeClick = {},
+        onTriggerUpdateEpisodeDetails = {}
     )
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -77,14 +77,26 @@ abstract class EpisodeDao {
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY UPPER(title) ASC")
     abstract fun findByPodcastOrderTitleAsc(podcastUuid: String): List<PodcastEpisode>
 
+    @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY UPPER(title) ASC")
+    abstract suspend fun findByPodcastOrderTitleAscSuspend(podcastUuid: String): List<PodcastEpisode>
+
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY UPPER(title) DESC")
     abstract fun findByPodcastOrderTitleDesc(podcastUuid: String): List<PodcastEpisode>
+
+    @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY UPPER(title) DESC")
+    abstract suspend fun findByPodcastOrderTitleDescSuspend(podcastUuid: String): List<PodcastEpisode>
 
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY published_date ASC")
     abstract fun findByPodcastOrderPublishedDateAsc(podcastUuid: String): List<PodcastEpisode>
 
+    @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY published_date ASC")
+    abstract suspend fun findByPodcastOrderPublishedDateAscSuspend(podcastUuid: String): List<PodcastEpisode>
+
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY published_date DESC")
     abstract fun findByPodcastOrderPublishedDateDesc(podcastUuid: String): List<PodcastEpisode>
+
+    @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY published_date DESC")
+    abstract suspend fun findByPodcastOrderPublishedDateDescSuspend(podcastUuid: String): List<PodcastEpisode>
 
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid AND playing_status != 2 AND archived = 0 ORDER BY published_date DESC LIMIT 1")
     abstract fun findLatestUnfinishedEpisodeByPodcast(podcastUuid: String): PodcastEpisode?
@@ -92,8 +104,14 @@ abstract class EpisodeDao {
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY duration ASC")
     abstract fun findByPodcastOrderDurationAsc(podcastUuid: String): List<PodcastEpisode>
 
+    @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY duration ASC")
+    abstract suspend fun findByPodcastOrderDurationAscSuspend(podcastUuid: String): List<PodcastEpisode>
+
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY duration DESC")
     abstract fun findByPodcastOrderDurationDesc(podcastUuid: String): List<PodcastEpisode>
+
+    @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY duration DESC")
+    abstract suspend fun findByPodcastOrderDurationDescSuspend(podcastUuid: String): List<PodcastEpisode>
 
     // Find new episodes to display in notifications.
     @Query(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -17,11 +17,12 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.await
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import io.sentry.Sentry
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import timber.log.Timber
+import java.io.IOException
+import java.util.concurrent.TimeUnit
 
 @HiltWorker
 class UpdateEpisodeDetailsTask @AssistedInject constructor(
@@ -30,16 +31,19 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
     var episodeManager: EpisodeManager,
 ) : CoroutineWorker(context, params) {
     companion object {
-        const val TASK_NAME = "UpdateEpisodeDetailsTask"
-        const val INPUT_EPISODE_UUIDS = "episode_uuids"
+        private const val TASK_NAME = "UpdateEpisodeDetailsTask"
+        private const val INPUT_EPISODE_UUIDS = "episode_uuids"
+        private const val REQUEST_TIMEOUT_SECS = 20L
 
         fun enqueue(episodes: List<PodcastEpisode>, context: Context) {
             if (episodes.isEmpty()) {
                 return
             }
-            val episodeUuids = episodes.map { it.uuid }.toTypedArray()
+
+            val episodeUuids = episodes.map { it.uuid }
+            LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "$TASK_NAME - enqueued ${episodeUuids.joinToString()}")
             val workData = Data.Builder()
-                .putStringArray(INPUT_EPISODE_UUIDS, episodeUuids)
+                .putStringArray(INPUT_EPISODE_UUIDS, episodeUuids.toTypedArray())
                 .build()
             val workRequest = OneTimeWorkRequestBuilder<UpdateEpisodeDetailsTask>()
                 .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
@@ -61,63 +65,68 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
         }
 
         val startTime = SystemClock.elapsedRealtime()
-        LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "UpdateEpisodeDetailsJob - onStartJob")
+        info("Worker started - episodes: ${episodeUuids.joinToString()}}")
 
         try {
-            Timber.i("Downloading Meta Data for ${episodeUuids.size} episodes")
-
-            val client = OkHttpClient.Builder().build()
+            val client = OkHttpClient.Builder().callTimeout(REQUEST_TIMEOUT_SECS, TimeUnit.SECONDS).build()
 
             for (episodeUuid in episodeUuids) {
                 val episode = episodeManager.findByUuid(episodeUuid) ?: continue
                 val downloadUrl = episode.downloadUrl?.toHttpUrlOrNull() ?: continue
-
                 val request = Request.Builder()
                     .url(downloadUrl)
                     .addHeader("User-Agent", "Pocket Casts")
-                    .head()
                     .build()
 
                 if (isStopped) {
                     return Result.retry()
                 }
 
-                Sentry.addBreadcrumb("UpdateEpisodeDetailsJob - calling ${episode.uuid} - $downloadUrl")
-                val response = client.newCall(request).await()
+                try {
+                    val response = client.newCall(request).await()
 
-                val contentType = response.header("Content-Type")
-                if (contentType != null && contentType.isNotBlank()) {
-                    if ((episode.fileType.isNullOrBlank() && (contentType.startsWith("audio") || contentType.startsWith("video"))) || contentType.startsWith("video")) {
-                        episodeManager.updateFileType(episode, contentType)
-                        episode.fileType = contentType
-                    }
-                }
-
-                val contentLengthHeader = response.header("Content-Length")
-                if (!contentLengthHeader.isNullOrBlank()) {
-                    try {
-                        val contentLength = java.lang.Long.parseLong(contentLengthHeader)
-                        val sizeInBytes = episode.sizeInBytes
-                        if ((sizeInBytes == 0L || sizeInBytes != contentLength) && contentLength > 153600) {
-                            episodeManager.updateSizeInBytes(episode, contentLength)
-                            episode.sizeInBytes = contentLength
+                    val contentType = response.header("Content-Type")
+                    if (!contentType.isNullOrBlank()) {
+                        if ((episode.fileType.isNullOrBlank() && (contentType.startsWith("audio") || contentType.startsWith("video"))) || contentType.startsWith("video")) {
+                            episodeManager.updateFileType(episode, contentType)
+                            episode.fileType = contentType
                         }
-                    } catch (nfe: NumberFormatException) {
-                        Timber.e(nfe, "Unable to read content length.")
                     }
+
+                    val contentLengthHeader = response.header("Content-Length")
+                    if (!contentLengthHeader.isNullOrBlank()) {
+                        try {
+                            val contentLength = java.lang.Long.parseLong(contentLengthHeader)
+                            val sizeInBytes = episode.sizeInBytes
+                            if ((sizeInBytes == 0L || sizeInBytes != contentLength) && contentLength > 153600) {
+                                episodeManager.updateSizeInBytes(episode, contentLength)
+                                episode.sizeInBytes = contentLength
+                            }
+                        } catch (nfe: NumberFormatException) {
+                            Timber.i(nfe, "Unable to read content length.")
+                        }
+                    }
+                } catch (ioException: IOException) {
+                    // don't report IO issues such as timeouts to Sentry
+                    info("Unable to check episode file details with a head request for $episodeUuid. Error: ${ioException.message}")
                 }
             }
-        } catch (t: Throwable) {
-            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, t, "Unable to check episode file details with a head request.")
-            return if (runAttemptCount < 3) {
-                LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "UpdateEpisodeDetailsJob - onTaskCompleted - retry ${runAttemptCount + 1}")
-                Result.retry()
-            } else {
-                Result.failure()
-            }
-        }
 
-        LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "UpdateEpisodeDetailsJob - onTaskCompleted - ${String.format("%d ms", SystemClock.elapsedRealtime() - startTime)}")
-        return Result.success()
+            info("Worker completed - took ${SystemClock.elapsedRealtime() - startTime} ms")
+            return Result.success()
+        } catch (t: Throwable) {
+            info("Worker failed - took ${SystemClock.elapsedRealtime() - startTime} ms")
+            // report the error to Sentry and to the log buffer for support
+            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, t, "Unable to check episode file details with a head request.")
+            // mark the worker as a success or it will won't process all the chain tasks
+            return Result.success()
+        }
+    }
+
+    /**
+     * Log a message to the log buffer for support and to the console for debugging.
+     */
+    private fun info(message: String) {
+        LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "$TASK_NAME (Worker ID: $id) - $message")
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -32,7 +32,7 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
 ) : CoroutineWorker(context, params) {
     companion object {
         private const val TASK_NAME = "UpdateEpisodeDetailsTask"
-        private const val INPUT_EPISODE_UUIDS = "episode_uuids"
+        const val INPUT_EPISODE_UUIDS = "episode_uuids"
         private const val REQUEST_TIMEOUT_SECS = 20L
 
         fun enqueue(episodes: List<PodcastEpisode>, context: Context) {
@@ -76,6 +76,7 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
                 val request = Request.Builder()
                     .url(downloadUrl)
                     .addHeader("User-Agent", "Pocket Casts")
+                    .head()
                     .build()
 
                 if (isStopped) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -44,6 +44,7 @@ interface EpisodeManager {
     fun findEpisodesByUuids(uuids: Array<String>, ordered: Boolean): List<PodcastEpisode>
     fun findEpisodesByPodcast(podcast: Podcast): Single<List<PodcastEpisode>>
     fun findEpisodesByPodcastOrdered(podcast: Podcast): List<PodcastEpisode>
+    suspend fun findEpisodesByPodcastOrderedSuspend(podcast: Podcast): List<PodcastEpisode>
     fun findEpisodesByPodcastOrderedRx(podcast: Podcast): Single<List<PodcastEpisode>>
     fun findEpisodesByPodcastOrderedByPublishDate(podcast: Podcast): List<PodcastEpisode>
     fun findNotificationEpisodes(date: Date): List<PodcastEpisode>


### PR DESCRIPTION
## Description

As part of the investigation into the Android ANR and the Sentry issue "Unable to check episode file details with a head request", I looked into the UpdateEpisodeDetailsTask. I don't believe there are any issues relating to ANRs but there are some improvements that could be made.

This change makes the following improvements:
- Adds a developer menu option to trigger the worker making it easier to test
- Increases the default timeout from 10 to 20 seconds. This matches iOS and will help with the megaphone calls that seem to take around 10 seconds to complete.
- Removes the retry logic. This isn't in iOS and if the job has failed after 20 seconds there is a small chance that it will succeed on a second or third attempt.
- It stops using `Result.failure()` as from my testing it causes the Work Manager to not run future tasks. 
- Any IO exception is not sent to Sentry as this relies on the user's network and the producer's servers which we can't fix.
- The task can be sent multiple episodes but if one fails because of a timeout all of them would be retried. Now the timeout is caught per episode. 

## Testing Instructions
1. Open the App Inspection window -> Background Task Inspector
2. Subscribe to some podcasts
3. Go to Profile tab -> settings cog -> Developer
4. Tap "Trigger update episode details"
5. ✅ Verify the workers are completing in the Background Task Inspector window
6. To test the timeout, change the UpdateEpisodeDetailsTask REQUEST_TIMEOUT_SECS amount to 2 seconds
7. Tap "Trigger update episode details" again
8. Filter logcat by "UpdateEpisodeDetailsTask"
9. ✅ Verify that an episode timeout is logged but the worker still completes

## Screenshots 

<img width="806" alt="Screenshot 2023-09-20 at 12 44 31 pm" src="https://github.com/Automattic/pocket-casts-android/assets/308331/1e4cc494-be96-4588-a882-8bf288570ad8">
