### PR TITLE
Fix podcast screen edit bookmark action

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -652,6 +652,23 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding?.setupMultiSelect()
+
+        if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+            viewLifecycleOwner.lifecycleScope.launch {
+                viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                    multiSelectBookmarksHelper.showEditBookmarkPage
+                        .collect { show ->
+                            if (show) onEditBookmarkClick()
+                        }
+                }
+            }
+        }
+    }
+
+    private fun onEditBookmarkClick() {
+        viewModel.buildBookmarkArguments { arguments ->
+            startActivity(arguments.getIntent(requireContext()))
+        }
     }
 
     private fun FragmentPodcastBinding.setupMultiSelect() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
+import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
@@ -18,6 +19,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
+import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarkArguments
 import au.com.shiftyjelly.pocketcasts.podcasts.helper.search.BookmarkSearchHandler
 import au.com.shiftyjelly.pocketcasts.podcasts.helper.search.EpisodeSearchHandler
 import au.com.shiftyjelly.pocketcasts.podcasts.helper.search.SearchHandler
@@ -26,6 +28,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortType
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeForPodcast
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
+import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -48,6 +51,7 @@ import io.reactivex.rxkotlin.Observables
 import io.reactivex.rxkotlin.addTo
 import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -80,6 +84,7 @@ class PodcastViewModel
     private val multiSelectBookmarksHelper: MultiSelectBookmarksHelper,
     private val settings: Settings,
     private val podcastAndEpisodeDetailsCoordinator: PodcastAndEpisodeDetailsCoordinator,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel(), CoroutineScope {
 
     private val disposables = CompositeDisposable()
@@ -409,6 +414,27 @@ class PodcastViewModel
                 }
             }
             playbackManager.seekToTimeMs(bookmark.timeSecs * 1000)
+        }
+    }
+
+    fun buildBookmarkArguments(onSuccess: (BookmarkArguments) -> Unit) {
+        multiSelectBookmarksHelper.selectedListLive.value?.firstOrNull()?.let { bookmark ->
+            val episodeUuid = bookmark.episodeUuid
+            viewModelScope.launch(ioDispatcher) {
+                val podcast = podcastManager.findPodcastByUuidSuspend(bookmark.podcastUuid)
+                val backgroundColor =
+                    if (podcast == null) 0xFF000000.toInt() else theme.playerBackgroundColor(podcast)
+                val tintColor =
+                    if (podcast == null) 0xFFFFFFFF.toInt() else theme.playerHighlightColor(podcast)
+                val arguments = BookmarkArguments(
+                    bookmarkUuid = bookmark.uuid,
+                    episodeUuid = episodeUuid,
+                    timeSecs = bookmark.timeSecs,
+                    backgroundColor = backgroundColor,
+                    tintColor = tintColor
+                )
+                onSuccess(arguments)
+            }
         }
     }
 


### PR DESCRIPTION
## Description
This fixes podcast edit bookmark action (p1699881209505099/1699879199.445519-slack-C02A333D8LQ)

## Testing Instructions
1. Open the app
2. Go to a podcast having bookmarks
3. Go to bookmarks tap
4. Long press a bookmark
5. Tap the edit icon on the multi-select toolbar
6. ✅  Notice that Change bookmark title screen is shown
7. Complete edit action
8. ✅ Notice that bookmark title has been changed

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack