### PR TITLE
Remove deprecated env vars from Fastfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,9 @@
 source "https://rubygems.org"
 gem 'fastlane', '~> 2'
 # These lines are kept to help with testing Release Toolkit changes
-# gem 'fastlane-plugin-wpmreleasetoolkit', '~> 9.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 9.2'
 # gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'deprecate/project-root-folder-env-var'
+# gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: ''
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,10 @@
 
 source "https://rubygems.org"
 gem 'fastlane', '~> 2'
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 9.1'
+# These lines are kept to help with testing Release Toolkit changes
+# gem 'fastlane-plugin-wpmreleasetoolkit', '~> 9.1'
+# gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'deprecate/project-root-folder-env-var'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,32 @@
+GIT
+  remote: https://github.com/wordpress-mobile/release-toolkit
+  revision: 4389f85a9e6a9264a14101eaf93589e0880f35d8
+  branch: deprecate/project-root-folder-env-var
+  specs:
+    fastlane-plugin-wpmreleasetoolkit (9.1.0)
+      activesupport (>= 6.1.7.1)
+      buildkit (~> 1.5)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      fastlane (~> 2.213)
+      git (~> 1.3)
+      google-cloud-storage (~> 1.31)
+      java-properties (~> 0.3.0)
+      nokogiri (~> 1.11)
+      octokit (~> 6.1)
+      parallel (~> 1.14)
+      plist (~> 3.1)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
+      xcodeproj (~> 1.22)
+
 GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.6)
       rexml
-    activesupport (7.1.0)
+    activesupport (7.1.1)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -18,7 +41,7 @@ GEM
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.834.0)
+    aws-partitions (1.842.0)
     aws-sdk-core (3.185.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
@@ -31,7 +54,7 @@ GEM
       aws-sdk-core (~> 3, >= 3.181.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.6)
-    aws-sigv4 (1.6.0)
+    aws-sigv4 (1.6.1)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     base64 (0.1.1)
@@ -126,28 +149,11 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-wpmreleasetoolkit (9.1.0)
-      activesupport (>= 6.1.7.1)
-      buildkit (~> 1.5)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      fastlane (~> 2.213)
-      git (~> 1.3)
-      google-cloud-storage (~> 1.31)
-      java-properties (~> 0.3.0)
-      nokogiri (~> 1.11)
-      octokit (~> 6.1)
-      parallel (~> 1.14)
-      plist (~> 3.1)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
-      xcodeproj (~> 1.22)
     gh_inspector (1.1.3)
     git (1.18.0)
       addressable (~> 2.8)
       rchardet (~> 1.8)
-    google-apis-androidpublisher_v3 (0.50.0)
+    google-apis-androidpublisher_v3 (0.51.0)
       google-apis-core (>= 0.11.0, < 2.a)
     google-apis-core (0.11.1)
       addressable (~> 2.5, >= 2.5.1)
@@ -275,12 +281,13 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-darwin-20
   x86_64-darwin-21
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit (~> 9.1)
+  fastlane-plugin-wpmreleasetoolkit!
 
 BUNDLED WITH
-   2.4.12
+   2.4.21

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,3 @@
-GIT
-  remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 4389f85a9e6a9264a14101eaf93589e0880f35d8
-  branch: deprecate/project-root-folder-env-var
-  specs:
-    fastlane-plugin-wpmreleasetoolkit (9.1.0)
-      activesupport (>= 6.1.7.1)
-      buildkit (~> 1.5)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      fastlane (~> 2.213)
-      git (~> 1.3)
-      google-cloud-storage (~> 1.31)
-      java-properties (~> 0.3.0)
-      nokogiri (~> 1.11)
-      octokit (~> 6.1)
-      parallel (~> 1.14)
-      plist (~> 3.1)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
-      xcodeproj (~> 1.22)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -149,6 +126,23 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    fastlane-plugin-wpmreleasetoolkit (9.2.0)
+      activesupport (>= 6.1.7.1)
+      buildkit (~> 1.5)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      fastlane (~> 2.213)
+      git (~> 1.3)
+      google-cloud-storage (~> 1.31)
+      java-properties (~> 0.3.0)
+      nokogiri (~> 1.11)
+      octokit (~> 6.1)
+      parallel (~> 1.14)
+      plist (~> 3.1)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
+      xcodeproj (~> 1.22)
     gh_inspector (1.1.3)
     git (1.18.0)
       addressable (~> 2.8)
@@ -281,13 +275,14 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-20
   x86_64-darwin-21
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit!
+  fastlane-plugin-wpmreleasetoolkit (~> 9.2)
 
 BUNDLED WITH
    2.4.21

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -56,9 +56,6 @@ SUPPORTED_LOCALES = [
 # Environment
 ########################################################################
 Dotenv.load(USER_ENV_FILE_PATH)
-ENV["PROJECT_NAME"] = "pocket-casts-android"
-ENV["PROJECT_ROOT_FOLDER"] = "./"
-ENV['FL_RELEASE_TOOLKIT_DEFAULT_BRANCH'] = 'main'
 DEFAULT_BRANCH = 'main'
 ENV['SUPPLY_UPLOAD_MAX_RETRIES']='5'
 GH_REPOSITORY = "automattic/pocket-casts-android"
@@ -341,7 +338,9 @@ platform :android do
   end
 
   lane :finalize_release do | options |
-    UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes') if android_current_branch_is_hotfix
+    if android_current_branch_is_hotfix(version_properties_path: VERSION_PROPERTIES_PATH)
+      UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes')
+    end
     ensure_git_branch(branch: '^release/') # Match branch names that begin with `release/`
     ensure_git_status_clean
 


### PR DESCRIPTION
This PR removes deprecated environment variables from the Fastfile:
- An explicit path is now passed to `android_current_branch_is_hotfix` instead of using the `PROJECT_ROOT_FOLDER` env var

- [x] ~I added the "Do Not Merge" label because this PR relies upon changes in the Release Toolkit: https://github.com/wordpress-mobile/release-toolkit/pull/519. That PR must be merged and this PR updated to a new version of the Release Toolkit before it can be merged.~ This was completed in https://github.com/Automattic/pocket-casts-android/pull/1493/commits/f4dbcf3a58a0ec5509c4833fe6dca68ffb785f7b