### PR TITLE
Feature added: Keep selected podcasts when toggling new episode

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
@@ -144,6 +144,7 @@ class AppDatabaseTest {
                 AppDatabase.MIGRATION_75_76,
                 AppDatabase.MIGRATION_76_77,
                 AppDatabase.MIGRATION_77_78,
+                AppDatabase.MIGRATION_78_79,
             )
             .build()
         // close the database and release any stream resources when the test finishes

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -69,6 +69,7 @@ import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelp
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
@@ -247,6 +248,11 @@ class PodcastAdapter(
 
     private fun bindPodcastViewHolder(holder: PodcastViewHolder) {
         holder.binding.podcast = podcast
+        ratingsViewModel.launch {
+            settings.notifyRefreshPodcast.flow.collect { value ->
+                holder.binding.isNotificationEnabled = value
+            }
+        }
         holder.binding.expanded = headerExpanded
         holder.binding.tintColor = ThemeColor.podcastText02(theme.activeTheme, tintColor)
         holder.binding.headerColor = ThemeColor.podcastUi03(theme.activeTheme, podcast.backgroundColor)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -441,7 +441,9 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
     private val onNotificationsClicked: () -> Unit = {
         context?.let {
-            viewModel.toggleNotifications(it)
+            lifecycleScope.launch {
+                viewModel.toggleNotifications(it)
+            }
         }
     }
 

--- a/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
     <data>
         <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast"/>
+        <variable name="isNotificationEnabled" type="Boolean" />
         <variable name="tintColor" type="int"/>
         <variable name="headerColor" type="int"/>
         <variable name="expanded" type="boolean" />
@@ -94,7 +95,7 @@
             android:focusable="true"
             app:tint="?attr/primary_icon_02"
             app:show="@{podcast.isSubscribed}"
-            android:src="@{podcast.isShowNotifications() ? @drawable/ic_notifications_on : @drawable/ic_notifications_off}"
+            android:src="@{isNotificationEnabled &amp;&amp; podcast.isShowNotifications() ? @drawable/ic_notifications_on : @drawable/ic_notifications_off}"
             android:scaleType="center"
             app:layout_constraintEnd_toStartOf="@+id/settings"
             app:layout_constraintBottom_toBottomOf="parent" />

--- a/modules/features/podcasts/src/main/res/layout/adapter_podcast_header.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_podcast_header.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <data>
         <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast"/>
+        <variable name="isNotificationEnabled" type="Boolean" />
         <variable name="expanded" type="boolean" />
         <variable name="tintColor" type="int"/>
         <variable name="headerColor" type="int"/>
@@ -21,7 +22,9 @@
             app:tintColor="@{tintColor}"
             app:headerColor="@{headerColor}"
             app:expanded="@{expanded}"
-            app:isPlusOrPatronUser="@{isPlusOrPatronUser}"/>
+            app:isPlusOrPatronUser="@{isPlusOrPatronUser}"
+            app:isNotificationEnabled="@{isNotificationEnabled}"
+            />
 
         <include
             android:id="@+id/bottom"

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
     <data>
         <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast"/>
+        <variable name="isNotificationEnabled" type="Boolean" />
         <variable name="tintColor" type="int"/>
         <variable name="headerColor" type="int"/>
         <variable name="expanded" type="boolean" />
@@ -97,11 +98,11 @@
             android:layout_marginEnd="8dp"
             android:background="?android:attr/actionBarItemBackground"
             android:clickable="true"
-            android:contentDescription="@{podcast.isShowNotifications() ? @string/podcast_notifications_on : @string/podcast_notifications_off}"
-            android:tooltipText="@{podcast.isShowNotifications() ? @string/podcast_notifications_on : @string/podcast_notifications_off}"
+            android:contentDescription="@{isNotificationEnabled &amp;&amp; podcast.isShowNotifications() ? @string/podcast_notifications_on : @string/podcast_notifications_off}"
+            android:tooltipText="@{isNotificationEnabled &amp;&amp; podcast.isShowNotifications() ? @string/podcast_notifications_on : @string/podcast_notifications_off}"
             android:focusable="true"
             android:scaleType="center"
-            android:src="@{podcast.isShowNotifications() ? @drawable/ic_notifications_on : @drawable/ic_notifications_off}"
+            android:src="@{isNotificationEnabled &amp;&amp; podcast.isShowNotifications() ? @drawable/ic_notifications_on : @drawable/ic_notifications_off}"
             app:tint="?attr/primary_icon_02"
             app:layout_constraintEnd_toStartOf="@+id/settings"
             app:layout_constraintTop_toBottomOf="@+id/header"

--- a/modules/features/settings/src/main/res/xml/preferences_notifications.xml
+++ b/modules/features/settings/src/main/res/xml/preferences_notifications.xml
@@ -23,6 +23,12 @@
             android:summary=""
             android:title="@string/settings_notification_actions" />
 
+        <PreferenceScreen
+            android:key="notificationPreviousSelectedPodcast"
+            android:persistent="false"
+            android:summary="@string/settings_notification_previous_selected_podcast_summary"
+            android:title="@string/settings_notification_previous_selected_podcast" />
+
         <Preference
             android:key="notificationRingtone"
             android:persistent="false"

--- a/modules/services/localization/src/main/res/values-ar/strings.xml
+++ b/modules/services/localization/src/main/res/values-ar/strings.xml
@@ -787,6 +787,8 @@ Language: ar
     <string name="settings_notification_advanced_summary">اختيار الأصوات وخيارات النظام الأخرى</string>
     <string name="settings_notification_advanced">الإعدادات المتقدمة</string>
     <string name="settings_notification_actions">الإجراءات</string>
+    <string name="settings_notification_previous_selected_podcast">البودكاست السابق المحدد</string>
+    <string name="settings_notification_previous_selected_podcast_summary">تمكين الإشعارات لجميع البودكاست السابقة المحددة</string>
     <string name="settings_notifications_new_episodes">حلقات جديدة</string>
     <string name="settings_no_thanks">لا شكرًا</string>
     <string name="settings_manage_downloads_total">الإجمالي</string>

--- a/modules/services/localization/src/main/res/values-de/strings.xml
+++ b/modules/services/localization/src/main/res/values-de/strings.xml
@@ -858,6 +858,8 @@ Language: de
     <string name="settings_notification_advanced_summary">Töne und andere Systemoptionen auswählen</string>
     <string name="settings_notification_advanced">Erweiterte Einstellungen</string>
     <string name="settings_notification_actions">Aktionen</string>
+    <string name="settings_notification_previous_selected_podcast">Vorher ausgewählter Podcast</string>
+    <string name="settings_notification_previous_selected_podcast_summary">Benachrichtigungen für alle zuvor ausgewählten Podcasts aktivieren</string>
     <string name="settings_notifications_new_episodes">Neue Folgen</string>
     <string name="settings_no_thanks">Nein, danke</string>
     <string name="settings_manage_downloads_total">Gesamt</string>

--- a/modules/services/localization/src/main/res/values-en-rGB/strings.xml
+++ b/modules/services/localization/src/main/res/values-en-rGB/strings.xml
@@ -802,6 +802,8 @@ Language: en_GB
     <string name="settings_notification_advanced_summary">Choose sounds and other system options</string>
     <string name="settings_notification_advanced">Advanced settings</string>
     <string name="settings_notification_actions">Actions</string>
+    <string name="settings_notification_previous_selected_podcast">Previous Selected Podcast</string>
+    <string name="settings_notification_previous_selected_podcast_summary">Enable notifications for all previously selected podcasts</string>
     <string name="settings_notifications_new_episodes">New Episodes</string>
     <string name="settings_no_thanks">No thanks</string>
     <string name="settings_manage_downloads_total">Total</string>

--- a/modules/services/localization/src/main/res/values-es-rMX/strings.xml
+++ b/modules/services/localization/src/main/res/values-es-rMX/strings.xml
@@ -858,6 +858,8 @@ Language: es
     <string name="settings_notification_advanced_summary">Elegir los sonidos y otras opciones del sistema</string>
     <string name="settings_notification_advanced">Configuración avanzada</string>
     <string name="settings_notification_actions">Acciones</string>
+    <string name="settings_notification_previous_selected_podcast">Podcast Anterior Seleccionado</string>
+    <string name="settings_notification_previous_selected_podcast_summary">Habilitar notificaciones para todos los podcasts previamente seleccionados</string>
     <string name="settings_notifications_new_episodes">Nuevos episodios</string>
     <string name="settings_no_thanks">No, gracias</string>
     <string name="settings_manage_downloads_total">Total</string>

--- a/modules/services/localization/src/main/res/values-es/strings.xml
+++ b/modules/services/localization/src/main/res/values-es/strings.xml
@@ -858,6 +858,8 @@ Language: es
     <string name="settings_notification_advanced_summary">Elegir los sonidos y otras opciones del sistema</string>
     <string name="settings_notification_advanced">Configuración avanzada</string>
     <string name="settings_notification_actions">Acciones</string>
+    <string name="settings_notification_previous_selected_podcast">Podcast Anterior Seleccionado</string>
+    <string name="settings_notification_previous_selected_podcast_summary">Habilitar notificaciones para todos los podcasts previamente seleccionados</string>
     <string name="settings_notifications_new_episodes">Nuevos episodios</string>
     <string name="settings_no_thanks">No, gracias</string>
     <string name="settings_manage_downloads_total">Total</string>

--- a/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
@@ -858,6 +858,8 @@ Language: fr
     <string name="settings_notification_advanced_summary">Sélectionner des sons et d’autres options du système</string>
     <string name="settings_notification_advanced">Réglages avancés</string>
     <string name="settings_notification_actions">Actions</string>
+    <string name="settings_notification_previous_selected_podcast">Podcast précédemment sélectionné</string>
+    <string name="settings_notification_previous_selected_podcast_summary">Activer les notifications pour tous les podcasts précédemment sélectionnés</string>
     <string name="settings_notifications_new_episodes">Nouveaux épisodes</string>
     <string name="settings_no_thanks">Non merci</string>
     <string name="settings_manage_downloads_total">Total</string>

--- a/modules/services/localization/src/main/res/values-fr/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr/strings.xml
@@ -858,6 +858,8 @@ Language: fr
     <string name="settings_notification_advanced_summary">Sélectionner des sons et d’autres options du système</string>
     <string name="settings_notification_advanced">Réglages avancés</string>
     <string name="settings_notification_actions">Actions</string>
+    <string name="settings_notification_previous_selected_podcast">Podcast précédemment sélectionné</string>
+    <string name="settings_notification_previous_selected_podcast_summary">Activer les notifications pour tous les podcasts précédemment sélectionnés</string>
     <string name="settings_notifications_new_episodes">Nouveaux épisodes</string>
     <string name="settings_no_thanks">Non merci</string>
     <string name="settings_manage_downloads_total">Total</string>

--- a/modules/services/localization/src/main/res/values-it/strings.xml
+++ b/modules/services/localization/src/main/res/values-it/strings.xml
@@ -858,6 +858,8 @@ Language: it
     <string name="settings_notification_advanced_summary">Seleziona i suoni e altre opzioni di sistema</string>
     <string name="settings_notification_advanced">Impostazioni avanzate</string>
     <string name="settings_notification_actions">Azioni</string>
+    <string name="settings_notification_previous_selected_podcast">Podcast Precedentemente Selezionato</string>
+    <string name="settings_notification_previous_selected_podcast_summary">Abilita le notifiche per tutti i podcast precedentemente selezionati</string>
     <string name="settings_notifications_new_episodes">Nuovi episodi</string>
     <string name="settings_no_thanks">No, grazie</string>
     <string name="settings_manage_downloads_total">Totale</string>

--- a/modules/services/localization/src/main/res/values-ja/strings.xml
+++ b/modules/services/localization/src/main/res/values-ja/strings.xml
@@ -858,6 +858,8 @@ Language: ja_JP
     <string name="settings_notification_advanced_summary">音声とその他のシステムオプションを選択</string>
     <string name="settings_notification_advanced">詳細設定</string>
     <string name="settings_notification_actions">処理</string>
+    <string name="settings_notification_previous_selected_podcast">以前に選択したポッドキャスト</string>
+    <string name="settings_notification_previous_selected_podcast_summary">以前に選択したすべてのポッドキャストの通知を有効にする</string>
     <string name="settings_notifications_new_episodes">新規エピソード</string>
     <string name="settings_no_thanks">いいえ、結構です</string>
     <string name="settings_manage_downloads_total">合計</string>

--- a/modules/services/localization/src/main/res/values-ko/strings.xml
+++ b/modules/services/localization/src/main/res/values-ko/strings.xml
@@ -858,6 +858,8 @@ Language: ko_KR
     <string name="settings_notification_advanced_summary">소리 및 기타 시스템 옵션 선택</string>
     <string name="settings_notification_advanced">고급 설정</string>
     <string name="settings_notification_actions">작업</string>
+    <string name="settings_notification_previous_selected_podcast">이전에 선택한 팟캐스트</string>
+    <string name="settings_notification_previous_selected_podcast_summary">이전에 선택한 모든 팟캐스트에 대한 알림 활성화</string>
     <string name="settings_notifications_new_episodes">새 에피소드</string>
     <string name="settings_no_thanks">괜찮습니다</string>
     <string name="settings_manage_downloads_total">합계</string>

--- a/modules/services/localization/src/main/res/values-nb/strings.xml
+++ b/modules/services/localization/src/main/res/values-nb/strings.xml
@@ -786,6 +786,8 @@ Language: nb_NO
     <string name="settings_notification_advanced_summary">Velg lyder og andre systemalternativer</string>
     <string name="settings_notification_advanced">Avanserte innstillinger</string>
     <string name="settings_notification_actions">Handlinger</string>
+    <string name="settings_notification_previous_selected_podcast">Tidligere valgt podcast</string>
+    <string name="settings_notification_previous_selected_podcast_summary">Aktiver varsler for alle tidligere valgte podcaster</string>
     <string name="settings_notifications_new_episodes">Nye episoder</string>
     <string name="settings_no_thanks">Nei takk</string>
     <string name="settings_manage_downloads_total">Totalt</string>

--- a/modules/services/localization/src/main/res/values-nl/strings.xml
+++ b/modules/services/localization/src/main/res/values-nl/strings.xml
@@ -858,6 +858,8 @@ Language: nl
     <string name="settings_notification_advanced_summary">Kies geluiden en andere systeemopties</string>
     <string name="settings_notification_advanced">Geavanceerde instellingen</string>
     <string name="settings_notification_actions">Acties</string>
+    <string name="settings_notification_previous_selected_podcast">Eerder Geselecteerde Podcast</string>
+    <string name="settings_notification_previous_selected_podcast_summary">Meldingen inschakelen voor alle eerder geselecteerde podcasts</string>
     <string name="settings_notifications_new_episodes">Nieuwe afleveringen</string>
     <string name="settings_no_thanks">Nee, dank je</string>
     <string name="settings_manage_downloads_total">Totaal</string>

--- a/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
+++ b/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
@@ -858,6 +858,8 @@ Language: pt_BR
     <string name="settings_notification_advanced_summary">Escolher sons e outras opções de sistema</string>
     <string name="settings_notification_advanced">Configurações avançadas</string>
     <string name="settings_notification_actions">Ações</string>
+    <string name="settings_notification_previous_selected_podcast">Podcast Anterior Selecionado</string>
+    <string name="settings_notification_previous_selected_podcast_summary">Ativar notificações para todos os podcasts previamente selecionados</string>
     <string name="settings_notifications_new_episodes">Novos episódios</string>
     <string name="settings_no_thanks">Não, obrigado</string>
     <string name="settings_manage_downloads_total">Total</string>

--- a/modules/services/localization/src/main/res/values-ru/strings.xml
+++ b/modules/services/localization/src/main/res/values-ru/strings.xml
@@ -858,6 +858,8 @@ Language: ru
     <string name="settings_notification_advanced_summary">Выбрать звуки и другие параметры системы</string>
     <string name="settings_notification_advanced">Расширенные настройки</string>
     <string name="settings_notification_actions">Действия</string>
+    <string name="settings_notification_previous_selected_podcast">Предыдущий выбранный подкаст</string>
+    <string name="settings_notification_previous_selected_podcast_summary">Включить уведомления для всех ранее выбранных подкастов</string>
     <string name="settings_notifications_new_episodes">Новые выпуски</string>
     <string name="settings_no_thanks">Нет, спасибо</string>
     <string name="settings_manage_downloads_total">Итого</string>

--- a/modules/services/localization/src/main/res/values-sv/strings.xml
+++ b/modules/services/localization/src/main/res/values-sv/strings.xml
@@ -858,6 +858,8 @@ Language: sv_SE
     <string name="settings_notification_advanced_summary">Välj ljud och andra systemalternativ</string>
     <string name="settings_notification_advanced">Avancerade inställningar</string>
     <string name="settings_notification_actions">Åtgärder</string>
+    <string name="settings_notification_previous_selected_podcast">Tidigare vald podcast</string>
+    <string name="settings_notification_previous_selected_podcast_summary">Aktivera aviseringar för alla tidigare valda podcaster</string>
     <string name="settings_notifications_new_episodes">Nya avsnitt</string>
     <string name="settings_no_thanks">Nej tack</string>
     <string name="settings_manage_downloads_total">Totalsumma</string>

--- a/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
@@ -858,6 +858,8 @@ Language: zh_TW
     <string name="settings_notification_advanced_summary">選擇音效和其他系統選項</string>
     <string name="settings_notification_advanced">進階設定</string>
     <string name="settings_notification_actions">動作</string>
+    <string name="settings_notification_previous_selected_podcast">先前選定的播客</string>
+    <string name="settings_notification_previous_selected_podcast_summary">啟用所有先前選定的播客的通知</string>
     <string name="settings_notifications_new_episodes">新單集</string>
     <string name="settings_no_thanks">不用！謝謝</string>
     <string name="settings_manage_downloads_total">總計</string>

--- a/modules/services/localization/src/main/res/values-zh/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh/strings.xml
@@ -858,6 +858,8 @@ Language: zh_CN
     <string name="settings_notification_advanced_summary">选择声音和其他系统选项</string>
     <string name="settings_notification_advanced">高级设置</string>
     <string name="settings_notification_actions">动作</string>
+    <string name="settings_notification_previous_selected_podcast">先前选定的播客</string>
+    <string name="settings_notification_previous_selected_podcast_summary">启用所有先前选定播客的通知</string>
     <string name="settings_notifications_new_episodes">新剧集</string>
     <string name="settings_no_thanks">不，谢谢</string>
     <string name="settings_manage_downloads_total">总共</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1144,6 +1144,8 @@
     <string name="settings_no_thanks">No thanks</string>
     <string name="settings_notifications_new_episodes">New Episodes</string>
     <string name="settings_notification_actions">Actions</string>
+    <string name="settings_notification_previous_selected_podcast">Previous Selected Podcast</string>
+    <string name="settings_notification_previous_selected_podcast_summary">Enable notifications for all previously selected podcasts</string>
     <string name="settings_notification_advanced">Advanced settings</string>
     <string name="settings_notification_advanced_summary">Choose sounds and other system options</string>
     <string name="settings_notification_choose_podcasts">Choose podcasts</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -63,7 +63,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
         UserEpisode::class,
         PodcastRatings::class
     ],
-    version = 78,
+    version = 79,
     exportSchema = true
 )
 @TypeConverters(
@@ -484,6 +484,13 @@ abstract class AppDatabase : RoomDatabase() {
             database.execSQL("ALTER TABLE `temp_podcast_ratings` RENAME TO `podcast_ratings`;")
         }
 
+        val MIGRATION_78_79 = addMigration(78, 79) { database ->
+            val podcastColumnNames = getColumnNames(database, "podcasts")
+            if (!podcastColumnNames.contains("previous_selected_podcast")) {
+                database.execSQL("ALTER TABLE podcasts ADD COLUMN previous_selected_podcast BOOLEAN NOT NULL DEFAULT 0")
+            }
+        }
+
         fun addMigrations(databaseBuilder: Builder<AppDatabase>, context: Context) {
             databaseBuilder.addMigrations(
                 addMigration(1, 2) { },
@@ -852,6 +859,7 @@ abstract class AppDatabase : RoomDatabase() {
                 MIGRATION_75_76,
                 MIGRATION_76_77,
                 MIGRATION_77_78,
+                MIGRATION_78_79,
             )
         }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -367,4 +367,14 @@ abstract class PodcastDao {
 
     @Query("SELECT * FROM podcasts ORDER BY random() LIMIT :limit")
     abstract suspend fun findRandomPodcasts(limit: Int): List<Podcast>
+
+    @Query("UPDATE podcasts SET previous_selected_podcast = :show WHERE uuid = :uuid")
+    abstract fun updatePreviousSelectPodcast(show: Boolean, uuid: String)
+
+    @Query("UPDATE podcasts SET previous_selected_podcast = show_notifications, show_notifications = 0")
+    abstract fun cpyShowNotificationToPreviousSelectedPodcast()
+
+    @Query("UPDATE podcasts SET show_notifications = previous_selected_podcast, previous_selected_podcast = 0")
+    abstract fun cpyPreviousSelectedPodcastToShowNotification()
+
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
@@ -77,6 +77,7 @@ data class Podcast(
     @ColumnInfo(name = "folder_uuid") var folderUuid: String? = null,
     @ColumnInfo(name = "licensing") var licensing: Licensing = Licensing.KEEP_EPISODES,
     @ColumnInfo(name = "isPaid") var isPaid: Boolean = false,
+    @ColumnInfo(name = "previous_selected_podcast") var previousSelectedPodcast: Boolean = false,
     @Embedded(prefix = "bundle") var singleBundle: Bundle? = null,
     @Ignore val episodes: MutableList<PodcastEpisode> = mutableListOf()
 ) : Serializable {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -143,4 +143,10 @@ interface PodcastManager {
     suspend fun findTopPodcasts(fromEpochMs: Long, toEpochMs: Long, limit: Int): List<TopPodcast>
 
     suspend fun findRandomPodcasts(limit: Int): List<Podcast>
+
+    fun updatePreviousSelectPodcast(podcast: Podcast, show: Boolean)
+
+    fun cpyShowNotificationToPreviousSelectedPodcast()
+
+    fun cpyPreviousSelectedPodcastToShowNotification()
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -800,4 +800,19 @@ class PodcastManagerImpl @Inject constructor(
     override suspend fun findRandomPodcasts(limit: Int): List<Podcast> {
         return podcastDao.findRandomPodcasts(limit)
     }
+
+    override fun updatePreviousSelectPodcast(podcast: Podcast, show: Boolean) {
+        if (show) {
+            settings.notifyRefreshPodcast.set(true)
+        }
+        podcastDao.updatePreviousSelectPodcast(show, podcast.uuid)
+    }
+
+    override fun cpyShowNotificationToPreviousSelectedPodcast() {
+        podcastDao.cpyShowNotificationToPreviousSelectedPodcast()
+    }
+
+    override fun cpyPreviousSelectedPodcastToShowNotification() {
+        podcastDao.cpyPreviousSelectedPodcastToShowNotification()
+    }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -384,6 +384,10 @@ class RefreshPodcastsThread(
                 return
             }
 
+            if (!settings.notifyRefreshPodcast.flow.value){
+                return
+            }
+
             settings.setNotificationLastSeenToNow()
 
             val podcastsShowingNotifications = podcastManager.countNotificationsOn()


### PR DESCRIPTION
## Description
Added feature: Keep selected podcasts when toggling new episode notifications

Fixes #1263

## Solution
- Introduced a new column named `previous_selected_podcast` in the podcasts table to keep track of the previously selected podcast.
- Modified the behavior of the `Notify me` toggle in the Notification Settings page. Instead of directly changing the value of the `show_notifications` column, it now checks the toggle status. Notifications will only be displayed when the toggle is turned on.
- Now for this part: If the user turns off the `Notify me` option in the Notification Settings page and then attempts to enable notifications from the podcast page then i am copying column `show_notifications` to `previous_selected_podcast` and making all values to false in `show_notication` except the selected podcast from podcast page 

> One small bit of trickiness with holding onto the podcasts you would get notified of when the setting is turned off is that if we persisted this data, it's not clear how we should handle a user turning on notifications for a single podcast from that podcast's screen. We woudln't want to turn on notifications for all the previously selected podcasts in this case.

- I have added enable previous podcast setting in notification settings page which will enable all the previous selected podcast i.e copying column `previous_selected_podcast` to `show_notifications` and making all values to false in `previous_selected_podcast`

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/134276544/8bb90bb3-963f-4f01-aee5-14d69a4e188f

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
