### PR TITLE
Fix bookmark Room warning

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -115,7 +115,7 @@ abstract class BookmarkDao {
     abstract fun findNotSynced(syncStatus: SyncStatus = SyncStatus.NOT_SYNCED): List<Bookmark>
 
     @Query(
-        """SELECT *
+        """SELECT bookmarks.*
             FROM bookmarks
             JOIN user_episodes ON bookmarks.episode_uuid = user_episodes.uuid 
             AND deleted = :deleted"""


### PR DESCRIPTION
## Description

I noticed during a release build the following warning. 

```
w: [ksp] /Users/philip/git_automattic/pocket-casts-android/modules/services/model/src/main/java/
au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt:123: The query returns some columns 
[published_date, episode_description, ..., upload_task_id] which are not used by 
au.com.shiftyjelly.pocketcasts.models.entity.Bookmark. You can use @ColumnInfo annotation on the 
fields to specify the mapping. You can annotate the method with 
@RewriteQueriesToDropUnusedColumns to direct Room to rewrite your query to avoid fetching unused 
columns.  You can suppress this warning by annotating the method with 
@SuppressWarnings(RoomWarnings.CURSOR_MISMATCH). Columns returned by the query: uuid, 
podcast_uuid, ... , has_custom_image, upload_task_id.
```

The issue is that the query returns more columns than is used to populate the Bookmark entity.

## Testing Instructions

### Test a build

1. Run a release build `./gradlew assembleRelease`
2. ✅ Verify the error message doesn't appear by searching for `BookmarkDao.kt`

### Test the query

1. Open the app 
2. Login to a user with a Plus subscription
3. Go to Profile -> Files
4. Add a file
5. Play the file
6. Add a bookmark
7. ✅ Verify the episode row on the Files page shows a bookmark icon

