### PR TITLE
Update leak canary

### DIFF
--- a/base.gradle
+++ b/base.gradle
@@ -252,10 +252,10 @@ dependencies {
     implementation libs.media3Extractor
     implementation libs.media3Ui
     implementation libs.showkase
-    implementation (libs.junit) {
+    testImplementation (libs.junit) {
         exclude group: 'org.hamcrest'
     }
-    implementation libs.kotlinCoroutinesTest
+    testImplementation libs.kotlinCoroutinesTest
     implementation libs.protobufKotlinLite
     implementation libs.protobufJavaLite
 

--- a/base.gradle
+++ b/base.gradle
@@ -153,7 +153,8 @@ android {
 
 dependencies {
     // Uncomment if you want to run with leak canary
-    //debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.6'
+//    debugImplementation androidLibs.leakCanary
+//    debugProdImplementation androidLibs.leakCanary
 
     implementation androidLibs.appCompat
     implementation androidLibs.auth

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -217,6 +217,8 @@ project.ext {
             accessibilityTestFramework: "com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:$versionAccessibilityTestFramework",
             // In-app reviews
             playReview: 'com.google.android.play:review-ktx:2.0.1',
+
+            leakCanary: 'com.squareup.leakcanary:leakcanary-android:2.10',
     ]
 
     libs = [

--- a/modules/services/sharedtest/build.gradle
+++ b/modules/services/sharedtest/build.gradle
@@ -6,3 +6,13 @@ android {
         buildConfig true
     }
 }
+
+dependencies {
+    // These dependencies have to be redeclared here event though they are already in
+    // base.gradle because here they need to not be test dependencies like they are in
+    // the main app.
+    implementation libs.kotlinCoroutinesTest
+    implementation (libs.junit) {
+        exclude group: 'org.hamcrest'
+    }
+}


### PR DESCRIPTION
## Description
This updates leak canary to use the latest version, which addresses a bug that was preventing me from using it. 

In addition, I am adding a commented out `debugProdImplementation` declaration just to give a hint about needing that if you're doing debugProd builds since I lost about 10 minute trying to figure out why Leak Canary wasn't working for me.

Lastly, this limits some test dependencies to only show up in tests. Leak Canary was seeing these classes and not running by default because those classes led it to believe that my debug app build actually a running test. This avoids that problem. FWIW, I don't think this would have been a release issue for us at all since proguard would have presumably stripped these classes out anyway on release builds.

## Testing Instructions
1. Uncomment the lead canary dependency
2. Do a build
3. Change the phone's orientation a few times
4. Observe that leak canary detects some leaks

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews