### PR TITLE
Playback 2023 - Shared element transition

### DIFF
--- a/base.gradle
+++ b/base.gradle
@@ -170,6 +170,7 @@ dependencies {
     implementation libs.bundles.retrofit
     implementation libs.bundles.rxjava
     implementation libs.bundles.sentry
+    implementation libs.bundles.shared.elements
     implementation libs.bundles.work
 
     implementation platform(libs.firebase.bom)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,7 @@ retrofit = "2.9.0"
 room = "2.5.1"
 sentry = "6.28.0"
 sentry-plugin = "3.10.0"
+shared-elements = "0.1.0-SNAPSHOT"
 showkase = "1.0.0-beta18"
 test = "1.5.0"
 wear-compose = "1.2.0-beta02"
@@ -218,6 +219,9 @@ sentry-bom = { module = "io.sentry:sentry-bom", version.ref = "sentry" }
 sentry-android-core = { module = "io.sentry:sentry-android-core" }
 sentry-fragment = { module = "io.sentry:sentry-android-fragment" }
 sentry-timber = { module = "io.sentry:sentry-android-timber" }
+
+# SharedElements
+shared-elements = { module = "com.mxalbert.sharedelements:shared-elements", version.ref = "shared-elements" }
 
 # Showkase
 showkase = { module = "com.airbnb.android:showkase", version.ref = "showkase" }
@@ -424,6 +428,10 @@ sentry = [
     "sentry-android-core",
     "sentry-fragment",
     "sentry-timber"
+]
+
+shared-elements =  [
+    "shared-elements"
 ]
 
 test = [

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesPage.kt
@@ -93,6 +93,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
+import com.mxalbert.sharedelements.SharedElementsRoot
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import timber.log.Timber
@@ -276,38 +277,42 @@ private fun StorySharableContent(
                     Modifier
                 }
             )
-            when (story) {
-                is StoryIntro -> StoryIntroView(storyModifier)
-                is StoryListeningTime -> StoryListeningTimeView(story, storyModifier)
-                is StoryListenedCategories -> StoryListenedCategoriesView(story, storyModifier)
-                is StoryTopListenedCategories -> StoryTopListenedCategoriesView(story, storyModifier)
-                is StoryListenedNumbers -> StoryListenedNumbersView(story, paused, storyModifier)
-                is StoryTopPodcast -> StoryTopPodcastView(story, storyModifier)
-                is StoryTopFivePodcasts -> StoryTopFivePodcastsView(story, storyModifier)
-                is StoryLongestEpisode -> StoryLongestEpisodeView(story, paused, storyModifier)
-                is StoryYearOverYear -> StoryYearOverYearView(
-                    story = story,
-                    userTier = userTier,
-                    modifier = storyModifier,
-                )
-                is StoryCompletionRate -> StoryCompletionRateView(
-                    story = story,
-                    userTier = userTier,
-                    modifier = storyModifier,
-                )
-                is StoryEpilogue -> StoryEpilogueView(
-                    story = story,
-                    userTier = userTier,
-                    onReplayClicked = onReplayClicked,
-                    modifier = storyModifier,
-                )
-            }
-            if (shouldShowUpsell()) {
-                PaidStoryWallView(
-                    freeTrial = freeTrial,
-                    onUpsellClicked = onUpsellClicked
-                )
-                onPause()
+            SharedElementsRoot {
+                when (story) {
+                    is StoryIntro -> StoryIntroView(storyModifier)
+                    is StoryListeningTime -> StoryListeningTimeView(story, storyModifier)
+                    is StoryListenedCategories -> StoryListenedCategoriesView(story, storyModifier)
+                    is StoryTopListenedCategories -> StoryTopListenedCategoriesView(story, storyModifier)
+                    is StoryListenedNumbers -> StoryListenedNumbersView(story, paused, storyModifier)
+                    is StoryTopPodcast -> StoryTopPodcastView(story, storyModifier)
+                    is StoryTopFivePodcasts -> StoryTopFivePodcastsView(story, storyModifier)
+                    is StoryLongestEpisode -> StoryLongestEpisodeView(story, paused, storyModifier)
+                    is StoryYearOverYear -> StoryYearOverYearView(
+                        story = story,
+                        userTier = userTier,
+                        modifier = storyModifier,
+                    )
+
+                    is StoryCompletionRate -> StoryCompletionRateView(
+                        story = story,
+                        userTier = userTier,
+                        modifier = storyModifier,
+                    )
+
+                    is StoryEpilogue -> StoryEpilogueView(
+                        story = story,
+                        userTier = userTier,
+                        onReplayClicked = onReplayClicked,
+                        modifier = storyModifier,
+                    )
+                }
+                if (shouldShowUpsell()) {
+                    PaidStoryWallView(
+                        freeTrial = freeTrial,
+                        onUpsellClicked = onUpsellClicked
+                    )
+                    onPause()
+                }
             }
         }
     }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopFivePodcastsView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopFivePodcastsView.kt
