### PR TITLE
Remove unused getPodcastEpisodesListOrderBy method

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -129,7 +129,6 @@ interface PodcastManager {
     fun reloadFoldersFromServer()
 
     fun checkForEpisodesToDownload(episodeUuidsAdded: List<String>, downloadManager: DownloadManager)
-    fun getPodcastEpisodesListOrderBy(podcast: Podcast): String
 
     fun countEpisodesInPodcastWithStatus(podcastUuid: String, episodeStatus: EpisodeStatusEnum): Int
     fun updateGroupingForAll(grouping: PodcastGrouping)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -575,17 +575,6 @@ class PodcastManagerImpl @Inject constructor(
         podcastDao.insert(podcast)
     }
 
-    override fun getPodcastEpisodesListOrderBy(podcast: Podcast): String {
-        return when (podcast.episodesSortType) {
-            EpisodesSortType.EPISODES_SORT_BY_TITLE_ASC -> "UPPER(title) ASC"
-            EpisodesSortType.EPISODES_SORT_BY_TITLE_DESC -> "UPPER(title) DESC"
-            EpisodesSortType.EPISODES_SORT_BY_DATE_ASC -> "published_date ASC"
-            EpisodesSortType.EPISODES_SORT_BY_DATE_DESC -> "published_date DESC"
-            EpisodesSortType.EPISODES_SORT_BY_LENGTH_ASC -> "duration ASC"
-            EpisodesSortType.EPISODES_SORT_BY_LENGTH_DESC -> "duration DESC"
-        }
-    }
-
     override fun updatePodcast(podcast: Podcast) {
         podcastDao.update(podcast)
     }


### PR DESCRIPTION
## Description
This removes the `getPodcastEpisodesListOrderBy` method because I noticed it wasn't being used.

## Testing Instructions
If CI is green we should be good.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews