### PR TITLE
Remove unused SignUpFragment code

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/SignInFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/SignInFragment.kt
@@ -1,12 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.account
 
-import android.app.PendingIntent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
-import androidx.core.os.BundleCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -27,13 +25,6 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @AndroidEntryPoint
 class SignInFragment : BaseFragment() {
-    companion object {
-        const val EXTRA_SUCCESS_INTENT = "success_intent"
-
-        fun newInstance(): SignInFragment {
-            return SignInFragment()
-        }
-    }
 
     private val viewModel: SignInViewModel by viewModels()
     private var binding: FragmentSignInBinding? = null
@@ -122,11 +113,6 @@ class SignInFragment : BaseFragment() {
                         findNavController().popBackStack(R.id.promoCodeFragment, false)
                     } else {
                         activity?.finish()
-
-                        val arguments = arguments
-                        if (arguments != null && arguments.containsKey(EXTRA_SUCCESS_INTENT)) {
-                            BundleCompat.getParcelable(arguments, EXTRA_SUCCESS_INTENT, PendingIntent::class.java)?.send()
-                        }
                     }
                 }
             }


### PR DESCRIPTION
## Description
This is removing some unused code around the creation of the `SignUpFragment`.  This code was originally added before the app was open sourced in commit 0ebec5f60130444e60efb6c90f93c8a88155fa24, and I missed removing this when I removed some of the related code that was unused in https://github.com/Automattic/pocket-casts-android/commit/9f5fa252a9bd68e8dedbce809fa7de587a052a16.

## Testing Instructions
Test the sign in flow to verify there are no issues, including:
* Creating an account with email
* Signing in by email
* Creating an account with Google
* Signing in with Google

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews