### PR TITLE
Playback 2023: prompt user to share when a screenshot is taken 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,8 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.VIBRATE"/>

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -19,6 +19,7 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.utils.ScreenshotDetector
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseAppCompatDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -35,6 +36,9 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
 
     @Inject
     lateinit var analyticsTracker: AnalyticsTrackerWrapper
+
+    @Inject
+    lateinit var screenshotDetector: ScreenshotDetector
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState)
@@ -64,6 +68,7 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
                     analyticsTracker.track(AnalyticsEvent.END_OF_YEAR_STORIES_SHOWN, AnalyticsProp.storiesShown(source))
                     StoriesPage(
                         viewModel = viewModel,
+                        screenshotDetector = screenshotDetector,
                         onCloseClicked = {
                             analyticsTracker.track(AnalyticsEvent.END_OF_YEAR_STORIES_DISMISSED, AnalyticsProp.StoriesDismissed.closeButton)
                             dismiss()

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/ShareScreenshotAlert.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/ShareScreenshotAlert.kt
@@ -1,0 +1,41 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.components.DialogButtonState
+import au.com.shiftyjelly.pocketcasts.compose.components.DialogFrame
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import com.afollestad.materialdialogs.ModalDialog.onDismiss
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun ShareScreenshotAlert(
+    onPositiveButtonClicked: () -> Unit,
+    onNegativeButtonClicked: () -> Unit,
+) {
+    DialogFrame(
+        title = stringResource(LR.string.end_of_year_share_story_alert_title),
+        buttons = listOf(
+            DialogButtonState(
+                text = stringResource(LR.string.share),
+                onClick = { onPositiveButtonClicked() }
+            ),
+            DialogButtonState(
+                text = stringResource(LR.string.not_now),
+                onClick = { onNegativeButtonClicked() }
+            ),
+        ),
+        onDismissRequest = { onDismiss() },
+        content = {
+            TextP40(
+                text = stringResource(LR.string.end_of_year_share_story_alert_description),
+                modifier = Modifier
+                    .padding(bottom = 12.dp)
+                    .padding(horizontal = 24.dp)
+            )
+        }
+    )
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1662,6 +1662,10 @@
     <string name="end_of_year_stories_theres_more">There\’s more!</string>>
     <!-- Subtitle explaining the user why they should susbcribe to Plus in the context of the end of year stories. -->
     <string name="end_of_year_stories_subscribe_to_plus">Subscribe to Plus and find out how your listening compares to 2022, other fun stats, and Premium features like bookmarks and folders.</string>
+    <!-- Title of an alert displayed to the user asking if they want to share the current story -->
+    <string name="end_of_year_share_story_alert_title">Share this Story?</string>
+    <!-- Message of an alert displayed to the user asking if they want to share the current story -->
+    <string name="end_of_year_share_story_alert_description">Paste this image to your socials and give a shout out to your favorite shows and creators</string>
 
     <!-- Onboarding -->
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/ScreenshotDetector.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/ScreenshotDetector.kt
@@ -1,0 +1,103 @@
+package au.com.shiftyjelly.pocketcasts.utils
+
+import android.content.ContentResolver
+import android.content.Context
+import android.database.ContentObserver
+import android.net.Uri
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.provider.MediaStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+/* https://rb.gy/lt9bux
+When the app targets Android 14, consider Android 14 screenshot detection feature
+https://developer.android.com/about/versions/14/features/screenshot-detection */
+class ScreenshotDetector @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private var contentObserver: ContentObserver? = null
+
+    private var onScreenshotDetected: (() -> Unit)? = null
+
+    fun start(onScreenshotDetected: () -> Unit) {
+        if (contentObserver == null) {
+            contentObserver = context.contentResolver.registerObserver()
+        }
+        this.onScreenshotDetected = onScreenshotDetected
+    }
+
+    fun stop() {
+        contentObserver?.let { context.contentResolver.unregisterContentObserver(it) }
+        contentObserver = null
+    }
+
+    private fun queryScreenshots(uri: Uri) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            queryRelativeDataColumn(uri)
+        } else {
+            queryDataColumn(uri)
+        }
+    }
+
+    private fun queryDataColumn(uri: Uri) {
+        val projection = arrayOf(
+            MediaStore.Images.Media.DATA
+        )
+        context.contentResolver.query(
+            uri,
+            projection,
+            null,
+            null,
+            null
+        )?.use { cursor ->
+            val dataColumn = cursor.getColumnIndex(MediaStore.Images.Media.DATA)
+            while (cursor.moveToNext()) {
+                val path = cursor.getString(dataColumn)
+                if (path.contains("screenshot", true)) {
+                    onScreenshotDetected?.invoke()
+                }
+            }
+        }
+    }
+
+    private fun queryRelativeDataColumn(uri: Uri) {
+        val projection = arrayOf(
+            MediaStore.Images.Media.DISPLAY_NAME,
+            MediaStore.Images.Media.RELATIVE_PATH
+        )
+        context.contentResolver.query(
+            uri,
+            projection,
+            null,
+            null,
+            null
+        )?.use { cursor ->
+            val relativePathColumn =
+                cursor.getColumnIndex(MediaStore.Images.Media.RELATIVE_PATH)
+            val displayNameColumn =
+                cursor.getColumnIndex(MediaStore.Images.Media.DISPLAY_NAME)
+            while (cursor.moveToNext()) {
+                val name = cursor.getString(displayNameColumn)
+                val relativePath = cursor.getString(relativePathColumn)
+                if (name.contains("screenshot", true) or
+                    relativePath.contains("screenshot", true)
+                ) {
+                    onScreenshotDetected?.invoke()
+                }
+            }
+        }
+    }
+
+    private fun ContentResolver.registerObserver(): ContentObserver {
+        val contentObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
+            override fun onChange(selfChange: Boolean, uri: Uri?) {
+                super.onChange(selfChange, uri)
+                uri?.let { queryScreenshots(it) }
+            }
+        }
+        registerContentObserver(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, true, contentObserver)
+        return contentObserver
+    }
+}


### PR DESCRIPTION
| 📘 Part of: #1463 |
|:---:|

Detects when a user takes a screenshot and displays an alert.

## Testing Instructions
1. Make sure you're logged in to an account that has a few episodes listened to this year and last year
2. Go to Profile
3. Open stories
4. Notice you get permission to read photos
5. Allow permission
6. When stories are loaded, take a screenshot
7. ✅ You should see an alert and the stories should pause
8. Tap "Not now"
9. ✅ Stories should resume
10. Take another screenshot
11. Tap "Share"
12. ✅ The share sheet should appear
13. Dismiss it
14. ✅ Stories should resume
15. Take another screenshot
16. Tap "Share"
17. Share the story from the share sheet that appears
18. ✅ Hashtags and share text should be present on the shared story

** It might be good to test on Android 12, Android 13, and Android 14 devices.

## Screenshots or Screencast 

Android 12 | Android 13
---|----
<img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/4b6393a6-f2af-4361-b658-f497e5ed8310"/> | <img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/95326d19-bf1b-4d11-8c13-e7d88f416f1c"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
