### PR TITLE
Fetch latest episode url before playing episode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 7.53
 -----
-
-
-7.53
------
-
+*   Bug Fixes:
+    *   Ensure we have the most up-to-date episode urls before attempting playback
+        ([#1561](https://github.com/Automattic/pocket-casts-android/pull/1561))
 
 7.52
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -165,4 +165,6 @@ interface EpisodeManager {
         toEpochMsCurrentYear: Long,
     ): YearOverYearListeningTime
     suspend fun countEpisodesStartedAndCompleted(fromEpochMs: Long, toEpochMs: Long): EpisodesStartedAndCompleted
+
+    suspend fun updateDownloadUrl(episode: PodcastEpisode): String?
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -1183,4 +1183,20 @@ class EpisodeManagerImpl @Inject constructor(
         started = episodeDao.countEpisodesStarted(fromEpochMs, toEpochMs),
         completed = episodeDao.countEpisodesCompleted(fromEpochMs, toEpochMs),
     )
+
+    /**
+     * Get the latest episode url from the server and persist it if it is different from
+     * the locally saved downloadUrl if it is different
+     * @return the latest download url for the episode
+     */
+    override suspend fun updateDownloadUrl(episode: PodcastEpisode): String? =
+        withContext(Dispatchers.IO) {
+            val newDownloadUrl = podcastCacheServerManager.getEpisodeUrl(episode)
+            if (newDownloadUrl != null && episode.downloadUrl != newDownloadUrl) {
+                Timber.i("Updating PodcastEpisode url in database for ${episode.uuid} to $newDownloadUrl")
+                episodeDao.updateDownloadUrl(newDownloadUrl, episode.uuid)
+            }
+
+            return@withContext newDownloadUrl ?: episode.downloadUrl
+        }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServer.kt
@@ -5,6 +5,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import io.reactivex.Single
+import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -80,6 +81,9 @@ interface PodcastCacheServer {
 
     @GET("/mobile/podcast/findbyepisode/{podcastUuid}/{episodeUuid}")
     suspend fun getPodcastAndEpisode(@Path("podcastUuid") podcastUuid: String, @Path("episodeUuid") episodeUuid: String): PodcastResponse
+
+    @GET("/mobile/episode/url/{podcastUuid}/{episodeUuid}")
+    suspend fun getEpisodeUrl(@Path("podcastUuid") podcastUuid: String, @Path("episodeUuid") episodeUuid: String): Response<ResponseBody>
 
     @POST("/mobile/podcast/episode/search")
     fun searchPodcastForEpisodes(@Body searchBody: SearchBody): Single<SearchResultBody>

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManager.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.servers.podcast
 
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastRatings
 import au.com.shiftyjelly.pocketcasts.servers.discover.EpisodeSearch
 import io.reactivex.Single
@@ -16,4 +17,5 @@ interface PodcastCacheServerManager {
     suspend fun getPodcastRatings(podcastUuid: String): PodcastRatings
     suspend fun getShowNotes(podcastUuid: String): ShowNotesResponse
     suspend fun getShowNotesCache(podcastUuid: String): ShowNotesResponse?
+    suspend fun getEpisodeUrl(episode: PodcastEpisode): String?
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
@@ -1,9 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.servers.podcast
 
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.servers.di.PodcastCacheServerRetrofit
 import au.com.shiftyjelly.pocketcasts.servers.discover.EpisodeSearch
 import io.reactivex.Single
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import retrofit2.HttpException
 import retrofit2.Response
 import retrofit2.Retrofit
@@ -60,4 +63,17 @@ class PodcastCacheServerManagerImpl @Inject constructor(@PodcastCacheServerRetro
             null
         }
     }
+
+    override suspend fun getEpisodeUrl(episode: PodcastEpisode): String? =
+        withContext(Dispatchers.IO) {
+            try {
+                val response = server.getEpisodeUrl(episode.podcastUuid, episode.uuid)
+                if (response.isSuccessful) {
+                    response.body()?.string()
+                } else null
+            } catch (e: Exception) {
+                Timber.e(e)
+                null
+            }
+        }
 }


### PR DESCRIPTION
## Description
This has the app check the server for updated episode URLs before playing an episode. This avoids a problem where patreon podcasts would fail to play because the app had an expired URL. This was particularly problematic on the Automotive app because on the Automotive app there was no way to update the URL for an existing episode (refresh would just pull in new episodes). This could also be a problem on the phone app though as the only way to update the URL for an existing episode is to go to the screen for the podcast, which automatically updates all the episodes automatically (but this isn't made apparent to the user in any way).

I initially thought about only getting the URL after we see playback fails, but iOS is fetching all the episode data for a podcast before playback starts without problems apparently, and it turns out that the Android app used to fetch episode data before playback as well. It's not clear why that functionality was removed, and I don't want to download all the episode data before every playback when all we need at that point is the URL, so I'm using a more specific endpoint that only returns the episode's URL and nothing else. In the future, we can consider when/how we want to do a better job of more generally updating all the episodes for a podcast.

Fixes #272 

> [!NOTE]
> Because this fix touches our core playback logic, I have it targeting the `main` branch instead of being a betafix this late in the release process. Let me know if you feel differently.

## Testing Instructions

You'll need to use the information for a private Patreon podcast to test this. Relvant information for a private patreon podcast is in [this google doc](https://docs.google.com/document/d/1HWjWlkiofoEwytbQ5ger4rmefAv5FRI6uvDD6qK42Xc/edit).

### 1. Testing an Expired URL

Please perform the following tests on both the phone app and an Android Automotive build

#### 1.a. Verify the test episode works normally and fails when the expired URL is injected when building from `main`

1. Fresh install a version of the app build **from the `main` branch**
3. Subscribe to the private patreon podcast from the [google doc](https://docs.google.com/document/d/1HWjWlkiofoEwytbQ5ger4rmefAv5FRI6uvDD6qK42Xc/edit)
4. Verify that you can stream the "“Apps for Noteworthy Events” episode from that podcast without any issues
5. Begin playing a different episode and pause playback
6. Inject an expired URL for the "Apps for Noteworthy Events" episode into the app's database by following the directions from the [google doc](https://docs.google.com/document/d/1HWjWlkiofoEwytbQ5ger4rmefAv5FRI6uvDD6qK42Xc/edit)
7. Do NOT go to the podcasts screen on your phone after injecting the expired URL because that could cause the URL to be updated.
8. Attempt to play the "Apps for Noteworthy Events" episode again and observe that playback now fails

#### 1.b. Verify that this PR fixes playback when there is an expired url
1. Fresh install a version of the app build from **THIS PR**
2. Subscribe to the private patreon podcast from the [google doc](https://docs.google.com/document/d/1HWjWlkiofoEwytbQ5ger4rmefAv5FRI6uvDD6qK42Xc/edit)
3. Inject an expired URL for the "Apps for Noteworthy Events" episode into the app's database by following the directions from the [google doc](https://docs.google.com/document/d/1HWjWlkiofoEwytbQ5ger4rmefAv5FRI6uvDD6qK42Xc/edit)
4. Do NOT go to the podcasts screen on your phone after injecting the expired URL because that could cause the URL to be updated.
5. Attempt to play the "Apps for Noteworthy Events" episode and observe that the app fetches and uses the new URL (you can see that in the logs) and playback succeeds.

### 2. Other Scenarios to smoke test

Because this change touches our core playback logic, I think it makes sense to verify that other playback scenarios are still working as expected.

#### 2.a. Phone

1. Test a recent episode that has a working download URL that does not need to be updated (the most recent episode from the test Patreon podcast will work here)
7. Verify that you can do the following without crashing the app or seeing any other unexpected behavior:
    1. Trying to stream an episode in airplane mode
    2. Playing a downloaded episode when online
    8. Playing a downloaded episode when not online
    9. Playing user episode not uploaded to cloud and only stored locally
    10. Playing a user episode uploaded to cloud and not stored locally

#### 2.b. Automotive

1. Test a recent episode that has a working download URL that does not need to be updated (the most recent episode from the test Patreon podcast will work here)
2. Verify that you can do the following without crashing the app or seeing any other unexpected behavior:
    1. Playback works for user episode uploaded to cloud and not stored locally
    2. Playing an episode when not online doesn't crash

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews

