### PR TITLE
Allow bookmark incremental sync when delete is null

### DIFF
--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
@@ -250,14 +250,14 @@ class SyncUpdateResponseParser(
         }
         reader.endObject()
 
-        if (uuid != null && podcastUuid != null && episodeUuid != null && time != null && title != null && deleted != null && createdAt != null) {
+        if (uuid != null && podcastUuid != null && episodeUuid != null && time != null && title != null && createdAt != null) {
             val bookmark = Bookmark(
                 uuid = uuid,
                 podcastUuid = podcastUuid,
                 episodeUuid = episodeUuid,
                 timeSecs = time,
                 title = title,
-                deleted = deleted,
+                deleted = deleted ?: false,
                 createdAt = createdAt,
                 syncStatus = SyncStatus.SYNCED
             )


### PR DESCRIPTION
## Description
This allows incremental sync of bookmarks when the `delete` value is null.

## Testing Instructions

1. Add a breakpoint at line 254 in `SyncUpdateResponseParser.kt`
2. Install debug app from this branch 
3. Login into web staging server and debug app with the same Plus account.
4. Create a bookmark for an episode on the web (it is important that bookmark is created after login into the app to test incremental syncing)
5. Enable debugging for the app
6. Tap Refresh now under Profile in the app
7.  Make sure that breakpoint added at step 1 is hit
8. Resume from debugging
9. Open the episode in the app to which bookmark was added in step 4
10. Switch to bookmarks tab
11. ✅ Notice that the bookmark added at step 4 is displayed



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
