### PR TITLE
Add markAsPlayed in UserEpisodeManager

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -525,7 +525,7 @@ class EpisodeManagerImpl @Inject constructor(
 
         if (episode is UserEpisode) {
             launch {
-                userEpisodeManager.deletePlayedEpisodeIfReq(episode, playbackManager)
+                userEpisodeManager.markAsPlayed(episode, playbackManager)
             }
         }
     }


### PR DESCRIPTION
## Description
This PR makes a small improvement to where a user's episode is marked as played (as suggested [here](https://github.com/Automattic/pocket-casts-android/pull/1548#pullrequestreview-1749794111)).

## Testing Instructions
Same as
- #1248 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
