### PR TITLE
Fix occasional crash on moving player shelf item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
         ([#1525](https://github.com/Automattic/pocket-casts-android/pull/1525))
     *   Fix multiselect not working in some cases
         ([#1535](https://github.com/Automattic/pocket-casts-android/pull/1535))
+    *   Fix occasional crash on rearranging player shelf items 
+        ([#1551](https://github.com/Automattic/pocket-casts-android/pull/1551))
     
 7.51
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
@@ -166,7 +166,7 @@ class ShelfFragment : BaseFragment(), ShelfTouchCallback.ItemTouchHelperAdapter 
         dragStartPosition?.let {
             val title = try {
                 (items[position] as? ShelfItem)?.analyticsValue
-            } catch (e: ArrayIndexOutOfBoundsException) {
+            } catch (e: IndexOutOfBoundsException) {
                 LogBuffer.i(LogBuffer.TAG_INVALID_STATE, "Error getting title for position $position in ShelfFragment", e)
             } ?: AnalyticsProp.Value.UNKNOWN
             val movedFrom = sectionTitleAt(it)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfTouchCallback.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfTouchCallback.kt
@@ -59,7 +59,9 @@ class ShelfTouchCallback(
         if (viewHolder is ItemTouchHelperViewHolder) {
             viewHolder.onItemClear()
         }
-        listener.onShelfItemTouchHelperFinished(viewHolder.bindingAdapterPosition)
+        if (viewHolder.bindingAdapterPosition != NO_POSITION) {
+            listener.onShelfItemTouchHelperFinished(viewHolder.bindingAdapterPosition)
+        }
     }
 
     override fun isItemViewSwipeEnabled(): Boolean {


### PR DESCRIPTION
## Description

This fixes an occasional crash on moving a shelf item.

Slack discussion: p1700183407328549-slack-C02A333D8LQ

Sentry issue: https://a8c.sentry.io/share/issue/1dea38e7cea647018dbb4235e0e42942/ 

I was able to reproduce it on the latest debug build after a few attempts and noticed this exception was thrown:

<img width=400 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/ed2d4344-a969-46dd-bf65-862ae63687c6"/>

## Testing Instructions
1. Open full-screen player
2. From the bottom shelf, tap more menu
3. On the Rearrange actions screen, move action rows a few times (I was able to reproduce after 10-15 attempts)
4. ✅ Notice that there is no crash 


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack