### PR TITLE
Improve wear handling of user files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 *   Updates:
     *   Save selected tab on Player screen after screen rotation
         ([#1598](https://github.com/Automattic/pocket-casts-android/issues/1598))
+*   Bug Fixes:
+    *   Improve handling of user files on watch
+        ([#1638](https://github.com/Automattic/pocket-casts-android/pull/1638))
 
 7.54
 -----

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/UserEpisodeImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/UserEpisodeImage.kt
@@ -24,6 +24,7 @@ fun UserEpisodeImage(
             .build(),
         contentDescription = contentDescription,
         placeholder = painterResource(placeholder),
+        fallback = painterResource(placeholder),
         modifier = modifier,
     )
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/DeleteState.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/DeleteState.kt
@@ -35,7 +35,7 @@ object CloudDeleteHelper {
 
     fun deleteEpisode(
         episode: UserEpisode,
-        deleteState: DeleteState,
+        deleteState: DeleteState = getDeleteState(episode),
         playbackManager: PlaybackManager,
         episodeManager: EpisodeManager,
         userEpisodeManager: UserEpisodeManager,

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -106,6 +106,7 @@ dependencies {
     implementation(project(":modules:services:servers"))
     implementation(project(":modules:services:ui"))
     implementation(project(":modules:services:utils"))
+    implementation(project(":modules:services:views"))
     testImplementation(project(":modules:services:sharedtest"))
 
     implementation(project(":modules:features:account"))

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -471,7 +471,7 @@ class EpisodeViewModel @Inject constructor(
         }
     }
 
-    private suspend fun extractColorFromEpisodeArtwork(userEpisode: UserEpisode): Color? =
+    private suspend fun extractColorFromEpisodeArtwork(userEpisode: UserEpisode): Color =
         userEpisode.artworkUrl?.let { artworkUrl ->
             val context = getApplication<Application>()
             val loader = ImageLoader(context)
@@ -480,8 +480,11 @@ class EpisodeViewModel @Inject constructor(
                 .allowHardware(false) // Disable hardware bitmaps.
                 .build()
 
-            val result = (loader.execute(request) as SuccessResult).drawable
-            val bitmap = (result as BitmapDrawable).bitmap
+            val successResult = loader.execute(request) as? SuccessResult
+                ?: return@let null
+            val resultDrawable = successResult.drawable as? BitmapDrawable
+                ?: return@let null
+            val bitmap = resultDrawable.bitmap
 
             // Set a timeout to make sure the user isn't blocked for too long just
             // because we're trying to extract a tint color.
@@ -497,5 +500,5 @@ class EpisodeViewModel @Inject constructor(
                     }
                 }
             }
-        }
+        } ?: Color.White
 }


### PR DESCRIPTION
## Description
This PR improves the handling of user files on the watch in a few ways:
1. When the file does not have any associated image/color, the episode details screen will not crash. Instead, a white color will be used.
2. When a downloaded episode is removed, we will call `CloudDeleteHelper::deleteEpisode`, which handles the deletion of episodes that are in various different states (uploaded, device only, or both) appropriately.
3. We added a fallback image for when a user episode image URL fails to load

Fixes #1473

## Testing Instructions

### 1. Handles user episodes appropriately
1. Install the app onto your watch and log in
4. From the web or another device, add two files to the cloud for the account you're using on your watch
5. Sync your watch
6. Verify that both files have appeared on your watch
7. Tap on each file to open the episode screen for them
8. Verify that the episode screen looks fine and is colored with a color from the image/color associated with the file (or white if there is no image/color for the file)
9. From the episode screen for only one of the files, download the file to your watch
10. From the web or another device, remove both files from your account
11. Sync your watch
12. Observe that the file you did not download is no longer shown on the files screen. Instead, that screen only has the file you downloaded.
13. Tap on the downloaded file to open the episode details screen
14. Verify that you can play the file
15. Delete the downloaded file from the episode details screen
16. Back out of the episode screen
17. Verify that the file whose download you just deleted (and which was previously removed from your account in the cloud) is no longer shown on the Files screen in the watch.

### 2. Handles missing tint_color_index
I think it might no longer be possible to get into this state with the updates in this PR through the app, so these test steps will recreate the situation by editing the db just to verify that if a user does get into this state, it no longer crashes the app.

1. Install the app on your watch
2. Make sure you have at least one file on your account that is synced to your watch
3. Open the database inspector and run a command like `UPDATE user_episodes SET tint_color_index = 0`
4. Notice that the files on your watch no longer have an image
5. Tap on one of the files to open the episode details screen
6. Observe that the app does not crash

| Before | After |
| --- | --- |
| <video width="350px" src="https://github.com/Automattic/pocket-casts-android/assets/4656348/d42bbac8-973d-4623-acda-4cc07105e78c" /> | <video width="350px" src="https://github.com/Automattic/pocket-casts-android/assets/4656348/1b74db7f-8772-46ae-8acd-f2bd77250b72" /> |

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews