### PR TITLE
Hide Plus Upgrade banner for Patron users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 7.52
 -----
 
+* Bug Fixes
+    *   Hide Plus upgrade banner for Patron users
+        ([#1508](https://github.com/Automattic/pocket-casts-android/pull/1508))
 
 7.51
 -----

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -175,7 +175,7 @@ class ProfileFragment : BaseFragment() {
         viewModel.signInState.observe(viewLifecycleOwner) { state ->
             binding.userView.signedInState = state
 
-            binding.upgradeLayout.root.isInvisible = settings.getUpgradeClosedProfile() || state.isSignedInAsPlus
+            binding.upgradeLayout.root.isInvisible = settings.getUpgradeClosedProfile() || state.isSignedInAsPlusOrPatron
             if (binding.upgradeLayout.root.isInvisible) {
                 // We need this to get the correct padding below refresh
                 binding.upgradeLayout.root.updateLayoutParams<ConstraintLayout.LayoutParams> { height = 16.dpToPx(view.context) }


### PR DESCRIPTION
## Description
This ensures we only show the Plus upgrade banner at the bottom of the Profile screen for free users. Before this change, the banner would show for Patron users.

## Testing Instructions
1. Log into a free account
2. Tap on the profile tab
3. ✅ Verify that the Plus Upgrade banner shows at the bottom of the Profile screen
4. Switch to a Plus account
5. ✅ Verify that the Plus Upgrade banner does NOT show at the bottom of the Profile screen
6. Switch to a Patron account
7.  ✅ Verify that the Plus Upgrade banner does NOT show at the bottom of the Profile screen


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews