### PR TITLE
Playback 2023 - Update listened time font size 

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListeningTimeView.kt
@@ -8,12 +8,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.paddingFromBaseline
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.LocalTextStyle
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.compose.extensions.nonScaledSp
 import au.com.shiftyjelly.pocketcasts.endofyear.components.DayCirclesView
@@ -41,7 +42,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListen
 import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-private const val ListenedTimeFontSize = 100
+private const val ListenedTimeFontSize = 200
 
 @Composable
 fun StoryListeningTimeView(
@@ -118,13 +119,14 @@ private fun ListenedTimeTexts(story: StoryListeningTime) {
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier.fillMaxWidth(),
     ) {
-        Text(
+        AutoResizeText(
             text = listeningTimeDisplayStrings.firstNumber,
             color = story.tintColor,
-            fontSize = ListenedTimeFontSize.nonScaledSp,
+            maxFontSize = ListenedTimeFontSize.nonScaledSp,
             lineHeight = ListenedTimeFontSize.nonScaledSp,
             fontWeight = FontWeight.W300,
             fontFamily = StoryFontFamily,
+            maxLines = 1,
             style = LocalTextStyle.current.merge(
                 @Suppress("DEPRECATION")
                 TextStyle(
@@ -146,6 +148,7 @@ private fun ListenedTimeTexts(story: StoryListeningTime) {
             fontFamily = StoryFontFamily,
             fontWeight = FontWeight.W600,
             disableScale = disableScale(),
+            modifier = Modifier.offset(y = (-50).dp),
         )
     }
 }


### PR DESCRIPTION
| 📘 Part of: #1463 |
|:---:|

## Description
This increases listened time font size while keeping subtitle close to the title (https://github.com/Automattic/pocket-casts-android/pull/1495#discussion_r1376655773)

## Screenshots or Screencast 

Small Display | Large Display
|----|---|
|<img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/9abf8708-df48-4564-9f77-6f46ed2f93c2"/>|<img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/3beb4555-5728-4aca-a8d8-1768f2393ef6"/>|

Tablet
|----|
|<img width=500 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/7d2b887c-a219-449b-a3ea-b36a650721c0"/>|

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
