### PR TITLE
Give Ratings: Prompt user to connect to internet when submitting rating

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.platform.ComposeView
@@ -58,7 +59,11 @@ class GiveRatingFragment : BaseDialogFragment() {
                         setStars = viewModel::setStars,
                         submitRating = {
                             viewModel.submitRating(
-                                onSuccess = ::dismiss,
+                                context = context,
+                                onSuccess = {
+                                    Toast.makeText(context, "TODO: Submit rating", Toast.LENGTH_LONG).show()
+                                    dismiss()
+                                },
                             )
                         },
                     )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings
 
-import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -22,7 +21,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -43,26 +41,6 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun GiveRatingScreen(
-    state: GiveRatingViewModel.State.Loaded,
-    setStars: (Stars) -> Unit,
-    submitRating: () -> Unit,
-    onDismiss: () -> Unit,
-) {
-
-    val context = LocalContext.current
-    Content(
-        state = state,
-        setStars = { setStars(it) },
-        submitRating = {
-            Toast.makeText(context, "TODO: Submit rating", Toast.LENGTH_LONG).show()
-            submitRating()
-        },
-        onDismiss = onDismiss,
-    )
-}
-
-@Composable
-private fun Content(
     state: GiveRatingViewModel.State.Loaded,
     setStars: (Stars) -> Unit,
     submitRating: () -> Unit,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
@@ -1,10 +1,14 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.viewmodel
 
+import android.content.Context
+import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastRatings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.ratings.RatingsManager
+import au.com.shiftyjelly.pocketcasts.utils.Network
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,6 +18,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
 class GiveRatingViewModel @Inject constructor(
@@ -96,7 +101,17 @@ class GiveRatingViewModel @Inject constructor(
         }
     }
 
-    fun submitRating(onSuccess: () -> Unit) {
+    fun submitRating(context: Context, onSuccess: () -> Unit) {
+        if (!Network.isConnected(context)) {
+            LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Cannot submit rating, no network connection")
+            Toast.makeText(
+                context,
+                context.getString(LR.string.podcast_submit_rating_no_internet),
+                Toast.LENGTH_LONG
+            ).show()
+            return
+        }
+
         Timber.e("submitRating function not implemented yet")
         onSuccess()
     }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -547,6 +547,7 @@
     <string name="podcast_refresh_artwork">Refresh artwork</string>
     <string name="podcast_rate">Rate %s</string>
     <string name="podcast_not_enough_ratings">Not enough ratings</string>
+    <string name="podcast_submit_rating_no_internet">No internet connection found. Please connect to the internet to submit a rating.</string>
 
     <!-- Episodes -->
 


### PR DESCRIPTION
## Description
This PR adds a Toast message prompting the user to connect to the internet if they try to submit a rating without an internet connection.

## Testing Instructions
1. Make sure the Give Ratings feature toggle is turned on
2. Go to a podcast and tap on the ratings stars
3. Turn on airplane mode
4. Tap "Submit"
5. ✅  Observe that you are left on the give ratings screen and a toast is displayed asking you to connect to the internet
6. Turn off airplane mode
7. Tap "Submit"
8. ✅ Observe that the ratings screen is closed and a placeholder toast message is displayed noting that rating submission has not been implemented yet

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews