### PR TITLE
Bookmarks - Fix add bookmark not showing at times

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -33,6 +33,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -43,6 +44,8 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+private const val DELAY_IN_MS = 300L
 
 @HiltViewModel
 class BookmarksViewModel
@@ -212,13 +215,15 @@ class BookmarksViewModel
     fun play(bookmark: Bookmark) {
         viewModelScope.launch {
             val bookmarkEpisode = episodeManager.findEpisodeByUuid(bookmark.episodeUuid)
+            var shouldLoadOrSwitchEpisode = false
             bookmarkEpisode?.let {
-                val shouldPlayEpisode = !playbackManager.isPlaying() ||
+                shouldLoadOrSwitchEpisode = !playbackManager.isPlaying() ||
                     playbackManager.getCurrentEpisode()?.uuid != bookmarkEpisode.uuid
-                if (shouldPlayEpisode) {
+                if (shouldLoadOrSwitchEpisode) {
                     playbackManager.playNow(it, sourceView = sourceView)
                 }
             }
+            delay(if (shouldLoadOrSwitchEpisode) DELAY_IN_MS else 0) // Allow to load or switch episode
             playbackManager.seekToTimeMs(positionMs = bookmark.timeSecs * 1000)
             analyticsTracker.track(
                 AnalyticsEvent.BOOKMARK_PLAY_TAPPED,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -203,6 +203,7 @@ class PlayerViewModel @Inject constructor(
         if (list.isEmpty()) {
             ShelfItems.itemsList
         } else {
+            // Add missing bookmark item if the feature flag is enabled
             val updatedList = when {
                 list.contains(ShelfItem.Bookmark.id) -> list
                 FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) -> {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -41,6 +41,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Util
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.helper.CloudDeleteHelper
@@ -201,7 +203,16 @@ class PlayerViewModel @Inject constructor(
         if (list.isEmpty()) {
             ShelfItems.itemsList
         } else {
-            list.mapNotNull { id ->
+            val updatedList = when {
+                list.contains(ShelfItem.Bookmark.id) -> list
+                FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) -> {
+                    list.toMutableList().apply {
+                        add(list.size - 1, ShelfItem.Bookmark.id)
+                    }
+                }
+                else -> list
+            }
+            updatedList.mapNotNull { id ->
                 ShelfItems.itemForId(id)
             }
         }


### PR DESCRIPTION
## Description

Fixes add bookmark not showing at times.

** This also adds a small delay when playing at a bookmark position when the selected episode is loading or switching from a different one.

## Testing Instructions

#### Test.1. Add bookmark
1. Install release build from `release/7.51` branch
2. Play an episode and open full-screen player
3. From the bottom shelf, open more option
4. Rearrange a few shelf items
5. Install release build from this branch
6. Play an episode and open full-screen player
7.  From the bottom shelf, open more option
8. ✅ Notice you see the Add bookmark option

#### Test.2 Confirm bookmark position for archived episode

1. Continue from above
2. Add a bookmark for the selected episode
3. (Optionally) Archive it
4. Play an episode from another podcast
5. Select the previous episode to which bookmark was added
6. Tap the bookmark play button for the episode
7. ✅ Notice that the bookmark episode is selected and the bookmark position is correctly seeked

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
