### PR TITLE
Direct EOY banner to use onboarding flow

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -652,8 +652,7 @@ class MainActivity :
             showStories(StoriesSource.fromString(source))
         } else {
             viewModel.waitingForSignInToShowStories = true
-            val intent = Intent(this, AccountActivity::class.java)
-            startActivity(intent)
+            openOnboardingFlow(OnboardingFlow.LoggedOut)
         }
     }
 


### PR DESCRIPTION
## Description
This makes it so that the EOY banner uses the onboarding flow instead of the old AccountActivity sign in screen.

Related to #1499 (but does not entirely fix that issue since we still have `AccountActivity` code in other places).

## Testing Instructions
1. Fresh install the app
2. Tap on the EOY banner on the profile screen
3. ✅ Observe that you are taken to the OnboardingFlow sign in screen (easy to tell because this screen has a Google Sign In option whereas the old AccountActivity screen does not provide that option).
4. Sign in
5. ✅ Observe that after sign in you are taken to the EOY stories
6. Exit the EOY stories
7. Tap on the EOY banner again
8. ✅  Observe that you are taken to the EOY stories

## Video

https://github.com/Automattic/pocket-casts-android/assets/4656348/3c861f97-a72c-46bd-8272-21658ad00eb7

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews