### PR TITLE
Require users log in before leaving a rating

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.rememberCoroutineScope
@@ -19,6 +20,7 @@ import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.seconds
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private const val ARG_PODCAST_UUID = "podcastUuid"
 
@@ -50,11 +52,14 @@ class GiveRatingFragment : BaseDialogFragment() {
                 val viewModel = hiltViewModel<GiveRatingViewModel>()
 
                 val coroutineScope = rememberCoroutineScope()
+                val context = requireContext()
                 LaunchedEffect(podcastUuid) {
                     viewModel.checkIfUserCanRatePodcast(
                         podcastUuid = podcastUuid,
                         onUserSignedOut = {
                             OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.LoggedOut)
+                            Toast.makeText(requireContext(), context.getString(LR.string.podcast_log_in_to_rate), Toast.LENGTH_LONG)
+                                .show()
                             coroutineScope.launch {
                                 // a short delay prevents the screen from flashing before the onboarding flow is shown
                                 delay(1.seconds)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
@@ -58,7 +58,7 @@ class GiveRatingFragment : BaseDialogFragment() {
                         podcastUuid = podcastUuid,
                         onUserSignedOut = {
                             OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.LoggedOut)
-                            Toast.makeText(requireContext(), context.getString(LR.string.podcast_log_in_to_rate), Toast.LENGTH_LONG)
+                            Toast.makeText(context, context.getString(LR.string.podcast_log_in_to_rate), Toast.LENGTH_LONG)
                                 .show()
                             coroutineScope.launch {
                                 // a short delay prevents the screen from flashing before the onboarding flow is shown

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
@@ -6,13 +6,19 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.bundleOf
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.GiveRatingViewModel
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
 
 private const val ARG_PODCAST_UUID = "podcastUuid"
 
@@ -43,9 +49,18 @@ class GiveRatingFragment : BaseDialogFragment() {
 
                 val viewModel = hiltViewModel<GiveRatingViewModel>()
 
+                val coroutineScope = rememberCoroutineScope()
                 LaunchedEffect(podcastUuid) {
                     viewModel.checkIfUserCanRatePodcast(
                         podcastUuid = podcastUuid,
+                        onUserSignedOut = {
+                            OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.LoggedOut)
+                            coroutineScope.launch {
+                                // a short delay prevents the screen from flashing before the onboarding flow is shown
+                                delay(1.seconds)
+                                dismiss()
+                            }
+                        },
                         onFailure = ::exitWithError
                     )
                 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -547,6 +547,7 @@
     <string name="podcast_refresh_artwork">Refresh artwork</string>
     <string name="podcast_rate">Rate %s</string>
     <string name="podcast_not_enough_ratings">Not enough ratings</string>
+    <string name="podcast_log_in_to_rate">You must log in to leave a rating</string>
 
     <!-- Episodes -->
 


### PR DESCRIPTION
## Description
If a user taps on a podcast's rating, this PR routes the user to the onboarding flow and presents a toast informing them that they must log in to leave a rating.

## Testing Instructions
1. Make sure the rating feature flag is enabled
2. Make sure you're logged out of the app
3. Tap on the star rating of a podcast
4.  ✅ Observe that you are taken to the onboarding flow and presented with a toast informing you that you need to log in
5. Log into the app
6. Tap on the star rating of a podcast
7. ✅  Observe that you are taken to the give rating screen

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews