### PR TITLE
Add component for tapping and swiping on stars

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
@@ -55,7 +55,7 @@ class GiveRatingFragment : BaseDialogFragment() {
                     is GiveRatingViewModel.State.Loaded -> GiveRatingScreen(
                         state = state,
                         onDismiss = ::dismiss,
-                        setStars = viewModel::setStars,
+                        setRating = viewModel::setRating,
                         submitRating = {
                             viewModel.submitRating(
                                 onSuccess = ::dismiss,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
@@ -1,50 +1,34 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings
 
 import android.widget.Toast
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.StarBorder
-import androidx.compose.material.icons.filled.StarHalf
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastCover
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
-import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.GiveRatingViewModel
-import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.GiveRatingViewModel.State.Loaded.Stars
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun GiveRatingScreen(
     state: GiveRatingViewModel.State.Loaded,
-    setStars: (Stars) -> Unit,
+    setRating: (Double) -> Unit,
     submitRating: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -52,7 +36,7 @@ fun GiveRatingScreen(
     val context = LocalContext.current
     Content(
         state = state,
-        setStars = { setStars(it) },
+        setRating = { setRating(it) },
         submitRating = {
             Toast.makeText(context, "TODO: Submit rating", Toast.LENGTH_LONG).show()
             submitRating()
@@ -64,7 +48,7 @@ fun GiveRatingScreen(
 @Composable
 private fun Content(
     state: GiveRatingViewModel.State.Loaded,
-    setStars: (Stars) -> Unit,
+    setRating: (Double) -> Unit,
     submitRating: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -102,9 +86,11 @@ private fun Content(
 
             Spacer(Modifier.height(32.dp))
 
-            StarsRow(
-                stars = state.stars,
-                setStars = setStars,
+            SwipeableStars(
+                onStarsChanged = setRating,
+                modifier = Modifier
+                    .height(48.dp)
+                    .padding(horizontal = 16.dp)
             )
         }
 
@@ -113,96 +99,6 @@ private fun Content(
         RowButton(
             text = stringResource(LR.string.submit),
             onClick = submitRating
-        )
-    }
-}
-
-@Composable
-private fun StarsRow(
-    stars: Stars,
-    setStars: (Stars) -> Unit,
-) {
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-
-        Star(
-            starState = when (stars) {
-                Stars.Zero -> StarState.Empty
-                Stars.Half -> StarState.Half
-                else -> StarState.Full
-            },
-            onClick = { setStars(Stars.One) },
-        )
-
-        Star(
-            starState = when {
-                stars <= Stars.One -> StarState.Empty
-                stars == Stars.OneAndHalf -> StarState.Half
-                else -> StarState.Full
-            },
-            onClick = { setStars(Stars.Two) },
-        )
-
-        Star(
-            starState = when {
-                stars <= Stars.Two -> StarState.Empty
-                stars == Stars.TwoAndHalf -> StarState.Half
-                else -> StarState.Full
-            },
-            onClick = { setStars(Stars.Three) },
-        )
-
-        Star(
-            starState = when {
-                stars <= Stars.Three -> StarState.Empty
-                stars == Stars.ThreeAndHalf -> StarState.Half
-                else -> StarState.Full
-            },
-            onClick = { setStars(Stars.Four) },
-        )
-
-        Star(
-            starState = when {
-                stars <= Stars.Four -> StarState.Empty
-                stars == Stars.FourAndHalf -> StarState.Half
-                else -> StarState.Full
-            },
-            onClick = { setStars(Stars.Five) },
-        )
-    }
-}
-
-@Composable
-private fun Star(
-    starState: StarState,
-    onClick: () -> Unit,
-) {
-    Icon(
-        imageVector = starState.icon,
-        tint = MaterialTheme.theme.colors.primaryIcon01,
-        contentDescription = null,
-        modifier = Modifier
-            .size(48.dp)
-            .clickable { onClick() },
-    )
-}
-
-private enum class StarState(val icon: ImageVector) {
-    Empty(Icons.Filled.StarBorder),
-    Half(Icons.Default.StarHalf),
-    Full(Icons.Filled.Star),
-}
-
-@Preview
-@Composable
-private fun PodcastRatingsPreview(
-    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
-) {
-    AppThemeWithBackground(themeType) {
-        StarsRow(
-            stars = Stars.TwoAndHalf,
-            setStars = {},
         )
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/SwipeableStars.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/SwipeableStars.kt
@@ -1,0 +1,304 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.StarBorder
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import kotlin.math.abs
+import kotlin.math.max
+
+private const val numStars = 5
+
+@Composable
+fun SwipeableStars(
+    onStarsChanged: (Double) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+
+    var stopPointType by remember { mutableStateOf(StopPointType.FullAndHalfStars) }
+    var changeType by remember { mutableStateOf(ChangeType.Animated) }
+    var touchX by remember { mutableStateOf(0f) }
+    var iconPositions by remember { mutableStateOf(listOf<Position>()) }
+
+    val stopPoints: List<Double> = stopPointsFromIconPositions(iconPositions)
+    val desiredStopPoint = getDesiredStopPoint(
+        touchX = touchX,
+        stopPoints = stopPoints,
+        stopPointType = stopPointType
+    )
+    onStarsChanged(getStarsDouble(stopPoints, desiredStopPoint))
+
+    val sliderPosition = remember {
+        Animatable(initialValue = 0f)
+    }
+    LaunchedEffect(touchX, desiredStopPoint) {
+        when (changeType) {
+            ChangeType.Immediate -> sliderPosition.snapTo(touchX)
+            ChangeType.Animated -> sliderPosition.animateTo(
+                targetValue = desiredStopPoint,
+                animationSpec = spring(stiffness = Spring.StiffnessMediumLow)
+            )
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .height(IntrinsicSize.Min)
+            .pointerInput(Unit) {
+                detectHorizontalDragGestures(
+                    onHorizontalDrag = { _, dragAmount ->
+                        stopPointType = StopPointType.None
+                        changeType = ChangeType.Immediate
+                        touchX += dragAmount
+                    },
+                    onDragEnd = {
+                        stopPointType = StopPointType.FullAndHalfStars
+                        changeType = ChangeType.Animated
+                    },
+                )
+            }
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    // Check onPress so we can jump to the touch point as soon as a drag
+                    // starts. We're using onPress instead of onDragStart because it seems better
+                    // to update touchX immediately when the screen is touched instead of
+                    // waiting for the drag to start. But set this as a dragging touch state
+                    // so that the position stays at the touch point instead of jumping to a
+                    // stop point.
+                    onPress = {
+                        stopPointType = StopPointType.None
+                        changeType = ChangeType.Animated
+                        touchX = it.x
+                    },
+                    onTap = {
+                        stopPointType = StopPointType.FullStars
+                        changeType = ChangeType.Animated
+                        touchX = it.x
+                    }
+                )
+            }
+    ) {
+        Stars(filled = false)
+
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .drawWithLayer {
+                    // Destination
+                    drawContent()
+
+                    // Source
+                    drawRect(
+                        topLeft = Offset(sliderPosition.value, 0f),
+                        color = Color.Transparent,
+                        blendMode = BlendMode.SrcOut,
+                    )
+                }
+        ) {
+            Stars(
+                filled = true,
+                modifier = Modifier
+                    // We could have applied this onGloballyePositioned modifier to the empty stars with the same effect
+                    .onGloballyPositioned {
+                        val left = it.positionInParent().x
+                        val right = left + it.size.width
+                        iconPositions += Position(
+                            left = left,
+                            right = right,
+                        )
+                    }
+                    .fillMaxHeight()
+                    .aspectRatio(1f)
+            )
+        }
+    }
+}
+
+// Takes the left and right coordinates for the icons and finds the
+// points that are between them and in the middle of them since those
+// are the positions we want to fill to in order to get unfilled,
+// half-filled, and fully-filled icons.
+@Composable
+private fun stopPointsFromIconPositions(positions: List<Position>) =
+    remember(positions) {
+        if (positions.isEmpty()) {
+            emptyList()
+        } else {
+            val intermediate = positions
+                .flatMap { listOf(it.left, it.right) }
+                .windowed(size = 2, step = 1)
+                .map { it.average() }
+
+            buildList {
+                add(positions.first().left.toDouble())
+                addAll(intermediate)
+                add(positions.last().right.toDouble())
+            }
+        }
+    }
+
+@Composable
+private fun getDesiredStopPoint(
+    touchX: Float,
+    stopPoints: List<Double>,
+    stopPointType: StopPointType
+) = remember(stopPoints, touchX, stopPointType) {
+    when (stopPointType) {
+
+        StopPointType.None -> touchX // ignore stop points
+
+        StopPointType.FullAndHalfStars ->
+            stopPoints
+                .minByOrNull { abs(it - touchX) }
+                ?.toFloat()
+                ?: 0f
+
+        StopPointType.FullStars -> {
+
+            // These stop points are used to determine which star to fill based on the
+            // the touch point. For that reason, these stop points are in the middle of the stars.
+            val touchStopPoints = buildList {
+                val stopPointsInTheMiddleOfStars = stopPoints
+                    .filterIndexed { i, _ -> i % 2 != 0 }
+
+                // Add the 0.0 stop point so the user can tap the first quarter
+                // of the first star to select 0 stars. Anything to further to the
+                // right will be closer to the stop point in the middle of the first
+                // star, which gets translated to the first full star.
+                add(0.0)
+                addAll(stopPointsInTheMiddleOfStars)
+            }
+            val nearestTouchStopPoint = touchStopPoints
+                .minByOrNull {
+                    // Assumes all of the stop points are the same distance apart
+
+                    abs(it - touchX)
+                }
+                ?.toFloat()
+                ?: 0f
+
+            // These stop points are in between the stars, so filling to one of them will
+            // result in every star being either entirely filled or entirely unfilled
+            val betweenStarStopPoints = stopPoints.filterIndexed { i, _ -> i % 2 == 0 }
+
+            // Use the relevant touch stop point to determine which between star stop point to fill to
+            val nearestFullStarStopPoint = betweenStarStopPoints
+                .minByOrNull {
+                    // We've filtered the touch stop points to only include the stop points that
+                    // are in the middle of each star for detecting touch, so we need to add
+                    // a half-icon width to them to make them match up with the between star stop
+                    // points.
+                    val halfIconWidth = stopPoints[1] - stopPoints[0]
+                    val translatedTouchStopPoint = nearestTouchStopPoint + halfIconWidth
+                    abs(it - translatedTouchStopPoint)
+                }
+                ?.toFloat()
+                ?: 0f
+            nearestFullStarStopPoint
+        }
+    }
+}
+
+@Composable
+fun Stars(
+    filled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Row {
+        for (i in 0 until numStars) {
+            Icon(
+                imageVector = if (filled) {
+                    Icons.Filled.Star
+                } else {
+                    Icons.Filled.StarBorder
+                },
+                tint = MaterialTheme.theme.colors.primaryIcon01,
+                contentDescription = null,
+                modifier = modifier
+                    .fillMaxHeight()
+                    .aspectRatio(1f)
+            )
+        }
+    }
+}
+
+// Returns the numbers of stars as a double: 0.0, 0.5, 1.0, ..., 5.0
+@Composable
+private fun getStarsDouble(stopPoints: List<Double>, positionX: Float): Double {
+    val nearestStopPoint = stopPoints.minByOrNull { abs(it - positionX) }
+    val index = stopPoints.indexOf(nearestStopPoint)
+    val starsPerStopPoint = 0.5
+    return max(0, index) * starsPerStopPoint
+}
+
+// From https://stackoverflow.com/a/73590696/1910286
+private fun Modifier.drawWithLayer(block: ContentDrawScope.() -> Unit) = this.then(
+    Modifier.drawWithContent {
+        with(drawContext.canvas.nativeCanvas) {
+            val checkPoint = saveLayer(null, null)
+            block()
+            restoreToCount(checkPoint)
+        }
+    }
+)
+
+private data class Position(
+    val left: Float,
+    val right: Float,
+)
+
+// A stop point is a point at which the slider will come to stop
+private enum class StopPointType {
+    None, // No stop points
+    FullStars, // stop points for full stars only
+    FullAndHalfStars, // stop points for full and half stars
+}
+
+private enum class ChangeType {
+    Immediate,
+    Animated,
+}
+
+@Preview
+@Composable
+private fun SwipeableStarsPreview() {
+    SwipeableStars(
+        onStarsChanged = {},
+        modifier = Modifier.size(
+            height = 30.dp,
+            width = 150.dp,
+        )
+    )
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/SwipeableStars.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/SwipeableStars.kt
@@ -130,7 +130,7 @@ fun SwipeableStars(
             Stars(
                 filled = true,
                 modifier = Modifier
-                    // We could have applied this onGloballyePositioned modifier to the empty stars with the same effect
+                    // We could have applied this onGloballyPositioned modifier to the empty stars with the same effect
                     .onGloballyPositioned {
                         val left = it.positionInParent().x
                         val right = left + it.size.width

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
@@ -28,9 +28,8 @@ class GiveRatingViewModel @Inject constructor(
             val podcastTitle: String,
             private val _stars: Stars?,
         ) : State() {
-
             val stars: Stars = _stars
-                ?: Stars.TwoAndHalf // default to 2.5 stars if there is no previous rating
+                ?: Stars.Zero
 
             enum class Stars {
                 Zero,
@@ -97,15 +96,31 @@ class GiveRatingViewModel @Inject constructor(
     }
 
     fun submitRating(onSuccess: () -> Unit) {
-        Timber.e("submitRating function not implemented yet")
+        val stars = (state.value as State.Loaded).stars
+        Timber.e("submitRating function not implemented yet, but would have submitted a rating of $stars")
         onSuccess()
     }
 
-    fun setStars(stars: State.Loaded.Stars) {
+    fun setRating(rating: Double) {
+        val stars = ratingToStars(rating)
         val stateValue = _state.value
         if (stateValue !is State.Loaded) {
             throw IllegalStateException("Cannot set stars when state is not CanRate")
         }
         _state.value = stateValue.copy(_stars = stars)
+    }
+
+    private fun ratingToStars(rating: Double) = when {
+        rating <= 0 -> State.Loaded.Stars.Zero
+        rating <= 0.5 -> State.Loaded.Stars.Half
+        rating <= 1 -> State.Loaded.Stars.One
+        rating <= 1.5 -> State.Loaded.Stars.OneAndHalf
+        rating <= 2 -> State.Loaded.Stars.Two
+        rating <= 2.5 -> State.Loaded.Stars.TwoAndHalf
+        rating <= 3 -> State.Loaded.Stars.Three
+        rating <= 3.5 -> State.Loaded.Stars.ThreeAndHalf
+        rating <= 4 -> State.Loaded.Stars.Four
+        rating <= 4.5 -> State.Loaded.Stars.FourAndHalf
+        else -> State.Loaded.Stars.Five
     }
 }


### PR DESCRIPTION
## Description
This adds a swipeable star component for giving ratings

## Testing Instructions
1. Open up a podcst with ratings
2. Tap on the rating to open up the Give ratings view
3. ✅ Tapping on a star animates to that number of stars being filled (no half values). You can tap on the left side of the first star to select 0 stars.
4. ✅ Dragging over the stars with your finger will update the stars based on where you drag (it should reflect exactly where your finger is and not animate to your finger's location), and when you release your finger, the filled star state will animate to the nearest half-star.

> **Warning**
> This component is NOT accessible currently. I will address that in a follow-up PR.

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/4656348/645c4a0d-db21-4df5-b7e6-1da5d10e844d


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [X] with different themes
- [X] with a landscape orientation
- [X] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack ⚠️ 
