### PR TITLE
Remove no-longer-used default for search improvements feature flag

### DIFF
--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
@@ -5,12 +5,10 @@ object FirebaseConfig {
     const val PODCAST_SEARCH_DEBOUNCE_MS = "podcast_search_debounce_ms"
     const val EPISODE_SEARCH_DEBOUNCE_MS = "episode_search_debounce_ms"
     const val CLOUD_STORAGE_LIMIT = "custom_storage_limit_gb"
-    const val FEATURE_FLAG_SEARCH_IMPROVEMENTS = "feature_flag_search_improvements"
-    val defaults = mapOf(
+    val defaults = mapOf<String, Any>(
         PERIODIC_SAVE_TIME_MS to 60000L,
         PODCAST_SEARCH_DEBOUNCE_MS to 2000L,
         EPISODE_SEARCH_DEBOUNCE_MS to 2000L,
         CLOUD_STORAGE_LIMIT to 10L,
-        FEATURE_FLAG_SEARCH_IMPROVEMENTS to false
     )
 }


### PR DESCRIPTION
## Description
This is just removing the firebase remote feature flag default to go along with the removal of the feature flag in https://github.com/Automattic/pocket-casts-android/pull/1086.

## Testing Instructions
If CI is happy, I think we're good.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews