### PR TITLE
Disable playback 2023

### DIFF
--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -14,10 +14,10 @@ enum class Feature(
     END_OF_YEAR_ENABLED(
         key = "end_of_year_enabled",
         title = "End of Year",
-        defaultValue = true,
+        defaultValue = false,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = false,
     ),
     ADD_PATRON_ENABLED(
         key = "add_patron_enabled",


### PR DESCRIPTION
## Description

This disables Playback 2023.

> [!NOTE]
> Merge this PR in the first week of Jan 2024.


## Testing Instructions

1. Run the app
2. Go to Profile
3. ✅ You should not see the Playback 2023 banner 
4. Go to Profile -> Settings -> Developer 
5. Tap "Reset modal/profile badge" 
6. Restart the app
7. ✅ You should not see Playback 2023 launch modal

## Checklist
- If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- with different themes
- with a landscape orientation
- with the device set to have a large display and font size
- for accessibility with TalkBack
