### PR TITLE
Playback 2023 - Update completion rate query

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -419,7 +419,7 @@ abstract class EpisodeDao {
         """
         SELECT COUNT(DISTINCT uuid) AS completed 
         FROM podcast_episodes 
-        WHERE playing_status = 3 OR played_up_to >= 0.9 * duration 
+        WHERE (playing_status = 3 OR played_up_to >= 0.9 * duration) 
         AND podcast_episodes.last_playback_interaction_date IS NOT NULL 
         AND podcast_episodes.last_playback_interaction_date > :fromEpochMs AND podcast_episodes.last_playback_interaction_date < :toEpochMs
         """


### PR DESCRIPTION
## Description
This matches iOS query: https://github.com/Automattic/pocket-casts-ios/pull/1213/commits/8aedf1708010448ccd942402a5d9fd0855341483

## Testing Instructions
1. Make sure you're logged in to an account that has a few episodes listened
3. Go to Profile and tap the End of Year card
4. Go to the completion rate story
5. ✅ Your data should appear correctly


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
