### PR TITLE
Fix change email handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 *   Bug Fixes:
     *   Avoid brief audio skip back when a streaming episode is downloaded
         ([#1510](https://github.com/Automattic/pocket-casts-android/pull/1510))
+    *   Fix change email handling issues
+        ([#1518](https://github.com/Automattic/pocket-casts-android/pull/1518))
 
 7.51
 -----

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ChangeEmailViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ChangeEmailViewModel.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.account.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -93,7 +92,6 @@ class ChangeEmailViewModel
             })
             .addTo(disposables)
     }
-
 }
 
 enum class ChangeEmailError {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ChangeEmailViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ChangeEmailViewModel.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -18,7 +19,8 @@ class ChangeEmailViewModel
 
     var existingEmail = syncManager.getEmail()
 
-    val changeEmailState = MutableLiveData<ChangeEmailState>().apply { value = ChangeEmailState.Empty }
+    val changeEmailState =
+        MutableLiveData<ChangeEmailState>().apply { value = ChangeEmailState.Empty }
     private val disposables = CompositeDisposable()
 
     private fun errorUpdate(error: ChangeEmailError, add: Boolean, message: String?) {
@@ -27,6 +29,7 @@ class ChangeEmailViewModel
             is ChangeEmailState.Failure -> {
                 errors.addAll(existingState.errors)
             }
+
             else -> {}
         }
         if (add) errors.add(error) else errors.remove(error)
@@ -81,7 +84,9 @@ class ChangeEmailViewModel
                 }
             }
             .doFinally {
-                disposables.clear()
+                if (disposables.isDisposed.not()) {
+                    disposables.clear()
+                }
             }
             .subscribeBy(onError = {
                 Timber.e(it)
@@ -101,5 +106,6 @@ sealed class ChangeEmailState {
     object Empty : ChangeEmailState()
     object Loading : ChangeEmailState()
     data class Success(val result: String) : ChangeEmailState()
-    data class Failure(val errors: MutableSet<ChangeEmailError>, val message: String?) : ChangeEmailState()
+    data class Failure(val errors: MutableSet<ChangeEmailError>, val message: String?) :
+        ChangeEmailState()
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ChangeEmailViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ChangeEmailViewModel.kt
@@ -80,14 +80,15 @@ class ChangeEmailViewModel
                     changeEmailState.postValue(ChangeEmailState.Failure(errors, response.message))
                 }
             }
-            .subscribeBy(onError = { Timber.e(it) })
+            .doFinally {
+                disposables.clear()
+            }
+            .subscribeBy(onError = {
+                Timber.e(it)
+            })
             .addTo(disposables)
     }
 
-    override fun onCleared() {
-        super.onCleared()
-        disposables.clear()
-    }
 }
 
 enum class ChangeEmailError {


### PR DESCRIPTION
## Description
I moved the ```disposables.clear()``` in the ```onCleared()``` viewmodel to the ```doFinally { }``` in the ```changeEmail()``` function. Clear composite disposables in the ```onCleared()``` inflict the http request canceled by the client upon ```ChangeEmailFragment``` destroyed, since the http request already sent and being processed by server with http canceled by client we lost our response and can't update email in the AccountManager. By moving ```disposables.clear()``` to the ```doFinally{}``` we ensure that the http call not canceled when we navigate from the ```ChangeEmailFragment``` and the disposable cleared upon request finished.

Fixes #1511 

## Testing Instructions
1. login with an email address 
2. Go to ```Profile``` -> ```Account```
3. On the ```Pocket Casts Account``` screen, tap ```Change email address```
4. On the ```Change Email Address``` screen, enter new email and confirm password
5. Tap ```Confirm```
6. Quickly navigate away from the screen while the request is in progress
7. Notice that in ```Profile``` tab email already updated if the change email success.
<!-- 3. etc. -->

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/37836973/b3713f77-bb1d-4506-932b-077f9d7202a8


<!-- if applicable -->

## Checklist
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes

 
