### PR TITLE
Bookmarks: Use feature availablity checks

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import au.com.shiftyjelly.pocketcasts.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlagWrapper
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
@@ -46,6 +48,7 @@ class PodcastSyncProcessTest {
     private lateinit var retrofit: Retrofit
     private lateinit var okhttpCache: Cache
     private lateinit var appDatabase: AppDatabase
+    private val featureFlagWrapper: FeatureFlagWrapper = mock()
 
     @Before
     fun setUp() {
@@ -56,7 +59,8 @@ class PodcastSyncProcessTest {
 
         appDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
 
-        val moshi = ServersModule.provideMoshiBuilder().build()
+        whenever(featureFlagWrapper.isEnabled(Feature.BOOKMARKS_ENABLED)) doReturn true
+        val moshi = ServersModule.provideMoshiBuilder(featureFlagWrapper).build()
         val okHttpClient = OkHttpClient.Builder().build()
         retrofit = ServersModule.provideRetrofit(baseUrl = mockWebServer.url("/").toString(), okHttpClient = okHttpClient, moshi = moshi)
         okhttpCache = ServersModule.provideCache(folder = "TestCache", context = context)
@@ -146,7 +150,8 @@ class PodcastSyncProcessTest {
                 userEpisodeManager = mock(),
                 subscriptionManager = mock(),
                 folderManager = folderManager,
-                syncManager = syncManager
+                syncManager = syncManager,
+                featureFlagWrapper = featureFlagWrapper,
             )
 
             val response = MockResponse()

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/BetaFeaturesViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/BetaFeaturesViewModel.kt
@@ -21,12 +21,14 @@ class BetaFeaturesViewModel @Inject constructor() : ViewModel() {
     val state: StateFlow<State> = _state
 
     private val featureFlags: List<FeatureFlagWrapper>
-        get() = Feature.values().map {
-            FeatureFlagWrapper(
-                featureFlag = it,
-                isEnabled = FeatureFlag.isEnabled(it)
-            )
-        }
+        get() = Feature.values()
+            .filter { it.hasDevToggle }
+            .map {
+                FeatureFlagWrapper(
+                    featureFlag = it,
+                    isEnabled = FeatureFlag.isEnabled(it)
+                )
+            }
 
     fun setFeatureEnabled(feature: Feature, enabled: Boolean) {
         FeatureFlag.setEnabled(feature, enabled)

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/Feature.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/Feature.kt
@@ -33,7 +33,7 @@ enum class Feature(
     BOOKMARKS_ENABLED(
         key = "bookmarks_enabled",
         title = "Bookmarks",
-        defaultValue = false,
+        defaultValue = BuildConfig.DEBUG,
         tier = FeatureTier.Plus(null),
         hasDevToggle = true,
     ),

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/Feature.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/Feature.kt
@@ -50,8 +50,10 @@ enum class Feature(
         fun isAvailable(feature: Feature, userTier: UserTier) = when (userTier) {
 
             // Patron users can use all features
-            UserTier.Patron -> {
-                feature.defaultValue
+            UserTier.Patron -> when (feature.tier) {
+                FeatureTier.Patron,
+                is FeatureTier.Plus,
+                FeatureTier.Free -> FeatureFlag.isEnabled(feature)
             }
 
             UserTier.Plus -> {
@@ -63,10 +65,10 @@ enum class Feature(
 
                     // Plus users cannot use Plus features during early access for patrons
                     is FeatureTier.Plus ->
-                        feature.defaultValue &&
+                        FeatureFlag.isEnabled(feature) &&
                             !feature.tier.patronExclusiveAccessRelease.matchesCurrentReleaseForEarlyPatronAccess()
 
-                    FeatureTier.Free -> feature.defaultValue
+                    FeatureTier.Free -> FeatureFlag.isEnabled(feature)
                 }
             }
 
@@ -74,7 +76,7 @@ enum class Feature(
             UserTier.Free -> when (feature.tier) {
                 FeatureTier.Patron -> false
                 is FeatureTier.Plus -> false
-                FeatureTier.Free -> feature.defaultValue
+                FeatureTier.Free -> FeatureFlag.isEnabled(feature)
             }
         }
     }

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/Feature.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/Feature.kt
@@ -1,33 +1,95 @@
 package au.com.shiftyjelly.pocketcasts.featureflag
 
+import au.com.shiftyjelly.pocketcasts.featureflag.ReleaseVersion.Companion.matchesCurrentReleaseForEarlyPatronAccess
+
 enum class Feature(
     val key: String,
     val title: String,
     val defaultValue: Boolean,
+    val tier: FeatureTier,
+    val hasDevToggle: Boolean,
 ) {
     END_OF_YEAR_ENABLED(
         key = "end_of_year_enabled",
         title = "End of Year",
-        defaultValue = false
+        defaultValue = false,
+        tier = FeatureTier.Free,
+        hasDevToggle = false,
     ),
     SHOW_RATINGS_ENABLED(
         key = "show_ratings_enabled",
         title = "Show Ratings",
-        defaultValue = true
+        defaultValue = true,
+        tier = FeatureTier.Free,
+        hasDevToggle = false,
     ),
     ADD_PATRON_ENABLED(
         key = "add_patron_enabled",
         title = "Patron",
-        defaultValue = false
+        defaultValue = false,
+        tier = FeatureTier.Free,
+        hasDevToggle = true,
     ),
     BOOKMARKS_ENABLED(
         key = "bookmarks_enabled",
         title = "Bookmarks",
-        defaultValue = BuildConfig.DEBUG
+        defaultValue = false,
+        tier = FeatureTier.Plus(null),
+        hasDevToggle = true,
     ),
     IN_APP_REVIEW_ENABLED(
         key = "in_app_review_enabled",
         title = "In App Review",
-        defaultValue = BuildConfig.DEBUG
-    ),
+        defaultValue = false,
+        tier = FeatureTier.Free,
+        hasDevToggle = true,
+    );
+
+    companion object {
+
+        fun isAvailable(feature: Feature, userTier: UserTier) = when (userTier) {
+
+            // Patron users can use all features
+            UserTier.Patron -> {
+                feature.defaultValue
+            }
+
+            UserTier.Plus -> {
+
+                when (feature.tier) {
+
+                    // Patron features can only be used by Patrons
+                    FeatureTier.Patron -> false
+
+                    // Plus users cannot use Plus features during early access for patrons
+                    is FeatureTier.Plus ->
+                        feature.defaultValue &&
+                            !feature.tier.patronExclusiveAccessRelease.matchesCurrentReleaseForEarlyPatronAccess()
+
+                    FeatureTier.Free -> feature.defaultValue
+                }
+            }
+
+            // Free users can only use free features
+            UserTier.Free -> when (feature.tier) {
+                FeatureTier.Patron -> false
+                is FeatureTier.Plus -> false
+                FeatureTier.Free -> feature.defaultValue
+            }
+        }
+    }
+}
+
+// It would be nice to be able to use Subscription.SubscriptionTier here, but that's in the
+// models module, which already depends on this featureflag module, so we can't depend on it
+enum class UserTier {
+    Patron,
+    Plus,
+    Free,
+}
+
+sealed class FeatureTier {
+    object Patron : FeatureTier()
+    class Plus(val patronExclusiveAccessRelease: ReleaseVersion?) : FeatureTier()
+    object Free : FeatureTier()
 }

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/ReleaseVersion.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/ReleaseVersion.kt
@@ -1,0 +1,63 @@
+package au.com.shiftyjelly.pocketcasts.featureflag
+
+import androidx.annotation.VisibleForTesting
+import timber.log.Timber
+
+data class ReleaseVersion(
+    val major: Int,
+    val minor: Int,
+    val patch: Int? = null,
+    val releaseCandidate: Int? = null,
+) : Comparable<ReleaseVersion> {
+
+    override fun compareTo(other: ReleaseVersion): Int {
+        return when {
+            this.major != other.major -> this.major - other.major
+            this.minor != other.minor -> this.minor - other.minor
+            (this.patch ?: 0) != (other.patch ?: 0) -> (this.patch ?: 0) - (other.patch ?: 0)
+            (this.releaseCandidate ?: Int.MAX_VALUE) != (other.releaseCandidate ?: Int.MAX_VALUE) ->
+                (this.releaseCandidate ?: Int.MAX_VALUE) - (other.releaseCandidate ?: Int.MAX_VALUE)
+            else -> 0
+        }
+    }
+
+    companion object {
+
+        private val currentReleaseVersion by lazy {
+            fromString(BuildConfig.VERSION_NAME) ?: error("Invalid version name: ${BuildConfig.VERSION_NAME}")
+        }
+
+        fun ReleaseVersion?.matchesCurrentReleaseForEarlyPatronAccess() =
+            this.matchesCurrentReleaseForEarlyPatronAccess(currentReleaseVersion)
+
+        // If major and minor versions match, and this is not a release candidate, this is the
+        // early access release. We don't want to include release candidates because we want to
+        // allow broader testing of the feature. Patch versions are ignored.
+        @VisibleForTesting
+        internal fun ReleaseVersion?.matchesCurrentReleaseForEarlyPatronAccess(
+            currentReleaseVersion: ReleaseVersion, // this parameter is just to allow testing
+        ) = when {
+            this == null -> {
+                Timber.e("ReleaseVersion.matchesCurrentReleaseForEarlyPatronAccess called on null")
+                false
+            }
+            this.major != currentReleaseVersion.major -> false
+            minor != currentReleaseVersion.minor -> false
+            releaseCandidate != null -> false
+            else -> true
+        }
+
+        fun fromString(versionName: String): ReleaseVersion? {
+            val regex = Regex("""(\d+)\.(\d+)(?:\.(\d+))?(?:-rc-(\d+))?""")
+            val match = regex.find(versionName) ?: return null
+
+            val (majorStr, minorStr, patchStr, rcStr) = match.destructured
+            val major = majorStr.toInt()
+            val minor = minorStr.toInt()
+            val patch = if (patchStr.isNotBlank()) patchStr.toInt() else null
+            val rc = if (rcStr.isNotBlank()) rcStr.toInt() else null
+
+            return ReleaseVersion(major, minor, patch, rc)
+        }
+    }
+}

--- a/modules/services/featureflag/src/test/java/au/com/shiftyjelly/pocketcasts/featureflag/FeatureTest.kt
+++ b/modules/services/featureflag/src/test/java/au/com/shiftyjelly/pocketcasts/featureflag/FeatureTest.kt
@@ -46,18 +46,34 @@ class FeatureTest {
 
     @Test
     fun `patron can use features that default to true`() {
-        val feature = mock<Feature> {
-            on { defaultValue } doReturn true
+        listOf(
+            FeatureTier.Free,
+            FeatureTier.Plus(null),
+            FeatureTier.Patron,
+        ).forEach { featureTier ->
+
+            val feature = mock<Feature> {
+                on { defaultValue } doReturn true
+                on { tier } doReturn featureTier
+            }
+            assertTrue("$featureTier", Feature.isAvailable(feature, UserTier.Patron))
         }
-        assertTrue(Feature.isAvailable(feature, UserTier.Patron))
     }
 
     @Test
     fun `patron cannot use features that default to false`() {
-        val feature = mock<Feature> {
-            on { defaultValue } doReturn false
+        listOf(
+            FeatureTier.Free,
+            FeatureTier.Plus(null),
+            FeatureTier.Patron,
+        ).forEach { featureTier ->
+
+            val feature = mock<Feature> {
+                on { defaultValue } doReturn false
+                on { tier } doReturn featureTier
+            }
+            assertFalse("$featureTier", Feature.isAvailable(feature, UserTier.Patron))
         }
-        assertFalse(Feature.isAvailable(feature, UserTier.Patron))
     }
 
     /*

--- a/modules/services/featureflag/src/test/java/au/com/shiftyjelly/pocketcasts/featureflag/FeatureTest.kt
+++ b/modules/services/featureflag/src/test/java/au/com/shiftyjelly/pocketcasts/featureflag/FeatureTest.kt
@@ -1,0 +1,152 @@
+package au.com.shiftyjelly.pocketcasts.featureflag
+
+import au.com.shiftyjelly.pocketcasts.featureflag.ReleaseVersion.Companion.matchesCurrentReleaseForEarlyPatronAccess
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+@RunWith(MockitoJUnitRunner::class)
+class FeatureTest {
+
+    /*
+     * isAvailable: all users
+     */
+
+    @Test
+    fun `no users can use free features that default to false`() {
+        listOf(
+            UserTier.Free,
+            UserTier.Plus,
+            UserTier.Patron,
+        ).forEach { userTier ->
+
+            listOf(
+                FeatureTier.Free,
+                FeatureTier.Plus(null),
+                FeatureTier.Patron,
+            ).forEach { featureTier ->
+
+                val feature = mock<Feature> {
+                    on { defaultValue } doReturn false
+                    on { tier } doReturn featureTier
+                }
+                assertFalse("$userTier", Feature.isAvailable(feature, userTier))
+            }
+        }
+    }
+
+    /*
+     * isAvailable: patron users
+     */
+
+    @Test
+    fun `patron can use features that default to true`() {
+        val feature = mock<Feature> {
+            on { defaultValue } doReturn true
+        }
+        assertTrue(Feature.isAvailable(feature, UserTier.Patron))
+    }
+
+    @Test
+    fun `patron cannot use features that default to false`() {
+        val feature = mock<Feature> {
+            on { defaultValue } doReturn false
+        }
+        assertFalse(Feature.isAvailable(feature, UserTier.Patron))
+    }
+
+    /*
+     * isAvailble: plus user
+     */
+
+    @Test
+    @Ignore("Test fails because it can't mock companion method")
+    fun `plus can use plus features that default to true and are not in early access`() {
+        val exclusiveAccessRelease = mock<ReleaseVersion> {
+            on { matchesCurrentReleaseForEarlyPatronAccess() } doReturn false
+        }
+        val plusTier = mock<FeatureTier.Plus> {
+            on { exclusiveAccessRelease } doReturn exclusiveAccessRelease
+        }
+        val feature = mock<Feature> {
+            on { defaultValue } doReturn true
+            on { tier } doReturn plusTier
+        }
+        assertTrue(Feature.isAvailable(feature, UserTier.Plus))
+    }
+
+    @Test
+    @Ignore("Test fails because it can't mock companion method")
+    fun `plus cannot use plus features that default to false even if not in early access`() {
+        val exclusiveAccessRelease = mock<ReleaseVersion> {
+            on { matchesCurrentReleaseForEarlyPatronAccess() } doReturn false
+        }
+        val plusTier = mock<FeatureTier.Plus> {
+            on { exclusiveAccessRelease } doReturn exclusiveAccessRelease
+        }
+        val feature = mock<Feature> {
+            on { defaultValue } doReturn false
+            on { tier } doReturn plusTier
+        }
+        assertFalse(Feature.isAvailable(feature, UserTier.Plus))
+    }
+
+    @Test
+    @Ignore("Test fails because it can't mock companion method")
+    fun `plus cannot use plus features that default to true if in early access`() {
+        val exclusiveAccessRelease = mock<ReleaseVersion> {
+            on { matchesCurrentReleaseForEarlyPatronAccess() } doReturn true
+        }
+        val plusTier = mock<FeatureTier.Plus> {
+            on { exclusiveAccessRelease } doReturn exclusiveAccessRelease
+        }
+        val feature = mock<Feature> {
+            on { defaultValue } doReturn true
+            on { tier } doReturn plusTier
+        }
+        assertFalse(Feature.isAvailable(feature, UserTier.Plus))
+    }
+
+    /*
+     * isAvailable: free user
+     */
+
+    @Test
+    fun `free user can use free features that default to true`() {
+        val feature = mock<Feature> {
+            on { defaultValue } doReturn true
+            on { tier } doReturn FeatureTier.Free
+        }
+        assertTrue(Feature.isAvailable(feature, UserTier.Free))
+    }
+
+    @Test
+    fun `free user cannot use free features that default to false`() {
+        val feature = mock<Feature> {
+            on { defaultValue } doReturn false
+            on { tier } doReturn FeatureTier.Free
+        }
+        assertFalse(Feature.isAvailable(feature, UserTier.Free))
+    }
+
+    @Test
+    fun `free user cannot use Plus features`() {
+        val feature = mock<Feature> {
+            on { tier } doReturn FeatureTier.Plus(null)
+        }
+        assertFalse(Feature.isAvailable(feature, UserTier.Free))
+    }
+
+    @Test
+    fun `free user cannot use Patron features`() {
+        val feature = mock<Feature> {
+            on { tier } doReturn FeatureTier.Patron
+        }
+        assertFalse(Feature.isAvailable(feature, UserTier.Free))
+    }
+}

--- a/modules/services/featureflag/src/test/java/au/com/shiftyjelly/pocketcasts/featureflag/ReleaseVersionTest.kt
+++ b/modules/services/featureflag/src/test/java/au/com/shiftyjelly/pocketcasts/featureflag/ReleaseVersionTest.kt
@@ -1,0 +1,150 @@
+package au.com.shiftyjelly.pocketcasts.featureflag
+
+import au.com.shiftyjelly.pocketcasts.featureflag.ReleaseVersion.Companion.matchesCurrentReleaseForEarlyPatronAccess
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class ReleaseVersionTest {
+
+    /*
+     * fromString
+     */
+
+    @Test
+    fun `fromString handles simple release`() {
+        assertEquals(
+            ReleaseVersion(1, 2),
+            ReleaseVersion.fromString("1.2")
+        )
+    }
+
+    @Test
+    fun `fromString handles patch release`() {
+        assertEquals(
+            ReleaseVersion(major = 1, minor = 2, patch = 3),
+            ReleaseVersion.fromString("1.2.3")
+        )
+    }
+
+    @Test
+    fun `fromString handles rc release`() {
+        assertEquals(
+            ReleaseVersion(major = 1, minor = 2, releaseCandidate = 3),
+            ReleaseVersion.fromString("1.2-rc-3")
+        )
+    }
+
+    @Test
+    fun `fromString handles rc release for patch`() {
+        assertEquals(
+            ReleaseVersion(major = 1, minor = 2, patch = 3, releaseCandidate = 4),
+            ReleaseVersion.fromString("1.2.3-rc-4")
+        )
+    }
+
+    @Test
+    fun `fromString handles multiple digits`() {
+        assertEquals(
+            ReleaseVersion(major = 1111, minor = 222222, patch = 333333333, releaseCandidate = 444444),
+            ReleaseVersion.fromString("1111.222222.333333333-rc-444444")
+        )
+    }
+
+    /*
+     * Comparing release versions
+     */
+
+    @Test
+    fun `compares major before minor`() {
+        assertFirstLessThanSecond("1.2", "2.1")
+    }
+
+    @Test
+    fun `compares minor if major is equal`() {
+        assertFirstLessThanSecond("1.1", "1.2")
+    }
+
+    @Test
+    fun `compares patch if major and minor are equal`() {
+        assertFirstLessThanSecond("1.1.1", "1.1.2")
+    }
+
+    @Test
+    fun `considers absence of patch as lower than its presence`() {
+        assertFirstLessThanSecond("1.2", "1.2.3")
+    }
+
+    @Test
+    fun `compares releaseCandidate if major, minor, and patch are equal`() {
+        assertFirstLessThanSecond("1.2.3-rc-4", "1.2.3-rc-5")
+    }
+
+    @Test
+    fun `considers release with same major and minor higher than its RC counterpart`() {
+        assertFirstLessThanSecond("1.2-rc-3", "1.2")
+    }
+
+    @Test
+    fun `considers release with same major, minor, and patch higher than its RC counterpart`() {
+        assertFirstLessThanSecond("1.2.3-rc-4", "1.2.3")
+    }
+
+    /*
+     * matchesCurrentReleaseForEarlyPatronAccess
+     */
+
+    @Test
+    fun `returns false when called on null`() {
+        assertFalse(null.matchesCurrentReleaseForEarlyPatronAccess(ReleaseVersion(1, 1)))
+    }
+
+    @Test
+    fun `returns false when major version does not match`() {
+        val version = ReleaseVersion(major = 1, minor = 1)
+        assertFalse(version.matchesCurrentReleaseForEarlyPatronAccess(ReleaseVersion(2, 1)))
+    }
+
+    @Test
+    fun `returns false when minor version does not match`() {
+        val version = ReleaseVersion(major = 1, minor = 1)
+        assertFalse(version.matchesCurrentReleaseForEarlyPatronAccess(ReleaseVersion(1, 2)))
+    }
+
+    @Test
+    fun `returns false for release candidates`() {
+        val version = ReleaseVersion(major = 2, minor = 3, releaseCandidate = 1)
+        assertFalse(version.matchesCurrentReleaseForEarlyPatronAccess(ReleaseVersion(2, 3, 4)))
+    }
+
+    @Test
+    fun `returns true when major and minor versions match, and it's not a release candidate`() {
+        val version = ReleaseVersion(major = 2, minor = 3)
+        assertTrue(version.matchesCurrentReleaseForEarlyPatronAccess(ReleaseVersion(2, 3, 4)))
+    }
+
+    @Test
+    fun `returns true when major and minor versions match, even if current release is a patch`() {
+        val version = ReleaseVersion(major = 1, minor = 1)
+        assertTrue(
+            version.matchesCurrentReleaseForEarlyPatronAccess(
+                currentReleaseVersion = ReleaseVersion(1, 1, 1)
+            )
+        )
+    }
+
+    private fun assertFirstLessThanSecond(first: String, second: String) {
+        val firstVersion = ReleaseVersion.fromString(first)
+        val secondVersion = ReleaseVersion.fromString(second)
+        if (firstVersion == null || secondVersion == null) {
+            Assert.fail()
+        } else {
+            assertTrue(firstVersion < secondVersion)
+        }
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -15,6 +15,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
 import androidx.work.ListenableWorker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlagWrapper
 import au.com.shiftyjelly.pocketcasts.localization.BuildConfig
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -82,6 +83,7 @@ class RefreshPodcastsThread(
         fun notificationHelper(): NotificationHelper
         fun userManager(): UserManager
         fun syncManager(): SyncManager
+        fun featureFlagWrapper(): FeatureFlagWrapper
     }
 
     @Volatile
@@ -252,6 +254,7 @@ class RefreshPodcastsThread(
             subscriptionManager = entryPoint.subscriptionManager(),
             folderManager = entryPoint.folderManager(),
             syncManager = entryPoint.syncManager(),
+            featureFlagWrapper = entryPoint.featureFlagWrapper()
         )
         val startTime = SystemClock.elapsedRealtime()
         val syncCompletable = sync.run()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.os.Build
 import android.os.SystemClock
 import au.com.shiftyjelly.pocketcasts.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlagWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
@@ -68,7 +68,8 @@ class PodcastSyncProcess(
     var userEpisodeManager: UserEpisodeManager,
     var subscriptionManager: SubscriptionManager,
     var folderManager: FolderManager,
-    var syncManager: SyncManager
+    var syncManager: SyncManager,
+    var featureFlagWrapper: FeatureFlagWrapper
 ) : CoroutineScope {
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
@@ -219,7 +220,7 @@ class PodcastSyncProcess(
     }
 
     private suspend fun downloadAndImportBookmarks() {
-        if (!FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+        if (!featureFlagWrapper.isEnabled(Feature.BOOKMARKS_ENABLED)) {
             return
         }
         val bookmarks = syncManager.getBookmarks()
@@ -511,7 +512,7 @@ class PodcastSyncProcess(
     }
 
     private fun uploadBookmarksChanges(records: JSONArray) {
-        if (!FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+        if (!featureFlagWrapper.isEnabled(Feature.BOOKMARKS_ENABLED)) {
             return
         }
         try {
@@ -641,7 +642,7 @@ class PodcastSyncProcess(
     }
 
     private suspend fun importBookmarks(bookmarks: List<Bookmark>) {
-        if (!FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+        if (!featureFlagWrapper.isEnabled(Feature.BOOKMARKS_ENABLED)) {
             return
         }
         for (bookmark in bookmarks) {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.servers.di
 
 import android.accounts.AccountManager
 import android.content.Context
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlagWrapper
 import au.com.shiftyjelly.pocketcasts.localization.BuildConfig
 import au.com.shiftyjelly.pocketcasts.models.entity.AnonymousBumpStat
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
@@ -119,10 +120,10 @@ class ServersModule {
                 .build()
         }
 
-        fun provideMoshiBuilder(): Moshi.Builder {
+        fun provideMoshiBuilder(featureFlagWrapper: FeatureFlagWrapper = FeatureFlagWrapper()): Moshi.Builder {
             return Moshi.Builder()
                 .add(Date::class.java, Rfc3339DateJsonAdapter().nullSafe())
-                .add(SyncUpdateResponse::class.java, SyncUpdateResponseParser())
+                .add(SyncUpdateResponse::class.java, SyncUpdateResponseParser(featureFlagWrapper))
                 .add(EpisodePlayingStatus::class.java, EpisodePlayingStatusMoshiAdapter())
                 .add(PodcastsSortType::class.java, PodcastsSortTypeMoshiAdapter())
                 .add(AccessToken::class.java, AccessToken.Adapter)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.servers.sync.update
 
 import au.com.shiftyjelly.pocketcasts.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.featureflag.FeatureFlagWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
@@ -27,7 +27,9 @@ import retrofit2.HttpException
 import retrofit2.Response
 import java.util.Date
 
-class SyncUpdateResponseParser : JsonAdapter<SyncUpdateResponse>() {
+class SyncUpdateResponseParser(
+    private val featureFlagWrapper: FeatureFlagWrapper,
+) : JsonAdapter<SyncUpdateResponse>() {
 
     @ToJson
     override fun toJson(writer: JsonWriter, value: SyncUpdateResponse?) {}
@@ -222,7 +224,7 @@ class SyncUpdateResponseParser : JsonAdapter<SyncUpdateResponse>() {
     }
 
     private fun readBookmark(reader: JsonReader, response: SyncUpdateResponse) {
-        if (!FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+        if (!featureFlagWrapper.isEnabled(Feature.BOOKMARKS_ENABLED)) {
             return
         }
 


### PR DESCRIPTION
## Description

This cherry picks feature availability changes from #1332. 

## Testing Instructions

1. Make sure that tests are run and CI is green
2. Head over to PR #1419 to test the changes for the bookmarks feature.

## Merge Instructions

1. Make sure that PR #1419 is approved
2. Remove `not ready for merge` label
3. Merge the PR.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
