### PR TITLE
Playback 2023: Top 5 shows - update query to remove weighted average

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -354,13 +354,12 @@ abstract class PodcastDao {
 
     @Query(
         """
-         SELECT (totalPlayedTime * 0.4) * (numberOfPlayedEpisodes * 0.6) as weighted, * FROM (
-            SELECT DISTINCT podcast_episodes.uuid as episodeId, podcasts.uuid, podcasts.title, podcasts.author, podcasts.primary_color as tintColorForLightBg, podcasts.secondary_color as tintColorForDarkBg, SUM(podcast_episodes.played_up_to) as totalPlayedTime, COUNT(podcast_episodes.uuid) as numberOfPlayedEpisodes
+         SELECT DISTINCT podcast_episodes.uuid as episodeId, podcasts.uuid, podcasts.title, podcasts.author, podcasts.primary_color as tintColorForLightBg, podcasts.secondary_color as tintColorForDarkBg, SUM(podcast_episodes.played_up_to) as totalPlayedTime, COUNT(podcast_episodes.uuid) as numberOfPlayedEpisodes
             FROM podcast_episodes
             JOIN podcasts ON podcast_episodes.podcast_id = podcasts.uuid
             WHERE podcast_episodes.last_playback_interaction_date IS NOT NULL AND podcast_episodes.last_playback_interaction_date > :fromEpochMs AND podcast_episodes.last_playback_interaction_date < :toEpochMs
-            GROUP BY podcast_id)
-            ORDER BY weighted DESC
+            GROUP BY podcast_id
+            ORDER BY totalPlayedTime DESC, numberOfPlayedEpisodes DESC
             LIMIT :limit
         """
     )

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/TopPodcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/TopPodcast.kt
@@ -11,7 +11,6 @@ data class TopPodcast(
     val tintColorForDarkBg: Int,
     val numberOfPlayedEpisodes: Int,
     val totalPlayedTime: Double,
-    val weighted: Double,
 ) {
     fun toPodcast() = Podcast(
         uuid = uuid,


### PR DESCRIPTION
| 📘 Part of: #1463  |
|:---:|

Updates query to calculate top 5 shows using listening time instead of a weighted average of listening time and no. of episodes.

Corresponding iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/1242
Internal Ref: p1701355249378659/1701343447.304769-slack-C041BGTFQ5R

## To test

1. Run the app
2. Check your Playback 2023 stories
3. Go to your top 5 stories
4. ✅ Check that is ordered by listening time

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- with different themes
- with a landscape orientation
- with the device set to have a large display and font size
- for accessibility with TalkBack