### PR TITLE
Bookmarks - Fix user bookmarks sync when feature is disabled

### DIFF
--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
@@ -91,10 +91,10 @@ class SyncUpdateResponseParser(
             "UserFolder" -> readFolder(reader, response)
             "UserPodcast" -> readPodcast(reader, response)
             "UserEpisode" -> readEpisode(reader, response)
-            "UserBookmark" -> if (!featureFlagWrapper.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-                reader.skipValue()
-            } else {
+            "UserBookmark" -> if (featureFlagWrapper.isEnabled(Feature.BOOKMARKS_ENABLED)) {
                 readBookmark(reader, response)
+            } else {
+                reader.skipValue()
             }
             null -> throw Exception("No type found for field")
             else -> reader.skipValue()

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
@@ -91,7 +91,11 @@ class SyncUpdateResponseParser(
             "UserFolder" -> readFolder(reader, response)
             "UserPodcast" -> readPodcast(reader, response)
             "UserEpisode" -> readEpisode(reader, response)
-            "UserBookmark" -> readBookmark(reader, response)
+            "UserBookmark" -> if (!featureFlagWrapper.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+                reader.skipValue()
+            } else {
+                readBookmark(reader, response)
+            }
             null -> throw Exception("No type found for field")
             else -> reader.skipValue()
         }
@@ -224,10 +228,6 @@ class SyncUpdateResponseParser(
     }
 
     private fun readBookmark(reader: JsonReader, response: SyncUpdateResponse) {
-        if (!featureFlagWrapper.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-            return
-        }
-
         var uuid: String? = null
         var podcastUuid: String? = null
         var episodeUuid: String? = null


### PR DESCRIPTION
## Description
This fixes "user bookmark" sync when bookmark feature is disabled. (p1699988968426399-slack-C02A333D8LQ)

If a user bookmark is synced using a build with the feature enabled, then syncing fails on a build where the feature is disabled and gives this error:

```
SyncProcess: Sync failed
com.squareup.moshi.JsonDataException: Expected a name but was BEGIN_OBJECT at path $.result.changes[0].fields
    at com.squareup.moshi.i.m(SourceFile:96)
    at au.com.shiftyjelly.pocketcasts.servers.sync.update.SyncUpdateResponseParser.m(SourceFile:20)
    at au.com.shiftyjelly.pocketcasts.servers.sync.update.SyncUpdateResponseParser.t(SourceFile:50)
    at au.com.shiftyjelly.pocketcasts.servers.sync.update.SyncUpdateResponseParser.fromJson(SourceFile:127)
 ```

This PR skips parsing user bookmark when the feature is disabled.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack