### PR TITLE
Clear reference to item touch helper in podcast fragment

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -116,7 +116,6 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         }
     }
 
-    private lateinit var itemTouchHelper: EpisodeItemTouchHelper
     @Inject lateinit var settings: Settings
     @Inject lateinit var podcastManager: PodcastManager
     @Inject lateinit var episodeManager: EpisodeManager
@@ -137,6 +136,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
     private val swipeButtonLayoutViewModel: SwipeButtonLayoutViewModel by viewModels()
     private var adapter: PodcastAdapter? = null
     private var binding: FragmentPodcastBinding? = null
+    private var itemTouchHelper: EpisodeItemTouchHelper? = null
 
     private var featuredPodcast = false
     private var fromListUuid: String? = null
@@ -623,7 +623,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             it.addOnScrollListener(onScrollListener)
         }
 
-        itemTouchHelper.attachToRecyclerView(binding.episodesRecyclerView)
+        itemTouchHelper?.attachToRecyclerView(binding.episodesRecyclerView)
 
         binding.btnRetry.setOnClickListener {
             loadData()
@@ -703,7 +703,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
     ) {
         binding?.episodesRecyclerView?.let { recyclerView ->
             recyclerView.findViewHolderForAdapterPosition(index)?.let {
-                itemTouchHelper.clearView(recyclerView, it)
+                itemTouchHelper?.clearView(recyclerView, it)
             }
         }
 
@@ -818,6 +818,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
     override fun onDestroyView() {
         binding?.episodesRecyclerView?.adapter = null
+        itemTouchHelper = null
 
         multiSelectEpisodesHelper.cleanup()
         if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -543,8 +543,6 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         statusBarColor = StatusBarColor.Custom(headerColor, true)
         updateStatusBar()
 
-        itemTouchHelper = EpisodeItemTouchHelper()
-
         loadData()
 
         binding.toolbar.let {
@@ -623,7 +621,9 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             it.addOnScrollListener(onScrollListener)
         }
 
-        itemTouchHelper?.attachToRecyclerView(binding.episodesRecyclerView)
+        itemTouchHelper = EpisodeItemTouchHelper().apply {
+            attachToRecyclerView(binding.episodesRecyclerView)
+        }
 
         binding.btnRetry.setOnClickListener {
             loadData()


### PR DESCRIPTION
## Description

This clears reference to `PodcastFragment.itemTouchHelper` when `PodcastFragment` is destroyed.

## Testing Instructions
1. With leak canary enabled,  go to the podcast tab
2. Open a podcast
3. With podcast details open, go to the filters tab and open a filter's episode list
4. Notice that leak is not found

#### Regression

1. Continue from above
2. Go back to the podcast tab -> podcast details tab
3. Perform a few actions from swipe gestures on the podcast episode rows
4. Notice that they work as before

## Screenshots or Screencast 

Fixes this leak:
<img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/d37079cc-dce7-4016-b7d8-8004f1aeec36"/>

## Checklist (N/A)
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
