### PR TITLE
Use android-staging Buildkite agent to test 'ami-0478bb518557adf72-round-2'

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ common_params:
     - automattic/bash-cache#2.11.0
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   - label: "Gradle Wrapper Validation"


### PR DESCRIPTION
This PR changes the Buildkite agent from `android` to `android-staging`. This change is not meant to be merged, but rather used to verify that the new AMI `ami-0478bb518557adf72-round-2` works as expected.

Note that this PR, and several others for various projects, was generated from a bash script. Please reach out to `@apps-infrastructure` team if you have any feedback.