### PR TITLE
Stop the search history loading infinitely

### DIFF
--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -71,7 +72,9 @@ internal fun SearchHistoryPage(
         onRowClick = onClick,
         onScroll = onScroll,
     )
-    viewModel.start()
+    LaunchedEffect(Unit) {
+        viewModel.start()
+    }
 }
 
 @Composable


### PR DESCRIPTION
## Description

When the search page was opened and there was search history, the history was constantly loaded. This was due to the load being in the Compose render loop. I believe the correct approach is to use a `LaunchedEffect` but it would be good to confirm that. The fix only loads the history once when opening the search page. 

Fixes https://github.com/Automattic/pocket-casts-android/issues/1396

## Testing Instructions
1. Open `SearchHistoryViewModel.kt`
2. Go to [line 59](https://github.com/Automattic/pocket-casts-android/blob/93013f4bbd564dacc23dfdbb1a3a0e79302ab0c6/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryViewModel.kt#L59C5-L59C5)
3. Add `LogBuffer.i("🚨","loadSearchHistory")`
4. Run the app
5. Go to Discover > Tap Search
7. Make sure you have a search history term
8. ✅ Verify the log statement is only printed once
