### PR TITLE
Playback 2023 - animations

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
@@ -195,6 +195,7 @@ private fun StoriesView(
                     convertibleToBitmap(content = {
                         StorySharableContent(
                             story,
+                            state.paused,
                             state.userTier,
                             state.freeTrial,
                             shouldShowUpsell,
@@ -244,6 +245,7 @@ private fun LoadingOverContentView() {
 @Composable
 private fun StorySharableContent(
     story: Story,
+    paused: Boolean,
     userTier: UserTier,
     freeTrial: FreeTrial,
     shouldShowUpsell: () -> Boolean,
@@ -279,7 +281,7 @@ private fun StorySharableContent(
                 is StoryListeningTime -> StoryListeningTimeView(story, storyModifier)
                 is StoryListenedCategories -> StoryListenedCategoriesView(story, storyModifier)
                 is StoryTopListenedCategories -> StoryTopListenedCategoriesView(story, storyModifier)
-                is StoryListenedNumbers -> StoryListenedNumbersView(story, storyModifier)
+                is StoryListenedNumbers -> StoryListenedNumbersView(story, paused, storyModifier)
                 is StoryTopPodcast -> StoryTopPodcastView(story, storyModifier)
                 is StoryTopFivePodcasts -> StoryTopFivePodcastsView(story, storyModifier)
                 is StoryLongestEpisode -> StoryLongestEpisodeView(story, storyModifier)

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
@@ -284,7 +284,7 @@ private fun StorySharableContent(
                 is StoryListenedNumbers -> StoryListenedNumbersView(story, paused, storyModifier)
                 is StoryTopPodcast -> StoryTopPodcastView(story, storyModifier)
                 is StoryTopFivePodcasts -> StoryTopFivePodcastsView(story, storyModifier)
-                is StoryLongestEpisode -> StoryLongestEpisodeView(story, storyModifier)
+                is StoryLongestEpisode -> StoryLongestEpisodeView(story, paused, storyModifier)
                 is StoryYearOverYear -> StoryYearOverYearView(
                     story = story,
                     userTier = userTier,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModel.kt
@@ -127,9 +127,8 @@ class StoriesViewModel @Inject constructor(
     }
 
     fun start() {
-        if (state.value !is State.Loaded) return
-
-        val currentState = state.value as State.Loaded
+        val currentState = state.value as? State.Loaded ?: return
+        mutableState.value = currentState.copy(paused = false)
         val progressFraction =
             (PROGRESS_UPDATE_INTERVAL_MS / totalLengthInMs.toFloat())
                 .coerceAtMost(PROGRESS_END_VALUE)
@@ -149,7 +148,10 @@ class StoriesViewModel @Inject constructor(
                         currentIndex = nextIndex
                     }
                     mutableState.value =
-                        currentState.copy(currentStory = stories.value[currentIndex])
+                        currentState.copy(
+                            currentStory = stories.value[currentIndex],
+                            paused = false,
+                        )
                 }
 
                 mutableProgress.value = newProgress
@@ -175,6 +177,7 @@ class StoriesViewModel @Inject constructor(
     }
 
     fun pause() {
+        mutableState.value = (state.value as State.Loaded).copy(paused = true)
         cancelTimer()
     }
 
@@ -187,7 +190,10 @@ class StoriesViewModel @Inject constructor(
         if (timer == null) start()
         mutableProgress.value = getXStartOffsetAtIndex(index)
         currentIndex = index
-        mutableState.value = (state.value as State.Loaded).copy(currentStory = stories.value[index])
+        mutableState.value = (state.value as State.Loaded).copy(
+            currentStory = stories.value[index],
+            paused = false
+        )
     }
 
     fun onRetryClicked() {
@@ -302,6 +308,7 @@ class StoriesViewModel @Inject constructor(
             val preparingShareText: Boolean = false,
             val userTier: UserTier,
             val freeTrial: FreeTrial,
+            val paused: Boolean = false,
         ) : State() {
             data class SegmentsData(
                 val widths: List<Float> = emptyList(),

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/utils/Util.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/utils/Util.kt
@@ -1,7 +1,14 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.utils
 
 import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import kotlin.math.min
 
-fun List<TopPodcast>.atSafeIndex(index: Int) =
-    this[index.coerceAtMost(size - 1)]
+fun List<TopPodcast>.atSafeIndex(
+    index: Int,
+    maxSize: Int = 8
+): Podcast {
+    val size = min(size, maxSize)
+    return this[(index % size).coerceAtMost(size - 1)]
         .toPodcast()
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedNumbersView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedNumbersView.kt
@@ -38,6 +38,7 @@ private const val PodcastCoverScaleFactor = 1.5f
 @Composable
 fun StoryListenedNumbersView(
     story: StoryListenedNumbers,
+    paused: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Box {
@@ -65,7 +66,7 @@ fun StoryListenedNumbersView(
 
             Spacer(modifier = modifier.weight(1f))
 
-            PodcastCoverStack(story.topPodcasts.reversed())
+            PodcastCoverStack(story.topPodcasts.reversed(), paused)
 
             Spacer(modifier = modifier.weight(1f))
         }
@@ -75,6 +76,7 @@ fun StoryListenedNumbersView(
 @Composable
 private fun PodcastCoverStack(
     topPodcasts: List<TopPodcast>,
+    paused: Boolean,
 ) {
     val context = LocalContext.current
     val currentLocalView = LocalView.current
@@ -92,6 +94,7 @@ private fun PodcastCoverStack(
         ScrollingRow(
             scrollDirection = ScrollDirection.RIGHT,
             spacedBy = spacedBy,
+            paused = paused,
         ) {
             for (i in 0..3) {
                 PodcastCover(
@@ -104,6 +107,7 @@ private fun PodcastCoverStack(
         ScrollingRow(
             scrollDirection = ScrollDirection.LEFT,
             spacedBy = spacedBy,
+            paused = paused,
         ) {
             for (i in 4..7) {
                 PodcastCover(

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedNumbersView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedNumbersView.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -15,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -22,6 +22,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastCover
+import au.com.shiftyjelly.pocketcasts.compose.components.ScrollDirection
+import au.com.shiftyjelly.pocketcasts.compose.components.ScrollingRow
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryBlurredBackground
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryPrimaryText
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StorySecondaryText
@@ -30,6 +32,8 @@ import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryListenedNumbers
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
+
+private const val PodcastCoverScaleFactor = 1.5f
 
 @Composable
 fun StoryListenedNumbersView(
@@ -75,55 +79,38 @@ private fun PodcastCoverStack(
     val context = LocalContext.current
     val currentLocalView = LocalView.current
     val screenWidth = currentLocalView.width.pxToDp(context).dp
-    val size = screenWidth * 0.4f
+    val size = screenWidth * 0.4f / PodcastCoverScaleFactor
+    val spacedBy = (16 / PodcastCoverScaleFactor).dp
     Column(
         Modifier
-            .wrapContentWidth(unbounded = true)
-            .rotate(-15f),
+            .wrapContentWidth()
+            .rotate(-15f)
+            .scale(PodcastCoverScaleFactor),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+        verticalArrangement = Arrangement.spacedBy(spacedBy)
     ) {
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ScrollingRow(
+            scrollDirection = ScrollDirection.RIGHT,
+            spacedBy = spacedBy,
         ) {
-            PodcastCover(
-                coverWidth = size,
-                uuid = topPodcasts.atSafeIndex(0).uuid,
-            )
-            PodcastCover(
-                coverWidth = size,
-                uuid = topPodcasts.atSafeIndex(1).uuid,
-            )
-            PodcastCover(
-                coverWidth = size,
-                uuid = topPodcasts.atSafeIndex(2).uuid,
-            )
-            PodcastCover(
-                coverWidth = size,
-                uuid = topPodcasts.atSafeIndex(3).uuid,
-            )
+            for (i in 0..3) {
+                PodcastCover(
+                    coverWidth = size,
+                    uuid = topPodcasts.atSafeIndex(i).uuid,
+                )
+            }
         }
 
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier.padding(start = screenWidth * 0.35f)
+        ScrollingRow(
+            scrollDirection = ScrollDirection.LEFT,
+            spacedBy = spacedBy,
         ) {
-            PodcastCover(
-                coverWidth = size,
-                uuid = topPodcasts.atSafeIndex(4).uuid,
-            )
-            PodcastCover(
-                coverWidth = size,
-                uuid = topPodcasts.atSafeIndex(5).uuid,
-            )
-            PodcastCover(
-                coverWidth = size,
-                uuid = topPodcasts.atSafeIndex(6).uuid,
-            )
-            PodcastCover(
-                coverWidth = size,
-                uuid = topPodcasts.atSafeIndex(7).uuid,
-            )
+            for (i in 4..7) {
+                PodcastCover(
+                    coverWidth = size,
+                    uuid = topPodcasts.atSafeIndex(i).uuid,
+                )
+            }
         }
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedNumbersView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryListenedNumbersView.kt
@@ -88,19 +88,19 @@ private fun PodcastCoverStack(
         ) {
             PodcastCover(
                 coverWidth = size,
-                uuid = topPodcasts.atSafeIndex(5).uuid,
-            )
-            PodcastCover(
-                coverWidth = size,
-                uuid = topPodcasts.atSafeIndex(4).uuid,
-            )
-            PodcastCover(
-                coverWidth = size,
                 uuid = topPodcasts.atSafeIndex(0).uuid,
             )
             PodcastCover(
                 coverWidth = size,
+                uuid = topPodcasts.atSafeIndex(1).uuid,
+            )
+            PodcastCover(
+                coverWidth = size,
                 uuid = topPodcasts.atSafeIndex(2).uuid,
+            )
+            PodcastCover(
+                coverWidth = size,
+                uuid = topPodcasts.atSafeIndex(3).uuid,
             )
         }
 
@@ -110,11 +110,11 @@ private fun PodcastCoverStack(
         ) {
             PodcastCover(
                 coverWidth = size,
-                uuid = topPodcasts.atSafeIndex(1).uuid,
+                uuid = topPodcasts.atSafeIndex(4).uuid,
             )
             PodcastCover(
                 coverWidth = size,
-                uuid = topPodcasts.atSafeIndex(3).uuid,
+                uuid = topPodcasts.atSafeIndex(5).uuid,
             )
             PodcastCover(
                 coverWidth = size,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryLongestEpisodeView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryLongestEpisodeView.kt
@@ -1,5 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,11 +14,14 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastCover
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryPrimaryText
@@ -25,10 +30,18 @@ import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryLongestEpisode
 import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import kotlin.math.roundToInt
+
+private const val AnimDurationInMs = 1000
+private val animTargetValue = listOf(0.4f, 0.32f, 0.24f, 0.16f, 0.08f, 0f)
 
 @Composable
 fun StoryLongestEpisodeView(
     story: StoryLongestEpisode,
+    paused: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -50,7 +63,7 @@ fun StoryLongestEpisodeView(
 
         Spacer(modifier = modifier.weight(0.2f))
 
-        PodcastCoverStack(story)
+        PodcastCoverStack(story, paused)
 
         Spacer(modifier = modifier.weight(1f))
     }
@@ -59,65 +72,66 @@ fun StoryLongestEpisodeView(
 @Composable
 private fun PodcastCoverStack(
     story: StoryLongestEpisode,
+    paused: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val currentLocalView = LocalView.current
     val width = currentLocalView.width
     val podcastUuid = story.longestEpisode.podcastUuid
+
     Box(
         modifier = modifier
-            .wrapContentSize()
-            .offset(
-                x = (width * 0.04f).toInt().pxToDp(context).dp,
-                y = (width * 0.05f).toInt().pxToDp(context).dp,
-            ),
-        contentAlignment = Alignment.Center,
+            .wrapContentSize(),
+        contentAlignment = Alignment.BottomStart,
     ) {
-        PodcastCover(
-            uuid = podcastUuid,
-            coverWidth = (width * 0.5f).toInt().pxToDp(context).dp,
-            modifier = Modifier.offset(
-                x = -(width * 0.4f).toInt().pxToDp(context).dp,
-                y = (width * 0.4f).toInt().pxToDp(context).dp,
-            ),
+        val animationSpec = tween<Float>(
+            durationMillis = AnimDurationInMs,
+            delayMillis = 0,
         )
-        PodcastCover(
-            uuid = podcastUuid,
-            coverWidth = (width * 0.55f).toInt().pxToDp(context).dp,
-            modifier = Modifier.offset(
-                x = -(width * 0.32f).toInt().pxToDp(context).dp,
-                y = (width * 0.32f).toInt().pxToDp(context).dp,
-            ),
-        )
-        PodcastCover(
-            uuid = podcastUuid,
-            coverWidth = (width * 0.6f).toInt().pxToDp(context).dp,
-            modifier = Modifier.offset(
-                x = -(width * 0.24f).toInt().pxToDp(context).dp,
-                y = (width * 0.24f).toInt().pxToDp(context).dp,
-            ),
-        )
-        PodcastCover(
-            uuid = podcastUuid,
-            coverWidth = (width * 0.65f).toInt().pxToDp(context).dp,
-            modifier = Modifier.offset(
-                x = -(width * 0.16f).toInt().pxToDp(context).dp,
-                y = (width * 0.16f).toInt().pxToDp(context).dp,
-            ),
-        )
-        PodcastCover(
-            uuid = podcastUuid,
-            coverWidth = (width * 0.7f).toInt().pxToDp(context).dp,
-            modifier = Modifier.offset(
-                x = -(width * 0.08f).toInt().pxToDp(context).dp,
-                y = (width * 0.08f).toInt().pxToDp(context).dp,
-            ),
-        )
-        PodcastCover(
-            uuid = podcastUuid,
-            coverWidth = (width * 0.75f).toInt().pxToDp(context).dp,
-        )
+        for (i in 0..5) {
+            val animOffsetX = remember { Animatable(1f) }
+            val animOffsetY = remember { Animatable(0.5f) }
+            LaunchedEffect(paused) {
+                try {
+                    if (paused) {
+                        /* Stop animations when story is paused */
+                        animOffsetX.stop()
+                        animOffsetY.stop()
+                    }
+                    /* Launch concurrent offset animations along x and y axis */
+                    launch {
+                        if (!paused) {
+                            animOffsetY.animateTo(
+                                targetValue = animTargetValue[i],
+                                animationSpec = animationSpec
+                            )
+                        }
+                    }
+                    launch {
+                        if (!paused) {
+                            animOffsetX.animateTo(
+                                targetValue = animTargetValue[i],
+                                animationSpec = animationSpec
+                            )
+                        }
+                    }
+                } catch (e: CancellationException) {
+                    Timber.e(e)
+                }
+            }
+
+            PodcastCover(
+                uuid = podcastUuid,
+                coverWidth = (width * (0.5f + i * 0.05f)).toInt().pxToDp(context).dp,
+                modifier = Modifier.offset {
+                    IntOffset(
+                        -(width * animOffsetX.value).roundToInt(),
+                        (width * animOffsetY.value).roundToInt()
+                    )
+                },
+            )
+        }
     }
 }
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ScrollingRow.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ScrollingRow.kt
@@ -1,0 +1,91 @@
+package au.com.shiftyjelly.pocketcasts.compose.components
+
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import java.lang.Long.max
+
+private const val MAX_ITEMS = 500
+
+@Composable
+fun ScrollingRow(
+    scrollAutomatically: Boolean = true,
+    rowItems: @Composable () -> Unit,
+) {
+
+    // Not using rememberLazyListState() because we want to reset
+    // the scroll state on orientation changes so that the hardcoded column
+    // is redisplayed, which insures the height is correctly calculated. For that
+    // reason, we want to use remember, not rememberSaveable.
+    val state = remember { LazyListState() }
+
+    val localConfiguration = LocalConfiguration.current
+    LaunchedEffect(scrollAutomatically) {
+        if (scrollAutomatically) {
+            // This seems to get a good scroll speed across multiple devices
+            val scrollDelay = max(1L, (1000L - localConfiguration.densityDpi) / 90)
+            autoScroll(scrollDelay, state)
+        }
+    }
+    LazyRow(
+        state = state,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        userScrollEnabled = !scrollAutomatically,
+    ) {
+        if (scrollAutomatically) {
+            items(MAX_ITEMS) { // arbitrary large number that users will probably never hit
+                // Nesting a Row of items inside the LazyRow because a Row can use IntrinsidSize.Max
+                // to determine the height of the tallest list item and keep a consistent
+                // height, regardless of which items are visible. This ensures that the
+                // LazyRow as a whole always has a single, consistent height that does not
+                // change as items scroll into/out-of view. If IntrinsicSize.Max could work
+                // with LazyRows, we wouldn't need to nest Rows in the LazyRow.
+                NestedRow(rowItems)
+            }
+        } else {
+            item {
+                NestedRow(rowItems)
+            }
+        }
+    }
+}
+
+@Composable
+fun NestedRow(
+    rowItems: @Composable () -> Unit,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = Modifier
+            .height(IntrinsicSize.Max)
+    ) {
+        rowItems()
+    }
+}
+
+// Based on https://stackoverflow.com/a/71344813/1910286
+private tailrec suspend fun autoScroll(
+    scrollDelay: Long,
+    lazyListState: LazyListState,
+) {
+    val scrollAmount = lazyListState.scrollBy(1f)
+    if (scrollAmount == 0f) {
+        // If we can't scroll, we're at the end, so jump to the beginning.
+        // This will be an abrupt jump, but users shouldn't really ever be
+        // getting to the end of the list, so it should be very rare.
+        lazyListState.scrollToItem(0)
+    }
+    delay(scrollDelay)
+    autoScroll(scrollDelay, lazyListState)
+}


### PR DESCRIPTION
| 📘 Part of: #1463| 🎨 Designs: lH66LwxxgG8btQ8NrM0ldx-fi-1599_20385 |
|:---:|:---:|

## Description
Animates the following stories with ability to pause/ resume animation when story is paused/ resumed:

- *Listened time (2nd story)* (reuses [endless scrolling effect](https://github.com/Automattic/pocket-casts-android/commit/e82c7aafc6dd9154e904d50778e6b2914b41f61c) from previous onboarding flow features list)
- *Longest episode (seventh story)* (just animates offset along x and y axis: [core logic](https://github.com/Automattic/pocket-casts-android/commit/574b9b13af51f167f9eeed5786061041fe391b58#diff-5400c9888d444c9189e25cb92c45b455575c5ed5bad4bf8eb78b66a43a74abeaR93-R122))

For "Top one podcast to top five podcast (third to fourth story)", see my Slack note (p1699771341436249-slack-C041BGTFQ5R). 

## Testing Instructions

1. Make sure you're logged in to an account that has a few episodes listened
2. Go to Profile 
3. Tap the End of Year card
4. Go to the second story
5. ✅ The two rows of podcasts should move
6. Tap the story and hold (to pause it)
7. ✅ The animation should pause
8. ✅ Untap and the animation should resume
9. Go to the longest episode story
10. ✅ The covers should slide into the screen
11. ✅ Pause/resume the story and the animation should follow

## Screenshots or Screencast 

Listened time 

https://github.com/Automattic/pocket-casts-android/assets/1405144/cb7b644e-49b7-433f-a238-291a57fe9950

Longest episode 

https://github.com/Automattic/pocket-casts-android/assets/1405144/36a7e592-4bfb-47f6-8d33-ca1b2a3aad7b

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack