### PR TITLE
Fix Chapter Length Calculation Mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
         ([#1510](https://github.com/Automattic/pocket-casts-android/pull/1510))
     *   Fix change email handling issues
         ([#1518](https://github.com/Automattic/pocket-casts-android/pull/1518))
-
+    *   Fix Chapter Length Calculation Mismatch
+        ([#1525](https://github.com/Automattic/pocket-casts-android/pull/1525))
 7.51
 -----
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/to/ChapterTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/to/ChapterTest.kt
@@ -15,7 +15,7 @@ class ChapterTest {
 
         assertEquals("1m", chapter.remainingTime(5000))
         assertEquals("59s", chapter.remainingTime(11000))
-        assertEquals("2s", chapter.remainingTime(68000))
+        assertEquals("1s", chapter.remainingTime(68000))
         assertEquals("0s", chapter.remainingTime(70000))
     }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapter.kt
@@ -35,11 +35,11 @@ data class Chapter(
         val length = endTime - startTime
         val remaining = length * (1f - progress)
         val minutesRemaining = remaining / 1000f / 60f
-        if (minutesRemaining >= 1) {
-            return "${minutesRemaining.roundToInt()}m"
+        return if (minutesRemaining >= 1) {
+            "${minutesRemaining.toInt()}m"
         } else {
             val secondsRemaining = remaining / 1000f
-            return "${secondsRemaining.roundToInt()}s"
+            "${secondsRemaining.toInt()}s"
         }
     }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapter.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.models.to
 
 import okhttp3.HttpUrl
-import kotlin.math.roundToInt
 
 data class Chapter(
     val title: String,


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Change convert ```rountToInt()``` in ```au.com.shiftyjelly.pocketcasts.models.to.Chapter.remainingTime``` to ```toInt()``` so that the minutes not rounded up. For example before when we have ```timeMs``` 1 min 39 s in the ```Now Playing``` tab displayed 2 min but in the ```Chapters``` tab displayed 1 min.

Fixes #1505  <!-- issue number, if applicable -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->
1. Play episode [https://pca.st/ap314mdp](https://pca.st/ap314mdp)
2. In the ```Now Playing``` tab check the chapter length
3. In the ```Chapters``` tab check whether the chapter length same with displayed in the ```Now Playing``` tab.

## Screenshots or Screencast 
<!-- if applicable -->
<img width="369" alt="Screenshot 2023-11-07 at 22 46 20" src="https://github.com/Automattic/pocket-casts-android/assets/37836973/27cf3fa6-f844-4d0f-86f9-4f4dcc68bb92">
<img width="384" alt="Screenshot 2023-11-07 at 22 45 49" src="https://github.com/Automattic/pocket-casts-android/assets/37836973/b58b256a-387f-46b2-a242-7a785d024799">


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
