### PR TITLE
Bookmarks - What's new confirm button action

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -936,12 +936,28 @@ class MainActivity :
         updateStatusBar()
     }
 
-    override fun openPlayer() {
+    override fun openPlayer(source: String?) {
+        val sourceView = SourceView.fromString(source)
         binding.playerBottomSheet.openPlayer()
+
+        if (sourceView == SourceView.WHATS_NEW) {
+            showNowPlayingTab(sourceView)
+        }
     }
 
     override fun closePlayer() {
         binding.playerBottomSheet.closePlayer()
+    }
+
+    private fun showNowPlayingTab(sourceView: SourceView?) {
+        launch {
+            delay(300) // To let the player open
+            withContext(Dispatchers.Main) {
+                val playerContainerFragment =
+                    supportFragmentManager.fragments.find { it is PlayerContainerFragment } as? PlayerContainerFragment
+                playerContainerFragment?.openPlayer(sourceView)
+            }
+        }
     }
 
     override fun onPlayClicked() {

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
@@ -74,7 +74,7 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
         onBackPressed()
     }
 
-    override fun openPlayer() {
+    override fun openPlayer(source: String?) {
     }
 
     override fun closePlayer() {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -22,7 +22,6 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
-import au.com.shiftyjelly.pocketcasts.models.to.Chapters
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentPlayerContainerBinding
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarksFragment
@@ -215,10 +214,15 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
         (activity as? FragmentHostListener)?.showBottomSheet(upNextFragment)
     }
 
-    fun openPlayer() {
+    fun openPlayer(sourceView: SourceView? = null) {
         val index = adapter.indexOfPlayer
         if (index == -1) return
         binding?.viewPager?.currentItem = index
+
+        if (sourceView == SourceView.WHATS_NEW) {
+            ((childFragmentManager.fragments.firstOrNull { it is PlayerHeaderFragment }) as? PlayerHeaderFragment)
+                ?.openMoreMenu(sourceView)
+        }
     }
 
     fun openBookmarks() {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -221,7 +221,7 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
 
         if (sourceView == SourceView.WHATS_NEW) {
             ((childFragmentManager.fragments.firstOrNull { it is PlayerHeaderFragment }) as? PlayerHeaderFragment)
-                ?.openMoreMenu(sourceView)
+                ?.onMoreClicked(sourceView)
         }
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -525,11 +525,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         viewModel.nextChapter()
     }
 
-    fun openMoreMenu(sourceView: SourceView?) {
-        onMoreClicked(sourceView)
-    }
-
-    private fun onMoreClicked(sourceView: SourceView? = null) {
+    fun onMoreClicked(sourceView: SourceView? = null) {
         // stop double taps
         if (childFragmentManager.fragments.firstOrNull() is ShelfBottomSheet) {
             return

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -525,13 +525,17 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         viewModel.nextChapter()
     }
 
-    fun onMoreClicked() {
+    fun openMoreMenu(sourceView: SourceView?) {
+        onMoreClicked(sourceView)
+    }
+
+    private fun onMoreClicked(sourceView: SourceView? = null) {
         // stop double taps
         if (childFragmentManager.fragments.firstOrNull() is ShelfBottomSheet) {
             return
         }
         analyticsTracker.track(AnalyticsEvent.PLAYER_SHELF_OVERFLOW_MENU_SHOWN)
-        ShelfBottomSheet().show(childFragmentManager, "shelf_bottom_sheet")
+        ShelfBottomSheet.newInstance(sourceView).show(childFragmentManager, "shelf_bottom_sheet")
     }
 
     override fun onPlayClicked() {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
@@ -1,19 +1,27 @@
 package au.com.shiftyjelly.pocketcasts.player.view
 
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.ValueAnimator
+import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentShelfBottomSheetBinding
 import au.com.shiftyjelly.pocketcasts.player.view.ShelfFragment.Companion.AnalyticsProp
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.ChromeCastAnalytics
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.ui.R
+import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.views.extensions.applyColor
@@ -36,6 +44,9 @@ class ShelfBottomSheet : BaseDialogFragment() {
     private val adapter = ShelfAdapter(editable = false, listener = this::onClick, dragListener = null)
     private var binding: FragmentShelfBottomSheetBinding? = null
 
+    private val source: SourceView
+        get() = SourceView.fromString(arguments?.getString(ARG_SOURCE))
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentShelfBottomSheetBinding.inflate(inflater, container, false)
         return binding?.root
@@ -56,7 +67,12 @@ class ShelfBottomSheet : BaseDialogFragment() {
 
         playerViewModel.trimmedShelfLive.observe(viewLifecycleOwner) {
             adapter.episode = it.second
-            adapter.submitList(it.first.drop(4))
+            val shelfItemsToBeDisplayed = it.first.drop(4)
+            adapter.submitList(shelfItemsToBeDisplayed)
+
+            if (source == SourceView.WHATS_NEW) {
+                binding.highlightAddBookmarkMenu(shelfItemsToBeDisplayed)
+            }
         }
 
         playerViewModel.playingEpisodeLive.observe(viewLifecycleOwner) { (_, backgroundColor) ->
@@ -73,6 +89,43 @@ class ShelfBottomSheet : BaseDialogFragment() {
         binding.mediaRouteButton.setOnClickListener {
             chromeCastAnalytics.trackChromeCastViewShown()
         }
+    }
+
+    private fun FragmentShelfBottomSheetBinding.highlightAddBookmarkMenu(
+        shelfItems: List<ShelfItem>,
+    ) {
+        val bookmarkItemIndex = shelfItems.indexOf(ShelfItem.Bookmark)
+        recyclerView.post {
+            val itemView = recyclerView.findViewHolderForAdapterPosition(bookmarkItemIndex)?.itemView
+            itemView?.let {
+                it.setBackgroundColor(requireContext().getThemeColor(R.attr.primary_icon_02))
+                animateItemAlpha(itemView)
+            }
+        }
+    }
+
+    private fun animateItemAlpha(itemView: View) {
+        val flashAlphaAnimator = ValueAnimator.ofFloat(0f, 1f)
+        with(flashAlphaAnimator) {
+            duration = FLASH_ANIMATION_DURATION
+            addUpdateListener { animation ->
+                val alpha = animation.animatedValue as Float
+                itemView.background.alpha = (alpha * 255).toInt()
+            }
+
+            addListener(object : AnimatorListenerAdapter() {
+                override fun onAnimationEnd(animation: Animator) {
+                    super.onAnimationEnd(animation)
+                    itemView.background.alpha = 255
+                    itemView.setBackgroundColor(Color.TRANSPARENT)
+                    setFloatValues(0f)
+                }
+            })
+        }
+
+        itemView.postDelayed({
+            flashAlphaAnimator.start()
+        }, FLASH_ANIMATION_DELAY)
     }
 
     private fun onClick(item: ShelfItem) {
@@ -121,5 +174,16 @@ class ShelfBottomSheet : BaseDialogFragment() {
             mapOf(AnalyticsProp.Key.FROM to AnalyticsProp.Value.OVERFLOW_MENU, AnalyticsProp.Key.ACTION to item.analyticsValue)
         )
         dismiss()
+    }
+
+    companion object {
+        private const val ARG_SOURCE = "source"
+        private const val FLASH_ANIMATION_DURATION = 300L
+        private const val FLASH_ANIMATION_DELAY = 300L
+        fun newInstance(sourceView: SourceView? = null) = ShelfBottomSheet().apply {
+            arguments = bundleOf(
+                ARG_SOURCE to sourceView?.analyticsValue,
+            )
+        }
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -80,7 +80,7 @@ class WhatsNewFragment : BaseFragment() {
         when (navigationState) {
             NavigationState.PlaybackSettings -> openFragment(PlaybackSettingsFragment.newInstance(scrollToAutoPlay = true))
             NavigationState.HeadphoneControlsSettings -> openFragment(HeadphoneControlsSettingsFragment())
-            NavigationState.FullScreenPlayerScreen -> {}
+            NavigationState.FullScreenPlayerScreen -> openPlayer()
             NavigationState.StartUpsellFlow -> startUpsellFlow()
         }
     }
@@ -89,6 +89,12 @@ class WhatsNewFragment : BaseFragment() {
         val fragmentHostListener = activity as? FragmentHostListener
             ?: throw IllegalStateException("Activity must implement FragmentHostListener")
         fragmentHostListener.addFragment(fragment)
+    }
+
+    private fun openPlayer() {
+        val fragmentHostListener = activity as? FragmentHostListener
+            ?: throw IllegalStateException("Activity must implement FragmentHostListener")
+        fragmentHostListener.openPlayer()
     }
 
     private fun startUpsellFlow() {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -87,14 +88,14 @@ class WhatsNewFragment : BaseFragment() {
 
     private fun openFragment(fragment: Fragment) {
         val fragmentHostListener = activity as? FragmentHostListener
-            ?: throw IllegalStateException("Activity must implement FragmentHostListener")
+            ?: throw IllegalStateException(FRAGMENT_HOST_LISTENER_NOT_IMPLEMENTED)
         fragmentHostListener.addFragment(fragment)
     }
 
     private fun openPlayer() {
         val fragmentHostListener = activity as? FragmentHostListener
-            ?: throw IllegalStateException("Activity must implement FragmentHostListener")
-        fragmentHostListener.openPlayer()
+            ?: throw IllegalStateException(FRAGMENT_HOST_LISTENER_NOT_IMPLEMENTED)
+        fragmentHostListener.openPlayer(SourceView.WHATS_NEW.analyticsValue)
     }
 
     private fun startUpsellFlow() {
@@ -108,6 +109,7 @@ class WhatsNewFragment : BaseFragment() {
     }
 
     companion object {
+        private const val FRAGMENT_HOST_LISTENER_NOT_IMPLEMENTED = "Activity must implement FragmentHostListener"
         fun isWhatsNewNewerThan(versionCode: Int?): Boolean {
             return Settings.WHATS_NEW_VERSION_CODE > (versionCode ?: 0)
         }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -80,6 +80,7 @@ class WhatsNewFragment : BaseFragment() {
         when (navigationState) {
             NavigationState.PlaybackSettings -> openFragment(PlaybackSettingsFragment.newInstance(scrollToAutoPlay = true))
             NavigationState.HeadphoneControlsSettings -> openFragment(HeadphoneControlsSettingsFragment())
+            NavigationState.FullScreenPlayerScreen -> {}
             NavigationState.StartUpsellFlow -> startUpsellFlow()
         }
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
@@ -242,6 +242,7 @@ private fun WhatsNewBookmarksPreview(
                 feature = WhatsNewFeature.Bookmarks(
                     title = LR.string.whats_new_bookmarks_title,
                     message = LR.string.whats_new_bookmarks_body,
+                    confirmButtonTitle = LR.string.whats_new_bookmarks_try_now_button,
                     hasFreeTrial = false,
                     isUserEntitled = true,
                     subscriptionTier = Subscription.SubscriptionTier.PLUS,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
@@ -190,7 +190,7 @@ class WhatsNewViewModel @Inject constructor(
         ) : WhatsNewFeature(
             title = title,
             message = message,
-            confirmButtonTitle = LR.string.whats_new_bookmarks_try_now_button,
+            confirmButtonTitle = LR.string.whats_new_bookmarks_enable_now_button,
         )
     }
 

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/whatsnew/WhatsNewViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/whatsnew/WhatsNewViewModelTest.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.whatsnew
 import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewViewModel
@@ -39,6 +40,9 @@ class WhatsNewViewModelTest {
 
     @Mock
     lateinit var settings: Settings
+
+    @Mock
+    lateinit var playbackManager: PlaybackManager
 
     @Mock
     lateinit var subscriptionManager: SubscriptionManager
@@ -207,6 +211,7 @@ class WhatsNewViewModelTest {
         whenever(featureFlag.isEnabled(feature.bookmarksFeature)).thenReturn(true)
 
         viewModel = WhatsNewViewModel(
+            playbackManager = playbackManager,
             subscriptionManager = subscriptionManager,
             settings = settings,
             releaseVersion = releaseVersion,

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
@@ -32,7 +32,8 @@ enum class SourceView(val analyticsValue: String) {
     TASKER("tasker"),
     EPISODE_SWIPE_ACTION("episode_swipe_action"),
     MULTI_SELECT("multi_select"),
-    STATS("stats");
+    STATS("stats"),
+    WHATS_NEW("whats_new");
 
     fun skipTracking() = this in listOf(AUTO_PLAY, AUTO_PAUSE)
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1415,7 +1415,7 @@
     <string name="whats_new_autoplay_maybe_later_button">Maybe later</string>
     <string name="whats_new_bookmarks_title">Bookmarks are here!</string>
     <string name="whats_new_bookmarks_body" translatable="false">@string/bookmarks_create_instructions</string>
-    <string name="whats_new_bookmarks_try_now_button">Try it now</string>
+    <string name="whats_new_bookmarks_enable_now_button">Enable it now</string>
     <string name="whats_new_boomarks_join_beta_testing_title">Join us in the beta testing for bookmarks!</string>
 
     <!-- Errors -->

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1416,6 +1416,7 @@
     <string name="whats_new_bookmarks_title">Bookmarks are here!</string>
     <string name="whats_new_bookmarks_body" translatable="false">@string/bookmarks_create_instructions</string>
     <string name="whats_new_bookmarks_enable_now_button">Enable it now</string>
+    <string name="whats_new_bookmarks_try_now_button">Try it now</string>
     <string name="whats_new_boomarks_join_beta_testing_title">Join us in the beta testing for bookmarks!</string>
 
     <!-- Errors -->

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -458,6 +458,7 @@ open class PlaybackManager @Inject constructor(
             SourceView.UNKNOWN,
             SourceView.UP_NEXT,
             SourceView.STATS,
+            SourceView.WHATS_NEW,
             -> null
 
             SourceView.MEDIA_BUTTON_BROADCAST_SEARCH_ACTION,

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
@@ -9,7 +9,7 @@ interface FragmentHostListener {
     fun replaceFragment(fragment: Fragment)
     fun showBottomSheet(fragment: Fragment)
     fun bottomSheetClosePressed(fragment: Fragment)
-    fun openPlayer()
+    fun openPlayer(source: String? = null)
     fun closePlayer()
     fun showModal(fragment: Fragment)
     fun closeModal(fragment: Fragment)


### PR DESCRIPTION
## Description

This updates what's new confirm button title and action to show 

If an episode is 
- Selected:  Label: "Try it now", Action: Open Player -> More Menu -> Highlight "Add bookmark"
- Not selected: Label:  "Enable it now",  Action:  Open `Headphone controls` settings

Internal ref: 
p1697115913259019/1697115334.479459-slack-C055BDMU09, 
pdeCcb-25g-p2#comment-2752

## Testing Instructions

1. Install debug build
2. Login with a Plus account
3. Play an episode
4. Increment `Settings.WHATS_NEW_VERSION_CODE`
5. Reinstall the build
6. ✅ Notice that "What's new" is displayed with "Try it now" button
7. Tap on  "Try it now"
8. ✅ Notice that the full-screen player is opened and shelf bottom sheet is shown highlighting "Add bookmark" item
9. Clear up next queue (or login with Plus account having no upnext queue)
10. Increment `Settings.WHATS_NEW_VERSION_CODE`
11. Reinstall the build
12. ✅ Notice that "What's new" is displayed with "Enable it now" button
13. Tap on "Enable it now"
14.  ✅ Notice that `Headphone controls` settings is shown

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/7a1817fc-1a53-4d8e-9d48-daef60d7d723

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack