### PR TITLE
Fix Play button color not updating after changing filter

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/PlayButton.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/PlayButton.kt
@@ -36,6 +36,7 @@ class PlayButton @JvmOverloads constructor(
     private var buttonType: PlayButtonType = PlayButtonType.PLAY
     private var episodeUuid: String? = null
     private var podcastUuid: String? = null
+    private var buttonColor: Int? = null
     private var fromListUuid: String? = null
     private var episodeStatus: EpisodeStatusEnum = EpisodeStatusEnum.NOT_DOWNLOADED
     private val progressCircle: ProgressCircleView
@@ -127,7 +128,7 @@ class PlayButton @JvmOverloads constructor(
     }
 
     fun setButtonType(episode: BaseEpisode, buttonType: PlayButtonType, @ColorInt color: Int, fromListUuid: String?) {
-        if (buttonType == this.buttonType && episode.uuid == this.episodeUuid) {
+        if (buttonType == this.buttonType && episode.uuid == this.episodeUuid && this.buttonColor == color) {
             return
         }
 
@@ -142,6 +143,7 @@ class PlayButton @JvmOverloads constructor(
             PlayButtonType.PLAYED -> context.getThemeColor(UR.attr.primary_icon_02)
             else -> color
         }
+        this.buttonColor = buttonColor
         setIconDrawable(buttonType.drawableId, buttonColor)
         progressCircle.setColor(buttonColor)
         progressCircle.setEpisode(episode, buttonType == PlayButtonType.PLAYED)


### PR DESCRIPTION

## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

`PlayButton.setButtonType()` is used to update the button appearance. This method did an early return without checking if the color was updated.

To fix the issue a check was added to check if the previous color is same as current color, if no then we update the button. To keep track of the previous color an additional variable was added. PlayButton now keeps track of the previous selected color.

Fixes #1435 

## Testing Instructions
1. Open the episode list for a filter
2. Open the filter settings from the three dot menu
3. Change the color of the filter
4. Exit the filter settings
5. With the change the play button should be updated with the selected color

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
