### PR TITLE
Start migrating the build to version catalogs

### DIFF
--- a/automotive/build.gradle
+++ b/automotive/build.gradle
@@ -58,9 +58,9 @@ dependencies {
     implementation androidLibs.ktx
     implementation androidLibs.design
     implementation androidLibs.constraintLayout
-    implementation libs.aboutLibrariesCore
-    implementation libs.aboutLibrariesCompose
-    testImplementation libs.junit
+    implementation androidLibs.aboutLibrariesCore
+    implementation androidLibs.aboutLibrariesCompose
+    testImplementation androidLibs.junit
     androidTestImplementation androidLibs.junitExt
     androidTestImplementation androidLibs.testEspressoCore
 

--- a/base.gradle
+++ b/base.gradle
@@ -60,7 +60,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion project.versionComposeCompiler
+        kotlinCompilerExtensionVersion libs.versions.compose.kotlin.compiler.get()
     }
 
     testOptions {
@@ -209,78 +209,77 @@ dependencies {
     implementation androidLibs.composeUiUtil
     implementation androidLibs.wearPlayServices
 
-    implementation libs.kotlinCoroutines
-    implementation libs.kotlinCoroutinesAndroid
-    implementation libs.kotlinCoroutinesPlayServices
-    implementation libs.kotlinCoroutinesRx
-    implementation libs.deviceNames
-    implementation libs.glide
-    implementation libs.glideOkHttp
-    implementation libs.coil
-    implementation libs.coilCompose
-    implementation libs.okHttp
-    implementation libs.okHttpLogging
-    implementation libs.rxJava
-    implementation libs.rxAndroid
-    implementation libs.rxKoltin
-    implementation libs.rxRelay
-    implementation libs.retrofit
-    implementation libs.retrofitMoshi
-    implementation(libs.retrofitProtobuf) {
+    implementation androidLibs.kotlinCoroutines
+    implementation androidLibs.kotlinCoroutinesAndroid
+    implementation androidLibs.kotlinCoroutinesPlayServices
+    implementation androidLibs.kotlinCoroutinesRx
+    implementation androidLibs.deviceNames
+    implementation androidLibs.glide
+    implementation androidLibs.glideOkHttp
+    implementation androidLibs.coil
+    implementation androidLibs.coilCompose
+    implementation androidLibs.okHttp
+    implementation androidLibs.okHttpLogging
+    implementation androidLibs.rxJava
+    implementation androidLibs.rxAndroid
+    implementation androidLibs.rxKoltin
+    implementation androidLibs.rxRelay
+    implementation androidLibs.retrofit
+    implementation androidLibs.retrofitMoshi
+    implementation(androidLibs.retrofitProtobuf) {
         exclude group: 'com.google.protobuf', module: 'protobuf-java'
     }
-    implementation libs.retrofitRxJava
-    implementation libs.moshi
-    implementation libs.moshiAdapters
-    implementation libs.kotlin
-    implementation libs.timber
-    implementation libs.materialDialog
-    implementation libs.lottie
-    implementation libs.lottieCompose
-    implementation libs.materialProgressBar
-    implementation libs.hiltAndroid
-    implementation libs.hiltWorkManager
-    implementation libs.hiltNavigationCompose
-    implementation libs.accompanistFlowLayout
-    implementation libs.accompanistSystemUiController
-    implementation platform(libs.sentryBom)
-    implementation libs.sentryAndroidCore
-    implementation libs.sentryFragment
-    implementation libs.sentryTimber
-    implementation libs.media3Cast
-    implementation libs.media3Datasource
-    implementation libs.media3Exoplayer
-    implementation libs.media3ExoplayerHls
-    implementation libs.media3Extractor
-    implementation libs.media3Ui
-    implementation libs.showkase
-    testImplementation (libs.junit) {
+    implementation androidLibs.retrofitRxJava
+    implementation androidLibs.moshi
+    implementation androidLibs.moshiAdapters
+    implementation androidLibs.timber
+    implementation androidLibs.materialDialog
+    implementation androidLibs.lottie
+    implementation androidLibs.lottieCompose
+    implementation androidLibs.materialProgressBar
+    implementation libs.dagger.hilt.android
+    implementation androidLibs.hiltWorkManager
+    implementation androidLibs.hiltNavigationCompose
+    implementation androidLibs.accompanistFlowLayout
+    implementation androidLibs.accompanistSystemUiController
+    implementation platform(androidLibs.sentryBom)
+    implementation androidLibs.sentryAndroidCore
+    implementation androidLibs.sentryFragment
+    implementation androidLibs.sentryTimber
+    implementation androidLibs.media3Cast
+    implementation androidLibs.media3Datasource
+    implementation androidLibs.media3Exoplayer
+    implementation androidLibs.media3ExoplayerHls
+    implementation androidLibs.media3Extractor
+    implementation androidLibs.media3Ui
+    implementation androidLibs.showkase
+    testImplementation (androidLibs.junit) {
         exclude group: 'org.hamcrest'
     }
-    testImplementation libs.kotlinCoroutinesTest
-    implementation libs.protobufKotlinLite
-    implementation libs.protobufJavaLite
+    testImplementation androidLibs.kotlinCoroutinesTest
+    implementation androidLibs.protobufKotlinLite
+    implementation androidLibs.protobufJavaLite
 
-    ksp libs.moshiKotlinCompile
-    ksp libs.glideCompile
-    ksp libs.showkaseProcessor
+    ksp androidLibs.moshiKotlinCompile
+    ksp androidLibs.glideCompile
+    ksp androidLibs.showkaseProcessor
     // Dagger doesn't support KSP yet https://github.com/google/dagger/issues/2349
-    kapt libs.hiltCompiler
-    kapt libs.hiltDaggerCompiler
+    kapt libs.hilt.compiler
+    kapt libs.dagger.compiler
 
     debugImplementation androidLibs.composeUiTooling
     debugProdImplementation androidLibs.composeUiTooling
     debugImplementation androidLibs.composeUiTestManifest
     debugProdImplementation androidLibs.composeUiTestManifest
 
-    testImplementation libs.junit
-    testImplementation libs.jsonAssert
-    testImplementation libs.mockWebServer
-    testImplementation libs.testMokitoKotlin
-    testImplementation libs.turbine
-    testImplementation libs.testMokitoKotlinInline
-    testImplementation libs.kotlinCoroutinesTest
-    androidTestImplementation libs.jsonAssert
+    testImplementation androidLibs.junit
+    testImplementation androidLibs.jsonAssert
+    testImplementation androidLibs.mockWebServer
+    testImplementation androidLibs.testMokitoKotlin
+    testImplementation androidLibs.turbine
+    testImplementation androidLibs.testMokitoKotlinInline
+    testImplementation androidLibs.kotlinCoroutinesTest
+    androidTestImplementation androidLibs.jsonAssert
     androidTestImplementation androidLibs.androidTestCore
     androidTestImplementation androidLibs.roomTest
     androidTestImplementation androidLibs.annotations
@@ -295,22 +294,15 @@ dependencies {
     androidTestImplementation androidLibs.testUiautomator
     androidTestImplementation androidLibs.workManagerTest
     androidTestImplementation androidLibs.composeUiTestJunit
-    androidTestImplementation libs.testMockitoAndroid
-    androidTestImplementation libs.testMokitoKotlin
-    androidTestImplementation libs.mockWebServer
-    androidTestImplementation(libs.barista) {
+    androidTestImplementation androidLibs.testMockitoAndroid
+    androidTestImplementation androidLibs.testMokitoKotlin
+    androidTestImplementation androidLibs.mockWebServer
+    androidTestImplementation(androidLibs.barista) {
         exclude group: 'org.jetbrains.kotlin'
     }
     androidTestImplementation androidLibs.accessibilityTestFramework
 
     coreLibraryDesugaring androidLibs.desugarJdk
-
-    constraints {
-        // Avoid duplicate class compile failure: https://stackoverflow.com/a/75298544/1910286
-        implementation(libs.kotlinJdk8) {
-            because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
-        }
-    }
 }
 
 // Exclude the Timber integration from the Sentry Android SDK temporarily.

--- a/build.gradle
+++ b/build.gradle
@@ -1,36 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext {
-        kotlin_version = '1.7.10'
-        // KSP releases need to match the Kotlin version - https://github.com/google/ksp/releases
-        ksp_version = "$kotlin_version-1.0.6"
-        hilt_version = '2.43.2'
-    }
-    repositories {
-        google()
-        mavenLocal()
-
-        maven {
-            url 'https://a8c-libs.s3.amazonaws.com/android' 
-            content {
-                includeGroup "com.automattic.android"
-                includeGroup "com.automattic.android.publish-to-s3"
-            }
-        }
-    }
-
     // Gradle Plugins
     dependencies {
-        // Android - https://developer.android.com/studio/releases/gradle-plugin
-        classpath 'com.android.tools.build:gradle:8.1.0'
         // Google Services - https://developers.google.com/android/guides/google-services-plugin
         classpath "com.google.gms:google-services:4.3.14"
-        // Kotlin
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // Open source licenses plugin
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.5'
-        // Hilt dependency injection
-        classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
     }
 
     // Force proguard to the new version to fix "proguard.ParseException: Use of generics not allowed for java type at '<1>_<2>_<3>JsonAdapter' in line 31 of file '/Users/philip/.gradle/caches/transforms-2/files-2.1/d5ca2d039e1d32e9ba6bfd6a67df5151/META-INF/proguard/moshi.pro'"
@@ -42,11 +17,15 @@ buildscript {
 }
 
 plugins {
+    alias libs.plugins.android.application apply false
+    alias libs.plugins.kotlin.android apply false
+    alias libs.plugins.kapt apply false
+    alias libs.plugins.ksp apply false
+    alias libs.plugins.hilt apply false
     id 'com.mikepenz.aboutlibraries.plugin' version '10.4.0' apply false
     id 'com.github.ben-manes.versions' version '0.42.0'
     id 'com.diffplug.spotless' version '6.2.2'
     id 'io.sentry.android.gradle' version '3.10.0' apply false
-    id 'com.google.devtools.ksp' version "$ksp_version" apply false
 }
 
 apply plugin: 'base'
@@ -71,20 +50,6 @@ dependencyUpdates.resolutionStrategy {
             }
             if (rejected) {
                 selection.reject('Release candidate')
-            }
-        }
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        maven {
-            url "https://a8c-libs.s3.amazonaws.com/android"
-            content {
-                includeGroup "com.automattic"
-                includeGroup "com.automattic.tracks"
             }
         }
     }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -88,7 +88,6 @@ project.ext {
     versionBillingClient = '5.2.1'
     versionCompose = '1.4.2' // When updating this, also check if versionComposeAccompanist should be updated as well: https://github.com/google/accompanist#compose-versions
     versionComposeAccompanist = '0.30.1'
-    versionComposeCompiler = '1.3.0'
     versionComposeWear = '1.2.0-beta02'
     versionDagger = '2.41'
     versionEspresso = '3.4.0'
@@ -220,11 +219,7 @@ project.ext {
             playReview: 'com.google.android.play:review-ktx:2.0.1',
 
             leakCanary: 'com.squareup.leakcanary:leakcanary-android:2.10',
-    ]
 
-    libs = [
-            kotlin: "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version",
-            kotlinJdk8: "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10",
             kotlinCoroutines: "org.jetbrains.kotlinx:kotlinx-coroutines-core:$versionKotlinCoroutines",
             kotlinCoroutinesAndroid: "org.jetbrains.kotlinx:kotlinx-coroutines-android:$versionKotlinCoroutines",
             kotlinCoroutinesPlayServices: "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$versionKotlinCoroutines",
@@ -268,8 +263,6 @@ project.ext {
             // RxKotlin
             rxKoltin: "io.reactivex.rxjava2:rxkotlin:2.4.0",
             // Hilt
-            hiltAndroid: "com.google.dagger:hilt-android:$versionHilt",
-            hiltDaggerCompiler: "com.google.dagger:hilt-compiler:$versionHilt",
             hiltCompiler: "androidx.hilt:hilt-compiler:1.0.0",
             hiltWorkManager: "androidx.hilt:hilt-work:1.0.0",
             hiltNavigationCompose: "androidx.hilt:hilt-navigation-compose:1.0.0",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,31 @@
+# Upgrade Guide
+# -------------
+# When upgrading the Compose, Kotlin, and KSP versions need to be compatible.
+#
+# 1. Check here for the Compose Compiler and Kotlin versions. https://developer.android.com/jetpack/androidx/releases/compose-kotlin
+# compose-kotlin-compiler = Compose Compiler Version (can be found in composeOptions -> kotlinCompilerExtensionVersion)
+# kotlin = Kotlin Version
+#
+# 2. Upgrade KSP version to match Kotlin version:
+# https://github.com/google/ksp/releases
+
+[versions]
+# Android Gradle Plugin - https://developer.android.com/studio/releases/gradle-plugin
+android-application = "8.1.0"
+# @keep
+compose-kotlin-compiler = "1.3.0"
+kotlin = "1.7.10"
+ksp = "1.7.10-1.0.6"
+hilt = "2.43.2"
+
+[libraries]
+dagger-hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
+hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
+dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "hilt" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "android-application" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }

--- a/modules/features/cartheme/build.gradle
+++ b/modules/features/cartheme/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation androidLibs.appCompat
     implementation androidLibs.ktx
-    testImplementation libs.junit
+    testImplementation androidLibs.junit
     androidTestImplementation androidLibs.junitExt
     androidTestImplementation androidLibs.testEspressoCore
 }

--- a/modules/services/analytics/build.gradle
+++ b/modules/services/analytics/build.gradle
@@ -9,7 +9,7 @@ android {
 }
 
 dependencies {
-    implementation libs.automatticTracks
+    implementation androidLibs.automatticTracks
     implementation project(':modules:services:utils')
     implementation project(':modules:services:preferences')
     implementation project(':modules:services:model')

--- a/modules/services/sharedtest/build.gradle
+++ b/modules/services/sharedtest/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     // These dependencies have to be redeclared here event though they are already in
     // base.gradle because here they need to not be test dependencies like they are in
     // the main app.
-    implementation libs.kotlinCoroutinesTest
-    implementation (libs.junit) {
+    implementation androidLibs.kotlinCoroutinesTest
+    implementation (androidLibs.junit) {
         exclude group: 'org.hamcrest'
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,27 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven {
+            url "https://a8c-libs.s3.amazonaws.com/android"
+            content {
+                includeGroup "com.automattic"
+                includeGroup "com.automattic.tracks"
+            }
+        }
+    }
+}
+
+
 include ':app'
 include ':automotive'
 include ':wear'

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     implementation androidLibs.composeUi
     implementation androidLibs.composeMaterialIconsExtended
     implementation androidLibs.composeUiToolingPreview
-    implementation libs.hiltNavigationCompose
+    implementation androidLibs.hiltNavigationCompose
 
     // Compose for Wear OS Dependencies
     implementation androidLibs.wearComposeMaterial


### PR DESCRIPTION
## Description

Google recommends using version catalogs and provides a [migration guide](https://developer.android.com/build/migrate-to-catalogs#groovy). 
> Gradle version catalogs enable you to add and maintain dependencies and plugins in a scalable way. Using Gradle version catalogs makes managing dependencies and plugins easier when you have [multiple modules](https://developer.android.com/topic/modularization). Instead of hardcoding dependency names and versions in individual build files and updating each entry whenever you need to upgrade a dependency, you can create a central version catalog of dependencies that various modules can reference in a type-safe way with Android Studio assistance.

I have tried this migration before and failed, so I'm only migrating small parts of the app at a time in this attempt.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