@@ -40,8 +40,13 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopFivePodcasts
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
+import com.mxalbert.sharedelements.ProgressThresholds
+import com.mxalbert.sharedelements.SharedElement
+import com.mxalbert.sharedelements.SharedElementsTransitionSpec
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
+
+private const val AniDurationInMs = 500
 
 @Composable
 fun StoryTopFivePodcastsView(
@@ -101,6 +106,7 @@ private fun SecondaryText(
 private fun PodcastList(story: StoryTopFivePodcasts) {
     story.topPodcasts.forEachIndexed { index, topPodcast ->
         PodcastItem(
+            storyIdentifier = story.identifier,
             podcast = topPodcast.toPodcast(),
             position = index,
             tintColor = story.tintColor,
@@ -111,6 +117,7 @@ private fun PodcastList(story: StoryTopFivePodcasts) {
 
 @Composable
 fun PodcastItem(
+    storyIdentifier: String,
     podcast: Podcast,
     position: Int,
     tintColor: Color,
@@ -142,10 +149,19 @@ fun PodcastItem(
                 .weight(1f),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            PodcastImage(
-                uuid = podcast.uuid,
-                modifier = modifier.size((heightInDp * 0.09f).dp)
-            )
+            SharedElement(
+                key = "cover$position",
+                screenKey = storyIdentifier,
+                transitionSpec = SharedElementsTransitionSpec(
+                    durationMillis = AniDurationInMs,
+                    scaleProgressThresholds = ProgressThresholds(0f, 0.9f),
+                )
+            ) {
+                PodcastImage(
+                    uuid = podcast.uuid,
+                    modifier = modifier.size((heightInDp * 0.09f).dp)
+                )
+            }
             Column(
                 modifier = modifier
                     .padding(start = 14.dp)
@@ -181,6 +197,7 @@ private fun PodcastItemPreview(
     AppTheme(themeType) {
         Surface(color = Color.Black) {
             PodcastItem(
+                storyIdentifier = "storyIdentifier",
                 podcast = Podcast(
                     uuid = "",
                     title = "Title",

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopPodcastView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopPodcastView.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import au.com.shiftyjelly.pocketcasts.compose.components.CoverSize
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastCover
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryBlurredBackground
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryPrimaryText
@@ -30,6 +29,10 @@ import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopPodcast
 import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
+import com.mxalbert.sharedelements.SharedElement
+import com.mxalbert.sharedelements.SharedElementsTransitionSpec
+
+private const val AniDurationInMs = 500
 
 @Composable
 fun StoryTopPodcastView(
@@ -126,10 +129,11 @@ private fun PodcastCoverStack(
                 )
                 .alpha(0.2f)
         )
-        PodcastCover(
-            uuid = story.topPodcast.uuid,
+        PodcastCoverOrEmpty(
+            story = story,
+            index = 0,
             coverWidth = (widthInDp * .7).dp,
-            coverSize = CoverSize.BIG
+            modifier = Modifier,
         )
     }
 }
@@ -142,11 +146,20 @@ private fun PodcastCoverOrEmpty(
     modifier: Modifier,
 ) {
     if (index < story.topPodcasts.size) {
-        PodcastCover(
-            uuid = story.topPodcasts[index].uuid,
-            coverWidth = coverWidth,
-            modifier = modifier
-        )
+        SharedElement(
+            key = "cover$index",
+            screenKey = story.identifier,
+            transitionSpec = SharedElementsTransitionSpec(
+                durationMillis = AniDurationInMs,
+                waitForFrames = 0,
+            )
+        ) {
+            PodcastCover(
+                uuid = story.topPodcasts[index].uuid,
+                coverWidth = coverWidth,
+                modifier = modifier
+            )
+        }
     } else {
         Unit
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,7 @@ dependencyResolutionManagement {
                 includeGroup("com.automattic.tracks")
             }
         }
+        maven("https://s01.oss.sonatype.org/content/repositories/snapshots")
     }
 }
 


### PR DESCRIPTION
## Description
This adds shared element transition for top one podcast to top five podcast (third to fourth) story (p1699771341436249-slack-C041BGTFQ5R).

## Testing Instructions

1. Make sure you're logged in to an account that has a few episodes listened
2. Go to Profile 
3. Tap the End of Year card
4. Go to the third story
5. Wait for it to transition to the fourth story
6. Notice that it includes shared element transition

## Screenshots or Screencast 

On API 33

https://github.com/Automattic/pocket-casts-android/assets/1405144/11ffe303-c558-406c-8b8d-1f9fd113ba1b

On API 24

https://github.com/Automattic/pocket-casts-android/assets/1405144/39418c07-4eb5-4ff3-a00a-acd2d96f5bd0



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack