### PR TITLE
Add autoSizeTextType to discover search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
         ([#1548](https://github.com/Automattic/pocket-casts-android/pull/1548))
     *   Fix crash when database emits unexpected null value
         ([#1596](https://github.com/Automattic/pocket-casts-android/pull/1596))
+    *   Fix text being cut off in discover search bar at high zoom 
+        ([#1601](https://github.com/Automattic/pocket-casts-android/pull/1601))
 *   Updates:
     *   Display dynamic colors for widget
         ([#1588](https://github.com/Automattic/pocket-casts-android/pull/1588))

--- a/modules/features/discover/src/main/res/layout/row_carousel_list.xml
+++ b/modules/features/discover/src/main/res/layout/row_carousel_list.xml
@@ -42,6 +42,7 @@
             android:textColor="?attr/contrast_01"
             android:maxLines="1"
             android:ellipsize="end"
+            app:autoSizeTextType="uniform"
             android:text="@string/search_podcasts_or_add_url"/>
     </LinearLayout>
 


### PR DESCRIPTION
## Description
Adapts the discover search bar text to the device zoom when the device has a high display zoom set.

## Testing Instructions
1. Set device display zoom to a high level
2. Navigate to the Discover tab
3. Check that the "Search podcasts or add RSS URL" text in the top bar auto-resizes to the device scale

## Screenshots or Screencast 
![Screenshot_20231208-175205](https://github.com/Automattic/pocket-casts-android/assets/10982418/2ebb8ebb-f080-421c-a4ee-1b60c3b9e2a1)

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
