### PR TITLE
Playback2023 - UI design feedback

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/GradientPillar.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/GradientPillar.kt
@@ -30,7 +30,7 @@ fun GradientPillar(
         contentAlignment = Alignment.TopStart,
         modifier = modifier
             .pillarGradient(pillarStyle)
-            .padding(horizontal = 24.dp),
+            .padding(horizontal = 24.dp, vertical = 16.dp),
     ) {
         content()
     }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/PaidStoryWallView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/PaidStoryWallView.kt
@@ -99,7 +99,7 @@ private fun UpsellButton(
             hasFreeTrial = freeTrial.exists
         ),
         onClick = onUpsellClicked,
-        modifier = modifier.fillMaxSize(.65f)
+        modifier = modifier.fillMaxSize(.75f)
     )
 }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/PaidStoryWallView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/PaidStoryWallView.kt
@@ -49,7 +49,7 @@ fun PaidStoryWallView(
 
         SubscriptionBadgeForTier(
             tier = SubscriptionTier.PLUS,
-            displayMode = SubscriptionBadgeDisplayMode.Colored,
+            displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
         )
 
         Spacer(modifier = modifier.height(14.dp))

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/StoryButton.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/StoryButton.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 
@@ -20,11 +21,13 @@ fun StoryButton(
     RowButton(
         text = text,
         fontFamily = StoryFontFamily,
+        fontWeight = FontWeight.W600,
         colors = ButtonDefaults.buttonColors(backgroundColor = Color.White),
         cornerRadius = 4.dp,
         textColor = ButtonTextColor,
         onClick = onClick,
         modifier = modifier,
+        textVerticalPadding = 10.dp,
         textIcon = textIcon,
     )
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/StoryText.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/components/StoryText.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.Font
@@ -56,7 +55,6 @@ fun StorySecondaryText(
         disableScale = disableScale(),
         modifier = modifier
             .fillMaxWidth()
-            .alpha(0.8f)
             .padding(horizontal = 24.dp)
     )
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryCompletionRateView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryCompletionRateView.kt
@@ -47,7 +47,7 @@ fun StoryCompletionRateView(
 
         SubscriptionBadgeForTier(
             tier = SubscriptionTier.fromUserTier(userTier),
-            displayMode = SubscriptionBadgeDisplayMode.Colored,
+            displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
         )
 
         Spacer(modifier = modifier.height(14.dp))

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryEpilogueView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryEpilogueView.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -147,7 +146,8 @@ private fun ReplayButton(
         text = stringResource(id = LR.string.end_of_year_replay),
         onClick = onClick,
         textIcon = IR.drawable.ic_retry,
-        modifier = modifier.width(250.dp)
+        modifier = modifier
+            .fillMaxSize(.75f)
     )
 }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopFivePodcastsView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopFivePodcastsView.kt
@@ -38,6 +38,7 @@ import au.com.shiftyjelly.pocketcasts.endofyear.components.StorySecondaryText
 import au.com.shiftyjelly.pocketcasts.endofyear.components.disableScale
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopFivePodcasts
+import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -102,6 +103,7 @@ private fun PodcastList(story: StoryTopFivePodcasts) {
     story.topPodcasts.forEachIndexed { index, topPodcast ->
         PodcastItem(
             podcast = topPodcast.toPodcast(),
+            totalPlayedTimeInSecs = topPodcast.totalPlayedTime,
             position = index,
             tintColor = story.tintColor,
             subtitleColor = story.subtitleColor,
@@ -112,6 +114,7 @@ private fun PodcastList(story: StoryTopFivePodcasts) {
 @Composable
 fun PodcastItem(
     podcast: Podcast,
+    totalPlayedTimeInSecs: Double,
     position: Int,
     tintColor: Color,
     subtitleColor: Color,
@@ -119,6 +122,8 @@ fun PodcastItem(
 ) {
     val context = LocalContext.current
     val currentLocalView = LocalView.current
+    val timeText =
+        StatsHelper.secondsToFriendlyString(totalPlayedTimeInSecs.toLong(), context.resources)
     val heightInDp = currentLocalView.height.pxToDp(context)
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -161,7 +166,7 @@ fun PodcastItem(
                         .padding(bottom = 3.dp)
                 )
                 TextH70(
-                    text = podcast.author,
+                    text = timeText,
                     color = subtitleColor,
                     maxLines = 1,
                     fontFamily = FontFamily(listOf(Font(UR.font.dm_sans))),
@@ -186,6 +191,7 @@ private fun PodcastItemPreview(
                     title = "Title",
                     author = "Author",
                 ),
+                totalPlayedTimeInSecs = 1000.0,
                 position = 0,
                 tintColor = Color.White,
                 subtitleColor = Color(0xFF8F97A4),

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopListenedCategoriesView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryTopListenedCategoriesView.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
@@ -44,7 +45,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 private val CategoryColor = Color(0xFF686C74)
-private val CategoryFontSize = 40.sp
+private val CategoryFontSize = 50.sp
 private val DefaultFontFamily = FontFamily(listOf(Font(UR.font.dm_sans)))
 
 @Composable
@@ -150,7 +151,7 @@ fun CategoryItem(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 40.dp)
+            .padding(horizontal = 24.dp)
     ) {
         TextH30(
             text = "${position + 1}",
@@ -164,7 +165,7 @@ fun CategoryItem(
         )
         Row(
             modifier = modifier
-                .padding(vertical = 10.dp)
+                .padding(vertical = 5.dp)
                 .weight(1f),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -218,6 +219,7 @@ private fun CategoryTexts(
             fontFamily = DefaultFontFamily,
             fontWeight = FontWeight.W600,
             disableScale = disableScale(),
+            modifier = Modifier.offset(y = (-10).dp),
         )
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryYearOverYearView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryYearOverYearView.kt
@@ -63,7 +63,7 @@ fun StoryYearOverYearView(
 
         SubscriptionBadgeForTier(
             tier = SubscriptionTier.fromUserTier(userTier),
-            displayMode = SubscriptionBadgeDisplayMode.Colored,
+            displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
         )
 
         Spacer(modifier = modifier.height(14.dp))

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryYearOverYearView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryYearOverYearView.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -41,7 +42,7 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import kotlin.math.max
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-private const val YearFontSize = 50
+private const val YearFontSize = 60
 private const val MinimumPillarPercentage = 0.4
 
 @Composable
@@ -74,7 +75,7 @@ fun StoryYearOverYearView(
 
         SecondaryText(story)
 
-        Spacer(modifier = modifier.weight(0.2f))
+        Spacer(modifier = modifier.weight(0.15f))
 
         YearPillars(
             story = story,
@@ -198,6 +199,7 @@ private fun YearTextContent(
             fontWeight = FontWeight.W500,
             maxFontSize = YearFontSize.sp,
             maxLines = 1,
+            letterSpacing = 0.sp,
         )
         TextH50(
             text = timeText,
@@ -205,6 +207,7 @@ private fun YearTextContent(
             disableScale = disableScale(),
             fontFamily = StoryFontFamily,
             fontWeight = FontWeight.W600,
+            modifier = Modifier.offset(y = (-8).dp)
         )
     }
 }
@@ -212,7 +215,7 @@ private fun YearTextContent(
 private fun previousYearPillarPercentageSize(
     yearOverYearListeningTime: YearOverYearListeningTime,
 ) = when {
-    yearOverYearListeningTime.percentage == Double.POSITIVE_INFINITY -> 0.25
+    yearOverYearListeningTime.percentage == Double.POSITIVE_INFINITY -> 0.3
     yearOverYearListeningTime.percentage > 0.0 -> max(
         yearOverYearListeningTime.totalPlayedTimeLastYear.toDouble() / yearOverYearListeningTime.totalPlayedTimeThisYear,
         MinimumPillarPercentage

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellView.kt
@@ -72,7 +72,7 @@ private fun UpsellViewContent(
                 Spacer(modifier = Modifier.width(8.dp))
                 SubscriptionBadgeForTier(
                     tier = state.freeTrial.subscriptionTier,
-                    displayMode = SubscriptionBadgeDisplayMode.Colored
+                    displayMode = SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground
                 )
             }
         },

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
@@ -127,7 +127,7 @@ private fun WhatsNewPageLoaded(
 
                 SubscriptionBadgeForTier(
                     tier = Subscription.SubscriptionTier.fromUserTier(state.tier),
-                    displayMode = SubscriptionBadgeDisplayMode.Colored
+                    displayMode = SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground
                 )
 
                 Spacer(

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowButton.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowButton.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -41,9 +42,11 @@ fun RowButton(
     colors: ButtonColors = ButtonDefaults.buttonColors(),
     textColor: Color = MaterialTheme.theme.colors.primaryInteractive02,
     fontFamily: FontFamily? = null,
+    fontWeight: FontWeight? = null,
     @DrawableRes leadingIcon: Int? = null,
     onClick: () -> Unit,
     cornerRadius: Dp = 12.dp,
+    textVerticalPadding: Dp = 6.dp,
     @DrawableRes textIcon: Int? = null,
 ) {
     Box(
@@ -85,8 +88,9 @@ fun RowButton(
                     TextP40(
                         text = text,
                         fontFamily = fontFamily,
+                        fontWeight = fontWeight,
                         modifier = Modifier
-                            .padding(6.dp),
+                            .padding(vertical = textVerticalPadding, horizontal = 6.dp),
                         textAlign = TextAlign.Center,
                         color = textColor
                     )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ScrollingRow.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ScrollingRow.kt
@@ -53,7 +53,7 @@ fun ScrollingRow(
     }
     LazyRow(
         state = state,
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(spacedBy),
         userScrollEnabled = !scrollAutomatically,
     ) {
         if (scrollAutomatically) {

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -84,15 +84,18 @@ fun SubscriptionBadgeForTier(
             shortNameRes = LR.string.pocket_casts_plus_short,
             iconColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> SubscriptionTierColor.plusGold
-                SubscriptionBadgeDisplayMode.Colored -> Color.White
+                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
+                SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
             backgroundColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.Black
-                SubscriptionBadgeDisplayMode.Colored -> SubscriptionTierColor.plusGold
+                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
+                SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> SubscriptionTierColor.plusGold
             },
             textColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> SubscriptionTierColor.plusGold
-                SubscriptionBadgeDisplayMode.Colored -> Color.White
+                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
+                SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
         )
         SubscriptionTier.PATRON -> SubscriptionBadge(
@@ -100,15 +103,18 @@ fun SubscriptionBadgeForTier(
             shortNameRes = LR.string.pocket_casts_patron_short,
             iconColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> SubscriptionTierColor.patronPurpleLight
-                SubscriptionBadgeDisplayMode.Colored -> Color.White
+                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
+                SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
             backgroundColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.Black
-                SubscriptionBadgeDisplayMode.Colored -> SubscriptionTierColor.patronPurple
+                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
+                SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> SubscriptionTierColor.patronPurple
             },
             textColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.White
-                SubscriptionBadgeDisplayMode.Colored -> Color.White
+                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
+                SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
         )
         SubscriptionTier.UNKNOWN -> Unit
@@ -117,7 +123,8 @@ fun SubscriptionBadgeForTier(
 
 enum class SubscriptionBadgeDisplayMode {
     Black,
-    Colored,
+    ColoredWithWhiteForeground,
+    ColoredWithBlackForeground,
 }
 
 object SubscriptionTierColor {
@@ -132,7 +139,7 @@ object SubscriptionTierColor {
 fun SubscriptionBadgePlusColoredPreview() {
     SubscriptionBadgeForTier(
         tier = SubscriptionTier.PLUS,
-        displayMode = SubscriptionBadgeDisplayMode.Colored
+        displayMode = SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground
     )
 }
 
@@ -152,7 +159,7 @@ fun SubscriptionBadgePlusBlackPreview() {
 fun SubscriptionBadgePatronColoredPreview() {
     SubscriptionBadgeForTier(
         tier = SubscriptionTier.PATRON,
-        displayMode = SubscriptionBadgeDisplayMode.Colored
+        displayMode = SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground
     )
 }
 
@@ -163,5 +170,25 @@ fun SubscriptionBadgePatronBlackPreview() {
     SubscriptionBadgeForTier(
         tier = SubscriptionTier.PATRON,
         displayMode = SubscriptionBadgeDisplayMode.Black
+    )
+}
+
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored with black foreground")
+@Preview(name = "ColoredWithBlackForeground")
+@Composable
+fun SubscriptionBadgePlusColoredWithBlackForegroundPreview() {
+    SubscriptionBadgeForTier(
+        tier = SubscriptionTier.PLUS,
+        displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground
+    )
+}
+
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored with black foreground")
+@Preview(name = "ColoredWithBlackForeground")
+@Composable
+fun SubscriptionBadgePatronColoredWithBlackForegroundPreview() {
+    SubscriptionBadgeForTier(
+        tier = SubscriptionTier.PATRON,
+        displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground
     )
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1576,8 +1576,8 @@
     <string name="end_of_year_prompt_card_summary">See your listening stats, top podcasts, and more.</string>
     <string name="end_of_year_share_via" translatable="false">@string/podcasts_share_via</string>
     <string name="end_of_year_replay">Play again</string>
-    <string name="end_of_year_listening_time_title">This was your total time listening to podcasts.</string>
-    <string name="end_of_year_listening_time_title_english_only" translatable="false">This was your total time\nlistening to podcasts.</string>
+    <string name="end_of_year_listening_time_title">This was your total time listening to podcasts</string>
+    <string name="end_of_year_listening_time_title_english_only" translatable="false">This was your total time\nlistening to podcasts</string>
     <string name="end_of_year_listening_time_subtitle">We hope you loved every minute of it!</string>
     <string name="end_of_year_share_story">Share this story</string>
     <string name="end_of_year_story_intro_title">Let’s celebrate your year of listening!</string>
@@ -1625,8 +1625,8 @@
     <!-- Title of the top categories story. -->
     <string name="end_of_year_story_top_categories">Your Top Categories</string>
     <!-- Title of the top categories story. %1$s being the name of the most listened category. -->
-    <string name="end_of_year_story_top_categories_title">Did you know that %1$s was your favorite category</string>
-    <string name="end_of_year_story_top_categories_title_english_only" translatable="false">Did you know that %1$s\nwas your favorite\ncategory</string>
+    <string name="end_of_year_story_top_categories_title">Did you know that %1$s was your favorite category?</string>
+    <string name="end_of_year_story_top_categories_title_english_only" translatable="false">Did you know that %1$s\nwas your favorite\ncategory?</string>
     <!-- Subtitle of the top categories story. %1$s is the total number of episodes and %2$s is the total listened time. -->
     <string name="end_of_year_story_top_categories_subtitle">You listened to %1$s episodes for a total of %2$s</string>
     <!-- Text that appear when someone share the top categories story to Twitter. -->

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/Story.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/stories/Story.kt
@@ -5,7 +5,7 @@ import au.com.shiftyjelly.pocketcasts.utils.seconds
 
 abstract class Story {
     abstract val identifier: String
-    open val storyLength: Long = 5.seconds()
+    open val storyLength: Long = 7.seconds()
     open val backgroundColor: Color = Color.Black
     open val plusOnly: Boolean = false
     val tintColor: Color = TintColor


### PR DESCRIPTION
## Description

This addresses quick Playback2023 UI feedback (pdeCcb-3NF-p2)

1. Top 5 shows - Replace publisher with total listening time for the show cbb60986662f47e13dcd26c80aaa368309ac6d05
2. Autoplay speed - Update to 7 seconds 9e4ba1db0ae0c3cef2609ac26ea1781ce004f071
3. Total listening time - Removed the “.” at the end of the heading d6b4e8655ca866fbe73b9e4836603a5e9ab7bb2d
4. Top 4 categories - 
   - Add a question mark “?” at the end of the heading d6b4e8655ca866fbe73b9e4836603a5e9ab7bb2d
   - Font Size - Incremented so that they still appear correctly on Tablet bff76bc70d5c1198e8a1d0092b03ff229ff4cd7f
     [No changes to Weight(Category Title W500, Category SubTitle W600), Font (DM Sans)]
5. Number of shows & episodes - Distance between each artwork made more even 41d52304ed0c38083c6346bae96247b1fc6add1a
6. Button styles - Updated for Play now and Upsell buttons d247af8e846ec6408fee844247d9018004f4c232
7. Plus stories - Improved subscription badge text color  1a90cd40c9df446e51b3265bc88582a3ddec2353
8. Year over Year story - Improvements to “2022” and “2023” texts 17981bd803fa74db2b5c748d30bd22088734774e

## Testing Instructions

1. Log in to an account that has a few episodes listened this year and last year
2. Go to Profile and tap the End of Year card
4. ✅ Notice that each of the above feedback is addressed

## Screenshots or Screencast 

|1. Top 5 shows|3. Total listening time|4. Top 4 categories| 
|------|---|------|
| <img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/8830089c-6640-42c6-830f-c5a50e9c2f46"/>|<img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/b05a3194-9a06-40f0-8008-8178e5dc2817"/>|<img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/faa6c867-15b2-4e78-a144-07f031534df3"/>|

|4. Top 4 categories - Tablet - Nexus 9 (normal display)|
|-----|
|<img width=400 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/587ad678-4d0e-47d8-9ee5-c2bd9436a0a2"/> |


|6. Button Style| 7. Subscription Badge | 8. Year over Year story 
|------|------| -----|
<img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/274674bf-7f1c-47d1-8695-1597a50e9615"/> |<img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/fd306e0e-fdc3-4b99-ac04-313242605917"/>| <img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/5ded7800-c655-49f4-94cd-92a89c2b9ef4"/>



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack