### PR TITLE
Playback 2023: Sync 2022 and 2023 listening history

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
@@ -18,6 +18,6 @@ interface EndOfYearManager {
     suspend fun findListenedNumbersForYear(year: Int): ListenedNumbers
     suspend fun findTopPodcastsForYear(year: Int, limit: Int): List<TopPodcast>
     suspend fun findLongestPlayedEpisodeForYear(year: Int): LongestEpisode?
-    suspend fun getYearOverYearListeningTime(): YearOverYearListeningTime?
-    suspend fun countEpisodesStartedAndCompleted(): EpisodesStartedAndCompleted
+    suspend fun getYearOverYearListeningTime(thisYear: Int): YearOverYearListeningTime?
+    suspend fun countEpisodesStartedAndCompleted(year: Int): EpisodesStartedAndCompleted
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -6,6 +6,7 @@ import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.db.helper.LongestEpisode
 import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
 import au.com.shiftyjelly.pocketcasts.models.db.helper.YearOverYearListeningTime
+import au.com.shiftyjelly.pocketcasts.preferences.BuildConfig
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.Story
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryCompletionRate
@@ -82,9 +83,15 @@ class EndOfYearManagerImpl @Inject constructor(
             awaitAll(
                 *yearsToSync.map { year ->
                     // Download listening history for each year in parallel
+                    if (BuildConfig.DEBUG) {
+                        Timber.i("End of Year: Downloading listening history for year $year")
+                    }
                     async { downloadListeningHistory(year, onProgressChanged) }
                 }.toTypedArray()
             )
+        }
+        if (BuildConfig.DEBUG) {
+            Timber.i("End of Year: listening history sync complete")
         }
         onProgressChanged(1f)
     }
@@ -115,6 +122,9 @@ class EndOfYearManagerImpl @Inject constructor(
                 onProgressChanged = {
                     synced += 1
                     val progress = min((0.2f + (synced / syncTotal) * 0.8f), 0.95).toFloat()
+                    if (BuildConfig.DEBUG) {
+                        Timber.i("End of Year: listening history sync year: $year total progress: $progress")
+                    }
                     onProgressChanged(progress)
                 },
             )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/HistoryManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/HistoryManager.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.HistorySyncResponse
