### PR TITLE
Decrease widget background alpha

### DIFF
--- a/modules/services/images/src/main/res/color/color_primary_container_60.xml
+++ b/modules/services/images/src/main/res/color/color_primary_container_60.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:alpha="0.8" android:color="?attr/colorPrimaryContainer" />
+    <item android:alpha="0.6" android:color="?attr/colorPrimaryContainer" />
 </selector>

--- a/modules/services/images/src/main/res/drawable/widget_background.xml
+++ b/modules/services/images/src/main/res/drawable/widget_background.xml
@@ -1,4 +1,4 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/color_primary_container_80" />
+    <solid android:color="@color/color_primary_container_60" />
     <corners android:radius="3dp" />
 </shape>


### PR DESCRIPTION
## Description

This decreases widget background alpha value.

## Screenshots or Screencast 

<img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/012f0f44-dae7-4cf4-abb0-e88a68f33f52"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
