### PR TITLE
Enables the Patron feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
         ([#1399](https://github.com/Automattic/pocket-casts-android/pull/1399))
     *   Improve RTL handling in episode search box
         ([#1405](https://github.com/Automattic/pocket-casts-android/pull/1405))
+*   New Feature:
+    *   Enables Patron (Internal)
+        ([#1442](https://github.com/Automattic/pocket-casts-android/pull/1442))
 
 7.48
 -----

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/Feature.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/Feature.kt
@@ -26,7 +26,7 @@ enum class Feature(
     ADD_PATRON_ENABLED(
         key = "add_patron_enabled",
         title = "Patron",
-        defaultValue = false,
+        defaultValue = true,
         tier = FeatureTier.Free,
         hasDevToggle = true,
     ),

--- a/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/FirebaseRemoteFeatureProvider.kt
+++ b/modules/services/featureflag/src/main/java/au/com/shiftyjelly/pocketcasts/featureflag/providers/FirebaseRemoteFeatureProvider.kt
@@ -16,10 +16,10 @@ class FirebaseRemoteFeatureProvider @Inject constructor(
         firebaseRemoteConfig.getBoolean(feature.key)
 
     override fun hasFeature(feature: Feature) = when (feature) {
-        Feature.IN_APP_REVIEW_ENABLED -> true
+        Feature.IN_APP_REVIEW_ENABLED,
+        Feature.ADD_PATRON_ENABLED -> true
         Feature.END_OF_YEAR_ENABLED,
         Feature.SHOW_RATINGS_ENABLED,
-        Feature.ADD_PATRON_ENABLED,
         Feature.BOOKMARKS_ENABLED -> false
     }
 

--- a/modules/services/localization/src/main/res/values-en-rGB/strings.xml
+++ b/modules/services/localization/src/main/res/values-en-rGB/strings.xml
@@ -149,7 +149,7 @@ Language: en_GB
     <string name="onboarding_plus_feature_gratitude_title">The undying gratitude of everyone here at Pocket Casts</string>
     <string name="onboarding_patron_feature_special_icons_title">Special Pocket Casts app icons</string>
     <string name="onboarding_patron_feature_profile_badge_title">Supporters profile badge</string>
-    <string name="onboarding_patron_feature_cloud_storage_title">50GB Cloud Storage</string>
+    <string name="onboarding_patron_feature_cloud_storage_title">100GB Cloud Storage</string>
     <string name="onboarding_patron_feature_everything_in_plus_title">Everything in Plus</string>
     <string name="onboarding_patron_features_title">Believe in what we’re doing and want to show your support?</string>
     <string name="server_user_delete_account_with_sub_failed">Your account has an active Pocket Casts Plus subscription. Please cancel this first before deleting your account.</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1644,7 +1644,7 @@
     <string name="onboarding_patron_features_title">Believe in what we\’re doing and want to show your support?</string>
     <string name="onboarding_patron_feature_everything_in_plus_title">Everything in Plus</string>
     <string name="onboarding_patron_feature_early_access_title">Early access to features</string>
-    <string name="onboarding_patron_feature_cloud_storage_title">50GB Cloud Storage</string>
+    <string name="onboarding_patron_feature_cloud_storage_title">100GB Cloud Storage</string>
     <string name="onboarding_patron_feature_profile_badge_title">Supporters profile badge</string>
     <string name="onboarding_patron_feature_special_icons_title">Special Pocket Casts app icons</string>
     <string name="onboarding_patron_feature_gratitude_title" translatable="false">@string/onboarding_plus_feature_gratitude_title</string>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
@@ -7,6 +7,7 @@ object FirebaseConfig {
     const val CLOUD_STORAGE_LIMIT = "custom_storage_limit_gb"
     const val FEATURE_FLAG_SEARCH_IMPROVEMENTS = "feature_flag_search_improvements"
     private const val IN_APP_REVIEW_ENABLED = "in_app_review_enabled"
+    private const val ADD_PATRON_ENABLED = "add_patron_enabled"
     val defaults = mapOf(
         PERIODIC_SAVE_TIME_MS to 60000L,
         PODCAST_SEARCH_DEBOUNCE_MS to 2000L,
@@ -14,5 +15,6 @@ object FirebaseConfig {
         CLOUD_STORAGE_LIMIT to 10L,
         FEATURE_FLAG_SEARCH_IMPROVEMENTS to false,
         IN_APP_REVIEW_ENABLED to true,
+        ADD_PATRON_ENABLED to true,
     )
 }


### PR DESCRIPTION
> **Warning**
> Targets 7.49

## Description
Enables the Patron feature flag and updates the cloud storage limit to 100. 

Right now the cloud storage limit is a static change since this is targeting the frozen branch, but we should update it to a remote one soon.

## Testing Instructions
1. Run the app
2. ✅ Verify Patron appears in the upgrade view
3. ✅ Verify the Patron storage limit is 100 GB
4. ✅ Verify Patron appears in the account details view
5. ✅ Verify purchasing Patron unlocks it and the new app icons

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
