### PR TITLE
Enable bookmarks with Patron early access in 7.52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 7.52
 -----
 
+* New Features:
+    *   Bookmarks entering Patron early access with full release for Plus users in 7.53
+        ([#1526](https://github.com/Automattic/pocket-casts-android/pull/1526))
 *   Bug Fixes:
     *   Avoid brief audio skip back when a streaming episode is downloaded
         ([#1510](https://github.com/Automattic/pocket-casts-android/pull/1510))

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -30,8 +30,8 @@ enum class Feature(
     BOOKMARKS_ENABLED(
         key = "bookmarks_enabled",
         title = "Bookmarks",
-        defaultValue = BuildConfig.DEBUG,
-        tier = FeatureTier.Plus(null),
+        defaultValue = true,
+        tier = FeatureTier.Plus(ReleaseVersion(major = 7, minor = 52)),
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -34,7 +34,7 @@ enum class Feature(
         tier = FeatureTier.Plus(
             patronExclusiveAccessRelease = ReleaseVersion(major = 7, minor = 52)
         ),
-        hasFirebaseRemoteFlag = false,
+        hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
     IN_APP_REVIEW_ENABLED(

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -31,7 +31,9 @@ enum class Feature(
         key = "bookmarks_enabled",
         title = "Bookmarks",
         defaultValue = true,
-        tier = FeatureTier.Plus(ReleaseVersion(major = 7, minor = 52)),
+        tier = FeatureTier.Plus(
+            patronExclusiveAccessRelease = ReleaseVersion(major = 7, minor = 52)
+        ),
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),


### PR DESCRIPTION
## Description
This enables bookmarks for entering Patron early access in `7.52` and for full release in `7.53`.

## Testing Instructions

I think it's worth double-checking that our logic is hitting all the right states for the right releases now that we know the release version. Using release builds with the following versions (specified in [versions.properties](https://github.com/Automattic/pocket-casts-android/blob/main/version.properties)), you should see the following behavior for bookmarks:

| App version | Not signed in | Free          | Plus          | Patron    |
| ---| ---- | ----- | ------ | ------|
| `7.52-rc-1`   | Plus upsell   | Plus upsell   | Available     | Available |
| `7.52`        | Patron upsell | Patron upsell | Patron upsell | Available |
| `7.53-rc-1`   | Plus upsell   | Plus upsell   | Available     | Available |
| `7.53`        | Plus upsell   | Plus upsell   | Available     | Available |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews