### PR TITLE
Clear multiselect listener when destroying UpNextFragment to avoid memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 *   New Feature:
     *   Suggest episodes to play in Automotive
         ([#1362](https://github.com/Automattic/pocket-casts-android/pull/1362)).
+*   Bug Fixes:
+    *   Avoid memory leak when opening Up Next queue
+        ([#1397](https://github.com/Automattic/pocket-casts-android/pull/1397))
 
 7.47
 -----

--- a/base.gradle
+++ b/base.gradle
@@ -252,10 +252,10 @@ dependencies {
     implementation libs.media3Extractor
     implementation libs.media3Ui
     implementation libs.showkase
-    implementation (libs.junit) {
+    testImplementation (libs.junit) {
         exclude group: 'org.hamcrest'
     }
-    implementation libs.kotlinCoroutinesTest
+    testImplementation libs.kotlinCoroutinesTest
     implementation libs.protobufKotlinLite
     implementation libs.protobufJavaLite
 

--- a/base.gradle
+++ b/base.gradle
@@ -153,7 +153,8 @@ android {
 
 dependencies {
     // Uncomment if you want to run with leak canary
-    //debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.6'
+//    debugImplementation androidLibs.leakCanary
+//    debugProdImplementation androidLibs.leakCanary
 
     implementation androidLibs.appCompat
     implementation androidLibs.auth

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -217,6 +217,8 @@ project.ext {
             accessibilityTestFramework: "com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:$versionAccessibilityTestFramework",
             // In-app reviews
             playReview: 'com.google.android.play:review-ktx:2.0.1',
+
+            leakCanary: 'com.squareup.leakcanary:leakcanary-android:2.10',
     ]
 
     libs = [

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -123,6 +123,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
         binding.recyclerView.adapter = null
         super.onDestroyView()
         multiSelectHelper.context = null
+        multiSelectHelper.listener = null
         realBinding = null
     }
 

--- a/modules/services/sharedtest/build.gradle
+++ b/modules/services/sharedtest/build.gradle
@@ -6,3 +6,13 @@ android {
         buildConfig true
     }
 }
+
+dependencies {
+    // These dependencies have to be redeclared here event though they are already in
+    // base.gradle because here they need to not be test dependencies like they are in
+    // the main app.
+    implementation libs.kotlinCoroutinesTest
+    implementation (libs.junit) {
+        exclude group: 'org.hamcrest'
+    }
+}

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
@@ -44,8 +44,6 @@ class MultiSelectBookmarksHelper @Inject constructor(
             )
         }
 
-    override var listener: Listener<Bookmark>? = null
-
     override fun isSelected(multiSelectable: Bookmark) =
         selectedList.count { it.uuid == multiSelectable.uuid } > 0
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
@@ -44,7 +44,7 @@ class MultiSelectBookmarksHelper @Inject constructor(
             )
         }
 
-    override lateinit var listener: Listener<Bookmark>
+    override var listener: Listener<Bookmark>? = null
 
     override fun isSelected(multiSelectable: Bookmark) =
         selectedList.count { it.uuid == multiSelectable.uuid } > 0

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -66,8 +66,6 @@ class MultiSelectEpisodesHelper @Inject constructor(
             }
         }
 
-    override var listener: Listener<BaseEpisode>? = null
-
     override fun isSelected(multiSelectable: BaseEpisode) =
         selectedList.count { it.uuid == multiSelectable.uuid } > 0
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -66,7 +66,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
             }
         }
 
-    override lateinit var listener: Listener<BaseEpisode>
+    override var listener: Listener<BaseEpisode>? = null
 
     override fun isSelected(multiSelectable: BaseEpisode) =
         selectedList.count { it.uuid == multiSelectable.uuid } > 0

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectHelper.kt
@@ -31,7 +31,7 @@ abstract class MultiSelectHelper<T> : CoroutineScope {
         fun multiDeselectAllAbove(multiSelectable: T)
     }
 
-    open var listener: Listener<T>? = null
+    var listener: Listener<T>? = null
 
     private val _isMultiSelectingLive = MutableLiveData<Boolean>().apply { value = false }
     val isMultiSelectingLive: LiveData<Boolean> = _isMultiSelectingLive

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectHelper.kt
@@ -31,7 +31,7 @@ abstract class MultiSelectHelper<T> : CoroutineScope {
         fun multiDeselectAllAbove(multiSelectable: T)
     }
 
-    open lateinit var listener: Listener<T>
+    open var listener: Listener<T>? = null
 
     private val _isMultiSelectingLive = MutableLiveData<Boolean>().apply { value = false }
     val isMultiSelectingLive: LiveData<Boolean> = _isMultiSelectingLive
@@ -122,19 +122,19 @@ abstract class MultiSelectHelper<T> : CoroutineScope {
     }
 
     fun selectAll() {
-        listener.multiSelectSelectAll()
+        listener?.multiSelectSelectAll()
     }
 
     fun unselectAll() {
-        listener.multiSelectSelectNone()
+        listener?.multiSelectSelectNone()
     }
 
     private fun selectAllAbove(multiSelectable: T) {
-        listener.multiSelectSelectAllUp(multiSelectable)
+        listener?.multiSelectSelectAllUp(multiSelectable)
     }
 
     private fun selectAllBelow(multiSelectable: T) {
-        listener.multiSelectSelectAllDown(multiSelectable)
+        listener?.multiSelectSelectAllDown(multiSelectable)
     }
 
     fun selectAllInList(multiSelectables: List<T>) {
@@ -181,15 +181,15 @@ abstract class MultiSelectHelper<T> : CoroutineScope {
     }
 
     private fun deselectAll() {
-        listener.multiSelectSelectNone()
+        listener?.multiSelectSelectNone()
     }
 
     private fun deselectAllAbove(deselectAllBelow: T) {
-        listener.multiDeselectAllAbove(deselectAllBelow)
+        listener?.multiDeselectAllAbove(deselectAllBelow)
     }
 
     private fun deselectAllBelow(deselectAllBelow: T) {
-        listener.multiDeselectAllBelow(deselectAllBelow)
+        listener?.multiDeselectAllBelow(deselectAllBelow)
     }
 
     fun closeMultiSelect() {


### PR DESCRIPTION
## Description
This clears the multiselect listener when destroying the UpNextFragment to avoid retaining a reference to the Fragment.

> **Note**
> This PR builds on #1393. Please merge that PR before this one.

## Testing Instructions
1. Enable Leak Canary
2. Open and close the up next queue from the miniplayer
3. Observe that there is no memory leak
4. Generally smoke test the up next queue screens both from the miniplayer and the full screen player to check for regressions.

| Before | After |
| --- | --- |
| <video src="https://github.com/Automattic/pocket-casts-android/assets/4656348/4e568369-8842-49e0-9c1d-a92e49a49995"/> | <video src="https://github.com/Automattic/pocket-casts-android/assets/4656348/4ab21c3e-c577-47f3-9618-5e398737e26d"/> |


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
