### PR TITLE
Playback2023: Fix completed episodes query 

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/utils/Util.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/utils/Util.kt
@@ -1,7 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.utils
 
+import androidx.compose.runtime.Composable
+import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryBlurredBackgroundStyle
 import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import kotlin.math.min
 
 fun List<TopPodcast>.atSafeIndex(
@@ -11,4 +14,10 @@ fun List<TopPodcast>.atSafeIndex(
     val size = min(size, maxSize)
     return this[(index % size).coerceAtMost(size - 1)]
         .toPodcast()
+}
+
+@Composable
+fun blurredBackgroundStyle(userTier: UserTier) = when (userTier) {
+    UserTier.Patron, UserTier.Plus -> StoryBlurredBackgroundStyle.Plus
+    UserTier.Free -> StoryBlurredBackgroundStyle.Default
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryCompletionRateView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryCompletionRateView.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.endofyear.views.stories
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,6 +13,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -19,12 +22,15 @@ import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeDisplayMode
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
 import au.com.shiftyjelly.pocketcasts.endofyear.components.CompletionRateCircle
+import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryBlurredBackground
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryPrimaryText
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StorySecondaryText
+import au.com.shiftyjelly.pocketcasts.endofyear.utils.blurredBackgroundStyle
 import au.com.shiftyjelly.pocketcasts.models.db.helper.EpisodesStartedAndCompleted
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryCompletionRate
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -34,41 +40,54 @@ fun StoryCompletionRateView(
     userTier: UserTier,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        verticalArrangement = Arrangement.Bottom,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier
+    BoxWithConstraints(
+        modifier = Modifier
             .fillMaxSize()
             .background(story.backgroundColor)
-            .verticalScroll(rememberScrollState())
-            .padding(vertical = 30.dp)
     ) {
-        Spacer(modifier = modifier.height(40.dp))
-
-        SubscriptionBadgeForTier(
-            tier = SubscriptionTier.fromUserTier(userTier),
-            displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
+        val context = LocalView.current.context
+        StoryBlurredBackground(
+            offset = Offset(
+                maxWidth.value.toInt().dpToPx(context) * 0.4f,
+                -maxHeight.value.toInt().dpToPx(context) * 0.35f
+            ),
+            style = blurredBackgroundStyle(userTier),
         )
-
-        Spacer(modifier = modifier.height(14.dp))
-
-        PrimaryText(story)
-
-        Spacer(modifier = modifier.height(14.dp))
-
-        SecondaryText(story)
-
-        Spacer(modifier = modifier.weight(0.2f))
-
-        CompletionRateCircle(
-            percent = story.episodesStartedAndCompleted.percentage.toInt(),
-            titleColor = story.tintColor,
-            subTitleColor = story.subtitleColor,
+        Column(
+            verticalArrangement = Arrangement.Bottom,
+            horizontalAlignment = Alignment.CenterHorizontally,
             modifier = modifier
-                .weight(1f)
-        )
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(vertical = 30.dp)
+        ) {
+            Spacer(modifier = modifier.height(40.dp))
 
-        Spacer(modifier = modifier.weight(0.2f))
+            SubscriptionBadgeForTier(
+                tier = SubscriptionTier.fromUserTier(userTier),
+                displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
+            )
+
+            Spacer(modifier = modifier.height(14.dp))
+
+            PrimaryText(story)
+
+            Spacer(modifier = modifier.height(14.dp))
+
+            SecondaryText(story)
+
+            Spacer(modifier = modifier.weight(0.2f))
+
+            CompletionRateCircle(
+                percent = story.episodesStartedAndCompleted.percentage.toInt(),
+                titleColor = story.tintColor,
+                subTitleColor = story.subtitleColor,
+                modifier = modifier
+                    .weight(1f)
+            )
+
+            Spacer(modifier = modifier.weight(0.2f))
+        }
     }
 }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryEpilogueView.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/views/stories/StoryEpilogueView.kt
@@ -32,10 +32,10 @@ import au.com.shiftyjelly.pocketcasts.compose.components.Confetti
 import au.com.shiftyjelly.pocketcasts.endofyear.R
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryAppLogo
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryBlurredBackground
-import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryBlurredBackgroundStyle
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryButton
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StoryPrimaryText
 import au.com.shiftyjelly.pocketcasts.endofyear.components.StorySecondaryText
+import au.com.shiftyjelly.pocketcasts.endofyear.utils.blurredBackgroundStyle
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryEpilogue
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
@@ -149,12 +149,6 @@ private fun ReplayButton(
         modifier = modifier
             .fillMaxSize(.75f)
     )
-}
-
-@Composable
-private fun blurredBackgroundStyle(userTier: UserTier) = when (userTier) {
-    UserTier.Patron, UserTier.Plus -> StoryBlurredBackgroundStyle.Plus
-    UserTier.Free -> StoryBlurredBackgroundStyle.Default
 }
 
 @Preview(name = "Free user")

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -419,7 +419,7 @@ abstract class EpisodeDao {
         """
         SELECT COUNT(DISTINCT uuid) AS completed 
         FROM podcast_episodes 
-        WHERE (playing_status = 3 OR played_up_to >= 0.9 * duration) 
+        WHERE (playing_status = 2 OR played_up_to >= 0.9 * duration) 
         AND podcast_episodes.last_playback_interaction_date IS NOT NULL 
         AND podcast_episodes.last_playback_interaction_date > :fromEpochMs AND podcast_episodes.last_playback_interaction_date < :toEpochMs
         """


### PR DESCRIPTION
| 📘 Part of: #1463  |
|:---:|

## Description

This updates `playing_status` value for completed episodes in the completed episodes query. The values comes as `3` in the json but stored as `2` in the db ([source](https://github.com/Automattic/pocket-casts-android/blob/fa7189474f5a0670d0db475448ddea0ec10a9101/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/EpisodePlayingStatus.kt#L19-L21)).
Additionally, it adds a blurred background for the completion rate story.

> [!WARNING]  
> Targets 7.53

## Testing Instructions

1. Fresh install the app 
2. Log in to a Plus account that has a few episodes listened more than 90% of duration + a few episodes having EpisodePlayingStatus as completed
3. Go to Profile
4. Tap the EOY image
5. Skip to the Completion Rate story
5. ✅ Check that the story completion rate is correct

** It might be good to compare it with the iOS app (make sure you fresh install the app).

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
