### PR TITLE
Enable in app review

### DIFF
--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/Feature.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/Feature.kt
@@ -40,7 +40,7 @@ enum class Feature(
     IN_APP_REVIEW_ENABLED(
         key = "in_app_review_enabled",
         title = "In App Review",
-        defaultValue = false,
+        defaultValue = true,
         tier = FeatureTier.Free,
         hasDevToggle = true,
     );

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/FirebaseRemoteFeatureProvider.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/FirebaseRemoteFeatureProvider.kt
@@ -15,8 +15,12 @@ class FirebaseRemoteFeatureProvider @Inject constructor(
     override fun isEnabled(feature: Feature): Boolean =
         firebaseRemoteConfig.getBoolean(feature.key)
 
-    override fun hasFeature(feature: Feature): Boolean {
-        return false
+    override fun hasFeature(feature: Feature) = when (feature) {
+        Feature.IN_APP_REVIEW_ENABLED -> true
+        Feature.END_OF_YEAR_ENABLED,
+        Feature.SHOW_RATINGS_ENABLED,
+        Feature.ADD_PATRON_ENABLED,
+        Feature.BOOKMARKS_ENABLED -> false
     }
 
     override fun refresh() {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
@@ -6,11 +6,13 @@ object FirebaseConfig {
     const val EPISODE_SEARCH_DEBOUNCE_MS = "episode_search_debounce_ms"
     const val CLOUD_STORAGE_LIMIT = "custom_storage_limit_gb"
     const val FEATURE_FLAG_SEARCH_IMPROVEMENTS = "feature_flag_search_improvements"
+    private const val IN_APP_REVIEW_ENABLED = "in_app_review_enabled"
     val defaults = mapOf(
         PERIODIC_SAVE_TIME_MS to 60000L,
         PODCAST_SEARCH_DEBOUNCE_MS to 2000L,
         EPISODE_SEARCH_DEBOUNCE_MS to 2000L,
         CLOUD_STORAGE_LIMIT to 10L,
-        FEATURE_FLAG_SEARCH_IMPROVEMENTS to false
+        FEATURE_FLAG_SEARCH_IMPROVEMENTS to false,
+        IN_APP_REVIEW_ENABLED to true,
     )
 }


### PR DESCRIPTION
## Description

This enables in-app review. It can be turned off using Firebase remote config for the key `in_app_review_enabled`.

> **Warning**
> Targets 7.49

## Testing Instructions

#### Test.1 Feature on
- Test that the in-app review dialog is shown for the testing steps in https://github.com/Automattic/pocket-casts-android/pull/1305

#### Test.2 Feature off

- Turn off the feature in the Firebase remote config for the key `in_app_review_enabled` and publish changes
- Search for `setMinimumFetchIntervalInSeconds(...)` in the code and set to 5s
- Add a `LogBuffer.i(...)` just before line 94 in `StatsViewModel` to print value for `featureFlag.isEnabled(Feature.IN_APP_REVIEW_ENABLED)`
- Install release build
- Open `Profile` -> `Stats`
- Open `Profile` -> `Settings` -> `Help & feedback` -> `Logs` 
- ✅ Notice that the value is `false` for `featureFlag.isEnabled(Feature.IN_APP_REVIEW_ENABLED)`
- Turn on the feature in the Firebase remote config for the key `in_app_review_enabled` and publish changes

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
