### PR TITLE
Catch exception if Stories call to load history fails

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -100,22 +100,26 @@ class EndOfYearManagerImpl @Inject constructor(
         if (anyEpisodeInteractionBeforeYear(year)) {
             return
         }
-        // only download the count to check if we are missing history episodes
-        val countResponse = syncManager.historyYear(year = year, count = true)
-        onProgressChanged(0.1f)
-        val serverCount = countResponse.count ?: 0
-        val localCount = countEpisodeInteractionsInYear(year)
-        Timber.i("End of Year: Server listening history. server: ${countResponse.count} local: $localCount")
-        if (serverCount > localCount) {
-            // sync the year's listening history
-            val response = syncManager.historyYear(year = year, count = false)
-            onProgressChanged(0.2f)
-            val history = response.history ?: return
-            historyManager.processServerResponse(
-                response = history,
-                updateServerModified = false,
-                onProgressChanged = onProgressChanged,
-            )
+        try {
+            // only download the count to check if we are missing history episodes
+            val countResponse = syncManager.historyYear(year = year, count = true)
+            onProgressChanged(0.1f)
+            val serverCount = countResponse.count ?: 0
+            val localCount = countEpisodeInteractionsInYear(year)
+            Timber.i("End of Year: Server listening history. server: ${countResponse.count} local: $localCount")
+            if (serverCount > localCount) {
+                // sync the year's listening history
+                val response = syncManager.historyYear(year = year, count = false)
+                onProgressChanged(0.2f)
+                val history = response.history ?: return
+                historyManager.processServerResponse(
+                    response = history,
+                    updateServerModified = false,
+                    onProgressChanged = onProgressChanged,
+                )
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "End of Year: Error downloading listening history for year $year")
         }
     }
 


### PR DESCRIPTION
## Description
This catches the exception that gets thrown when the call to download the listening history fails.

Fixes #1553

> [!IMPORTANT]
> I have this PR targeting `release/7.52`

## Testing Instructions
1. Log into an account with some listening history and make sure EOY is available.
2. Make sure the EOY Stories banner is showing on the Profile tab. You might need to listen to 5 minutes of a podcast.
3. Turn on airplane mode
4. Tap the Stories banner on the Profile tab
5. Verify that the stories load (i.e., there is not a crash), and go through each story making sure all the stories have data.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews