### PR TITLE
Update billing lib version to 6.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ aboutlibraries = "10.5.0"
 accompanist = "0.30.1"
 # Android Gradle Plugin - https://developer.android.com/studio/releases/gradle-plugin
 android-application = "8.1.0"
-billing = "5.2.1"
+billing = "6.0.1"
 coil = "2.2.1"
 compose = "1.4.2"
 # @keep

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -374,8 +374,8 @@ class SubscriptionManagerImpl @Inject constructor(
                             BillingFlowParams.SubscriptionUpdateParams.newBuilder()
                                 .setOldPurchaseToken(existingPurchase.purchaseToken)
                                 /* User is changing subscription entitlement, proration rate applied at runtime (https://rb.gy/e876y)
-                                   Also, since upgrading to a more expensive tier, recommended proration rate is IMMEDIATE_AND_CHARGE_PRORATED_PRICE (https://rb.gy/acghw) */
-                                .setReplaceProrationMode(BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE)
+                                   Also, since upgrading to a more expensive tier, recommended replacement mode is CHARGE_PRORATED_PRICE (https://rb.gy/acghw) */
+                                .setSubscriptionReplacementMode(BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.CHARGE_PRORATED_PRICE)
                                 .build()
                         )
                     }


### PR DESCRIPTION
## Description

This bumps billing lib version from `5.2.1` to `6.0.1` and makes necessary changes. 
Internal ref: pdeCcb-3t4-p2

[Release notes - v6.0.1](https://developer.android.com/google/play/billing/release-notes#6-0-1)

> Added new [ReplacementMode](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode) enum to replace [ProrationMode](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.ProrationMode).

I replaced the deprecated enum in 8efbbe9c0c923bf4902e0737aff28fa52aeb9509

> [!Warning]
> Not ready to merge since I need to check if everything is still good backend side

## Testing Instructions

Prerequisites
- Release build
- License test account

1. Login with a free account
2. Subscribe to Plus
3. ✅  Notice that the subscription succeeds
4. Go to profile
5. Tap Upgrade to Patron
6. ✅  Notice that the upgrade proceeds as expected with the correct replacement mode.
 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack