### PR TITLE
Remove usage of GlobalScope

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
@@ -20,6 +20,8 @@ import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
 import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshServerManager
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import io.reactivex.Single
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -70,8 +72,30 @@ class PodcastManagerTest {
         val refreshServerManager = mock<RefreshServerManager> {}
         val subscribeManager = SubscribeManager(appDatabase, podcastCacheServer, staticServerManager, syncManagerSignedOut, application, settings)
         podcastDao = appDatabase.podcastDao()
-        podcastManagerSignedOut = PodcastManagerImpl(episodeManager, playlistManager, settings, application, subscribeManager, podcastCacheServer, refreshServerManager, syncManagerSignedOut, appDatabase)
-        podcastManagerSignedIn = PodcastManagerImpl(episodeManager, playlistManager, settings, application, subscribeManager, podcastCacheServer, refreshServerManager, syncManagerSignedIn, appDatabase)
+        podcastManagerSignedOut = PodcastManagerImpl(
+            episodeManager = episodeManager,
+            playlistManager = playlistManager,
+            settings = settings,
+            context = application,
+            subscribeManager = subscribeManager,
+            cacheServerManager = podcastCacheServer,
+            refreshServerManager = refreshServerManager,
+            syncManager = syncManagerSignedOut,
+            appDatabase = appDatabase,
+            applicationScope = CoroutineScope(Dispatchers.Default),
+        )
+        podcastManagerSignedIn = PodcastManagerImpl(
+            episodeManager = episodeManager,
+            playlistManager = playlistManager,
+            settings = settings,
+            context = application,
+            subscribeManager = subscribeManager,
+            cacheServerManager = podcastCacheServer,
+            refreshServerManager = refreshServerManager,
+            syncManager = syncManagerSignedIn,
+            applicationScope = CoroutineScope(Dispatchers.Default),
+            appDatabase = appDatabase
+        )
     }
 
     @After

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -22,6 +22,8 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNull
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import okhttp3.Cache
 import okhttp3.OkHttpClient
@@ -152,6 +154,7 @@ class PodcastSyncProcessTest {
                 folderManager = folderManager,
                 syncManager = syncManager,
                 featureFlagWrapper = featureFlagWrapper,
+                applicationScope = CoroutineScope(Dispatchers.Default),
             )
 
             val response = MockResponse()

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -11,7 +11,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.TracksAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
 import au.com.shiftyjelly.pocketcasts.repositories.file.StorageOptions
@@ -74,7 +74,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
     @Inject lateinit var tracksTracker: TracksAnalyticsTracker
     @Inject lateinit var bumpStatsTracker: AnonymousBumpStatsTracker
     @Inject lateinit var syncManager: SyncManager
-    @Inject @ForApplicationScope lateinit var applicationScope: CoroutineScope
+    @Inject @ApplicationScope lateinit var applicationScope: CoroutineScope
 
     override fun onCreate() {
         if (BuildConfig.DEBUG) {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.TracksAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
 import au.com.shiftyjelly.pocketcasts.repositories.file.StorageOptions
@@ -41,9 +42,8 @@ import dagger.hilt.android.HiltAndroidApp
 import io.sentry.Sentry
 import io.sentry.android.core.SentryAndroid
 import io.sentry.protocol.User
-import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -74,6 +74,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
     @Inject lateinit var tracksTracker: TracksAnalyticsTracker
     @Inject lateinit var bumpStatsTracker: AnonymousBumpStatsTracker
     @Inject lateinit var syncManager: SyncManager
+    @Inject @ForApplicationScope lateinit var applicationScope: CoroutineScope
 
     override fun onCreate() {
         if (BuildConfig.DEBUG) {
@@ -138,7 +139,6 @@ class PocketCastsApplication : Application(), Configuration.Provider {
             .build()
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     private fun setupApp() {
         LogBuffer.i("Application", "App started. ${settings.getVersion()} (${settings.getVersionCode()})")
 
@@ -223,7 +223,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
             }
         }
 
-        GlobalScope.launch(Dispatchers.IO) { fileStorage.fixBrokenFiles(episodeManager) }
+        applicationScope.launch(Dispatchers.IO) { fileStorage.fixBrokenFiles(episodeManager) }
 
         userEpisodeManager.monitorUploads(applicationContext)
         downloadManager.beginMonitoringWorkManager(applicationContext)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -82,6 +82,7 @@ import au.com.shiftyjelly.pocketcasts.profile.cloud.CloudFileBottomSheetFragment
 import au.com.shiftyjelly.pocketcasts.profile.cloud.CloudFilesFragment
 import au.com.shiftyjelly.pocketcasts.profile.sonos.SonosAppLinkActivity
 import au.com.shiftyjelly.pocketcasts.repositories.bumpstats.BumpStatsTask
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.di.NotificationPermissionChecker
 import au.com.shiftyjelly.pocketcasts.repositories.opml.OpmlImportTask
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -133,9 +134,7 @@ import io.reactivex.rxkotlin.addTo
 import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -189,6 +188,7 @@ class MainActivity :
     @Inject lateinit var episodeAnalytics: EpisodeAnalytics
     @Inject lateinit var syncManager: SyncManager
     @Inject lateinit var watchSync: WatchSync
+    @Inject @ForApplicationScope lateinit var applicationScope: CoroutineScope
 
     private lateinit var bottomNavHideManager: BottomNavHideManager
     private lateinit var observeUpNext: LiveData<UpNextQueue.State>
@@ -678,7 +678,6 @@ class MainActivity :
             .show(supportFragmentManager, "stories_dialog")
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     @Suppress("DEPRECATION")
     private fun setupPlayerViews(showMiniPlayerImmediately: Boolean) {
         binding.playerBottomSheet.listener = this
@@ -756,7 +755,7 @@ class MainActivity :
                     }
                 }
             } else {
-                GlobalScope.launch { userEpisodeManager.removeCloudStatusFromFiles(playbackManager) }
+                applicationScope.launch { userEpisodeManager.removeCloudStatusFromFiles(playbackManager) }
             }
 
             if (viewModel.shouldShowTrialFinished(signinState)) {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -82,7 +82,7 @@ import au.com.shiftyjelly.pocketcasts.profile.cloud.CloudFileBottomSheetFragment
 import au.com.shiftyjelly.pocketcasts.profile.cloud.CloudFilesFragment
 import au.com.shiftyjelly.pocketcasts.profile.sonos.SonosAppLinkActivity
 import au.com.shiftyjelly.pocketcasts.repositories.bumpstats.BumpStatsTask
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.di.NotificationPermissionChecker
 import au.com.shiftyjelly.pocketcasts.repositories.opml.OpmlImportTask
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -188,7 +188,7 @@ class MainActivity :
     @Inject lateinit var episodeAnalytics: EpisodeAnalytics
     @Inject lateinit var syncManager: SyncManager
     @Inject lateinit var watchSync: WatchSync
-    @Inject @ForApplicationScope lateinit var applicationScope: CoroutineScope
+    @Inject @ApplicationScope lateinit var applicationScope: CoroutineScope
 
     private lateinit var bottomNavHideManager: BottomNavHideManager
     private lateinit var observeUpNext: LiveData<UpNextQueue.State>

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -496,7 +496,12 @@ class MainActivity :
             doRefresh()
         }
 
-        PocketCastsShortcuts.update(playlistManager, true, this)
+        PocketCastsShortcuts.update(
+            playlistManager = playlistManager,
+            force = true,
+            coroutineScope = applicationScope,
+            context = this
+        )
 
         subscriptionManager.refreshPurchases()
 
@@ -508,7 +513,7 @@ class MainActivity :
     private suspend fun refreshAppAndWait() = withContext(Dispatchers.Main) {
         val dialog = android.app.ProgressDialog.show(this@MainActivity, getString(LR.string.loading), getString(LR.string.please_wait), true)
         LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Running refresh from refresh and wait")
-        RefreshPodcastsTask.runNowSync(application)
+        RefreshPodcastsTask.runNowSync(application, applicationScope)
 
         UiUtil.hideProgressDialog(dialog)
     }

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
@@ -15,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.helper.tryToLocalise
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.repositories.playback.EXTRA_CONTENT_STYLE_GROUP_TITLE_HINT
 import au.com.shiftyjelly.pocketcasts.repositories.playback.FOLDER_ROOT_PREFIX
@@ -31,6 +32,7 @@ import au.com.shiftyjelly.pocketcasts.servers.model.ListType
 import au.com.shiftyjelly.pocketcasts.servers.model.transformWithRegion
 import au.com.shiftyjelly.pocketcasts.servers.server.ListRepository
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -49,10 +51,11 @@ const val PROFILE_LISTENING_HISTORY = "__LISTENING_HISTORY__"
 class AutoPlaybackService : PlaybackService() {
 
     @Inject lateinit var listSource: ListRepository
+    @Inject @ForApplicationScope lateinit var applicationScope: CoroutineScope
 
     override fun onCreate() {
         super.onCreate()
-        RefreshPodcastsTask.runNow(this)
+        RefreshPodcastsTask.runNow(this, applicationScope)
 
         Log.d(Settings.LOG_TAG_AUTO, "Auto playback service created")
     }

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
@@ -15,7 +15,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.helper.tryToLocalise
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.repositories.playback.EXTRA_CONTENT_STYLE_GROUP_TITLE_HINT
 import au.com.shiftyjelly.pocketcasts.repositories.playback.FOLDER_ROOT_PREFIX
@@ -51,7 +51,7 @@ const val PROFILE_LISTENING_HISTORY = "__LISTENING_HISTORY__"
 class AutoPlaybackService : PlaybackService() {
 
     @Inject lateinit var listSource: ListRepository
-    @Inject @ForApplicationScope lateinit var applicationScope: CoroutineScope
+    @Inject @ApplicationScope lateinit var applicationScope: CoroutineScope
 
     override fun onCreate() {
         super.onCreate()

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
@@ -10,6 +10,7 @@ import androidx.work.Configuration
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -28,6 +29,7 @@ import com.google.android.gms.common.GoogleApiAvailability
 import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.HiltAndroidApp
 import io.sentry.android.core.SentryAndroid
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -49,6 +51,7 @@ class AutomotiveApplication : Application(), Configuration.Provider {
     @Inject lateinit var settings: Settings
     @Inject lateinit var userManager: UserManager
     @Inject lateinit var workerFactory: HiltWorkerFactory
+    @Inject @ForApplicationScope lateinit var applicationScope: CoroutineScope
 
     override fun onCreate() {
         super.onCreate()
@@ -77,7 +80,7 @@ class AutomotiveApplication : Application(), Configuration.Provider {
             withContext(Dispatchers.Default) {
                 playbackManager.setup()
                 downloadManager.setup(episodeManager, podcastManager, playlistManager, playbackManager)
-                RefreshPodcastsTask.runNow(this@AutomotiveApplication)
+                RefreshPodcastsTask.runNow(this@AutomotiveApplication, applicationScope)
             }
         }
 

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
@@ -10,7 +10,7 @@ import androidx.work.Configuration
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -51,7 +51,7 @@ class AutomotiveApplication : Application(), Configuration.Provider {
     @Inject lateinit var settings: Settings
     @Inject lateinit var userManager: UserManager
     @Inject lateinit var workerFactory: HiltWorkerFactory
-    @Inject @ForApplicationScope lateinit var applicationScope: CoroutineScope
+    @Inject @ApplicationScope lateinit var applicationScope: CoroutineScope
 
     override fun onCreate() {
         super.onCreate()

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/di/AuthModule.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/di/AuthModule.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.account.di
 
 import android.content.Context
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.data.WearDataLayerRegistry
 import dagger.Module
@@ -9,19 +10,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object AuthModule {
-
-    @Singleton
-    @Provides
-    @ForApplicationScope
-    fun coroutineScope(): CoroutineScope =
-        CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     @OptIn(ExperimentalHorologistApi::class)
     @Singleton

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/di/AuthModule.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/di/AuthModule.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.account.di
 
 import android.content.Context
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.data.WearDataLayerRegistry
 import dagger.Module
@@ -21,7 +21,7 @@ object AuthModule {
     @Provides
     fun providesWearDataLayerRegistry(
         @ApplicationContext context: Context,
-        @ForApplicationScope coroutineScope: CoroutineScope
+        @ApplicationScope coroutineScope: CoroutineScope
     ): WearDataLayerRegistry {
         return WearDataLayerRegistry.fromContext(
             application = context,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/di/AuthPhoneModule.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/di/AuthPhoneModule.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.account.di
 
 import au.com.shiftyjelly.pocketcasts.account.watchsync.WatchSyncAuthData
 import au.com.shiftyjelly.pocketcasts.account.watchsync.WatchSyncAuthDataSerializer
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.auth.data.phone.tokenshare.TokenBundleRepository
 import com.google.android.horologist.auth.data.phone.tokenshare.impl.TokenBundleRepositoryImpl
@@ -11,7 +12,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
-import javax.inject.Qualifier
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -30,7 +30,3 @@ object AuthPhoneModule {
         )
     }
 }
-
-@Qualifier
-@Retention(AnnotationRetention.BINARY)
-annotation class ForApplicationScope

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/di/AuthPhoneModule.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/di/AuthPhoneModule.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.account.di
 
 import au.com.shiftyjelly.pocketcasts.account.watchsync.WatchSyncAuthData
 import au.com.shiftyjelly.pocketcasts.account.watchsync.WatchSyncAuthDataSerializer
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.auth.data.phone.tokenshare.TokenBundleRepository
 import com.google.android.horologist.auth.data.phone.tokenshare.impl.TokenBundleRepositoryImpl
@@ -21,7 +21,7 @@ object AuthPhoneModule {
     @Provides
     fun providesTokenBundleRepository(
         wearDataLayerRegistry: WearDataLayerRegistry,
-        @ForApplicationScope coroutineScope: CoroutineScope,
+        @ApplicationScope coroutineScope: CoroutineScope,
     ): TokenBundleRepository<WatchSyncAuthData?> {
         return TokenBundleRepositoryImpl(
             registry = wearDataLayerRegistry,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -27,7 +27,7 @@ import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarkArguments
 import au.com.shiftyjelly.pocketcasts.player.view.dialog.ClearUpNextDialog
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getUrlForArtwork
@@ -87,7 +87,7 @@ class PlayerViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val episodeAnalytics: EpisodeAnalytics,
     @ApplicationContext private val context: Context,
-    @ForApplicationScope private val applicationScope: CoroutineScope,
+    @ApplicationScope private val applicationScope: CoroutineScope,
 ) : ViewModel(), CoroutineScope {
 
     override val coroutineContext: CoroutineContext

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -27,6 +27,7 @@ import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarkArguments
 import au.com.shiftyjelly.pocketcasts.player.view.dialog.ClearUpNextDialog
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getUrlForArtwork
@@ -57,7 +58,6 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.Flowables
 import io.reactivex.rxkotlin.Observables
-import io.reactivex.rxkotlin.combineLatest
 import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineScope
@@ -87,6 +87,7 @@ class PlayerViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val episodeAnalytics: EpisodeAnalytics,
     @ApplicationContext private val context: Context,
+    @ForApplicationScope private val applicationScope: CoroutineScope,
 ) : ViewModel(), CoroutineScope {
 
     override val coroutineContext: CoroutineContext
@@ -478,7 +479,16 @@ class PlayerViewModel @Inject constructor(
                 .setOnConfirm { archiveConfirmed(episode) }
         } else if (episode is UserEpisode) {
             val deleteState = CloudDeleteHelper.getDeleteState(episode)
-            val deleteFunction: (UserEpisode, DeleteState) -> Unit = { ep, delState -> CloudDeleteHelper.deleteEpisode(ep, delState, playbackManager, episodeManager, userEpisodeManager) }
+            val deleteFunction: (UserEpisode, DeleteState) -> Unit = { ep, delState ->
+                CloudDeleteHelper.deleteEpisode(
+                    episode = ep,
+                    deleteState = delState,
+                    playbackManager = playbackManager,
+                    episodeManager = episodeManager,
+                    userEpisodeManager = userEpisodeManager,
+                    applicationScope = applicationScope,
+                )
+            }
             return CloudDeleteHelper.getDeleteDialog(episode, deleteState, deleteFunction, resources)
         }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
@@ -60,7 +60,14 @@ class CloudBottomSheetViewModel @Inject constructor(
     }
 
     fun deleteEpisode(episode: UserEpisode, deleteState: DeleteState) {
-        CloudDeleteHelper.deleteEpisode(episode, deleteState, playbackManager, episodeManager, userEpisodeManager)
+        CloudDeleteHelper.deleteEpisode(
+            episode = episode,
+            deleteState = deleteState,
+            playbackManager = playbackManager,
+            episodeManager = episodeManager,
+            userEpisodeManager = userEpisodeManager,
+            applicationScope = applicationScope,
+        )
         analyticsTracker.track(AnalyticsEvent.USER_FILE_DELETED)
         episodeAnalytics.trackEvent(
             event = if (deleteState == DeleteState.Cloud && !episode.isDownloaded) AnalyticsEvent.EPISODE_DELETED_FROM_CLOUD else AnalyticsEvent.EPISODE_DOWNLOAD_DELETED,

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -22,9 +23,8 @@ import au.com.shiftyjelly.pocketcasts.views.helper.DeleteState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.BackpressureStrategy
 import io.reactivex.rxkotlin.Flowables
-import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -37,6 +37,7 @@ class CloudBottomSheetViewModel @Inject constructor(
     private val podcastManager: PodcastManager,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val episodeAnalytics: EpisodeAnalytics,
+    @ForApplicationScope private val applicationScope: CoroutineScope,
     userManager: UserManager
 ) : ViewModel() {
     lateinit var state: LiveData<BottomSheetState>
@@ -101,17 +102,15 @@ class CloudBottomSheetViewModel @Inject constructor(
         trackOptionTapped(UP_NEXT_DELETE)
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     fun playNext(episode: UserEpisode) {
-        GlobalScope.launch(Dispatchers.Default) {
+        applicationScope.launch(Dispatchers.Default) {
             playbackManager.playNext(episode = episode, source = source)
             trackOptionTapped(UP_NEXT_ADD_TOP)
         }
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     fun playLast(episode: UserEpisode) {
-        GlobalScope.launch(Dispatchers.Default) {
+        applicationScope.launch(Dispatchers.Default) {
             playbackManager.playLast(episode = episode, source = source)
             trackOptionTapped(UP_NEXT_ADD_BOTTOM)
         }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
@@ -9,7 +9,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -37,7 +37,7 @@ class CloudBottomSheetViewModel @Inject constructor(
     private val podcastManager: PodcastManager,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val episodeAnalytics: EpisodeAnalytics,
-    @ForApplicationScope private val applicationScope: CoroutineScope,
+    @ApplicationScope private val applicationScope: CoroutineScope,
     userManager: UserManager
 ) : ViewModel() {
     lateinit var state: LiveData<BottomSheetState>

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/ExportSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/ExportSettingsFragment.kt
@@ -9,7 +9,7 @@ import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.opml.OpmlImportTask
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
@@ -33,7 +33,7 @@ class ExportSettingsFragment : PreferenceFragmentCompat() {
     @Inject lateinit var podcastManager: PodcastManager
     @Inject lateinit var theme: Theme
     @Inject lateinit var syncManager: SyncManager
-    @Inject @ForApplicationScope lateinit var applicationScope: CoroutineScope
+    @Inject @ApplicationScope lateinit var applicationScope: CoroutineScope
 
     private val viewModel by viewModels<ExportSettingsViewModel>()
     private var exporter: OpmlExporter? = null

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/ExportSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/ExportSettingsFragment.kt
@@ -9,6 +9,7 @@ import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.opml.OpmlImportTask
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
@@ -20,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
 import au.com.shiftyjelly.pocketcasts.views.helper.OpmlExporter
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -31,6 +33,7 @@ class ExportSettingsFragment : PreferenceFragmentCompat() {
     @Inject lateinit var podcastManager: PodcastManager
     @Inject lateinit var theme: Theme
     @Inject lateinit var syncManager: SyncManager
+    @Inject @ForApplicationScope lateinit var applicationScope: CoroutineScope
 
     private val viewModel by viewModels<ExportSettingsViewModel>()
     private var exporter: OpmlExporter? = null
@@ -73,7 +76,15 @@ class ExportSettingsFragment : PreferenceFragmentCompat() {
 
         findPreference<Preference>("exportSendEmail")?.setOnPreferenceClickListener {
             viewModel.onExportByEmail()
-            exporter = OpmlExporter(this@ExportSettingsFragment, serverManager, podcastManager, syncManager, activity, viewModel.analyticsTracker).apply {
+            exporter = OpmlExporter(
+                fragment = this@ExportSettingsFragment,
+                serverManager = serverManager,
+                podcastManager = podcastManager,
+                syncManager = syncManager,
+                context = activity,
+                analyticsTracker = viewModel.analyticsTracker,
+                applicationScope = applicationScope,
+            ).apply {
                 sendEmail()
             }
             true
@@ -81,7 +92,15 @@ class ExportSettingsFragment : PreferenceFragmentCompat() {
 
         findPreference<Preference>("exportSaveFile")?.setOnPreferenceClickListener {
             viewModel.onExportFile()
-            exporter = OpmlExporter(this@ExportSettingsFragment, serverManager, podcastManager, syncManager, activity, viewModel.analyticsTracker).apply {
+            exporter = OpmlExporter(
+                fragment = this@ExportSettingsFragment,
+                serverManager = serverManager,
+                podcastManager = podcastManager,
+                syncManager = syncManager,
+                context = activity,
+                analyticsTracker = viewModel.analyticsTracker,
+                applicationScope = applicationScope,
+            ).apply {
                 saveFile()
             }
             true

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -50,7 +50,7 @@ import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isPositive
@@ -72,7 +72,7 @@ class PlaybackSettingsFragment : BaseFragment() {
     @Inject lateinit var settings: Settings
     @Inject lateinit var podcastManager: PodcastManager
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
-    @Inject @ForApplicationScope lateinit var applicationScope: CoroutineScope
+    @Inject @ApplicationScope lateinit var applicationScope: CoroutineScope
 
     companion object {
         private const val ARG_SCROLL_TO_AUTOPLAY = "scroll_to_autoplay"

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -50,14 +50,14 @@ import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isPositive
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.util.*
@@ -72,6 +72,7 @@ class PlaybackSettingsFragment : BaseFragment() {
     @Inject lateinit var settings: Settings
     @Inject lateinit var podcastManager: PodcastManager
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
+    @Inject @ForApplicationScope lateinit var applicationScope: CoroutineScope
 
     companion object {
         private const val ARG_SCROLL_TO_AUTOPLAY = "scroll_to_autoplay"
@@ -557,7 +558,6 @@ class PlaybackSettingsFragment : BaseFragment() {
             modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) }
         )
 
-    @OptIn(DelicateCoroutinesApi::class)
     private fun showSetAllGroupingDialog(grouping: PodcastGrouping) {
         ConfirmationDialog()
             .setButtonType(ConfirmationDialog.ButtonType.Normal(getString(LR.string.settings_apply_to_existing)))
@@ -571,14 +571,13 @@ class PlaybackSettingsFragment : BaseFragment() {
             )
             .setIconId(R.drawable.ic_podcasts)
             .setOnConfirm {
-                GlobalScope.launch {
+                applicationScope.launch {
                     podcastManager.updateGroupingForAll(grouping)
                 }
             }
             .show(parentFragmentManager, "podcast_grouping_set_all_warning")
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     private fun showSetAllArchiveDialog(shouldShow: Boolean) {
         ConfirmationDialog()
             .setButtonType(ConfirmationDialog.ButtonType.Normal(getString(LR.string.settings_apply_to_existing)))
@@ -587,7 +586,7 @@ class PlaybackSettingsFragment : BaseFragment() {
             .setSummary(getString(if (shouldShow) LR.string.settings_apply_archived_show else LR.string.settings_apply_archived_hide))
             .setIconId(R.drawable.ic_podcasts)
             .setOnConfirm {
-                GlobalScope.launch {
+                applicationScope.launch {
                     podcastManager.updateAllShowArchived(shouldShow)
                 }
             }

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import au.com.shiftyjelly.pocketcasts.analytics.AppLifecycleAnalytics
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.PackageUtil
 import au.com.shiftyjelly.pocketcasts.utils.Util
@@ -15,6 +16,8 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.providers.DefaultRelease
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.providers.FirebaseRemoteFeatureProvider
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.providers.PreferencesFeatureProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import javax.inject.Inject
 
 class AppLifecycleObserver constructor(
@@ -26,6 +29,7 @@ class AppLifecycleObserver constructor(
     private val firebaseRemoteFeatureProvider: FirebaseRemoteFeatureProvider,
     private val packageUtil: PackageUtil,
     private val settings: Settings,
+    private val applicationScope: CoroutineScope,
 ) : DefaultLifecycleObserver {
 
     @Inject
@@ -37,6 +41,7 @@ class AppLifecycleObserver constructor(
         firebaseRemoteFeatureProvider: FirebaseRemoteFeatureProvider,
         packageUtil: PackageUtil,
         settings: Settings,
+        @ForApplicationScope applicationScope: CoroutineScope,
     ) : this(
         appContext = appContext,
         appLifecycleAnalytics = appLifecycleAnalytics,
@@ -45,7 +50,8 @@ class AppLifecycleObserver constructor(
         defaultReleaseFeatureProvider = defaultReleaseFeatureProvider,
         firebaseRemoteFeatureProvider = firebaseRemoteFeatureProvider,
         packageUtil = packageUtil,
-        settings = settings
+        settings = settings,
+        applicationScope = applicationScope,
     )
 
     fun setup() {
@@ -63,6 +69,11 @@ class AppLifecycleObserver constructor(
     override fun onPause(owner: LifecycleOwner) {
         super.onPause(owner)
         appLifecycleAnalytics.onApplicationEnterBackground()
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        applicationScope.cancel("Application onTerminate")
+        super.onDestroy(owner)
     }
 
     private fun setupFeatureFlags() {

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import au.com.shiftyjelly.pocketcasts.analytics.AppLifecycleAnalytics
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.PackageUtil
 import au.com.shiftyjelly.pocketcasts.utils.Util
@@ -41,7 +41,7 @@ class AppLifecycleObserver constructor(
         firebaseRemoteFeatureProvider: FirebaseRemoteFeatureProvider,
         packageUtil: PackageUtil,
         settings: Settings,
-        @ForApplicationScope applicationScope: CoroutineScope,
+        @ApplicationScope applicationScope: CoroutineScope,
     ) : this(
         appContext = appContext,
         appLifecycleAnalytics = appLifecycleAnalytics,

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
@@ -12,6 +12,8 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.providers.DefaultRelease
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.providers.FirebaseRemoteFeatureProvider
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.providers.PreferencesFeatureProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -61,6 +63,7 @@ class AppLifecycleObserverTest {
             firebaseRemoteFeatureProvider = firebaseRemoteFeatureProvider,
             packageUtil = packageUtil,
             settings = settings,
+            applicationScope = CoroutineScope(Dispatchers.Default),
         )
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/ChromeCastAnalytics.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/ChromeCastAnalytics.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.chromecast
 
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -10,7 +10,7 @@ import javax.inject.Inject
 class ChromeCastAnalytics @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val castManager: CastManager,
-    @ForApplicationScope private val applicationScope: CoroutineScope
+    @ApplicationScope private val applicationScope: CoroutineScope
 ) {
     fun trackChromeCastViewShown() {
         applicationScope.launch {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/ChromeCastAnalytics.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/ChromeCastAnalytics.kt
@@ -2,18 +2,18 @@ package au.com.shiftyjelly.pocketcasts.repositories.chromecast
 
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.GlobalScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class ChromeCastAnalytics @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val castManager: CastManager,
+    @ForApplicationScope private val applicationScope: CoroutineScope
 ) {
     fun trackChromeCastViewShown() {
-        @OptIn(DelicateCoroutinesApi::class)
-        GlobalScope.launch {
+        applicationScope.launch {
             val isConnected = castManager.isConnected()
             analyticsTracker.track(
                 AnalyticsEvent.CHROMECAST_VIEW_SHOWN,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/Annotations.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/Annotations.kt
@@ -26,3 +26,11 @@ annotation class DownloadOkHttpClient
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class DownloadRequestBuilder
+
+/**
+ * Annotation for providing coroutine scope that lasts the entire time the application
+ * is running. Essentially, this is the better form of GlobalScope.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ForApplicationScope

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/Annotations.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/Annotations.kt
@@ -33,4 +33,4 @@ annotation class DownloadRequestBuilder
  */
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
-annotation class ForApplicationScope
+annotation class ApplicationScope

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
@@ -6,6 +6,9 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
@@ -33,4 +36,10 @@ class RepositoryProviderModule {
             .readTimeout(30, TimeUnit.SECONDS)
             .build()
     }
+
+    @Provides
+    @Singleton
+    @ForApplicationScope
+    fun coroutineScope(): CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.Default)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
@@ -39,7 +39,7 @@ class RepositoryProviderModule {
 
     @Provides
     @Singleton
-    @ForApplicationScope
+    @ApplicationScope
     fun coroutineScope(): CoroutineScope =
         CoroutineScope(SupervisorJob() + Dispatchers.Default)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -8,6 +8,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.calculateCombinedIconId
@@ -39,6 +40,7 @@ class PlaylistManagerImpl @Inject constructor(
     private val playlistUpdateAnalytics: PlaylistUpdateAnalytics,
     private val syncManager: SyncManager,
     @ApplicationContext private val context: Context,
+    @ForApplicationScope private val applicationScope: CoroutineScope,
     appDatabase: AppDatabase
 ) : PlaylistManager, CoroutineScope {
 
@@ -198,7 +200,12 @@ class PlaylistManagerImpl @Inject constructor(
     override fun create(playlist: Playlist): Long {
         val id = playlistDao.insert(playlist)
         if (countPlaylists() == 1 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-            PocketCastsShortcuts.update(this, true, context)
+            PocketCastsShortcuts.update(
+                playlistManager = this,
+                force = true,
+                coroutineScope = applicationScope,
+                context = context
+            )
         }
         return id
     }
@@ -298,7 +305,12 @@ class PlaylistManagerImpl @Inject constructor(
         playlistDao.updateSortPositions(playlists)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-            PocketCastsShortcuts.update(this, true, context)
+            PocketCastsShortcuts.update(
+                playlistManager = this,
+                force = true,
+                coroutineScope = applicationScope,
+                context = context
+            )
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -8,7 +8,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.calculateCombinedIconId
@@ -40,7 +40,7 @@ class PlaylistManagerImpl @Inject constructor(
     private val playlistUpdateAnalytics: PlaylistUpdateAnalytics,
     private val syncManager: SyncManager,
     @ApplicationContext private val context: Context,
-    @ForApplicationScope private val applicationScope: CoroutineScope,
+    @ApplicationScope private val applicationScope: CoroutineScope,
     appDatabase: AppDatabase
 ) : PlaylistManager, CoroutineScope {
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -15,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getUrlForArtwork
@@ -57,6 +58,7 @@ class PodcastManagerImpl @Inject constructor(
     private val cacheServerManager: PodcastCacheServerManager,
     private val refreshServerManager: RefreshServerManager,
     private val syncManager: SyncManager,
+    @ForApplicationScope private val applicationScope: CoroutineScope,
     appDatabase: AppDatabase
 ) : PodcastManager, CoroutineScope {
 
@@ -188,7 +190,7 @@ class PodcastManagerImpl @Inject constructor(
 
     override fun refreshPodcasts(fromLog: String) {
         LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Running refresh from $fromLog")
-        RefreshPodcastsTask.runNow(context)
+        RefreshPodcastsTask.runNow(context, applicationScope)
     }
 
     override suspend fun refreshPodcastsAfterSignIn() {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -15,7 +15,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getUrlForArtwork
@@ -58,7 +58,7 @@ class PodcastManagerImpl @Inject constructor(
     private val cacheServerManager: PodcastCacheServerManager,
     private val refreshServerManager: RefreshServerManager,
     private val syncManager: SyncManager,
-    @ForApplicationScope private val applicationScope: CoroutineScope,
+    @ApplicationScope private val applicationScope: CoroutineScope,
     appDatabase: AppDatabase
 ) : PodcastManager, CoroutineScope {
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsTask.kt
@@ -9,7 +9,7 @@ import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit
 class RefreshPodcastsTask @AssistedInject constructor(
     @Assisted val context: Context,
     @Assisted val params: WorkerParameters,
-    @ForApplicationScope private val applicationScope: CoroutineScope,
+    @ApplicationScope private val applicationScope: CoroutineScope,
 ) : Worker(context, params) {
     private var refreshRunnable: RefreshPodcastsThread? = null
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -52,6 +52,7 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.EntryPoints
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 import java.util.Date
@@ -60,6 +61,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 class RefreshPodcastsThread(
     private val context: Context,
+    private val applicationScope: CoroutineScope,
     private val runNow: Boolean
 ) {
 
@@ -241,6 +243,7 @@ class RefreshPodcastsThread(
 
         val sync = PodcastSyncProcess(
             context = context,
+            applicationScope = applicationScope,
             settings = entryPoint.settings(),
             episodeManager = entryPoint.episodeManager(),
             podcastManager = entryPoint.podcastManager(),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shortcuts/PocketCastsShortcuts.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shortcuts/PocketCastsShortcuts.kt
@@ -9,9 +9,8 @@ import android.graphics.drawable.Icon
 import android.os.Build
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.shortcutDrawableId
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
-import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -27,14 +26,18 @@ object PocketCastsShortcuts {
      * - Up Next
      * - Top Filter
      */
-    @OptIn(DelicateCoroutinesApi::class)
     @TargetApi(Build.VERSION_CODES.N_MR1)
-    fun update(playlistManager: PlaylistManager, force: Boolean, context: Context) {
+    fun update(
+        playlistManager: PlaylistManager,
+        force: Boolean,
+        coroutineScope: CoroutineScope,
+        context: Context,
+    ) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N_MR1) {
             return
         }
 
-        GlobalScope.launch(Dispatchers.Main) {
+        coroutineScope.launch(Dispatchers.Main) {
             val shortcutManager = context.getSystemService(ShortcutManager::class.java) ?: return@launch
 
             val topPlaylist = withContext(Dispatchers.Default) { playlistManager.findAll().firstOrNull() }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -16,7 +16,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionPurchaseRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionResponse
@@ -61,7 +61,7 @@ import javax.inject.Singleton
 class SubscriptionManagerImpl @Inject constructor(
     private val syncManager: SyncManager,
     private val settings: Settings,
-    @ForApplicationScope private val applicationScope: CoroutineScope
+    @ApplicationScope private val applicationScope: CoroutineScope
 ) : SubscriptionManager,
     PurchasesUpdatedListener,
     AcknowledgePurchaseResponseListener {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -16,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionPurchaseRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionResponse
@@ -45,9 +46,8 @@ import io.reactivex.Flowable
 import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
-import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
@@ -61,6 +61,7 @@ import javax.inject.Singleton
 class SubscriptionManagerImpl @Inject constructor(
     private val syncManager: SyncManager,
     private val settings: Settings,
+    @ForApplicationScope private val applicationScope: CoroutineScope
 ) : SubscriptionManager,
     PurchasesUpdatedListener,
     AcknowledgePurchaseResponseListener {
@@ -199,7 +200,6 @@ class SubscriptionManagerImpl @Inject constructor(
         }
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     override fun onPurchasesUpdated(billingResult: BillingResult, purchases: MutableList<Purchase>?) {
         if (billingResult.responseCode == BillingClient.BillingResponseCode.OK && purchases != null) {
             for (purchase in purchases) {
@@ -209,7 +209,7 @@ class SubscriptionManagerImpl @Inject constructor(
             purchaseEvents.accept(PurchaseEvent.Cancelled(billingResult.responseCode))
         } else {
             if (billingResult.responseCode == BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED) {
-                GlobalScope.launch {
+                applicationScope.launch {
                     val purchasesResult = getPurchases()
                     if (purchasesResult == null) {
                         LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, "unable to update purchase because billing result returned null purchases")
@@ -255,12 +255,11 @@ class SubscriptionManagerImpl @Inject constructor(
         }
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     override fun handlePurchase(purchase: Purchase) {
         if (purchase.purchaseState == Purchase.PurchaseState.PURCHASED) {
             Timber.d("Purchase: ${purchase.purchaseToken}")
             // Grant entitlement to the user.
-            GlobalScope.launch {
+            applicationScope.launch {
                 try {
                     sendPurchaseToServer(purchase)
                     // Acknowledge the purchase if it hasn't already been acknowledged.
@@ -339,9 +338,8 @@ class SubscriptionManagerImpl @Inject constructor(
         return billingClient.queryPurchasesAsync(params = queryPurchasesParams)
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     override fun launchBillingFlow(activity: Activity, productDetails: ProductDetails, offerToken: String) {
-        GlobalScope.launch {
+        applicationScope.launch {
             val productDetailsParams =
                 BillingFlowParams.ProductDetailsParams.newBuilder()
                     .setProductDetails(productDetails)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -56,6 +56,7 @@ import kotlin.coroutines.CoroutineContext
 
 class PodcastSyncProcess(
     val context: Context,
+    val applicationScope: CoroutineScope,
     var settings: Settings,
     var episodeManager: EpisodeManager,
     var podcastManager: PodcastManager,
@@ -606,7 +607,7 @@ class PodcastSyncProcess(
     private fun updateShortcuts(playlists: List<Playlist>): Completable {
         // if any playlists have changed update the launcher shortcuts
         if (playlists.isNotEmpty() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-            PocketCastsShortcuts.update(playlistManager, true, context)
+            PocketCastsShortcuts.update(playlistManager, true, applicationScope, context)
         }
         return Completable.complete()
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -9,7 +9,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -49,7 +49,7 @@ class UserManagerImpl @Inject constructor(
     val podcastManager: PodcastManager,
     val userEpisodeManager: UserEpisodeManager,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-    @ForApplicationScope private val applicationScope: CoroutineScope,
+    @ApplicationScope private val applicationScope: CoroutineScope,
 ) : UserManager, CoroutineScope {
 
     companion object {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/DeleteState.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/DeleteState.kt
@@ -9,9 +9,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.views.R
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
-import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -34,9 +33,15 @@ object CloudDeleteHelper {
         }
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
-    fun deleteEpisode(episode: UserEpisode, deleteState: DeleteState, playbackManager: PlaybackManager, episodeManager: EpisodeManager, userEpisodeManager: UserEpisodeManager) {
-        GlobalScope.launch(Dispatchers.Default) {
+    fun deleteEpisode(
+        episode: UserEpisode,
+        deleteState: DeleteState,
+        playbackManager: PlaybackManager,
+        episodeManager: EpisodeManager,
+        userEpisodeManager: UserEpisodeManager,
+        applicationScope: CoroutineScope,
+    ) {
+        applicationScope.launch(Dispatchers.Default) {
             when (deleteState) {
                 is DeleteState.DeviceOnly -> {
                     if (episode.serverStatus == UserEpisodeServerStatus.UPLOADED) {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/OpmlExporter.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/OpmlExporter.kt
@@ -17,9 +17,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.ServerCallback
 import au.com.shiftyjelly.pocketcasts.servers.ServerManager
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
-import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import okhttp3.Call
 import timber.log.Timber
@@ -36,6 +35,7 @@ class OpmlExporter(
     private val syncManager: SyncManager,
     private val context: Context,
     private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val applicationScope: CoroutineScope,
 ) {
 
     companion object {
@@ -92,12 +92,11 @@ class OpmlExporter(
         }
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     private fun exportPodcasts() {
         analyticsTracker.track(AnalyticsEvent.SETTINGS_IMPORT_EXPORT_STARTED)
         showProgressDialog()
 
-        GlobalScope.launch(Dispatchers.IO) {
+        applicationScope.launch(Dispatchers.IO) {
             val uuidToTitle = podcastManager.findSubscribed().associateBy({ it.uuid }, { it.title })
             val uuids = uuidToTitle.keys.toList()
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
@@ -12,6 +12,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -19,6 +20,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.views.dialog.ShareDialog
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -32,6 +34,7 @@ class SwipeButtonLayoutViewModel @Inject constructor(
     private val playbackManager: PlaybackManager,
     private val podcastManager: PodcastManager,
     private val userEpisodeManager: UserEpisodeManager,
+    @ForApplicationScope private val applicationScope: CoroutineScope,
 ) : ViewModel() {
 
     fun share(
@@ -161,6 +164,7 @@ class SwipeButtonLayoutViewModel @Inject constructor(
                     playbackManager = playbackManager,
                     episodeManager = episodeManager,
                     userEpisodeManager = userEpisodeManager,
+                    applicationScope = applicationScope,
                 )
                 episodeAnalytics.trackEvent(
                     event = if (deleteState == DeleteState.Cloud && !episode.isDownloaded) AnalyticsEvent.EPISODE_DELETED_FROM_CLOUD else AnalyticsEvent.EPISODE_DOWNLOAD_DELETED,

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
@@ -12,7 +12,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -34,7 +34,7 @@ class SwipeButtonLayoutViewModel @Inject constructor(
     private val playbackManager: PlaybackManager,
     private val podcastManager: PodcastManager,
     private val userEpisodeManager: UserEpisodeManager,
-    @ForApplicationScope private val applicationScope: CoroutineScope,
+    @ApplicationScope private val applicationScope: CoroutineScope,
 ) : ViewModel() {
 
     fun share(

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
@@ -11,7 +11,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -39,7 +39,7 @@ class WarningsHelper @Inject constructor(
     private val systemBatteryRestrictions: SystemBatteryRestrictions,
     private val userEpisodeManager: UserEpisodeManager,
     private val episodeAnalytics: EpisodeAnalytics,
-    @ForApplicationScope private val applicationScope: CoroutineScope,
+    @ApplicationScope private val applicationScope: CoroutineScope,
 ) {
 
     fun streamingWarningDialog(

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -22,8 +23,7 @@ import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BatteryRestrictionsSettingsFragment
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.qualifiers.ActivityContext
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.util.*
 import javax.inject.Inject
@@ -39,16 +39,16 @@ class WarningsHelper @Inject constructor(
     private val systemBatteryRestrictions: SystemBatteryRestrictions,
     private val userEpisodeManager: UserEpisodeManager,
     private val episodeAnalytics: EpisodeAnalytics,
+    @ForApplicationScope private val applicationScope: CoroutineScope,
 ) {
 
-    @OptIn(DelicateCoroutinesApi::class)
     fun streamingWarningDialog(
         episode: BaseEpisode,
         snackbarParentView: View? = null,
         sourceView: SourceView
     ): ConfirmationDialog {
         return streamingWarningDialog(onConfirm = {
-            GlobalScope.launch {
+            applicationScope.launch {
                 playbackManager.playNow(episode = episode, forceStream = true, sourceView = sourceView)
                 showBatteryWarningSnackbarIfAppropriate(snackbarParentView)
             }
@@ -92,9 +92,8 @@ class WarningsHelper @Inject constructor(
             .setOnSecondary { upload(episodeUuid, waitForWifi = true, source = source) }
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     private fun upload(episodeUuid: String, waitForWifi: Boolean, source: SourceView) {
-        GlobalScope.launch {
+        applicationScope.launch {
             episodeManager.findEpisodeByUuid(episodeUuid)?.let {
                 if (it !is UserEpisode) return@let
 
@@ -106,9 +105,8 @@ class WarningsHelper @Inject constructor(
         }
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     private fun download(episodeUuid: String, waitForWifi: Boolean, from: String) {
-        GlobalScope.launch {
+        applicationScope.launch {
             episodeManager.findEpisodeByUuid(episodeUuid)?.let {
                 if (it.isDownloading) {
                     episodeManager.stopDownloadAndCleanUp(episodeUuid, from)

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -15,7 +15,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -53,7 +53,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
     val analyticsTracker: AnalyticsTrackerWrapper,
     val settings: Settings,
     private val episodeAnalytics: EpisodeAnalytics,
-    @ForApplicationScope private val applicationScope: CoroutineScope,
+    @ApplicationScope private val applicationScope: CoroutineScope,
 ) : MultiSelectHelper<BaseEpisode>() {
     override val maxToolbarIcons = 4
 

--- a/modules/services/views/src/test/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModelTest.kt
+++ b/modules/services/views/src/test/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModelTest.kt
@@ -8,6 +8,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNull
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Test
@@ -46,6 +48,7 @@ class SwipeButtonLayoutViewModelTest {
             playbackManager = playbackManager,
             podcastManager = mock(),
             userEpisodeManager = mock(),
+            applicationScope = CoroutineScope(Dispatchers.Default)
         )
     }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/IsEmulator.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/IsEmulator.kt
@@ -5,7 +5,3 @@ import javax.inject.Qualifier
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class IsEmulator
-
-@Qualifier
-@Retention(AnnotationRetention.BINARY)
-annotation class ForApplicationScope

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/WearAppModule.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/WearAppModule.kt
@@ -8,20 +8,11 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object WearAppModule {
-
-    @Singleton
-    @Provides
-    @ForApplicationScope
-    fun coroutineScope(): CoroutineScope =
-        CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     @Provides
     fun connectivityManager(

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/WearNetworkModule.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/WearNetworkModule.kt
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager
 import au.com.shiftyjelly.pocketcasts.repositories.di.DownloadCallFactory
 import au.com.shiftyjelly.pocketcasts.repositories.di.DownloadOkHttpClient
 import au.com.shiftyjelly.pocketcasts.repositories.di.DownloadRequestBuilder
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.wear.networking.PocketCastsNetworkingRules
 import com.google.android.horologist.networks.data.RequestType
 import com.google.android.horologist.networks.highbandwidth.HighBandwidthNetworkMediator

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/WearNetworkModule.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/WearNetworkModule.kt
@@ -2,10 +2,10 @@ package au.com.shiftyjelly.pocketcasts.wear.di
 
 import android.content.Context
 import android.net.ConnectivityManager
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.di.DownloadCallFactory
 import au.com.shiftyjelly.pocketcasts.repositories.di.DownloadOkHttpClient
 import au.com.shiftyjelly.pocketcasts.repositories.di.DownloadRequestBuilder
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.wear.networking.PocketCastsNetworkingRules
 import com.google.android.horologist.networks.data.RequestType
 import com.google.android.horologist.networks.highbandwidth.HighBandwidthNetworkMediator
@@ -38,7 +38,7 @@ object WearNetworkModule {
     @Provides
     fun networkRepository(
         @ApplicationContext application: Context,
-        @ForApplicationScope coroutineScope: CoroutineScope
+        @ApplicationScope coroutineScope: CoroutineScope
     ): NetworkRepository = NetworkRepositoryImpl.fromContext(
         application,
         coroutineScope
@@ -64,7 +64,7 @@ object WearNetworkModule {
     @Singleton
     fun provideHighBandwidthNetworkMediator(
         connectivityManager: ConnectivityManager,
-        @ForApplicationScope coroutineScope: CoroutineScope,
+        @ApplicationScope coroutineScope: CoroutineScope,
     ): HighBandwidthNetworkMediator =
         StandardHighBandwidthNetworkMediator(
             logger = NetworkStatusLogger.Logging,
@@ -84,7 +84,7 @@ object WearNetworkModule {
         networkRepository: NetworkRepository,
         networkingRulesEngine: NetworkingRulesEngine,
         @DownloadOkHttpClient phoneCallFactory: OkHttpClient,
-        @ForApplicationScope coroutineScope: CoroutineScope,
+        @ApplicationScope coroutineScope: CoroutineScope,
         logger: NetworkStatusLogger
     ): Call.Factory {
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -20,6 +20,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.profile.cloud.AddFileActivity
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextPosition
@@ -31,7 +32,6 @@ import au.com.shiftyjelly.pocketcasts.servers.shownotes.ShowNotesState
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.combine6
-import au.com.shiftyjelly.pocketcasts.wear.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.AudioOutputSelectorHelper
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.StreamingConfirmationScreen
 import coil.ImageLoader

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -20,7 +20,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.profile.cloud.AddFileActivity
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextPosition
@@ -78,7 +78,7 @@ class EpisodeViewModel @Inject constructor(
     private val showNotesManager: ShowNotesManager,
     theme: Theme,
     @ApplicationContext appContext: Context,
-    @ForApplicationScope private val coroutineScope: CoroutineScope,
+    @ApplicationScope private val coroutineScope: CoroutineScope,
     private val audioOutputSelectorHelper: AudioOutputSelectorHelper,
 ) : AndroidViewModel(appContext as Application) {
     private var playAttempt: Job? = null

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.wear.di.ForApplicationScope
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ForApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
@@ -27,7 +27,7 @@ class NowPlayingViewModel @Inject constructor(
     private val playbackManager: PlaybackManager,
     settings: Settings,
     private val theme: Theme,
-    @ForApplicationScope private val coroutineScope: CoroutineScope,
+    @ApplicationScope private val coroutineScope: CoroutineScope,
     private val audioOutputSelectorHelper: AudioOutputSelectorHelper,
 ) : ViewModel() {
     private var playAttempt: Job? = null


### PR DESCRIPTION
## Description
This replaces our usage of GlobalScope in the app with an applicationScope. I'm not sure that we're experiencing any direct negative effects from how we use GlobalScope, but it's usage is [strongly discouraged](https://medium.com/androiddevelopers/coroutines-patterns-for-work-that-shouldnt-be-cancelled-e26c40f142ad#:~:text=%E2%9D%8C-,GlobalScope,-There%20are%20multiple) and it feels like the kind of thing that could eventually cause us problems. If nothing else, testing can be more difficult with a hard-coded `GlobalScope`.

There are definitely further improvements we can do here, but my hope is that this is a step in the right direction.

One change I made in this PR (in https://github.com/Automattic/pocket-casts-android/commit/ba4f5669565c5f9b9c1ab6e7d00839a466faef8c) is to provide the application scope in a lower module (the repository) instead of the top-level app modules. I did this just because it makes the DI setup much simpler if we don't have to inject something into low-level modules that is provided by high-level modules. That's certainly doable, but it's a bit more complicated (among other things, the watch, phone, and automotive apps each have to indepenently provide the dependency), so I thought that keeping this simple made more sense. If we need to start providing the application scope at the app-level for some reason in the future, it will be easy enough to make that change then.

## Testing Instructions

No specific test steps for this, just generally smoke test the app making sure you do various actions with playback, syncing, and downloading.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews