### PR TITLE
Show no ratings text when no ratings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 7.50
 -----
+
+*   Updates:
+    *   Show if a podcast has no ratings
+        ([#1453](https://github.com/Automattic/pocket-casts-android/pull/1453))
 *   Bug Fixes:
     *   Fixed show notes loading issues
         ([#1436](https://github.com/Automattic/pocket-casts-android/pull/1436))

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
@@ -78,7 +78,7 @@ private fun Content(
         state.total?.let {
             TextP40(
                 text = when (it) {
-                    0 -> stringResource(LR.string.podcast_no_ratings)
+                    0 -> stringResource(LR.string.podcast_not_enough_ratings)
                     else -> it.abbreviated
                 },
                 modifier = Modifier.padding(start = 6.dp)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -30,6 +31,7 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.abbreviated
 import java.util.UUID
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun StarRatingView(
@@ -62,9 +64,6 @@ private fun Content(
     state: RatingState.Loaded,
     onClick: () -> Unit
 ) {
-    if (state.noRatings) {
-        return
-    }
     Row(
         modifier = Modifier
             .padding(horizontal = 14.dp, vertical = 4.dp)
@@ -78,7 +77,10 @@ private fun Content(
         )
         state.total?.let {
             TextP40(
-                text = it.abbreviated,
+                text = when (it) {
+                    0 -> stringResource(LR.string.podcast_no_ratings)
+                    else -> it.abbreviated
+                },
                 modifier = Modifier.padding(start = 6.dp)
             )
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
@@ -111,10 +111,7 @@ class PodcastRatingsViewModel
             val podcastUuid: String,
             val stars: List<Star>,
             val total: Int?,
-        ) : RatingState() {
-            val noRatings: Boolean
-                get() = total == null || total == 0
-        }
+        ) : RatingState()
 
         object Error : RatingState()
     }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -544,7 +544,7 @@
     <string name="podcast_no_season">No season</string>
     <string name="podcast_season_x">Season %d</string>
     <string name="podcast_refresh_artwork">Refresh artwork</string>
-    <string name="podcast_no_ratings">No ratings</string>
+    <string name="podcast_not_enough_ratings">Not enough ratings</string>
 
     <!-- Episodes -->
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -544,6 +544,7 @@
     <string name="podcast_no_season">No season</string>
     <string name="podcast_season_x">Season %d</string>
     <string name="podcast_refresh_artwork">Refresh artwork</string>
+    <string name="podcast_no_ratings">No ratings</string>
 
     <!-- Episodes -->
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/ratings/RatingsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/ratings/RatingsManagerImpl.kt
@@ -20,7 +20,7 @@ class RatingsManagerImpl @Inject constructor(
 
     override fun podcastRatings(podcastUuid: String) =
         podcastRatingsDao.podcastRatings(podcastUuid)
-            .map { it.firstOrNull() ?: PodcastRatings(podcastUuid, 0.0) }
+            .map { it.firstOrNull() ?: noRatings(podcastUuid) }
 
     override suspend fun refreshPodcastRatings(podcastUuid: String) {
         val ratings = cacheServerManager.getPodcastRatings(podcastUuid)
@@ -30,6 +30,14 @@ class RatingsManagerImpl @Inject constructor(
                 total = ratings.total,
                 average = ratings.average
             )
+        )
+    }
+
+    companion object {
+        private fun noRatings(podcastUuid: String) = PodcastRatings(
+            podcastUuid = podcastUuid,
+            average = 0.0,
+            total = 0
         )
     }
 }


### PR DESCRIPTION
## Description
As discussed internally, this updates our rating view so that it shows no stars with "No ratings" text when there are no ratings (internal ref: pdeCcb-3ic-p2#comment-2707).

## Testing Instructions
1. Go to a podcast that does not have any ratings (i.e., The Big Dip on the Trending section of Discover)
2. If necessary, expand the podcast details so you can see the rating
3. Observe that the rating shows 5 empty stars and the text "No ratings"

## Screenshots or Screencast 

![image](https://github.com/Automattic/pocket-casts-android/assets/4656348/1e41ca56-cdd7-4111-ab76-51aa790c946b)

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [X] for accessibility with TalkBack