### PR TITLE
Playback 2023 - Top podcast story

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
@@ -272,6 +272,7 @@ private fun ShareButton(
                 backgroundColor = Color.Transparent,
                 contentColor = Color.White,
             ),
+        disableScale = true,
         fontSize = 14.sp,
         fontFamily = FontFamily(listOf(Font(UR.font.dm_sans))),
         textIcon = rememberVectorPainter(Icons.Default.Share),

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/utils/Util.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/utils/Util.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.utils
+
+import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
+
+fun List<TopPodcast>.atSafeIndex(index: Int) =
+    this[index.coerceAtMost(size - 1)]
+        .toPodcast()

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedNumbersView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedNumbersView.kt
@@ -24,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.PodcastCover
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryBlurredBackground
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryPrimaryText
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StorySecondaryText
+import au.com.shiftyjelly.pocketcasts.endofyear.utils.atSafeIndex
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListenedNumbers
@@ -153,7 +154,3 @@ private fun SecondaryText(
     val text = stringResource(R.string.end_of_year_story_listened_to_numbers_subtitle)
     StorySecondaryText(text = text, color = story.tintColor, modifier = modifier)
 }
-
-private fun List<TopPodcast>.atSafeIndex(index: Int) =
-    this[index.coerceAtMost(size - 1)]
-        .toPodcast()

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopPodcastView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopPodcastView.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -20,9 +21,9 @@ import au.com.shiftyjelly.pocketcasts.compose.components.CoverSize
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastCover
 import au.com.shiftyjelly.pocketcasts.compose.components.RectangleCover
 import au.com.shiftyjelly.pocketcasts.compose.components.transformPodcastCover
+import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryBlurredBackground
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryPrimaryText
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StorySecondaryText
-import au.com.shiftyjelly.pocketcasts.endofyear.utils.podcastDynamicBackground
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopPodcast
 import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
@@ -33,27 +34,35 @@ fun StoryTopPodcastView(
     story: StoryTopPodcast,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        verticalArrangement = Arrangement.Top,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier
-            .fillMaxSize()
-            .podcastDynamicBackground(story.topPodcast.toPodcast())
-            .verticalScroll(rememberScrollState())
-    ) {
-        Spacer(modifier = modifier.weight(0.2f))
+    Box {
+        StoryBlurredBackground(
+            Offset(
+                -LocalView.current.width * 0.75f,
+                LocalView.current.height * 0.3f
+            ),
+        )
+        Column(
+            verticalArrangement = Arrangement.Top,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(vertical = 40.dp)
+        ) {
+            Spacer(modifier = modifier.weight(0.2f))
 
-        PrimaryText(story)
+            PrimaryText(story)
 
-        Spacer(modifier = modifier.weight(0.1f))
+            Spacer(modifier = modifier.weight(0.1f))
 
-        SecondaryText(story)
+            SecondaryText(story)
 
-        Spacer(modifier = modifier.weight(1f))
+            Spacer(modifier = modifier.weight(1f))
 
-        PodcastCoverStack(story)
+            PodcastCoverStack(story)
 
-        Spacer(modifier = modifier.weight(1f))
+            Spacer(modifier = modifier.weight(1f))
+        }
     }
 }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopPodcastView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopPodcastView.kt
@@ -92,7 +92,7 @@ private fun PodcastCoverStack(
                 .alpha(0.3f)
         )
         PodcastCover(
-            uuid = story.topPodcasts.atSafeIndex(2).uuid,
+            uuid = story.topPodcasts.atSafeIndex(3).uuid,
             coverWidth = (widthInDp * .25).dp,
             modifier = Modifier
                 .offset(
@@ -102,7 +102,7 @@ private fun PodcastCoverStack(
                 .alpha(0.5f)
         )
         PodcastCover(
-            uuid = story.topPodcasts.atSafeIndex(3).uuid,
+            uuid = story.topPodcasts.atSafeIndex(2).uuid,
             coverWidth = (widthInDp * .32).dp,
             modifier = Modifier
                 .offset(

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopPodcastView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopPodcastView.kt
@@ -18,13 +18,13 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.CoverSize
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastCover
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryBlurredBackground
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryPrimaryText
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StorySecondaryText
-import au.com.shiftyjelly.pocketcasts.endofyear.utils.atSafeIndex
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopPodcast
 import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
@@ -81,8 +81,9 @@ private fun PodcastCoverStack(
             .wrapContentSize(unbounded = true),
         contentAlignment = Alignment.Center,
     ) {
-        PodcastCover(
-            uuid = story.topPodcasts.atSafeIndex(1).uuid,
+        PodcastCoverOrEmpty(
+            story = story,
+            index = 1,
             coverWidth = (widthInDp * .3).dp,
             modifier = Modifier
                 .offset(
@@ -91,8 +92,9 @@ private fun PodcastCoverStack(
                 )
                 .alpha(0.3f)
         )
-        PodcastCover(
-            uuid = story.topPodcasts.atSafeIndex(3).uuid,
+        PodcastCoverOrEmpty(
+            story = story,
+            index = 3,
             coverWidth = (widthInDp * .25).dp,
             modifier = Modifier
                 .offset(
@@ -101,8 +103,9 @@ private fun PodcastCoverStack(
                 )
                 .alpha(0.5f)
         )
-        PodcastCover(
-            uuid = story.topPodcasts.atSafeIndex(2).uuid,
+        PodcastCoverOrEmpty(
+            story = story,
+            index = 2,
             coverWidth = (widthInDp * .32).dp,
             modifier = Modifier
                 .offset(
@@ -111,8 +114,9 @@ private fun PodcastCoverStack(
                 )
                 .alpha(0.5f)
         )
-        PodcastCover(
-            uuid = story.topPodcasts.atSafeIndex(4).uuid,
+        PodcastCoverOrEmpty(
+            story = story,
+            index = 4,
             coverWidth = (widthInDp * .2).dp,
             modifier = Modifier
                 .offset(
@@ -126,6 +130,24 @@ private fun PodcastCoverStack(
             coverWidth = (widthInDp * .7).dp,
             coverSize = CoverSize.BIG
         )
+    }
+}
+
+@Composable
+private fun PodcastCoverOrEmpty(
+    story: StoryTopPodcast,
+    index: Int,
+    coverWidth: Dp,
+    modifier: Modifier,
+) {
+    if (index < story.topPodcasts.size) {
+        PodcastCover(
+            uuid = story.topPodcasts[index].uuid,
+            coverWidth = coverWidth,
+            modifier = modifier
+        )
+    } else {
+        Unit
     }
 }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopPodcastView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopPodcastView.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -42,19 +41,17 @@ fun StoryTopPodcastView(
             .podcastDynamicBackground(story.topPodcast.toPodcast())
             .verticalScroll(rememberScrollState())
     ) {
-        Spacer(modifier = modifier.height(40.dp))
-
-        Spacer(modifier = modifier.weight(0.7f))
-
-        PodcastCoverStack(story)
-
-        Spacer(modifier = modifier.weight(0.3f))
+        Spacer(modifier = modifier.weight(0.2f))
 
         PrimaryText(story)
 
-        Spacer(modifier = modifier.weight(0.25f))
+        Spacer(modifier = modifier.weight(0.1f))
 
         SecondaryText(story)
+
+        Spacer(modifier = modifier.weight(1f))
+
+        PodcastCoverStack(story)
 
         Spacer(modifier = modifier.weight(1f))
     }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopPodcastView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopPodcastView.kt
@@ -5,25 +5,26 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.CoverSize
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastCover
-import au.com.shiftyjelly.pocketcasts.compose.components.RectangleCover
-import au.com.shiftyjelly.pocketcasts.compose.components.transformPodcastCover
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryBlurredBackground
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryPrimaryText
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StorySecondaryText
+import au.com.shiftyjelly.pocketcasts.endofyear.utils.atSafeIndex
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopPodcast
 import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
@@ -57,7 +58,7 @@ fun StoryTopPodcastView(
 
             SecondaryText(story)
 
-            Spacer(modifier = modifier.weight(1f))
+            Spacer(modifier = modifier.weight(0.5f))
 
             PodcastCoverStack(story)
 
@@ -73,42 +74,58 @@ private fun PodcastCoverStack(
 ) {
     val context = LocalContext.current
     val currentLocalView = LocalView.current
-    val coverWidth = (currentLocalView.width.pxToDp(context).dp) / 2.2f
-
-    Box {
-        (0..2).reversed().forEach { index ->
-            Box(
-                modifier = modifier
-                    .padding(top = (index * (coverWidth.value * .17)).dp)
-                    .transformPodcastCover()
-            ) {
-                with(story.topPodcast) {
-                    when (index) {
-                        0 -> PodcastCover(
-                            uuid = uuid,
-                            coverWidth = coverWidth,
-                            coverSize = CoverSize.BIG
-                        )
-
-                        1 -> {
-                            val backgroundColor = Color(toPodcast().getTintColor(false))
-                            RectangleCover(
-                                coverWidth = coverWidth,
-                                backgroundColor = backgroundColor
-                            )
-                        }
-
-                        2 -> {
-                            val backgroundColor = Color(toPodcast().getTintColor(true))
-                            RectangleCover(
-                                coverWidth = coverWidth,
-                                backgroundColor = backgroundColor
-                            )
-                        }
-                    }
-                }
-            }
-        }
+    val widthInDp = currentLocalView.width.pxToDp(context)
+    val heightInDp = currentLocalView.height.pxToDp(context)
+    Box(
+        modifier = modifier
+            .wrapContentSize(unbounded = true),
+        contentAlignment = Alignment.Center,
+    ) {
+        PodcastCover(
+            uuid = story.topPodcasts.atSafeIndex(1).uuid,
+            coverWidth = (widthInDp * .3).dp,
+            modifier = Modifier
+                .offset(
+                    x = -(widthInDp * .53).dp,
+                    y = -(heightInDp * .13).dp,
+                )
+                .alpha(0.3f)
+        )
+        PodcastCover(
+            uuid = story.topPodcasts.atSafeIndex(2).uuid,
+            coverWidth = (widthInDp * .25).dp,
+            modifier = Modifier
+                .offset(
+                    x = -(widthInDp * .3).dp,
+                    y = (heightInDp * .2).dp,
+                )
+                .alpha(0.5f)
+        )
+        PodcastCover(
+            uuid = story.topPodcasts.atSafeIndex(3).uuid,
+            coverWidth = (widthInDp * .32).dp,
+            modifier = Modifier
+                .offset(
+                    x = (widthInDp * .3).dp,
+                    y = (heightInDp * .23).dp,
+                )
+                .alpha(0.5f)
+        )
+        PodcastCover(
+            uuid = story.topPodcasts.atSafeIndex(4).uuid,
+            coverWidth = (widthInDp * .2).dp,
+            modifier = Modifier
+                .offset(
+                    x = (widthInDp * .4).dp,
+                    y = -(heightInDp * .11).dp,
+                )
+                .alpha(0.2f)
+        )
+        PodcastCover(
+            uuid = story.topPodcast.uuid,
+            coverWidth = (widthInDp * .7).dp,
+            coverSize = CoverSize.BIG
+        )
     }
 }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopPodcastView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopPodcastView.kt
@@ -113,7 +113,7 @@ private fun PrimaryText(
 ) {
     val text = stringResource(
         id = R.string.end_of_year_story_top_podcast,
-        story.topPodcast.title, story.topPodcast.author
+        story.topPodcast.title
     )
     StoryPrimaryText(text = text, color = story.tintColor, modifier = modifier)
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowOutlinedButton.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowOutlinedButton.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.extensions.nonScaledSp
 import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
@@ -45,6 +46,7 @@ fun RowOutlinedButton(
     includePadding: Boolean = true,
     border: BorderStroke? = outlinedBorder,
     colors: ButtonColors = ButtonDefaults.outlinedButtonColors(),
+    disableScale: Boolean = false,
     textIcon: Painter? = null,
     fontFamily: FontFamily? = null,
     fontSize: TextUnit? = null,
@@ -85,7 +87,7 @@ fun RowOutlinedButton(
                         color = colors.contentColor(enabled = true).value,
                         textAlign = TextAlign.Center,
                         fontFamily = fontFamily,
-                        fontSize = fontSize,
+                        fontSize = if (disableScale) fontSize?.value?.nonScaledSp else fontSize,
                         modifier = Modifier.padding(6.dp)
                     )
                 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
@@ -8,7 +8,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -20,18 +19,11 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.extensions.nonScaledSp
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import java.util.Locale
-
-private val Float.nonScaledSp
-    @Composable
-    get() = (this / LocalDensity.current.fontScale).sp
-
-private val Int.nonScaledSp
-    @Composable
-    get() = (this / LocalDensity.current.fontScale).sp
 
 @Composable
 fun TextH10(

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Float.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Float.kt
@@ -1,0 +1,9 @@
+package au.com.shiftyjelly.pocketcasts.compose.extensions
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.sp
+
+val Float.nonScaledSp
+    @Composable
+    get() = (this / LocalDensity.current.fontScale).sp

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Int.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Int.kt
@@ -1,0 +1,9 @@
+package au.com.shiftyjelly.pocketcasts.compose.extensions
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.sp
+
+val Int.nonScaledSp
+    @Composable
+    get() = (this / LocalDensity.current.fontScale).sp

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1591,7 +1591,7 @@
     <!-- Text that appear when someone share the listened numbers story to Twitter. %1$d is a placeholder for the number of podcasts listened and %2$d for the number of episodes. -->
     <string name="end_of_year_story_listened_to_numbers_share_text">I listened to %1$d different podcasts and %2$d episodes in 2022</string>
     <!-- Title for the story that display the most listened podcast by the user this year. %1$s is a placeholder for the podcast title and %2$s is a placeholder for the author. -->
-    <string name="end_of_year_story_top_podcast">Your top podcast was %1$s by %2$s</string>
+    <string name="end_of_year_story_top_podcast">%1$s was your most listened show in 2023</string>
     <!-- Subtitle for the story that display the most listened podcast by the user this year. %1$d is a placeholder for the number of episodes and %2$s is a placeholder for the listened time. -->
     <string name="end_of_year_story_top_podcast_subtitle">You listened to %1$d episodes for a total of %2$s</string>
     <!-- Text that appear when someone share the top podcast of the year story to Twitter. %1$s is the URL to the podcast. -->

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -105,7 +105,7 @@ class EndOfYearManagerImpl @Inject constructor(
             stories.add(StoryTopListenedCategories(listenedCategories))
         }
         if (topPodcasts.isNotEmpty()) {
-            stories.add(StoryTopPodcast(topPodcasts.first()))
+            stories.add(StoryTopPodcast(topPodcasts))
             if (topPodcasts.size > 1) {
                 stories.add(StoryTopFivePodcasts(topPodcasts.take(5)))
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -99,16 +99,16 @@ class EndOfYearManagerImpl @Inject constructor(
         if (listenedNumbers.numberOfEpisodes > 1 && listenedNumbers.numberOfPodcasts > 1) {
             stories.add(StoryListenedNumbers(listenedNumbers, topPodcasts))
         }
+        if (topPodcasts.isNotEmpty()) {
+            stories.add(StoryTopPodcast(topPodcasts = topPodcasts))
+            if (topPodcasts.size > 1) {
+                stories.add(StoryTopFivePodcasts(topPodcasts.take(5)))
+            }
+        }
         listeningTime?.let { stories.add(StoryListeningTime(it, topPodcasts.takeLast(3))) }
         if (listenedCategories.isNotEmpty()) {
             stories.add(StoryListenedCategories(listenedCategories))
             stories.add(StoryTopListenedCategories(listenedCategories))
-        }
-        if (topPodcasts.isNotEmpty()) {
-            stories.add(StoryTopPodcast(topPodcasts))
-            if (topPodcasts.size > 1) {
-                stories.add(StoryTopFivePodcasts(topPodcasts.take(5)))
-            }
         }
         longestEpisode?.let { stories.add(StoryLongestEpisode(it)) }
         stories.add(StoryEpilogue())

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/StoryTopPodcast.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/StoryTopPodcast.kt
@@ -3,7 +3,8 @@ package au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories
 import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
 
 class StoryTopPodcast(
-    val topPodcast: TopPodcast,
+    val topPodcasts: List<TopPodcast>,
 ) : Story() {
     override val identifier: String = "top_one_podcast"
+    val topPodcast = topPodcasts[0]
 }


### PR DESCRIPTION
| 📘 Part of: #1463 | 🎨 Designs: lH66LwxxgG8btQ8NrM0ldx-fi-1599_20385 |
|:---:|:---:|

## Description

Adds the 2023 visual for the Top Show Story.

**Animations are not part of this task and will be tackled later.**

## Testing Instructions

#### Test.1 Story visual
1. Make sure you're logged in into an account that has a few episodes listened
2. Go to Profile
3. Tap the EOY image
4. Skip to the third story
5. ✅ Check that the story looks good
    - Also check that the ordering is as specified in Figma (lH66LwxxgG8btQ8NrM0ldx-fi-1764_3353)
7. Share the story
8. ✅ The story image asset should look good

#### Test.2 Less no. of listened shows
1. Login with an account having less than 5 listened shows
2. Repeat Test.1 Step 2-4
3. ✅ Notice that images are omitted at places where a show doesn't exist

## Screenshots or Screencast 

Pixel 7 (Normal display) | Pixel 7 (Large Display, Long Title) | Less than 5 listened shows
---|----|---
<img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/8ced3456-ab65-48c0-9bf6-adcde6d0c28d"/> | <img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/204bed77-47c6-43e7-8232-44ae5875657b"/> | <img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/175d2807-6587-463a-9fca-1534181a1152">

Tablet
|----|
|<img width=500 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/e985e8d8-3160-44a8-84af-a63d8f94a648"/>|

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack