### PR TITLE
Improved the UpdateEpisodeTask to use Hilt and Coroutines

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeTaskTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeTaskTest.kt
@@ -1,0 +1,119 @@
+package au.com.shiftyjelly.pocketcasts.repositories.download
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import androidx.work.ListenableWorker
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import androidx.work.testing.TestListenableWorkerBuilder
+import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
+import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.download.task.UpdateEpisodeTask
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.never
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import java.util.Date
+import java.util.UUID
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class UpdateEpisodeTaskTest {
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    /**
+     * Test the download url is updated when the server has a different url.
+     */
+    @Test
+    fun testDownloadUrlChanged() {
+        testDownloadUrl(
+            deviceUrl = "https://www.pocketcasts.com/old_url.mp3",
+            serverUrl = "https://www.pocketcasts.com/new_url.mp3",
+            shouldUpdate = true
+        )
+    }
+
+    /**
+     * Test the download url is not updated when the server and device have the same url.
+     */
+    @Test
+    fun testDownloadUrlSame() {
+        testDownloadUrl(
+            deviceUrl = "https://www.pocketcasts.com/url.mp3",
+            serverUrl = "https://www.pocketcasts.com/url.mp3",
+            shouldUpdate = false
+        )
+    }
+
+    private fun testDownloadUrl(deviceUrl: String, serverUrl: String, shouldUpdate: Boolean) {
+        val podcastUuid = UUID.randomUUID().toString()
+        val episodeUuid = UUID.randomUUID().toString()
+        val deviceEpisode = PodcastEpisode(
+            uuid = episodeUuid,
+            publishedDate = Date(),
+            podcastUuid = podcastUuid,
+            downloadUrl = deviceUrl
+        )
+        val serverEpisode = PodcastEpisode(
+            uuid = episodeUuid,
+            publishedDate = Date(),
+            podcastUuid = podcastUuid,
+            downloadUrl = serverUrl
+        )
+        val serverPodcast = Podcast(uuid = podcastUuid).apply {
+            episodes.add(serverEpisode)
+        }
+
+        val podcastCacheServerManager = mock<PodcastCacheServerManager> {
+            onBlocking { getPodcastAndEpisode(podcastUuid, episodeUuid) } doReturn serverPodcast
+        }
+        val episodeDao = mock<EpisodeDao> {
+            onBlocking { findByUuid(episodeUuid) } doReturn deviceEpisode
+        }
+        val appDatabase = mock<AppDatabase> {
+            on { episodeDao() } doReturn episodeDao
+        }
+        val inputData = UpdateEpisodeTask.buildInputData(deviceEpisode)
+        val worker = TestListenableWorkerBuilder<UpdateEpisodeTask>(context = context, inputData = inputData)
+            .setWorkerFactory(TestWorkerFactory(podcastCacheServerManager, appDatabase))
+            .build()
+
+        runTest {
+            val result = worker.doWork()
+            assertTrue("Worker should succeed", result is ListenableWorker.Result.Success)
+
+            if (shouldUpdate) {
+                verify(episodeDao, times(1)).updateDownloadUrl(serverUrl, episodeUuid)
+                verify(episodeDao, never()).updateDownloadUrl(deviceUrl, episodeUuid)
+            } else {
+                verify(episodeDao, never()).updateDownloadUrl(serverUrl, episodeUuid)
+                verify(episodeDao, never()).updateDownloadUrl(deviceUrl, episodeUuid)
+            }
+        }
+    }
+
+    class TestWorkerFactory(private val podcastCacheServerManager: PodcastCacheServerManager, private val appDatabase: AppDatabase) : WorkerFactory() {
+        override fun createWorker(context: Context, workerClassName: String, workerParameters: WorkerParameters): ListenableWorker? {
+            return UpdateEpisodeTask(
+                context = context,
+                params = workerParameters,
+                podcastCacheServerManager = podcastCacheServerManager,
+                appDatabase = appDatabase
+            )
+        }
+    }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -204,7 +204,7 @@ abstract class EpisodeDao {
     abstract fun updateSizeInBytes(sizeInBytes: Long, uuid: String)
 
     @Query("UPDATE podcast_episodes SET download_url = :url WHERE uuid = :uuid")
-    abstract fun updateDownloadUrl(url: String, uuid: String)
+    abstract suspend fun updateDownloadUrl(url: String, uuid: String)
 
     @Query("UPDATE podcast_episodes SET download_task_id = :taskId WHERE uuid = :uuid")
     abstract fun updateDownloadTaskId(uuid: String, taskId: String?)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateEpisodeTask.kt
@@ -1,61 +1,65 @@
 package au.com.shiftyjelly.pocketcasts.repositories.download.task
 
 import android.content.Context
-import androidx.work.Worker
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.Data
 import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManagerImpl
-import com.squareup.moshi.Moshi
-import okhttp3.OkHttpClient
-import retrofit2.Retrofit
-import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
-import retrofit2.converter.moshi.MoshiConverterFactory
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import timber.log.Timber
 
-class UpdateEpisodeTask(val context: Context, val params: WorkerParameters) : Worker(context, params) {
+/**
+ * This task updates the download url of an episode.
+ */
+@HiltWorker
+class UpdateEpisodeTask @AssistedInject constructor(
+    @Assisted val context: Context,
+    @Assisted val params: WorkerParameters,
+    val podcastCacheServerManager: PodcastCacheServerManager,
+    val appDatabase: AppDatabase
+) : CoroutineWorker(context, params) {
     companion object {
         const val INPUT_PODCAST_UUID = "podcast_uuid"
         const val INPUT_EPISODE_UUID = "episode_uuid"
+
+        fun buildInputData(episode: PodcastEpisode): Data {
+            return Data.Builder()
+                .putString(INPUT_EPISODE_UUID, episode.uuid)
+                .putString(INPUT_PODCAST_UUID, episode.podcastUuid)
+                .build()
+        }
     }
 
-    private val moshi = Moshi.Builder().build()
-    private val httpClient = OkHttpClient()
-    private val retrofit = Retrofit.Builder()
-        .addConverterFactory(MoshiConverterFactory.create(moshi))
-        .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
-        .baseUrl(Settings.SERVER_CACHE_URL)
-        .client(httpClient)
-        .build()
+    private val podcastUuid = inputData.getString(INPUT_PODCAST_UUID)
+    private val episodeUuid = inputData.getString(INPUT_EPISODE_UUID)
+    private val episodeDao = appDatabase.episodeDao()
 
-    private val podcastUUID = inputData.getString(INPUT_PODCAST_UUID)
-    private val episodeUUID = inputData.getString(INPUT_EPISODE_UUID)!!
-
-    override fun doWork(): Result {
+    override suspend fun doWork(): Result {
         try {
-            if (podcastUUID == null) {
-                return Result.success() // Nothing to do without a podcast
+            if (podcastUuid == null || episodeUuid == null) {
+                return Result.success()
             }
 
-            // TODO use @HiltWorker and inject these
-            val serverPodcast = PodcastCacheServerManagerImpl(retrofit).getPodcastAndEpisode(podcastUUID, episodeUUID).blockingGet()
-            val appDatabase = AppDatabase.getInstance(context)
-            val episodeDao = appDatabase.episodeDao()
+            val serverPodcast = podcastCacheServerManager.getPodcastAndEpisode(podcastUuid, episodeUuid)
 
-            val episode = episodeDao.findByUuidSync(episodeUUID)
+            val episode = episodeDao.findByUuid(episodeUuid)
             val serverEpisodeUrl = serverPodcast.episodes.firstOrNull()?.downloadUrl
             if (episode != null &&
-                serverEpisodeUrl != null &&
-                serverEpisodeUrl.isNotBlank() &&
+                !serverEpisodeUrl.isNullOrBlank() &&
                 episode.downloadUrl != serverEpisodeUrl
             ) {
                 episode.downloadUrl = serverEpisodeUrl
-
                 episodeDao.updateDownloadUrl(serverEpisodeUrl, episode.uuid)
             }
 
             return Result.success()
         } catch (e: Exception) {
-            return Result.failure()
+            Timber.i(e, "Failed to update episode download url. Podcast: $podcastUuid Episode: $episodeUuid")
+            return Result.success()
         }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -84,7 +84,6 @@ interface EpisodeManager {
     fun updateDownloadFilePath(episode: BaseEpisode?, filePath: String, markAsDownloaded: Boolean)
     fun updateFileType(episode: BaseEpisode?, fileType: String)
     fun updateSizeInBytes(episode: BaseEpisode?, sizeInBytes: Long)
-    fun updateDownloadUrl(episode: BaseEpisode?, url: String)
     fun updateDownloadTaskId(episode: BaseEpisode, id: String?)
     fun updateLastDownloadAttemptDate(episode: BaseEpisode?)
     fun updateDownloadErrorDetails(episode: BaseEpisode?, message: String?)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -428,16 +428,6 @@ class EpisodeManagerImpl @Inject constructor(
         }
     }
 
-    override fun updateDownloadUrl(episode: BaseEpisode?, url: String) {
-        episode ?: return
-        if (episode is PodcastEpisode) {
-            episodeDao.updateDownloadUrl(url, episode.uuid)
-        } else if (episode is UserEpisode) {
-            episode.downloadUrl = url
-            // We shouldn't hold on to these urls in the database
-        }
-    }
-
     override fun updateLastDownloadAttemptDate(episode: BaseEpisode?) {
         episode ?: return
         val now = Date()
@@ -1119,7 +1109,7 @@ class EpisodeManagerImpl @Inject constructor(
                 if (episodeExists || podcastUuid == Podcast.userPodcast.uuid) {
                     observeEpisodeByUuidRx(episodeUuid).firstElement()
                 } else {
-                    podcastCacheServerManager.getPodcastAndEpisode(podcastUuid, episodeUuid).flatMapMaybe { response ->
+                    podcastCacheServerManager.getPodcastAndEpisodeSingle(podcastUuid, episodeUuid).flatMapMaybe { response ->
                         val episode = response.episodes.firstOrNull() ?: skeletonEpisode
                         add(episode, downloadMetaData = downloadMetaData)
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServer.kt
@@ -76,7 +76,10 @@ interface PodcastCacheServer {
     suspend fun getShowNotesCache(@Path("podcastUuid") podcastUuid: String): ShowNotesResponse
 
     @GET("/mobile/podcast/findbyepisode/{podcastUuid}/{episodeUuid}")
-    fun getPodcastAndEpisode(@Path("podcastUuid") podcastUuid: String, @Path("episodeUuid") episodeUuid: String): Single<PodcastResponse>
+    fun getPodcastAndEpisodeSingle(@Path("podcastUuid") podcastUuid: String, @Path("episodeUuid") episodeUuid: String): Single<PodcastResponse>
+
+    @GET("/mobile/podcast/findbyepisode/{podcastUuid}/{episodeUuid}")
+    suspend fun getPodcastAndEpisode(@Path("podcastUuid") podcastUuid: String, @Path("episodeUuid") episodeUuid: String): PodcastResponse
 
     @POST("/mobile/podcast/episode/search")
     fun searchPodcastForEpisodes(@Body searchBody: SearchBody): Single<SearchResultBody>

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManager.kt
@@ -8,7 +8,8 @@ import retrofit2.Response
 
 interface PodcastCacheServerManager {
     fun getPodcast(podcastUuid: String): Single<Podcast>
-    fun getPodcastAndEpisode(podcastUuid: String, episodeUuid: String): Single<Podcast>
+    fun getPodcastAndEpisodeSingle(podcastUuid: String, episodeUuid: String): Single<Podcast>
+    suspend fun getPodcastAndEpisode(podcastUuid: String, episodeUuid: String): Podcast
     fun searchEpisodes(podcastUuid: String, searchTerm: String): Single<List<String>>
     fun searchEpisodes(searchTerm: String): Single<EpisodeSearch>
     fun getPodcastResponse(podcastUuid: String): Single<Response<PodcastResponse>>

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
@@ -23,8 +23,12 @@ class PodcastCacheServerManagerImpl @Inject constructor(@PodcastCacheServerRetro
             .map(PodcastResponse::toPodcast)
     }
 
-    override fun getPodcastAndEpisode(podcastUuid: String, episodeUuid: String): Single<Podcast> {
-        return server.getPodcastAndEpisode(podcastUuid, episodeUuid).map(PodcastResponse::toPodcast)
+    override fun getPodcastAndEpisodeSingle(podcastUuid: String, episodeUuid: String): Single<Podcast> {
+        return server.getPodcastAndEpisodeSingle(podcastUuid, episodeUuid).map(PodcastResponse::toPodcast)
+    }
+
+    override suspend fun getPodcastAndEpisode(podcastUuid: String, episodeUuid: String): Podcast {
+        return server.getPodcastAndEpisode(podcastUuid, episodeUuid).toPodcast()
     }
 
     override fun searchEpisodes(podcastUuid: String, searchTerm: String): Single<List<String>> {


### PR DESCRIPTION
## Description

When investigating the Work Manager I noticed that the UpdateEpisodeTask wasn't yet using Hilt or Coroutines, this change fixes that.

As part of this PR I have also changed the downloads to not create the UpdateEpisodeTask for user files as the the download URL doesn't need to be updated. The podcast uuid was being sent to the worker as null so it would just start and then stop immediately with a null check.

## Testing Instructions

I have included a test for updating the download URL as it's hard to test. It would be good to still test the episodes still download successfully. 

1. Open the App Inspection window -> Background Task Inspector
2. Download a podcast episode
3. ✅ Verify UpdateEpisodeTask runs and then DownloadEpisodeTask
4. Download a user file 
5. ✅ Verify DownloadEpisodeTask runs but UpdateEpisodeTask doesn't
