### PR TITLE
Revert "Avoid creating new UpNextFragment when tapping up next button"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@
 *   Bug Fixes:
     *   Avoid memory leak when opening Up Next queue
         ([#1397](https://github.com/Automattic/pocket-casts-android/pull/1397))
-    *   Improved multiselect handling in Up Next queue
-        ([#1395](https://github.com/Automattic/pocket-casts-android/pull/1392))
     *   Improved the downloading of episode show notes
         ([#1390](https://github.com/Automattic/pocket-casts-android/pull/1390))
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -210,9 +210,8 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
     }
 
     fun openUpNext() {
-        binding?.let {
-            BottomSheetBehavior.from(it.upNextFrameBottomSheet).state = BottomSheetBehavior.STATE_EXPANDED
-        }
+        val upNextFragment = UpNextFragment.newInstance(source = UpNextSource.PLAYER)
+        (activity as? FragmentHostListener)?.showBottomSheet(upNextFragment)
     }
 
     fun openPlayer() {


### PR DESCRIPTION
## Description
This reverts the change in #1395 because it introduces an issue where the bottom sheet will not be opened if from the full screen player you tap the up next button before doing any swipe motions with the bottom sheet. Basically, the bottom sheet doesn't get laid out until it is swiped, and until it is laid out, you cannot programmatically open it (see [Google issue tracker](https://issuetracker.google.com/issues/37090839#c18)).

Because this PR is targeting a release branch, I'm keeping this as a simple revert instead of trying to fix the issue because the fix does not seem super-straightforward.

## Testing Instructions
1. Open the full screen player
2. Do NOT swipe the screen to open the up next queue
3. Tap the up next button on the full screen player to open the up next queue
4. ✅ Observe that the up next queue opens

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews