### PR TITLE
Catch exceptions thrown when refreshing podcasts in the background

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -36,6 +36,7 @@ import io.reactivex.Maybe
 import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
+import io.sentry.Sentry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -321,6 +322,7 @@ class PodcastManagerImpl @Inject constructor(
                 }
             } catch (e: Exception) {
                 LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, e, "Error refreshing podcast ${existingPodcast.uuid} in background")
+                Sentry.captureException(e)
             }
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -199,97 +199,128 @@ class PodcastManagerImpl @Inject constructor(
     @Suppress("NAME_SHADOWING")
     override fun refreshPodcastInBackground(existingPodcast: Podcast, playbackManager: PlaybackManager) {
         launch {
-            LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Refreshing podcast ${existingPodcast.uuid}")
-            val updatedPodcast = cacheServerManager.getPodcastResponse(existingPodcast.uuid)
-                .map {
-                    val responsePodcast = it.body()?.toPodcast()
-                    if (it.wasCached()) {
-                        Optional.empty<Podcast>()
-                    } else {
-                        Optional.of(responsePodcast)
+            try {
+                LogBuffer.i(
+                    LogBuffer.TAG_BACKGROUND_TASKS,
+                    "Refreshing podcast ${existingPodcast.uuid}"
+                )
+                val updatedPodcast = cacheServerManager.getPodcastResponse(existingPodcast.uuid)
+                    .map {
+                        val responsePodcast = it.body()?.toPodcast()
+                        if (it.wasCached()) {
+                            Optional.empty<Podcast>()
+                        } else {
+                            Optional.of(responsePodcast)
+                        }
                     }
-                }
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribeOn(Schedulers.io())
-                .onErrorReturnItem(Optional.empty())
-                .blockingGet()
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribeOn(Schedulers.io())
+                    .onErrorReturnItem(Optional.empty())
+                    .blockingGet()
 
-            updatedPodcast.get()?.let { updatedPodcast ->
-                val originalPodcast = existingPodcast.copy()
-                existingPodcast.title = updatedPodcast.title
-                existingPodcast.author = updatedPodcast.author
-                existingPodcast.podcastCategory = updatedPodcast.podcastCategory
-                existingPodcast.podcastDescription = updatedPodcast.podcastDescription
-                existingPodcast.estimatedNextEpisode = updatedPodcast.estimatedNextEpisode
-                existingPodcast.episodeFrequency = updatedPodcast.episodeFrequency
-                existingPodcast.refreshAvailable = updatedPodcast.refreshAvailable
-                val existingEpisodes = episodeManager.findEpisodesByPodcastOrderedByPublishDate(existingPodcast)
-                val mostRecentEpisode = existingEpisodes.firstOrNull()
-                val insertEpisodes = mutableListOf<PodcastEpisode>()
-                updatedPodcast.episodes.map { newEpisode ->
-                    val existingEpisode = existingEpisodes.find { it.uuid == newEpisode.uuid }
-                    if (existingEpisode != null) {
-                        val originalEpisode = existingEpisode.copy()
-                        existingEpisode.title = newEpisode.title
-                        existingEpisode.downloadUrl = newEpisode.downloadUrl
-                        // as new episodes are added a task is run to get the content type and file size from the server file as it is more reliable
-                        if (existingEpisode.fileType.isNullOrBlank()) {
-                            existingEpisode.fileType = newEpisode.fileType
-                        }
-                        if (existingEpisode.sizeInBytes <= 0) {
-                            existingEpisode.sizeInBytes = newEpisode.sizeInBytes
-                        }
-                        if (existingEpisode.duration <= 0) {
-                            existingEpisode.duration = newEpisode.duration
-                        }
-                        existingEpisode.publishedDate = newEpisode.publishedDate
-                        existingEpisode.season = newEpisode.season
-                        existingEpisode.number = newEpisode.number
-                        existingEpisode.type = newEpisode.type
-                        // only update the db if the fields have changed
-                        if (originalEpisode != existingEpisode) {
-                            episodeManager.update(existingEpisode)
-                        }
-                    } else {
-                        // don't add anything newer than the latest episode so it runs through the refresh logic (auto download, auto add to Up Next etc
-                        if (!existingPodcast.isSubscribed || (mostRecentEpisode != null && newEpisode.publishedDate.before(mostRecentEpisode.publishedDate))) {
-                            newEpisode.podcastUuid = existingPodcast.uuid
-                            newEpisode.episodeStatus = EpisodeStatusEnum.NOT_DOWNLOADED
-                            newEpisode.playingStatus = EpisodePlayingStatus.NOT_PLAYED
-
-                            // for podcast you're subscribed to, if we find episodes older than a week, we add them in as archived so they don't flood your filters, etc
-                            val newEpisodeIs7DaysOld = if (mostRecentEpisode != null) {
-                                DateUtil.daysBetweenTwoDates(newEpisode.publishedDate, mostRecentEpisode.publishedDate) >= 7
-                            } else {
-                                true
+                updatedPodcast.get()?.let { updatedPodcast ->
+                    val originalPodcast = existingPodcast.copy()
+                    existingPodcast.title = updatedPodcast.title
+                    existingPodcast.author = updatedPodcast.author
+                    existingPodcast.podcastCategory = updatedPodcast.podcastCategory
+                    existingPodcast.podcastDescription = updatedPodcast.podcastDescription
+                    existingPodcast.estimatedNextEpisode = updatedPodcast.estimatedNextEpisode
+                    existingPodcast.episodeFrequency = updatedPodcast.episodeFrequency
+                    existingPodcast.refreshAvailable = updatedPodcast.refreshAvailable
+                    val existingEpisodes = episodeManager.findEpisodesByPodcastOrderedByPublishDate(existingPodcast)
+                    val mostRecentEpisode = existingEpisodes.firstOrNull()
+                    val insertEpisodes = mutableListOf<PodcastEpisode>()
+                    updatedPodcast.episodes.map { newEpisode ->
+                        val existingEpisode = existingEpisodes.find { it.uuid == newEpisode.uuid }
+                        if (existingEpisode != null) {
+                            val originalEpisode = existingEpisode.copy()
+                            existingEpisode.title = newEpisode.title
+                            existingEpisode.downloadUrl = newEpisode.downloadUrl
+                            // as new episodes are added a task is run to get the content type and file size from the server file as it is more reliable
+                            if (existingEpisode.fileType.isNullOrBlank()) {
+                                existingEpisode.fileType = newEpisode.fileType
                             }
-                            newEpisode.isArchived = existingPodcast.isSubscribed && newEpisodeIs7DaysOld
+                            if (existingEpisode.sizeInBytes <= 0) {
+                                existingEpisode.sizeInBytes = newEpisode.sizeInBytes
+                            }
+                            if (existingEpisode.duration <= 0) {
+                                existingEpisode.duration = newEpisode.duration
+                            }
+                            existingEpisode.publishedDate = newEpisode.publishedDate
+                            existingEpisode.season = newEpisode.season
+                            existingEpisode.number = newEpisode.number
+                            existingEpisode.type = newEpisode.type
+                            // only update the db if the fields have changed
+                            if (originalEpisode != existingEpisode) {
+                                episodeManager.update(existingEpisode)
+                            }
+                        } else {
+                            // don't add anything newer than the latest episode so it runs through the refresh logic (auto download, auto add to Up Next etc
+                            if (!existingPodcast.isSubscribed || (
+                                mostRecentEpisode != null && newEpisode.publishedDate.before(
+                                        mostRecentEpisode.publishedDate
+                                    )
+                                )
+                            ) {
+                                newEpisode.podcastUuid = existingPodcast.uuid
+                                newEpisode.episodeStatus = EpisodeStatusEnum.NOT_DOWNLOADED
+                                newEpisode.playingStatus = EpisodePlayingStatus.NOT_PLAYED
 
-                            newEpisode.archivedModified = Date().time
-                            newEpisode.lastArchiveInteraction = Date().time
-                            // give it an old added date so it doesn't trigger a new episode notification
-                            newEpisode.addedDate = existingPodcast.addedDate ?: Date()
-                            existingPodcast.addEpisode(newEpisode)
-                            insertEpisodes.add(newEpisode)
+                                // for podcast you're subscribed to, if we find episodes older than a week, we add them in as archived so they don't flood your filters, etc
+                                val newEpisodeIs7DaysOld = if (mostRecentEpisode != null) {
+                                    DateUtil.daysBetweenTwoDates(
+                                        newEpisode.publishedDate,
+                                        mostRecentEpisode.publishedDate
+                                    ) >= 7
+                                } else {
+                                    true
+                                }
+                                newEpisode.isArchived =
+                                    existingPodcast.isSubscribed && newEpisodeIs7DaysOld
+
+                                newEpisode.archivedModified = Date().time
+                                newEpisode.lastArchiveInteraction = Date().time
+                                // give it an old added date so it doesn't trigger a new episode notification
+                                newEpisode.addedDate = existingPodcast.addedDate ?: Date()
+                                existingPodcast.addEpisode(newEpisode)
+                                insertEpisodes.add(newEpisode)
+                            }
                         }
                     }
-                }
-                if (insertEpisodes.isNotEmpty()) {
-                    episodeManager.add(insertEpisodes, podcastUuid = existingPodcast.uuid, downloadMetaData = false)
-                }
-                val episodeUuidsToDelete = existingEpisodes.map { it.uuid }.subtract(updatedPodcast.episodes.map { it.uuid })
-                val calendar = Calendar.getInstance()
-                calendar.add(Calendar.DAY_OF_MONTH, -14)
-                val twoWeeksAgo = calendar.time
-                val episodesToDelete = episodeUuidsToDelete.mapNotNull { uuid -> existingEpisodes.find { it.uuid == uuid } }.filter { it.addedDate.before(twoWeeksAgo) && episodeManager.episodeCanBeCleanedUp(it, playbackManager) }
-                if (episodesToDelete.isNotEmpty()) {
-                    episodeManager.deleteEpisodesWithoutSync(episodesToDelete, playbackManager)
-                }
+                    if (insertEpisodes.isNotEmpty()) {
+                        episodeManager.add(
+                            insertEpisodes,
+                            podcastUuid = existingPodcast.uuid,
+                            downloadMetaData = false
+                        )
+                    }
+                    val episodeUuidsToDelete = existingEpisodes.map { it.uuid }
+                        .subtract(updatedPodcast.episodes.map { it.uuid })
+                    val calendar = Calendar.getInstance()
+                    calendar.add(Calendar.DAY_OF_MONTH, -14)
+                    val twoWeeksAgo = calendar.time
+                    val episodesToDelete =
+                        episodeUuidsToDelete.mapNotNull { uuid -> existingEpisodes.find { it.uuid == uuid } }
+                            .filter {
+                                it.addedDate.before(twoWeeksAgo) && episodeManager.episodeCanBeCleanedUp(
+                                    it,
+                                    playbackManager
+                                )
+                            }
+                    if (episodesToDelete.isNotEmpty()) {
+                        episodeManager.deleteEpisodesWithoutSync(episodesToDelete, playbackManager)
+                    }
 
-                if (originalPodcast != existingPodcast) {
-                    LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Refresh required update for podcast ${existingPodcast.uuid}")
-                    updatePodcast(existingPodcast)
+                    if (originalPodcast != existingPodcast) {
+                        LogBuffer.i(
+                            LogBuffer.TAG_BACKGROUND_TASKS,
+                            "Refresh required update for podcast ${existingPodcast.uuid}"
+                        )
+                        updatePodcast(existingPodcast)
+                    }
                 }
+            } catch (e: Exception) {
+                LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, e, "Error refreshing podcast ${existingPodcast.uuid} in background")
             }
         }
     }


### PR DESCRIPTION
## Description
Currently the app crashes if any errors are thrown when we refresh podcast data in the background using `PodcastManagerImpl::refreshPodcastInBackground`. This is why #1572 causes a crash. I don't think there's any reason we would ever want an error when fetching podcasts in the background to crash the app, so this PR catches any exception thrown in that method, and logs the exceptions as errors (which means they'll still get sent to Sentry and show up [like this](https://a8c.sentry.io/discover/pocket-casts-android:92da7c0d37a24705b4862d4dcec4ca4d/?field=title&field=release&field=environment&field=user.display&field=timestamp&name=IllegalStateException%3A+Expected+non-null+java.util.Date%2C+but+it+was+null.&project=6711064&query=issue%3APOCKET-CASTS-ANDROID-R3M&sort=-timestamp&statsPeriod=90d&yAxis=count%28%29)).

**Although this avoids the crash in #1572, it does not address the underlying issue or resolve the problem for our users.** Instead of crashing, users who have that issue when they go to the podcast screen should now get an error screen stating "There was an error loading the podcast" and a retry button (on debug builds you'll see an error pop-up, but that is not used in release builds).

The reason why the exception was not crashing the app unless the user was subscribed to the podcast is because unsubscribed podcasts go through a different route to perform the database query that I'm forcing to crash for testing purposes ([PodcastManagerImpl::deletePodcastIfUnused](https://github.com/Automattic/pocket-casts-android/blob/73cf37bacbdf752fc39bc566d7550bd0b81c752a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt#L132) →[EpisodeManagerImpl::findEpisodesByPodcastOrdered](https://github.com/Automattic/pocket-casts-android/blob/0400d0be7f4b724b5dece558567fc9dc73ea98fc/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt#L355)), and that route has [its own exception catcher](https://github.com/Automattic/pocket-casts-android/blob/73cf37bacbdf752fc39bc566d7550bd0b81c752a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt#L180-L183). 

The diff on this PR makes it look like more of a change than it is. I'm just wrapping the functionality of the `refreshPodcastInBackground` method in a try-catch.

## Testing Instructions

### 1. Crash no longer occurs on debug builds
1. Make sure you're subscribed to at least one podcast
2. Edit the `DateTypeConverter::toDate` method to always return `null`. This will cause the error to be thrown within Room because it will result in a `null` value being "returned" from the `publishedDate` column which is not allowed to be null.
3. Build the app
4. Open the podcast screen for a podcast you are subscribed to
5. ✅  Observe that the app does not crash, and you are shown an error screen with a retry button (if you're on a debug build you'll also see an error pop-up--you won't see this on a release build). Without the changes in this PR, this would crash.
6. Open a podcast that you are not subscribed to
7. Observe that you are shown an error screen with a retry button.

### 2. Crash no longer occurs on release builds

Perform the test steps from the previous test scenario, but with a release build.

In addition, confirm that the error is sent to Sentry since going forward this will be the only way we have to track the severity of #1572 and whether we have fixed it.

### 3. Regression check
1. Make sure you're subscribed to at least one podcast
2. Open the podcast screen for a podcast you are subscribed to
5. Observe that the podcast screen functions normally and shows the list of episodes
6. Open a podcast that you are not subscribed to
5. Observe that the podcast screen functions normally and shows the list of episodes

## Screenshots or Screencast 

These videos are with the code changes from the test steps to simulate the getting an improper `null` value from the database.

| Debug Build (with popup) | Release Build (w/o popup) |
| --- | --- |
| <video width="350px" src="https://github.com/Automattic/pocket-casts-android/assets/4656348/833279a1-21b1-4ecb-87fa-afe8aff3ba4b" /> |  <video width="350px" src="https://github.com/Automattic/pocket-casts-android/assets/4656348/78317e22-5012-4895-9571-14acbf8e096a" /> |



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
