### PR TITLE
Change bookmarks tab order

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -330,12 +330,12 @@ private class ViewPagerAdapter(fragmentManager: FragmentManager, lifecycle: Life
             newSections.add(Section.Notes)
         }
 
-        if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-            newSections.add(Section.Bookmarks)
-        }
-
         if (hasChapters) {
             newSections.add(Section.Chapters)
+        }
+
+        if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
+            newSections.add(Section.Bookmarks)
         }
 
         this.sections = newSections


### PR DESCRIPTION
## Description
This changes the Bookmarks tab position so that it is shown after the Chapters tab.
(Internal Ref: p1701267305022489/1701225559.781909-slack-C055BDMU095)

## Testing Instructions
1. Launch the app
2. Play a podcast with chapters like https://pca.st/kfyb6kvc
3. Open the full screen player
4. ✅ Verify the order of the tabs is: Now Playing, Details, Chapters, Bookmarks

## Screenshots or Screencast 
<img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/869406ce-116e-4694-a116-4dce9ee66586"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack