### PR TITLE
Fixing show notes loading issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.50
 -----
-
+*   Bug Fixes:
+    *   Fixed show notes loading issues
+        ([#1436](https://github.com/Automattic/pocket-casts-android/pull/1436))
 
 7.49
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
@@ -21,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.player.viewmodel.NotesViewModel
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.servers.shownotes.ShowNotesState
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toSecondsFromColonFormattedString
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -78,13 +79,14 @@ class NotesFragment : BaseFragment() {
 
         setupShowNotes()
 
-        viewModel.showNotes.observe(viewLifecycleOwner) { (notes, inProgress) ->
+        viewModel.showNotes.observe(viewLifecycleOwner) { state ->
             if (webView == null) {
                 // If the webview has crashed we need to reinitialise it or
                 // else it won't show any notes until the app is restarted
                 setupShowNotes()
             }
-            binding?.progressBar?.showIf(inProgress)
+            binding?.progressBar?.showIf(state is ShowNotesState.Loading)
+            val notes = if (state is ShowNotesState.Loaded) state.showNotes else ""
             loadShowNotes(notes)
         }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/NotesViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/NotesViewModel.kt
@@ -73,10 +73,10 @@ class NotesViewModel
             showNotesFormatter.linkColor = ColorUtils.colorIntToHexString(linkColor)
             // load the show notes
             val state = serverShowNotesManager.loadShowNotes(podcastUuid = podcastUuid, episodeUuid = episode.uuid)
-            // theme the show notes
+            // show an error message if the show notes couldn't be loaded
             val text = if (state is ShowNotesState.Loaded) state.showNotes else errorLoadingString
+            // theme the show notes
             val formattedText = showNotesFormatter.format(text) ?: ""
-            // post
             showNotes.postValue(ShowNotesState.Loaded(formattedText))
         } catch (e: Exception) {
             Timber.e(e)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/NotesViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/NotesViewModel.kt
@@ -4,10 +4,10 @@ import android.content.Context
 import android.graphics.Color
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.servers.ServerShowNotesManager
 import au.com.shiftyjelly.pocketcasts.servers.shownotes.ShowNotesState
@@ -15,13 +15,8 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.ColorUtils
 import au.com.shiftyjelly.pocketcasts.views.helper.ShowNotesFormatter
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import io.reactivex.Completable
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.rxkotlin.addTo
-import io.reactivex.rxkotlin.subscribeBy
-import io.reactivex.schedulers.Schedulers
-import kotlinx.coroutines.rx2.rxCompletable
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -31,12 +26,10 @@ class NotesViewModel
 @Inject constructor(
     private val podcastManager: PodcastManager,
     private val playbackManager: PlaybackManager,
-    private val episodeManager: EpisodeManager,
     private val serverShowNotesManager: ServerShowNotesManager,
     @ApplicationContext context: Context
 ) : ViewModel() {
 
-    private val disposables = CompositeDisposable()
     private val showNotesFormatter = ShowNotesFormatter(context).apply {
         backgroundColor = "#FFFFFF"
         textColor = "#FFFFFF"
@@ -44,6 +37,7 @@ class NotesViewModel
         setConvertTimesToLinks(true)
     }
     private val errorLoadingString = context.getString(LR.string.error_loading_show_notes)
+    private var loadShowNotesJob: Job? = null
 
     val showNotes = MutableLiveData<ShowNotesState>().apply { postValue(ShowNotesState.Loaded("")) }
     val episode = MutableLiveData<PodcastEpisode>()
@@ -56,33 +50,37 @@ class NotesViewModel
         this.episode.postValue(episode)
         // convert times to links if the episode is now playing
         showNotesFormatter.setConvertTimesToLinks(playbackManager.upNextQueue.isCurrentEpisode(episode))
-        podcastManager.findPodcastByUuidRx(episode.podcastUuid)
-            // update the show notes link tint
-            .doOnSuccess { podcast ->
-                val linkColor = if (podcast.tintColorForDarkBg == 0) Color.WHITE else podcast.tintColorForDarkBg
-                showNotesFormatter.linkColor = ColorUtils.colorIntToHexString(linkColor)
-            }
-            // load the show notes
-            .flatMapCompletable { loadShowNotes(podcastUuid = episode.podcastUuid, episodeUuid = episode.uuid) }
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribeOn(Schedulers.io())
-            .subscribeBy(onError = { Timber.e(it) })
-            .addTo(disposables)
-    }
-
-    private fun loadShowNotes(podcastUuid: String, episodeUuid: String): Completable {
-        // Clear previous show notes while loading new notes
+        // show the loading state
         showNotes.postValue(ShowNotesState.Loading)
-        return rxCompletable {
-            val state = serverShowNotesManager.loadShowNotes(podcastUuid = podcastUuid, episodeUuid = episodeUuid)
-            val text = if (state is ShowNotesState.Loaded) state.showNotes else errorLoadingString
-            val formattedText = showNotesFormatter.format(text) ?: ""
-            showNotes.postValue(ShowNotesState.Loaded(formattedText))
+        // cancel any previous jobs
+        loadShowNotesJob?.cancel()
+        // load the podcast and show notes in the background
+        loadShowNotesJob = viewModelScope.launch {
+            loadPodcastAndShowNotes(episode)
         }
     }
 
-    override fun onCleared() {
-        super.onCleared()
-        disposables.clear()
+    private suspend fun loadPodcastAndShowNotes(episode: PodcastEpisode) {
+        try {
+            val podcastUuid = episode.podcastUuid
+            val podcast = podcastManager.findPodcastByUuidSuspend(podcastUuid)
+            if (podcast == null) {
+                showNotes.postValue(ShowNotesState.NotFound)
+                return
+            }
+            // update the show notes link tint
+            val linkColor = if (podcast.tintColorForDarkBg == 0) Color.WHITE else podcast.tintColorForDarkBg
+            showNotesFormatter.linkColor = ColorUtils.colorIntToHexString(linkColor)
+            // load the show notes
+            val state = serverShowNotesManager.loadShowNotes(podcastUuid = podcastUuid, episodeUuid = episode.uuid)
+            // theme the show notes
+            val text = if (state is ShowNotesState.Loaded) state.showNotes else errorLoadingString
+            val formattedText = showNotesFormatter.format(text) ?: ""
+            // post
+            showNotes.postValue(ShowNotesState.Loaded(formattedText))
+        } catch (e: Exception) {
+            Timber.e(e)
+            showNotes.postValue(ShowNotesState.Error(e))
+        }
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1412,7 +1412,7 @@
     <!-- Errors -->
 
     <string name="error_webview_not_installed">Unable to load show notes due to no system WebView installed.</string>
-    <string name="error_loading_show_notes">Unable to load show notes.</string>
+    <string name="error_loading_show_notes">Unable to find show notes for this episode.</string>
     <string name="error_chartable">The producer is using Chartable analytics which is being blocked, if you run any filtering app such as AdGuard you will need to whitelist chtbl.com to play the episode.</string>
     <string name="error_chartable_streaming">Streaming failed. The producer is using Chartable analytics which is being blocked, if you run any filtering app such as AdGuard you will need to whitelist chtbl.com to play the episode.</string>
     <string name="error_streaming_internet">Streaming failed check your internet connection.</string>

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerShowNotesManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerShowNotesManager.kt
@@ -51,9 +51,9 @@ class ServerShowNotesManager @Inject constructor(
      * Download the show notes, if that fails try the cache.
      */
     suspend fun loadShowNotes(podcastUuid: String, episodeUuid: String): ShowNotesState {
-        val showNotesDownloaded = downloadShowNotes(podcastUuid = podcastUuid, episodeUuid = episodeUuid)
         var downloadException: Exception? = null
         try {
+            val showNotesDownloaded = downloadShowNotes(podcastUuid = podcastUuid, episodeUuid = episodeUuid)
             if (showNotesDownloaded != null) {
                 return ShowNotesState.Loaded(showNotesDownloaded)
             }


### PR DESCRIPTION
## Description

This change addresses some issues loading show notes in the full-screen player. 

One issue fixed is when the show notes were being loaded if the user was offline and the cache wanted to check the server for a new version it would throw an exception and never load the cached version. 

Before the fix:

https://github.com/Automattic/pocket-casts-android/assets/308331/6da96cdc-d280-4ca9-a039-8593b247cf46

Another possible issue that I wasn't able to repeat is that if the playing episode changed quickly it might be possible the wrong show notes could be displayed. The view model would start an Rx flow to update the show notes but not cancel the previous flow. I have rewritten this in Coroutines and cancelled the previous job.

There is still an issue I would like to resolve but I will leave for another PR. If you are in airplane mode and the show notes don't load when you come back online it should try to load the show notes but it doesn't.

## Testing Instructions
1. Find a new podcast
2. Download an episode
3. Play then pause the episode so it's loaded in the mini player
4. Turn on airplane mode
5. Force close the app
6. Open the full-screen player
7. Go to the notes page
8. Verify the show notes load
