### PR TITLE
Disable Sentry Timber integration temporarily

### DIFF
--- a/base.gradle
+++ b/base.gradle
@@ -312,7 +312,9 @@ dependencies {
     }
 }
 
+// Exclude the Timber integration from the Sentry Android SDK temporarily.
 // Exclude the NDK from the Sentry Android SDK as we don't use it and Tracks includes it.
 configurations.configureEach {
+    exclude group: "io.sentry", module: "sentry-android-timber"
     exclude group: "io.sentry", module: "sentry-android-ndk"
 }


### PR DESCRIPTION
## Description
This disables Sentry Timber integration temporarily. 
Slack ref: p1695799385962079/1695652459.530499-slack-C028JAG44VD

> **Warning**
> Targets 7.48

## Testing Instructions
1. Add `Timber.e(...)` statement in `SettingsFragmentPage`

```
AboutRow(onClick = {
    Timber.e("test", "test disable timber")
    openFragment(AboutFragment())
})
```
2. Install release build
3. Open `About` page
4. Make sure that the log is not captured in `Sentry`.


## Checklist (N/A)
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack