### PR TITLE
Enable Playback 2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * New Features:
     *   Bookmarks entering Patron early access with full release for Plus users in 7.53
         ([#1526](https://github.com/Automattic/pocket-casts-android/pull/1526))
+    *   Enables Playback 2023
+        ([#1537](https://github.com/Automattic/pocket-casts-android/pull/1537))
 *   Bug Fixes:
     *   Avoid brief audio skip back when a streaming episode is downloaded
         ([#1510](https://github.com/Automattic/pocket-casts-android/pull/1510))

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -14,7 +14,7 @@ enum class Feature(
     END_OF_YEAR_ENABLED(
         key = "end_of_year_enabled",
         title = "End of Year",
-        defaultValue = BuildConfig.DEBUG,
+        defaultValue = true,
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -16,7 +16,7 @@ enum class Feature(
         title = "End of Year",
         defaultValue = true,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = false,
+        hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
     ADD_PATRON_ENABLED(


### PR DESCRIPTION
| 📘 Part of: #1463| 
|:---:|

## Description
This enables Playback 2023.

## Testing Instructions
1. Install release build
2. Make sure you're logged in to an account that has a few episodes listened
3. Go to Profile 
4. Notice you see End of Year card

** I also enabled remote flag for the feature in https://github.com/Automattic/pocket-casts-android/pull/1537/commits/4cdd3e53ab1bd5d51c1d9926a66bbf32a84279cb and added the key to Firebase console.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack