### PR TITLE
Bookmarks + Playback: Add handling for when both the bookmarks what's new and the playback prompt will show

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -373,7 +373,10 @@ class MainActivity :
                             VR.id.navigation_podcasts -> FirebaseAnalyticsTracker.navigatedToPodcasts()
                             VR.id.navigation_filters -> FirebaseAnalyticsTracker.navigatedToFilters()
                             VR.id.navigation_discover -> FirebaseAnalyticsTracker.navigatedToDiscover()
-                            VR.id.navigation_profile -> FirebaseAnalyticsTracker.navigatedToProfile()
+                            VR.id.navigation_profile -> {
+                                resetEoYBadgeIfNeeded()
+                                FirebaseAnalyticsTracker.navigatedToProfile()
+                            }
                         }
                     }
                     settings.setSelectedTab(currentTab)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -743,7 +743,7 @@ class MainActivity :
                     showStories(StoriesSource.USER_LOGIN)
                     viewModel.waitingForSignInToShowStories = false
                 } else if (settings.getEndOfYearShowModal()) {
-                    if(isWhatsNewShowing()) return@observe
+                    if (isWhatsNewShowing()) return@observe
                     showEndOfYearModal()
                 }
             }
@@ -925,7 +925,7 @@ class MainActivity :
 
     override fun isUpNextShowing() = bottomSheetTag == UpNextFragment::class.java.name
 
-    private fun isWhatsNewShowing()  = bottomSheetTag == WhatsNewFragment::class.java.name
+    private fun isWhatsNewShowing() = bottomSheetTag == WhatsNewFragment::class.java.name
 
     private fun removeBottomSheetFragment(fragment: Fragment) {
         val tag = fragment::class.java.name

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -654,6 +654,13 @@ class MainActivity :
         )
     }
 
+    private fun showEndOfYearModal() {
+        viewModel.updateStoriesModalShowState(true)
+        launch(Dispatchers.Main) {
+            if (viewModel.isEndOfYearStoriesEligible()) setupEndOfYearLaunchBottomSheet()
+        }
+    }
+
     override fun showStoriesOrAccount(source: String) {
         if (viewModel.isSignedIn) {
             showStories(StoriesSource.fromString(source))
@@ -733,10 +740,8 @@ class MainActivity :
                     showStories(StoriesSource.USER_LOGIN)
                     viewModel.waitingForSignInToShowStories = false
                 } else if (settings.getEndOfYearShowModal()) {
-                    viewModel.updateStoriesModalShowState(true)
-                    launch(Dispatchers.Main) {
-                        if (viewModel.isEndOfYearStoriesEligible()) setupEndOfYearLaunchBottomSheet()
-                    }
+                    if(isWhatsNewShowing()) return@observe
+                    showEndOfYearModal()
                 }
             }
 
@@ -796,6 +801,11 @@ class MainActivity :
                     }
                 }
             })
+    }
+
+    override fun whatsNewDismissed(fromConfirmAction: Boolean) {
+        if (fromConfirmAction) return
+        if (settings.getEndOfYearShowModal()) showEndOfYearModal()
     }
 
     override fun updatePlayerView() {
@@ -911,6 +921,8 @@ class MainActivity :
     }
 
     override fun isUpNextShowing() = bottomSheetTag == UpNextFragment::class.java.name
+
+    private fun isWhatsNewShowing()  = bottomSheetTag == WhatsNewFragment::class.java.name
 
     private fun removeBottomSheetFragment(fragment: Fragment) {
         val tag = fragment::class.java.name

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -119,7 +119,9 @@ class MainActivityViewModel
     suspend fun isEndOfYearStoriesEligible() = endOfYearManager.isEligibleForStories()
     fun updateStoriesModalShowState(show: Boolean) {
         viewModelScope.launch {
-            shouldShowStoriesModal.value = show && isEndOfYearStoriesEligible()
+            shouldShowStoriesModal.value = show &&
+                isEndOfYearStoriesEligible() &&
+                !state.value.shouldShowWhatsNew
         }
     }
 

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -57,32 +57,34 @@ class MainActivityViewModel
     var waitingForSignInToShowStories = false
 
     init {
-        showWhatsNewIfNeeded()
-        updateStoriesModalShowState(settings.getEndOfYearShowModal())
+        viewModelScope.launch {
+            showWhatsNewIfNeeded()
+            if (!state.value.shouldShowWhatsNew) {
+                updateStoriesModalShowState(settings.getEndOfYearShowModal())
+            }
+        }
     }
 
     private fun showWhatsNewIfNeeded() {
-        viewModelScope.launch {
-            val lastSeenVersionCode = settings.getWhatsNewVersionCode()
-            val migratedVersion = settings.getMigratedVersionCode()
-            if (migratedVersion != 0) { // We don't want to show this to new users, there is a race condition between this and the version migration
-                var whatsNewShouldBeShown = WhatsNewFragment.isWhatsNewNewerThan(lastSeenVersionCode)
-                val isBookmarksEnabled = featureFlag.isEnabled(feature.bookmarksFeature)
-                if (isBookmarksEnabled) {
-                    val isUserEntitled = feature.isUserEntitled(feature.bookmarksFeature, settings.userTier)
+        val lastSeenVersionCode = settings.getWhatsNewVersionCode()
+        val migratedVersion = settings.getMigratedVersionCode()
+        if (migratedVersion != 0) { // We don't want to show this to new users, there is a race condition between this and the version migration
+            var whatsNewShouldBeShown = WhatsNewFragment.isWhatsNewNewerThan(lastSeenVersionCode)
+            val isBookmarksEnabled = featureFlag.isEnabled(feature.bookmarksFeature)
+            if (isBookmarksEnabled) {
+                val isUserEntitled = feature.isUserEntitled(feature.bookmarksFeature, settings.userTier)
 
-                    val patronExclusiveAccessRelease = (feature.bookmarksFeature.tier as? FeatureTier.Plus)?.patronExclusiveAccessRelease
-                    val relativeToEarlyPatronAccess = patronExclusiveAccessRelease?.let {
-                        releaseVersion.currentReleaseVersion.comparedToEarlyPatronAccess(it)
-                    }
-                    val shouldShowWhatsNewWhenUserNotEntitled = patronExclusiveAccessRelease == null ||
-                        relativeToEarlyPatronAccess == EarlyAccessState.After
-
-                    whatsNewShouldBeShown = whatsNewShouldBeShown &&
-                        (isUserEntitled || shouldShowWhatsNewWhenUserNotEntitled)
+                val patronExclusiveAccessRelease = (feature.bookmarksFeature.tier as? FeatureTier.Plus)?.patronExclusiveAccessRelease
+                val relativeToEarlyPatronAccess = patronExclusiveAccessRelease?.let {
+                    releaseVersion.currentReleaseVersion.comparedToEarlyPatronAccess(it)
                 }
-                _state.update { state -> state.copy(shouldShowWhatsNew = whatsNewShouldBeShown) }
+                val shouldShowWhatsNewWhenUserNotEntitled = patronExclusiveAccessRelease == null ||
+                    relativeToEarlyPatronAccess == EarlyAccessState.After
+
+                whatsNewShouldBeShown = whatsNewShouldBeShown &&
+                    (isUserEntitled || shouldShowWhatsNewWhenUserNotEntitled)
             }
+            _state.update { state -> state.copy(shouldShowWhatsNew = whatsNewShouldBeShown) }
         }
     }
 

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
@@ -143,4 +143,7 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
 
     override fun showStoriesOrAccount(source: String) {
     }
+
+    override fun whatsNewDismissed(fromConfirmAction: Boolean) {
+    }
 }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -236,7 +236,7 @@ class ProfileFragment : BaseFragment() {
                             analyticsTracker.track(AnalyticsEvent.END_OF_YEAR_PROFILE_CARD_TAPPED)
                             // once stories prompt card is tapped, we don't want to show stories launch modal if not already shown
                             if (settings.getEndOfYearShowModal()) {
-                                settings.setEndOfYearShowModal(true)
+                                settings.setEndOfYearShowModal(false)
                             }
                             (activity as? FragmentHostListener)?.showStoriesOrAccount(StoriesSource.PROFILE.value)
                         }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -234,6 +234,10 @@ class ProfileFragment : BaseFragment() {
                     EndOfYearPromptCard(
                         onClick = {
                             analyticsTracker.track(AnalyticsEvent.END_OF_YEAR_PROFILE_CARD_TAPPED)
+                            // once stories prompt card is tapped, we don't want to show stories launch modal if not already shown
+                            if (settings.getEndOfYearShowModal()) {
+                                settings.setEndOfYearShowModal(true)
+                            }
                             (activity as? FragmentHostListener)?.showStoriesOrAccount(StoriesSource.PROFILE.value)
                         }
                     )

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -4,6 +4,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.ComposeView
@@ -56,6 +61,7 @@ class WhatsNewFragment : BaseFragment() {
                         @Suppress("DEPRECATION")
                         activity?.onBackPressed()
                     }
+                    var confirmActionClicked: Boolean by remember { mutableStateOf(false) }
                     WhatsNewPage(
                         onConfirm = {
                             analyticsTracker.track(
@@ -64,6 +70,7 @@ class WhatsNewFragment : BaseFragment() {
                             )
                             onClose()
                             performConfirmAction(it)
+                            confirmActionClicked = true
                         },
                         onClose = {
                             analyticsTracker.track(
@@ -72,7 +79,16 @@ class WhatsNewFragment : BaseFragment() {
                             )
                             onClose()
                         },
+
                     )
+
+                    DisposableEffect(Unit) {
+                        onDispose {
+                            val fragmentHostListener = activity as? FragmentHostListener
+                                ?: throw IllegalStateException(FRAGMENT_HOST_LISTENER_NOT_IMPLEMENTED)
+                            fragmentHostListener.whatsNewDismissed(fromConfirmAction = confirmActionClicked)
+                        }
+                    }
                 }
             }
         }

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
@@ -29,4 +29,5 @@ interface FragmentHostListener {
     fun overrideNextRefreshTimer()
     fun isUpNextShowing(): Boolean
     fun showStoriesOrAccount(source: String)
+    fun whatsNewDismissed(fromConfirmAction: Boolean = false)
 }


### PR DESCRIPTION
## Description

Updated logic to show Playback Prompt (modal bottom sheet) without clashing with Bookmarks what's new:

1. If the What's New is displayed the Playback Prompt will not be
2. If the user dismisses the announcement (maybe later button), the Playback Prompt will be shown if the user is eligible
3. If the user uses the announcements action button (blue button), the Playback prompt will not be shown until the next launch. At which point only the Playback prompt will be displayed
4. If the user opens the Playback Stories without seeing the prompt, the prompt will no longer display on the next launch
5. If the what's new is not displayed, the Playback prompt will show as it did before.

Profile Badge
- Fixes scenario when the badge is shown and the user first taps another tab before tapping the Profile tab

Note that:
** Android app differs from iOS behavior:  iOS app waits for sync to complete, whereas on Android, login screen is dismissed without waiting for sync to complete and the user enters inside the app where the logic to show the prompt is checked at first entry. For this reason, if there are no listened episodes before login, then the Playback prompt is shown when the app is next opened after login.

** What's New is not shown if is a fresh install of the app**

## Testing Instructions

Prerequisites
- Set versionName=7.52-rc-1 in version.properties 

### Fresh Install 

#### Logged out user
1. Perform a fresh install of the app
2. ✅ Verify you see the initial onboarding prompt
3. ✅ Verify you do not see the what's new or playback prompt

#### Logged out user → Signs In → Not Eligible for Playback 
1. Continue from above
2. Sign into or create an account that is not eligible for playback
3. ✅ Verify you do not see the playback prompt after signing in + app reopen

#### Logged out user → Becomes eligible for Playback
1. Continue from above
2. Listen to at least 5 minutes of an episode
3. Go to the Profile tab
4. ✅ Verify you see the Playback section
5. Relaunch the app6. ✅ Verify you see the Playback Prompt

#### Logged out user → Signs In → Eligible for Playback
1. Perform a fresh install of the app
2. ✅ Verify you see the initial onboarding prompt
3. Sign into an account that is eligible for playback
4. Wait for sync to complete 
5. Reopen the app
6. ✅ Verify you see the Playback Prompt
8. ✅ Verify you see the Playback section in Profile

#### Logged out user → Becomes eligible for Playback → Open Stories without seeing prompt
1. Perform a fresh install of the app
2. Dismiss the login
3. Listen to at least 5 minutes of an episode
4. Go to the Profile tab
8. Tap the Playback section
9. Sign into an account or create an account
10. ✅ Verify you see the Playback stories
11. Dismiss it
18. Relaunch the app
19. ✅ Verify you do not see the Playback Prompt

### Update

For each test below, increment the `WHATS_NEW_VERSION_CODE` in `Settings.kt` as the what's new dialog is shown only when the new what's new version code is newer than last shown what's new version code.

#### Logged In → Eligible for What's New and for Playback → Dismisses What's New
1. Launch the app from a previous version that is signed into an account eligible for Playback and has Plus
2. ✅ Verify you see the What's New
3. Tap the x button
4. ✅ Verify you see the Playback Prompt

#### Logged In → Eligible for What's New and for Playback → What's New Action
1. Launch the app from a previous version that is signed into an account eligible for Playback and has Plus
2. ✅ Verify you see the What's New
3. Tap the action button
4. ✅ Verify the action is performed
5. ✅ Verify you don't see the Playback prompt
6. Relaunch the app
7. ✅ Verify you see the Playback Prompt

#### Logged out → Eligible for Playback → Signs in
1. Launch the app from a previous version that is signed into an account eligible for Playback and does not have Plus
2. ✅ Verify you see the Playback prompt
6. Tap the View button
9. ✅ Verify you are prompted to sign in
10. Sign in
11. ✅ Verify you see the Playback Stories
12. Dismiss it
13. ✅ Verify you do not see anything
14. Relaunch the app
15. ✅ Verify you see nothing

### Profile Badge

1. Fresh install the app
2. Dismiss the login
3. Listen to at least 5 minutes of an episode
4. Swipe away the app
5. Reopen the app
7. ✅ Playback Prompt is shown
9. ✅ Playback Badge is shown on Profile tab
10. Tap a non Profile tab
11. Tap Profile tab
12. ✅ Playback Badge is removed

If you want to reset the modal being shown and badge, go to Profile > Settings > Developer > Reset modal/profile badge

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
