### PR TITLE
Remove the playing episode when playing the next in queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 *   Bug Fixes:
     *   Improve multiselect handling in Up Next queue
         ([#1398](https://github.com/Automattic/pocket-casts-android/pull/1390))
+    *   Improve the next episode action to remove the playing episode from the Up Next
+        ([#1422](https://github.com/Automattic/pocket-casts-android/pull/1422))
     *   Fixed bug where theme selection UI was not functioning as intended
         ([#1399](https://github.com/Automattic/pocket-casts-android/pull/1399))
     *   Improve RTL handling in episode search box

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -490,6 +490,9 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
+    /**
+     * Add the episode to the Up Next queue so it will play after the current episode.
+     */
     suspend fun playNext(
         episode: BaseEpisode,
         source: SourceView,
@@ -719,12 +722,15 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
+    /**
+     * Remove the currently playing episode from the Up Next and load the next episode in the queue.
+     */
     fun playNextInQueue(sourceView: SourceView = SourceView.UNKNOWN) {
-        launch {
-            upNextQueue.queueEpisodes.getOrNull(0)?.let {
-                playNowSync(episode = it, sourceView = sourceView)
-            }
+        val currentEpisode = upNextQueue.currentEpisode
+        if (currentEpisode == null || upNextQueue.queueEpisodes.isEmpty()) {
+            return
         }
+        removeEpisode(currentEpisode, sourceView)
     }
 
     fun skipForward(


### PR DESCRIPTION
## Description

The playback manager `playNextInQueue` method works differently on iOS and Android. On iOS when you ask to play the next episode in the queue, it removes the currently playing episode. But Android puts the current playing episode back on the Up Next queue. It makes more sense to me that the episode is removed from the queue or if you keep saying next episode it will just switch between the two episodes.

Fixes https://github.com/Automattic/pocket-casts-android/issues/1421

## Testing Instructions
1. Add multiple episodes to your Up Next queue
2. Play the current episode
3. Open the full-screen player
4. Long press the skip forward button
5. Tap "Next episode"
6. Open the Up Next
7. ✅ The currently playing episode should of been removed and not put on the Up Next queue

## Screencast 

[Screen_recording_20230929_090836.webm](https://github.com/Automattic/pocket-casts-android/assets/308331/5aa20e21-f62c-448a-9381-6776f575dbd7)