+import au.com.shiftyjelly.pocketcasts.preferences.BuildConfig
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import io.reactivex.Observable
@@ -14,6 +15,7 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
+import kotlin.math.min
 
 class HistoryManager @Inject constructor(
     private val podcastManager: PodcastManager,
@@ -30,17 +32,18 @@ class HistoryManager @Inject constructor(
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
 
+    private var synced: Double = 0.0
+    private var syncTotal: Double = 0.0
+
     /**
      * Read the server listening history response.
      * @param response The server response.
      * @param updateServerModified Set to true when this is latest listening history, rather than part of the user's history.
-     * @param updateSyncTotal Callback to update the total number of podcasts to sync.
      */
     suspend fun processServerResponse(
         response: HistorySyncResponse,
         updateServerModified: Boolean,
-        updateSyncTotal: ((Float) -> Unit)? = null,
-        onProgressChanged: (() -> Unit)? = null,
+        onProgressChanged: ((Float) -> Unit)? = null,
     ) = withContext(Dispatchers.IO) {
         if (!response.hasChanged(0) || response.changes.isNullOrEmpty()) {
             return@withContext
@@ -57,7 +60,7 @@ class HistoryManager @Inject constructor(
         val missingPodcastUuids = podcastUuids.minus(databaseSubscribedPodcastUuids)
 
         val total = missingPodcastUuids.size.toFloat()
-        updateSyncTotal?.invoke(total)
+        syncTotal += total
 
         // add the podcasts five at a time
         Observable.fromIterable(missingPodcastUuids)
@@ -71,7 +74,15 @@ class HistoryManager @Inject constructor(
                 }, true, ADD_PODCAST_CONCURRENCY
             )
             .doOnNext {
-                onProgressChanged?.invoke()
+                synced += 1
+                // Progress events towards the end can be too close to 100%
+                // giving an impression that nothing is happening even when progress is complete,
+                // so we cap it at 95% until it's done.
+                val progress = min((0.2f + (synced / syncTotal) * 0.8f), 0.95).toFloat()
+                if (BuildConfig.DEBUG) {
+                    Timber.i("Listening history sync progress: $progress")
+                }
+                onProgressChanged?.invoke(progress)
             }
             .toList()
             .await()
@@ -108,5 +119,10 @@ class HistoryManager @Inject constructor(
         if (updateServerModified) {
             settings.setHistoryServerModified(response.serverModified)
         }
+    }
+
+    fun resetSyncCount() {
+        synced = 0.0
+        syncTotal = 0.0
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImplTest.kt
@@ -3,23 +3,32 @@ package au.com.shiftyjelly.pocketcasts.repositories.endofyear
 import au.com.shiftyjelly.pocketcasts.models.db.helper.EpisodesStartedAndCompleted
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.db.helper.YearOverYearListeningTime
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryCompletionRate
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.HistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.servers.sync.history.HistoryYearResponse
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mock
+import org.mockito.Mockito.atLeast
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -40,10 +49,82 @@ class EndOfYearManagerImplTest {
     @Mock
     lateinit var syncManager: SyncManager
 
+    @Mock
+    lateinit var settings: Settings
+
     private lateinit var endOfYearManagerImpl: EndOfYearManagerImpl
 
-    @Before
-    fun setup() = runTest {
+    @Test
+    fun testCompletionRateStory() = runTest {
+        initEndOfYearManager()
+        whenever(episodeManager.countEpisodesStartedAndCompleted(anyLong(), anyLong())).thenReturn(
+            EpisodesStartedAndCompleted(100, 50)
+        )
+        val stories = endOfYearManagerImpl.loadStories()
+
+        val storyCompletionRate = stories.firstOrNull { it is StoryCompletionRate } as? StoryCompletionRate
+        assertTrue(storyCompletionRate?.episodesStartedAndCompleted?.percentage == 50.0)
+    }
+
+    /* Sync */
+    @Test
+    fun testRequiresNoSyncWhenServerCountEqualsLocalCount() = runTest {
+        initEndOfYearManager(
+            userTier = listOf(UserTier.Free, UserTier.Plus).random(),
+            listeningHistorySyncLocalCount = 10,
+            listeningHistorySyncServerCount = 10,
+        )
+
+        endOfYearManagerImpl.downloadListeningHistory {}
+
+        verify(historyManager, times(0))
+            .processServerResponse(any(), any(), anyOrNull(), anyOrNull())
+    }
+
+    @Test
+    fun testRequiresSyncWhenServerCountGreaterThanLocalCount() = runTest {
+        initEndOfYearManager(
+            userTier = listOf(UserTier.Free, UserTier.Plus).random(),
+            listeningHistorySyncLocalCount = 5,
+            listeningHistorySyncServerCount = 10,
+        )
+
+        endOfYearManagerImpl.downloadListeningHistory {}
+
+        verify(historyManager, atLeast(1))
+            .processServerResponse(any(), any(), anyOrNull(), anyOrNull())
+    }
+
+    @Test
+    fun testSyncWhenFreeUser() = runTest {
+        initEndOfYearManager(userTier = UserTier.Free)
+
+        endOfYearManagerImpl.downloadListeningHistory {}
+
+        with(syncManager) {
+            verify(this).historyYear(2023, false) // synced for this year
+            verify(this, times(0)).historyYear(2022, false) // not synced for last year
+        }
+    }
+
+    @Test
+    fun testSyncWhenPlusUser() = runTest {
+        initEndOfYearManager(userTier = UserTier.Plus)
+
+        endOfYearManagerImpl.downloadListeningHistory {}
+
+        with(syncManager) {
+            verify(this).historyYear(2023, false) // synced for this year
+            verify(this).historyYear(2022, false) // synced for last year
+        }
+    }
+
+    private fun initEndOfYearManager(
+        userTier: UserTier = UserTier.Free,
+        listeningHistorySyncLocalCount: Int = 5,
+        listeningHistorySyncServerCount: Long = 10,
+    ) = runTest {
+        whenever(settings.userTier).thenReturn(userTier)
         whenever(episodeManager.findListenedNumbers(anyLong(), anyLong())).thenReturn(ListenedNumbers())
         whenever(podcastManager.findTopPodcasts(anyLong(), anyLong(), anyInt())).thenReturn(emptyList())
         whenever(episodeManager.findListenedCategories(anyLong(), anyLong())).thenReturn(emptyList())
@@ -53,22 +134,19 @@ class EndOfYearManagerImplTest {
         whenever(episodeManager.countEpisodesStartedAndCompleted(anyLong(), anyLong())).thenReturn(
             EpisodesStartedAndCompleted(0, 0)
         )
+        whenever(syncManager.isLoggedIn()).thenReturn(true)
+        val historyCountResponse = mock<HistoryYearResponse>()
+        whenever(historyCountResponse.count).thenReturn(listeningHistorySyncServerCount) // set server count
+        whenever(historyCountResponse.history).thenReturn(mock())
+        whenever(syncManager.historyYear(anyInt(), anyBoolean())).thenReturn(historyCountResponse)
+        whenever(episodeManager.countEpisodesInListeningHistory(anyLong(), anyLong())).thenReturn(listeningHistorySyncLocalCount) // set local count
+
         endOfYearManagerImpl = EndOfYearManagerImpl(
             episodeManager = episodeManager,
             podcastManager = podcastManager,
             historyManager = historyManager,
-            syncManager = syncManager
+            syncManager = syncManager,
+            settings = settings,
         )
-    }
-
-    @Test
-    fun testCompletionRateStory() = runTest {
-        whenever(episodeManager.countEpisodesStartedAndCompleted(anyLong(), anyLong())).thenReturn(
-            EpisodesStartedAndCompleted(100, 50)
-        )
-        val stories = endOfYearManagerImpl.loadStories()
-
-        val storyCompletionRate = stories.firstOrNull { it is StoryCompletionRate } as? StoryCompletionRate
-        assertTrue(storyCompletionRate?.episodesStartedAndCompleted?.percentage == 50.0)
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImplTest.kt
@@ -78,7 +78,7 @@ class EndOfYearManagerImplTest {
         endOfYearManagerImpl.downloadListeningHistory {}
 
         verify(historyManager, times(0))
-            .processServerResponse(any(), any(), anyOrNull(), anyOrNull())
+            .processServerResponse(any(), any(), anyOrNull())
     }
 
     @Test
@@ -92,7 +92,7 @@ class EndOfYearManagerImplTest {
         endOfYearManagerImpl.downloadListeningHistory {}
 
         verify(historyManager, atLeast(1))
-            .processServerResponse(any(), any(), anyOrNull(), anyOrNull())
+            .processServerResponse(any(), any(), anyOrNull())
     }
 
     @Test


### PR DESCRIPTION
| 📘 Part of: #1463 |
|:---:|

This PR adds logic for syncing 2022 and 2023 data.

## Testing Instructions

#### Test.1 Plus user  

1. Clean install debug build
2. Make sure you're logged in with a plus account that has a few episodes listened to this year and last year
3. Open stories
4. ✅ You should see in logs `End of Year: Downloading listening history for year xxx` for both 2022, 2023
6. Go to the "Year over Year" story
7. Notice you do not see any upsell button
8. Tap next
9. ✅ You should see the completion rate story

#### Test.2 Free user - Purchase from stories (release build) - triggers purchase flow

Prerequisites
- Enable EoY Year for release build
- Release build
- License test account 

 _(See Test.2 (Optional) if you want to test it on debug build)_

1. Clean install release build
2. Make sure you're logged in to a license account as a free user that has a few episodes listened to this year and last year
3. Open stories
4. Go to the "Year over Year" story
5. Purchase Plus or Patron
6. ✅ You should see a screen with a spinner, meaning your 2022 data is syncing
7. After it finishes, you should see the "Year over Year" story
8. Tap next
9. ✅ You should see the completion rate story

#### Test.3 (Optional) Free user - Purchase from stories (debug build)  - does not trigger purchase flow but you can test syncing

Prerequisites
- Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/13265366/test_syncing.patch)

1. Clean install debug build
2. Make sure you're logged in with a free account that has a few episodes listened to this year and last year
3. Open stories
4. ✅ You should see in logs `End of Year: Downloading listening history for year xxx` for 2023 only
5. Wait for 2023 sync to complete
6. Go to the "Year over Year" story
7. Add Plus plan to the account using admin console
8. Tap upsell button
9. ✅ You should see in logs `End of Year: Downloading listening history for year xxx` for 2023, 2022. Since 2023 data is already synced at step 6, 2022 data should be synced now.
10. ✅ You should see a screen with a spinner, meaning your 2022 data is syncing
11. After it finishes, you should see the "Year over Year" story
12. Tap next
13. ✅ You should see the completion rate story


https://github.com/Automattic/pocket-casts-android/assets/1405144/6d13ba17-ff2b-482c-8d3b-532acd9e72cb

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
