### PR TITLE
Whenever users switches from wifi to mobile data he will get notified…

### DIFF
--- a/modules/features/player/build.gradle
+++ b/modules/features/player/build.gradle
@@ -25,5 +25,6 @@ dependencies {
     implementation project(':modules:services:utils')
     implementation project(':modules:services:ui')
     implementation project(':modules:services:views')
+    implementation project(path: ':modules:services:protobuf')
     testImplementation project(':modules:services:sharedtest')
 }

--- a/modules/features/player/src/main/AndroidManifest.xml
+++ b/modules/features/player/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application>
         <activity
             android:name=".view.video.VideoActivity"


### PR DESCRIPTION
Linked Issue #1374 

## Description

Whenever a user streams podcast on Mobile Data he/she will get a toast warning that its streaming on mobile data. 

## Testing Instructions

1. Turn on the setting to warn when streaming an episode.
2. Connect to wifi and a metered connection
3. Start streaming an episode
4. Disconnect from wifi
5. You will get a toast saying its connected to mobile data. (for log testing filter the log with Check Data Connectivity)


### Improvements 

Needs to be only called when the episode is playing, not when its paused/stopped xyz.

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/4656348/4ebe4f3f-0cd4-49bd-9152-281fbfc84472

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [ ] with a landscape orientation
- [X] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
