### PR TITLE
Improve multiselect listener handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@
 *   Bug Fixes:
     *   Avoid memory leak when opening Up Next queue
         ([#1397](https://github.com/Automattic/pocket-casts-android/pull/1397))
-    *   Improved multiselect handling in Up Next queue
-        ([#1395](https://github.com/Automattic/pocket-casts-android/pull/1392))
     *   Improved the downloading of episode show notes
         ([#1390](https://github.com/Automattic/pocket-casts-android/pull/1390))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+7.49
+-----
+
+*   Bug Fixes:
+    *   Improve multiselect handling in Up Next queue
+        ([#1398](https://github.com/Automattic/pocket-casts-android/pull/1390))
+
 7.48
 -----
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -101,7 +101,7 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
                         theme.updateWindowStatusBar(it.window, StatusBarColor.Custom(ThemeColor.primaryUi01(Theme.ThemeType.DARK), true), it)
                     }
 
-                    upNextFragment.startTour()
+                    upNextFragment.onExpanded()
 
                     FirebaseAnalyticsTracker.openedUpNext()
                 } else if (newState == BottomSheetBehavior.STATE_COLLAPSED) {
@@ -109,6 +109,7 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
                     updateUpNextVisibility(false)
 
                     (activity as? FragmentHostListener)?.updateSystemColors()
+                    upNextFragment.onCollapsed()
                 }
             }
         })

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -211,9 +211,8 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
     }
 
     fun openUpNext() {
-        binding?.let {
-            BottomSheetBehavior.from(it.upNextFrameBottomSheet).state = BottomSheetBehavior.STATE_EXPANDED
-        }
+        val upNextFragment = UpNextFragment.newInstance(source = UpNextSource.PLAYER)
+        (activity as? FragmentHostListener)?.showBottomSheet(upNextFragment)
     }
 
     fun openPlayer() {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -108,6 +108,64 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
     val overrideTheme: Theme.ThemeType
         get() = if (Theme.isDark(context)) theme.activeTheme else Theme.ThemeType.DARK
 
+    val multiSelectListener = object : MultiSelectHelper.Listener<BaseEpisode> {
+        override fun multiSelectSelectAll() {
+            trackUpNextEvent(
+                AnalyticsEvent.UP_NEXT_SELECT_ALL_TAPPED,
+                mapOf(SELECT_ALL_KEY to true)
+            )
+            multiSelectHelper.selectAllInList(upNextEpisodes)
+            adapter.notifyDataSetChanged()
+        }
+
+        override fun multiSelectSelectNone() {
+            trackUpNextEvent(
+                AnalyticsEvent.UP_NEXT_SELECT_ALL_TAPPED,
+                mapOf(SELECT_ALL_KEY to false)
+            )
+            multiSelectHelper.deselectAllInList(upNextEpisodes)
+            adapter.notifyDataSetChanged()
+        }
+
+        override fun multiSelectSelectAllUp(multiSelectable: BaseEpisode) {
+            val startIndex = upNextEpisodes.indexOf(multiSelectable)
+            if (startIndex > -1) {
+                val episodesAbove = upNextEpisodes.subList(0, startIndex + 1)
+                multiSelectHelper.selectAllInList(episodesAbove)
+            }
+
+            adapter.notifyDataSetChanged()
+        }
+
+        override fun multiSelectSelectAllDown(multiSelectable: BaseEpisode) {
+            val startIndex = upNextEpisodes.indexOf(multiSelectable)
+            if (startIndex > -1) {
+                val episodesBelow = upNextEpisodes.subList(startIndex, upNextEpisodes.size)
+                multiSelectHelper.selectAllInList(episodesBelow)
+            }
+
+            adapter.notifyDataSetChanged()
+        }
+
+        override fun multiDeselectAllBelow(multiSelectable: BaseEpisode) {
+            val startIndex = upNextEpisodes.indexOf(multiSelectable)
+            if (startIndex > -1) {
+                val episodesBelow = upNextEpisodes.subList(startIndex, upNextEpisodes.size)
+                multiSelectHelper.deselectAllInList(episodesBelow)
+            }
+            adapter.notifyDataSetChanged()
+        }
+
+        override fun multiDeselectAllAbove(multiSelectable: BaseEpisode) {
+            val startIndex = upNextEpisodes.indexOf(multiSelectable)
+            if (startIndex > -1) {
+                val episdesAbove = upNextEpisodes.subList(0, startIndex + 1)
+                multiSelectHelper.deselectAllInList(episdesAbove)
+            }
+            adapter.notifyDataSetChanged()
+        }
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         val themedContext = ContextThemeWrapper(activity, UR.style.ThemeDark)
         val themedInflater = if (!Theme.isDark(context)) inflater.cloneInContext(themedContext) else inflater // If the theme is not dark we force it to ThemeDark
@@ -243,57 +301,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
 
             adapter.notifyDataSetChanged()
         }
-        multiSelectHelper.listener = object : MultiSelectHelper.Listener<BaseEpisode> {
-            override fun multiSelectSelectAll() {
-                trackUpNextEvent(AnalyticsEvent.UP_NEXT_SELECT_ALL_TAPPED, mapOf(SELECT_ALL_KEY to true))
-                multiSelectHelper.selectAllInList(upNextEpisodes)
-                adapter.notifyDataSetChanged()
-            }
-
-            override fun multiSelectSelectNone() {
-                trackUpNextEvent(AnalyticsEvent.UP_NEXT_SELECT_ALL_TAPPED, mapOf(SELECT_ALL_KEY to false))
-                multiSelectHelper.deselectAllInList(upNextEpisodes)
-                adapter.notifyDataSetChanged()
-            }
-
-            override fun multiSelectSelectAllUp(multiSelectable: BaseEpisode) {
-                val startIndex = upNextEpisodes.indexOf(multiSelectable)
-                if (startIndex > -1) {
-                    val episodesAbove = upNextEpisodes.subList(0, startIndex + 1)
-                    multiSelectHelper.selectAllInList(episodesAbove)
-                }
-
-                adapter.notifyDataSetChanged()
-            }
-
-            override fun multiSelectSelectAllDown(multiSelectable: BaseEpisode) {
-                val startIndex = upNextEpisodes.indexOf(multiSelectable)
-                if (startIndex > -1) {
-                    val episodesBelow = upNextEpisodes.subList(startIndex, upNextEpisodes.size)
-                    multiSelectHelper.selectAllInList(episodesBelow)
-                }
-
-                adapter.notifyDataSetChanged()
-            }
-
-            override fun multiDeselectAllBelow(multiSelectable: BaseEpisode) {
-                val startIndex = upNextEpisodes.indexOf(multiSelectable)
-                if (startIndex > -1) {
-                    val episodesBelow = upNextEpisodes.subList(startIndex, upNextEpisodes.size)
-                    multiSelectHelper.deselectAllInList(episodesBelow)
-                }
-                adapter.notifyDataSetChanged()
-            }
-
-            override fun multiDeselectAllAbove(multiSelectable: BaseEpisode) {
-                val startIndex = upNextEpisodes.indexOf(multiSelectable)
-                if (startIndex > -1) {
-                    val episdesAbove = upNextEpisodes.subList(0, startIndex + 1)
-                    multiSelectHelper.deselectAllInList(episdesAbove)
-                }
-                adapter.notifyDataSetChanged()
-            }
-        }
+        multiSelectHelper.listener = multiSelectListener
 
         multiSelectHelper.context = view.context
         multiSelectToolbar.setup(viewLifecycleOwner, multiSelectHelper, menuRes = VR.menu.menu_multiselect_upnext, fragmentManager = parentFragmentManager)
@@ -310,7 +318,16 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
         }
     }
 
-    fun startTour() {
+    fun onExpanded() {
+        multiSelectHelper.listener = multiSelectListener
+        startTour()
+    }
+
+    fun onCollapsed() {
+        multiSelectHelper.listener = null
+    }
+
+    private fun startTour() {
         val upNextTourView = realBinding?.upNextTourView ?: return
         if (settings.getSeenUpNextTour()) {
             (upNextTourView.parent as? ViewGroup)?.removeView(upNextTourView)


### PR DESCRIPTION
## Description
Have the `PlayerContainerFragment` initiate the addition/removal of the multiSelectHelper's listener as the UpNextFragment is expanded/contracted. This should help make sure that the UpNextFragment on the full screen player always has the right listener attached, regardless of whether a different instance of `UpNextFragment` gets created and destroyed in the meantime.

This avoids the problem where multiselection would not work after swiping up to open the up next screen on the full screen player, if the up next screen had been viewed already by tapping the up next button on either the full screen player or the miniplayer. See the description of #1395 for some more discussion about this.

Note that this PR also contains the changes from #1404 reverting the removal of the creation of new `UpNextFragment`s on the full screen player because that introduced issues opening the up next queue solely using the full screen player button, which could cause issues when testing this. If you think it would be better to leave that change out of this PR and to bring it in via the `release/7.48`, feel free to just remove that commit from this branch.

## Testing Instructions
1. Tap on the Up Next queue button on the miniplayer
2. Close the Up next queue
3. Open the full screen player
4. Open the up next queue by swiping up from the bottom
5. Open multiselect mode
6. ✅ Try select all/below/above/none and make sure they work
7. Dismiss the up next queue
8. Tap on the button to open the up next queue in the full screen player (i.e., do _**not**_ swipe the up next queue open)
9. Dismiss the up next queue
10. Swipe open the up next queue
11. ✅ Try select all/below/above/none and make sure they work

## Screenshots or Screencast 


| Before | After |

Uploading Screen Recording 2023-09-21 at 3.55.17 PM.mov…


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
