### PR TITLE
Handle an illegal state exception 

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -215,13 +215,25 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
     }
 
     fun onPlayerOpen() {
-        ((childFragmentManager.fragments.firstOrNull { it is BookmarksFragment }) as? BookmarksFragment)
-            ?.onPlayerOpen()
+        try {
+            if (isAdded) {
+                ((childFragmentManager.fragments.firstOrNull { it is BookmarksFragment }) as? BookmarksFragment)
+                    ?.onPlayerOpen()
+            }
+        } catch (e: IllegalStateException) {
+            Timber.e(e)
+        }
     }
 
     fun onPlayerClose() {
-        ((childFragmentManager.fragments.firstOrNull { it is BookmarksFragment }) as? BookmarksFragment)
-            ?.onPlayerClose()
+        try {
+            if (isAdded) {
+                ((childFragmentManager.fragments.firstOrNull { it is BookmarksFragment }) as? BookmarksFragment)
+                    ?.onPlayerClose()
+            }
+        } catch (e: IllegalStateException) {
+            Timber.e(e)
+        }
     }
 
     fun openPlayer(sourceView: SourceView? = null) {


### PR DESCRIPTION
## Description

This PR builds on top of https://github.com/Automattic/pocket-casts-android/pull/1557 and adds checks so that the app doesn't enter into an illegal state. It seems to happen when the player is opened and the childFragmentManager is accessed to get the bookmarks fragment from the `PlayerContainerFragment` before it is attached to the parent.

## Testing Instructions
I was unable to reproduce the issue but I see at least one report [in Sentry](https://a8c.sentry.io/share/issue/651e51c99c89431d92181a0d491de351/). 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
