### PR TITLE
Fix wear update effects UI not updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
         ([#1620](https://github.com/Automattic/pocket-casts-android/pull/1620))
     *   Fix tap to view action from bookmark added notification
         ([#1614](https://github.com/Automattic/pocket-casts-android/pull/1614))
+    *   Fix playback effects UI not updating on watch
+        ([#1643](https://github.com/Automattic/pocket-casts-android/pull/1643))
 *   Updates:
     *   Display dynamic colors for widget
         ([#1588](https://github.com/Automattic/pocket-casts-android/pull/1588))

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/PlaybackEffectsDataTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/PlaybackEffectsDataTest.kt
@@ -1,0 +1,19 @@
+package au.com.shiftyjelly.pocketcasts.models.to
+
+import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+
+class PlaybackEffectsDataTest {
+
+    @Test
+    fun `data to effects and back to data is equal`() {
+        val start = PlaybackEffectsData(
+            playbackSpeed = 1.5,
+            trimMode = TrimMode.MEDIUM,
+            isVolumeBoosted = true,
+        )
+        val end = start.toEffects().toData()
+        assertEquals(start, end)
+    }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PlaybackEffects.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PlaybackEffects.kt
@@ -14,4 +14,20 @@ class PlaybackEffects {
     override fun toString(): String {
         return String.format(Locale.ENGLISH, "Speed: %f Trim: %d Boost: %s", playbackSpeed, trimMode.ordinal, isVolumeBoosted)
     }
+
+    fun toData() = PlaybackEffectsData(playbackSpeed, trimMode, isVolumeBoosted)
+}
+
+// This class can be useful when you need things like a well-behaved equals()
+// method, or a "copy" method.
+data class PlaybackEffectsData(
+    val playbackSpeed: Double,
+    val trimMode: TrimMode,
+    val isVolumeBoosted: Boolean,
+) {
+    fun toEffects() = PlaybackEffects().apply {
+        playbackSpeed = this@PlaybackEffectsData.playbackSpeed
+        trimMode = this@PlaybackEffectsData.trimMode
+        isVolumeBoosted = this@PlaybackEffectsData.isVolumeBoosted
+    }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PlaybackEffects.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PlaybackEffects.kt
@@ -17,17 +17,3 @@ class PlaybackEffects {
 
     fun toData() = PlaybackEffectsData(playbackSpeed, trimMode, isVolumeBoosted)
 }
-
-// This class can be useful when you need things like a well-behaved equals()
-// method, or a "copy" method.
-data class PlaybackEffectsData(
-    val playbackSpeed: Double,
-    val trimMode: TrimMode,
-    val isVolumeBoosted: Boolean,
-) {
-    fun toEffects() = PlaybackEffects().apply {
-        playbackSpeed = this@PlaybackEffectsData.playbackSpeed
-        trimMode = this@PlaybackEffectsData.trimMode
-        isVolumeBoosted = this@PlaybackEffectsData.isVolumeBoosted
-    }
-}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PlaybackEffectsData.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PlaybackEffectsData.kt
@@ -1,0 +1,17 @@
+package au.com.shiftyjelly.pocketcasts.models.to
+
+import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
+
+// This class can be useful when you need things like a well-behaved equals()
+// method, or a "copy" method.
+data class PlaybackEffectsData(
+    val playbackSpeed: Double,
+    val trimMode: TrimMode,
+    val isVolumeBoosted: Boolean,
+) {
+    fun toEffects() = PlaybackEffects().apply {
+        playbackSpeed = this@PlaybackEffectsData.playbackSpeed
+        trimMode = this@PlaybackEffectsData.trimMode
+        isVolumeBoosted = this@PlaybackEffectsData.isVolumeBoosted
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsScreen.kt
@@ -30,7 +30,7 @@ import androidx.wear.compose.material.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
-import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
+import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffectsData
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
@@ -247,11 +247,11 @@ private fun EffectsScreenDarkPreview() {
         Content(
             columnState = belowTimeTextPreview(),
             state = EffectsViewModel.State.Loaded(
-                playbackEffects = PlaybackEffects().apply {
-                    trimMode = TrimMode.MEDIUM
-                    playbackSpeed = 1.5
-                    isVolumeBoosted = true
-                }
+                playbackEffects = PlaybackEffectsData(
+                    trimMode = TrimMode.MEDIUM,
+                    playbackSpeed = 1.5,
+                    isVolumeBoosted = true,
+                )
             ),
             increasePlaybackSpeed = {},
             decreasePlaybackSpeed = {},

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsViewModel.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.rx2.asFlow
 import javax.inject.Inject
 import kotlin.math.round
 
@@ -25,11 +24,8 @@ class EffectsViewModel
 ) : ViewModel() {
 
     val state: StateFlow<State> =
-        playbackManager.playbackStateRelay
-            .asFlow()
-            .map {
-                State.Loaded(settings.globalPlaybackEffects.value.toData())
-            }
+        settings.globalPlaybackEffects.flow
+            .map { State.Loaded(it.toData()) }
             .stateIn(
                 scope = viewModelScope,
                 started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),


### PR DESCRIPTION
## Description
This PR fixes an issue where the effects UI on the watch was not updating even though the values were being updated and taking effect. This was because the UI was not detecting that there were changes to the underlying effects.

We might want to add proper equals handling to the `PlaybackEffects` class, but because that could have wide-ranging and hard to anticipate consequences, I instead opted to create a related data class that gives us the behavior we want because that seemed like a simpler and much safer approach.

> [!NOTE]
> I have this PR targeting the `release/7.54` branch.

## Testing Instructions
1. From the watch's now playing screen, tap on the playback effects button
2. Change each of the effects
3. ✅ Confirm that the UI updates to reflect the change
4. ✅ Confirm that if you exit the playback effects screen and return to it the updated value is shown
5. ✅ Confirm that playback reflects the active effects

## Screenshots or Screencast 

| Before | After |
| --- | --- |
| <video width="350px" src="https://github.com/Automattic/pocket-casts-android/assets/4656348/e2addab8-9bf6-4018-bf71-cea215fec6c2" /> | <video width="350px" src="https://github.com/Automattic/pocket-casts-android/assets/4656348/cc38a180-c024-4b6a-8008-1b3ed2a36224" /> |

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
