### PR TITLE
Avoid audio skip back when a streaming episode is downloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 7.52
 -----
 
+*   Bug Fixes:
+    *   Avoid brief audio skip back when a streaming episode is downloaded
+        ([#1510](https://github.com/Automattic/pocket-casts-android/pull/1510))
 
 7.51
 -----


### PR DESCRIPTION
## Description
This fixes an issue where the download of an episode that is being streamed could cause playback to jump back a second or so.

When the app downloads an episode that is currently being streamed we usually (but [not always](https://github.com/Automattic/pocket-casts-android/issues/1509)), reset the player. When doing this, the new player was loading the last position of the episode that was saved to the database, which would often be out-of-date by a second or so.

This fixes that by (1) ensuring that we get the current playing position at the last possible moment before resetting the player, (2) updating the database with that playing position, and (3) ensuring that we fetch the latest episode data from the database before restoring the playback position.

It would be nice if we didn't have to manually refetch the episode from the db and if instead the `UpNextQueue` would always provide an up-to-date version of the currentEpisode, but that is a larger refactor that I don't have time to take on right now.

Note that this issue does not seem to occur _every_ time that we finish downloading an episode that is streaming because in some circumstances, we do not reset the player. I have not had time to isolate why that is, so I filed https://github.com/Automattic/pocket-casts-android/issues/1509 to track it.

Fixes #1491 

## Testing Instructions

1. Fresh install of the app
2. Begin playing an episode. Note that although the steps to reproduce in #1491 include setting various playback effects, I can reproduce the issue without those playback effects).
3. Start downloading the currently playing episode. You can either initiate this download manually or let the app start the download automatically by turning on the setting to download episodes added to the Up Next queue.
4. Observe that once the episode is downloaded, _if the player gets reset_ (which does not always happen, see [#1509](https://github.com/Automattic/pocket-casts-android/issues/1509)), the audio will pause for ~1 second and then resume as the player gets reset, and the audio should NOT jump backwards by ~1 second (i.e., there should not hear any audio repeated both before the pause and after the pause). Note that you can check the logs for "Resetting player" to confirm whether the player was reset.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews