### PR TITLE
Remove feature flag for showing ratings

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -363,10 +363,8 @@ class PodcastAdapter(
         // expand the podcast description and details if the user hasn't subscribed
         if (this.podcast.uuid != podcast.uuid) {
             headerExpanded = !podcast.isSubscribed
-            if (FeatureFlag.isEnabled(Feature.SHOW_RATINGS_ENABLED)) {
-                ratingsViewModel.loadRatings(podcast.uuid)
-                ratingsViewModel.refreshPodcastRatings(podcast.uuid)
-            }
+            ratingsViewModel.loadRatings(podcast.uuid)
+            ratingsViewModel.refreshPodcastRatings(podcast.uuid)
             onHeaderSummaryToggled(headerExpanded, false)
         }
         this.podcast = podcast

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
@@ -5,8 +5,6 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.repositories.ratings.RatingsManager
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -36,24 +34,22 @@ class PodcastRatingsViewModel
     val stateFlow: StateFlow<RatingState> = _stateFlow
 
     fun loadRatings(podcastUuid: String) {
-        if (FeatureFlag.isEnabled(Feature.SHOW_RATINGS_ENABLED)) {
-            viewModelScope.launch {
-                try {
-                    ratingsManager.podcastRatings(podcastUuid)
-                        .stateIn(viewModelScope)
-                        .collect { ratings ->
-                            _stateFlow.update {
-                                RatingState.Loaded(
-                                    podcastUuid = ratings.podcastUuid,
-                                    stars = getStars(ratings.average),
-                                    total = ratings.total
-                                )
-                            }
+        viewModelScope.launch {
+            try {
+                ratingsManager.podcastRatings(podcastUuid)
+                    .stateIn(viewModelScope)
+                    .collect { ratings ->
+                        _stateFlow.update {
+                            RatingState.Loaded(
+                                podcastUuid = ratings.podcastUuid,
+                                stars = getStars(ratings.average),
+                                total = ratings.total
+                            )
                         }
-                } catch (e: IOException) {
-                    Timber.e(e, "Failed to load podcast ratings")
-                    _stateFlow.update { RatingState.Error }
-                }
+                    }
+            } catch (e: IOException) {
+                Timber.e(e, "Failed to load podcast ratings")
+                _stateFlow.update { RatingState.Error }
             }
         }
     }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -19,14 +19,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = false,
         hasDevToggle = false,
     ),
-    SHOW_RATINGS_ENABLED(
-        key = "show_ratings_enabled",
-        title = "Show Ratings",
-        defaultValue = true,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = false,
-        hasDevToggle = false,
-    ),
     ADD_PATRON_ENABLED(
         key = "add_patron_enabled",
         title = "Patron",

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/DefaultReleaseFeatureProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/DefaultReleaseFeatureProvider.kt
@@ -20,7 +20,6 @@ class DefaultReleaseFeatureProvider @Inject constructor() : FeatureProvider {
     override fun isEnabled(feature: Feature) =
         when (feature) {
             Feature.END_OF_YEAR_ENABLED -> Feature.END_OF_YEAR_ENABLED.defaultValue
-            Feature.SHOW_RATINGS_ENABLED -> Feature.SHOW_RATINGS_ENABLED.defaultValue
             Feature.ADD_PATRON_ENABLED -> Feature.ADD_PATRON_ENABLED.defaultValue
             Feature.BOOKMARKS_ENABLED -> Feature.BOOKMARKS_ENABLED.defaultValue
             Feature.IN_APP_REVIEW_ENABLED -> Feature.IN_APP_REVIEW_ENABLED.defaultValue


### PR DESCRIPTION
## Description
This is removing the no-longer-needed local feature flag for showing the ratings flag since it is no longer being used.

## Testing Instructions
Verify that when viewing the expanded details for a podcast you still see the rating for the podcast.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
