### PR TITLE
Remove unused episode query methods

### DIFF
--- a/base.gradle
+++ b/base.gradle
@@ -165,7 +165,6 @@ dependencies {
     implementation libs.bundles.moshi
     implementation libs.bundles.navigation
     implementation libs.bundles.okhttp
-    implementation libs.bundles.paging
     implementation libs.bundles.protobuf
     implementation libs.bundles.retrofit
     implementation libs.bundles.rxjava

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,6 @@ mockito-android = "4.6.1"
 moshi = "1.13.0"
 navigation = "2.5.1"
 okhttp = "4.9.3"
-paging = "3.1.1"
 protobuf = "3.23.4"
 retrofit = "2.9.0"
 room = "2.5.1"
@@ -183,10 +182,6 @@ navigation-ui = { module = "androidx.navigation:navigation-ui-ktx", version.ref 
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okHttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okHttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
-
-# Paging
-paging-runtime = { module = "androidx.paging:paging-runtime", version.ref = "paging" }
-paging-rxjava2 = { module = "androidx.paging:paging-rxjava2", version.ref = "paging" }
 
 # Protobuf
 # For Android users, it's recommended to use protobuf Java Lite runtime because of its smaller code size.
@@ -391,11 +386,6 @@ navigation = [
 okhttp = [
     "okhttp",
     "okHttp-logging"
-]
-
-paging = [
-    "paging-runtime",
-    "paging-rxjava2"
 ]
 
 protobuf = [

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -59,9 +59,6 @@ abstract class EpisodeDao {
     @Query("SELECT * FROM podcast_episodes WHERE download_task_id IS NOT NULL")
     abstract fun observeDownloadingEpisodesRx(): Flowable<List<PodcastEpisode>>
 
-    @Query("SELECT * FROM podcast_episodes WHERE uuid IN (:uuids)")
-    abstract fun findByUuids(uuids: List<String>): List<PodcastEpisode>
-
     @Query("SELECT * FROM podcast_episodes WHERE UPPER(title) = UPPER(:query) LIMIT 1")
     abstract suspend fun findFirstBySearchQuery(query: String): PodcastEpisode?
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -157,9 +157,6 @@ abstract class EpisodeDao {
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY duration DESC")
     abstract fun observeByPodcastOrderDurationDesc(podcastUuid: String): Flowable<List<PodcastEpisode>>
 
-    @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid AND playing_status != :playingStatus")
-    abstract fun findByPodcastAndNotPlayingStatus(podcastUuid: String, playingStatus: Int): List<PodcastEpisode>
-
     @Query("UPDATE podcast_episodes SET downloaded_error_details = NULL, episode_status = :episodeStatusNotDownloaded WHERE episode_status = :episodeStatusFailed")
     abstract fun clearAllDownloadErrors(episodeStatusNotDownloaded: EpisodeStatusEnum, episodeStatusFailed: EpisodeStatusEnum)
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -219,9 +219,6 @@ abstract class EpisodeDao {
     @Query("UPDATE podcast_episodes SET auto_download_status = :autoDownloadStatus WHERE uuid = :uuid")
     abstract suspend fun updateAutoDownloadStatus(autoDownloadStatus: Int, uuid: String)
 
-    @Query("UPDATE podcast_episodes SET thumbnail_status = :thumbnailStatus WHERE uuid = :uuid")
-    abstract fun updateThumbnailStatus(thumbnailStatus: Int, uuid: String)
-
     @Query("UPDATE podcast_episodes SET play_error_details = :playErrorDetails WHERE uuid = :uuid")
     abstract fun updatePlayErrorDetails(playErrorDetails: String?, uuid: String)
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.models.db.dao
 
 import androidx.lifecycle.LiveData
-import androidx.paging.DataSource
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
@@ -64,9 +63,6 @@ abstract class EpisodeDao {
 
     @Query("SELECT * FROM podcast_episodes WHERE last_playback_interaction_sync_status <> 1 AND last_playback_interaction_date IS NOT NULL ORDER BY last_playback_interaction_date DESC LIMIT 1000")
     abstract fun findEpisodesForHistorySync(): List<PodcastEpisode>
-
-    @Query("SELECT * FROM podcast_episodes")
-    abstract fun findAll(): DataSource.Factory<Int, PodcastEpisode>
 
     @Query("SELECT * FROM podcast_episodes WHERE playing_status = :episodePlayingStatus AND archived = :archived AND podcast_id = :podcastUuid")
     abstract fun findByEpisodePlayingAndArchiveStatus(podcastUuid: String, episodePlayingStatus: EpisodePlayingStatus, archived: Boolean): List<PodcastEpisode>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -71,9 +71,6 @@ abstract class EpisodeDao {
     @Query("SELECT * FROM podcast_episodes")
     abstract fun findAll(): DataSource.Factory<Int, PodcastEpisode>
 
-    @Query("SELECT * FROM podcast_episodes WHERE playing_status = :episodePlayingStatus AND podcast_id = :podcastUuid")
-    abstract fun findByEpisodePlayingStatus(podcastUuid: String, episodePlayingStatus: EpisodePlayingStatus): List<PodcastEpisode>
-
     @Query("SELECT * FROM podcast_episodes WHERE playing_status = :episodePlayingStatus AND archived = :archived AND podcast_id = :podcastUuid")
     abstract fun findByEpisodePlayingAndArchiveStatus(podcastUuid: String, episodePlayingStatus: EpisodePlayingStatus, archived: Boolean): List<PodcastEpisode>
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.models.db.dao
 
-import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
@@ -49,10 +48,6 @@ abstract class EpisodeDao {
 
     @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")
     abstract fun observeByUuid(uuid: String): Flow<PodcastEpisode?>
-
-    @Transaction
-    @Query("SELECT * FROM podcast_episodes WHERE download_task_id IS NOT NULL")
-    abstract fun observeDownloadingEpisodes(): LiveData<List<PodcastEpisode>>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE download_task_id IS NOT NULL")

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -194,9 +194,6 @@ abstract class EpisodeDao {
     @Query("DELETE FROM podcast_episodes")
     abstract suspend fun deleteAll()
 
-    @Query("DELETE FROM podcast_episodes WHERE uuid = :uuid")
-    abstract fun deleteByUuid(uuid: String)
-
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     abstract fun insert(episode: PodcastEpisode)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -42,7 +42,6 @@ interface EpisodeManager {
     suspend fun findFirstBySearchQuery(query: String): PodcastEpisode?
 
     fun findEpisodesWhere(queryAfterWhere: String, forSubscribedPodcastsOnly: Boolean = true): List<PodcastEpisode>
-    fun findEpisodesByPodcast(podcast: Podcast): Single<List<PodcastEpisode>>
     fun findEpisodesByPodcastOrdered(podcast: Podcast): List<PodcastEpisode>
     suspend fun findEpisodesByPodcastOrderedSuspend(podcast: Podcast): List<PodcastEpisode>
     fun findEpisodesByPodcastOrderedRx(podcast: Podcast): Single<List<PodcastEpisode>>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -112,7 +112,6 @@ interface EpisodeManager {
 
     fun deleteEpisodeWithoutSync(episode: PodcastEpisode?, playbackManager: PlaybackManager)
     suspend fun deleteEpisodeFile(episode: BaseEpisode?, playbackManager: PlaybackManager?, disableAutoDownload: Boolean, updateDatabase: Boolean = true, removeFromUpNext: Boolean = true)
-    fun deleteCustomFolderEpisode(episode: PodcastEpisode?, playbackManager: PlaybackManager)
     fun deleteFinishedEpisodes(playbackManager: PlaybackManager)
     fun deleteDownloadedEpisodeFiles()
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -61,8 +61,6 @@ interface EpisodeManager {
     fun observeStarredEpisodes(): Flowable<List<PodcastEpisode>>
     suspend fun findStarredEpisodes(): List<PodcastEpisode>
 
-    fun exists(episodeUuid: String): Boolean
-
     /** Add methods  */
     fun add(episode: PodcastEpisode, downloadMetaData: Boolean): Boolean
     fun add(episodes: List<PodcastEpisode>, podcastUuid: String, downloadMetaData: Boolean): List<PodcastEpisode>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -126,7 +126,6 @@ interface EpisodeManager {
     fun checkPodcastForAutoArchive(podcast: Podcast, playbackManager: PlaybackManager?)
     fun episodeCanBeCleanedUp(episode: PodcastEpisode, playbackManager: PlaybackManager): Boolean
     fun markAsUnplayed(episodes: List<BaseEpisode>)
-    fun unarchiveAllInListAsync(episodes: List<PodcastEpisode>)
     suspend fun findEpisodeByUuid(uuid: String): BaseEpisode?
     fun observeDownloadingEpisodesRx(): Flowable<List<BaseEpisode>>
     fun setDownloadFailed(episode: BaseEpisode, errorMessage: String)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -41,7 +41,6 @@ interface EpisodeManager {
     fun observeEpisodeByUuid(uuid: String): Flow<BaseEpisode>
     suspend fun findFirstBySearchQuery(query: String): PodcastEpisode?
 
-    fun findAll(rowParser: (PodcastEpisode) -> Boolean)
     fun findEpisodesWhere(queryAfterWhere: String, forSubscribedPodcastsOnly: Boolean = true): List<PodcastEpisode>
     fun findEpisodesByUuids(uuids: Array<String>, ordered: Boolean): List<PodcastEpisode>
     fun findEpisodesByPodcast(podcast: Podcast): Single<List<PodcastEpisode>>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -16,7 +16,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayerEvent
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Maybe
-import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
 import java.util.Date
 
@@ -85,7 +84,6 @@ interface EpisodeManager {
     fun updateAllEpisodeStatus(episodeStatus: EpisodeStatusEnum)
 
     fun markAsNotPlayed(episode: BaseEpisode?)
-    fun markAsNotPlayedRx(episode: PodcastEpisode): Single<PodcastEpisode>
     suspend fun markAllAsPlayed(episodes: List<BaseEpisode>, playbackManager: PlaybackManager, podcastManager: PodcastManager)
     fun markedAsPlayedExternally(episode: PodcastEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager)
     fun markAsPlayedAsync(episode: BaseEpisode?, playbackManager: PlaybackManager, podcastManager: PodcastManager)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -81,7 +81,6 @@ interface EpisodeManager {
     suspend fun updateDownloadTaskId(episode: BaseEpisode, id: String?)
     fun updateLastDownloadAttemptDate(episode: BaseEpisode?)
     fun updateDownloadErrorDetails(episode: BaseEpisode?, message: String?)
-    fun setEpisodeThumbnailStatus(episode: PodcastEpisode?, thumbnailStatus: Int)
 
     fun updateAllEpisodeStatus(episodeStatus: EpisodeStatusEnum)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
-import androidx.lifecycle.LiveData
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.helper.EpisodesStartedAndCompleted
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
@@ -50,7 +49,6 @@ interface EpisodeManager {
     fun findLatestEpisodeToPlay(): PodcastEpisode?
     fun observeEpisodesByPodcastOrderedRx(podcast: Podcast): Flowable<List<PodcastEpisode>>
     fun observeEpisodesWhere(queryAfterWhere: String): Flowable<List<PodcastEpisode>>
-    fun observeDownloadingEpisodes(): LiveData<List<PodcastEpisode>>
 
     fun findEpisodesToSync(): List<PodcastEpisode>
     fun findEpisodesForHistorySync(): List<PodcastEpisode>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -42,7 +42,6 @@ interface EpisodeManager {
     suspend fun findFirstBySearchQuery(query: String): PodcastEpisode?
 
     fun findEpisodesWhere(queryAfterWhere: String, forSubscribedPodcastsOnly: Boolean = true): List<PodcastEpisode>
-    fun findEpisodesByUuids(uuids: Array<String>, ordered: Boolean): List<PodcastEpisode>
     fun findEpisodesByPodcast(podcast: Podcast): Single<List<PodcastEpisode>>
     fun findEpisodesByPodcastOrdered(podcast: Podcast): List<PodcastEpisode>
     suspend fun findEpisodesByPodcastOrderedSuspend(podcast: Podcast): List<PodcastEpisode>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -55,7 +55,6 @@ interface EpisodeManager {
     fun markAllEpisodesSynced(episodes: List<PodcastEpisode>)
 
     fun findEpisodesDownloading(queued: Boolean = true, waitingForPower: Boolean = true, waitingForWifi: Boolean = true, downloading: Boolean = true): List<PodcastEpisode>
-    fun countEpisodesDownloading(queued: Boolean, waitingForPower: Boolean, waitingForWifi: Boolean, downloading: Boolean): Int
 
     fun observeDownloadEpisodes(): Flowable<List<PodcastEpisode>>
     fun observeDownloadedEpisodes(): Flowable<List<PodcastEpisode>>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -44,7 +44,6 @@ interface EpisodeManager {
     fun findEpisodesWhere(queryAfterWhere: String, forSubscribedPodcastsOnly: Boolean = true): List<PodcastEpisode>
     fun findEpisodesByPodcastOrdered(podcast: Podcast): List<PodcastEpisode>
     suspend fun findEpisodesByPodcastOrderedSuspend(podcast: Podcast): List<PodcastEpisode>
-    fun findEpisodesByPodcastOrderedRx(podcast: Podcast): Single<List<PodcastEpisode>>
     fun findEpisodesByPodcastOrderedByPublishDate(podcast: Podcast): List<PodcastEpisode>
     fun findNotificationEpisodes(date: Date): List<PodcastEpisode>
     fun findLatestUnfinishedEpisodeByPodcast(podcast: Podcast): PodcastEpisode?

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -112,7 +112,6 @@ interface EpisodeManager {
 
     fun deleteEpisodeWithoutSync(episode: PodcastEpisode?, playbackManager: PlaybackManager)
     suspend fun deleteEpisodeFile(episode: BaseEpisode?, playbackManager: PlaybackManager?, disableAutoDownload: Boolean, updateDatabase: Boolean = true, removeFromUpNext: Boolean = true)
-    fun deleteFinishedEpisodes(playbackManager: PlaybackManager)
     fun deleteDownloadedEpisodeFiles()
 
     /** Utility methods  */

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -13,7 +13,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayerEvent
-import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Maybe
 import kotlinx.coroutines.flow.Flow
@@ -88,7 +87,6 @@ interface EpisodeManager {
     fun markedAsPlayedExternally(episode: PodcastEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager)
     fun markAsPlayedAsync(episode: BaseEpisode?, playbackManager: PlaybackManager, podcastManager: PodcastManager)
     fun markAsPlayed(episode: BaseEpisode?, playbackManager: PlaybackManager, podcastManager: PodcastManager)
-    fun rxMarkAsPlayed(episode: PodcastEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager): Completable
     fun markAsPlaybackError(episode: BaseEpisode?, errorMessage: String?)
     fun markAsPlaybackError(episode: BaseEpisode?, event: PlayerEvent.PlayerError, isPlaybackRemote: Boolean)
     suspend fun starEpisode(episode: PodcastEpisode, starred: Boolean, sourceView: SourceView)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -112,7 +112,6 @@ interface EpisodeManager {
 
     fun deleteEpisodeWithoutSync(episode: PodcastEpisode?, playbackManager: PlaybackManager)
     suspend fun deleteEpisodeFile(episode: BaseEpisode?, playbackManager: PlaybackManager?, disableAutoDownload: Boolean, updateDatabase: Boolean = true, removeFromUpNext: Boolean = true)
-    fun deleteDownloadedEpisodeFiles()
 
     /** Utility methods  */
     suspend fun countEpisodes(): Int

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -572,14 +572,6 @@ class EpisodeManagerImpl @Inject constructor(
         return episodeDao.countWhere(queryAfterWhere, appDatabase)
     }
 
-    override fun deleteCustomFolderEpisode(episode: PodcastEpisode?, playbackManager: PlaybackManager) {
-        episode ?: return
-
-        playbackManager.removeEpisode(episode, source = SourceView.UNKNOWN, userInitiated = false)
-
-        episodeDao.delete(episode)
-    }
-
     override fun add(episode: PodcastEpisode, downloadMetaData: Boolean): Boolean {
         val episodes = ArrayList<PodcastEpisode>()
         episodes.add(episode)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -39,7 +39,6 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.anyMessageContains
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.timeIntervalSinceNow
 import dagger.hilt.android.qualifiers.ApplicationContext
-import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Maybe
 import io.reactivex.rxkotlin.zipWith
@@ -836,10 +835,6 @@ class EpisodeManagerImpl @Inject constructor(
 
     override suspend fun findStarredEpisodes(): List<PodcastEpisode> {
         return episodeDao.findStarredEpisodes()
-    }
-
-    override fun rxMarkAsPlayed(episode: PodcastEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager): Completable {
-        return Completable.fromAction { markAsPlayed(episode, playbackManager, podcastManager) }
     }
 
     override fun findEpisodesDownloading(queued: Boolean, waitingForPower: Boolean, waitingForWifi: Boolean, downloading: Boolean): List<PodcastEpisode> {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.media3.exoplayer.source.UnrecognizedInputFormatException
-import androidx.paging.PagedList
 import androidx.room.withTransaction
 import androidx.sqlite.db.SimpleSQLiteQuery
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
@@ -60,7 +59,6 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.File
 import java.util.Date
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -122,24 +120,6 @@ class EpisodeManagerImpl @Inject constructor(
 
     override suspend fun findFirstBySearchQuery(query: String): PodcastEpisode? =
         episodeDao.findFirstBySearchQuery(query)
-
-    @Suppress("DEPRECATION")
-    override fun findAll(rowParser: (PodcastEpisode) -> Boolean) {
-        val pagingConfig = PagedList.Config.Builder()
-            .setPageSize(100)
-            .setEnablePlaceholders(false)
-            .build()
-        val episodes = episodeDao.findAll().create()
-        val pagedList = PagedList.Builder(episodes, pagingConfig)
-            .setFetchExecutor(Executors.newSingleThreadExecutor())
-            .setNotifyExecutor(Executors.newSingleThreadExecutor())
-            .build()
-        for (episode in pagedList) {
-            if (!rowParser(episode)) {
-                break
-            }
-        }
-    }
 
     /**
      * Find a podcast episodes

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -845,10 +845,6 @@ class EpisodeManagerImpl @Inject constructor(
         return episodeDao.findStarredEpisodes()
     }
 
-    override fun exists(episodeUuid: String): Boolean {
-        return episodeDao.exists(episodeUuid)
-    }
-
     override fun markAsNotPlayedRx(episode: PodcastEpisode): Single<PodcastEpisode> {
         return Single.fromCallable {
             markAsNotPlayed(episode)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -594,12 +594,6 @@ class EpisodeManagerImpl @Inject constructor(
         episodeDao.update(episode)
     }
 
-    override fun setEpisodeThumbnailStatus(episode: PodcastEpisode?, thumbnailStatus: Int) {
-        episode ?: return
-        episode.thumbnailStatus = thumbnailStatus
-        episodeDao.updateThumbnailStatus(thumbnailStatus, episode.uuid)
-    }
-
     override fun setDownloadFailed(episode: BaseEpisode, errorMessage: String) {
         if (episode is PodcastEpisode) {
             episodeDao.updateDownloadError(episode.uuid, errorMessage, EpisodeStatusEnum.DOWNLOAD_FAILED)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -765,17 +765,6 @@ class EpisodeManagerImpl @Inject constructor(
         }
     }
 
-    override fun deleteFinishedEpisodes(playbackManager: PlaybackManager) {
-        val episodes = findEpisodesWhere("episode_status = " + EpisodeStatusEnum.DOWNLOADED.ordinal + " AND playing_status = " + EpisodePlayingStatus.COMPLETED.ordinal)
-        if (episodes.isEmpty()) return
-
-        runBlocking {
-            for (episode in episodes) {
-                deleteEpisodeFile(episode, playbackManager, true, true)
-            }
-        }
-    }
-
     override suspend fun deleteAll() {
         episodeDao.deleteAll()
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -891,12 +891,6 @@ class EpisodeManagerImpl @Inject constructor(
         }
     }
 
-    override fun unarchiveAllInListAsync(episodes: List<PodcastEpisode>) {
-        launch {
-            unarchiveAllInList(episodes)
-        }
-    }
-
     override fun unarchiveAllInList(episodes: List<PodcastEpisode>) {
         episodes.filter { it.isArchived }.chunked(500).forEach { chunked ->
             episodeDao.unarchiveAllInList(chunked.map { it.uuid }, System.currentTimeMillis())

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -42,7 +42,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Maybe
-import io.reactivex.Single
 import io.reactivex.rxkotlin.zipWith
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -837,13 +836,6 @@ class EpisodeManagerImpl @Inject constructor(
 
     override suspend fun findStarredEpisodes(): List<PodcastEpisode> {
         return episodeDao.findStarredEpisodes()
-    }
-
-    override fun markAsNotPlayedRx(episode: PodcastEpisode): Single<PodcastEpisode> {
-        return Single.fromCallable {
-            markAsNotPlayed(episode)
-            episode
-        }
     }
 
     override fun rxMarkAsPlayed(episode: PodcastEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager): Completable {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -13,7 +13,6 @@ import au.com.shiftyjelly.pocketcasts.models.db.helper.EpisodesStartedAndComplet
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedCategory
 import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.db.helper.LongestEpisode
-import au.com.shiftyjelly.pocketcasts.models.db.helper.QueryHelper
 import au.com.shiftyjelly.pocketcasts.models.db.helper.YearOverYearListeningTime
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -230,19 +229,6 @@ class EpisodeManagerImpl @Inject constructor(
     override fun observeDownloadingEpisodesRx(): Flowable<List<BaseEpisode>> {
         return episodeDao.observeDownloadingEpisodesRx().map { it as List<BaseEpisode> }.mergeWith(userEpisodeManager.observeDownloadUserEpisodes())
     }
-
-    override fun findEpisodesByUuids(uuids: Array<String>, ordered: Boolean): List<PodcastEpisode> =
-        if (uuids.isEmpty()) {
-            emptyList()
-        } else if (ordered) {
-            uuids.mapNotNull {
-                runBlocking {
-                    findByUuid(it)
-                }
-            }
-        } else {
-            findEpisodesWhere("uuid IN " + QueryHelper.convertStringArrayToInStatement(uuids))
-        }
 
     override fun updatePlayedUpTo(episode: BaseEpisode?, playedUpTo: Double, forceUpdate: Boolean) {
         if (playedUpTo < 0 || episode == null) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -123,9 +123,6 @@ class EpisodeManagerImpl @Inject constructor(
     /**
      * Find a podcast episodes
      */
-    override fun findEpisodesByPodcast(podcast: Podcast): Single<List<PodcastEpisode>> {
-        return Single.fromCallable { episodeDao.findByPodcastOrderPublishedDateDesc(podcastUuid = podcast.uuid) }
-    }
 
     override fun findEpisodesByPodcastOrderedByPublishDate(podcast: Podcast): List<PodcastEpisode> {
         return episodeDao.findByPodcastOrderPublishedDateDesc(podcastUuid = podcast.uuid)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -865,11 +865,6 @@ class EpisodeManagerImpl @Inject constructor(
         return findEpisodesWhere(sql)
     }
 
-    override fun countEpisodesDownloading(queued: Boolean, waitingForPower: Boolean, waitingForWifi: Boolean, downloading: Boolean): Int {
-        val sql = buildEpisodeStatusWhere(queued, waitingForPower, waitingForWifi, downloading)
-        return countEpisodesWhere(sql)
-    }
-
     private fun buildEpisodeStatusWhere(queued: Boolean, waitingForPower: Boolean, waitingForWifi: Boolean, downloading: Boolean): String {
         val status = mutableSetOf<EpisodeStatusEnum>()
         if (queued) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import android.content.Context
-import androidx.lifecycle.LiveData
 import androidx.media3.exoplayer.source.UnrecognizedInputFormatException
 import androidx.room.withTransaction
 import androidx.sqlite.db.SimpleSQLiteQuery
@@ -212,10 +211,6 @@ class EpisodeManagerImpl @Inject constructor(
 
     override suspend fun findPlaybackHistoryEpisodes(): List<PodcastEpisode> {
         return episodeDao.findPlaybackHistoryEpisodes()
-    }
-
-    override fun observeDownloadingEpisodes(): LiveData<List<PodcastEpisode>> {
-        return episodeDao.observeDownloadingEpisodes()
     }
 
     @Suppress("USELESS_CAST")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -769,25 +769,6 @@ class EpisodeManagerImpl @Inject constructor(
         episodeDao.deleteAll()
     }
 
-    override fun deleteDownloadedEpisodeFiles() {
-        // remove all the files off the disk, ignore any errors and continue
-        try {
-            fileStorage.removeDirectoryFiles(fileStorage.podcastDirectory)
-            fileStorage.removeDirectoryFiles(fileStorage.tempPodcastDirectory)
-        } catch (e: Exception) {
-            Timber.e(e)
-        }
-
-        val episodes = findEpisodesWhere("episode_status = " + EpisodeStatusEnum.DOWNLOADED.ordinal)
-        if (episodes.isEmpty()) return
-
-        for (episode in episodes) {
-            runBlocking {
-                updateEpisodeStatus(episode, EpisodeStatusEnum.NOT_DOWNLOADED)
-            }
-        }
-    }
-
     override fun deleteEpisodes(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager) {
         val episodesCopy = episodes.toList()
         launch {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -162,10 +162,6 @@ class EpisodeManagerImpl @Inject constructor(
         }
     }
 
-    override fun findEpisodesByPodcastOrderedRx(podcast: Podcast): Single<List<PodcastEpisode>> {
-        return Single.fromCallable { findEpisodesByPodcastOrdered(podcast) }
-    }
-
     override fun observeEpisodesByPodcastOrderedRx(podcast: Podcast): Flowable<List<PodcastEpisode>> {
         return when (podcast.episodesSortType) {
             EpisodesSortType.EPISODES_SORT_BY_TITLE_ASC -> episodeDao.observeByPodcastOrderTitleAsc(podcastUuid = podcast.uuid)


### PR DESCRIPTION
## Description
Removing some unused episode query methods. Doing this as a follow-up to https://github.com/Automattic/pocket-casts-android/pull/1589 so that we don't have risky methods that aren't using transactions laying around.

## Testing Instructions

If CI is green, this should be good.


## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
