### PR TITLE
Reduce the logging to Sentry

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -18,6 +18,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
 import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServerManager
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toIsoString
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNull
 import kotlinx.coroutines.test.runTest
@@ -33,7 +34,6 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import retrofit2.Retrofit
-import timber.log.Timber
 import java.net.HttpURLConnection
 import java.util.Date
 import java.util.concurrent.TimeUnit
@@ -210,8 +210,8 @@ class PodcastSyncProcessTest {
             val lastModified = System.currentTimeMillis().toString()
 
             syncProcess.performIncrementalSync(lastModified)
-                .doOnError {
-                    Timber.e(it)
+                .doOnError { exception ->
+                    LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, exception, "Incremental sync failed")
                 }
                 .test()
                 .awaitDone(5, TimeUnit.SECONDS)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -203,7 +203,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
                 try {
                     fileStorage.opmlFileFolder
                 } catch (e: Exception) {
-                    Timber.e(e, "Unable to create opml folder.")
+                    Timber.w(e, "Unable to create opml folder.")
                 }
 
                 VersionMigrationsJob.run(

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -110,7 +110,6 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.Network
-import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.observeOnce
 import au.com.shiftyjelly.pocketcasts.view.BottomNavHideManager
@@ -474,7 +473,7 @@ class MainActivity :
                     .doOnNext {
                         podcastManager.refreshPodcastsIfRequired(fromLog = "open app")
                     }
-                    .subscribeBy(onError = { Timber.e(it) })
+                    .subscribeBy(onError = { LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, it, "Starting refresh failed") })
                     .addTo(disposables)
             }
         }
@@ -1194,8 +1193,7 @@ class MainActivity :
                 playbackManager.playQueue()
             }
         } catch (e: Exception) {
-            Timber.e(e)
-            SentryHelper.recordException(e)
+            LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Handle intent failed")
         }
     }
 
@@ -1333,7 +1331,7 @@ class MainActivity :
                     throwable: Throwable?
                 ) {
                     UiUtil.hideProgressDialog(dialog)
-                    Timber.e(serverMessage)
+                    Timber.w(serverMessage)
                     UiUtil.displayAlertError(
                         this@MainActivity,
                         getString(LR.string.podcast_share_open_fail_title),

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/extensions/Fragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/extensions/Fragment.kt
@@ -9,6 +9,6 @@ fun Fragment.openUrl(url: String) {
     try {
         this.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
     } catch (e: Exception) {
-        Timber.e(e)
+        Timber.w(e)
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ChangeEmailViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ChangeEmailViewModel.kt
@@ -2,12 +2,12 @@ package au.com.shiftyjelly.pocketcasts.account.viewmodel
 
 import androidx.lifecycle.MutableLiveData
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.addTo
 import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.schedulers.Schedulers
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -80,7 +80,7 @@ class ChangeEmailViewModel
                     changeEmailState.postValue(ChangeEmailState.Failure(errors, response.message))
                 }
             }
-            .subscribeBy(onError = { Timber.e(it) })
+            .subscribeBy(onError = { LogBuffer.logException(LogBuffer.TAG_CRASH, it, "Change email failed") })
             .addTo(disposables)
     }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ChangePwdViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ChangePwdViewModel.kt
@@ -3,9 +3,9 @@ package au.com.shiftyjelly.pocketcasts.account.viewmodel
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -100,7 +100,7 @@ class ChangePwdViewModel
                 )
                 changePasswordState.postValue(ChangePasswordState.Success("OK"))
             } catch (ex: Exception) {
-                Timber.e(ex, "Failed update password")
+                LogBuffer.logException(LogBuffer.TAG_CRASH, ex, "Update password failed")
                 changePasswordState.postValue(ChangePasswordState.Failure(errors = setOf(ChangePasswordError.SERVER), message = null))
             }
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/GoogleSignInButtonViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/GoogleSignInButtonViewModel.kt
@@ -83,7 +83,7 @@ class GoogleSignInButtonViewModel @Inject constructor(
                 val intentRequest = IntentSenderRequest.Builder(result.pendingIntent).build()
                 onSuccess(intentRequest)
             } catch (e: Exception) {
-                LogBuffer.e(LogBuffer.TAG_CRASH, e, "Unable to sign in with Google One Tap")
+                LogBuffer.logException(LogBuffer.TAG_CRASH, e, "Unable to sign in with Google One Tap")
                 onError()
             }
         }
@@ -115,7 +115,7 @@ class GoogleSignInButtonViewModel @Inject constructor(
                     )
                 }
             } catch (ex: Exception) {
-                LogBuffer.e(LogBuffer.TAG_CRASH, ex, "Unable to sign in with legacy Google Sign-In")
+                LogBuffer.logException(LogBuffer.TAG_CRASH, ex, "Unable to sign in with legacy Google Sign-In")
                 onError()
             }
         }
@@ -143,7 +143,7 @@ class GoogleSignInButtonViewModel @Inject constructor(
                     // user declined to sign in
                     return@launch
                 }
-                LogBuffer.e(LogBuffer.TAG_CRASH, e, "Unable to get sign in credentials from Google One Tap result.")
+                LogBuffer.logException(LogBuffer.TAG_CRASH, e, "Unable to get sign in credentials from Google One Tap result.")
                 onError()
             }
         }
@@ -161,11 +161,7 @@ class GoogleSignInButtonViewModel @Inject constructor(
                     onError = onError
                 )
             } catch (e: Exception) {
-                LogBuffer.e(
-                    LogBuffer.TAG_CRASH,
-                    e,
-                    "Unable to get sign in credentials from legacy Google Sign-In result."
-                )
+                LogBuffer.logException(LogBuffer.TAG_CRASH, e, "Unable to get sign in credentials from legacy Google Sign-In result.")
                 onError()
             }
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
@@ -131,7 +131,7 @@ class OnboardingRecommendationsStartPageViewModel @Inject constructor(
             val feed = try {
                 repository.getDiscoverFeed().await()
             } catch (e: Exception) {
-                Timber.e("Exception retrieving Discover feed: $e")
+                Timber.w("Exception retrieving Discover feed: $e")
                 return@launch
             }
 
@@ -139,7 +139,7 @@ class OnboardingRecommendationsStartPageViewModel @Inject constructor(
             val region = feed.regions[regionCode]
                 ?: feed.regions[feed.defaultRegionCode]
                     .let {
-                        Timber.e("Could not get region for $regionCode")
+                        Timber.w("Could not get region for $regionCode")
                         return@launch
                     }
 
@@ -246,7 +246,7 @@ class OnboardingRecommendationsStartPageViewModel @Inject constructor(
     ) {
         val listItem = updatedList.find { it.id == id }
         if (listItem == null) {
-            Timber.e("Could not find section with id $id")
+            Timber.w("Could not find section with id $id")
             return
         }
 
@@ -255,7 +255,7 @@ class OnboardingRecommendationsStartPageViewModel @Inject constructor(
                 .await()
                 ?: return
         } catch (e: Exception) {
-            Timber.e(e)
+            Timber.w(e)
             return
         }
 
@@ -292,7 +292,7 @@ class OnboardingRecommendationsStartPageViewModel @Inject constructor(
                             )
                         }
                 } catch (e: Exception) {
-                    Timber.e(e)
+                    Timber.w(e)
                     null
                 }
             } ?: emptyList()

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/watchsync/WatchSync.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/watchsync/WatchSync.kt
@@ -49,10 +49,7 @@ class WatchSync @OptIn(ExperimentalHorologistApi::class)
                 // Don't catch CancellationException since this represents the normal cancellation of a coroutine
                 throw cancellationException
             } catch (exception: Exception) {
-                LogBuffer.e(
-                    LogBuffer.TAG_BACKGROUND_TASKS,
-                    "Saving refresh token to data layer failed: $exception"
-                )
+                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, exception, "Saving refresh token to data layer failed")
             }
         }
     }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -134,7 +134,7 @@ class DiscoverViewModel @Inject constructor(
                 val isInvalidSponsoredSource = it.source == null || it.position == null
                 if (isInvalidSponsoredSource) {
                     val message = "Invalid sponsored source found."
-                    Timber.e(message)
+                    Timber.w(message)
                     SentryHelper.recordException(InvalidObjectException(message))
                 }
                 !isInvalidSponsoredSource

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -12,7 +12,6 @@ import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State.Loaded.Se
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManager
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.Story
 import au.com.shiftyjelly.pocketcasts.utils.FileUtilWrapper
-import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -82,9 +81,7 @@ class StoriesViewModel @Inject constructor(
             mutableState.value = state
             if (state is State.Loaded) start()
         } catch (ex: Exception) {
-            val message = "Failed to load end of year stories."
-            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, ex, message)
-            SentryHelper.recordException(message, ex)
+            LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, ex, "Failed to load end of year stories.")
             mutableState.value = State.Error
         }
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
@@ -130,7 +130,7 @@ class NotesFragment : BaseFragment() {
                     }
 
                     override fun onRenderProcessGone(view: WebView?, detail: RenderProcessGoneDetail?): Boolean {
-                        LogBuffer.e(LogBuffer.TAG_CRASH, "Show notes fragment webview gone for episode ${viewModel.episode.value?.title}")
+                        LogBuffer.w(LogBuffer.TAG_CRASH, "Show notes fragment webview gone for episode ${viewModel.episode.value?.title}")
                         view.cleanup()
                         webView = null
                         return true

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -523,7 +523,7 @@ class EpisodeFragment : BaseFragment() {
                         }
 
                         override fun onRenderProcessGone(view: WebView?, detail: RenderProcessGoneDetail?): Boolean {
-                            LogBuffer.e(LogBuffer.TAG_CRASH, "Episode fragment webview gone for episode ${viewModel.episode?.title}")
+                            LogBuffer.w(LogBuffer.TAG_CRASH, "Episode fragment webview gone for episode ${viewModel.episode?.title}")
                             view.cleanup()
                             webView = null
                             return true

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
@@ -7,6 +7,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.repositories.ratings.RatingsManager
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,7 +16,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import retrofit2.HttpException
 import timber.log.Timber
 import java.io.IOException
 import javax.inject.Inject
@@ -63,13 +63,7 @@ class PodcastRatingsViewModel
             try {
                 ratingsManager.refreshPodcastRatings(uuid)
             } catch (e: Exception) {
-                val message = "Failed to refresh podcast ratings"
-                // don't report missing rating or network errors to Sentry
-                if (e is HttpException || e is IOException) {
-                    Timber.i(e, message)
-                } else {
-                    Timber.e(e, message)
-                }
+                LogBuffer.logException(LogBuffer.TAG_CRASH, e, "Failed to refresh podcast ratings")
             }
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -178,7 +178,7 @@ class PodcastViewModel
                 }
             }
             .onErrorReturn {
-                LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, it, "Could not load podcast page")
+                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, it, "Could not load podcast page")
                 UiState.Error(it.message ?: "Unknown error")
             }
             .observeOn(AndroidSchedulers.mainThread())

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
@@ -20,15 +20,14 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.utils.Optional
-import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import au.com.shiftyjelly.pocketcasts.utils.combineLatest
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.addTo
 import io.reactivex.rxkotlin.combineLatest
 import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.schedulers.Schedulers
-import timber.log.Timber
 import java.util.Date
 import javax.inject.Inject
 
@@ -94,8 +93,7 @@ class AccountDetailsViewModel
 
     private fun deleteAccountError(throwable: Throwable) {
         deleteAccountState.postValue(DeleteAccountState.Failure(message = null))
-        Timber.e(throwable)
-        SentryHelper.recordException("Delete account failed", throwable)
+        LogBuffer.logException(LogBuffer.TAG_CRASH, throwable, "Delete account failed")
     }
 
     fun clearDeleteAccountState() {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -515,7 +515,7 @@ class AddFileActivity :
             }
         } catch (e: Exception) {
             binding.layoutLoading.isVisible = false
-            Timber.e(e, "Could not load file")
+            Timber.w(e, "Could not load file")
             AlertDialog.Builder(this)
                 .setTitle(LR.string.error)
                 .setMessage(getString(LR.string.profile_cloud_add_file_error, e.message))
@@ -594,7 +594,7 @@ class AddFileActivity :
                 return outImageFile
             }
         } catch (t: Throwable) {
-            Timber.e(t, "Could not save bitmap to file")
+            Timber.w(t, "Could not save bitmap to file")
         }
         return null
     }
@@ -627,7 +627,7 @@ class AddFileActivity :
                 }
             }
         } catch (t: Throwable) {
-            Timber.e(t, "Failed to get file name.")
+            Timber.w(t, "Failed to get file name.")
         }
         return null
     }
@@ -645,7 +645,7 @@ class AddFileActivity :
                 }
             }
         } catch (t: Throwable) {
-            Timber.e(t, "Failed to get file mime type.")
+            Timber.w(t, "Failed to get file mime type.")
         }
         return null
     }
@@ -665,7 +665,7 @@ class AddFileActivity :
                 return cursor.getLong(columnIndex)
             }
         } catch (e: Exception) {
-            Timber.e(e, "Failed to get file size.")
+            Timber.w(e, "Failed to get file size.")
         }
         return null
     }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/sonos/SonosAppLinkActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/sonos/SonosAppLinkActivity.kt
@@ -115,7 +115,7 @@ class SonosAppLinkActivity : AppCompatActivity(), CoroutineScope {
             setResult(SONOS_APP_ACTIVITY_RESULT, result)
             finish()
         } catch (e: Exception) {
-            LogBuffer.e(LogBuffer.TAG_CRASH, e, "Failed to link Sonos")
+            LogBuffer.logException(LogBuffer.TAG_CRASH, e, "Failed to link Sonos")
 
             binding.connectBtn.setText(LR.string.profile_sonos_retry)
             UiUtil.displayAlert(this, getString(LR.string.profile_sonos_linking_failed), getString(LR.string.profile_sonos_linking_failed_summary), null)

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -16,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.servers.ServerManager
 import au.com.shiftyjelly.pocketcasts.servers.discover.GlobalServerSearch
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.jakewharton.rxrelay2.BehaviorRelay
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Observable
@@ -23,7 +24,6 @@ import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.rxkotlin.Observables
 import io.reactivex.schedulers.Schedulers
-import timber.log.Timber
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -186,7 +186,7 @@ class SearchHandler @Inject constructor(
             }
         }
     }
-        .doOnError { Timber.e(it) }
+        .doOnError { exception -> LogBuffer.logException(LogBuffer.TAG_CRASH, exception, "Failed incremental sync") }
         .onErrorReturn { exception ->
             analyticsTracker.track(AnalyticsEvent.SEARCH_FAILED, AnalyticsProp.sourceMap(source))
             SearchState.Results(

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadFiltersFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadFiltersFragment.kt
@@ -66,7 +66,7 @@ class AutoDownloadFiltersFragment : androidx.fragment.app.Fragment(), FilterAuto
                 }
 
                 override fun onError(throwable: Throwable) {
-                    Timber.e(throwable)
+                    Timber.w(throwable)
                 }
             }).addTo(disposables)
     }
@@ -81,7 +81,7 @@ class AutoDownloadFiltersFragment : androidx.fragment.app.Fragment(), FilterAuto
                 }
 
                 override fun onError(throwable: Throwable) {
-                    Timber.e(throwable)
+                    Timber.w(throwable)
                 }
             })
             .addTo(disposables)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -342,7 +342,7 @@ class AutoDownloadSettingsFragment :
         countPodcastsAutoDownloading()
             .map { it > 0 }
             .subscribeBy(
-                onError = { Timber.e(it) },
+                onError = { Timber.w(it) },
                 onSuccess = { on ->
                     updateNewEpisodesSwitch(on)
                     newEpisodesPreference?.isChecked = on

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
@@ -107,7 +107,7 @@ class HeadphoneControlsSettingsPageViewModel @Inject constructor(
         HeadphoneAction.ADD_BOOKMARK -> state.value.isAddBookmarkEnabled
         HeadphoneAction.NEXT_CHAPTER,
         HeadphoneAction.PREVIOUS_CHAPTER -> {
-            Timber.e("Headphone action not supported")
+            Timber.w("Headphone action not supported")
             false
         }
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
@@ -220,7 +220,7 @@ class NotificationsSettingsFragment :
                 settings.notificationSound.set(NotificationSound(value, it))
                 ringtonePreference?.summary = getRingtoneValue(value)
                 analyticsTracker.track(AnalyticsEvent.SETTINGS_NOTIFICATIONS_SOUND_CHANGED)
-            } ?: Timber.e("Context was null when trying to set notification sound")
+            } ?: Timber.w("Context was null when trying to set notification sound")
         } else {
             super.onActivityResult(requestCode, resultCode, data)
         }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.download.UpdateEpisodeDetails
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.disposables.CompositeDisposable
@@ -145,7 +146,7 @@ class DeveloperViewModel
                     Toast.makeText(context, "Running update episode details", Toast.LENGTH_LONG).show()
                 }
             } catch (e: Exception) {
-                Timber.e(e)
+                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Failed to run update episode details")
                 withContext(Dispatchers.Main) {
                     Toast.makeText(context, "Failed to run update episode details", Toast.LENGTH_LONG).show()
                 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModel.kt
@@ -14,6 +14,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.settings.util.FunnyTimeConverter
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.timeIntervalSinceNow
 import au.com.shiftyjelly.pocketcasts.views.review.InAppReviewHelper
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -97,7 +98,7 @@ class StatsViewModel @Inject constructor(
                     }
                 }
             } catch (e: Exception) {
-                Timber.e(e)
+                LogBuffer.logException(LogBuffer.TAG_CRASH, e, "Loading stats failed")
                 mutableState.value = State.Error
             }
         }

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/FirebaseRemoteFeatureProvider.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/FirebaseRemoteFeatureProvider.kt
@@ -25,7 +25,7 @@ class FirebaseRemoteFeatureProvider @Inject constructor(
                 firebaseRemoteConfig.activate()
                 Timber.i("Firebase feature flag refreshed")
             } else {
-                Timber.e("Could not fetch remote config: ${it.exception?.message ?: "Unknown error"}")
+                Timber.w("Could not fetch remote config: ${it.exception?.message ?: "Unknown error"}")
             }
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkHelper.kt
@@ -109,7 +109,7 @@ private fun buildAndShowNotification(
         NotificationManagerCompat.from(context)
             .notify(Settings.NotificationId.BOOKMARK.value, notification)
     } else {
-        LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, "Post notification permission not granted.")
+        LogBuffer.w(LogBuffer.TAG_BACKGROUND_TASKS, "Post notification permission not granted.")
     }
 }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/CastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/CastManagerImpl.kt
