### PR TITLE
progress bar is made white

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerSeekBar.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerSeekBar.kt
@@ -65,7 +65,7 @@ class PlayerSeekBar @JvmOverloads constructor(context: Context, attrs: Attribute
     fun setTintColor(color: Int?, theme: Theme.ThemeType) {
         val themeColor = ThemeColor.playerHighlight01(theme, color ?: Color.WHITE)
         seekBar.thumbTintList = ColorStateList.valueOf(ThemeColor.playerContrast01(theme))
-        seekBar.progressTintList = ColorStateList.valueOf(themeColor)
+        seekBar.progressTintList = ColorStateList.valueOf(ThemeColor.playerContrast01(theme))
         seekBar.secondaryProgressTintList = ColorStateList.valueOf(ThemeColor.playerContrast05(theme))
         seekBar.backgroundTintList = ColorStateList.valueOf(ThemeColor.playerContrast05(theme))
 

--- a/modules/features/player/src/main/res/layout/view_playback_seek_bar.xml
+++ b/modules/features/player/src/main/res/layout/view_playback_seek_bar.xml
@@ -19,10 +19,10 @@
         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
         android:layout_width="match_parent"
         android:layout_height="4dp"
-        android:indeterminate="true"
-        android:layout_marginTop="19dp"
         android:layout_marginStart="16dp"
+        android:layout_marginTop="19dp"
         android:layout_marginEnd="16dp"
+        android:indeterminate="true"
         app:mpb_progressStyle="horizontal" />
 
     <TextView


### PR DESCRIPTION
## Description
Linked Issue : #116 


## Testing Instructions

1. Open any podcast which has video
2. Then check the seek bar

## Screenshots or Screencast 

![Screenshot_20230928_020049](https://github.com/Automattic/pocket-casts-android/assets/60827173/ecfdb3ae-0e87-4ac3-939f-5284285e2fc9)

## Fixed
The full screen video player has some features that could be nice to adopt on Android:

- [ ] We could make all the background the black alpha layer.
- [X] The progress bar might look better white.
- [ ] We could include a button to change the ratio.
- [ ] We could round the ends of the progress bar.
- [ ] The current time and time left could use a monospaced font.


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [X] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
