### PR TITLE
Fix user episodes getting removed from up next

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1467,7 +1467,7 @@ open class PlaybackManager @Inject constructor(
                 userEpisodeManager.findEpisodeByUuidRx(currentUpNextEpisode.uuid)
                     .flatMap {
                         if (it.serverStatus == UserEpisodeServerStatus.MISSING) {
-                            userEpisodeManager.downloadMissingUserEpisode(currentUpNextEpisode.uuid, placeholderTitle = null, placeholderPublished = null)
+                            userEpisodeManager.downloadMissingUserEpisode(currentUpNextEpisode.uuid, placeholderTitle = currentUpNextEpisode.title, placeholderPublished = null)
                         } else {
                             Maybe.just(it)
                         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -245,7 +245,12 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
 
         val uri: Uri = when (location) {
             is EpisodeLocation.Stream -> {
-                Uri.parse(location.uri)
+                if (location.uri != null) {
+                    Uri.parse(location.uri)
+                } else {
+                    onError(PlayerEvent.PlayerError("Stream has no uri"))
+                    return
+                }
             }
             is EpisodeLocation.Downloaded -> {
                 val filePath = location.filePath

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -133,6 +133,7 @@ class UserEpisodeManagerImpl @Inject constructor(
 
     private val usageRelay = BehaviorRelay.create<Optional<FileAccount>>()
     private val userEpisodeDao = appDatabase.userEpisodeDao()
+    private val upNextDao = appDatabase.upNextDao()
 
     override fun monitorUploads(context: Context) {
         WorkManager.getInstance(context).getWorkInfosByTagLiveData(WORK_MANAGER_UPLOAD_TASK)
@@ -398,9 +399,11 @@ class UserEpisodeManagerImpl @Inject constructor(
             val episode = findEpisodeByUuid(it)
             if (episode != null) {
                 if (!episode.isDownloaded) {
-                    // File deleted from server
-                    playbackManager.removeEpisode(episode, source = SourceView.UNKNOWN, userInitiated = false)
-                    userEpisodeDao.delete(episode)
+                    // Remove file not found on server only if it is not added to up-next to prevent it from being removed from up-next (Github Issue#356)
+                    if (!upNextDao.containsEpisode(episode.uuid)) {
+                        playbackManager.removeEpisode(episode, source = SourceView.UNKNOWN, userInitiated = false)
+                        userEpisodeDao.delete(episode)
+                    }
                 } else {
                     if (episode.serverStatus == UserEpisodeServerStatus.UPLOADED) {
                         userEpisodeDao.updateServerStatus(episode.uuid, UserEpisodeServerStatus.LOCAL)


### PR DESCRIPTION
## Description

This fixes user episodes getting removed from up next.

Fixes https://github.com/Automattic/pocket-casts-android/issues/356

## Testing Instructions

1. Device 1
    1. Add a local file to the up next queue
    1. Sync the device with the server
2. Device 2 
    1. Log into the same account as Device 1
    2. Sync with the server
    3. ✅ Observe that the Up Next queue does not have the downloaded episode
    4. Sync with the server again
3. Device 1
    1. Sync with the server
    2. ✅ Observe that the downloaded episode has disappeared from the Up Next queue

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/64860cdd-95d9-46fd-bdfc-48465f62c1f1

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` N/A
- [ ] Any jetpack compose components I added or changed are covered by compose previews N/A
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes N/A
- [ ] with a landscape orientation N/A
- [ ] with the device set to have a large display and font size N/A
- [ ] for accessibility with TalkBack N/A