@@ -32,10 +32,10 @@ class CastManagerImpl @Inject constructor(
         try {
             val executor = ContextCompat.getMainExecutor(context)
             CastContext.getSharedInstance(context, executor)
-                .addOnFailureListener { e -> LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Failed to init CastContext shared instance ${e.message}") }
+                .addOnFailureListener { e -> LogBuffer.logException(LogBuffer.TAG_PLAYBACK, e, "Failed to init CastContext shared instance") }
                 .addOnSuccessListener { castContext -> castContext.sessionManager.addSessionManagerListener(sessionManagerListener) }
         } catch (e: Exception) {
-            Timber.e(e, "Failed to setup Chromecast.")
+            Timber.w(e, "Failed to setup Chromecast.")
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/CastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/CastManagerImpl.kt
@@ -100,7 +100,7 @@ class CastManagerImpl @Inject constructor(
         return try {
             CastContext.getSharedInstance()?.sessionManager
         } catch (e: Exception) {
-            LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Couldn't load cast despite it reporting it is available")
+            LogBuffer.w(LogBuffer.TAG_PLAYBACK, "Couldn't load cast despite it reporting it is available")
             null
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/colors/ColorManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/colors/ColorManager.kt
@@ -64,7 +64,7 @@ class ColorManager @Inject constructor(
             )
             Timber.i("ColorManager successfully updated colors for podcast ${podcast.uuid}")
         } catch (e: Exception) {
-            Timber.e(e, "ColorManager could not update colors for podcast ${podcast.uuid}")
+            Timber.w(e, "ColorManager could not update colors for podcast ${podcast.uuid}")
         }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
@@ -230,13 +230,13 @@ class DownloadManagerImpl @Inject constructor(
                 val state = workManager.getWorkInfoById(uuid).get()
                 if (state == null) {
                     episodeManager.updateDownloadTaskId(episode, null)
-                    LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, "Cleaned up old workmanager task for ${episode.uuid}.")
+                    LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Cleaned up old workmanager task for ${episode.uuid}.")
                 } else {
                     // This should not happen
-                    LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, "Workmanager knows about ${episode.uuid} but it is marked as not downloaded.")
+                    LogBuffer.w(LogBuffer.TAG_BACKGROUND_TASKS, "Workmanager knows about ${episode.uuid} but it is marked as not downloaded.")
                 }
             } catch (e: Exception) {
-                LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, "Could not clean up stale download ${episode.uuid}.", e)
+                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Could not clean up stale download ${episode.uuid}.")
             }
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -118,7 +118,7 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
         } catch (t: Throwable) {
             info("Worker failed - took ${SystemClock.elapsedRealtime() - startTime} ms")
             // report the error to Sentry and to the log buffer for support
-            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, t, "Unable to check episode file details with a head request.")
+            LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, t, "Unable to check episode file details with a head request.")
             // mark the worker as a success or it will won't process all the chain tasks
             return Result.success()
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
@@ -5,7 +5,6 @@ import android.media.MediaExtractor
 import android.media.MediaFormat
 import android.system.ErrnoException
 import android.system.OsConstants
-import android.util.Log
 import androidx.hilt.work.HiltWorker
 import androidx.work.Data
 import androidx.work.ForegroundInfo
@@ -511,9 +510,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
             call?.cancel()
         }
         if (exception != null) {
-            // don't report issues such as timeouts to Sentry
-            val logPriority = if (exception is IOException) Log.INFO else Log.ERROR
-            LogBuffer.addLog(logPriority, LogBuffer.TAG_BACKGROUND_TASKS, exception, "Download failed %s", this.episode.downloadUrl ?: "")
+            LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, exception, "Download failed %s", this.episode.downloadUrl ?: "")
         }
 
         if (!emitter.isDisposed) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
@@ -125,7 +125,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
             this.episode = runBlocking { episodeManager.findEpisodeByUuid(episodeUUID!!) } ?: return Result.failure()
 
             if (this.episode.downloadTaskId != id.toString()) {
-                LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, "Mismatched download task id for episode ${episode.title}. Cancelling. downloadTaskId: ${this.episode.downloadTaskId} id: $id.")
+                LogBuffer.w(LogBuffer.TAG_BACKGROUND_TASKS, "Mismatched download task id for episode ${episode.title}. Cancelling. downloadTaskId: ${this.episode.downloadTaskId} id: $id.")
                 return Result.failure()
             }
 
@@ -235,7 +235,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
                 }
             } catch (interrupt: InterruptedIOException) {
             } catch (e: Exception) {
-                Timber.e(e)
+                Timber.w(e)
                 if (!emitter.isDisposed) {
                     emitter.onError(e)
                 }
@@ -404,7 +404,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
                                 try {
                                     fireProgressUpdate(emitter)
                                 } catch (e: Exception) {
-                                    Timber.e(e)
+                                    Timber.w(e)
                                 }
 
                                 lastReportedProgressTime = System.currentTimeMillis()
@@ -430,7 +430,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
                     try {
                         FileUtil.copyFile(tempDownloadFile, fullDownloadFile)
                     } catch (exception: IOException) {
-                        LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, exception, "Could not move download temp ${tempDownloadFile.path} to $pathToSaveTo. SavePathFileExists: ${fullDownloadFile.exists()}")
+                        LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, exception, "Could not move download temp ${tempDownloadFile.path} to $pathToSaveTo. SavePathFileExists: ${fullDownloadFile.exists()}")
 
                         // the move failed, so delete the temp file
                         if (tempDownloadFile.exists()) {
@@ -555,7 +555,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
                 return
             }
         } catch (e: Exception) {
-            Timber.e(e, "Failed to fix missing duration.")
+            LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Failed to fix missing duration.")
         }
     }
 
@@ -640,7 +640,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
                 writer.write(data)
             }
         } catch (e: Exception) {
-            Timber.e(e)
+            Timber.w(e)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateShowNotesTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateShowNotesTask.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.repositories.download.task
 
 import android.content.Context
 import android.os.SystemClock
-import android.util.Log
 import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
@@ -17,7 +16,6 @@ import au.com.shiftyjelly.pocketcasts.servers.ServerShowNotesManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import retrofit2.HttpException
 
 /**
  * Try to cache the show notes so they can be viewed offline. This task happens when the user downloads an episode.
@@ -61,8 +59,7 @@ class UpdateShowNotesTask @AssistedInject constructor(
             Result.success()
         } catch (e: Exception) {
             info("Worker failed - took ${SystemClock.elapsedRealtime() - startTime} ms")
-            val logPriority = if (e is HttpException) Log.INFO else Log.ERROR
-            LogBuffer.addLog(logPriority, LogBuffer.TAG_BACKGROUND_TASKS, e, "Failed to update show notes")
+            LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Failed to update show notes")
             // Don't keep retrying if the download fails. The user can download the show notes when viewing them.
             Result.success()
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UploadEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UploadEpisodeTask.kt
@@ -43,7 +43,7 @@ class UploadEpisodeTask @AssistedInject constructor(
             }
             .andThen(Single.just(Result.success(outputData.build())))
             .onErrorReturn {
-                LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, it, "Could not upload file")
+                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, it, "Could not upload file")
                 var errorMessage: String?
                 val retry: Boolean
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
@@ -104,7 +104,7 @@ class VersionMigrationsJob : JobService() {
                 }
             } catch (t: Throwable) {
                 Timber.e(t)
-                LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, t, "VersionMigrationsTask jobFinished failed.")
+                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, t, "VersionMigrationsTask jobFinished failed.")
             } finally {
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "VersionMigrationsTask jobFinished shouldReschedule? $shouldReschedule")
                 jobFinished(jobParameters, shouldReschedule)
@@ -160,7 +160,7 @@ class VersionMigrationsJob : JobService() {
             val oldTempDirectory = fileStorage.oldTempPodcastDirectory
             FileUtil.deleteDirectoryContents(oldTempDirectory.absolutePath)
         } catch (e: Exception) {
-            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, "Could not clear old podcast temp directory")
+            LogBuffer.w(LogBuffer.TAG_BACKGROUND_TASKS, "Could not clear old podcast temp directory")
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
@@ -165,7 +165,7 @@ class OpmlImportTask @AssistedInject constructor(
             trackProcessed(numberProcessed)
             return Result.success()
         } catch (t: Throwable) {
-            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, t, "OPML import failed.")
+            LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, t, "OPML import failed.")
             trackFailure(reason = "unknown")
             return Result.failure()
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeFileMetadata.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeFileMetadata.kt
@@ -81,7 +81,7 @@ class EpisodeFileMetadata(val filenamePrefix: String? = null) {
             }
             chapters = Chapters(newChapters)
         } catch (e: Exception) {
-            Timber.e(e, "Unable to read chapters from ID3 tags.")
+            Timber.w(e, "Unable to read chapters from ID3 tags.")
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FocusManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FocusManager.kt
@@ -98,7 +98,7 @@ open class FocusManager(private val settings: Settings, context: Context?) : Aud
                 audioFocus = AUDIO_NO_FOCUS_NO_DUCK
                 LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Giving up audio focus. Request granted")
             } else {
-                LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Giving up audio focus request failed")
+                LogBuffer.w(LogBuffer.TAG_PLAYBACK, "Giving up audio focus request failed")
             }
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -328,13 +328,13 @@ class MediaSessionManager(
             .switchMap { (state, episode) -> getPlaybackStateRx(state, episode).toObservable().onErrorResumeNext(Observable.empty()) }
             .switchMap {
                 Observable.fromCallable { updatePlaybackState(it) }
-                    .doOnError { LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Error updating playback state in media session: ${it.message}") }.retry(3)
+                    .doOnError { LogBuffer.w(LogBuffer.TAG_PLAYBACK, "Error updating playback state in media session: ${it.message}") }.retry(3)
             }
             .ignoreElements()
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeBy(
                 onError = { throwable ->
-                    LogBuffer.e(LogBuffer.TAG_PLAYBACK, "MEDIA SESSION ERROR: Error updating playback state: ${throwable.message}")
+                    LogBuffer.w(LogBuffer.TAG_PLAYBACK, "MEDIA SESSION ERROR: Error updating playback state: ${throwable.message}")
                 }
             ).addTo(disposables)
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -291,7 +291,7 @@ open class PlaybackManager @Inject constructor(
                     Observable.empty<EpisodeSyncResponse>()
                 }
             }
-            .doOnError { LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Could not sync episode progress. ${it.javaClass.name} ${it.message ?: ""}") }
+            .doOnError { exception -> LogBuffer.logException(LogBuffer.TAG_PLAYBACK, exception, "Could not sync episode progress.") }
             .onErrorReturnItem(EpisodeSyncResponse())
             .subscribeBy(
                 onNext = {
@@ -958,7 +958,7 @@ open class PlaybackManager @Inject constructor(
             Timber.e(e, "Problems logging error.")
         }
 
-        LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Player error %s", event.message)
+        LogBuffer.w(LogBuffer.TAG_PLAYBACK, "Player error %s", event.message)
 
         val currentEpisode = getCurrentEpisode()
         if (currentEpisode is BaseEpisode) {
@@ -1753,9 +1753,7 @@ open class PlaybackManager @Inject constructor(
                 manager.notify(notificationTag, NotificationBroadcastReceiver.NOTIFICATION_ID, notification)
             }
         } catch (e: Exception) {
-            val message = "Could not post notification ${e.message}"
-            LogBuffer.e(LogBuffer.TAG_PLAYBACK, message)
-            SentryHelper.recordException(message, e)
+            LogBuffer.logException(LogBuffer.TAG_PLAYBACK, e, "Could not post notification")
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -191,8 +191,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
                         onPlaybackStateChangedWithNotification(state, notification)
                     },
                     onError = { throwable ->
-                        Timber.e(throwable)
-                        LogBuffer.e(LogBuffer.TAG_PLAYBACK, throwable, "Playback service error")
+                        LogBuffer.logException(LogBuffer.TAG_CRASH, throwable, "Playback service error")
                     }
                 )
                 .addTo(disposables)
@@ -295,7 +294,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
                     }
 
                     if (state == PlaybackStateCompat.STATE_ERROR) {
-                        LogBuffer.e(
+                        LogBuffer.w(
                             LogBuffer.TAG_PLAYBACK,
                             "Playback state error: ${playbackStatusRelay.value?.errorCode
                                 ?: -1} ${playbackStatusRelay.value?.errorMessage
@@ -602,7 +601,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
                 serverManager.searchForPodcastsSuspend(searchTerm = term, resources = resources).searchResults
             }
         } catch (ex: Exception) {
-            Timber.e(ex)
+            LogBuffer.logException(LogBuffer.TAG_CRASH, ex, "Podcast search failed")
             // display the error message when the server call fails only if there is no local podcasts to display
             if (localPodcasts.isEmpty()) {
                 return null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -255,7 +255,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
                             notificationManager.enteredForeground(notification)
                             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "startForeground state: $state")
                         } catch (e: Exception) {
-                            LogBuffer.e(LogBuffer.TAG_PLAYBACK, "attempted startForeground for state: $state, but that threw an exception we caught: $e")
+                            LogBuffer.w(LogBuffer.TAG_PLAYBACK, "attempted startForeground for state: $state, but that threw an exception we caught: $e")
                             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
                                 e is ForegroundServiceStartNotAllowedException
                             ) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -224,7 +224,7 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
             }
 
             override fun onPlayerError(error: PlaybackException) {
-                LogBuffer.e(LogBuffer.TAG_PLAYBACK, error, "Play failed.")
+                LogBuffer.w(LogBuffer.TAG_PLAYBACK, error, "Play failed.")
                 val event = PlayerEvent.PlayerError(error.message ?: "", error)
                 this@SimplePlayer.onError(event)
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
@@ -53,7 +53,7 @@ class SleepTimer @Inject constructor(@ApplicationContext private val context: Co
             sleepTimeMs = timeMs
             true
         } catch (e: Exception) {
-            LogBuffer.e(LogBuffer.TAG_CRASH, e, "Unable to start sleep timer.")
+            LogBuffer.w(LogBuffer.TAG_CRASH, e, "Unable to start sleep timer.")
             if (Build.VERSION.SDK_INT >= 31 && !alarmManager.canScheduleExactAlarms()) {
                 Toast.makeText(context, LR.string.player_sleep_timer_start_failed, Toast.LENGTH_LONG).show()
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
@@ -27,7 +27,6 @@ import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 import java.util.Collections
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -85,7 +84,7 @@ class UpNextQueueImpl @Inject constructor(
             // send server changes in bulk
             .debounce(5, TimeUnit.SECONDS)
             .doOnNext { sendToServer() }
-            .subscribeBy(onError = { Timber.e(it) })
+            .subscribeBy(onError = { exception -> LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, exception, "Failed to send Up Next changes to server") })
             .addTo(disposables)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -837,7 +837,7 @@ class EpisodeManagerImpl @Inject constructor(
             fileStorage.removeDirectoryFiles(fileStorage.podcastDirectory)
             fileStorage.removeDirectoryFiles(fileStorage.tempPodcastDirectory)
         } catch (e: Exception) {
-            Timber.e(e)
+            LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Failed to delete downloaded episodes")
         }
 
         val episodes = findEpisodesWhere("episode_status = " + EpisodeStatusEnum.DOWNLOADED.ordinal)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/HistoryManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/HistoryManager.kt
@@ -59,7 +59,7 @@ class HistoryManager @Inject constructor(
             .flatMap(
                 { podcastUuid ->
                     podcastManager.addPodcast(podcastUuid = podcastUuid, sync = false, subscribed = false)
-                        .doOnError { throwable -> LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "History manager could not add podcast") }
+                        .doOnError { throwable -> LogBuffer.w(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "History manager could not add podcast") }
                         .onErrorReturn { Podcast(uuid = podcastUuid) }
                         .toObservable()
                 }, true, ADD_PODCAST_CONCURRENCY

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -97,7 +97,7 @@ class PodcastManagerImpl @Inject constructor(
                 unsubscribeRelay.accept(podcastUuid)
             }
         } catch (t: Throwable) {
-            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, t, "Could not unsubscribe from $podcastUuid")
+            LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, t, "Could not unsubscribe from $podcastUuid")
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -660,7 +660,7 @@ class PodcastManagerImpl @Inject constructor(
         try {
             podcastDao.updateColors(background, tintForLightBg, tintForDarkBg, fabForLightBg, fabForDarkBg, linkForLightBg, linkForDarkBg, colorLastDownloaded, podcastUuid)
         } catch (e: Exception) {
-            Timber.e(e, "Podcast colors update failed.")
+            LogBuffer.logException(LogBuffer.TAG_CRASH, e, "Podcast colors update failed.")
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SharePodcastHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SharePodcastHelper.kt
@@ -9,8 +9,8 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import okhttp3.Call
-import timber.log.Timber
 import java.io.File
 import kotlin.math.round
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -64,7 +64,7 @@ data class SharePodcastHelper(
             intent.putExtra(Intent.EXTRA_STREAM, uri)
             this.context.startActivity(Intent.createChooser(intent, context.getString(LR.string.podcasts_share_via)))
         } catch (e: Exception) {
-            Timber.e(e)
+            LogBuffer.logException(LogBuffer.TAG_CRASH, e, "Failed to send file")
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -58,7 +58,7 @@ class SubscribeManager @Inject constructor(
             .observeOn(Schedulers.io())
             .doOnNext { info -> Timber.i("Adding podcast to addPodcast queue ${info.podcastUuid}") }
             .flatMap({ info -> addPodcast(info.podcastUuid, sync = info.sync, subscribed = true).toObservable() }, true, 5)
-            .doOnError { throwable -> LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "Could not subscribe to podcast") }
+            .doOnError { throwable -> LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "Could not subscribe to podcast") }
             .subscribeBy(
                 onNext = { podcast ->
                     uuidsInQueue.remove(podcast.uuid)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -271,7 +271,7 @@ class UserEpisodeManagerImpl @Inject constructor(
             try {
                 syncFiles(playbackManager)
             } catch (e: Exception) {
-                Timber.e("Could not sync cloud files: ${e.message}")
+                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Could not sync cloud files.")
             }
         }
     }
@@ -460,8 +460,8 @@ class UserEpisodeManagerImpl @Inject constructor(
             // the api server will call S3 to check the file exists if it doesn't know
             .andThen(
                 syncManager.getFileUploadStatus(userEpisode.uuid)
-                    .onErrorReturn {
-                        Timber.e(it)
+                    .onErrorReturn { exception ->
+                        LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, exception, "Failed to get file upload status")
                         false
                     }
                     .flatMapCompletable { success ->
@@ -476,7 +476,9 @@ class UserEpisodeManagerImpl @Inject constructor(
             )
             .andThen(
                 rxCompletable { syncFiles(playbackManager) }
-                    .doOnError { Timber.e(it) }
+                    .doOnError { exception ->
+                        LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, exception, "Failed to sync files")
+                    }
                     .onErrorComplete()
             )
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -293,7 +293,7 @@ class UserEpisodeManagerImpl @Inject constructor(
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Synced cloud files successfully")
                 userEpisodeDao.markAllSynced()
             } else {
-                LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, "Couldn't sync cloud files")
+                LogBuffer.w(LogBuffer.TAG_BACKGROUND_TASKS, "Couldn't sync cloud files")
                 throw HttpException(response)
             }
         }
@@ -500,7 +500,7 @@ class UserEpisodeManagerImpl @Inject constructor(
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeBy(
                 onError = {
-                    LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, it, "Could not upload file ${userEpisode.uuid} - ${userEpisode.title}")
+                    LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, it, "Could not upload file ${userEpisode.uuid} - ${userEpisode.title}")
                 }
             )
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsTask.kt
@@ -105,7 +105,7 @@ class RefreshPodcastsTask @AssistedInject constructor(
                 val result = refreshJob?.await()
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "RefreshPodcastsTask - runNow - Finished $result")
             } catch (e: Exception) {
-                LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, e, "RefreshPodcastsTask - runNow - Exception")
+                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "RefreshPodcastsTask - runNow - Exception")
             } finally {
                 refreshJob = null
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -176,7 +176,7 @@ class RefreshPodcastsThread(
                 ) {
                     LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Not refreshing as server call failed errorCode: $errorCode serverMessage: ${serverMessage ?: ""}")
                     if (throwable != null) {
-                        LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "Server call failed")
+                        LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "Server call failed")
                     }
                     refreshFailedOrCancelled("Not refreshing as server call failed errorCode: $errorCode serverMessage: ${serverMessage ?: ""}")
                 }
@@ -257,12 +257,11 @@ class RefreshPodcastsThread(
         LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Refresh - sync complete - ${String.format("%d ms", SystemClock.elapsedRealtime() - startTime)}")
         val throwable = syncCompletable.blockingGet()
         if (throwable != null) {
-            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "SyncProcess: Sync failed")
-
             if (throwable is RefreshTokenExpiredException) {
-                LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, "Signing out user because server post failed to log in")
+                LogBuffer.w(LogBuffer.TAG_BACKGROUND_TASKS, "Signing out user because server post failed to log in")
                 userManager.signOut(playbackManager, wasInitiatedByUser = false)
             } else {
+                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "SyncProcess: Sync failed")
                 return RefreshState.Failed("Sync threw an error: ${throwable.message}")
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -131,16 +131,15 @@ class RefreshPodcastsThread(
 
             return ListenableWorker.Result.success()
         } catch (e: Exception) {
-            Timber.e(e)
-            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, e, "Refresh failed")
-
             if (e is RefreshTokenExpiredException) {
-                LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, "Signed out user because the refresh token has expired.")
+                LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Signed out user because the refresh token has expired.")
 
                 val userManager = entryPoint.userManager()
                 val playbackManager = entryPoint.playbackManager()
                 userManager.signOut(playbackManager, wasInitiatedByUser = false)
             } else {
+                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Refresh failed")
+
                 refreshFailedOrCancelled(e.message ?: "Unknown error")
             }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -139,7 +139,7 @@ class SubscriptionManagerImpl @Inject constructor(
                     Timber.d("Connected to google play")
                     loadProducts()
                 } else {
-                    Timber.e("Couldn't set up billing connection: ${billingResult.debugMessage}")
+                    Timber.w("Couldn't set up billing connection: ${billingResult.debugMessage}")
                     loadProducts()
                 }
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -121,7 +121,7 @@ class Support @Inject constructor(
                     }
                 }
             } catch (e: Exception) {
-                Timber.e(e)
+                LogBuffer.logException(LogBuffer.TAG_CRASH, e, "Failed to share logs")
 
                 val debugStr = StringBuilder()
                 debugStr.append(intro)
@@ -161,7 +161,7 @@ class Support @Inject constructor(
                     FileUtil.createUriWithReadPermissions(debugFile, intent, context)
                 intent.putExtra(Intent.EXTRA_STREAM, fileUri)
             } catch (e: Exception) {
-                Timber.e(e)
+                LogBuffer.logException(LogBuffer.TAG_CRASH, e, "Failed to share wear logs")
                 intent.putExtra(Intent.EXTRA_TEXT, String(logBytes))
             }
             intent

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -31,7 +31,6 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.FolderResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.PodcastResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.SyncSettingsTask
 import au.com.shiftyjelly.pocketcasts.servers.sync.update.SyncUpdateResponse
-import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.parseIsoDate
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toIsoString
@@ -42,7 +41,6 @@ import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.rxkotlin.Singles
 import io.reactivex.schedulers.Schedulers
-import io.sentry.Sentry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -110,7 +108,6 @@ class PodcastSyncProcess(
             )
         return syncUpNextObservable
             .doOnError { throwable ->
-                SentryHelper.recordException("Sync failed", throwable)
                 LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "SyncProcess: Sync failed")
             }
             .doOnComplete {
@@ -548,7 +545,6 @@ class PodcastSyncProcess(
             }
             records.put(record)
         } catch (e: JSONException) {
-            Sentry.captureException(e)
             Timber.e(e, "Unable to save bookmark")
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -108,7 +108,7 @@ class PodcastSyncProcess(
             )
         return syncUpNextObservable
             .doOnError { throwable ->
-                LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "SyncProcess: Sync failed")
+                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "SyncProcess: Sync failed")
             }
             .doOnComplete {
                 Timber.i("SyncProcess: Sync success")
@@ -228,7 +228,7 @@ class PodcastSyncProcess(
         return podcastManager.subscribeToPodcastRx(podcastUuid = podcastUuid, sync = false)
             .flatMap { podcast -> updatePodcastSyncValues(podcast, podcastResponse).toSingleDefault(podcast) }
             .toMaybe()
-            .doOnError { LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, "Could not import server podcast $podcastResponse.uuid", it) }
+            .doOnError { LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, it, "Could not import server podcast $podcastResponse.uuid", it) }
             .onErrorComplete()
     }
 
@@ -738,7 +738,7 @@ class PodcastSyncProcess(
                     podcastManager.updatePodcast(podcast)
                 }
                 .toMaybe()
-                .doOnError { LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, "Could not import server podcast $podcastUuid", it) }
+                .doOnError { LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, it, "Could not import server podcast $podcastUuid") }
                 .onErrorComplete()
         } else {
             return Maybe.empty<Podcast>()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManagerImpl.kt
@@ -84,7 +84,7 @@ open class SyncAccountManagerImpl @Inject constructor(
                     AccessToken(token)
                 }
             } catch (e: Exception) {
-                LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, e, "Could not get token")
+                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Could not get token")
                 throw e // Rethrow the exception so it carries on
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManagerImpl.kt
@@ -84,7 +84,12 @@ open class SyncAccountManagerImpl @Inject constructor(
                     AccessToken(token)
                 }
             } catch (e: Exception) {
-                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Could not get token")
+                if (e is RefreshTokenExpiredException) {
+                    LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, e, "Refresh token expired")
+                } else {
+                    LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Could not get token")
+                }
+
                 throw e // Rethrow the exception so it carries on
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncHistoryTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncHistoryTask.kt
@@ -114,7 +114,7 @@ class SyncHistoryTask @AssistedInject constructor(
 
             LogBuffer.i(TAG, "Sync history completed successfully")
         } catch (e: Exception) {
-            LogBuffer.e(TAG, "Sync history failed: ${e.message}")
+            LogBuffer.logException(TAG, e, "Sync history failed")
             return Result.failure()
         }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -147,10 +147,10 @@ class SyncManagerImpl @Inject constructor(
             syncAccountManager.setAccessToken(tokenResponse.accessToken)
             tokenResponse.accessToken
         } catch (ex: Exception) {
-            LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, ex, "Unable to fetch access token.")
             if (isHttpClientError(ex)) {
                 throw RefreshTokenExpiredException()
             } else {
+                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, ex, "Unable to fetch access token.")
                 throw ex
             }
         }
@@ -557,7 +557,7 @@ class SyncManagerImpl @Inject constructor(
         return rxSingle {
             syncAccountManager.getAccessToken() ?: throw RuntimeException("Failed to get token")
         }.doOnError {
-            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, it, "Refresh token threw an error.")
+            LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, it, "Refresh token threw an error.")
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -147,7 +147,7 @@ class SyncManagerImpl @Inject constructor(
             syncAccountManager.setAccessToken(tokenResponse.accessToken)
             tokenResponse.accessToken
         } catch (ex: Exception) {
-            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, ex, "Unable to fetch access token.")
+            LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, ex, "Unable to fetch access token.")
             if (isHttpClientError(ex)) {
                 throw RefreshTokenExpiredException()
             } else {
@@ -196,7 +196,7 @@ class SyncManagerImpl @Inject constructor(
             val result = handleTokenResponse(loginIdentity = loginIdentity, response = response)
             LoginResult.Success(result)
         } catch (ex: Exception) {
-            Timber.e(ex, "Failed to sign in with Pocket Casts")
+            LogBuffer.logException(LogBuffer.TAG_CRASH, ex, "Failed to sign in with Pocket Casts")
             exceptionToAuthResult(exception = ex, fallbackMessage = LR.string.error_login_failed)
         }
 
@@ -211,7 +211,7 @@ class SyncManagerImpl @Inject constructor(
             val result = handleTokenResponse(loginIdentity = LoginIdentity.PocketCasts, response = response)
             LoginResult.Success(result)
         } catch (ex: Exception) {
-            Timber.e(ex, "Failed to create a Pocket Casts account")
+            LogBuffer.logException(LogBuffer.TAG_CRASH, ex, "Failed to create a Pocket Casts account")
             exceptionToAuthResult(exception = ex, fallbackMessage = LR.string.server_login_unable_to_create_account)
         }
         trackRegister(loginResult)
@@ -228,7 +228,7 @@ class SyncManagerImpl @Inject constructor(
                 onError(response.message)
             }
         } catch (ex: Exception) {
-            Timber.e(ex, "Failed to reset password.")
+            LogBuffer.logException(LogBuffer.TAG_CRASH, ex, "Failed to reset password.")
             onError(context.resources.getString(LR.string.profile_reset_password_failed))
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/UpNextSyncJob.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/UpNextSyncJob.kt
@@ -103,7 +103,7 @@ class UpNextSyncJob : JobService() {
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeBy(
                 onError = { throwable ->
-                    LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "UpNextSyncJob - failed - ${String.format("%d ms", SystemClock.elapsedRealtime() - startTime)}")
+                    LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "UpNextSyncJob - failed - ${String.format("%d ms", SystemClock.elapsedRealtime() - startTime)}")
                     jobFinished(jobParameters, false)
                 },
                 onComplete = {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/StatsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/StatsManagerImpl.kt
@@ -3,10 +3,10 @@ package au.com.shiftyjelly.pocketcasts.repositories.user
 import au.com.shiftyjelly.pocketcasts.models.to.StatsBundle
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import io.reactivex.Single
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.rx2.rxSingle
-import timber.log.Timber
 import javax.inject.Inject
 
 class StatsManagerImpl @Inject constructor(
@@ -225,7 +225,7 @@ class StatsManagerImpl @Inject constructor(
             cachedMergedStats = mergeStats(stats.values, localStatsInServerFormat)
             persistTimes()
         } catch (ex: Exception) {
-            Timber.e("Could not load server stats for cache ${ex.message}")
+            LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, ex, "Could not load server stats for cache")
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import timber.log.Timber
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
@@ -93,8 +92,8 @@ class UserManagerImpl @Inject constructor(
                             analyticsTracker.refreshMetadata()
                             SignInState.SignedIn(email = syncManager.getEmail() ?: "", subscriptionStatus = it)
                         }
-                        .onErrorReturn {
-                            Timber.e(it, "Error getting subscription state")
+                        .onErrorReturn { exception ->
+                            LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, exception, "Error getting subscription state")
                             SignInState.SignedIn(syncManager.getEmail() ?: "", SubscriptionStatus.Free())
                         }
                 } else {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
@@ -53,7 +53,7 @@ class WidgetManagerImpl @Inject constructor(
                     updateOnClicks(views, context)
                     appWidgetManager.updateAppWidget(widgetName, views)
                 } catch (e: Exception) {
-                    Timber.e(e)
+                    Timber.w(e)
                 }
             }
         }
@@ -95,7 +95,7 @@ class WidgetManagerImpl @Inject constructor(
                 manager.updateAppWidget(widgetId, views)
             } catch (e: Exception) {
                 // sometimes widgets are not able to be updated, ignore this one and move on to the next one
-                Timber.e(e)
+                Timber.w(e)
             }
         }
     }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerManager.kt
@@ -292,8 +292,7 @@ open class ServerManager @Inject constructor(
             }
 
             override fun onFailure(call: Call, e: IOException) {
-                Timber.e(e, "Post response failed.")
-                LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, e, "Response failed from ${call.request().url}.")
+                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Response failed from ${call.request().url}.")
                 if (callbackOnUiThread) {
                     Handler(Looper.getMainLooper()).post {
                         callback.onFailed(
@@ -329,7 +328,7 @@ open class ServerManager @Inject constructor(
                     requestCallback.onFailure(call, IOException("Unexpected code $response"))
                 }
             } catch (e: IOException) {
-                Timber.e(e)
+                Timber.w(e)
                 requestCallback.onFailure(call, e)
                 return null
             }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerShowNotesManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerShowNotesManager.kt
@@ -2,9 +2,9 @@ package au.com.shiftyjelly.pocketcasts.servers
 
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
 import au.com.shiftyjelly.pocketcasts.servers.shownotes.ShowNotesState
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -38,7 +38,7 @@ class ServerShowNotesManager @Inject constructor(
                     emit(ShowNotesState.NotFound)
                 }
             } catch (e: Exception) {
-                Timber.e(e)
+                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Failed load show notes")
                 // only emit error if we haven't already loaded something
                 if (!loaded) {
                     emit(ShowNotesState.Error(e))
@@ -58,7 +58,7 @@ class ServerShowNotesManager @Inject constructor(
                 return ShowNotesState.Loaded(showNotesDownloaded)
             }
         } catch (e: Exception) {
-            Timber.e(e)
+            LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Failed load show notes")
             downloadException = e
         }
 
@@ -68,7 +68,7 @@ class ServerShowNotesManager @Inject constructor(
                 return ShowNotesState.Loaded(showNotesCached)
             }
         } catch (e: Exception) {
-            Timber.e(e)
+            LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Failed load show notes from cache")
         }
 
         return if (downloadException != null) ShowNotesState.Error(downloadException) else ShowNotesState.NotFound

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
@@ -3,11 +3,10 @@ package au.com.shiftyjelly.pocketcasts.servers.podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.servers.di.PodcastCacheServerRetrofit
 import au.com.shiftyjelly.pocketcasts.servers.discover.EpisodeSearch
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import io.reactivex.Single
-import retrofit2.HttpException
 import retrofit2.Response
 import retrofit2.Retrofit
-import timber.log.Timber
 import javax.inject.Inject
 
 class PodcastCacheServerManagerImpl @Inject constructor(@PodcastCacheServerRetrofit private val retrofit: Retrofit) : PodcastCacheServerManager {
@@ -49,9 +48,7 @@ class PodcastCacheServerManagerImpl @Inject constructor(@PodcastCacheServerRetro
             server.getShowNotesCache(podcastUuid)
         } catch (e: Exception) {
             // if the cache can't be found a HTTP 504 Unsatisfiable Request will be thrown
-            if (e !is HttpException) {
-                Timber.e(e)
-            }
+            LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Failed to get show notes cache")
             // ignore the error when the cache is empty
             null
         }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -47,7 +47,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     }
                 }
             } catch (e: Exception) {
-                LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, e, "Sync settings failed")
+                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Sync settings failed")
                 return Result.failure()
             }
 

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/worker/RefreshArtworkWorker.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/worker/RefreshArtworkWorker.kt
@@ -48,7 +48,7 @@ class RefreshArtworkWorker @AssistedInject constructor(
                 try {
                     imageLoader.cacheSubscribedArtworkSuspend(podcast)
                 } catch (e: Exception) {
-                    Timber.e(e)
+                    Timber.w(e)
                 }
             }
         }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilWrapper.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilWrapper.kt
@@ -31,7 +31,7 @@ class FileUtilWrapper @Inject constructor() {
                 stream.flush()
             }
         } catch (e: IOException) {
-            Timber.e("Error while saving image to file " + e.message)
+            Timber.w("Error while saving image to file " + e.message)
         }
         file
     }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SentryHelper.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SentryHelper.kt
@@ -1,9 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.utils
 
 import io.sentry.Sentry
+import retrofit2.HttpException
 import java.io.IOException
 import java.util.concurrent.CancellationException
-import javax.net.ssl.SSLException
 
 object SentryHelper {
     const val GLOBAL_TAG_APP_PLATFORM = "app.platform"
@@ -39,10 +39,10 @@ object SentryHelper {
         return (
             // ignore worker job cancels as they will retry
             throwable is CancellationException ||
-                // ignore exceptions such as SocketTimeoutException, SocketException or UnknownHostException, as with episode urls we don't control this
+                // ignore exceptions such as SocketTimeoutException, SocketException, SSLException or UnknownHostException, as with episode urls we don't control this
                 throwable is IOException ||
-                // ignore producer certificate exceptions
-                throwable is SSLException
+                // ignore exceptions such as 401 - Unauthorized
+                throwable is HttpException
             )
     }
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SystemBatteryRestrictions.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SystemBatteryRestrictions.kt
@@ -69,7 +69,7 @@ class SystemBatteryRestrictions @Inject constructor(@ApplicationContext private 
         // granting this request will only ignore battery optimizations, it will not remove the
         // app's background restrictions.
         if (status == Status.Restricted) {
-            Timber.e(
+            Timber.w(
                 "Improperly requesting that the user turn off battery optimization when their current " +
                     "setting is $status. Use SystemBatteryOptimization::goToAppSettings prompt instead"
             )

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/di/FirebaseModule.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/di/FirebaseModule.kt
@@ -26,7 +26,7 @@ class FirebaseModule {
                 if (it.isSuccessful) {
                     activate()
                 } else {
-                    Timber.e("Could not fetch remote config: ${it.exception?.message ?: "Unknown error"}")
+                    Timber.w("Could not fetch remote config: ${it.exception?.message ?: "Unknown error"}")
                 }
             }
         }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/GoogleApiAvailability.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/GoogleApiAvailability.kt
@@ -9,7 +9,7 @@ fun GoogleApiAvailability.isGooglePlayServicesAvailableSuccess(context: Context,
     return try {
         isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS
     } catch (ex: Exception) {
-        Timber.e("Unable to check if Google Play Services is installed.", ex)
+        Timber.w("Unable to check if Google Play Services is installed.", ex)
         exceptionDefault
     }
 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/String.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/String.kt
@@ -31,7 +31,7 @@ fun String.parseIsoDate(): Date? {
             // try next format
         }
     }
-    Timber.e("Parsing ISO date failed [${toString()}]")
+    Timber.w("Parsing ISO date failed [${toString()}]")
     return null
 }
 
@@ -51,7 +51,7 @@ fun String.toSecondsFromColonFormattedString(): Int? {
 
         return time.toInt()
     } catch (e: NumberFormatException) {
-        Timber.e(e)
+        Timber.w(e)
     }
 
     return null

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/String.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/String.kt
@@ -78,6 +78,6 @@ private fun String.hashString(algorithm: String) =
             .digest(toByteArray())
             .joinToString("") { "%02x".format(it) }
     } catch (e: Exception) {
-        LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Error applying $algorithm to $this: ${e.message}")
+        LogBuffer.w(LogBuffer.TAG_INVALID_STATE, "Error applying $algorithm to $this: ${e.message}")
         null
     }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBuffer.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBuffer.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.utils.log
 
 import android.util.Log
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
-import retrofit2.HttpException
+import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import timber.log.Timber
 import timber.log.Timber.Forest.tag
 import java.io.File
@@ -137,10 +137,7 @@ object LogBuffer {
      * Exceptions such as network timeouts are logged at the info level as they can't be fixed.
      */
     fun logException(tag: String, throwable: Throwable, message: String, vararg args: Any) {
-        val priority = when (throwable) {
-            is IOException, is HttpException -> Log.INFO
-            else -> Log.ERROR
-        }
+        val priority = if (SentryHelper.shouldIgnoreExceptions(throwable)) Log.INFO else Log.ERROR
         addLog(priority, tag, throwable, message, *args)
     }
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBuffer.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBuffer.kt
@@ -120,6 +120,10 @@ object LogBuffer {
         addLog(Log.WARN, tag, null, message, *args)
     }
 
+    fun w(tag: String, throwable: Throwable, message: String, vararg args: Any) {
+        addLog(Log.WARN, tag, throwable, message, *args)
+    }
+
     fun e(tag: String, message: String, vararg args: Any) {
         addLog(Log.ERROR, tag, null, message, *args)
     }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBuffer.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBuffer.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.utils.log
 
 import android.util.Log
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
+import retrofit2.HttpException
 import timber.log.Timber
 import timber.log.Timber.Forest.tag
 import java.io.File
@@ -129,6 +130,18 @@ object LogBuffer {
 
     fun e(tag: String, throwable: Throwable, message: String, vararg args: Any) {
         addLog(Log.ERROR, tag, throwable, message, *args)
+    }
+
+    /**
+     * Log the exception with the appropriate priority based on the exception type.
+     * Exceptions such as network timeouts are logged at the info level as they can't be fixed.
+     */
+    fun logException(tag: String, throwable: Throwable, message: String, vararg args: Any) {
+        val priority = when (throwable) {
+            is IOException, is HttpException -> Log.INFO
+            else -> Log.ERROR
+        }
+        addLog(priority, tag, throwable, message, *args)
     }
 
     @Suppress("NAME_SHADOWING")

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBufferUncaughtExceptionHandler.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBufferUncaughtExceptionHandler.kt
@@ -6,7 +6,7 @@ class LogBufferUncaughtExceptionHandler(private val defaultHandler: Thread.Uncau
 
     override fun uncaughtException(thread: Thread, throwable: Throwable) {
         try {
-            LogBuffer.e(LogBuffer.TAG_CRASH, throwable, "Fatal crash.")
+            LogBuffer.logException(LogBuffer.TAG_CRASH, throwable, "Fatal crash.")
         } catch (throwable: Throwable) {
             Log.e("POCKETCASTS", "Logging crash", throwable)
         }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/RxJavaUncaughtExceptionHandling.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/RxJavaUncaughtExceptionHandling.kt
@@ -11,7 +11,7 @@ object RxJavaUncaughtExceptionHandling {
 
                 is UndeliverableException -> {
                     // Merely log undeliverable exceptions
-                    Timber.e(exception)
+                    Timber.w(exception)
                     LogBuffer.i(LogBuffer.TAG_RX_JAVA_DEFAULT_ERROR_HANDLER, "Caught undeliverable exception: ${exception.cause}")
                 }
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/RxJavaUncaughtExceptionHandling.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/RxJavaUncaughtExceptionHandling.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.utils.log
 
 import io.reactivex.exceptions.UndeliverableException
 import io.reactivex.plugins.RxJavaPlugins
-import timber.log.Timber
 
 object RxJavaUncaughtExceptionHandling {
     fun setUp() {
@@ -11,8 +10,7 @@ object RxJavaUncaughtExceptionHandling {
 
                 is UndeliverableException -> {
                     // Merely log undeliverable exceptions
-                    Timber.w(exception)
-                    LogBuffer.i(LogBuffer.TAG_RX_JAVA_DEFAULT_ERROR_HANDLER, "Caught undeliverable exception: ${exception.cause}")
+                    LogBuffer.w(LogBuffer.TAG_RX_JAVA_DEFAULT_ERROR_HANDLER, exception, "Caught undeliverable exception.")
                 }
 
                 else -> {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/OpmlExporter.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/OpmlExporter.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.ServerCallback
 import au.com.shiftyjelly.pocketcasts.servers.ServerManager
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -80,7 +81,7 @@ class OpmlExporter(
                 }
             }
         } catch (e: Exception) {
-            Timber.e(e, "OPML export failed.")
+            LogBuffer.logException(LogBuffer.TAG_CRASH, e, "OPML export failed.")
             UiUtil.hideProgressDialog(progressDialog)
             UiUtil.displayAlertError(
                 context = context, title = context.getString(LR.string.settings_opml_export_failed_title),
@@ -131,7 +132,7 @@ class OpmlExporter(
                         } catch (e: Exception) {
                             trackFailure(reason = "unknown")
                             UiUtil.hideProgressDialog(progressDialog)
-                            Timber.e(e)
+                            LogBuffer.logException(LogBuffer.TAG_CRASH, e, "OPML export failed.")
                         }
                     }
                 }
@@ -155,11 +156,11 @@ class OpmlExporter(
             try {
                 context.startActivity(intent)
             } catch (e: ActivityNotFoundException) {
-                Timber.e(e)
+                Timber.w(e)
                 UiUtil.displayAlertError(context, context.getString(LR.string.settings_no_file_browser_title), context.getString(LR.string.settings_no_file_browser), null)
             }
         } catch (e: Exception) {
-            Timber.e(e)
+            Timber.w(e)
         }
     }
 
@@ -181,11 +182,11 @@ class OpmlExporter(
                 context.startActivity(intent)
                 // fragment.startActivityForResult(intent, EXPORT_PICKER_REQUEST_CODE);
             } catch (e: ActivityNotFoundException) {
-                Timber.e(e)
+                Timber.w(e)
                 UiUtil.displayAlertError(context, context.getString(LR.string.settings_no_email_app_title), context.getString(LR.string.settings_no_email_app), null)
             }
         } catch (e: Exception) {
-            Timber.e(e)
+            Timber.w(e)
         }
     }
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/UiUtil.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/UiUtil.kt
@@ -26,7 +26,7 @@ object UiUtil {
                 progressDialog.dismiss()
             }
         } catch (e: Exception) {
-            Timber.e(e)
+            Timber.w(e)
         }
     }
 
@@ -50,7 +50,7 @@ object UiUtil {
                 .show()
         } catch (e: Exception) {
             // you can get exceptions sometimes, like if you try to launch a message from an invalid activity
-            Timber.e(e)
+            Timber.w(e)
         }
     }
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -408,7 +408,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
 
         val episode = selectedList.let { list ->
             if (list.size != 1) {
-                LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Can only share one episode, but trying to share ${selectedList.size} episodes when multi selecting")
+                LogBuffer.w(LogBuffer.TAG_INVALID_STATE, "Can only share one episode, but trying to share ${selectedList.size} episodes when multi selecting")
                 return
             } else {
                 list.first()
@@ -416,14 +416,14 @@ class MultiSelectEpisodesHelper @Inject constructor(
         }
 
         if (episode !is PodcastEpisode) {
-            LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Can only share a ${PodcastEpisode::class.java.simpleName}")
+            LogBuffer.w(LogBuffer.TAG_INVALID_STATE, "Can only share a ${PodcastEpisode::class.java.simpleName}")
             Toast.makeText(context, LR.string.podcasts_share_failed, Toast.LENGTH_SHORT).show()
             return
         }
 
         launch {
             val podcast = podcastManager.findPodcastByUuidSuspend(episode.podcastUuid) ?: run {
-                LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Share failed because unable to find podcast from uuid")
+                LogBuffer.w(LogBuffer.TAG_INVALID_STATE, "Share failed because unable to find podcast from uuid")
                 return@launch
             }
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/review/InAppReviewHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/review/InAppReviewHelper.kt
@@ -7,10 +7,9 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlagWrapper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.google.android.play.core.review.ReviewManager
 import kotlinx.coroutines.delay
-import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -45,8 +44,7 @@ class InAppReviewHelper @Inject constructor(
                 }
             }
         } catch (e: Exception) {
-            Timber.e("Could not launch review dialog.")
-            SentryHelper.recordException(e)
+            LogBuffer.logException(LogBuffer.TAG_CRASH, e, "Could not launch review dialog.")
         }
     }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/WearMainActivityViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/WearMainActivityViewModel.kt
@@ -15,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionMana
 import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.google.android.horologist.auth.data.tokenshare.TokenBundleRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -25,7 +26,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -124,7 +124,7 @@ class WearMainActivityViewModel @Inject constructor(
             try {
                 podcastManager.refreshPodcastsIfRequired(fromLog = "watch - open app")
             } catch (e: Exception) {
-                Timber.e(e)
+                LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, e, "Failed to start refresh")
             }
         }
         // Schedule next refresh in the background

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/LoggingInScreenViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/LoggingInScreenViewModel.kt
@@ -56,7 +56,7 @@ class LoggingInScreenViewModel @Inject constructor(
         val stateValue = state.value
 
         if (stateValue is State.None) {
-            LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Immediately closing LoggingInScreen because refresh is not in progress")
+            LogBuffer.w(LogBuffer.TAG_INVALID_STATE, "Immediately closing LoggingInScreen because refresh is not in progress")
             return true
         }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -353,7 +353,7 @@ class EpisodeViewModel @Inject constructor(
 
     fun onPauseClicked() {
         if ((stateFlow.value as? State.Loaded)?.isPlayingEpisode != true) {
-            Timber.e("Attempted to pause when not playing")
+            Timber.w("Attempted to pause when not playing")
             return
         }
         playAttempt?.cancel()

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/AudioOutputSelectorHelper.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/AudioOutputSelectorHelper.kt
@@ -29,7 +29,7 @@ class AudioOutputSelectorHelper @Inject constructor(
             if (canPlayWithNewOutput) {
                 play()
             } else {
-                Timber.e("Cannot play audio on output $newAudioOutput")
+                Timber.w("Cannot play audio on output $newAudioOutput")
             }
         }
     }


### PR DESCRIPTION
## Description

Since upgrading Sentry it has been sending Timber logs. Lots are IO issues that we can't fix so this change reduces the log priority so they aren't sent. 

As we are going over our usage limit I have changed lots of the logging. I think this might be better than turning off the Timber integration completely. Let me know if you think we should turn it off.

I made the following choices with the exception logging. 

## Example 1
Before:
```
Timber.e(it)
```

After:
```
LogBuffer.logException(LogBuffer.TAG_BACKGROUND_TASKS, exception, "Incremental sync failed")
```

The Timber error will get sent to Sentry. By using my new `logException` method it filters out exceptions that maybe shouldn't be sent to the server. It does this by logging in Timber using `info` instead of `error`.

Changing from Timber to LogBuffer seems like a good idea for some exceptions so we have visibility on the server or at least in the support emails. 

## Example 2

Before:
```
Timber.e("Attempted to pause when not playing")
```

After:
```
Timber.w("Attempted to pause when not playing")
```

In other cases if we don't need to know about the exception in Sentry I have changed the to a warning.

> The integration is added with minEventLevel set to ERROR and minBreadcrumbLevel set to INFO.

The [documentation](https://docs.sentry.io/platforms/android/configuration/integrations/timber/#install) indicates that only errors get created as events.


