### PR TITLE
Bookmarks - Fix upsell display

### DIFF
--- a/base.gradle
+++ b/base.gradle
@@ -241,6 +241,7 @@ dependencies {
     androidTestImplementation libs.uiautomator
     androidTestImplementation libs.work.test
 
+    testImplementation libs.arch.core
     testImplementation libs.coroutines.test
     testImplementation libs.jsonassert
     testImplementation (libs.junit) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -243,6 +243,7 @@ work-test = { module = "androidx.work:work-testing", version.ref = "work" }
 accessibility-test-framework = "com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:4.0.0" # Fixes instrumentation tests, see: https://github.com/android/android-test/issues/861#issuecomment-1180219978
 annotation = "androidx.annotation:annotation:1.3.0"
 appcompat = "androidx.appcompat:appcompat:1.5.0"
+arch-core = "androidx.arch.core:core-testing:2.2.0"
 auth = "com.google.android.gms:play-services-auth:20.4.0"
 automattic-tracks = "com.automattic:Automattic-Tracks-Android:trunk-b3655d42123501a1d9a304789b738610ab4403c8"
 barista = "com.adevinta.android:barista:4.2.0"

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -37,7 +37,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
@@ -1,11 +1,15 @@
 package au.com.shiftyjelly.pocketcasts.player.viewmodel
 
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeDefault
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -19,6 +23,7 @@ import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -28,6 +33,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -36,6 +42,10 @@ import java.util.UUID
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class BookmarksViewModelTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
     @get:Rule
     val coroutineRule = MainCoroutineRule()
 
@@ -82,6 +92,15 @@ class BookmarksViewModelTest {
         whenever(settings.cachedSubscriptionStatus).thenReturn(userSetting)
         whenever(episodeManager.findEpisodeByUuid(episodeUuid)).thenReturn(episode)
         whenever(feature.isUserEntitled(eq(Feature.BOOKMARKS_ENABLED), anyOrNull())).thenReturn(true)
+        whenever(bookmarkManager.findEpisodeBookmarksFlow(episode, BookmarksSortTypeDefault.TIMESTAMP)).thenReturn(flowOf(emptyList()))
+        val playerBookmarksSortType = mock<UserSetting<BookmarksSortTypeDefault>> {
+            on { flow } doReturn MutableStateFlow(BookmarksSortTypeDefault.TIMESTAMP)
+        }
+        whenever(settings.playerBookmarksSortType).thenReturn(playerBookmarksSortType)
+        whenever(multiSelectHelper.isMultiSelectingLive)
+            .thenReturn(MutableLiveData<Boolean>().apply { value = false })
+        whenever(multiSelectHelper.selectedListLive)
+            .thenReturn(MutableLiveData<List<Bookmark>>().apply { value = emptyList() })
 
         bookmarksViewModel = BookmarksViewModel(
             bookmarkManager = bookmarkManager,


### PR DESCRIPTION
## Description
This fixes upsell not showing correctly at times on full-screen player screen bookmarks view

Fixes #1519

## Testing Instructions
1. Log in with a Plus account with bookmarks enabled
2. Open the full-screen player and look at the bookmarks tab
3. Sign out of your Plus account
4. Return to the full-screen player and observe that the bookmarks tab shows the upsell view. Collapse and expand the full-screen again to see that upsell is shown. 

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/5d1f78f1-1273-4087-a23a-983fa1e311a4


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack