### PR TITLE
Use suspend method when playing bookmarks

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -33,7 +33,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelChildren
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -43,8 +42,6 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-private const val DELAY_IN_MS = 300L
 
 @HiltViewModel
 class BookmarksViewModel
@@ -211,15 +208,13 @@ class BookmarksViewModel
     fun play(bookmark: Bookmark) {
         viewModelScope.launch {
             val bookmarkEpisode = episodeManager.findEpisodeByUuid(bookmark.episodeUuid)
-            var shouldLoadOrSwitchEpisode = false
             bookmarkEpisode?.let {
-                shouldLoadOrSwitchEpisode = !playbackManager.isPlaying() ||
+                val shouldLoadOrSwitchEpisode = !playbackManager.isPlaying() ||
                     playbackManager.getCurrentEpisode()?.uuid != bookmarkEpisode.uuid
                 if (shouldLoadOrSwitchEpisode) {
-                    playbackManager.playNow(it, sourceView = sourceView)
+                    playbackManager.playNowSync(it, sourceView = sourceView)
                 }
             }
-            delay(if (shouldLoadOrSwitchEpisode) DELAY_IN_MS else 0) // Allow to load or switch episode
             playbackManager.seekToTimeMs(positionMs = bookmark.timeSecs * 1000)
             analyticsTracker.track(
                 AnalyticsEvent.BOOKMARK_PLAY_TAPPED,


### PR DESCRIPTION
## Description
This updates the call to play a bookmark to use the suspended `playNowSync` function instead of the asynchronous `playNow` function. This helps make sure that the episode is loaded before we update the playback position. 

With this change I don't think we need the manual delay anymore, but let me know what you think @ashiagr since you're more familiar. We could leave the delay in if you think that is needed.

Without this change, I was seeing that playing a bookmark from an archived episode had a race condition where one of three things would occur:

1. The bookmarked episode is loaded and the playback position on the episode is properly set. This is the happy path.
2. The bookmarked episode is loaded, but the playback position is not set. As a result, the episode is played from the beginning.
3. The bookmark playback position is set on the currently playing episode _before the bookmarked episode is loaded_. I only saw this happen a couple of times. This could cause the currently playing episode to be completed and archived if the bookmark position is beyond the end of the episode.

This was reported in the [Pocket Casts Beta Slack](https://pocketcastsbeta.slack.com/archives/C013F9S9C2W/p1699972221471819?thread_ts=1699923175.314329&cid=C013F9S9C2W), and builds on the changes in https://github.com/Automattic/pocket-casts-android/pull/1544

I do think it is probably still technically possible to get in a race condition scenario because even though `playNowSync` is a suspended method, it launches a new coroutine in the `onAdd` callback that it passes to the `upNextQueue.playNow` method. Changing that would be tricky and have wide-ranging impact, and I didn't see this causing any race condition issues in my testing, so I don't think it makes sense to changing that now.

> [!CAUTION] 
> This PR is targeting the `release/7.52` branch.

## Testing Instructions

### 1. Avoids playback race conditions 
Run through these steps a few times. Since the problem this is fixing is a race condition, it does not consistently occur.

1. Add some bookmarks to an episode
2. Archive that episode
3. [optional] Force close and restart the app (this makes it take longer to reload the bookmarked episode)
4. Start playing some other episode
5. Go to the bookmarks for this episode on the podcast screen or on the episode screen (run through these test steps with both screens)
6. Tap play on one of the bookmarks for the episode you archived
7. Observe that the bookmarked episode is loaded and the correct playback position is set

### 2. Playing bookmarks from full screen player still works

Tap the play button on a few bookmarks in the full-screen player to verify that this still works as before.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews