### PR TITLE
Avoid race conditions with media command events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
     *   Fix issues where multi-select on one screen would affect another screen
         ([#1579](https://github.com/Automattic/pocket-casts-android/pull/1579),
          [#1580](https://github.com/Automattic/pocket-casts-android/pull/1580))
+    *   Fix skip forward/backward commands from Pixel Buds
+        ([#1620](https://github.com/Automattic/pocket-casts-android/pull/1620))
 *   Updates:
     *   Display dynamic colors for widget
         ([#1588](https://github.com/Automattic/pocket-casts-android/pull/1588))

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -122,7 +122,7 @@ class MediaSessionManager(
                     if (added) {
                         Timber.i("Added command to queue: $tag")
                     } else {
-                        Timber.e("Failed to add command to queue: $tag")
+                        LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Failed to add command to queue: $tag")
                     }
                 },
             )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -54,7 +54,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -152,11 +151,6 @@ class MediaSessionManager(
             commandQueue.collect { (tag, command) ->
                 LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Executing queued command: $tag")
                 command()
-
-                // arbitrary delay to increase the chance that the command will be executed before the next one
-                // is run. Ideally we wouldn't need this, but as long as the PlaybackManager launches coroutines,
-                // this is a helpful bit of extra security.
-                delay(200)
             }
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -655,7 +655,6 @@ class MediaSessionManager(
         override fun onCustomAction(action: String?, extras: Bundle?) {
             action ?: return
 
-            // FIXME enqueue these?
             when (action) {
                 APP_ACTION_SKIP_BACK -> enqueueCommand("custom action: skip back") {
                     playbackManager.skipBackwardSuspend()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -610,24 +610,8 @@ open class PlaybackManager @Inject constructor(
     }
 
     fun pause(transientLoss: Boolean = false, sourceView: SourceView = SourceView.UNKNOWN) {
-        if (!transientLoss) {
-            focusManager.giveUpAudioFocus()
-            playbackStateRelay.blockingFirst().let { playbackState ->
-                playbackStateRelay.accept(playbackState.copy(transientLoss = false))
-            }
-            LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Paused - Not transient")
-            trackPlayback(AnalyticsEvent.PLAYBACK_PAUSE, sourceView)
-        } else {
-            playbackStateRelay.blockingFirst().let { playbackState ->
-                playbackStateRelay.accept(playbackState.copy(transientLoss = true))
-            }
-            LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Paused - Transient")
-        }
-
-        cancelUpdateTimer()
-
         launch {
-            player?.pause()
+            pauseSuspend(transientLoss, sourceView)
         }
     }
 


### PR DESCRIPTION
## Description
This PR addresses a problem with the skip-forward and skip-back functionality on pixel buds, and fixes #1578.=

I think this is only an issue if the earbuds are [set up to use Google Assistant](https://support.google.com/assistant/answer/9027902?hl=en). At least that's what I've observed when using my usb-c pixel buds which can be used without Google Assistant integration because I only see the issue when the Google Assistant integration is enabled).

I don't have Bluetooth pixel buds to test this, but we have quite a few users reporting this issue with the Bluetooth pixel buds as well. This issue does not appear to occur with regular Bluetooth headphones/speakers in my testing.

I believe this issue is caused by the fact that many of our playback functions in the playback manager launch coroutines for their work, which allows commands that happen in a quick sequence to "overlap" and have race conditions (i.e., the first command is still finishing when the second command starts). When the issue occurs you can see the playback scrubber briefly jumps to the appropriate position and then quickly bounces back to the position before it was at before the skip command, which is why it seems like the skip command isn't working.

To avoid this, I am creating a command queue that all media events send the relevant commands to. This command queue executes the commands one at a time. In addition, I have created suspended versions of the relevant `PlaybackManager` methods that do not launch new coroutines (although the `PlaybackManager` diff looks large, the only change is really to create suspended versions of the methods that already existed). This helps us complete one command before the next command is run. 

There are still a number of other places in the `PlaybackManager` where we are launching new coroutines, and I think that we should also be migrating these to be suspended methods (with rare exceptions, I don't think the PlaybackManager should be launching coroutines, that should be handled classes that are calling the `PlaybackManager` methods).

I have not found a way to consistently recreate this issue (among the things I've tried are hardcoding playback commands and sending media events with adb, but nothing seems to work). The issue does seem to occur a bit more consistently for me with skipping back compared to skipping forward, but it's never been perfectly reproducible for me and other users have reported it suddenly start/stop working as well.

I isolated that the issue got significantly worse after the changes in #1510. The reason for that is likely because it changed the timing of when we fetch the playback position when playing a podcast, and that made us more susceptible to the race condition. I didn't take the approach of reverting that change because it was fixing a bug and the better approach (imo) is avoiding the race condition entirely, which is what this PR is trying to do.

This issue does seem to come and go a bit for me, which is not too surprising since it is a race condition. My suspicion is that this issue has been possible for a long time, but it the changes in #1510 just made it occur far more frequency with Pixel Buds that are using Google assistant.

<details><summary>Some more detail about what is happening when the problem occurs</summary>

It appears that part of the reason the issue can come and go is because even the order in which the playback commands come into our `MediaSessionManager` can change from one triple/double tap to the next. For example, I added [a bunch of logs](https://gist.github.com/mchowning/956c79471708ba2501226ec505d584a7) to the media session events (before the changes from this PR), and when the skip backward worked fine the logs consistently showed:

```
16:20:20.044  I  TEST123, KeyEvent { action=ACTION_DOWN, keyCode=KEYCODE_MEDIA_PAUSE, ... }
16:20:20.045  I  TEST123, onPause
16:20:20.068  I  TEST123, KeyEvent { action=ACTION_UP, keyCode=KEYCODE_MEDIA_PAUSE, ... }
16:20:20.545  I  TEST123, KeyEvent { action=ACTION_DOWN, keyCode=KEYCODE_MEDIA_PREVIOUS, ... }
16:20:20.546  I  TEST123, KeyEvent { action=ACTION_UP, keyCode=KEYCODE_MEDIA_PLAY, ... }
16:20:20.546  I  TEST123, KeyEvent { action=ACTION_DOWN, keyCode=KEYCODE_MEDIA_PLAY, ... }
16:20:20.549  I  TEST123, onPlay
16:20:20.556  I  TEST123, KeyEvent { action=ACTION_UP, keyCode=KEYCODE_MEDIA_PREVIOUS, ... }
16:20:20.556  I  TEST123, handleMediaButtonTripleTap
16:20:20.559  I  TEST123, onSkipToPrevious
```

When the skip backward did not occur, however, the logs consistently showed a different order of events:

```
16:21:03.836  I  TEST123, KeyEvent { action=ACTION_DOWN, keyCode=KEYCODE_MEDIA_PAUSE, ... }
16:21:03.836  I  TEST123, onPause
16:21:03.848  I  TEST123, KeyEvent { action=ACTION_UP, keyCode=KEYCODE_MEDIA_PAUSE, ... }
16:21:04.395  I  TEST123, KeyEvent { action=ACTION_DOWN, keyCode=KEYCODE_MEDIA_PREVIOUS, ... }
16:21:04.396  I  TEST123, KeyEvent { action=ACTION_UP, keyCode=KEYCODE_MEDIA_PREVIOUS, ... }
16:21:04.396  I  TEST123, handleMediaButtonTripleTap
16:21:04.398  I  TEST123, onSkipToPrevious
16:21:04.405  I  TEST123, KeyEvent { action=ACTION_UP, keyCode=KEYCODE_MEDIA_PLAY, ... }
16:21:04.405  I  TEST123, KeyEvent { action=ACTION_DOWN, keyCode=KEYCODE_MEDIA_PLAY, ... }
16:21:04.407  I  TEST123, onPlay
```

I observed a very similar pattern with the skip forward action as well. With the changes in this PR, though, the skip works successfully no matter which of the (apparently two possible) orders the events come in.

</details>

> [!Note]
> I have this PR targeting the `release/7.54` branch because I think this deserves a beta fix. Given how hard this is to test, I don't think it makes sense to do a hotfix at this point. But, we have beta users confirm that this fixes the issue and we continue to get complaints from production users about the issue, I think that a hotfix might make sense in the future.

## Testing Instructions

### 1. Addresses #1578 with pixel buds
1. Connect a pair of Pixel Buds with the Google Assistant active (i.e., long-pressing on the headset button activates the Google Assistant). These can be either usb-c pixel earbuds (that's what I have) or Bluetooth pixel earbuds (that's what most of our users complaining of the issue have)
2. Confirm that your "Headphone controls" settings in the app have the previous action as "Skip back" and the next action as "Skip forward"
3. Begin playing an episode
4. Verify that using a single-tap on the earbuds pauses/starts playback
5. Verify that double-tapping on the earbuds causes playback to skip forward
6. Verify that triple-tapping on the earbuds causes playback to skip backward
7. Change your "Headphone controls" settings to perform different actions (i.e., skip forward, skip back, add bookmark) and confirm that the headphone controls respond according to that setting value

### 2. Regular Bluetooth speakers/headphones still work as expected
1. Connect a Bluetooth speaker or non-pixel Bluetooth headphones
2. Try the different "Headphone controls" settings and confirm that playback responds appropriately based on that setting (i.e., double tapping does the selected "next action" and triple-tapping does the selected "previous action")

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
