### PR TITLE
Playback 2023: Plus Upsell story

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
@@ -74,6 +74,7 @@ import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryTopListenedCa
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryTopPodcastView
 import au.com.shiftyjelly.pocketcasts.endofyear.views.stories.StoryYearOverYearView
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.Story
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryCompletionRate
@@ -87,6 +88,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopFiv
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopListenedCategories
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopPodcast
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryYearOverYear
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.FreeTrial
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import au.com.shiftyjelly.pocketcasts.utils.Util
@@ -191,6 +193,7 @@ private fun StoriesView(
                         StorySharableContent(
                             story,
                             state.userTier,
+                            state.freeTrial,
                             shouldShowUpsell,
                             onSkipPrevious,
                             onSkipNext,
@@ -238,6 +241,7 @@ private fun LoadingOverContentView() {
 private fun StorySharableContent(
     story: Story,
     userTier: UserTier,
+    freeTrial: FreeTrial,
     shouldShowUpsell: () -> Boolean,
     onSkipPrevious: () -> Unit,
     onSkipNext: () -> Unit,
@@ -292,7 +296,7 @@ private fun StorySharableContent(
                 )
             }
             if (shouldShowUpsell()) {
-                PaidStoryWallView()
+                PaidStoryWallView(freeTrial)
                 onPause()
             }
         }
@@ -527,6 +531,10 @@ private fun StoriesScreenPreview(
                     widths = listOf(0.25f, 0.75f)
                 ),
                 userTier = UserTier.Free,
+                freeTrial = FreeTrial(
+                    subscriptionTier = Subscription.SubscriptionTier.PLUS,
+                    exists = false,
+                ),
             ),
             progress = MutableStateFlow(0.75f),
             shouldShowUpsell = { false },

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -195,6 +195,9 @@ class StoriesViewModel @Inject constructor(
         }
     }
 
+    fun shouldShowUpsell() =
+        currentStoryIsPlus && !isPaidUser()
+
     private fun numberOfPlusStoriesBeforeTheCurrentOne(): Int {
         if (isPaidUser()) return 0
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/PaidStoryWallView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/PaidStoryWallView.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -18,7 +17,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.UpsellButtonTitle
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeDisplayMode
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
@@ -86,27 +84,36 @@ private fun UpsellButton(
     freeTrial: FreeTrial,
     modifier: Modifier = Modifier,
 ) {
-    RowButton(
+    StoryButton(
         text = UpsellButtonTitle(
             tier = freeTrial.subscriptionTier,
             hasFreeTrial = freeTrial.exists,
         ),
-        colors = ButtonDefaults.buttonColors(backgroundColor = Color.White),
-        textColor = Color.Black,
-        onClick = {},
         modifier = modifier
-            .fillMaxSize(.65f)
     )
 }
 
-@Preview
+@Preview("has free trial")
 @Composable
-fun PaidStoryWallViewPreview() {
+fun PaidStoryWallViewFreeTrialPreview() {
     AppTheme(Theme.ThemeType.DARK) {
         PaidStoryWallView(
             freeTrial = FreeTrial(
                 subscriptionTier = SubscriptionTier.PLUS,
                 exists = true,
+            )
+        )
+    }
+}
+
+@Preview("does not have free trial")
+@Composable
+fun PaidStoryWallViewNoFreeTrialPreview() {
+    AppTheme(Theme.ThemeType.DARK) {
+        PaidStoryWallView(
+            freeTrial = FreeTrial(
+                subscriptionTier = SubscriptionTier.PLUS,
+                exists = false,
             )
         )
     }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/PaidStoryWallView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/PaidStoryWallView.kt
@@ -19,15 +19,18 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+import au.com.shiftyjelly.pocketcasts.compose.buttons.UpsellButtonTitle
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeDisplayMode
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.Story
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.FreeTrial
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun PaidStoryWallView(
+    freeTrial: FreeTrial,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -56,7 +59,7 @@ fun PaidStoryWallView(
 
         Spacer(modifier = modifier.height(14.dp))
 
-        UpgradeButton()
+        UpsellButton(freeTrial)
 
         Spacer(modifier = modifier.weight(1f))
     }
@@ -79,12 +82,15 @@ private fun SecondaryText(
 }
 
 @Composable
-private fun UpgradeButton(
+private fun UpsellButton(
+    freeTrial: FreeTrial,
     modifier: Modifier = Modifier,
 ) {
-    val text = stringResource(LR.string.trial_start)
     RowButton(
-        text = text,
+        text = UpsellButtonTitle(
+            tier = freeTrial.subscriptionTier,
+            hasFreeTrial = freeTrial.exists,
+        ),
         colors = ButtonDefaults.buttonColors(backgroundColor = Color.White),
         textColor = Color.Black,
         onClick = {},
@@ -97,6 +103,11 @@ private fun UpgradeButton(
 @Composable
 fun PaidStoryWallViewPreview() {
     AppTheme(Theme.ThemeType.DARK) {
-        PaidStoryWallView()
+        PaidStoryWallView(
+            freeTrial = FreeTrial(
+                subscriptionTier = SubscriptionTier.PLUS,
+                exists = true,
+            )
+        )
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/PaidStoryWallView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/PaidStoryWallView.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -12,7 +11,12 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -36,7 +40,7 @@ fun PaidStoryWallView(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
             .fillMaxSize()
-            .background(Color.White.copy(alpha = 0.3f))
+            .fadeBackground()
             .verticalScroll(rememberScrollState())
             .padding(vertical = 40.dp)
     ) {
@@ -92,6 +96,23 @@ private fun UpsellButton(
         modifier = modifier
     )
 }
+
+private fun Modifier.fadeBackground() = this
+    .graphicsLayer { alpha = 0.99f }
+    .drawWithCache {
+        onDrawWithContent {
+            drawRect(
+                brush = Brush.linearGradient(
+                    0.00f to Color.Black,
+                    1.00f to Color.Black.copy(alpha = 0f),
+                    start = Offset(0.5f * size.width, 0.24f * size.height),
+                    end = Offset(0.5f * size.width, 1.04f * size.height)
+                ),
+                blendMode = BlendMode.DstIn
+            )
+            drawContent()
+        }
+    }
 
 @Preview("has free trial")
 @Composable

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/PaidStoryWallView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/PaidStoryWallView.kt
@@ -1,0 +1,102 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeDisplayMode
+import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.Story
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun PaidStoryWallView(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        verticalArrangement = Arrangement.Bottom,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.White.copy(alpha = 0.3f))
+            .verticalScroll(rememberScrollState())
+            .padding(vertical = 40.dp)
+    ) {
+        Spacer(modifier = modifier.weight(0.2f))
+
+        SubscriptionBadgeForTier(
+            tier = SubscriptionTier.PLUS,
+            displayMode = SubscriptionBadgeDisplayMode.Colored,
+        )
+
+        Spacer(modifier = modifier.height(14.dp))
+
+        PrimaryText()
+
+        Spacer(modifier = modifier.height(14.dp))
+
+        SecondaryText()
+
+        Spacer(modifier = modifier.height(14.dp))
+
+        UpgradeButton()
+
+        Spacer(modifier = modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun PrimaryText(
+    modifier: Modifier = Modifier,
+) {
+    val text = stringResource(LR.string.end_of_year_stories_theres_more)
+    StoryPrimaryText(text = text, color = Story.TintColor, modifier = modifier)
+}
+
+@Composable
+private fun SecondaryText(
+    modifier: Modifier = Modifier,
+) {
+    val text = stringResource(LR.string.end_of_year_stories_subscribe_to_plus)
+    StorySecondaryText(text = text, color = Story.SubtitleColor, modifier = modifier)
+}
+
+@Composable
+private fun UpgradeButton(
+    modifier: Modifier = Modifier,
+) {
+    val text = stringResource(LR.string.trial_start)
+    RowButton(
+        text = text,
+        colors = ButtonDefaults.buttonColors(backgroundColor = Color.White),
+        textColor = Color.Black,
+        onClick = {},
+        modifier = modifier
+            .fillMaxSize(.65f)
+    )
+}
+
+@Preview
+@Composable
+fun PaidStoryWallViewPreview() {
+    AppTheme(Theme.ThemeType.DARK) {
+        PaidStoryWallView()
+    }
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/StoryButton.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/StoryButton.kt
@@ -1,0 +1,28 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.components
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+
+private val ButtonTextColor = Color(0xFF161718)
+
+@Composable
+fun StoryButton(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    RowButton(
+        text = text,
+        fontFamily = StoryFontFamily,
+        colors = ButtonDefaults.buttonColors(backgroundColor = Color.White),
+        cornerRadius = 4.dp,
+        textColor = ButtonTextColor,
+        onClick = {},
+        modifier = modifier
+            .fillMaxSize(.65f)
+    )
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellView.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.buttons.UpsellButtonTitle
 import au.com.shiftyjelly.pocketcasts.compose.images.HorizontalLogoText
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeDisplayMode
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
@@ -78,7 +79,10 @@ private fun UpsellViewContent(
         message = getMessage(
             state.showEarlyAccessMessage,
         ),
-        buttonTitle = getButtonTitle(state.freeTrial.subscriptionTier, state.freeTrial.exists),
+        buttonTitle = UpsellButtonTitle(
+            state.freeTrial.subscriptionTier,
+            state.freeTrial.exists
+        ),
         buttonAction = onClick,
         style = style,
         modifier = modifier,
@@ -89,23 +93,6 @@ private fun SubscriptionTier.getContentDescription() = when (this) {
     SubscriptionTier.PATRON -> LR.string.pocket_casts_patron
     SubscriptionTier.PLUS -> LR.string.pocket_casts_plus
     SubscriptionTier.UNKNOWN -> throw IllegalStateException("Unknown subscription tier")
-}
-
-@Composable
-private fun getButtonTitle(
-    tier: SubscriptionTier,
-    hasFreeTrial: Boolean
-) = if (hasFreeTrial) {
-    stringResource(LR.string.profile_start_free_trial)
-} else {
-    stringResource(
-        LR.string.upgrade_to,
-        when (tier) {
-            SubscriptionTier.PATRON -> stringResource(LR.string.pocket_casts_patron_short)
-            SubscriptionTier.PLUS -> stringResource(LR.string.pocket_casts_plus_short)
-            SubscriptionTier.UNKNOWN -> throw IllegalStateException("Unknown subscription tier")
-        }
-    )
 }
 
 @Composable

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellView.kt
@@ -23,6 +23,7 @@ import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.UpsellViewModel.UiState
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.FreeTrial
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -58,7 +59,7 @@ private fun UpsellViewContent(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val description = stringResource(state.tier.getContentDescription())
+    val description = stringResource(state.freeTrial.subscriptionTier.getContentDescription())
     MessageView(
         titleView = {
             Row(
@@ -69,7 +70,7 @@ private fun UpsellViewContent(
                 HorizontalLogoText()
                 Spacer(modifier = Modifier.width(8.dp))
                 SubscriptionBadgeForTier(
-                    tier = state.tier,
+                    tier = state.freeTrial.subscriptionTier,
                     displayMode = SubscriptionBadgeDisplayMode.Colored
                 )
             }
@@ -77,7 +78,7 @@ private fun UpsellViewContent(
         message = getMessage(
             state.showEarlyAccessMessage,
         ),
-        buttonTitle = getButtonTitle(state.tier, state.hasFreeTrial),
+        buttonTitle = getButtonTitle(state.freeTrial.subscriptionTier, state.freeTrial.exists),
         buttonAction = onClick,
         style = style,
         modifier = modifier,
@@ -125,8 +126,10 @@ private fun UpsellPreview(
         UpsellViewContent(
             style = MessageViewColors.Default,
             state = UiState.Loaded(
-                tier = SubscriptionTier.PATRON,
-                hasFreeTrial = false,
+                freeTrial = FreeTrial(
+                    exists = false,
+                    subscriptionTier = SubscriptionTier.PATRON,
+                ),
                 showEarlyAccessMessage = false,
             ),
             onClick = {},

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellViewModel.kt
@@ -5,10 +5,8 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
-import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
-import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.FreeTrial
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.EarlyAccessState
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
@@ -21,14 +19,13 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.reactive.asFlow
 import javax.inject.Inject
 
 @HiltViewModel
 class UpsellViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val subscriptionManager: SubscriptionManager,
-    private val feature: FeatureWrapper,
+    feature: FeatureWrapper,
     private val releaseVersion: ReleaseVersionWrapper,
 ) : ViewModel() {
 
@@ -36,31 +33,6 @@ class UpsellViewModel @Inject constructor(
     val state: StateFlow<UiState> = _state
 
     init {
-        viewModelScope.launch {
-            subscriptionManager
-                .observeProductDetails()
-                .asFlow()
-                .stateIn(viewModelScope)
-                .collect { productDetails ->
-                    val subscriptions = when (productDetails) {
-                        is ProductDetailsState.Error -> null
-                        is ProductDetailsState.Loaded -> productDetails.productDetails.mapNotNull { productDetailsState ->
-                            Subscription.fromProductDetails(
-                                productDetails = productDetailsState,
-                                isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(
-                                    SubscriptionMapper.mapProductIdToTier(productDetailsState.productId)
-                                )
-                            )
-                        }
-                    } ?: emptyList()
-                    updateState(subscriptions)
-                }
-        }
-    }
-
-    private fun updateState(
-        subscriptions: List<Subscription>,
-    ) {
         val bookmarksFeature = feature.bookmarksFeature
         val patronExclusiveAccessRelease = (bookmarksFeature.tier as? FeatureTier.Plus)?.patronExclusiveAccessRelease
 
@@ -71,23 +43,24 @@ class UpsellViewModel @Inject constructor(
         val availableForFeatureTier = when (relativeToEarlyPatronAccess) {
             null -> bookmarksFeature.tier
             EarlyAccessState.Before,
-            EarlyAccessState.During -> if (isReleaseCandidate) bookmarksFeature.tier else FeatureTier.Patron
+            EarlyAccessState.During,
+            -> if (isReleaseCandidate) bookmarksFeature.tier else FeatureTier.Patron
+
             EarlyAccessState.After -> bookmarksFeature.tier
         }
         val subscriptionTier = availableForFeatureTier.toSubscriptionTier()
 
-        // Check if subscription has a free trial
-        val trialExists = subscriptionManager.trialExists(
-            tier = availableForFeatureTier.toSubscriptionTier(),
-            subscriptions = subscriptions,
-        )
-
-        _state.update {
-            UiState.Loaded(
-                tier = subscriptionTier,
-                hasFreeTrial = trialExists,
-                showEarlyAccessMessage = bookmarksFeature.isCurrentlyExclusiveToPatron(releaseVersion),
-            )
+        viewModelScope.launch {
+            subscriptionManager.freeTrialForSubscriptionTierFlow(subscriptionTier)
+                .stateIn(this)
+                .collect { freeTrial ->
+                    _state.update {
+                        UiState.Loaded(
+                            freeTrial = freeTrial,
+                            showEarlyAccessMessage = bookmarksFeature.isCurrentlyExclusiveToPatron(releaseVersion),
+                        )
+                    }
+                }
         }
     }
 
@@ -107,8 +80,7 @@ class UpsellViewModel @Inject constructor(
     sealed class UiState {
         object Loading : UiState()
         data class Loaded(
-            val tier: SubscriptionTier,
-            val hasFreeTrial: Boolean,
+            val freeTrial: FreeTrial,
             val showEarlyAccessMessage: Boolean,
         ) : UiState()
     }

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/whatsnew/WhatsNewViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/whatsnew/WhatsNewViewModelTest.kt
@@ -2,9 +2,10 @@ package au.com.shiftyjelly.pocketcasts.whatsnew
 
 import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.localization.R
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.FreeTrial
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewViewModel
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
@@ -15,13 +16,10 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureWrapper
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersion
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersionWrapper
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
-import com.android.billingclient.api.ProductDetails
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.rx2.asFlowable
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -47,25 +45,12 @@ class WhatsNewViewModelTest {
     @Mock
     lateinit var subscriptionManager: SubscriptionManager
 
-    @Mock
-    private lateinit var productDetailsState: ProductDetailsState.Loaded
-
-    @Mock
-    private lateinit var productDetails: ProductDetails
-
     private lateinit var viewModel: WhatsNewViewModel
 
     private val betaEarlyAccessRelease = ReleaseVersion(7, 50, null, 1)
     private val productionEarlyAccessRelease = ReleaseVersion(7, 50)
     private val betaFullAccessRelease = ReleaseVersion(7, 51, null, 1)
     private val productionFullAccessRelease = ReleaseVersion(7, 51)
-
-    @Before
-    fun setUp() {
-        whenever(productDetailsState.productDetails).thenReturn(listOf(productDetails))
-        whenever(subscriptionManager.observeProductDetails()).thenReturn(flowOf(productDetailsState).asFlowable())
-        whenever(productDetails.productId).thenReturn("productId")
-    }
 
     /* Title */
     @Test
@@ -197,6 +182,9 @@ class WhatsNewViewModelTest {
         currentRelease: ReleaseVersion,
         patronExclusiveAccessRelease: ReleaseVersion?,
     ) {
+        whenever(subscriptionManager.freeTrialForSubscriptionTierFlow(Subscription.SubscriptionTier.PLUS))
+            .thenReturn(flowOf(FreeTrial(subscriptionTier = Subscription.SubscriptionTier.PLUS)))
+
         val releaseVersion = mock<ReleaseVersionWrapper>().apply {
             doReturn(currentRelease).whenever(this).currentReleaseVersion
         }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowButton.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowButton.kt
@@ -16,8 +16,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
@@ -34,8 +36,10 @@ fun RowButton(
     border: BorderStroke? = null,
     colors: ButtonColors = ButtonDefaults.buttonColors(),
     textColor: Color = MaterialTheme.theme.colors.primaryInteractive02,
+    fontFamily: FontFamily? = null,
     @DrawableRes leadingIcon: Int? = null,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    cornerRadius: Dp = 12.dp,
 ) {
     Box(
         modifier = modifier
@@ -44,7 +48,7 @@ fun RowButton(
     ) {
         Button(
             onClick = { onClick() },
-            shape = RoundedCornerShape(12.dp),
+            shape = RoundedCornerShape(cornerRadius),
             border = border,
             modifier = Modifier.fillMaxWidth(),
             colors = colors,
@@ -62,6 +66,7 @@ fun RowButton(
                 }
                 TextP40(
                     text = text,
+                    fontFamily = fontFamily,
                     modifier = Modifier
                         .padding(6.dp)
                         .align(Alignment.Center),

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/UpsellButtonTitle.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/UpsellButtonTitle.kt
@@ -1,0 +1,23 @@
+package au.com.shiftyjelly.pocketcasts.compose.buttons
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun UpsellButtonTitle(
+    tier: SubscriptionTier,
+    hasFreeTrial: Boolean,
+) = if (hasFreeTrial) {
+    stringResource(LR.string.profile_start_free_trial)
+} else {
+    stringResource(
+        LR.string.upgrade_to,
+        when (tier) {
+            SubscriptionTier.PATRON -> stringResource(LR.string.pocket_casts_patron_short)
+            SubscriptionTier.PLUS -> stringResource(LR.string.pocket_casts_plus_short)
+            SubscriptionTier.UNKNOWN -> stringResource(LR.string.pocket_casts_plus_short)
+        }
+    )
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1659,6 +1659,7 @@
     <string name="end_of_year_stories_theres_more">There\’s more!</string>>
     <!-- Subtitle explaining the user why they should susbcribe to Plus in the context of the end of year stories. -->
     <string name="end_of_year_stories_subscribe_to_plus">Subscribe to Plus and find out how your listening compares to 2022, other fun stats, and Premium features like bookmarks and folders.</string>
+
     <!-- Onboarding -->
 
     <string name="onboarding_welcome_back">Welcome Back</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1655,7 +1655,10 @@
     <!-- Title for the completion rate. %1$d is the total of episodes listened this year, %2$d is the total of episodes fully listened to. -->
     <string name="end_of_year_stories_year_completion_rate_subtitle">From the %1$d episodes you started you listened fully to a total of %2$d</string>
     <string name="end_of_year_stories_year_completion_rate">completion rate</string>
-
+    <!-- Title of the story paywall. Telling the users that there are more stories to check. -->
+    <string name="end_of_year_stories_theres_more">There\’s more!</string>>
+    <!-- Subtitle explaining the user why they should susbcribe to Plus in the context of the end of year stories. -->
+    <string name="end_of_year_stories_subscribe_to_plus">Subscribe to Plus and find out how your listening compares to 2022, other fun stats, and Premium features like bookmarks and folders.</string>
     <!-- Onboarding -->
 
     <string name="onboarding_welcome_back">Welcome Back</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/Story.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/Story.kt
@@ -8,7 +8,12 @@ abstract class Story {
     open val storyLength: Long = 5.seconds()
     open val backgroundColor: Color = Color.Black
     open val plusOnly: Boolean = false
-    val tintColor: Color = Color(0xFFFBFBFC)
-    val subtitleColor: Color = Color(0xFF8F97A4)
+    val tintColor: Color = TintColor
+    val subtitleColor: Color = SubtitleColor
     open val shareable: Boolean = true
+
+    companion object {
+        val TintColor = Color(0xFFFBFBFC)
+        val SubtitleColor = Color(0xFF8F97A4)
+    }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/StoryCompletionRate.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/StoryCompletionRate.kt
@@ -6,4 +6,5 @@ class StoryCompletionRate(
     val episodesStartedAndCompleted: EpisodesStartedAndCompleted,
 ) : Story() {
     override val identifier: String = "completion_rate"
+    override val plusOnly: Boolean = true
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/StoryYearOverYear.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/StoryYearOverYear.kt
@@ -6,4 +6,5 @@ class StoryYearOverYear(
     val yearOverYearListeningTime: YearOverYearListeningTime,
 ) : Story() {
     override val identifier: String = "year_over_year"
+    override val plusOnly: Boolean = true
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -12,6 +12,7 @@ import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchasesResult
 import io.reactivex.Flowable
 import io.reactivex.Single
+import kotlinx.coroutines.flow.Flow
 
 interface SubscriptionManager {
 
@@ -39,8 +40,5 @@ interface SubscriptionManager {
         tier: Subscription.SubscriptionTier? = null,
         frequency: SubscriptionFrequency? = null,
     ): Subscription?
-    fun trialExists(
-        tier: Subscription.SubscriptionTier,
-        subscriptions: List<Subscription>
-    ): Boolean
+    fun freeTrialForSubscriptionTierFlow(subscriptionTier: Subscription.SubscriptionTier): Flow<FreeTrial>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -46,8 +46,11 @@ import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.rx2.await
 import timber.log.Timber
 import java.util.Date
@@ -420,17 +423,35 @@ class SubscriptionManagerImpl @Inject constructor(
         } ?: tierSubscriptions.firstOrNull() // If no matching subscription is found, select first available one
     }
 
-    override fun trialExists(
-        tier: Subscription.SubscriptionTier,
-        subscriptions: List<Subscription>
-    ): Boolean {
-        val updatedSubscriptions = subscriptions.filter { it.tier == tier }
-        val defaultSubscription = getDefaultSubscription(
-            subscriptions = updatedSubscriptions,
-            tier = tier,
-        )
-        return defaultSubscription?.trialPricingPhase != null
-    }
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun freeTrialForSubscriptionTierFlow(subscriptionTier: Subscription.SubscriptionTier) = this
+        .observeProductDetails()
+        .asFlow()
+        .transformLatest { productDetails ->
+            val subscriptions = when (productDetails) {
+                is ProductDetailsState.Error -> null
+                is ProductDetailsState.Loaded -> productDetails.productDetails.mapNotNull { productDetailsState ->
+                    Subscription.fromProductDetails(
+                        productDetails = productDetailsState,
+                        isFreeTrialEligible = isFreeTrialEligible(
+                            mapProductIdToTier(productDetailsState.productId)
+                        )
+                    )
+                }
+            } ?: emptyList()
+
+            val updatedSubscriptions = subscriptions.filter { it.tier == subscriptionTier }
+            val defaultSubscription = getDefaultSubscription(
+                subscriptions = updatedSubscriptions,
+                tier = subscriptionTier,
+            )
+            emit(
+                FreeTrial(
+                    subscriptionTier = subscriptionTier,
+                    exists = defaultSubscription?.trialPricingPhase != null,
+                )
+            )
+        }
 }
 
 private fun shouldAllowUpgradePlan(
@@ -460,6 +481,11 @@ sealed class SubscriptionChangedEvent {
     object AccountUpgradedToPlus : SubscriptionChangedEvent()
     object AccountDowngradedToFree : SubscriptionChangedEvent()
 }
+
+data class FreeTrial(
+    val subscriptionTier: Subscription.SubscriptionTier,
+    val exists: Boolean = false,
+)
 
 private fun SubscriptionStatusResponse.toStatus(): SubscriptionStatus {
     val originalPlatform = SubscriptionPlatform.values().getOrNull(platform) ?: SubscriptionPlatform.NONE


### PR DESCRIPTION
| 📘 Part of: #1463 | 🎨 Designs: lH66LwxxgG8btQ8NrM0ldx-fi-1599_20385 |
|:---:|:---:|

## Description
Adds paid wall view for Plus Upsell story 

## Testing Instructions
1. Make sure you're logged in to an account that has a few episodes listened
2. Go to Profile
3. Tap the EOY image
4. Skip to the 1st Plus story
5. ✅ Notice you see Upsell button with a blurred background
6. ✅ Notice that Upsell button title is shown correctly based on free trial for Plus (this can also be checked in `PaidStoryWallView.kt `previews)
7.  ✅ Notice that story is paused
8. ✅ Notice that tapping on left on this Upsell story should take to the previous free story
9. ✅ Notice that tapping on right on this Upsell story  should take to the epilogue story skipping plus stories in between
10. ✅ Notice that tapping on close button on this Upsell story should dismiss the stories modal

## Screenshots or Screencast 

Upsell
|---|
|<img width =320 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/f3e3a989-6418-406f-836a-9abf5872cfea"/>|


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
