### PR TITLE
Fixes Multiselect: Does not work in some cases(#1507)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
         ([#1518](https://github.com/Automattic/pocket-casts-android/pull/1518))
     *   Fix Chapter Length Calculation Mismatch
         ([#1525](https://github.com/Automattic/pocket-casts-android/pull/1525))
+    *   Fix multiselect not working in some cases
+        ([#1535](https://github.com/Automattic/pocket-casts-android/pull/1535))
 7.51
 -----
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -212,6 +212,9 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
     }
 
     private fun <T> onRowLongPress(): (entity: T) -> Unit = {
+        when(multiSelectEpisodesHelper.listener){
+            null -> binding?.setupMultiSelect()
+        }
         when (it) {
             is PodcastEpisode ->
                 multiSelectEpisodesHelper

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -212,7 +212,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
     }
 
     private fun <T> onRowLongPress(): (entity: T) -> Unit = {
-        when(multiSelectEpisodesHelper.listener){
+        when (multiSelectEpisodesHelper.listener) {
             null -> binding?.setupMultiSelect()
         }
         when (it) {


### PR DESCRIPTION
## Description
The problem with current navigation system is that if there are two fragment A and B and we are changing fragment from fragment A to fragment B using `navigator.addFragment` function of MainActivity then onDestroy of A is running after onCreate of B which is not expected 

From the above observation i found that
- The `onDestroy` of `UpNextFragment` is nullifying the multiselect listener of `PodcastFragment` when navigating from `UpNextFragment` to `PodcastFragment`.
- when navigating from `PodcastFragment`  to `PodcastFragment`, when `podcastUuid` is different, is also making the multiselect listener as null

## Solution
Whenever `onRowLongPress` is invoked I am attaching the multiselect listeners again in `PodcastFragment`

Fixes #1507

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/134276544/d7fef0fa-a5b1-47f9-8b08-2a58ee56a637



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
