### PR TITLE
UI issues with large font fix issue#28

### DIFF
--- a/modules/services/views/src/main/res/layout/fragment_webview.xml
+++ b/modules/services/views/src/main/res/layout/fragment_webview.xml
@@ -24,7 +24,7 @@
         android:orientation="vertical"
         android:padding="64dp"
         android:layout_gravity="center"
-        android:visibility="gone">
+        android:visibility="visible">
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -42,12 +42,15 @@
             android:layout_gravity="center"
             android:text="@string/settings_help_contact_support" />
     </LinearLayout>
+
     <WebView
         android:id="@+id/webview"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="?android:attr/actionBarSize"
         android:background="#FFFFFF"
-        android:layout_marginTop="?android:attr/actionBarSize"/>
+        android:padding="10dp" />
     <ProgressBar
         android:id="@+id/progress_circle"
         style="?android:attr/progressBarStyle"

--- a/modules/services/views/src/main/res/layout/fragment_webview.xml
+++ b/modules/services/views/src/main/res/layout/fragment_webview.xml
@@ -24,7 +24,7 @@
         android:orientation="vertical"
         android:padding="64dp"
         android:layout_gravity="center"
-        android:visibility="visible">
+        android:visibility="gone">
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Linked Issue : #28 

## Testing Instructions
1. Change your device font size to large
2. Go to settings -> Then Go to Help and Feedback

## Screenshots or Screencast 
![Screenshot 2023-09-26 at 4 24 14 PM](https://github.com/Automattic/pocket-casts-android/assets/60827173/6e28ef44-e010-4068-bb9b-7916d44f0d62)

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [X] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack



## Fixed
- [X]  Help & Feedback Screen has a bit of horizontal scroll
- [X] Help & Feedback "Still stuck..." box cuts words in half
- [X] Help & Feedback "Get in touch popup" has buttons outside the popup
- [ ] Not all toolbars reflect the updated font size. 
- [ ]  Profile's Active Account section loses its top and bottom padding
- [ ] Podcast page's folder icon feels a bit crowded against the podcast picture
- [ ] The Choose Folder Color screen's colors crowd the right side of the screen

The tick indicates the fixed rest is not fixed. This PR is partial bug fixes.
