### PR TITLE
Make MultiSelectEpisodesHelper not a singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
         ([#1596](https://github.com/Automattic/pocket-casts-android/pull/1596))
     *   Fix text being cut off in discover search bar at high zoom 
         ([#1601](https://github.com/Automattic/pocket-casts-android/pull/1601))
+    *   Fix issues where multi-select on one screen would affect another screen
+        ([#1579](https://github.com/Automattic/pocket-casts-android/pull/1579))
 *   Updates:
     *   Display dynamic colors for widget
         ([#1588](https://github.com/Automattic/pocket-casts-android/pull/1588))

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -519,6 +519,14 @@ class MainActivity :
 
     @Suppress("DEPRECATION")
     override fun onBackPressed() {
+        if (isUpNextShowing()) {
+            val fragment = supportFragmentManager.findFragmentByTag(UpNextFragment::class.java.name)
+            if ((fragment as UpNextFragment).multiSelectHelper.isMultiSelecting) {
+                fragment.multiSelectHelper.isMultiSelecting = false
+                return
+            }
+        }
+
         if (frameBottomSheetBehavior.state != BottomSheetBehavior.STATE_COLLAPSED) {
             frameBottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
             return

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -121,7 +121,6 @@ import au.com.shiftyjelly.pocketcasts.views.helper.HasBackstack
 import au.com.shiftyjelly.pocketcasts.views.helper.IntentUtil
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import au.com.shiftyjelly.pocketcasts.views.helper.WarningsHelper
-import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -174,7 +173,6 @@ class MainActivity :
         const val PROMOCODE_REQUEST_CODE = 2
     }
 
-    @Inject lateinit var multiSelectHelper: MultiSelectEpisodesHelper
     @Inject lateinit var playbackManager: PlaybackManager
     @Inject lateinit var podcastManager: PodcastManager
     @Inject lateinit var playlistManager: PlaylistManager
@@ -521,11 +519,6 @@ class MainActivity :
 
     @Suppress("DEPRECATION")
     override fun onBackPressed() {
-        if (multiSelectHelper.isMultiSelecting) {
-            multiSelectHelper.isMultiSelecting = false
-            return
-        }
-
         if (frameBottomSheetBehavior.state != BottomSheetBehavior.STATE_COLLAPSED) {
             frameBottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
             return

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksContainerFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.OnBackPressedCallback
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
@@ -69,6 +70,19 @@ class BookmarksContainerFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val bottomSheetDialog = dialog as? BottomSheetDialog
+        bottomSheetDialog?.onBackPressedDispatcher?.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    if (multiSelectHelper.isMultiSelecting) {
+                        multiSelectHelper.isMultiSelecting = false
+                        return
+                    }
+                    dismiss()
+                }
+            }
+        )
+
         bottomSheetDialog?.behavior?.apply {
             isFitToContents = false
             state = BottomSheetBehavior.STATE_EXPANDED

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -9,6 +9,7 @@ import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.OnBackPressedCallback
 import androidx.annotation.StringRes
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
@@ -144,6 +145,18 @@ class EpisodeContainerFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val bottomSheetDialog = dialog as? BottomSheetDialog
+        bottomSheetDialog?.onBackPressedDispatcher?.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    if (multiSelectHelper.isMultiSelecting) {
+                        multiSelectHelper.isMultiSelecting = false
+                        return
+                    }
+                    dismiss()
+                }
+            }
+        )
         bottomSheetDialog?.behavior?.apply {
             isFitToContents = false
             state = BottomSheetBehavior.STATE_EXPANDED

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -34,14 +34,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
-import javax.inject.Singleton
 import kotlin.math.min
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 private const val WARNING_LIMIT = 3
-@Singleton
 class MultiSelectEpisodesHelper @Inject constructor(
     val episodeManager: EpisodeManager,
     val userEpisodeManager: UserEpisodeManager,


### PR DESCRIPTION
## Description
This is a follow-up to https://github.com/Automattic/pocket-casts-android/pull/1316. That PR contained quite a few changes, and we found other ways to address the ANRs and the worst multi-select issues, so we didn't move forward with it. We still had quite a few multi-select issues though. In particular, in my testing I observed that multi-select state was getting shared (which would cause things like the toolbar displaying the wrong number of selected items, and other multiselect bugs).

I initially tried porting over a few of the changes from #1316, but I found that they were introducing regressions. It turned out that just simply making the `MultiSelectEpisodesHelper` a singleton solved most of the multi-select issues I see.

This _almost_ fixes https://github.com/Automattic/pocket-casts-android/issues/98, but there is still a multiselect issue with bookmarks that I'm seeing. I'm not trying to address the one remaining multi-select issue in this PR just to keep this PR small and focused.

## Testing Instructions

### 1. Watch for ANR regressions

I think it's very unlikely that this change would cause any ANR issues, but given that we had some ANR issues the last time we made significant changes to multiselect, please keep an eye out for any unexpected slowness as you test this change

### 2. Mult-Select Improvement

I tested this by turning on multiselect in the first screen, navigating to the second screen, and verifying that the second screen was not put into a multiselect state. When running through these tests, make sure you clear multiselect state from the relevant screens before testing (speaking from experience, it's easy to forget to do that and then to think a subsequent test is failing when it really isn't).

Let me know if there are any other test scenarios we should be covering here.

#### 2.1. For each test:
1. Make sure both the start and end screens are not in multi-select mode
2. Enter multiselection on the start screen
3. Navigate to the end screen
4. Verify that the end screen is not in a multi-select state

#### 2.2. Before these changes
1. 🔴 Podcast Bookmarks → Full Screen Player Bookmarks
2. 🟢 Full Screen Player Bookmarks → Podcast Bookmarks
3. 🔴 Podcast Screen → Up Next
5. 🔴 Up Next → Podcast Screen
6. 🔴 Downloads/Starred/Listening-History → Up Next
7. 🔴 Up Next → Downloads/Starred/Listening-History
8. 🔴 Files  → Up Next
9. 🔴 Up Next → Files
10. 🟢 Downloads/Starred/Listening-History → Podcast
11. 🟢 Podcast → Downloads/Starred/Listening-History
12. 🟢 Files → Podcast
13. 🟢 Podcast → Files
14. 🟢 Viewing a podcast on Discover tab → Viewing a podcast on Podcasts tab

#### 2.3. Expected Results After These Changes
1. 🔴 Podcast Bookmarks → Full Screen Player Bookmarks
2. 🟢 Full Screen Player Bookmarks → Podcast Bookmarks
3. 🟢 Podcast Screen → Up Next
4. 🟢 Up Next → Podcast Screen
5. 🟢 Downloads/Starred/Listening-History → Up Next
6. 🟢 Up Next → Downloads/Starred/Listening-History
7. 🟢 Files  → Up Next
8. 🟢 Up Next → Files
9. 🟢 Downloads/Starred/Listening-History → Podcast
10. 🟢 Podcast → Downloads/Starred/Listening-History
11. 🟢 Files → Podcast
14. 🟢 Podcast → Files
15. 🟢 Viewing a podcast on Discover tab → Viewing a podcast on Podcasts tab


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews