### PR TITLE
Refactor what's new 

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -755,16 +755,17 @@ class MainActivity :
             lifecycleScope.launch { watchSync.sendAuthToDataLayer() }
         }
 
-        val lastSeenVersionCode = settings.getWhatsNewVersionCode()
-        val migratedVersion = settings.getMigratedVersionCode()
-        if (migratedVersion != 0) { // We don't want to show this to new users, there is a race condition between this and the version migration
-            val whatsNewShouldBeShown = WhatsNewFragment.isWhatsNewNewerThan(lastSeenVersionCode)
-            if (whatsNewShouldBeShown) {
-                settings.setWhatsNewVersionCode(Settings.WHATS_NEW_VERSION_CODE)
-                showBottomSheet(
-                    fragment = WhatsNewFragment(),
-                    swipeEnabled = false,
-                )
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.CREATED) {
+                viewModel.state.collect { state ->
+                    if (state.shouldShowWhatsNew) {
+                        showBottomSheet(
+                            fragment = WhatsNewFragment(),
+                            swipeEnabled = false,
+                        )
+                        viewModel.onWhatsNewShown()
+                    }
+                }
             }
         }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/AutoPlayHeader.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/AutoPlayHeader.kt
@@ -1,0 +1,97 @@
+package au.com.shiftyjelly.pocketcasts.settings.whatsnew
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.scaleIn
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.extensions.brush
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+
+@OptIn(ExperimentalAnimationApi::class)
+@Composable
+fun AutoPlayHeader() {
+    val gradientBrush = Brush.linearGradient(
+        0f to MaterialTheme.theme.colors.primaryInteractive01,
+        1f to MaterialTheme.theme.colors.primaryInteractive01Hover,
+    )
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .background(gradientBrush)
+            .fillMaxWidth(),
+    ) {
+
+        var iconIsVisible by remember { mutableStateOf(false) }
+        LaunchedEffect(Unit) {
+            iconIsVisible = true
+        }
+
+        // Using the same spring animation for the scaleIn and rotation ensures that they
+        // finish at the same time.
+        val springAnimation = spring<Float>(
+            stiffness = Spring.StiffnessVeryLow,
+            dampingRatio = Spring.DampingRatioLowBouncy,
+        )
+
+        AnimatedVisibility(
+            visible = iconIsVisible,
+            enter = scaleIn(animationSpec = springAnimation)
+        ) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .padding(all = 43.dp)
+                    .clip(shape = CircleShape)
+                    .background(Color.White)
+                    .size(95.dp),
+
+            ) {
+
+                var rotating by remember { mutableStateOf(false) }
+                val rotation by animateFloatAsState(
+                    targetValue = if (rotating) 2 * 360f else 0f,
+                    animationSpec = springAnimation
+                )
+                LaunchedEffect(Unit) {
+                    rotating = true
+                }
+
+                Icon(
+                    imageVector = ImageVector.vectorResource(IR.drawable.whatsnew_autoplay),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .height(24.dp)
+                        .rotate(rotation)
+                        .brush(gradientBrush),
+                )
+            }
+        }
+    }
+}

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -8,18 +8,17 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.res.stringResource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.settings.PlaybackSettingsFragment
+import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewViewModel.NavigationState
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @AndroidEntryPoint
 class WhatsNewFragment : BaseFragment() {
@@ -50,18 +49,13 @@ class WhatsNewFragment : BaseFragment() {
                         activity?.onBackPressed()
                     }
                     WhatsNewPage(
-                        title = stringResource(LR.string.whats_new_autoplay_title),
-                        message = stringResource(LR.string.whats_new_autoplay_body),
-                        confirmButtonTitle = stringResource(LR.string.whats_new_autoplay_enable_button),
-                        closeButtonTitle = stringResource(LR.string.whats_new_autoplay_maybe_later_button),
-                        header = { AutoPlayHeader() },
                         onConfirm = {
                             analyticsTracker.track(
                                 AnalyticsEvent.WHATSNEW_CONFIRM_BUTTON_TAPPED,
                                 mapOf("version" to Settings.WHATS_NEW_VERSION_CODE)
                             )
                             onClose()
-                            performConfirmAction()
+                            performConfirmAction(it)
                         },
                         onClose = {
                             analyticsTracker.track(
@@ -75,7 +69,13 @@ class WhatsNewFragment : BaseFragment() {
             }
         }
 
-    private fun performConfirmAction() {
+    private fun performConfirmAction(navigationState: NavigationState) {
+        when (navigationState) {
+            NavigationState.PlaybackSettings -> gotoPlaybackSettings()
+        }
+    }
+
+    private fun gotoPlaybackSettings() {
         val fragmentHostListener = activity as? FragmentHostListener
             ?: throw IllegalStateException("Activity must implement FragmentHostListener")
         val fragment = PlaybackSettingsFragment.newInstance(scrollToAutoPlay = true)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -1,80 +1,31 @@
 package au.com.shiftyjelly.pocketcasts.settings.whatsnew
 
-import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.spring
-import androidx.compose.animation.scaleIn
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
-import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
-import au.com.shiftyjelly.pocketcasts.compose.buttons.RowTextButton
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
-import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
-import au.com.shiftyjelly.pocketcasts.compose.extensions.brush
-import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
-import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.settings.PlaybackSettingsFragment
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @AndroidEntryPoint
 class WhatsNewFragment : BaseFragment() {
 
-    @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
+    @Inject
+    lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -99,13 +50,18 @@ class WhatsNewFragment : BaseFragment() {
                         activity?.onBackPressed()
                     }
                     WhatsNewPage(
-                        onGoToSettings = {
+                        title = stringResource(LR.string.whats_new_autoplay_title),
+                        message = stringResource(LR.string.whats_new_autoplay_body),
+                        confirmButtonTitle = stringResource(LR.string.whats_new_autoplay_enable_button),
+                        closeButtonTitle = stringResource(LR.string.whats_new_autoplay_maybe_later_button),
+                        header = { AutoPlayHeader() },
+                        onConfirm = {
                             analyticsTracker.track(
                                 AnalyticsEvent.WHATSNEW_CONFIRM_BUTTON_TAPPED,
                                 mapOf("version" to Settings.WHATS_NEW_VERSION_CODE)
                             )
                             onClose()
-                            goToPlaybackSettings()
+                            performConfirmAction()
                         },
                         onClose = {
                             analyticsTracker.track(
@@ -119,7 +75,7 @@ class WhatsNewFragment : BaseFragment() {
             }
         }
 
-    private fun goToPlaybackSettings() {
+    private fun performConfirmAction() {
         val fragmentHostListener = activity as? FragmentHostListener
             ?: throw IllegalStateException("Activity must implement FragmentHostListener")
         val fragment = PlaybackSettingsFragment.newInstance(scrollToAutoPlay = true)
@@ -130,155 +86,5 @@ class WhatsNewFragment : BaseFragment() {
         fun isWhatsNewNewerThan(versionCode: Int?): Boolean {
             return Settings.WHATS_NEW_VERSION_CODE > (versionCode ?: 0)
         }
-    }
-}
-
-@OptIn(ExperimentalAnimationApi::class)
-@Composable
-private fun WhatsNewPage(
-    onGoToSettings: () -> Unit,
-    onClose: () -> Unit,
-) {
-
-    var closing by remember { mutableStateOf(false) }
-    val targetAlpha = if (closing) 0f else 0.66f
-    val scrimAlpha: Float by animateFloatAsState(
-        targetValue = targetAlpha,
-        finishedListener = { onClose() }
-    )
-
-    val performClose = {
-        closing = true
-    }
-
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier
-            .background(Color.Black.copy(alpha = scrimAlpha))
-            .clickable(
-                indication = null,
-                interactionSource = remember { MutableInteractionSource() },
-                onClick = performClose,
-            )
-            .padding(horizontal = 16.dp)
-            .padding(top = 16.dp)
-            .fillMaxSize()
-    ) {
-        Column(Modifier.background(MaterialTheme.theme.colors.primaryUi01)) {
-            val gradientBrush = Brush.linearGradient(
-                0f to MaterialTheme.theme.colors.primaryInteractive01,
-                1f to MaterialTheme.theme.colors.primaryInteractive01Hover,
-            )
-
-            // Hide the top graphic if the phone is in landscape mode so there is room for the text
-            if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT) {
-                Box(
-                    contentAlignment = Alignment.Center,
-                    modifier = Modifier
-                        .background(gradientBrush)
-                        .fillMaxWidth(),
-                ) {
-
-                    var iconIsVisible by remember { mutableStateOf(false) }
-                    LaunchedEffect(Unit) {
-                        iconIsVisible = true
-                    }
-
-                    // Using the same spring animation for the scaleIn and rotation ensures that they
-                    // finish at the same time.
-                    val springAnimation = spring<Float>(
-                        stiffness = Spring.StiffnessVeryLow,
-                        dampingRatio = Spring.DampingRatioLowBouncy,
-                    )
-
-                    this@Column.AnimatedVisibility(
-                        visible = iconIsVisible,
-                        enter = scaleIn(animationSpec = springAnimation)
-                    ) {
-                        Box(
-                            contentAlignment = Alignment.Center,
-                            modifier = Modifier
-                                .padding(all = 43.dp)
-                                .clip(shape = CircleShape)
-                                .background(Color.White)
-                                .size(95.dp),
-
-                        ) {
-
-                            var rotating by remember { mutableStateOf(false) }
-                            val rotation by animateFloatAsState(
-                                targetValue = if (rotating) 2 * 360f else 0f,
-                                animationSpec = springAnimation
-                            )
-                            LaunchedEffect(Unit) {
-                                rotating = true
-                            }
-
-                            Icon(
-                                imageVector = ImageVector.vectorResource(IR.drawable.whatsnew_autoplay),
-                                contentDescription = null,
-                                modifier = Modifier
-                                    .height(24.dp)
-                                    .rotate(rotation)
-                                    .brush(gradientBrush),
-                            )
-                        }
-                    }
-                }
-            }
-
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier
-                    .padding(all = 16.dp),
-            ) {
-
-                TextH20(
-                    text = stringResource(LR.string.whats_new_autoplay_title),
-                    textAlign = TextAlign.Center,
-                    color = MaterialTheme.theme.colors.primaryText01,
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                TextP40(
-                    text = stringResource(LR.string.whats_new_autoplay_body),
-                    textAlign = TextAlign.Center,
-                    color = MaterialTheme.theme.colors.primaryText02,
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                RowButton(
-                    text = stringResource(LR.string.whats_new_autoplay_enable_button),
-                    onClick = onGoToSettings,
-                    includePadding = false,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                )
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                RowTextButton(
-                    text = stringResource(LR.string.whats_new_autoplay_maybe_later_button),
-                    fontSize = 15.sp,
-                    onClick = performClose,
-                    includePadding = false,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-@Preview
-private fun WhatsNewPagePreview(
-    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
-) {
-    AppThemeWithBackground(themeType) {
-        WhatsNewPage(
-            onGoToSettings = {},
-            onClose = {}
-        )
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
@@ -75,7 +75,7 @@ fun WhatsNewPage(
 }
 
 @Composable
-fun WhatsNewPageLoaded(
+private fun WhatsNewPageLoaded(
     state: UiState.Loaded,
     header: @Composable () -> Unit,
     onConfirm: () -> Unit,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
@@ -1,0 +1,144 @@
+package au.com.shiftyjelly.pocketcasts.settings.whatsnew
+
+import android.content.res.Configuration
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowTextButton
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.localization.R
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+
+@Composable
+fun WhatsNewPage(
+    title: String,
+    message: String,
+    confirmButtonTitle: String,
+    closeButtonTitle: String? = null,
+    header: @Composable () -> Unit,
+    onConfirm: () -> Unit,
+    onClose: () -> Unit,
+) {
+
+    var closing by remember { mutableStateOf(false) }
+    val targetAlpha = if (closing) 0f else 0.66f
+    val scrimAlpha: Float by animateFloatAsState(
+        targetValue = targetAlpha,
+        finishedListener = { onClose() }
+    )
+
+    val performClose = {
+        closing = true
+    }
+
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .background(Color.Black.copy(alpha = scrimAlpha))
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = performClose,
+            )
+            .padding(horizontal = 16.dp)
+            .padding(top = 16.dp)
+            .fillMaxSize()
+    ) {
+        Column(Modifier.background(MaterialTheme.theme.colors.primaryUi01)) {
+
+            // Hide the header graphic if the phone is in landscape mode so there is room for the text
+            if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT) {
+                header()
+            }
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .padding(all = 16.dp),
+            ) {
+
+                TextH20(
+                    text = title,
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.theme.colors.primaryText01,
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                TextP40(
+                    text = message,
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.theme.colors.primaryText02,
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                RowButton(
+                    text = confirmButtonTitle,
+                    onClick = onConfirm,
+                    includePadding = false,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                )
+
+                closeButtonTitle?.let {
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    RowTextButton(
+                        text = closeButtonTitle,
+                        fontSize = 15.sp,
+                        onClick = performClose,
+                        includePadding = false,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun WhatsNewPagePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppThemeWithBackground(themeType) {
+        WhatsNewPage(
+            title = stringResource(R.string.whats_new_autoplay_title),
+            message = stringResource(R.string.whats_new_autoplay_body),
+            confirmButtonTitle = stringResource(R.string.whats_new_autoplay_enable_button),
+            closeButtonTitle = stringResource(R.string.whats_new_autoplay_maybe_later_button),
+            header = { AutoPlayHeader() },
+            onConfirm = {},
+            onClose = {}
+        )
+    }
+}

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
@@ -45,7 +45,6 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 @Composable
 fun WhatsNewPage(
     viewModel: WhatsNewViewModel = hiltViewModel(),
-
     onConfirm: (WhatsNewViewModel.NavigationState) -> Unit,
     onClose: () -> Unit,
 ) {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
@@ -1,0 +1,59 @@
+package au.com.shiftyjelly.pocketcasts.settings.whatsnew
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@HiltViewModel
+class WhatsNewViewModel @Inject constructor() : ViewModel() {
+    private val _state: MutableStateFlow<UiState> = MutableStateFlow(UiState.Loading)
+    val state = _state.asStateFlow()
+
+    private val _navigationState: MutableSharedFlow<NavigationState> = MutableSharedFlow()
+    val navigationState = _navigationState.asSharedFlow()
+
+    init {
+        _state.value = UiState.Loaded(
+            feature = WhatsNewFeature.AutoPlay,
+        )
+    }
+
+    fun onConfirm() {
+        viewModelScope.launch {
+            _navigationState.emit(NavigationState.PlaybackSettings)
+        }
+    }
+
+    sealed class UiState {
+        object Loading : UiState()
+        data class Loaded(
+            val feature: WhatsNewFeature,
+        ) : UiState()
+    }
+
+    sealed class WhatsNewFeature(
+        @StringRes val title: Int,
+        @StringRes val message: Int,
+        @StringRes val confirmButtonTitle: Int,
+        @StringRes val closeButtonTitle: Int? = null,
+    ) {
+        object AutoPlay : WhatsNewFeature(
+            title = LR.string.whats_new_autoplay_title,
+            message = LR.string.whats_new_autoplay_body,
+            confirmButtonTitle = LR.string.whats_new_autoplay_enable_button,
+            closeButtonTitle = LR.string.whats_new_autoplay_maybe_later_button,
+        )
+    }
+
+    sealed class NavigationState {
+        object PlaybackSettings : NavigationState()
+    }
+}


### PR DESCRIPTION
## Description

This refactors `What's new` dialog to be independent of the feature and moves display logic to the view model so that we can reuse the code for `What's new for bookmarks` in a future PR.

## Testing Instructions

1. Fresh install the app 
2. Increment `Settings.WHATS_NEW_VERSION_CODE`
3. Re-install the app
4. Make sure that What's new for AutoPlay is shown and is same as before

## Screenshots or Screencast 

Before | After
----|----
![image](https://github.com/Automattic/pocket-casts-android/assets/1405144/d8b45187-579d-4f17-9338-d78a3f4d3ff2) | ![image](https://github.com/Automattic/pocket-casts-android/assets/1405144/521b111f-d911-466c-95e8-68b66ebff57b)


## Checklist 
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
