### PR TITLE
Fix the filter page multi-select analytic

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -13,7 +13,6 @@ import androidx.core.os.BundleCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -438,35 +437,34 @@ class FilterEpisodeListFragment : BaseFragment() {
 
         val multiSelectToolbar = binding.multiSelectToolbar
         multiSelectHelper.source = SourceView.FILTERS
-        multiSelectHelper.isMultiSelectingLive.observe(
-            viewLifecycleOwner,
-            Observer {
+        multiSelectHelper.isMultiSelectingLive.observe(viewLifecycleOwner) { isMultiSelecting ->
+            if (!multiSelectLoaded) {
+                multiSelectLoaded = true
+                return@observe // Skip the initial value or else it will always hide the filter controls on load
+            }
 
-                if (!multiSelectLoaded) {
-                    multiSelectLoaded = true
-                    return@Observer // Skip the initial value or else it will always hide the filter controls on load
-                }
-
+            val wasMultiSelecting = multiSelectToolbar.isVisible
+            if (wasMultiSelecting != isMultiSelecting) {
                 analyticsTracker.track(
-                    if (it) {
+                    if (isMultiSelecting) {
                         AnalyticsEvent.FILTER_MULTI_SELECT_ENTERED
                     } else {
                         AnalyticsEvent.FILTER_MULTI_SELECT_EXITED
                     }
                 )
-
-                if (!multiSelectToolbar.isVisible) {
-                    showingFilterOptionsBeforeMultiSelect = layoutFilterOptions.isVisible
-                    setShowFilterOptions(false)
-                } else {
-                    setShowFilterOptions(showingFilterOptionsBeforeMultiSelect)
-                }
-                multiSelectToolbar.isVisible = it
-                toolbar.isVisible = !it
-
-                adapter.notifyDataSetChanged()
             }
-        )
+
+            if (isMultiSelecting) {
+                showingFilterOptionsBeforeMultiSelect = layoutFilterOptions.isVisible
+                setShowFilterOptions(false)
+            } else {
+                setShowFilterOptions(showingFilterOptionsBeforeMultiSelect)
+            }
+            multiSelectToolbar.isVisible = isMultiSelecting
+            toolbar.isVisible = !isMultiSelecting
+
+            adapter.notifyDataSetChanged()
+        }
         multiSelectHelper.coordinatorLayout = (activity as FragmentHostListener).snackBarView()
         multiSelectHelper.listener = object : MultiSelectHelper.Listener<BaseEpisode> {
             override fun multiSelectSelectAll() {


### PR DESCRIPTION
## Description

The analytic event `pcandroid_filter_multi_select_exited` was getting triggered even when you didn't use the filter multi-select. This change fixes that. 

Fixes https://github.com/Automattic/pocket-casts-android/issues/1380

## Testing Instructions
1. Launch the app
2. Open any filter
3. Change tabs
4. ✅ Verify you don't see 🔵 Tracked: filter_multi_select_exited ... in the logs
5. Go back to the filter tab
6. ✅ Verify you don't see 🔵 Tracked: filter_multi_select_exited ... in the logs
7. Tap back in the toolbar to go back to the list of filters
8. ✅ Verify you don't see 🔵 Tracked: filter_multi_select_exited ... in the logs
9. Open the filter
10. Close the app
11. ✅ Verify you don't see 🔵 Tracked: filter_multi_select_exited ... in the logs
12. Long press on an episode to go into multi-select mode
13. ✅ Verify you see 🔵 Tracked: filter_multi_select_entered ... in the logs
14. Tap back in the toolbar to cancel multi-select
15. ✅ Verify you see 🔵 Tracked: filter_multi_select_exited ... in the logs
16. Long press on an episode
17. Change tabs
18. ✅ Verify you see 🔵 Tracked: filter_multi_select_exited ... in the logs
19. Go back to the filter tab
20. Long press on an episode
22. Close the app
23. ✅ Verify you see 🔵 Tracked: filter_multi_select_exited ... in the logs
