### PR TITLE
Bookmarks - Update Tap to view bookmark notification action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
     *   Fix issues where multi-select on one screen would affect another screen
         ([#1579](https://github.com/Automattic/pocket-casts-android/pull/1579),
          [#1580](https://github.com/Automattic/pocket-casts-android/pull/1580))
+    *   Fix tap to view action from bookmark added notification 
+        ([#1614](https://github.com/Automattic/pocket-casts-android/pull/1614))
 *   Updates:
     *   Display dynamic colors for widget
         ([#1588](https://github.com/Automattic/pocket-casts-android/pull/1588))

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/BookmarkDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/BookmarkDaoTest.kt
@@ -48,7 +48,7 @@ class BookmarkDaoTest {
             bookmarkDao.insert(FakeBookmarksGenerator.create(uuid))
             assertNotNull(
                 "Inserted bookmark should be able to be found",
-                bookmarkDao.findByUuid(uuid)
+                bookmarkDao.findByUuid(uuid, false)
             )
         }
     }
@@ -60,8 +60,7 @@ class BookmarkDaoTest {
             val bookmark = FakeBookmarksGenerator.create(uuid)
             bookmarkDao.insert(bookmark)
 
-            val createdBookmark = bookmarkDao.findByUuid(uuid)
-            assert(createdBookmark?.deleted == false)
+            val createdBookmark = bookmarkDao.findByUuid(uuid, false)
             assert(createdBookmark?.syncStatus == SyncStatus.NOT_SYNCED)
 
             bookmark.deleted = true
@@ -69,8 +68,7 @@ class BookmarkDaoTest {
 
             bookmarkDao.update(bookmark)
 
-            val updatedBookmark = bookmarkDao.findByUuid(uuid)
-            assert(updatedBookmark?.deleted == true)
+            val updatedBookmark = bookmarkDao.findByUuid(uuid, deleted = true)
             assert(updatedBookmark?.syncStatus == SyncStatus.SYNCED)
         }
     }
@@ -81,9 +79,9 @@ class BookmarkDaoTest {
             val uuid = UUID.randomUUID().toString()
             val bookmark = FakeBookmarksGenerator.create(uuid)
             bookmarkDao.insert(bookmark)
-            assertNotNull(bookmarkDao.findByUuid(uuid))
+            assertNotNull(bookmarkDao.findByUuid(uuid, false))
             bookmarkDao.delete(bookmark)
-            assertNull(bookmarkDao.findByUuid(uuid))
+            assertNull(bookmarkDao.findByUuid(uuid, true))
         }
     }
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerTest.kt
@@ -162,9 +162,8 @@ class BookmarkManagerTest {
         runTest {
             val bookmark = bookmarkManager.add(episode = episode, timeSecs = 61, title = "", creationSource = BookmarkManager.CreationSource.PLAYER)
             bookmarkManager.deleteToSync(bookmark.uuid)
-            val savedBookmark = bookmarkManager.findBookmark(bookmark.uuid)
+            val savedBookmark = bookmarkManager.findBookmark(bookmark.uuid, deleted = true)
             assertNotNull(savedBookmark)
-            assertEquals(true, savedBookmark?.deleted)
             assertEquals(SyncStatus.NOT_SYNCED, savedBookmark?.syncStatus)
         }
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -236,7 +236,7 @@ class PodcastSyncProcessTest {
             assertEquals("Bookmark Added", newBookmark?.title)
             assertEquals(875, newBookmark?.timeSecs)
             // check deleted bookmarks are removed
-            assertNull("Bookmark should of been deleted", bookmarkManager.findBookmark(bookmarkToDelete.uuid))
+            assertNull("Bookmark should have been deleted", bookmarkManager.findBookmark(bookmarkToDelete.uuid, deleted = true))
         }
     }
 }

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModelTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModelTest.kt
@@ -40,6 +40,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -168,7 +169,7 @@ class MainActivityViewModelTest {
     fun `given episode for bookmark is current playing, when bookmark viewed from notification, then bookmarks on player shown`() = runTest {
         whenever(bookmark.episodeUuid).thenReturn(TEST_EPISODE_UUID)
         whenever(episode.uuid).thenReturn(TEST_EPISODE_UUID)
-        whenever(bookmarkManager.findBookmark(anyString())).thenReturn(bookmark)
+        whenever(bookmarkManager.findBookmark(anyString(), eq(false))).thenReturn(bookmark)
         whenever(playbackManager.getCurrentEpisode()).thenReturn(episode)
         initViewModel()
 
@@ -181,7 +182,7 @@ class MainActivityViewModelTest {
     @Test
     fun `given podcast episode for bookmark currently not playing, when bookmark viewed from notification, then bookmarks for podcast episode shown`() = runTest {
         whenever(bookmark.episodeUuid).thenReturn(TEST_EPISODE_UUID)
-        whenever(bookmarkManager.findBookmark(anyString())).thenReturn(bookmark)
+        whenever(bookmarkManager.findBookmark(anyString(), eq(false))).thenReturn(bookmark)
         whenever(playbackManager.getCurrentEpisode()).thenReturn(null)
         whenever(episodeManager.findEpisodeByUuid(TEST_EPISODE_UUID)).thenReturn(mock<PodcastEpisode>())
         initViewModel()
@@ -195,7 +196,7 @@ class MainActivityViewModelTest {
     @Test
     fun `given user episode for bookmark currently not playing, when bookmark viewed from notification, then bookmarks for user episode shown`() = runTest {
         whenever(bookmark.episodeUuid).thenReturn(TEST_EPISODE_UUID)
-        whenever(bookmarkManager.findBookmark(anyString())).thenReturn(bookmark)
+        whenever(bookmarkManager.findBookmark(anyString(), eq(false))).thenReturn(bookmark)
         whenever(playbackManager.getCurrentEpisode()).thenReturn(null)
         whenever(episodeManager.findEpisodeByUuid(TEST_EPISODE_UUID)).thenReturn(mock<UserEpisode>())
         initViewModel()

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModelTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModelTest.kt
@@ -1,6 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.ui
 
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -8,9 +12,11 @@ import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.ui.MainActivityViewModel.NavigationState
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
@@ -29,6 +35,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.anyOrNull
@@ -36,11 +43,15 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
+private const val TEST_EPISODE_UUID = "test_episode_uuid"
 @RunWith(MockitoJUnitRunner::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainActivityViewModelTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
+
+    @Mock
+    lateinit var episodeManager: EpisodeManager
 
     @Mock
     lateinit var playbackManager: PlaybackManager
@@ -66,6 +77,12 @@ class MainActivityViewModelTest {
     @Mock
     lateinit var theme: Theme
 
+    @Mock
+    lateinit var bookmark: Bookmark
+
+    @Mock
+    lateinit var episode: BaseEpisode
+
     private lateinit var viewModel: MainActivityViewModel
 
     private val betaEarlyAccessRelease = ReleaseVersion(7, 50, null, 1)
@@ -77,6 +94,8 @@ class MainActivityViewModelTest {
     fun setup() = runTest {
         whenever(playbackManager.playbackStateRelay).thenReturn(BehaviorRelay.create<PlaybackState>().toSerialized())
     }
+
+    /* What's new tests */
 
     @Test
     fun `given user entitled for bookmarks, when any release, then what's new shown`() = runTest {
@@ -143,10 +162,54 @@ class MainActivityViewModelTest {
         }
     }
 
+    /* Bookmark added notification tests */
+
+    @Test
+    fun `given episode for bookmark is current playing, when bookmark viewed from notification, then bookmarks on player shown`() = runTest {
+        whenever(bookmark.episodeUuid).thenReturn(TEST_EPISODE_UUID)
+        whenever(episode.uuid).thenReturn(TEST_EPISODE_UUID)
+        whenever(bookmarkManager.findBookmark(anyString())).thenReturn(bookmark)
+        whenever(playbackManager.getCurrentEpisode()).thenReturn(episode)
+        initViewModel()
+
+        viewModel.navigationState.test {
+            viewModel.viewBookmark("")
+            assertTrue(awaitItem() is NavigationState.BookmarksForCurrentlyPlaying)
+        }
+    }
+
+    @Test
+    fun `given podcast episode for bookmark currently not playing, when bookmark viewed from notification, then bookmarks for podcast episode shown`() = runTest {
+        whenever(bookmark.episodeUuid).thenReturn(TEST_EPISODE_UUID)
+        whenever(bookmarkManager.findBookmark(anyString())).thenReturn(bookmark)
+        whenever(playbackManager.getCurrentEpisode()).thenReturn(null)
+        whenever(episodeManager.findEpisodeByUuid(TEST_EPISODE_UUID)).thenReturn(mock<PodcastEpisode>())
+        initViewModel()
+
+        viewModel.navigationState.test {
+            viewModel.viewBookmark("")
+            assertTrue(awaitItem() is NavigationState.BookmarksForPodcastEpisode)
+        }
+    }
+
+    @Test
+    fun `given user episode for bookmark currently not playing, when bookmark viewed from notification, then bookmarks for user episode shown`() = runTest {
+        whenever(bookmark.episodeUuid).thenReturn(TEST_EPISODE_UUID)
+        whenever(bookmarkManager.findBookmark(anyString())).thenReturn(bookmark)
+        whenever(playbackManager.getCurrentEpisode()).thenReturn(null)
+        whenever(episodeManager.findEpisodeByUuid(TEST_EPISODE_UUID)).thenReturn(mock<UserEpisode>())
+        initViewModel()
+
+        viewModel.navigationState.test {
+            viewModel.viewBookmark("")
+            assertTrue(awaitItem() is NavigationState.BookmarksForUserEpisode)
+        }
+    }
+
     private fun initViewModel(
-        isUserEntitled: Boolean,
-        currentRelease: ReleaseVersion,
-        patronExclusiveAccessRelease: ReleaseVersion?,
+        isUserEntitled: Boolean = true,
+        currentRelease: ReleaseVersion = productionFullAccessRelease,
+        patronExclusiveAccessRelease: ReleaseVersion? = productionEarlyAccessRelease,
     ) {
         whenever(settings.getMigratedVersionCode()).thenReturn(1) // this is not 0, we don't show what's new to new users
         whenever(settings.getWhatsNewVersionCode()).thenReturn(2) // this is less than the current what's new version code and so will trigger what's new
@@ -175,6 +238,7 @@ class MainActivityViewModelTest {
         whenever(featureFlag.isEnabled(feature.bookmarksFeature)).thenReturn(true)
 
         viewModel = MainActivityViewModel(
+            episodeManager = episodeManager,
             playbackManager = playbackManager,
             userManager = userManager,
             settings = settings,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -271,13 +271,9 @@ class BookmarksViewModel
     }
 
     private fun SourceView.mapToBookmarksSortTypeUserSetting() =
-        when (sourceView) {
-            SourceView.FILES,
-            SourceView.EPISODE_DETAILS,
-            -> settings.episodeBookmarksSortType
-
+        when (this) {
             SourceView.PLAYER -> settings.playerBookmarksSortType
-            else -> throw IllegalAccessException("Bookmarks sort accessed in unknown source view: $this")
+            else -> settings.episodeBookmarksSortType
         }
 
     sealed class UiState {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -215,6 +215,10 @@ class EpisodeContainerFragment :
                 viewModel.onPageSelected(position)
             }
         })
+
+        if (episodeViewSource == EpisodeViewSource.NOTIFICATION_BOOKMARK) {
+            openBookmarks()
+        }
     }
 
     private fun FragmentEpisodeContainerBinding.setupMultiSelectHelper() {
@@ -229,6 +233,12 @@ class EpisodeContainerFragment :
             menuRes = null,
             fragmentManager = parentFragmentManager,
         )
+    }
+
+    private fun openBookmarks() {
+        val index = adapter.indexOfBookmarks
+        if (index == -1) return
+        binding?.viewPager?.currentItem = index
     }
 
     override fun onDestroyView() {
@@ -251,6 +261,8 @@ class EpisodeContainerFragment :
         private val fromListUuid: String?,
         private val forceDarkTheme: Boolean,
     ) : FragmentStateAdapter(fragmentManager, lifecycle) {
+        val indexOfBookmarks: Int
+            get() = sections.indexOf(Section.Bookmarks)
 
         private sealed class Section(@StringRes val titleRes: Int) {
             object Details : Section(LR.string.details)

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
@@ -16,6 +16,7 @@ enum class SourceView(val analyticsValue: String) {
     MINIPLAYER("miniplayer"),
     PLAYER("player"),
     NOTIFICATION("notification"),
+    NOTIFICATION_BOOKMARK("notification_bookmark"),
     FULL_SCREEN_VIDEO("full_screen_video"),
     UP_NEXT("up_next"),
     MEDIA_BUTTON_BROADCAST_ACTION("media_button_broadcast_action"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1771,6 +1771,7 @@
     <string name="bookmarks_deleted_singular">1 bookmark deleted</string>
     <string name="bookmarks_delete_summary_plural">%d bookmarks will be deleted. This cannot be undone.</string>
     <string name="bookmarks_delete_summary_singular">This bookmark will be deleted. This cannot be undone.</string>
+    <string name="bookmark_not_found">Bookmark not found</string>
     <string name="bookmarks_select_option">Select bookmarks</string>
     <string name="bookmarks_search">Search bookmark</string>
     <string name="bookmarks_sort_option" translatable="false">@string/sort_by</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -26,8 +26,11 @@ abstract class BookmarkDao {
     @Query("DELETE FROM bookmarks WHERE uuid = :uuid")
     abstract suspend fun deleteByUuid(uuid: String)
 
-    @Query("SELECT * FROM bookmarks WHERE uuid = :uuid")
-    abstract suspend fun findByUuid(uuid: String): Bookmark?
+    @Query("SELECT * FROM bookmarks WHERE uuid = :uuid AND deleted = :deleted")
+    abstract suspend fun findByUuid(
+        uuid: String,
+        deleted: Boolean = false,
+    ): Bookmark?
 
     @Query("SELECT * FROM bookmarks WHERE podcast_uuid = :podcastUuid AND episode_uuid = :episodeUuid AND time = :timeSecs AND deleted = :deleted LIMIT 1")
     abstract suspend fun findByEpisodeTime(

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -29,7 +29,7 @@ abstract class BookmarkDao {
     @Query("SELECT * FROM bookmarks WHERE uuid = :uuid AND deleted = :deleted")
     abstract suspend fun findByUuid(
         uuid: String,
-        deleted: Boolean = false,
+        deleted: Boolean,
     ): Bookmark?
 
     @Query("SELECT * FROM bookmarks WHERE podcast_uuid = :podcastUuid AND episode_uuid = :episodeUuid AND time = :timeSecs AND deleted = :deleted LIMIT 1")

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/EpisodeViewSource.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/EpisodeViewSource.kt
@@ -10,6 +10,7 @@ enum class EpisodeViewSource(val value: String) {
     UP_NEXT("up_next"),
     SHARE("share"),
     NOTIFICATION("notification"),
+    NOTIFICATION_BOOKMARK("notification_bookmark"),
     SEARCH("search"),
     SEARCH_HISTORY("search_history"),
     UNKNOWN("unknown");

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -113,6 +113,8 @@ interface Settings {
         const val NOTIFICATIONS_DISABLED_MESSAGE_SHOWN = "notificationsDisabledMessageShown"
 
         const val APP_REVIEW_REQUESTED_DATES = "in_app_review_requested_dates"
+
+        const val BOOKMARK_UUID = "bookmark_uuid"
     }
 
     enum class NotificationChannel(val id: String) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 interface BookmarkManager {
     suspend fun add(episode: BaseEpisode, timeSecs: Int, title: String, creationSource: CreationSource): Bookmark
     suspend fun updateTitle(bookmarkUuid: String, title: String)
-    suspend fun findBookmark(bookmarkUuid: String): Bookmark?
+    suspend fun findBookmark(bookmarkUuid: String, deleted: Boolean = false): Bookmark?
     suspend fun findByEpisodeTime(episode: BaseEpisode, timeSecs: Int): Bookmark?
     suspend fun findEpisodeBookmarksFlow(
         episode: BaseEpisode,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -83,8 +83,11 @@ class BookmarkManagerImpl @Inject constructor(
     /**
      * Find the bookmark by its UUID.
      */
-    override suspend fun findBookmark(bookmarkUuid: String): Bookmark? {
-        return bookmarkDao.findByUuid(bookmarkUuid)
+    override suspend fun findBookmark(
+        bookmarkUuid: String,
+        deleted: Boolean,
+    ): Bookmark? {
+        return bookmarkDao.findByUuid(bookmarkUuid, deleted)
     }
 
     /**

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -461,6 +461,7 @@ open class PlaybackManager @Inject constructor(
             SourceView.UP_NEXT,
             SourceView.STATS,
             SourceView.WHATS_NEW,
+            SourceView.NOTIFICATION_BOOKMARK,
             -> null
 
             SourceView.MEDIA_BUTTON_BROADCAST_SEARCH_ACTION,


### PR DESCRIPTION
## Description
This makes adjustments to the `Tap to view` action on the `Bookmark added` notification to 
- display the bookmarks on the `Episode` screen instead of the player screen if the `PodcastEpisode` for which the bookmark was added  is not currently playing
- display the bookmarks for the `UserEpisode` if the `UserEpisode` for which the bookmark was added is not currently playing
- display bookmark not found message if the bookmark is deleted

Part of: https://github.com/Automattic/pocket-casts-android/issues/1595

## Testing Instructions

#### Test.1 For currently playing episode

1. Go to `Profile` -> `Settings` -> `Headphone controls`
2. Tap `Next action`
3. Select `Add bookmark`
4. Play any podcast episode
5. Minimize the app
6. Double-tap the headphone to add a bookmark
7. Notice that `Bookmark added` notification is displayed
8. Tap on the notification to view the bookmark
9. ✅ Notice that the `Bookmarks` tab on the `Player` screen is shown 

#### Test.2 For podcast episode not currently playing

1. Continue from above
2. Repeat steps 4-7
3. Open the app and play any other podcast episode 
4. Tap on the notification to view the bookmark
5. ✅ Notice that `Bookmarks` tab on the `Episode Details` screen for the bookmark episode is shown

#### Test.3 For user episode not currently playing

1. Continue from above
2. Play any user episode
3. Repeat steps 5-7
4. Open the app and play any other podcast episode 
5. Tap on the notification to view the bookmark
6. ✅ Notice that `Bookmarks` screen for the bookmark user episode is shown

#### Test.4 Bookmark deleted

1. Continue from above
2. Repeat steps 4-7
4. Open the app and delete the newly added bookmark
5. Tap on the notification to view the bookmark
6. ✅ Notice that `Bookmark not found` snack bar message is shown


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews N/A
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- with different themes N/A
- with a landscape orientation N/A
- with the device set to have a large display and font size N/A
- for accessibility with TalkBack N/A
