### PR TITLE
Playback 2023: Completion rate story

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -732,7 +732,7 @@ class MainActivity :
                 if (viewModel.waitingForSignInToShowStories) {
                     showStories(StoriesSource.USER_LOGIN)
                     viewModel.waitingForSignInToShowStories = false
-                } else if (!settings.getEndOfYearShowModal()) {
+                } else if (settings.getEndOfYearShowModal()) {
                     viewModel.updateStoriesModalShowState(true)
                     launch(Dispatchers.Main) {
                         if (viewModel.isEndOfYearStoriesEligible()) setupEndOfYearLaunchBottomSheet()

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
@@ -60,6 +60,7 @@ import au.com.shiftyjelly.pocketcasts.endofyear.StoriesViewModel.State
 import au.com.shiftyjelly.pocketcasts.endofyear.utils.waitForUpOrCancelInitial
 import au.com.shiftyjelly.pocketcasts.endofyear.views.SegmentedProgressIndicator
 import au.com.shiftyjelly.pocketcasts.endofyear.views.convertibleToBitmap
+import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryCompletionRateView
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryEpilogueView
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryIntroView
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryListenedCategoriesView
@@ -73,6 +74,7 @@ import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryYearOverYearV
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.Story
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryCompletionRate
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryEpilogue
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryIntro
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListenedCategories
@@ -259,6 +261,10 @@ private fun StorySharableContent(
                 is StoryTopFivePodcasts -> StoryTopFivePodcastsView(story)
                 is StoryLongestEpisode -> StoryLongestEpisodeView(story)
                 is StoryYearOverYear -> StoryYearOverYearView(
+                    story = story,
+                    userTier = userTier,
+                )
+                is StoryCompletionRate -> StoryCompletionRateView(
                     story = story,
                     userTier = userTier,
                 )

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/CompletionRateCircle.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/CompletionRateCircle.kt
@@ -1,0 +1,170 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
+import au.com.shiftyjelly.pocketcasts.endofyear.utils.rainbowBrush
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryCompletionRate
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
+
+private val PercentFontSize = 45.sp
+private const val CompletionCircleAvailableWidthPercent = .75f
+private val CompletionCircleBaseColor = Color(0xFF292B2E)
+
+@Composable
+fun CompletionCircle(
+    story: StoryCompletionRate,
+    modifier: Modifier = Modifier,
+) {
+    BoxWithConstraints(
+        modifier = modifier,
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(maxWidth * CompletionCircleAvailableWidthPercent)
+                .drawCompletionCircle(story.percent.toInt()),
+            contentAlignment = Alignment.Center,
+        ) {
+            CompletionTextContent(story)
+        }
+    }
+}
+
+@Composable
+private fun CompletionTextContent(
+    story: StoryCompletionRate,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        TextH10(
+            text = "${story.percent.toInt()}%",
+            fontSize = PercentFontSize,
+            color = story.tintColor,
+            disableScale = true,
+        )
+        TextH50(
+            text = "completion rate",
+            textAlign = TextAlign.Center,
+            color = story.subtitleColor,
+            disableScale = disableScale()
+        )
+    }
+}
+
+private fun Modifier.drawCompletionCircle(
+    completionPercent: Int,
+) = graphicsLayer { alpha = 0.99f }
+    .drawWithCache {
+        val circleColor = CompletionCircleBaseColor
+        val circleStroke = Stroke((size.height * 0.02f))
+        val circleRadius = (size.width - circleStroke.width) * 0.5f
+
+        val arcBrush = rainbowBrush(
+            start = Offset(-0.65f * size.width, 0.5f * size.height),
+            end = Offset(1.49f * size.width, 0.5f * size.height)
+        )
+        val arcStroke = Stroke((size.height * 0.05f))
+        val arcDiameterOffset = arcStroke.width / 2
+        val arcDimen = size.width - 2 * arcDiameterOffset
+        val arcSweepAngle = completionPercent.toDouble() / 100 * 360
+
+        onDrawWithContent {
+            drawCircle(
+                color = circleColor,
+                radius = circleRadius,
+                style = circleStroke,
+                blendMode = BlendMode.SrcOver
+            )
+            withTransform({ rotate(-90f) }) {
+                drawArc(
+                    brush = arcBrush,
+                    startAngle = 0f,
+                    sweepAngle = arcSweepAngle.toFloat(),
+                    useCenter = false,
+                    topLeft = Offset(arcDiameterOffset, arcDiameterOffset),
+                    size = Size(arcDimen, arcDimen),
+                    style = arcStroke,
+                    blendMode = BlendMode.SrcOver
+                )
+            }
+            drawContent()
+        }
+    }
+
+@ShowkaseComposable(name = "CompletionRateCircle", group = "Images", styleName = "10%")
+@Preview(name = "10%")
+@Composable
+fun CompletionRate10percentPreview() {
+    AppThemeWithBackground(Theme.ThemeType.DARK_CONTRAST) {
+        CompletionCircle(
+            StoryCompletionRate(
+                percent = 10f,
+            ),
+            Modifier.size(300.dp)
+        )
+    }
+}
+
+@ShowkaseComposable(name = "CompletionRateCircle", group = "Images", styleName = "30%")
+@Preview(name = "30%")
+@Composable
+fun CompletionRate30percentPreview() {
+    AppThemeWithBackground(Theme.ThemeType.DARK_CONTRAST) {
+        CompletionCircle(
+            StoryCompletionRate(
+                percent = 30f,
+            ),
+            Modifier.size(300.dp)
+        )
+    }
+}
+
+@ShowkaseComposable(name = "CompletionRateCircle", group = "Images", styleName = "70%")
+@Preview(name = "70%")
+@Composable
+fun CompletionRate70percentPreview() {
+    AppThemeWithBackground(Theme.ThemeType.DARK_CONTRAST) {
+        CompletionCircle(
+            StoryCompletionRate(
+                percent = 70f,
+            ),
+            Modifier.size(300.dp)
+        )
+    }
+}
+
+@ShowkaseComposable(name = "CompletionRateCircle", group = "Images", styleName = "100%")
+@Preview(name = "100%")
+@Composable
+fun CompletionRate100percentPreview() {
+    AppThemeWithBackground(Theme.ThemeType.DARK_CONTRAST) {
+        CompletionCircle(
+            StoryCompletionRate(
+                percent = 100f,
+            ),
+            Modifier.size(300.dp)
+        )
+    }
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/CompletionRateCircle.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/CompletionRateCircle.kt
@@ -3,6 +3,9 @@ package au.com.shiftyjelly.pocketcasts.endofyear.components
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -15,6 +18,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -23,52 +28,69 @@ import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.endofyear.utils.rainbowBrush
-import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryCompletionRate
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private val PercentFontSize = 45.sp
 private const val CompletionCircleAvailableWidthPercent = .75f
 private val CompletionCircleBaseColor = Color(0xFF292B2E)
 
 @Composable
-fun CompletionCircle(
-    story: StoryCompletionRate,
+fun CompletionRateCircle(
+    percent: Int,
+    titleColor: Color,
+    subTitleColor: Color,
     modifier: Modifier = Modifier,
 ) {
     BoxWithConstraints(
         modifier = modifier,
         contentAlignment = Alignment.Center,
     ) {
+        val availableWidth = maxWidth * CompletionCircleAvailableWidthPercent
         Box(
             modifier = Modifier
-                .size(maxWidth * CompletionCircleAvailableWidthPercent)
-                .drawCompletionCircle(story.percent.toInt()),
+                .size(availableWidth)
+                .drawCompletionCircle(percent),
             contentAlignment = Alignment.Center,
         ) {
-            CompletionTextContent(story)
+            CompletionTextContent(
+                percent = percent,
+                titleColor = titleColor,
+                subTitleColor = subTitleColor,
+            )
         }
     }
 }
 
 @Composable
 private fun CompletionTextContent(
-    story: StoryCompletionRate,
+    percent: Int,
+    titleColor: Color,
+    subTitleColor: Color,
+    modifier: Modifier = Modifier,
 ) {
     Column(
-        horizontalAlignment = Alignment.CenterHorizontally
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         TextH10(
-            text = "${story.percent.toInt()}%",
+            text = "$percent%",
+            color = titleColor,
+            fontFamily = StoryFontFamily,
             fontSize = PercentFontSize,
-            color = story.tintColor,
-            disableScale = true,
+            fontWeight = FontWeight.W300,
+            maxLines = 1,
+            textAlign = TextAlign.Center,
         )
         TextH50(
-            text = "completion rate",
+            text = stringResource(LR.string.end_of_year_stories_year_completion_rate),
+            color = subTitleColor,
+            fontFamily = StoryFontFamily,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.W600,
             textAlign = TextAlign.Center,
-            color = story.subtitleColor,
-            disableScale = disableScale()
+            modifier = Modifier.offset(y = (-5).dp)
         )
     }
 }
@@ -117,54 +139,40 @@ private fun Modifier.drawCompletionCircle(
 @Preview(name = "10%")
 @Composable
 fun CompletionRate10percentPreview() {
-    AppThemeWithBackground(Theme.ThemeType.DARK_CONTRAST) {
-        CompletionCircle(
-            StoryCompletionRate(
-                percent = 10f,
-            ),
-            Modifier.size(300.dp)
-        )
-    }
+    CompletionRateCirclePreview(10)
 }
 
 @ShowkaseComposable(name = "CompletionRateCircle", group = "Images", styleName = "30%")
 @Preview(name = "30%")
 @Composable
 fun CompletionRate30percentPreview() {
-    AppThemeWithBackground(Theme.ThemeType.DARK_CONTRAST) {
-        CompletionCircle(
-            StoryCompletionRate(
-                percent = 30f,
-            ),
-            Modifier.size(300.dp)
-        )
-    }
+    CompletionRateCirclePreview(30)
 }
 
 @ShowkaseComposable(name = "CompletionRateCircle", group = "Images", styleName = "70%")
 @Preview(name = "70%")
 @Composable
 fun CompletionRate70percentPreview() {
-    AppThemeWithBackground(Theme.ThemeType.DARK_CONTRAST) {
-        CompletionCircle(
-            StoryCompletionRate(
-                percent = 70f,
-            ),
-            Modifier.size(300.dp)
-        )
-    }
+    CompletionRateCirclePreview(70)
 }
 
 @ShowkaseComposable(name = "CompletionRateCircle", group = "Images", styleName = "100%")
 @Preview(name = "100%")
 @Composable
 fun CompletionRate100percentPreview() {
+    CompletionRateCirclePreview(100)
+}
+
+@Composable
+fun CompletionRateCirclePreview(percent: Int) {
     AppThemeWithBackground(Theme.ThemeType.DARK_CONTRAST) {
-        CompletionCircle(
-            StoryCompletionRate(
-                percent = 100f,
-            ),
-            Modifier.size(300.dp)
+        CompletionRateCircle(
+            percent = percent,
+            titleColor = Color.White,
+            subTitleColor = Color.Gray,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(300.dp)
         )
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/CompletionRateCircle.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/CompletionRateCircle.kt
@@ -32,7 +32,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-private val PercentFontSize = 45.sp
+private val PercentFontSize = 80.sp
 private const val CompletionCircleAvailableWidthPercent = .75f
 private val CompletionCircleBaseColor = Color(0xFF292B2E)
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryCompletionRateView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryCompletionRateView.kt
@@ -18,9 +18,10 @@ import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeDisplayMode
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
-import au.com.shiftyjelly.pocketcasts.endofyear.components.CompletionCircle
+import au.com.shiftyjelly.pocketcasts.endofyear.components.CompletionRateCircle
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryPrimaryText
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StorySecondaryText
+import au.com.shiftyjelly.pocketcasts.models.db.helper.EpisodesStartedAndCompleted
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryCompletionRate
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -59,8 +60,10 @@ fun StoryCompletionRateView(
 
         Spacer(modifier = modifier.weight(0.2f))
 
-        CompletionCircle(
-            story = story,
+        CompletionRateCircle(
+            percent = story.episodesStartedAndCompleted.percentage.toInt(),
+            titleColor = story.tintColor,
+            subTitleColor = story.subtitleColor,
             modifier = modifier
                 .weight(1f)
         )
@@ -76,7 +79,7 @@ private fun PrimaryText(
 ) {
     val text = stringResource(
         LR.string.end_of_year_stories_year_completion_rate_title,
-        "10%"
+        story.episodesStartedAndCompleted.percentage.toInt(),
     )
     StoryPrimaryText(text = text, color = story.tintColor, modifier = modifier)
 }
@@ -87,19 +90,20 @@ private fun SecondaryText(
     modifier: Modifier = Modifier,
 ) {
     val text = stringResource(
-        LR.string.end_of_year_stories_year_over_year_subtitle_went_up,
-        30
+        LR.string.end_of_year_stories_year_completion_rate_subtitle,
+        story.episodesStartedAndCompleted.started,
+        story.episodesStartedAndCompleted.completed,
     )
     StorySecondaryText(text = text, color = story.subtitleColor, modifier = modifier)
 }
 
 @Preview
 @Composable
-fun CompletionRate10percentPreview() {
+fun StoryCompletionRatPreview() {
     AppTheme(Theme.ThemeType.DARK) {
         StoryCompletionRateView(
             StoryCompletionRate(
-                percent = 40f,
+                EpisodesStartedAndCompleted(started = 100, completed = 30),
             ),
             userTier = UserTier.Plus,
         )

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryCompletionRateView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryCompletionRateView.kt
@@ -1,0 +1,80 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeDisplayMode
+import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
+import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryPrimaryText
+import au.com.shiftyjelly.pocketcasts.endofyear.components.StorySecondaryText
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryCompletionRate
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun StoryCompletionRateView(
+    story: StoryCompletionRate,
+    userTier: UserTier,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        verticalArrangement = Arrangement.Bottom,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(vertical = 40.dp)
+    ) {
+        Spacer(modifier = modifier.weight(0.2f))
+
+        SubscriptionBadgeForTier(
+            tier = SubscriptionTier.fromUserTier(userTier),
+            displayMode = SubscriptionBadgeDisplayMode.Colored,
+        )
+
+        Spacer(modifier = modifier.height(14.dp))
+
+        PrimaryText(story)
+
+        Spacer(modifier = modifier.height(14.dp))
+
+        SecondaryText(story)
+
+        Spacer(modifier = modifier.weight(0.2f))
+    }
+}
+
+@Composable
+private fun PrimaryText(
+    story: StoryCompletionRate,
+    modifier: Modifier = Modifier,
+) {
+    val text = stringResource(
+        LR.string.end_of_year_stories_year_completion_rate_title,
+        "10%"
+    )
+    StoryPrimaryText(text = text, color = story.tintColor, modifier = modifier)
+}
+
+@Composable
+private fun SecondaryText(
+    story: StoryCompletionRate,
+    modifier: Modifier = Modifier,
+) {
+    val text = stringResource(
+        LR.string.end_of_year_stories_year_over_year_subtitle_went_up,
+        30
+    )
+    StorySecondaryText(text = text, color = story.subtitleColor, modifier = modifier)
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryCompletionRateView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryCompletionRateView.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -12,13 +13,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeDisplayMode
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
+import au.com.shiftyjelly.pocketcasts.endofyear.components.CompletionCircle
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryPrimaryText
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StorySecondaryText
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryCompletionRate
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -33,6 +38,7 @@ fun StoryCompletionRateView(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
             .fillMaxSize()
+            .background(story.backgroundColor)
             .verticalScroll(rememberScrollState())
             .padding(vertical = 40.dp)
     ) {
@@ -50,6 +56,14 @@ fun StoryCompletionRateView(
         Spacer(modifier = modifier.height(14.dp))
 
         SecondaryText(story)
+
+        Spacer(modifier = modifier.weight(0.2f))
+
+        CompletionCircle(
+            story = story,
+            modifier = modifier
+                .weight(1f)
+        )
 
         Spacer(modifier = modifier.weight(0.2f))
     }
@@ -77,4 +91,17 @@ private fun SecondaryText(
         30
     )
     StorySecondaryText(text = text, color = story.subtitleColor, modifier = modifier)
+}
+
+@Preview
+@Composable
+fun CompletionRate10percentPreview() {
+    AppTheme(Theme.ThemeType.DARK) {
+        StoryCompletionRateView(
+            StoryCompletionRate(
+                percent = 40f,
+            ),
+            userTier = UserTier.Plus,
+        )
+    }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1650,10 +1650,11 @@
     <string name="eoy_year_over_year_title_skyrocketed">Compared to 2022, your listening time skyrocketed!</string>
     <!-- Text for when a user shares the story comparing the 2022 and 2023 listening time. -->
     <string name="end_of_year_stories_year_over_share_text">My 2023 listening time compared to 2022</string>
-    <!-- Title for the completion rate. %1$s is the percentage.-->
-    <string name="end_of_year_stories_year_completion_rate_title">Your completion rate this year was %1$s</string>
-    <!-- Title for the completion rate. %1$s is the total of episodes listened this year, %2$s is the total of episodes fully listened to. -->
-    <string name="end_of_year_stories_year_completion_rate_subtitle">From the %1$@ episodes you started you listened fully to a total of %2$s</string>
+    <!-- Title for the completion rate. %1$d is the percentage.-->
+    <string name="end_of_year_stories_year_completion_rate_title">Your completion rate this year was %1$d%%</string>
+    <!-- Title for the completion rate. %1$d is the total of episodes listened this year, %2$d is the total of episodes fully listened to. -->
+    <string name="end_of_year_stories_year_completion_rate_subtitle">From the %1$d episodes you started you listened fully to a total of %2$d</string>
+    <string name="end_of_year_stories_year_completion_rate">completion rate</string>
 
     <!-- Onboarding -->
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1650,6 +1650,10 @@
     <string name="eoy_year_over_year_title_skyrocketed">Compared to 2022, your listening time skyrocketed!</string>
     <!-- Text for when a user shares the story comparing the 2022 and 2023 listening time. -->
     <string name="end_of_year_stories_year_over_share_text">My 2023 listening time compared to 2022</string>
+    <!-- Title for the completion rate. %1$s is the percentage.-->
+    <string name="end_of_year_stories_year_completion_rate_title">Your completion rate this year was %1$s</string>
+    <!-- Title for the completion rate. %1$s is the total of episodes listened this year, %2$s is the total of episodes fully listened to. -->
+    <string name="end_of_year_stories_year_completion_rate_subtitle">From the %1$@ episodes you started you listened fully to a total of %2$s</string>
 
     <!-- Onboarding -->
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -405,4 +405,24 @@ abstract class EpisodeDao {
         """
     )
     abstract suspend fun findEpisodesCountInListeningHistory(fromEpochMs: Long, toEpochMs: Long): Int
+
+    @Query(
+        """
+            SELECT COUNT(DISTINCT uuid) AS started FROM podcast_episodes
+            WHERE podcast_episodes.last_playback_interaction_date IS NOT NULL 
+            AND podcast_episodes.last_playback_interaction_date > :fromEpochMs AND podcast_episodes.last_playback_interaction_date < :toEpochMs
+        """
+    )
+    abstract suspend fun countEpisodesStarted(fromEpochMs: Long, toEpochMs: Long): Int
+
+    @Query(
+        """
+        SELECT COUNT(DISTINCT uuid) AS completed 
+        FROM podcast_episodes 
+        WHERE playing_status = 3 OR played_up_to >= 0.9 * duration 
+        AND podcast_episodes.last_playback_interaction_date IS NOT NULL 
+        AND podcast_episodes.last_playback_interaction_date > :fromEpochMs AND podcast_episodes.last_playback_interaction_date < :toEpochMs
+        """
+    )
+    abstract suspend fun countEpisodesCompleted(fromEpochMs: Long, toEpochMs: Long): Int
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/EpisodesStartedAndCompleted.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/EpisodesStartedAndCompleted.kt
@@ -1,0 +1,12 @@
+package au.com.shiftyjelly.pocketcasts.models.db.helper
+
+data class EpisodesStartedAndCompleted(
+    val started: Int,
+    val completed: Int,
+) {
+    val percentage: Double = if (started == 0) {
+        100.0
+    } else {
+        (completed.toDouble() / started.toDouble()) * 100.0
+    }
+}

--- a/modules/services/repositories/build.gradle
+++ b/modules/services/repositories/build.gradle
@@ -25,4 +25,5 @@ dependencies {
     implementation project(':modules:services:protobuf')
     implementation project(':modules:services:servers')
     implementation project(':modules:services:utils')
+    testImplementation project(':modules:services:sharedtest')
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.endofyear
 
+import au.com.shiftyjelly.pocketcasts.models.db.helper.EpisodesStartedAndCompleted
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.db.helper.LongestEpisode
@@ -18,4 +19,5 @@ interface EndOfYearManager {
     suspend fun findTopPodcastsForYear(year: Int, limit: Int): List<TopPodcast>
     suspend fun findLongestPlayedEpisodeForYear(year: Int): LongestEpisode?
     suspend fun getYearOverYearListeningTime(): YearOverYearListeningTime?
+    suspend fun countEpisodesStartedAndCompleted(): EpisodesStartedAndCompleted
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -119,7 +119,11 @@ class EndOfYearManagerImpl @Inject constructor(
         if (yearOverYearListeningTime.totalPlayedTimeThisYear != 0L || yearOverYearListeningTime.totalPlayedTimeLastYear != 0L) {
             stories.add(StoryYearOverYear(yearOverYearListeningTime))
         }
-        stories.add(StoryCompletionRate())
+        stories.add(
+            StoryCompletionRate(
+                percent = 75f,
+            )
+        )
         stories.add(StoryEpilogue())
 
         return stories

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.endofyear
 
+import au.com.shiftyjelly.pocketcasts.models.db.helper.EpisodesStartedAndCompleted
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.db.helper.LongestEpisode
@@ -99,6 +100,7 @@ class EndOfYearManagerImpl @Inject constructor(
         val topPodcasts = findTopPodcastsForYear(YEAR, limit = 10)
         val longestEpisode = findLongestPlayedEpisodeForYear(YEAR)
         val yearOverYearListeningTime = getYearOverYearListeningTime()
+        val episodesStartedAndCompleted = countEpisodesStartedAndCompleted()
         val stories = mutableListOf<Story>()
 
         stories.add(StoryIntro())
@@ -119,11 +121,7 @@ class EndOfYearManagerImpl @Inject constructor(
         if (yearOverYearListeningTime.totalPlayedTimeThisYear != 0L || yearOverYearListeningTime.totalPlayedTimeLastYear != 0L) {
             stories.add(StoryYearOverYear(yearOverYearListeningTime))
         }
-        stories.add(
-            StoryCompletionRate(
-                percent = 75f,
-            )
-        )
+        stories.add(StoryCompletionRate(episodesStartedAndCompleted))
         stories.add(StoryEpilogue())
 
         return stories
@@ -170,5 +168,9 @@ class EndOfYearManagerImpl @Inject constructor(
             fromEpochMsCurrentYear = yearStart,
             toEpochMsCurrentYear = yearEnd,
         )
+    }
+
+    override suspend fun countEpisodesStartedAndCompleted(): EpisodesStartedAndCompleted {
+        return episodeManager.countEpisodesStartedAndCompleted(yearStart, yearEnd)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -6,6 +6,7 @@ import au.com.shiftyjelly.pocketcasts.models.db.helper.LongestEpisode
 import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
 import au.com.shiftyjelly.pocketcasts.models.db.helper.YearOverYearListeningTime
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.Story
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryCompletionRate
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryEpilogue
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryIntro
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListenedNumbers
@@ -118,6 +119,7 @@ class EndOfYearManagerImpl @Inject constructor(
         if (yearOverYearListeningTime.totalPlayedTimeThisYear != 0L || yearOverYearListeningTime.totalPlayedTimeLastYear != 0L) {
             stories.add(StoryYearOverYear(yearOverYearListeningTime))
         }
+        stories.add(StoryCompletionRate())
         stories.add(StoryEpilogue())
 
         return stories

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/StoryCompletionRate.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/StoryCompletionRate.kt
@@ -1,7 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories
 
+import au.com.shiftyjelly.pocketcasts.models.db.helper.EpisodesStartedAndCompleted
+
 class StoryCompletionRate(
-    val percent: Float,
+    val episodesStartedAndCompleted: EpisodesStartedAndCompleted,
 ) : Story() {
     override val identifier: String = "completion_rate"
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/StoryCompletionRate.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/StoryCompletionRate.kt
@@ -1,0 +1,9 @@
+package au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories
+
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
+
+class StoryCompletionRate(
+    val userTier: UserTier = UserTier.Plus,
+) : Story() {
+    override val identifier: String = "completion_rate"
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/StoryCompletionRate.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/StoryCompletionRate.kt
@@ -1,9 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories
 
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
-
 class StoryCompletionRate(
-    val userTier: UserTier = UserTier.Plus,
+    val percent: Float,
 ) : Story() {
     override val identifier: String = "completion_rate"
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import androidx.lifecycle.LiveData
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.db.helper.EpisodesStartedAndCompleted
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.db.helper.LongestEpisode
@@ -163,4 +164,5 @@ interface EpisodeManager {
         fromEpochMsCurrentYear: Long,
         toEpochMsCurrentYear: Long,
     ): YearOverYearListeningTime
+    suspend fun countEpisodesStartedAndCompleted(fromEpochMs: Long, toEpochMs: Long): EpisodesStartedAndCompleted
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
+import au.com.shiftyjelly.pocketcasts.models.db.helper.EpisodesStartedAndCompleted
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.db.helper.LongestEpisode
@@ -1174,4 +1175,12 @@ class EpisodeManagerImpl @Inject constructor(
             totalPlayedTimeThisYear = currentYearListeningTime ?: 0L
         )
     }
+
+    override suspend fun countEpisodesStartedAndCompleted(
+        fromEpochMs: Long,
+        toEpochMs: Long,
+    ) = EpisodesStartedAndCompleted(
+        started = episodeDao.countEpisodesStarted(fromEpochMs, toEpochMs),
+        completed = episodeDao.countEpisodesCompleted(fromEpochMs, toEpochMs),
+    )
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImplTest.kt
@@ -1,0 +1,74 @@
+package au.com.shiftyjelly.pocketcasts.repositories.endofyear
+
+import au.com.shiftyjelly.pocketcasts.models.db.helper.EpisodesStartedAndCompleted
+import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
+import au.com.shiftyjelly.pocketcasts.models.db.helper.YearOverYearListeningTime
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryCompletionRate
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.HistoryManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(MockitoJUnitRunner::class)
+class EndOfYearManagerImplTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    @Mock
+    lateinit var episodeManager: EpisodeManager
+
+    @Mock
+    lateinit var podcastManager: PodcastManager
+
+    @Mock
+    lateinit var historyManager: HistoryManager
+
+    @Mock
+    lateinit var syncManager: SyncManager
+
+    private lateinit var endOfYearManagerImpl: EndOfYearManagerImpl
+
+    @Before
+    fun setup() = runTest {
+        whenever(episodeManager.findListenedNumbers(anyLong(), anyLong())).thenReturn(ListenedNumbers())
+        whenever(podcastManager.findTopPodcasts(anyLong(), anyLong(), anyInt())).thenReturn(emptyList())
+        whenever(episodeManager.findListenedCategories(anyLong(), anyLong())).thenReturn(emptyList())
+        whenever(episodeManager.yearOverYearListeningTime(anyLong(), anyLong(), anyLong(), anyLong())).thenReturn(
+            YearOverYearListeningTime(0, 0)
+        )
+        whenever(episodeManager.countEpisodesStartedAndCompleted(anyLong(), anyLong())).thenReturn(
+            EpisodesStartedAndCompleted(0, 0)
+        )
+        endOfYearManagerImpl = EndOfYearManagerImpl(
+            episodeManager = episodeManager,
+            podcastManager = podcastManager,
+            historyManager = historyManager,
+            syncManager = syncManager
+        )
+    }
+
+    @Test
+    fun testCompletionRateStory() = runTest {
+        whenever(episodeManager.countEpisodesStartedAndCompleted(anyLong(), anyLong())).thenReturn(
+            EpisodesStartedAndCompleted(100, 50)
+        )
+        val stories = endOfYearManagerImpl.loadStories()
+
+        val storyCompletionRate = stories.firstOrNull { it is StoryCompletionRate } as? StoryCompletionRate
+        assertTrue(storyCompletionRate?.episodesStartedAndCompleted?.percentage == 50.0)
+    }
+}


### PR DESCRIPTION
| 📘 Part of: #1463 | 🎨 Designs: lH66LwxxgG8btQ8NrM0ldx-fi-1599_20385 |
|:---:|:---:|

## Description
Adds the 2023 visual for the Completion Rate Story.

## Testing Instructions

## Different states

1. Go to `CompletionRateCircle.kt`
2. Enable Preview
3. ✅ Go over all the different percentages
4. You can also play with the numbers to see if the circle updates accordingly

## Story appearing

1. Make sure you're logged in to an account that has a few episodes listened
3. Go to Profile
4. Tap the EOY image
5. Skip to the penultimate story
5. ✅ Check that the story looks good compared to the design
6. Share this story
9. ✅ The story image asset should look good
10. Add Plus plan to the account
11. Go to Profile tab and tap refresh now 
12. ✅ Check the story again, it should show a Plus badge
13. Add Patron plan to the account
14. Go to Profile tab and tap refresh now 
15. ✅ Check the story again, it should show a Patron badge

## Screenshots or Screencast 
Phone
|---|
|<img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/87bcf9f0-2c76-4d8d-8855-d8b217b28a5c"/>|

Tablet
|---|
|<img width=480 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/52f28c2c-8da4-4256-9972-4eecc05ca07b"/>|

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
