### PR TITLE
Fix chapter progress circle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
     *   Show if a podcast has no ratings
         ([#1453](https://github.com/Automattic/pocket-casts-android/pull/1453))
 *   Bug Fixes:
+    *   Fixed chapter progress circle on full-screen player
+        ([#1461](https://github.com/Automattic/pocket-casts-android/pull/1461))
     *   Fixed show notes loading issues
         ([#1436](https://github.com/Automattic/pocket-casts-android/pull/1436))
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/to/ChapterTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/to/ChapterTest.kt
@@ -1,0 +1,36 @@
+package au.com.shiftyjelly.pocketcasts.models.to
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChapterTest {
+
+    @Test
+    fun remainingTime() {
+        val chapter = Chapter(
+            title = "",
+            startTime = 5000,
+            endTime = 70000
+        )
+
+        assertEquals("1m", chapter.remainingTime(5000))
+        assertEquals("59s", chapter.remainingTime(11000))
+        assertEquals("2s", chapter.remainingTime(68000))
+        assertEquals("0s", chapter.remainingTime(70000))
+    }
+
+    @Test
+    fun calculateProgress() {
+        val chapter = Chapter(
+            title = "",
+            startTime = 5000,
+            endTime = 10000
+        )
+
+        assertEquals(0f, chapter.calculateProgress(1))
+        assertEquals(0f, chapter.calculateProgress(5000))
+        assertEquals(0.5f, chapter.calculateProgress(7500))
+        assertEquals(1f, chapter.calculateProgress(10000))
+        assertEquals(0f, chapter.calculateProgress(11000))
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/binding/BindingAdapters.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/binding/BindingAdapters.kt
@@ -16,9 +16,6 @@ import androidx.databinding.BindingConversion
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import androidx.transition.ChangeBounds
 import androidx.transition.TransitionManager
-import au.com.shiftyjelly.pocketcasts.models.to.Chapter
-import au.com.shiftyjelly.pocketcasts.player.view.ChapterProgressBar
-import au.com.shiftyjelly.pocketcasts.player.view.ChapterProgressCircle
 import au.com.shiftyjelly.pocketcasts.player.view.PlayerSeekBar
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -133,23 +130,5 @@ object BindingAdapters {
     @JvmStatic
     fun setConstraintWidthPercent(view: View, percent: Float) {
         view.updateLayoutParams<ConstraintLayout.LayoutParams> { matchConstraintPercentWidth = percent }
-    }
-
-    @BindingAdapter("progress")
-    @JvmStatic
-    fun setChapterProgress(view: ChapterProgressCircle, chapter: Chapter?) {
-        view.percent = 1f - (chapter?.progress ?: 0f)
-    }
-
-    @BindingAdapter("progress")
-    @JvmStatic
-    fun setChapterProgress(view: ChapterProgressBar, chapter: Chapter?) {
-        view.progress = chapter?.progress ?: 0f
-    }
-
-    @BindingAdapter("textRemaining")
-    @JvmStatic
-    fun setChapterTimeRemaining(view: TextView, chapter: Chapter?) {
-        view.text = chapter?.remainingTime()
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ChapterProgressCircle.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ChapterProgressCircle.kt
@@ -8,6 +8,10 @@ import android.graphics.RectF
 import android.util.AttributeSet
 import android.view.View
 
+/**
+ * A circular progress bar that is used to show the progress of a chapter.
+ * As the chapter progresses, the circle is emptied.
+ */
 class ChapterProgressCircle @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -21,10 +25,12 @@ class ChapterProgressCircle @JvmOverloads constructor(
     private var circleRect = RectF()
     private var degrees: Float = 0f
 
-    var percent: Float = 0f
+    // 0 = the chapter hasn't started and the circle is full
+    // 1 = the chapter is complete and the circle is empty
+    var progress: Float = 0f
         set(value) {
             field = value
-            degrees = 360f * value
+            degrees = 360f * (1f - value)
             invalidate()
         }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -288,6 +288,8 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
             }
 
             binding.archive.setImageResource(if (headerViewModel.isUserEpisode) R.drawable.ic_delete_32 else R.drawable.ic_archive_32)
+            binding.chapterProgressCircle.progress = headerViewModel.chapterProgress
+            binding.chapterTimeRemaining.text = headerViewModel.chapterTimeRemaining
 
             binding.executePendingBindings()
         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
@@ -39,7 +39,6 @@ import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.player.R
-import au.com.shiftyjelly.pocketcasts.player.view.ChapterProgressBar
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -104,7 +104,7 @@ class ChaptersViewModel
             } else if (chapter.containsTime(playbackPositionMs)) {
                 // the chapter currently playing
                 currentChapter = chapter
-                val progress = if (chapter.duration <= 0) 0f else ((playbackPositionMs - chapter.startTime) / chapter.duration.toFloat())
+                val progress = chapter.calculateProgress(playbackPositionMs)
                 ChapterState.Playing(chapter = chapter, progress = progress)
             } else {
                 // a chapter that has been played

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -126,6 +126,8 @@ class PlayerViewModel @Inject constructor(
 
         val isChaptersPresent: Boolean = !chapters.isEmpty
         val chapter: Chapter? = chapters.getChapter(positionMs)
+        val chapterProgress: Float = chapter?.calculateProgress(positionMs) ?: 0f
+        val chapterTimeRemaining: String = chapter?.remainingTime(positionMs) ?: ""
         val chapterSummary: String = chapters.getChapterSummary(positionMs)
         val isFirstChapter: Boolean = chapters.isFirstChapter(positionMs)
         val isLastChapter: Boolean = chapters.isLastChapter(positionMs)

--- a/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
@@ -172,20 +172,20 @@
                 android:background="?android:attr/actionBarItemBackground" />
 
             <au.com.shiftyjelly.pocketcasts.player.view.ChapterProgressCircle
+                android:id="@+id/chapterProgressCircle"
                 android:layout_width="30dp"
                 android:layout_height="30dp"
                 android:visibility="@{viewModel.isChaptersPresent}"
-                app:progress="@{viewModel.chapter}"
                 app:layout_constraintStart_toStartOf="@+id/nextChapter"
                 app:layout_constraintEnd_toEndOf="@+id/nextChapter"
                 app:layout_constraintTop_toTopOf="@+id/nextChapter"
                 app:layout_constraintBottom_toBottomOf="@+id/nextChapter" />
 
             <TextView
+                android:id="@+id/chapterTimeRemaining"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 tools:text="9m"
-                app:textRemaining="@{viewModel.chapter}"
                 android:layout_marginTop="6dp"
                 android:textAppearance="@style/H70"
                 android:textColor="@color/white"

--- a/modules/features/player/src/main/res/layout/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout/adapter_player_header.xml
@@ -208,16 +208,17 @@
                 app:layout_constraintTop_toTopOf="@+id/episodeTitle" />
 
             <au.com.shiftyjelly.pocketcasts.player.view.ChapterProgressCircle
+                android:id="@+id/chapterProgressCircle"
                 android:layout_width="30dp"
                 android:layout_height="30dp"
                 android:visibility="@{viewModel.isChaptersPresent}"
                 app:layout_constraintBottom_toBottomOf="@+id/nextChapter"
                 app:layout_constraintEnd_toEndOf="@+id/nextChapter"
                 app:layout_constraintStart_toStartOf="@+id/nextChapter"
-                app:layout_constraintTop_toTopOf="@+id/nextChapter"
-                app:progress="@{viewModel.chapter}" />
+                app:layout_constraintTop_toTopOf="@+id/nextChapter" />
 
             <TextView
+                android:id="@+id/chapterTimeRemaining"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="6dp"
@@ -227,7 +228,6 @@
                 app:layout_constraintEnd_toEndOf="@+id/nextChapter"
                 app:layout_constraintStart_toStartOf="@+id/nextChapter"
                 app:layout_constraintTop_toBottomOf="@+id/nextChapter"
-                app:textRemaining="@{viewModel.chapter}"
                 tools:text="9m" />
 
             <au.com.shiftyjelly.pocketcasts.player.view.PlayerSeekBar

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapter.kt
@@ -5,14 +5,12 @@ import kotlin.math.roundToInt
 
 data class Chapter(
     val title: String,
-    val url: HttpUrl?,
     var startTime: Int,
     var endTime: Int,
-    val imagePath: String?,
-    val mimeType: String?,
-    var played: Boolean = false,
-    var index: Int = 0,
-    var progress: Float = 0.0f
+    val url: HttpUrl? = null,
+    val imagePath: String? = null,
+    val mimeType: String? = null,
+    var index: Int = 0
 ) {
 
     val isImagePresent: Boolean
@@ -32,7 +30,8 @@ data class Chapter(
         return endTime <= currentTimeMs && endTime != -1
     }
 
-    fun remainingTime(): String {
+    fun remainingTime(playbackPositionMs: Int): String {
+        val progress = calculateProgress(playbackPositionMs)
         val length = endTime - startTime
         val remaining = length * (1f - progress)
         val minutesRemaining = remaining / 1000f / 60f
@@ -44,7 +43,10 @@ data class Chapter(
         }
     }
 
-    fun progressPercentage(): Int {
-        return (progress * 100f).roundToInt()
+    fun calculateProgress(playbackPositionMs: Int): Float {
+        if (playbackPositionMs == 0 || playbackPositionMs < startTime || playbackPositionMs > endTime || duration <= 0) {
+            return 0f
+        }
+        return (playbackPositionMs - startTime).toFloat() / duration.toFloat()
     }
 }


### PR DESCRIPTION
## Description

The next chapter on the full-screen player has a progress circle around it. This was broken recently when I upgraded the chapters tab to Compose. This change fixes that and cleans up some of the chapter code.

Fixes https://github.com/Automattic/pocket-casts-android/issues/1424

## Testing Instructions

1. Play a Podcast with chapters (for example [Upgrade](https://pca.st/upgrade))
2. Advance within the chapter
3. ✅ Verify the full screen player next chapter button progress is working

## Screencast 

https://github.com/Automattic/pocket-casts-android/assets/308331/c768e980-d675-418d-94a5-3a817f6e1ee9


