### PR TITLE
Make rating stars component accessible

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/SwipeableStars.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/SwipeableStars.kt
@@ -1,7 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings
 
-import android.content.Context
-import android.view.accessibility.AccessibilityManager
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
@@ -22,6 +20,7 @@ import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,13 +35,13 @@ import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import kotlin.math.abs
 import kotlin.math.max
@@ -54,6 +53,9 @@ fun SwipeableStars(
     onStarsChanged: (Double) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+
+    val viewModel = hiltViewModel<SwipeableStarsViewModel>()
+    val isTalkBackEnabled by viewModel.accessibilityActiveState.collectAsState()
 
     var stopPointType by remember { mutableStateOf(StopPointType.FullAndHalfStars) }
     var changeType by remember { mutableStateOf(ChangeType.Animated) }
@@ -135,12 +137,6 @@ fun SwipeableStars(
                     )
                 }
         ) {
-            val context = LocalContext.current
-            // Only check this once, this means that switching TalkBack on/off while on this screen
-            // will not update the screen and the user will have to exit and come back. This is
-            // something that could be improved.
-            val isTalkbackEnabled = remember { isTalkbackEnabled(context) }
-
             Stars(
                 filled = true,
                 modifier = { index ->
@@ -158,7 +154,7 @@ fun SwipeableStars(
                         .fillMaxHeight()
                         .aspectRatio(1f)
                         .then(
-                            if (isTalkbackEnabled) {
+                            if (isTalkBackEnabled) {
                                 Modifier
                                     .clickable {
                                         touchX = right // select the full star
@@ -318,13 +314,6 @@ private enum class StopPointType {
 private enum class ChangeType {
     Immediate,
     Animated,
-}
-
-private fun isTalkbackEnabled(context: Context): Boolean {
-    val accessibilityManager = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager?
-    val isEnabled = accessibilityManager?.isEnabled ?: false
-    val isTouchExplorationEnabled = accessibilityManager?.isTouchExplorationEnabled ?: false
-    return isEnabled && isTouchExplorationEnabled
 }
 
 @Preview

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/SwipeableStarsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/SwipeableStarsViewModel.kt
@@ -1,0 +1,35 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings
+
+import android.content.Context
+import android.view.accessibility.AccessibilityManager
+import android.view.accessibility.AccessibilityManager.AccessibilityStateChangeListener
+import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.utils.Util
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class SwipeableStarsViewModel @Inject constructor(
+    @ApplicationContext context: Context,
+) : ViewModel() {
+
+    private val accessibilityManager = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager?
+    private val _accessibilityEnabledState = MutableStateFlow(Util.isTalkbackOn(context))
+    val accessibilityActiveState = _accessibilityEnabledState.asStateFlow()
+
+    private val accessibilityStateChangeListener = AccessibilityStateChangeListener {
+        _accessibilityEnabledState.value = it
+    }
+
+    init {
+        accessibilityManager?.addAccessibilityStateChangeListener(accessibilityStateChangeListener)
+    }
+
+    override fun onCleared() {
+        accessibilityManager?.removeAccessibilityStateChangeListener(accessibilityStateChangeListener)
+        super.onCleared()
+    }
+}


### PR DESCRIPTION
## Description
This updates the rating stars component to be accessible. This is a relatively minimal approach in that using TalkBack you are only able to select full stars. It would be good to improve this, but I think it'll be a bit more complicated to add in the half stars, and I didn't want to go too far down that rabbit hole at this point since I'll be updating this component in the future to possibly not allow 0 or half star ratings and to accept a star rating parameter so users can update their rating. When I work on those I'll see if it make sense to improve this behavior as well.

## Testing Instructions
1. Go to an episode with a rating and tap on the stars to open the Add Rating screen
2. Observe that the stars component still works as before (see https://github.com/Automattic/pocket-casts-android/pull/1468)
3. Turn on TalkBack
4. Observe that you can select the stars with TalkBack either by switching between all the interaction points on the page or by directly double tapping on one of the stars.
5. Selecting one of the stars should fill the stars for that full value.
6. Turn off TalkBack
7. Observe that the behavior has returned to the behavior you observed in Step 2

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews