### PR TITLE
Dangermattic: fix release label typo

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -19,7 +19,7 @@ def requested_reviewers?
   has_requested_reviews || finished_reviews?
 end
 
-return if github.pr_labels.include?('Releases')
+return if github.pr_labels.include?('releases')
 
 github.dismiss_out_of_range_messages
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Automattic/dangermattic
-  revision: 8406e79e3b20e71421462a525c50a0525da697aa
+  revision: 06a54db4f546d20c0465e4d144049d061a2a1e20
   specs:
     danger-dangermattic (0.0.1)
       danger (~> 9.3)
@@ -284,7 +284,7 @@ GEM
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
     public_suffix (5.0.3)
-    racc (1.7.1)
+    racc (1.7.3)
     rainbow (3.1.1)
     rake (13.1.0)
     rake-compiler (1.2.5)


### PR DESCRIPTION
## Description
I have noticed that [this backmerge PR](https://github.com/Automattic/pocket-casts-android/pull/1532), marked with the label `releases`, was still getting warnings. In case of marking PRs as part of a release process, Dangermattic should skip most checks.
This was due to a typo with the label name, and this PR fixes it. I used this chance to also update Dangermattic gem to the latest one, containing a couple of fixes.

## Testing Instructions
You can run `danger` yourself on a PR with warnings and check the results:
```ruby
DANGER_GITHUB_API_TOKEN=<github_token> bundle exec danger pr https://github.com/Automattic/pocket-casts-android/pull/1532
```
