### PR TITLE
Fix discover search bar text at high device zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 *   Bug Fixes:
     *   Fixed show notes loading issues
         ([#1436](https://github.com/Automattic/pocket-casts-android/pull/1436))
+    *   Fixed discover search bar at high device zoom
+        ([#1469](https://github.com/Automattic/pocket-casts-android/pull/1442))
 
 7.49
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
     *   Fixed show notes loading issues
         ([#1436](https://github.com/Automattic/pocket-casts-android/pull/1436))
     *   Fixed discover search bar at high device zoom
-        ([#1469](https://github.com/Automattic/pocket-casts-android/pull/1442))
+        ([#1469](https://github.com/Automattic/pocket-casts-android/pull/1469))
 
 7.49
 -----

--- a/modules/features/discover/src/main/res/layout/row_carousel_list.xml
+++ b/modules/features/discover/src/main/res/layout/row_carousel_list.xml
@@ -40,6 +40,8 @@
             style="?attr/textBody1"
             android:importantForAccessibility="no"
             android:textColor="?attr/contrast_01"
+            android:maxLines="1"
+            android:ellipsize="end"
             android:text="@string/search_podcasts_or_add_url"/>
     </LinearLayout>
 


### PR DESCRIPTION
## Description
Fix the discover search bar text overflow when the device has a high display zoom set.

Fixes #1464

## Testing Instructions
1. Set device display zoom to a high level
2. Navigate to the Discover tab
3. Check that the "Search podcasts or add RSS URL" text in the top bar has an ellipses instead of wrapping around.

## Screenshots or Screencast 
![image](https://github.com/Automattic/pocket-casts-android/assets/10982418/cf1058a5-6047-4039-b583-55e7a11847cd)

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
