### PR TITLE
Request exact alarm permission if it is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 7.51
 -----
 
+*   Updates:
+    *   Take user to alarm permission when the app needs permission for sleep timer
+        ([#1487](https://github.com/Automattic/pocket-casts-android/pull/1487))
 
 7.50
 -----

--- a/modules/services/repositories/src/main/AndroidManifest.xml
+++ b/modules/services/repositories/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+
     <application
         android:usesCleartextTraffic="true">
         <provider


### PR DESCRIPTION
## Description
This updates the app so that instead of just presenting a Toast message asking the user to grant permission for exact alarms, we also prompt them with the screen for updating that permission. This is important because I'm seeing on the Android 14 emulator that the permission is not being granted by default and it is not particularly easy to find the place to update this permission for an app.

> **Note**
> In my testing, the permission was getting automatically granted on Android 13 devices, which surprised me (after reading [the developer documentation](https://developer.android.com/about/versions/14/changes/schedule-exact-alarms) I thought the permission would be denied by default on Android 13 as well, but apparently not). That's better for our users though, so I'm not complaining.

Fixes #1486 

## Testing Instructions

### 1. Android 14
1. Fresh install the app on an Android 14 device
2. Try to start a sleep timer from the Full Screen player
3. Observe that you are taken to the settings screen for granting the alarm permission and also shown the toast message indicating we need the permission.
4. Grant the permission
5. Try setting a sleep timer again
6. Observe that the sleep timer works

### 2. Android <14
1. Fresh install the app on a device running Android <14
2. Try to start a sleep timer from the Full Screen player
3. Observe that the sleep timer works

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/4656348/be1ca3df-ae2d-4f33-b6bc-7ca4fc02a3bf

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews