### PR TITLE
Use type converter that cannot return null for date to avoid crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 *   Bug Fixes:
     *   Ensure we have the most up-to-date episode urls before attempting playback
         ([#1561](https://github.com/Automattic/pocket-casts-android/pull/1561))
+    *   Prevent crash if database is missing date episode is published
+        ([#1573](https://github.com/Automattic/pocket-casts-android/pull/1573))
 
 7.52
 -----

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/DateTypeConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/DateTypeConverter.kt
@@ -31,7 +31,7 @@ class ShouldNotBeNullDateTypeConverter {
                 Timber.w(it)
                 Sentry.addBreadcrumb(it)
             }
-            Date(Instant.EPOCH.toEpochMilli())
+            EPOCH
         } else {
             Date(value)
         }
@@ -39,4 +39,8 @@ class ShouldNotBeNullDateTypeConverter {
 
     @TypeConverter
     fun toLong(value: SafeDate?): Long = value?.time ?: 0L
+
+    companion object {
+        private val EPOCH = Date(Instant.EPOCH.toEpochMilli())
+    }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/DateTypeConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/DateTypeConverter.kt
@@ -1,6 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.models.converter
 
 import androidx.room.TypeConverter
+import io.sentry.Sentry
+import timber.log.Timber
+import java.time.Instant
 import java.util.Date
 
 class DateTypeConverter {
@@ -14,4 +17,26 @@ class DateTypeConverter {
     fun toLong(value: Date?): Long? {
         return value?.time
     }
+}
+
+typealias ShouldNotBeNullDate = Date
+
+// Type converter for dates that will not return null even if a null parameter is passed in.
+class ShouldNotBeNullDateTypeConverter {
+
+    @TypeConverter
+    fun toDate(value: Long?): ShouldNotBeNullDate {
+        return if (value == null) {
+            "ShouldNotBeNullDateTypeConverter::toDate called with null parameter. Returning epoch date.".let {
+                Timber.w(it)
+                Sentry.addBreadcrumb(it)
+            }
+            Date(Instant.EPOCH.toEpochMilli())
+        } else {
+            Date(value)
+        }
+    }
+
+    @TypeConverter
+    fun toLong(value: ShouldNotBeNullDate?): Long = value?.time ?: 0L
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/DateTypeConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/DateTypeConverter.kt
@@ -19,13 +19,13 @@ class DateTypeConverter {
     }
 }
 
-typealias ShouldNotBeNullDate = Date
+typealias SafeDate = Date
 
 // Type converter for dates that will not return null even if a null parameter is passed in.
 class ShouldNotBeNullDateTypeConverter {
 
     @TypeConverter
-    fun toDate(value: Long?): ShouldNotBeNullDate {
+    fun toDate(value: Long?): SafeDate {
         return if (value == null) {
             "ShouldNotBeNullDateTypeConverter::toDate called with null parameter. Returning epoch date.".let {
                 Timber.w(it)
@@ -38,5 +38,5 @@ class ShouldNotBeNullDateTypeConverter {
     }
 
     @TypeConverter
-    fun toLong(value: ShouldNotBeNullDate?): Long = value?.time ?: 0L
+    fun toLong(value: SafeDate?): Long = value?.time ?: 0L
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/DateTypeConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/DateTypeConverter.kt
@@ -22,7 +22,7 @@ class DateTypeConverter {
 typealias SafeDate = Date
 
 // Type converter for dates that will not return null even if a null parameter is passed in.
-class ShouldNotBeNullDateTypeConverter {
+class SafeDateTypeConverter {
 
     @TypeConverter
     fun toDate(value: Long?): SafeDate {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -18,6 +18,7 @@ import au.com.shiftyjelly.pocketcasts.models.converter.EpisodesSortTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.PodcastAutoUpNextConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.PodcastLicensingEnumConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.PodcastsSortTypeConverter
+import au.com.shiftyjelly.pocketcasts.models.converter.ShouldNotBeNullDateTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.SyncStatusConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.TrimModeTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.UserEpisodeServerStatusConverter
@@ -69,6 +70,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
     AnonymousBumpStat.CustomEventPropsTypeConverter::class,
     BundlePaidTypeConverter::class,
     DateTypeConverter::class,
+    ShouldNotBeNullDateTypeConverter::class,
     EpisodePlayingStatusConverter::class,
     EpisodeStatusEnumConverter::class,
     EpisodesSortTypeConverter::class,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -18,7 +18,7 @@ import au.com.shiftyjelly.pocketcasts.models.converter.EpisodesSortTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.PodcastAutoUpNextConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.PodcastLicensingEnumConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.PodcastsSortTypeConverter
-import au.com.shiftyjelly.pocketcasts.models.converter.ShouldNotBeNullDateTypeConverter
+import au.com.shiftyjelly.pocketcasts.models.converter.SafeDateTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.SyncStatusConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.TrimModeTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.UserEpisodeServerStatusConverter
@@ -70,7 +70,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
     AnonymousBumpStat.CustomEventPropsTypeConverter::class,
     BundlePaidTypeConverter::class,
     DateTypeConverter::class,
-    ShouldNotBeNullDateTypeConverter::class,
+    SafeDateTypeConverter::class,
     EpisodePlayingStatusConverter::class,
     EpisodeStatusEnumConverter::class,
     EpisodesSortTypeConverter::class,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PodcastEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PodcastEpisode.kt
@@ -7,6 +7,7 @@ import androidx.room.Ignore
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import au.com.shiftyjelly.pocketcasts.localization.R
+import au.com.shiftyjelly.pocketcasts.models.converter.ShouldNotBeNullDate
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import java.io.Serializable
@@ -23,7 +24,7 @@ import java.util.Date
 data class PodcastEpisode(
     @PrimaryKey(autoGenerate = false) @ColumnInfo(name = "uuid") override var uuid: String,
     @ColumnInfo(name = "episode_description") override var episodeDescription: String = "",
-    @ColumnInfo(name = "published_date") override var publishedDate: Date,
+    @ColumnInfo(name = "published_date") override var publishedDate: ShouldNotBeNullDate,
     @ColumnInfo(name = "title") override var title: String = "",
     @ColumnInfo(name = "size_in_bytes") override var sizeInBytes: Long = 0,
     @ColumnInfo(name = "episode_status") override var episodeStatus: EpisodeStatusEnum = EpisodeStatusEnum.NOT_DOWNLOADED,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PodcastEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PodcastEpisode.kt
@@ -7,7 +7,7 @@ import androidx.room.Ignore
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import au.com.shiftyjelly.pocketcasts.localization.R
-import au.com.shiftyjelly.pocketcasts.models.converter.ShouldNotBeNullDate
+import au.com.shiftyjelly.pocketcasts.models.converter.SafeDate
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import java.io.Serializable
@@ -24,7 +24,7 @@ import java.util.Date
 data class PodcastEpisode(
     @PrimaryKey(autoGenerate = false) @ColumnInfo(name = "uuid") override var uuid: String,
     @ColumnInfo(name = "episode_description") override var episodeDescription: String = "",
-    @ColumnInfo(name = "published_date") override var publishedDate: ShouldNotBeNullDate,
+    @ColumnInfo(name = "published_date") override var publishedDate: SafeDate,
     @ColumnInfo(name = "title") override var title: String = "",
     @ColumnInfo(name = "size_in_bytes") override var sizeInBytes: Long = 0,
     @ColumnInfo(name = "episode_status") override var episodeStatus: EpisodeStatusEnum = EpisodeStatusEnum.NOT_DOWNLOADED,

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/SafeDateTypeConverterTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/SafeDateTypeConverterTest.kt
@@ -1,0 +1,39 @@
+package au.com.shiftyjelly.pocketcasts.models
+
+import au.com.shiftyjelly.pocketcasts.models.converter.SafeDateTypeConverter
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+import java.time.Instant
+import java.util.Date
+
+class SafeDateTypeConverterTest {
+
+    @Test
+    fun `creates date from non-null long`() {
+        val l = 125542352L
+        val expected = Date(l)
+        val actual = SafeDateTypeConverter().toDate(l)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `creates date from null long`() {
+        val expected = Date(Instant.EPOCH.toEpochMilli())
+        val actual = SafeDateTypeConverter().toDate(null)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `creates long from non-null date`() {
+        val expected = 125542352L
+        val d = Date(expected)
+        val actual = SafeDateTypeConverter().toLong(d)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `creates long from null date`() {
+        val actual = SafeDateTypeConverter().toLong(null)
+        assertEquals(0L, actual)
+    }
+}


### PR DESCRIPTION
## Description
This PR is adding a type converter that never returns null to address a crash we've seen a sudden increase in [on Sentry](https://a8c.sentry.io/discover/results/?field=title&field=release&field=environment&field=user.display&field=timestamp&name=IllegalStateException%3A+Expected+non-null+java.util.Date%2C+but+it+was+null.&project=6711064&query=issue%3APOCKET-CASTS-ANDROID-WJ2&sort=-timestamp&statsPeriod=90d&yAxis=count%28%29).

The root of the crash seems to be that a null `Long` is being retrieved from the `podcast_episodes` database table. This should never happen because that column [is not allowed to be null](https://github.com/Automattic/pocket-casts-android/blob/release/7.53/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PodcastEpisode.kt#L26). This is the generated code that is leading to the error:

``` kotlin
if (_cursor.isNull(_cursorIndexOfPublishedDate)) {
  _tmp = null;
} else {
  _tmp = _cursor.getLong(_cursorIndexOfPublishedDate);
}
final Date _tmp_1 = __dateTypeConverter.toDate(_tmp);
if(_tmp_1 == null) {
  throw new IllegalStateException("Expected non-null java.util.Date, but it was null.");
} else {
  _tmpPublishedDate = _tmp_1;
}
```

This PR adds a `SafeDate` typealias for the `Date` class along with a `TypeConverter` that will never return null and therefore handles providing valid `Date` objects even if it is passed a null. I'm doing this instead of updating the current `DateTypeConverter` because we need the type converter to be able to return null dates [in some instances](https://github.com/Automattic/pocket-casts-android/pull/1390#discussion_r1332484652). This is what the generated code looks like in the new type converter:

``` kotlin
final Date _tmpPublishedDate;
final long _tmp;
_tmp = _cursor.getLong(_cursorIndexOfPublishedDate);
final Long _tmp_1;
_tmp_1 = _tmp;      // No longer checking for null here because the type converter does never returns null values
_tmpPublishedDate = __shouldNotBeNullDateTypeConverter.toDate(_tmp_1);
```

Fixes #1572 

## Testing Instructions

I have not found a way to directly reproduce this error in an unaltered app, so let's do two tests, one with the unaltered app, and one with an altered build that forces the app to handle a null value from the database.

### 1. Unaltered app
1. Go to the podcast page for "The Daily" podcast
2. Observe that everything works as it should
3. Go to the podcast page for a few other podcasts, checking back on "The Daily" podcast a few times
4. Observe that they also work without any issues.

### 2. Force the type converter to handle a null value
1. Alter the `ShouldNotBeNullDateTypeConverter::toDate` method so that it always returns `            Date(Instant.EPOCH.toEpochMilli())` (i.e., what it would return if `null` was passed to the method).
2. Build the altered app and deploy it to your device
3. Go to the podcast page for "The Daily" podcast
4. Observe that all of the episodes have a date of "December 31, 1969" but that otherwise everything works as it should
5. Go to the podcast page for a few other podcasts
6. Observer that they also work within any issues apart from all the episodes having the date epoch date.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews