### PR TITLE
Prevent wear chips from getting cut off by round watch edges

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -144,7 +144,7 @@ fun WearApp(
 
         scrollable(
             route = WatchListScreen.route,
-            columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = true),
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
         ) {
             val pagerState = rememberPagerState { NowPlayingPager.pageCount }
             val coroutineScope = rememberCoroutineScope()

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -29,6 +29,7 @@ import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavHostState
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.wear.extensions.responsive
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 import au.com.shiftyjelly.pocketcasts.wear.ui.FilesScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.LoggingInScreen
@@ -50,6 +51,7 @@ import au.com.shiftyjelly.pocketcasts.wear.ui.player.StreamingConfirmationScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcast.PodcastScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.podcasts.PodcastsScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.settings.settingsRoutes
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
 import com.google.android.horologist.compose.navscaffold.ScrollableScaffoldContext
 import com.google.android.horologist.compose.navscaffold.WearNavScaffold
@@ -129,7 +131,10 @@ fun WearApp(
         state = navState,
     ) {
 
-        scrollable(RequirePlusScreen.route) {
+        scrollable(
+            route = RequirePlusScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = false),
+        ) {
             ScrollToTop.handle(navController, it.scrollableState)
             RequirePlusScreen(
                 columnState = it.columnState,
@@ -139,6 +144,7 @@ fun WearApp(
 
         scrollable(
             route = WatchListScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = true),
         ) {
             val pagerState = rememberPagerState { NowPlayingPager.pageCount }
             val coroutineScope = rememberCoroutineScope()
@@ -163,9 +169,7 @@ fun WearApp(
             }
         }
 
-        composable(
-            route = PCVolumeScreen.route,
-        ) {
+        composable(PCVolumeScreen.route) {
             it.timeTextMode = NavScaffoldViewModel.TimeTextMode.Off
             PCVolumeScreen()
         }
@@ -186,6 +190,7 @@ fun WearApp(
 
         scrollable(
             route = PodcastsScreen.routeHomeFolder,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = false),
         ) {
             PodcastsScreenContent(
                 navController = navController,
@@ -196,6 +201,7 @@ fun WearApp(
 
         scrollable(
             route = PodcastsScreen.routeFolder,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = false),
             arguments = listOf(
                 navArgument(PodcastsScreen.argumentFolderUuid) {
                     type = NavType.StringType
@@ -211,6 +217,7 @@ fun WearApp(
 
         scrollable(
             route = PodcastScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = false),
             arguments = listOf(
                 navArgument(PodcastScreen.argument) {
                     type = NavType.StringType
@@ -240,7 +247,10 @@ fun WearApp(
             swipeToDismissState = swipeToDismissState,
         )
 
-        scrollable(FiltersScreen.route) {
+        scrollable(
+            route = FiltersScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = false),
+        ) {
             NowPlayingPager(
                 navController = navController,
                 swipeToDismissState = swipeToDismissState,
@@ -257,6 +267,7 @@ fun WearApp(
 
         scrollable(
             route = FilterScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = false),
             arguments = listOf(
                 navArgument(FilterScreen.argumentFilterUuid) {
                     type = NavType.StringType
@@ -277,7 +288,10 @@ fun WearApp(
             }
         }
 
-        scrollable(DownloadsScreen.route) {
+        scrollable(
+            route = DownloadsScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = false),
+        ) {
             NowPlayingPager(
                 navController = navController,
                 swipeToDismissState = swipeToDismissState,
@@ -293,7 +307,10 @@ fun WearApp(
             }
         }
 
-        scrollable(FilesScreen.route) {
+        scrollable(
+            route = FilesScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = false),
+        ) {
             NowPlayingPager(
                 navController = navController,
                 swipeToDismissState = swipeToDismissState,
@@ -351,7 +368,10 @@ fun WearApp(
             PCVolumeScreen()
         }
 
-        scrollable(EffectsScreen.route,) {
+        scrollable(
+            route = EffectsScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = false),
+        ) {
             EffectsScreen(
                 columnState = it.columnState,
             )

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/extensions/ScalingLazyColumnDefaults.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/extensions/ScalingLazyColumnDefaults.kt
@@ -24,7 +24,7 @@ import androidx.wear.compose.foundation.lazy.ScalingLazyColumnDefaults as Founda
  */
 @ExperimentalHorologistApi
 fun ScalingLazyColumnDefaults.responsive(
-    firstItemIsFullWidth: Boolean = true,
+    firstItemIsFullWidth: Boolean,
     verticalArrangement: Arrangement.Vertical =
         Arrangement.spacedBy(
             space = 4.dp,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/extensions/ScalingLazyColumnDefaults.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/extensions/ScalingLazyColumnDefaults.kt
@@ -24,7 +24,7 @@ import androidx.wear.compose.foundation.lazy.ScalingLazyColumnDefaults as Founda
  */
 @ExperimentalHorologistApi
 fun ScalingLazyColumnDefaults.responsive(
-    firstItemIsFullWidth: Boolean,
+    firstItemIsFullWidth: Boolean = true,
     verticalArrangement: Arrangement.Vertical =
         Arrangement.spacedBy(
             space = 4.dp,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/extensions/ScalingLazyColumnDefaults.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/extensions/ScalingLazyColumnDefaults.kt
@@ -1,0 +1,115 @@
+package au.com.shiftyjelly.pocketcasts.wear.extensions
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.lerp
+import androidx.wear.compose.foundation.lazy.ScalingLazyListAnchorType
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import kotlin.math.sqrt
+import androidx.wear.compose.foundation.lazy.ScalingLazyColumnDefaults as FoundationScalingLazyColumnDefaults
+
+/**
+ * This is being manually copied from horologist's 0.4.17 release (https://github.com/google/horologist/releases/tag/v0.4.17).
+ * We should remove this once we update to that version.
+ *
+ */
+@ExperimentalHorologistApi
+fun ScalingLazyColumnDefaults.responsive(
+    firstItemIsFullWidth: Boolean = true,
+    verticalArrangement: Arrangement.Vertical =
+        Arrangement.spacedBy(
+            space = 4.dp,
+            alignment = Alignment.Top
+        ),
+    horizontalPaddingPercent: Float = 0.052f
+): ScalingLazyColumnState.Factory {
+    fun calculateVerticalOffsetForChip(
+        viewportDiameter: Float,
+        horizontalPaddingPercent: Float
+    ): Dp {
+        val childViewHeight: Float = 52.dp.value
+        val childViewWidth: Float = viewportDiameter * (1.0f - (2f * horizontalPaddingPercent))
+        val radius = viewportDiameter / 2f
+        return (
+            radius -
+                sqrt(
+                    (radius - childViewHeight + childViewWidth * 0.5f) * (radius - childViewWidth * 0.5f)
+                ) -
+                childViewHeight * 0.5f
+            ).dp
+    }
+
+    return object : ScalingLazyColumnState.Factory {
+        @Composable
+        override fun create(): ScalingLazyColumnState {
+            val density = LocalDensity.current
+            val configuration = LocalConfiguration.current
+            val screenWidthDp = configuration.screenWidthDp.toFloat()
+            val screenHeightDp = configuration.screenHeightDp.toFloat()
+
+            return remember {
+                val padding = screenWidthDp * horizontalPaddingPercent
+                val topPaddingDp: Dp = if (firstItemIsFullWidth && configuration.isScreenRound) {
+                    calculateVerticalOffsetForChip(screenWidthDp, horizontalPaddingPercent)
+                } else {
+                    32.dp
+                }
+                val bottomPaddingDp: Dp = if (configuration.isScreenRound) {
+                    calculateVerticalOffsetForChip(screenWidthDp, horizontalPaddingPercent)
+                } else {
+                    0.dp
+                }
+                val contentPadding = PaddingValues(
+                    start = padding.dp,
+                    end = padding.dp,
+                    top = topPaddingDp,
+                    bottom = bottomPaddingDp
+                )
+
+                val sizeRatio = ((screenWidthDp - 192) / (233 - 192).toFloat()).coerceIn(0f, 1.5f)
+                val presetRatio = 0f
+
+                val minElementHeight = lerp(0.2f, 0.157f, sizeRatio)
+                val maxElementHeight = lerp(0.6f, 0.472f, sizeRatio).coerceAtLeast(minElementHeight)
+                val minTransitionArea = lerp(0.35f, lerp(0.35f, 0.393f, presetRatio), sizeRatio)
+                val maxTransitionArea = lerp(0.55f, lerp(0.55f, 0.593f, presetRatio), sizeRatio)
+
+                val scalingParams = FoundationScalingLazyColumnDefaults.scalingParams(
+                    minElementHeight = minElementHeight,
+                    maxElementHeight = maxElementHeight,
+                    minTransitionArea = minTransitionArea,
+                    maxTransitionArea = maxTransitionArea
+                )
+
+                val screenHeightPx =
+                    with(density) { screenHeightDp.dp.roundToPx() }
+                val topPaddingPx = with(density) { topPaddingDp.roundToPx() }
+                val topScreenOffsetPx = screenHeightPx / 2 - topPaddingPx
+
+                val initialScrollPosition = ScalingLazyColumnState.ScrollPosition(
+                    index = 0,
+                    offsetPx = topScreenOffsetPx
+                )
+                ScalingLazyColumnState(
+                    initialScrollPosition = initialScrollPosition,
+                    autoCentering = null,
+                    anchorType = ScalingLazyListAnchorType.ItemStart,
+                    rotaryMode = ScalingLazyColumnState.RotaryMode.Scroll,
+                    verticalArrangement = verticalArrangement,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    contentPadding = contentPadding,
+                    scalingParams = scalingParams
+                )
+            }
+        }
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
@@ -4,7 +4,9 @@ import androidx.compose.runtime.Composable
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.navigation
+import au.com.shiftyjelly.pocketcasts.wear.extensions.responsive
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.navscaffold.composable
 import com.google.android.horologist.compose.navscaffold.scrollable
 
@@ -22,7 +24,10 @@ fun NavGraphBuilder.authenticationNavGraph(
 ) {
     navigation(startDestination = AuthenticationNavRoutes.loginScreen, route = authenticationSubGraph) {
 
-        scrollable(AuthenticationNavRoutes.loginScreen) {
+        scrollable(
+            route = AuthenticationNavRoutes.loginScreen,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = true),
+        ) {
             LoginScreen(
                 columnState = it.columnState,
                 onLoginWithGoogleClick = {
@@ -34,7 +39,10 @@ fun NavGraphBuilder.authenticationNavGraph(
             )
         }
 
-        scrollable(AuthenticationNavRoutes.loginWithPhone) {
+        scrollable(
+            route = AuthenticationNavRoutes.loginWithPhone,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = true),
+        ) {
             LoginWithPhoneScreen(
                 columnState = it.columnState,
                 onDone = { navController.popBackStack() },

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
@@ -26,7 +26,7 @@ fun NavGraphBuilder.authenticationNavGraph(
 
         scrollable(
             route = AuthenticationNavRoutes.loginScreen,
-            columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = true),
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
         ) {
             LoginScreen(
                 columnState = it.columnState,
@@ -41,7 +41,7 @@ fun NavGraphBuilder.authenticationNavGraph(
 
         scrollable(
             route = AuthenticationNavRoutes.loginWithPhone,
-            columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = true),
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
         ) {
             LoginWithPhoneScreen(
                 columnState = it.columnState,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/NowPlayingPager.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/NowPlayingPager.kt
@@ -13,10 +13,12 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.wear.compose.material.SwipeToDismissBoxState
 import androidx.wear.compose.material.edgeSwipeToDismiss
+import au.com.shiftyjelly.pocketcasts.wear.extensions.responsive
 import au.com.shiftyjelly.pocketcasts.wear.ui.UpNextScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.WatchListScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.episode.EpisodeScreenFlow
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.NowPlayingScreen
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.rememberColumnState
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
 import com.google.android.horologist.compose.navscaffold.ScrollableScaffoldContext
@@ -108,7 +110,9 @@ fun NowPlayingPager(
                     navigateToEpisode = { episodeUuid ->
                         navController.navigate(EpisodeScreenFlow.navigateRoute(episodeUuid))
                     },
-                    columnState = rememberColumnState(),
+                    columnState = rememberColumnState(
+                        ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = false)
+                    ),
                 )
             }
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreenFlow.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreenFlow.kt
@@ -17,6 +17,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.navigation
 import androidx.navigation.navArgument
 import androidx.wear.compose.material.SwipeToDismissBoxState
+import au.com.shiftyjelly.pocketcasts.wear.extensions.responsive
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.NotificationScreen
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.NowPlayingPager
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ObtainConfirmationScreen
@@ -58,7 +59,8 @@ object EpisodeScreenFlow {
         ) {
             scrollable(
                 route = episodeScreen,
-                columnStateFactory = ScalingLazyColumnDefaults.belowTimeText(
+                columnStateFactory = ScalingLazyColumnDefaults.responsive(
+                    firstItemIsFullWidth = false,
                     verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.Top)
                 )
             ) {
@@ -108,7 +110,10 @@ object EpisodeScreenFlow {
                 }
             }
 
-            scrollable(upNextOptionsScreen) {
+            scrollable(
+                route = upNextOptionsScreen,
+                columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = true),
+            ) {
                 it.viewModel.timeTextMode = NavScaffoldViewModel.TimeTextMode.Off
                 val episodeScreenBackStackEntry = remember(it.backStackEntry) {
                     navController.getBackStackEntry(episodeScreen)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreenFlow.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreenFlow.kt
@@ -112,7 +112,7 @@ object EpisodeScreenFlow {
 
             scrollable(
                 route = upNextOptionsScreen,
-                columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = true),
+                columnStateFactory = ScalingLazyColumnDefaults.responsive(),
             ) {
                 it.viewModel.timeTextMode = NavScaffoldViewModel.TimeTextMode.Off
                 val episodeScreenBackStackEntry = remember(it.backStackEntry) {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/HelpScreen.kt
@@ -69,6 +69,10 @@ private fun ScalingLazyListScope.phoneAvailableContent(
             onClick = onEmailLogsToSupport,
         )
     }
+
+    item {
+        Spacer(Modifier.height(8.dp))
+    }
 }
 
 private fun ScalingLazyListScope.noPhoneAvailableContent() {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsRoutes.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsRoutes.kt
@@ -43,7 +43,7 @@ fun NavGraphBuilder.settingsRoutes(navController: NavController) {
 
     scrollable(
         route = HelpScreen.route,
-        columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = true),
+        columnStateFactory = ScalingLazyColumnDefaults.responsive(),
     ) {
         HelpScreen(columnState = it.columnState)
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsRoutes.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsRoutes.kt
@@ -2,13 +2,18 @@ package au.com.shiftyjelly.pocketcasts.wear.ui.settings
 
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import au.com.shiftyjelly.pocketcasts.wear.extensions.responsive
 import au.com.shiftyjelly.pocketcasts.wear.ui.authentication.authenticationSubGraph
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.navscaffold.scrollable
 
 fun NavGraphBuilder.settingsRoutes(navController: NavController) {
     settingsUrlScreens()
 
-    scrollable(SettingsScreen.route) {
+    scrollable(
+        route = SettingsScreen.route,
+        columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = false),
+    ) {
         SettingsScreen(
             scrollState = it.columnState,
             signInClick = { navController.navigate(authenticationSubGraph) },
@@ -18,11 +23,17 @@ fun NavGraphBuilder.settingsRoutes(navController: NavController) {
         )
     }
 
-    scrollable(PrivacySettingsScreen.route) {
+    scrollable(
+        route = PrivacySettingsScreen.route,
+        columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = false),
+    ) {
         PrivacySettingsScreen(scrollState = it.columnState)
     }
 
-    scrollable(WearAboutScreen.route) {
+    scrollable(
+        route = WearAboutScreen.route,
+        columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = false),
+    ) {
         WearAboutScreen(
             columnState = it.columnState,
             onTermsOfServiceClick = { navController.navigate(UrlScreenRoutes.termsOfService) },
@@ -30,7 +41,10 @@ fun NavGraphBuilder.settingsRoutes(navController: NavController) {
         )
     }
 
-    scrollable(HelpScreen.route) {
+    scrollable(
+        route = HelpScreen.route,
+        columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = true),
+    ) {
         HelpScreen(columnState = it.columnState)
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/UrlScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/UrlScreen.kt
@@ -13,9 +13,11 @@ import androidx.navigation.NavGraphBuilder
 import androidx.wear.compose.material.Text
 import androidx.wear.remote.interactions.RemoteActivityHelper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.wear.extensions.responsive
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.navscaffold.scrollable
 import kotlinx.coroutines.guava.await
@@ -30,7 +32,10 @@ object UrlScreenRoutes {
 }
 
 fun NavGraphBuilder.settingsUrlScreens() {
-    scrollable(UrlScreenRoutes.termsOfService) {
+    scrollable(
+        route = UrlScreenRoutes.termsOfService,
+        columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = true),
+    ) {
         UrlScreen(
             title = stringResource(LR.string.settings_about_terms_of_serivce),
             message = stringResource(LR.string.settings_about_terms_of_service_available_at, Settings.INFO_TOS_URL),
@@ -39,7 +44,10 @@ fun NavGraphBuilder.settingsUrlScreens() {
         )
     }
 
-    scrollable(UrlScreenRoutes.privacy) {
+    scrollable(
+        route = UrlScreenRoutes.privacy,
+        columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = true),
+    ) {
         UrlScreen(
             title = stringResource(id = LR.string.settings_about_privacy_policy),
             message = stringResource(LR.string.settings_about_privacy_policy_available_at, Settings.INFO_PRIVACY_URL),

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/UrlScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/UrlScreen.kt
@@ -34,7 +34,7 @@ object UrlScreenRoutes {
 fun NavGraphBuilder.settingsUrlScreens() {
     scrollable(
         route = UrlScreenRoutes.termsOfService,
-        columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = true),
+        columnStateFactory = ScalingLazyColumnDefaults.responsive(),
     ) {
         UrlScreen(
             title = stringResource(LR.string.settings_about_terms_of_serivce),
@@ -46,7 +46,7 @@ fun NavGraphBuilder.settingsUrlScreens() {
 
     scrollable(
         route = UrlScreenRoutes.privacy,
-        columnStateFactory = ScalingLazyColumnDefaults.responsive(firstItemIsFullWidth = true),
+        columnStateFactory = ScalingLazyColumnDefaults.responsive(),
     ) {
         UrlScreen(
             title = stringResource(id = LR.string.settings_about_privacy_policy),


### PR DESCRIPTION
## Description
This PR is incorporating the `ScalingLazyColumnState.Factory` that was added relatively recently to [horologist](https://github.com/google/horologist). We're adding this because Google has rejected our latest submissions because some of the chips at the top and bottom of the screen cannot be scrolled fully onto the screen.

I cannot recreate this with any of the "top" chips on a scrollable screen, but I can recreate the issue on the bottom chips on some screens. Using `responsive` avoids the issue in every place I've observed it.

Although I haven't observed the issue at the top of the screen at all in my testing, Google's rejections included a screenshot that appeared near the top of the screen, so for any screen with large elements/chips at the top, I am making sure that the default of `true` for `firstItemIsFullWidth` is used in the `responsive` function. It seems unnecessary in my testing, but setting that doesn't really do any harm apart from possibly adding a small bit of extra padding to the top of the screen.

Ideally we would just update our version of horologist, but we need to fix this on the release branch, and updating horologist requires updating our compileSdk and a lot of other dependencies (kotlin, ksp, etc.) (PRs: [1](https://github.com/Automattic/pocket-casts-android/pull/1633), [2](https://github.com/Automattic/pocket-casts-android/pull/1634)), so my thinking is that it would be better to just manually bring in this specific change that we need into the release branch. We can merge the large dependency updates to `main` so we have more time to test and uncover any issues with that.

## Testing Instructions

For these tests, use the device with the smallest possible screen (i.e., the emulator with the small screen), and make sure that the device is using the highest possible text size and has bold text turned on (see [android dev documentation about clipping](https://developer.android.com/design/ui/wear/guides/behaviors-and-patterns/clipping).

Check every screen in the app to verify that both (1) the top element on the screen is not clipped when the screen is loaded or when you scroll all the way to the top and (2) the bottom element on the screen is not clipped when you scroll to the bottom of the screen.

The only screens where I have observed problems are the screens listing podcast episodes where I saw that the bottom chips can be clipped when the podcast name takes two lines:
1. Up Next Screen
2. Podcast screen 
3. Downloads
4. List of episodes in a FIlter
5. Files

Here is a list of the scrollable screens I found in the app. It would be good to double-check that there are no issues with clipping on the top or bottom of these:
1. Initial needs plus screen
2. Select how to sign on screen
3. Watch list screen
4. Now Playing Screen
6. Effects screen
7. Adjust volume screen
8. Up Next Screen
9. Podcasts screen
10. Podcast screen
11. EpisodeScreen
12. Up Next Options screen (add to top or bottom when adding from the ~EpisodeScreen~ if there are already items in the Up Next queue)
13. Downloads
14. Filters
15. Files
16. Settings
17. Analytics
18. Help & feedback
19. About
20. Terms of Service
21. Privacy policy

## Screenshots or Screencast 

It's a tough to see the edges of the round emulator due to the dark background, but if you look at the bottom chip you can see how it was getting cut off in the before column and how it is not getting cut off in the after column.

|  | Before | After |
| --- | --- | --- |
| Bottom of Up Next Queue | <img width="200" alt="Screenshot 2023-12-18 at 4 37 47 PM" src="https://github.com/Automattic/pocket-casts-android/assets/4656348/07970aac-f506-47a3-94f2-4f4caf4eab66"> | <img width="200" alt="Screenshot 2023-12-18 at 4 51 39 PM" src="https://github.com/Automattic/pocket-casts-android/assets/4656348/689e7ad8-de30-4f71-8ab3-902f93c4237f"> |
| Bottom of Podcast Episodes | <img width="200" alt="Screenshot 2023-12-18 at 4 41 43 PM" src="https://github.com/Automattic/pocket-casts-android/assets/4656348/3b2c40d8-3768-4ed8-832d-7fbb7814498a"> | <img width="200" alt="Screenshot 2023-12-18 at 4 54 33 PM" src="https://github.com/Automattic/pocket-casts-android/assets/4656348/9210a003-c68b-47dc-b7f5-ba81b55dd167"> |
| Bottom of Downloads | <img width="200" alt="Screenshot 2023-12-18 at 4 43 49 PM" src="https://github.com/Automattic/pocket-casts-android/assets/4656348/540681cd-ff31-4f53-af6a-b3fd33163b45"> | <img width="200" alt="Screenshot 2023-12-18 at 4 54 45 PM" src="https://github.com/Automattic/pocket-casts-android/assets/4656348/68ac54ba-a11b-451e-a571-6edf7af9144f"> |
| Bottom of Filter episodes | <img width="200" alt="Screenshot 2023-12-18 at 4 44 16 PM" src="https://github.com/Automattic/pocket-casts-android/assets/4656348/6e2645ae-6d42-4857-8545-c793274e036f"> | <img width="200" alt="Screenshot 2023-12-18 at 4 55 15 PM" src="https://github.com/Automattic/pocket-casts-android/assets/4656348/62221bb3-ecac-4477-ae4b-3358bcd0ff52"> |
| Bottom of Files | <img width="200" alt="Screenshot 2023-12-18 at 4 44 00 PM" src="https://github.com/Automattic/pocket-casts-android/assets/4656348/f047776c-22fc-4cc0-b3c9-5956cc38e272"> | <img width="200" alt="Screenshot 2023-12-18 at 4 55 23 PM" src="https://github.com/Automattic/pocket-casts-android/assets/4656348/b78be948-7ed7-4206-963f-9af66a9833ce"> |











## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [X] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
