### PR TITLE
Bookmarks - Update icon color

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
@@ -166,6 +166,7 @@ class EpisodeViewHolder constructor(
         val iconColor = context.getThemeColor(UR.attr.primary_icon_02)
         binding.progressCircle.setColor(captionColor)
         binding.progressBar.indeterminateTintList = ColorStateList.valueOf(captionColor)
+        binding.imgBookmark.imageTintList = ColorStateList.valueOf(tintColor)
 
         val downloadUpdates = downloadProgressUpdates
             .filter { it.episodeUuid == episode.uuid }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
@@ -271,7 +271,10 @@ class EpisodeViewHolder constructor(
                 updateRowText(episode, captionColor, tintColor, date, title, lblStatus, combinedData.isInUpNext)
 
                 val episodeGreyedOut = episode.playingStatus == EpisodePlayingStatus.COMPLETED || episode.isArchived
-                imgArtwork.alpha = if (episodeGreyedOut) 0.5f else 1f
+                val imageAlpha = if (episodeGreyedOut) 0.5f else 1f
+                imgArtwork.alpha = imageAlpha
+                binding.imgBookmark.alpha = imageAlpha
+
                 binding.executePendingBindings()
             }
             .subscribe()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/UserEpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/UserEpisodeViewHolder.kt
@@ -155,6 +155,7 @@ class UserEpisodeViewHolder(
             upNextChangesObservable = upNextChangesObservable,
             userBookmarksObservable = userBookmarksObservable,
             bookmarksAvailable = bookmarksAvailable,
+            tintColor = tintColor,
         )
 
         val downloadUpdates = downloadProgressUpdates

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheet.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheet.kt
@@ -146,7 +146,8 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
 
                 binding.lblTitle.text = episode.title
                 val btnPlay = binding.btnPlay
-                btnPlay.setCircleTintColor(btnPlay.context.getThemeColor(UR.attr.primary_interactive_01))
+                val tintColor = view.context.getThemeColor(UR.attr.primary_icon_01)
+                btnPlay.setCircleTintColor(tintColor)
                 btnPlay.setPlaying(isPlaying, false)
                 btnPlay.setOnPlayClicked {
                     if (!isPlaying) {
@@ -249,7 +250,8 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
                     playbackStateUpdates = playbackManager.playbackStateRelay,
                     upNextChangesObservable = upNextQueue.changesObservable,
                     userBookmarksObservable = userBookmarksObservable,
-                    hideErrorDetails = true
+                    hideErrorDetails = true,
+                    tintColor = tintColor,
                 )
 
                 binding.lblCloud.text = when (episode.serverStatus) {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/component/FileStatusIconsView.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/component/FileStatusIconsView.kt
@@ -231,7 +231,10 @@ class FileStatusIconsView @JvmOverloads constructor(
                 lblStatus.contentDescription = lblStatus.text.toString()
                 statusText = lblStatus.text.toString()
 
-                imgCloud.alpha = if (episodeGreyedOut) 0.5f else 1f
+                val imageAlpha = if (episodeGreyedOut) 0.5f else 1f
+                imgCloud.alpha = imageAlpha
+                imgBookmark.alpha = imageAlpha
+                imgIcon.alpha = imageAlpha
             }
             .subscribe()
             .addTo(disposables)

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/component/FileStatusIconsView.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/component/FileStatusIconsView.kt
@@ -81,12 +81,14 @@ class FileStatusIconsView @JvmOverloads constructor(
         userBookmarksObservable: Observable<List<Bookmark>>,
         hideErrorDetails: Boolean = false,
         bookmarksAvailable: Boolean = false,
+        tintColor: Int,
     ) {
         val captionColor = context.getThemeColor(UR.attr.primary_text_02)
         val captionWithAlpha = ColorUtils.colorWithAlpha(captionColor, 128)
         val iconColor = context.getThemeColor(UR.attr.primary_icon_02)
         progressCircle.setColor(captionColor)
         progressBar.indeterminateTintList = ColorStateList.valueOf(captionColor)
+        imgBookmark.imageTintList = ColorStateList.valueOf(tintColor)
 
         val downloadUpdates = downloadProgressUpdates
             .filter { it.episodeUuid == episode.uuid }


### PR DESCRIPTION
## Description

Part of https://github.com/Automattic/pocket-casts-android/issues/1307

This updates bookmark icon color on episode rows to match the Play button color. 

- Podcast episodes - uses podcast tint color
- Filter episodes - uses playlist color
- Others (Files,  Listening History, Starred, Downloads) - uses `primary_icon_01`

## Testing Instructions

1. Add bookmarks to 
    - Podcast episode
    - Subscribed podcast episode and add it to a filter
    - User file
2. Notice that the bookmark icon is correctly shown on the episode rows with appropriate color

## Screenshots or Screencast 

Podcast Episode | User Episode Light Theme | User Episode Rose Theme
----|---|---
<img width=250 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/332f66e3-5fab-423a-a494-de7883d42093"/> | <img width=250 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/6ecd1f31-628c-46bd-b53c-53ad8b3ace1a"/> | <img width=250 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/9ee89061-592d-4b4a-8169-09ceb60f8db6"/>

Filter Episode 
|-------|
<img width=250 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/f092f4a2-3ad8-46ce-a217-4703e851a4c9"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
