### PR TITLE
Avoid creating new UpNextFragment when tapping up next button on full screen player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 
 *   New Feature:
     *   Suggest episodes to play in Automotive
-        ([#1362](https://github.com/Automattic/pocket-casts-android/pull/1362)).
+        ([#1362](https://github.com/Automattic/pocket-casts-android/pull/1362))
+*   Bug Fixes:
+    *   Improved multiselect handling in Up Next queue
+        ([#1395](https://github.com/Automattic/pocket-casts-android/pull/1392))
 
 7.47
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -210,8 +210,9 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
     }
 
     fun openUpNext() {
-        val upNextFragment = UpNextFragment.newInstance(source = UpNextSource.PLAYER)
-        (activity as? FragmentHostListener)?.showBottomSheet(upNextFragment)
+        binding?.let {
+            BottomSheetBehavior.from(it.upNextFrameBottomSheet).state = BottomSheetBehavior.STATE_EXPANDED
+        }
     }
 
     fun openPlayer() {


### PR DESCRIPTION
## Description
There are three places where we have been creating new UpNextFragments:
1. Each time the up next button is tapped on the mini player
2. Each time the up next button is tapped on the full-screen player
3. The full screen player also creates another instance that it uses for when the user swipes up from the bottom of the screen.

This PR removes `#2` and instead has tapping on that up next button just expand the UpNextFragment that already exists and is used when the user swipes up from the bottom of the full screen player.

Ideally, I would like to get rid of `#1` as well, but that seems less straightforward, so this PR is just tackling the simple case.

This because we are storing some state around multi-selection, reducing the number of `UpNextFragment`s that we're creating should help improve things.

## Testing Instructions
1. Fresh install of the app
2. Add some episodes to your up next queue
1. Open the Full screen player
3. Swipe up from the bottom of the screen to show the up next queue
4. Use multi-select to select all the items
5. Dismiss the up next queue by swiping down
6. Tap the button to show the up next queue
7. Observe that all the items are still selected (this will happen as long as you dismissed the up next queue in step 5 by swiping down without dismissing multiselect)
8. Dismiss the up next queue by swiping down
9. Swipe up from the bottom to again see the up next queue
10. Observe that the items are all selected.
11. Verify that things like select all and select none work for multiselection.

Before this PR, on the last two steps none of the items would have been selected and select all/none/above/etc would not have worked anymore because the `multiSelectHelper.listener` field, which was initially set by this UpNextFragment instance, would have been replaced by the new UpNextFragment instance that was getting created by tapping the UpNextButton in the full screen player.

Note that you can still recreate this bug by exiting the full screen player and opening the up next queue from the miniplayer. Since that button is still creating a new `UpNextFragment`, it is replacing the `MultiSelectHelper`'s listener, meaning that the `UpNextFragment` instance that is being used by the full-screen player no longer has its listener assigned, and therefore multiselect will no longer work from the UpNextFragment on the full screen player screen.

I believe this behavior will be improved by #1398, but I haven't had a chance to fully test and evaluate that code yet.

## Screenshots or Screencast 

| Before | After | Still can create issue |
| --- | --- | --- |
| <video src="https://github.com/Automattic/pocket-casts-android/assets/4656348/81127e01-80cf-427f-9e8e-e47f3b724bb7"/> | <video src="https://github.com/Automattic/pocket-casts-android/assets/4656348/5d9dfe33-5a42-4b78-9d21-a9108dc8b638"/> | <video src="https://github.com/Automattic/pocket-casts-android/assets/4656348/dc148bb0-0ebf-4099-b910-a70b35b2610c"/> |

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
