### PR TITLE
Playback 2023 - Listened time story

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/DayCirclesView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/DayCirclesView.kt
@@ -29,7 +29,7 @@ private const val SecsInOneDay = 60 * 60 * 24
 private const val MissingDaysOverlayColor = 0xFF8F97A4
 
 @Composable
-fun TimeCirclesView(
+fun DayCirclesView(
     timeInSecs: Long,
 ) {
     val context = LocalContext.current

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/StoryText.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/StoryText.kt
@@ -18,6 +18,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 private const val MaxFontScale = 1.15f
+val StoryFontFamily = FontFamily(listOf(Font(UR.font.dm_sans)))
 
 @Composable
 fun StoryPrimaryText(

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/TimeCirclesView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/TimeCirclesView.kt
@@ -13,12 +13,12 @@ import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.BlendMode
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.endofyear.utils.rainbowBrush
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import kotlin.math.ceil
 import kotlin.math.max
@@ -77,12 +77,7 @@ private fun Modifier.timeCircleBackground(
 ) =
     graphicsLayer { alpha = 0.99f }
         .drawWithCache {
-            val brush = Brush.linearGradient(
-                0.00f to Color(red = 0.25f, green = 0.11f, blue = 0.92f),
-                0.24f to Color(red = 0.68f, green = 0.89f, blue = 0.86f),
-                0.50f to Color(red = 0.87f, green = 0.91f, blue = 0.53f),
-                0.74f to Color(red = 0.91f, green = 0.35f, blue = 0.26f),
-                1.00f to Color(red = 0.1f, green = 0.1f, blue = 0.1f),
+            val brush = rainbowBrush(
                 start = Offset(0f, 0f),
                 end = Offset(1.22f * size.width, 1.25f * size.height),
             )

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/TimeCirclesView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/TimeCirclesView.kt
@@ -1,0 +1,105 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
+import kotlin.math.ceil
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.sqrt
+
+private const val SecsInOneDay = 60 * 60 * 24
+private const val MissingDaysOverlayColor = 0xFF8F97A4
+
+@Composable
+fun TimeCirclesView(
+    timeInSecs: Long,
+) {
+    val context = LocalContext.current
+    val maxArea = Size(LocalView.current.width.toFloat(), LocalView.current.height * 0.3f)
+    val number = ceil(timeInSecs.toDouble() / SecsInOneDay)
+    val eachBallSquareArea = (maxArea.width * maxArea.height) / number
+    val numberOfBallsPerLine = max(7.0, ceil(maxArea.width / sqrt(eachBallSquareArea)))
+    val numberOfLines = min(ceil(number / numberOfBallsPerLine), max(1.0, ceil(maxArea.height / sqrt(eachBallSquareArea))))
+    val ballCalculatedWidth = maxArea.width / numberOfBallsPerLine
+    val ballCalculatedHeight = maxArea.height / numberOfLines
+    val ballPadding = min(ballCalculatedWidth, ballCalculatedHeight) * 0.05
+    val ballFinalWidth = min(ballCalculatedWidth, ballCalculatedHeight) - 4 * ballPadding
+    val missingDays = ((numberOfLines * numberOfBallsPerLine * SecsInOneDay) - timeInSecs) / SecsInOneDay
+    val ballWidthWithPadding = ballFinalWidth + (2 * ballPadding)
+    val missingDaysWidth = missingDays * ballWidthWithPadding
+
+    Column(
+        Modifier
+            .timeCircleBackground(
+                missingDaysOverlayXOffset = ((numberOfBallsPerLine - missingDays) * ballFinalWidth).toFloat(),
+                missingDaysOverlaySize = Size(missingDaysWidth.toFloat(), ballFinalWidth.toFloat())
+            ),
+    ) {
+        repeat(numberOfLines.toInt()) {
+            Row {
+                repeat(numberOfBallsPerLine.toInt()) {
+                    Box(
+                        modifier = Modifier
+                            .size(ballFinalWidth.toInt().pxToDp(context).dp)
+                            .padding(ballPadding.toInt().pxToDp(context).dp)
+                    ) {
+                        Canvas(modifier = Modifier.fillMaxSize()) {
+                            drawCircle(color = Color.White)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun Modifier.timeCircleBackground(
+    missingDaysOverlayXOffset: Float,
+    missingDaysOverlaySize: Size,
+) =
+    graphicsLayer { alpha = 0.99f }
+        .drawWithCache {
+            val brush = Brush.linearGradient(
+                0.00f to Color(red = 0.25f, green = 0.11f, blue = 0.92f),
+                0.24f to Color(red = 0.68f, green = 0.89f, blue = 0.86f),
+                0.50f to Color(red = 0.87f, green = 0.91f, blue = 0.53f),
+                0.74f to Color(red = 0.91f, green = 0.35f, blue = 0.26f),
+                1.00f to Color(red = 0.1f, green = 0.1f, blue = 0.1f),
+                start = Offset(0f, 0f),
+                end = Offset(1.22f * size.width, 1.25f * size.height),
+            )
+            onDrawWithContent {
+                drawContent()
+
+                drawRect(
+                    brush = brush,
+                    blendMode = BlendMode.SrcAtop
+                )
+
+                // Missing days overlay
+                drawRect(
+                    color = Color(MissingDaysOverlayColor),
+                    topLeft = Offset(missingDaysOverlayXOffset, size.height - missingDaysOverlaySize.height),
+                    size = missingDaysOverlaySize,
+                    blendMode = BlendMode.SrcAtop
+                )
+            }
+        }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/utils/StoryModifierExtensions.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/utils/StoryModifierExtensions.kt
@@ -12,6 +12,19 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 
 private const val Black60 = 0x99000000
 
+fun rainbowBrush(
+    start: Offset = Offset.Zero,
+    end: Offset = Offset.Infinite,
+) = Brush.linearGradient(
+    0.00f to Color(red = 0.25f, green = 0.11f, blue = 0.92f),
+    0.24f to Color(red = 0.68f, green = 0.89f, blue = 0.86f),
+    0.50f to Color(red = 0.87f, green = 0.91f, blue = 0.53f),
+    0.74f to Color(red = 0.91f, green = 0.35f, blue = 0.26f),
+    1.00f to Color(red = 0.1f, green = 0.1f, blue = 0.1f),
+    start = start,
+    end = end,
+)
+
 fun Modifier.podcastDynamicBackground(podcast: Podcast) =
     dynamicBackground(Color(podcast.getTintColor(false)))
 
@@ -42,12 +55,7 @@ fun Modifier.dynamicBackground(
 fun Modifier.textGradient() =
     graphicsLayer { alpha = 0.99f }
         .drawWithCache {
-            val brush = Brush.linearGradient(
-                0.00f to Color(red = 0.25f, green = 0.11f, blue = 0.92f),
-                0.24f to Color(red = 0.68f, green = 0.89f, blue = 0.86f),
-                0.50f to Color(red = 0.87f, green = 0.91f, blue = 0.53f),
-                0.74f to Color(red = 0.91f, green = 0.35f, blue = 0.26f),
-                1.00f to Color(red = 0.1f, green = 0.1f, blue = 0.1f),
+            val brush = rainbowBrush(
                 start = Offset(-0.3f * size.width, -0.27f * size.height),
                 end = Offset(1.5f * size.width, 1.19f * size.height),
             )

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
@@ -31,11 +31,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.compose.extensions.nonScaledSp
+import au.com.shiftyjelly.pocketcasts.endofyear.components.DayCirclesView
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryBlurredBackground
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryFontFamily
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryPrimaryText
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StorySecondaryText
-import au.com.shiftyjelly.pocketcasts.endofyear.components.TimeCirclesView
 import au.com.shiftyjelly.pocketcasts.endofyear.components.disableScale
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListeningTime
 import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
@@ -77,7 +77,7 @@ fun StoryListeningTimeView(
 
             Spacer(modifier = Modifier.weight(0.16f))
 
-            TimeCirclesView(story.listeningTimeInSecs)
+            DayCirclesView(story.listeningTimeInSecs)
 
             Spacer(modifier = modifier.weight(1f))
         }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
@@ -7,12 +7,14 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -22,9 +24,9 @@ import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.CoverSize
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastCover
 import au.com.shiftyjelly.pocketcasts.compose.components.transformPodcastCover
+import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryBlurredBackground
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryPrimaryText
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StorySecondaryText
-import au.com.shiftyjelly.pocketcasts.endofyear.utils.podcastDynamicBackground
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListeningTime
 import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
@@ -35,29 +37,35 @@ fun StoryListeningTimeView(
     story: StoryListeningTime,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        verticalArrangement = Arrangement.Top,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier
-            .fillMaxSize()
-            .podcastDynamicBackground(story.podcasts[0].toPodcast())
-            .verticalScroll(rememberScrollState())
-    ) {
-        Spacer(modifier = modifier.height(40.dp))
+    Box {
+        StoryBlurredBackground(
+            Offset(
+                -LocalView.current.width * 0.7f,
+                LocalView.current.height * 0.3f
+            ),
+        )
+        Column(
+            verticalArrangement = Arrangement.Top,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(vertical = 40.dp)
+        ) {
+            Spacer(modifier = modifier.weight(0.2f))
 
-        Spacer(modifier = modifier.weight(.75f))
+            PrimaryText(story, modifier)
 
-        PrimaryText(story, modifier)
+            Spacer(modifier = modifier.height(14.dp))
 
-        Spacer(modifier = modifier.weight(0.25f))
+            SecondaryText(story, modifier)
 
-        SecondaryText(story, modifier)
+            Spacer(modifier = modifier.weight(0.25f))
 
-        Spacer(modifier = modifier.weight(0.25f))
+            PodcastCoverRow(story, modifier)
 
-        PodcastCoverRow(story, modifier)
-
-        Spacer(modifier = modifier.weight(1f))
+            Spacer(modifier = modifier.weight(1f))
+        }
     }
 }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
@@ -27,7 +27,6 @@ import au.com.shiftyjelly.pocketcasts.endofyear.components.StorySecondaryText
 import au.com.shiftyjelly.pocketcasts.endofyear.utils.podcastDynamicBackground
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListeningTime
 import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
-import au.com.shiftyjelly.pocketcasts.settings.util.FunnyTimeConverter
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -71,9 +70,9 @@ private fun PrimaryText(
     val language = Locale.current.language
     val timeText = StatsHelper.secondsToFriendlyString(story.listeningTimeInSecs, context.resources)
     val textResId = if (language == "en") {
-        LR.string.end_of_year_listening_time_english_only
+        LR.string.end_of_year_listening_time_title_english_only
     } else {
-        LR.string.end_of_year_listening_time
+        LR.string.end_of_year_listening_time_title
     }
     val text = stringResource(textResId, timeText)
     StoryPrimaryText(text = text, color = story.tintColor, modifier = modifier)
@@ -84,12 +83,8 @@ private fun SecondaryText(
     story: StoryListeningTime,
     modifier: Modifier,
 ) {
-    val context = LocalContext.current
-    val funnyText = FunnyTimeConverter().timeSecsToFunnyText(
-        story.listeningTimeInSecs,
-        context.resources
-    )
-    StorySecondaryText(text = funnyText, color = story.subtitleColor, modifier = modifier)
+    val text = stringResource(LR.string.end_of_year_listening_time_subtitle)
+    StorySecondaryText(text = text, color = story.subtitleColor, modifier = modifier)
 }
 
 @Composable

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
@@ -1,36 +1,46 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
 
+import android.content.Context
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.paddingFromBaseline
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import au.com.shiftyjelly.pocketcasts.compose.components.CoverSize
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastCover
-import au.com.shiftyjelly.pocketcasts.compose.components.transformPodcastCover
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
+import au.com.shiftyjelly.pocketcasts.compose.extensions.nonScaledSp
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryBlurredBackground
+import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryFontFamily
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryPrimaryText
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StorySecondaryText
+import au.com.shiftyjelly.pocketcasts.endofyear.components.disableScale
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListeningTime
 import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
-import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+private const val ListenedTimeFontSize = 100
 
 @Composable
 fun StoryListeningTimeView(
@@ -62,7 +72,7 @@ fun StoryListeningTimeView(
 
             Spacer(modifier = modifier.weight(0.25f))
 
-            PodcastCoverRow(story, modifier)
+            ListenedTimeTexts(story)
 
             Spacer(modifier = modifier.weight(1f))
         }
@@ -96,33 +106,61 @@ private fun SecondaryText(
 }
 
 @Composable
-private fun PodcastCoverRow(
-    story: StoryListeningTime,
-    modifier: Modifier = Modifier,
-) {
+private fun ListenedTimeTexts(story: StoryListeningTime) {
     val context = LocalContext.current
-    val currentLocalView = LocalView.current
-    val coverWidth = (currentLocalView.width.pxToDp(context).dp - 15.dp) / 3
-    Box(
-        modifier = modifier
-            .graphicsLayer { translationY = coverWidth.toPx() / 1.75f }
-            .height(coverWidth * 2.2f)
+    val listeningTimeDisplayStrings = getListeningTimeDisplayStrings(context, story.listeningTimeInSecs)
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxWidth(),
     ) {
-        Row(
-            modifier
-                .transformPodcastCover()
-        ) {
-            listOf(1, 0, 2).forEach { index ->
-                val podcastIndex = index.coerceAtMost(story.podcasts.size - 1)
-                Row {
-                    PodcastCover(
-                        uuid = story.podcasts[podcastIndex].uuid,
-                        coverWidth = coverWidth,
-                        coverSize = CoverSize.SMALL
+        Text(
+            text = listeningTimeDisplayStrings.firstNumber,
+            color = story.tintColor,
+            fontSize = ListenedTimeFontSize.nonScaledSp,
+            lineHeight = ListenedTimeFontSize.nonScaledSp,
+            fontWeight = FontWeight.W300,
+            fontFamily = StoryFontFamily,
+            style = LocalTextStyle.current.merge(
+                @Suppress("DEPRECATION")
+                TextStyle(
+                    platformStyle = PlatformTextStyle(
+                        includeFontPadding = false,
+                    ),
+                    lineHeightStyle = LineHeightStyle(
+                        alignment = LineHeightStyle.Alignment.Top,
+                        trim = LineHeightStyle.Trim.Both
                     )
-                    Spacer(modifier = modifier.width(5.dp))
-                }
-            }
-        }
+                )
+            ),
+            modifier = Modifier.paddingFromBaseline(top = 0.sp, bottom = 0.sp),
+        )
+        TextH50(
+            text = listeningTimeDisplayStrings.subtitle,
+            textAlign = TextAlign.Center,
+            color = story.subtitleColor,
+            fontFamily = StoryFontFamily,
+            fontWeight = FontWeight.W600,
+            disableScale = disableScale(),
+        )
     }
 }
+
+private fun getListeningTimeDisplayStrings(
+    context: Context,
+    listeningTimeInSecs: Long,
+): ListeningTimeDisplayStrings {
+    val timeText = StatsHelper.secondsToFriendlyString(listeningTimeInSecs, context.resources)
+    val timeTextStrings = timeText.split(" ")
+    val firstNumber = timeTextStrings.firstOrNull() ?: ""
+    val subtitle = if (timeTextStrings.size > 1) {
+        timeTextStrings.drop(1).joinToString(" ")
+    } else {
+        ""
+    }
+    return ListeningTimeDisplayStrings(firstNumber, subtitle)
+}
+
+data class ListeningTimeDisplayStrings(
+    val firstNumber: String,
+    val subtitle: String,
+)

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
@@ -35,6 +35,7 @@ import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryBlurredBackgroun
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryFontFamily
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryPrimaryText
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StorySecondaryText
+import au.com.shiftyjelly.pocketcasts.endofyear.components.TimeCirclesView
 import au.com.shiftyjelly.pocketcasts.endofyear.components.disableScale
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListeningTime
 import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
@@ -73,6 +74,10 @@ fun StoryListeningTimeView(
             Spacer(modifier = modifier.weight(0.25f))
 
             ListenedTimeTexts(story)
+
+            Spacer(modifier = Modifier.weight(0.16f))
+
+            TimeCirclesView(story.listeningTimeInSecs)
 
             Spacer(modifier = modifier.weight(1f))
         }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1575,8 +1575,9 @@
     <string name="end_of_year_prompt_card_title" translatable="false">@string/end_of_year_launch_modal_title</string>
     <string name="end_of_year_prompt_card_summary">See your top podcasts, categories, listening stats and more.</string>
     <string name="end_of_year_share_via" translatable="false">@string/podcasts_share_via</string>
-    <string name="end_of_year_listening_time">In 2022, you spent %1$s listening to podcasts.</string>
-    <string name="end_of_year_listening_time_english_only" translatable="false">In 2022, you spent\n%1$s\nlistening to podcasts.</string>
+    <string name="end_of_year_listening_time_title">This was your total time listening to podcasts.</string>
+    <string name="end_of_year_listening_time_title_english_only" translatable="false">This was your total time\nlistening to podcasts.</string>
+    <string name="end_of_year_listening_time_subtitle">We hope you loved every minute of it!</string>
     <string name="end_of_year_replay">Replay</string>
     <string name="end_of_year_share_story">Share this story</string>
     <string name="end_of_year_story_intro_title">Let’s celebrate your year of listening!</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -107,7 +107,7 @@ class EndOfYearManagerImpl @Inject constructor(
         if (listenedCategories.isNotEmpty()) {
             stories.add(StoryTopListenedCategories(listenedCategories))
         }
-        listeningTime?.let { stories.add(StoryListeningTime(it, topPodcasts.takeLast(3))) }
+        listeningTime?.let { stories.add(StoryListeningTime(it)) }
         longestEpisode?.let { stories.add(StoryLongestEpisode(it)) }
         stories.add(StoryEpilogue())
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -7,7 +7,6 @@ import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.Story
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryEpilogue
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryIntro
-import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListenedCategories
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListenedNumbers
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListeningTime
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryLongestEpisode
@@ -107,7 +106,6 @@ class EndOfYearManagerImpl @Inject constructor(
         }
         if (listenedCategories.isNotEmpty()) {
             stories.add(StoryTopListenedCategories(listenedCategories))
-            stories.add(StoryListenedCategories(listenedCategories))
         }
         listeningTime?.let { stories.add(StoryListeningTime(it, topPodcasts.takeLast(3))) }
         longestEpisode?.let { stories.add(StoryLongestEpisode(it)) }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/Story.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/Story.kt
@@ -7,7 +7,7 @@ abstract class Story {
     abstract val identifier: String
     open val storyLength: Long = 5.seconds()
     open val backgroundColor: Color = Color.Black
-    val tintColor: Color = Color.White
+    val tintColor: Color = Color(0xFFFBFBFC)
     val subtitleColor: Color = Color(0xFF8F97A4)
     open val shareable: Boolean = true
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/StoryListeningTime.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/StoryListeningTime.kt
@@ -1,10 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories
 
-import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
-
 class StoryListeningTime(
     val listeningTimeInSecs: Long,
-    val podcasts: List<TopPodcast>,
 ) : Story() {
     override val identifier: String = "listening_time"
 }


### PR DESCRIPTION
| 📘 Part of: #1463 | 🎨 Designs: lH66LwxxgG8btQ8NrM0ldx-fi-1599_20385 |
|:---:|:---:|

## Description
Adds the 2023 visual for the Total Listening Time Story.

**Animations are not part of this task and will be tackled later.**

## Testing Instructions
1. Make sure you're logged in to an account that has a few episodes listened
3. Go to Profile
4. Tap the EOY image
5. Skip to the sixth story
5. ✅ Check that the story looks good, that it shows your total listening time and that the circles matches it correctly
6. Share this story
8. ✅ The shared story image asset should have your total listening time and look good
9. Stop the app
10. Go to `EndOfYearManagerImpl` and on line 100 add hardcoded`listeningTime`  as `StoryListeningTime(200000L)`
11. Run it again
12. ✅ Check the story and the circles
13. Stop the app, increment one zero in `listeningTime` and run it again
14. ✅ Check the story and the circles
15. Repeat the steps above a few times, manipulating the `listeningTime` so you can test that the displayed circles are correct


## Screenshots or Screencast 
Pixel 7 (few) | Pixel 7 (more) | Pixel 7 (extreme) | Pixel 7 (API 24)
| ---------- | ----------- | ----------- | ---------- |
![2days7hrs](https://github.com/Automattic/pocket-casts-android/assets/1405144/eb74b56a-0175-4d3c-98e3-78a7e7cc18ae) | ![23days3hrs](https://github.com/Automattic/pocket-casts-android/assets/1405144/e377b7e9-5736-437a-81ee-2a1541e13df1) | ![347days5hrs](https://github.com/Automattic/pocket-casts-android/assets/1405144/e7d802b3-bc77-4808-84c2-049576aa2790) | ![Screenshot_20231030_123543](https://github.com/Automattic/pocket-casts-android/assets/1405144/837e8449-decc-428a-b08a-e577bbb8974f)

Nexus 9 Tablet
|---|
|<img width=400 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/42b00415-f217-4733-8b70-4946d7cb824b"/>|

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
