### PR TITLE
Finish converting the root build.gradle to version catalogs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,17 +2,7 @@
 buildscript {
     // Gradle Plugins
     dependencies {
-        // Google Services - https://developers.google.com/android/guides/google-services-plugin
-        classpath "com.google.gms:google-services:4.3.14"
-        // Open source licenses plugin
-        classpath 'com.google.android.gms:oss-licenses-plugin:0.10.5'
-    }
-
-    // Force proguard to the new version to fix "proguard.ParseException: Use of generics not allowed for java type at '<1>_<2>_<3>JsonAdapter' in line 31 of file '/Users/philip/.gradle/caches/transforms-2/files-2.1/d5ca2d039e1d32e9ba6bfd6a67df5151/META-INF/proguard/moshi.pro'"
-    configurations.all {
-        resolutionStrategy {
-            force 'net.sf.proguard:proguard-gradle:6.1.1'
-        }
+        classpath libs.ossLicenses.plugin
     }
 }
 
@@ -22,10 +12,11 @@ plugins {
     alias libs.plugins.kapt apply false
     alias libs.plugins.ksp apply false
     alias libs.plugins.hilt apply false
-    id 'com.mikepenz.aboutlibraries.plugin' version '10.4.0' apply false
-    id 'com.github.ben-manes.versions' version '0.42.0'
-    id 'com.diffplug.spotless' version '6.2.2'
-    id 'io.sentry.android.gradle' version '3.10.0' apply false
+    alias libs.plugins.google.services apply false
+    alias libs.plugins.aboutlibraries apply false
+    alias libs.plugins.ben.manes.versions
+    alias libs.plugins.spotless
+    alias libs.plugins.sentry apply false
 }
 
 apply plugin: 'base'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,11 +16,18 @@ compose-kotlin-compiler = "1.3.0"
 kotlin = "1.7.10"
 ksp = "1.7.10-1.0.6"
 hilt = "2.43.2"
+google-services = "4.3.14"
+sentry = "3.10.0"
 
 [libraries]
+# Dagger / Hilt
 dagger-hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "hilt" }
+
+# Google Play Services OSS Licenses
+# (The following line is still needed as there is no plugin marker available as of yet)
+ossLicenses-plugin = "com.google.android.gms:oss-licenses-plugin:0.10.5"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-application" }
@@ -28,3 +35,8 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
+sentry = { id = "io.sentry.android.gradle", version.ref = "sentry" }
+aboutlibraries = "com.mikepenz.aboutlibraries.plugin:10.4.0"
+ben-manes-versions = "com.github.ben-manes.versions:0.42.0"
+spotless = "com.diffplug.spotless:6.2.2"


### PR DESCRIPTION
## Description

This change moves the remaining plugins in the root build.gradle to the libs.versions.toml file. 

## Testing Instructions
1. Run ./gradlew assemble
2. Deploy app/build/outputs/apk/release/app-release.apk to a device
3. ✅ Verify the build is successful and the runs.
4. Login to a sync account with podcasts 
5. ✅ Verify the podcast and episode sync data is working. 
6. ✅ Verify on the Profile tab that the refresh has been successful.
7. ✅ Verify there are no exceptions in logcat
