### PR TITLE
Unlock orientation after stories dismiss

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.endofyear
 
 import android.annotation.SuppressLint
 import android.app.Dialog
+import android.content.DialogInterface
 import android.content.pm.ActivityInfo
 import android.graphics.Color
 import android.os.Bundle
@@ -84,6 +85,11 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
             source = source,
         )
         OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
     }
 
     private object AnalyticsProp {


### PR DESCRIPTION
## Description
This unlocks portrait orientation after stories dismiss

## Testing Instructions
1. Open stories dialog
2. Rotate device
3. Notice that orientation is locked to portrait
4. Dismiss the dialog
5. Rotate device
6. Notice that orientation can be changed

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
