### PR TITLE
Fix error from observeByUuid flow containing unexpected nulls

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -49,7 +49,7 @@ abstract class EpisodeDao {
     abstract fun findByUuidRx(uuid: String): Maybe<PodcastEpisode>
 
     @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")
-    abstract fun observeByUuid(uuid: String): Flow<PodcastEpisode>
+    abstract fun observeByUuid(uuid: String): Flow<PodcastEpisode?>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE download_task_id IS NOT NULL")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1591,7 +1591,8 @@ open class PlaybackManager @Inject constructor(
                                 } else {
                                     Timber.d("Episode is not downloaded $this")
                                 }
-                            }
+                            },
+                            onError = { Timber.e(it, "Error observing episode") }
                         )
                 }
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -104,14 +104,17 @@ class EpisodeManagerImpl @Inject constructor(
     override fun findByUuidRx(uuid: String): Maybe<PodcastEpisode> =
         episodeDao.findByUuidRx(uuid)
 
-    override fun observeByUuid(uuid: String): Flow<PodcastEpisode> {
-        return episodeDao.observeByUuid(uuid)
-    }
+    override fun observeByUuid(uuid: String): Flow<PodcastEpisode> =
+        episodeDao.observeByUuid(uuid).filterNotNull()
 
     override fun observeEpisodeByUuidRx(uuid: String): Flowable<BaseEpisode> {
         @Suppress("DEPRECATION")
         return findByUuidRx(uuid)
-            .flatMapPublisher<BaseEpisode> { episodeDao.observeByUuid(uuid).asFlowable() }
+            .flatMapPublisher<BaseEpisode> {
+                episodeDao.observeByUuid(uuid)
+                    .filterNotNull()
+                    .asFlowable()
+            }
             .switchIfEmpty(userEpisodeManager.observeEpisodeRx(uuid))
     }
 


### PR DESCRIPTION
## Description
While testing https://github.com/Automattic/pocket-casts-android/pull/1589, I discovered that I could create a [new crash](https://a8c.sentry.io/issues/4413071773/events/aa0eee24c8d14b90b48a7035b1a6c9fb/?end=2023-09-28T23%3A59%3A59&project=6711064&query=is%3Aunresolved+missing+onError&referrer=next-event&start=2023-09-08T00%3A00%3A00&stream_index=0&utc=true), and that the stacktrace [matched this error in Sentry](https://a8c.sentry.io/issues/4413071773/events/aa0eee24c8d14b90b48a7035b1a6c9fb/?end=2023-09-28T23%3A59%3A59&project=6711064&query=is%3Aunresolved+missing+onError&referrer=next-event&start=2023-09-08T00%3A00%3A00&stream_index=0&utc=true).

The error happens because `EpisodeDao::observeByUuid` can apparently sometimes emit a null even though the type specifies that it should never be null. This PR includes two separate fixes for this issue. I think it makes sense to do both of them, but either one on its own avoids the crash:
1. First, in https://github.com/Automattic/pocket-casts-android/commit/58ef82da6669b49eb084f991954b22e4ad041f64 we are now implementing an onError handler for the location in the `EpisodeManagerImpl` where this error was occurring. I can't think of any reason we would want errors here to crash the app. We should probably do this to every place where we subscribe to an rxjava stream but dont' implement `onError` but I wanted to keep this PR focused, so I only added it here.
2. Second, I have updated the type of `observeByUuid` to indicate that the Flow can contain nulls. This gives us the type safety of forcing consumers of this flow to handle `null`. For example, it is no longer possible to call `asFlowable` on this `Flow` directly (because a `Flowable` can't contain nulls) like we could before. Instead, you now have to filter out any nulls before calling `asFlowable`.

I did test adding `@Transaction` to the `observeByUuid` method like we did in https://github.com/Automattic/pocket-casts-android/pull/1589, but that did not prevent this crash.

Fixes #1591 

## Testing Instructions

Reproducing the crash is a bit tricky. These are the steps I found allowed me to create it:
1. Go to the profile tab → ⚙️ → Developer Settings
2. Subscribe to "The Daily"
4. Go to the podcast tab and open "The Daily"
5. Select all the episodes and add them to the up next queue
6. As quickly as possible, tap on the profile tab and tap the "Delete first episodes" button as fast as you can until the up next count in the minibar stops increasing (i.e., the 100 episodes have all been added but because you're deleting episodes it probably won't actually get to 100, so just wait until that number stops increasing)
7. If the error hasn't occurred, tap on the Podcast tab, select all the episodes, and tap the archive button
8. As quickly as possible, tap on the profile tab and tap the "Delete first episodes" button as fast as you can until all the episodes are removed from the up next queue.
9. If the issue hasn't occurred, start over at step 4.

### 1. Verify RxJava error handling and confirm you can reproduce the error
1. Create a build of this PR without the updates to the `observeByUuid` type. In other words, build https://github.com/Automattic/pocket-casts-android/commit/58ef82da6669b49eb084f991954b22e4ad041f64. Doing this will allow the error to get to the RxJava `onError` function and you'll be able to see it in the logs
2. Repeat the steps for reproducing the issue until the issue appears in the logs

### 2. Verify error cannot be reproduced with changes in this PR
1. Create a build with all the changes in this PR.
2. Repeat the steps for reproducing the issue
3. Observe that you cannot crash the app or cause the error to appear in the logs anymore.

## Screenshots or Screencast 

This is a video of me reproducing the error in the logs with only the rxjava error handler (i.e., the build from the first scenario in the testing instructions). The video is a bit over a minute long just to accurately reflect that it can take a bit to cause the error.

https://github.com/Automattic/pocket-casts-android/assets/4656348/5110f37c-9316-472c-8ade-76a8612291aa

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews

