### PR TITLE
Bookmarks - fixes

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -881,6 +881,10 @@ class MainActivity :
         FirebaseAnalyticsTracker.nowPlayingOpen()
 
         viewModel.isPlayerOpen = true
+
+        val playerContainerFragment = supportFragmentManager.fragments
+            .find { it is PlayerContainerFragment } as? PlayerContainerFragment
+        playerContainerFragment?.onPlayerOpen()
     }
 
     override fun onPlayerClosed() {
@@ -888,6 +892,10 @@ class MainActivity :
 
         viewModel.isPlayerOpen = false
         viewModel.closeMultiSelect()
+
+        val playerContainerFragment = supportFragmentManager.fragments
+            .find { it is PlayerContainerFragment } as? PlayerContainerFragment
+        playerContainerFragment?.onPlayerClose()
     }
 
     override fun openTab(tabId: Int) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -214,6 +214,16 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
         (activity as? FragmentHostListener)?.showBottomSheet(upNextFragment)
     }
 
+    fun onPlayerOpen() {
+        ((childFragmentManager.fragments.firstOrNull { it is BookmarksFragment }) as? BookmarksFragment)
+            ?.onPlayerOpen()
+    }
+
+    fun onPlayerClose() {
+        ((childFragmentManager.fragments.firstOrNull { it is BookmarksFragment }) as? BookmarksFragment)
+            ?.onPlayerClose()
+    }
+
     fun openPlayer(sourceView: SourceView? = null) {
         val index = adapter.indexOfPlayer
         if (index == -1) return

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
@@ -202,4 +202,12 @@ class BookmarksFragment : BaseFragment() {
         )
         OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
     }
+
+    fun onPlayerOpen() {
+        bookmarksViewModel.onPlayerOpen()
+    }
+
+    fun onPlayerClose() {
+        bookmarksViewModel.onPlayerClose()
+    }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -63,6 +64,8 @@ class BookmarksViewModel
 
     private val _showOptionsDialog = MutableSharedFlow<Int>()
     val showOptionsDialog = _showOptionsDialog.asSharedFlow()
+
+    private var isFragmentActive: Boolean = true
 
     private var sourceView: SourceView = SourceView.UNKNOWN
         set(value) {
@@ -174,6 +177,8 @@ class BookmarksViewModel
                         )
                     }
                 }.stateIn(viewModelScope)
+                    .takeWhile { !isFragmentActive } /* Stop collecting on player close
+                    when viewModelScope is still active but fragment is not. */
             } ?: run { // This shouldn't happen in the ideal world
                 LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Episode not found.")
                 _uiState.value = UiState.Empty(sourceView)
@@ -182,10 +187,12 @@ class BookmarksViewModel
     }
 
     fun onPlayerOpen() {
+        isFragmentActive = true
         multiSelectHelper.listener = multiSelectListener
     }
 
     fun onPlayerClose() {
+        isFragmentActive = false
         multiSelectHelper.listener = null
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -70,6 +70,67 @@ class BookmarksViewModel
             multiSelectHelper.source = value
         }
 
+    private val multiSelectListener = object : MultiSelectHelper.Listener<Bookmark> {
+        override fun multiSelectSelectAll() {
+            (_uiState.value as? UiState.Loaded)?.bookmarks?.let {
+                multiSelectHelper.selectAllInList(it)
+            }
+        }
+
+        override fun multiSelectSelectNone() {
+            (_uiState.value as? UiState.Loaded)?.bookmarks?.let { bookmarks ->
+                multiSelectHelper.deselectAllInList(bookmarks)
+            }
+        }
+
+        override fun multiDeselectAllAbove(multiSelectable: Bookmark) {
+            (_uiState.value as? UiState.Loaded)?.bookmarks?.let { bookmarks ->
+                val startIndex = bookmarks.indexOf(multiSelectable)
+                if (startIndex > -1) {
+                    val episodesAbove = bookmarks.subList(0, startIndex + 1)
+                    multiSelectHelper.deselectAllInList(episodesAbove)
+                }
+            }
+        }
+
+        override fun multiDeselectAllBelow(multiSelectable: Bookmark) {
+            (_uiState.value as? UiState.Loaded)?.bookmarks?.let { bookmarks ->
+                val startIndex = bookmarks.indexOf(multiSelectable)
+                if (startIndex > -1) {
+                    val bookmarksBelow = bookmarks.subList(startIndex, bookmarks.size)
+                    multiSelectHelper.deselectAllInList(bookmarksBelow)
+                }
+            }
+        }
+
+        override fun multiSelectSelectAllUp(multiSelectable: Bookmark) {
+            (_uiState.value as? UiState.Loaded)?.bookmarks?.let { bookmarks ->
+                val startIndex = bookmarks.indexOf(multiSelectable)
+                if (startIndex > -1) {
+                    multiSelectHelper.selectAllInList(bookmarks.subList(0, startIndex + 1))
+                }
+            }
+        }
+
+        override fun multiSelectSelectAllDown(multiSelectable: Bookmark) {
+            (_uiState.value as? UiState.Loaded)?.bookmarks?.let { bookmarks ->
+                val startIndex = bookmarks.indexOf(multiSelectable)
+                if (startIndex > -1) {
+                    multiSelectHelper.selectAllInList(
+                        bookmarks.subList(
+                            startIndex,
+                            bookmarks.size
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    init {
+        multiSelectHelper.listener = multiSelectListener
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     fun loadBookmarks(
         episodeUuid: String,
@@ -118,63 +179,14 @@ class BookmarksViewModel
                 _uiState.value = UiState.Empty(sourceView)
             }
         }
+    }
 
-        multiSelectHelper.listener = object : MultiSelectHelper.Listener<Bookmark> {
-            override fun multiSelectSelectAll() {
-                (_uiState.value as? UiState.Loaded)?.bookmarks?.let {
-                    multiSelectHelper.selectAllInList(it)
-                }
-            }
+    fun onPlayerOpen() {
+        multiSelectHelper.listener = multiSelectListener
+    }
 
-            override fun multiSelectSelectNone() {
-                (_uiState.value as? UiState.Loaded)?.bookmarks?.let { bookmarks ->
-                    multiSelectHelper.deselectAllInList(bookmarks)
-                }
-            }
-
-            override fun multiDeselectAllAbove(multiSelectable: Bookmark) {
-                (_uiState.value as? UiState.Loaded)?.bookmarks?.let { bookmarks ->
-                    val startIndex = bookmarks.indexOf(multiSelectable)
-                    if (startIndex > -1) {
-                        val episodesAbove = bookmarks.subList(0, startIndex + 1)
-                        multiSelectHelper.deselectAllInList(episodesAbove)
-                    }
-                }
-            }
-
-            override fun multiDeselectAllBelow(multiSelectable: Bookmark) {
-                (_uiState.value as? UiState.Loaded)?.bookmarks?.let { bookmarks ->
-                    val startIndex = bookmarks.indexOf(multiSelectable)
-                    if (startIndex > -1) {
-                        val bookmarksBelow = bookmarks.subList(startIndex, bookmarks.size)
-                        multiSelectHelper.deselectAllInList(bookmarksBelow)
-                    }
-                }
-            }
-
-            override fun multiSelectSelectAllUp(multiSelectable: Bookmark) {
-                (_uiState.value as? UiState.Loaded)?.bookmarks?.let { bookmarks ->
-                    val startIndex = bookmarks.indexOf(multiSelectable)
-                    if (startIndex > -1) {
-                        multiSelectHelper.selectAllInList(bookmarks.subList(0, startIndex + 1))
-                    }
-                }
-            }
-
-            override fun multiSelectSelectAllDown(multiSelectable: Bookmark) {
-                (_uiState.value as? UiState.Loaded)?.bookmarks?.let { bookmarks ->
-                    val startIndex = bookmarks.indexOf(multiSelectable)
-                    if (startIndex > -1) {
-                        multiSelectHelper.selectAllInList(
-                            bookmarks.subList(
-                                startIndex,
-                                bookmarks.size
-                            )
-                        )
-                    }
-                }
-            }
-        }
+    fun onPlayerClose() {
+        multiSelectHelper.listener = null
     }
 
     private fun onRowClick(bookmark: Bookmark) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -224,6 +224,7 @@ class EpisodeContainerFragment :
         binding = null
         multiSelectHelper.isMultiSelecting = false
         multiSelectHelper.context = null
+        multiSelectHelper.listener = null
     }
 
     private class ViewPagerAdapter(

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -275,7 +275,8 @@ class EpisodeContainerFragment :
 
                 Section.Bookmarks -> BookmarksFragment.newInstance(
                     sourceView = SourceView.EPISODE_DETAILS,
-                    episodeUuid = requireNotNull(episodeUUID)
+                    episodeUuid = requireNotNull(episodeUUID),
+                    forceDarkTheme = forceDarkTheme
                 )
             }
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -212,16 +212,21 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
     }
 
     private fun <T> onRowLongPress(): (entity: T) -> Unit = {
-        when (multiSelectEpisodesHelper.listener) {
-            null -> binding?.setupMultiSelect()
-        }
         when (it) {
-            is PodcastEpisode ->
+            is PodcastEpisode -> {
+                if (multiSelectEpisodesHelper.listener == null) {
+                    binding?.setupMultiSelect()
+                }
                 multiSelectEpisodesHelper
                     .defaultLongPress(multiSelectable = it, fragmentManager = childFragmentManager)
-            is Bookmark ->
+            }
+            is Bookmark -> {
+                if (multiSelectBookmarksHelper.listener == null) {
+                    binding?.setupMultiSelect()
+                }
                 multiSelectBookmarksHelper
                     .defaultLongPress(multiSelectable = it, fragmentManager = childFragmentManager)
+            }
         }
         adapter?.notifyDataSetChanged()
     }
@@ -675,6 +680,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         listener = object : MultiSelectHelper.Listener<T> {
             override fun multiSelectSelectNone() {
                 viewModel.multiSelectSelectNone()
+                this@setUp.closeMultiSelect()
                 adapter?.notifyDataSetChanged()
             }
 


### PR DESCRIPTION
## Description

This 
- Updates multi-select listener between full-screen player screen and podcast screen (partially fixes p1699662181239419/1699651627.027039-slack-C028JAG44VD, there might be more cases of shared listener)
- Stops collecting flows in the bookmarks view model when the full-screen player is closed 
- Updates theme when bookmark view is opened from Upnext queue

## Testing Instructions

#### Test.1 Multiselect 

1. Open a podcast with a few bookmarks
2. From the selected podcast, play an episode with a few bookmarks 
3. Open full-screen player and scroll to the bookmarks view
4. Close full-screen player
5. Go to bookmarks tab on the podcast screen
6. Long press on a bookmark
7.  Tap select all 
8. ✅ Notice that all bookmarks are selected

#### Test.2 Bookmark view theme

1. Open the app in light theme mode
2. Add a few episodes to Upnext queue
3. Tap on an episode from upnext queue
4. Scroll to bookmarks view
5. ✅ Notice that the theme is dark similar to "Details" tab 

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack