### PR TITLE
Add setting to enable widget dynamic colors 

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.settings
 
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -173,6 +174,14 @@ class AppearanceSettingsFragment : BaseFragment() {
             binding.swtDarkUpNext.isChecked = !binding.swtDarkUpNext.isChecked
         }
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            binding.dividerViewWidget.isVisible = true
+            binding.lblWidget.isVisible = true
+            binding.lblUseDynamicColorsForWidget.isVisible = true
+            binding.lblDynamicColorsForWidgetDetails.isVisible = true
+            binding.swtDynamicColorsForWidget.isVisible = true
+            binding.btnUseDynamicColorsForWidget.isVisible = true
+        }
         binding.swtDynamicColorsForWidget.isChecked = settings.useDynamicColorsForWidget.value
         binding.swtDynamicColorsForWidget.setOnCheckedChangeListener { _, isChecked ->
             viewModel.updateWidgetForDynamicColors(isChecked)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
@@ -173,6 +173,14 @@ class AppearanceSettingsFragment : BaseFragment() {
             binding.swtDarkUpNext.isChecked = !binding.swtDarkUpNext.isChecked
         }
 
+        binding.swtDynamicColorsForWidget.isChecked = settings.useDynamicColorsForWidget.value
+        binding.swtDynamicColorsForWidget.setOnCheckedChangeListener { _, isChecked ->
+            viewModel.updateWidgetForDynamicColors(isChecked)
+        }
+        binding.btnUseDynamicColorsForWidget.setOnClickListener {
+            binding.swtDynamicColorsForWidget.isChecked = !binding.swtDynamicColorsForWidget.isChecked
+        }
+
         binding.swtShowArtwork.isChecked = viewModel.showArtworkOnLockScreen.value
         binding.swtShowArtwork.setOnCheckedChangeListener { _, isChecked ->
             viewModel.updateShowArtworkOnLockScreen(isChecked)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.repositories.widget.WidgetManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.AppIcon
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
@@ -26,6 +27,7 @@ class SettingsAppearanceViewModel @Inject constructor(
     val theme: Theme,
     private val appIcon: AppIcon,
     private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val widgetManager: WidgetManager,
 ) : ViewModel() {
 
     val signInState: LiveData<SignInState> = userManager.getSignInState().toLiveData()
@@ -123,6 +125,10 @@ class SettingsAppearanceViewModel @Inject constructor(
             AnalyticsEvent.SETTINGS_APPEARANCE_USE_DARK_UP_NEXT_TOGGLED,
             mapOf("enabled" to value)
         )
+    }
+
+    fun updateWidgetForDynamicColors(value: Boolean) {
+        settings.useDynamicColorsForWidget.set(value)
     }
 
     fun updateShowArtworkOnLockScreen(value: Boolean) {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
@@ -137,6 +137,10 @@ class SettingsAppearanceViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             widgetManager.updateWidgetFromSettings(playbackManager)
         }
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_APPEARANCE_USE_DYNAMIC_COLORS_WIDGET_TOGGLED,
+            mapOf("enabled" to value)
+        )
     }
 
     fun updateShowArtworkOnLockScreen(value: Boolean) {

--- a/modules/features/settings/src/main/res/layout/fragment_settings_appearance.xml
+++ b/modules/features/settings/src/main/res/layout/fragment_settings_appearance.xml
@@ -346,6 +346,7 @@
                 android:layout_height="@dimen/divider_height"
                 android:layout_marginTop="16dp"
                 android:background="?attr/primary_ui_05"
+                android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
@@ -360,6 +361,7 @@
                 android:text="@string/widget"
                 android:textAppearance="@style/H40"
                 android:textColor="?attr/primary_interactive_01"
+                android:visibility="gone"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/dividerViewWidget" />
 
@@ -373,6 +375,7 @@
                 android:textAppearance="@style/H40"
                 android:textColor="?attr/primary_text_01"
                 android:paddingTop="16dp"
+                android:visibility="gone"
                 app:layout_constraintEnd_toStartOf="@+id/swtShowArtwork"
                 app:layout_constraintStart_toStartOf="@+id/lblWidget"
                 app:layout_constraintTop_toBottomOf="@+id/lblWidget" />
@@ -383,6 +386,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="12dp"
                 android:layout_marginEnd="24dp"
+                android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="@+id/lblUseDynamicColorsForWidget"
                 app:layout_constraintBottom_toBottomOf="@+id/lblUseDynamicColorsForWidget"/>
@@ -397,6 +401,7 @@
                 android:text="@string/settings_use_dynamic_colors_widget_details"
                 android:textAppearance="@style/H40"
                 android:textColor="?attr/primary_text_02"
+                android:visibility="gone"
                 app:layout_constraintEnd_toStartOf="@+id/swtDynamicColorsForWidget"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="@+id/lblUseDynamicColorsForWidget"
@@ -408,6 +413,7 @@
                 android:layout_height="0dp"
                 android:background="?android:attr/selectableItemBackground"
                 android:importantForAccessibility="no"
+                android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="@+id/lblUseDynamicColorsForWidget"

--- a/modules/features/settings/src/main/res/layout/fragment_settings_appearance.xml
+++ b/modules/features/settings/src/main/res/layout/fragment_settings_appearance.xml
@@ -341,7 +341,7 @@
                 app:layout_constraintBottom_toBottomOf="@+id/lblUseDarkUpNextDetails"/>
 
             <View
-                android:id="@+id/dividerView"
+                android:id="@+id/dividerViewWidget"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/divider_height"
                 android:layout_marginTop="16dp"
@@ -350,6 +350,79 @@
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/btnUseDarkUpNext" />
+
+            <TextView
+                android:id="@+id/lblWidget"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="72dp"
+                android:layout_marginTop="16dp"
+                android:text="@string/widget"
+                android:textAppearance="@style/H40"
+                android:textColor="?attr/primary_interactive_01"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/dividerViewWidget" />
+
+            <TextView
+                android:id="@+id/lblUseDynamicColorsForWidget"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:layout_marginTop="8dp"
+                android:text="@string/settings_use_dynamic_colors_widget"
+                android:textAppearance="@style/H40"
+                android:textColor="?attr/primary_text_01"
+                android:paddingTop="16dp"
+                app:layout_constraintEnd_toStartOf="@+id/swtShowArtwork"
+                app:layout_constraintStart_toStartOf="@+id/lblWidget"
+                app:layout_constraintTop_toBottomOf="@+id/lblWidget" />
+
+            <Switch
+                android:id="@+id/swtDynamicColorsForWidget"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:layout_marginEnd="24dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/lblUseDynamicColorsForWidget"
+                app:layout_constraintBottom_toBottomOf="@+id/lblUseDynamicColorsForWidget"/>
+
+            <TextView
+                android:id="@+id/lblDynamicColorsForWidgetDetails"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="16dp"
+                android:paddingBottom="8dp"
+                android:text="@string/settings_use_dynamic_colors_widget_details"
+                android:textAppearance="@style/H40"
+                android:textColor="?attr/primary_text_02"
+                app:layout_constraintEnd_toStartOf="@+id/swtDynamicColorsForWidget"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="@+id/lblUseDynamicColorsForWidget"
+                app:layout_constraintTop_toBottomOf="@+id/lblUseDynamicColorsForWidget" />
+
+            <View
+                android:id="@+id/btnUseDynamicColorsForWidget"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:background="?android:attr/selectableItemBackground"
+                android:importantForAccessibility="no"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/lblUseDynamicColorsForWidget"
+                app:layout_constraintBottom_toBottomOf="@+id/lblDynamicColorsForWidgetDetails"/>
+
+            <View
+                android:id="@+id/dividerView"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/divider_height"
+                android:layout_marginTop="16dp"
+                android:background="?attr/primary_ui_05"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/btnUseDynamicColorsForWidget" />
 
             <androidx.constraintlayout.widget.Group
                 android:id="@+id/upgradeGroup"

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -445,6 +445,7 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_APPEARANCE_USE_EMBEDDED_ARTWORK_TOGGLED("settings_appearance_use_embedded_artwork_toggled"),
     SETTINGS_APPEARANCE_SHOW_ARTWORK_ON_LOCK_SCREEN_TOGGLED("settings_appearance_show_artwork_on_lock_screen_toggled"),
     SETTINGS_APPEARANCE_USE_DARK_UP_NEXT_TOGGLED("settings_appearance_use_dark_up_next_toggled"),
+    SETTINGS_APPEARANCE_USE_DYNAMIC_COLORS_WIDGET_TOGGLED("settings_appearance_use_dynamic_colors_widget_toggled"),
 
     /* Settings - Auto add */
     SETTINGS_AUTO_ADD_UP_NEXT_SHOWN("settings_auto_add_up_next_shown"),

--- a/modules/services/images/src/main/res/color/color_primary_container_40.xml
+++ b/modules/services/images/src/main/res/color/color_primary_container_40.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:alpha="0.6" android:color="?attr/colorPrimaryContainer" />
+    <item android:alpha="0.4" android:color="?attr/colorPrimaryContainer" />
 </selector>

--- a/modules/services/images/src/main/res/drawable/widget_background.xml
+++ b/modules/services/images/src/main/res/drawable/widget_background.xml
@@ -1,4 +1,4 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/color_primary_container_60" />
+    <solid android:color="@color/color_primary_container_40" />
     <corners android:radius="3dp" />
 </shape>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -153,6 +153,7 @@
     <string name="go_to_top">Go to top</string>
     <string name="go_to_bottom">Go to bottom</string>
     <string name="submit">Submit</string>
+    <string name="widget">Widget</string>
 
     <string name="multiselect_actions_shown">Shortcut in toolbar</string>
     <string name="multiselect_actions_hidden">In overflow</string>
@@ -1263,6 +1264,8 @@
     <string name="settings_use_android_light_dark_mode">Use Android Light/Dark Mode</string>
     <string name="settings_use_dark_up_next">Use Dark Up Next Theme</string>
     <string name="settings_use_dark_up_next_details">When enabled the Up Next will always use the dark theme, or will match the current theme when disabled</string>
+    <string name="settings_use_dynamic_colors_widget">Use dynamic colors for widget</string>
+    <string name="settings_use_dynamic_colors_widget_details">When enabled, widget colors will change based on the device theme colors.</string>
     <string name="settings_use_embedded_podcast_artwork">Use embedded podcast artwork</string>
     <string name="settings_version">Version %1$s (%2$s)</string>
     <string name="settings_view">View</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -423,4 +423,6 @@ interface Settings {
     fun getReviewRequestedDates(): List<String>
 
     val useDarkUpNextTheme: UserSetting<Boolean>
+
+    val useDynamicColorsForWidget: UserSetting<Boolean>
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1299,4 +1299,10 @@ class SettingsImpl @Inject constructor(
         defaultValue = true, // This default is overridden for new installs
         sharedPrefs = sharedPreferences,
     )
+
+    override val useDynamicColorsForWidget: UserSetting<Boolean> = UserSetting.BoolPref(
+        sharedPrefKey = "useDynamicColorsForWidget",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManager.kt
@@ -10,5 +10,6 @@ interface WidgetManager {
     fun updateWidget(podcast: Podcast?, playing: Boolean, playingEpisode: BaseEpisode?)
     fun updateWidgetFromProvider(context: Context, manager: AppWidgetManager, widgetIds: IntArray, playbackManager: PlaybackManager?)
     fun updateWidgetFromPlaybackState(playbackManager: PlaybackManager?)
+    fun updateWidgetFromSettings(playbackManager: PlaybackManager?)
     fun updateWidgetNotPlaying()
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
@@ -29,8 +29,10 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 class WidgetManagerImpl @Inject constructor(
     private val settings: Settings,
     private val podcastManager: PodcastManager,
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
 ) : WidgetManager {
+
+    private var remoteViewsLayoutId: Int = getRemoteViewsLayoutId()
 
     override fun updateWidget(podcast: Podcast?, playing: Boolean, playingEpisode: BaseEpisode?) {
         when (Util.getAppPlatform(context)) {
@@ -40,7 +42,7 @@ class WidgetManagerImpl @Inject constructor(
                 try {
                     val appWidgetManager = AppWidgetManager.getInstance(context)
 
-                    val views = RemoteViews(context.packageName, R.layout.widget)
+                    val views = RemoteViews(context.packageName, remoteViewsLayoutId)
                     val widgetName = ComponentName(context, PodcastWidget::class.java)
                     if (playingEpisode == null) {
                         showPlayingControls(false, views)
@@ -56,6 +58,26 @@ class WidgetManagerImpl @Inject constructor(
                     Timber.e(e)
                 }
             }
+        }
+    }
+
+    override fun updateWidgetFromSettings(playbackManager: PlaybackManager?) {
+        try {
+            /* We cannot apply a theme dynamically to an app widget.
+            As a workaround, multiple layouts are provided, and the correct theme/layout is picked
+            when remote views layout needs to be updated.
+            https://stackoverflow.com/a/4501902/193545 */
+            remoteViewsLayoutId = getRemoteViewsLayoutId()
+
+            val views = RemoteViews(context.packageName, remoteViewsLayoutId)
+            val widgetName = ComponentName(context, PodcastWidget::class.java)
+
+            val appWidgetManager = AppWidgetManager.getInstance(context)
+            appWidgetManager.updateAppWidget(widgetName, views)
+
+            updateWidgetFromPlaybackState(playbackManager)
+        } catch (e: Exception) {
+            Timber.e(e)
         }
     }
 
@@ -86,7 +108,7 @@ class WidgetManagerImpl @Inject constructor(
         for (i in widgetIds.indices) {
             val widgetId = widgetIds[i]
 
-            val views = RemoteViews(context.packageName, R.layout.widget)
+            val views = RemoteViews(context.packageName, remoteViewsLayoutId)
             updateOnClicks(views, context)
             updateSkipAmounts(views, settings)
             setupView(views, isPlaying, playbackManager, widgetName, context)
@@ -191,5 +213,11 @@ class WidgetManagerImpl @Inject constructor(
 
     private fun getSkipForwardIntent(): PendingIntent? {
         return MediaButtonReceiver.buildMediaButtonPendingIntent(context, PlaybackStateCompat.ACTION_SKIP_TO_NEXT)
+    }
+
+    private fun getRemoteViewsLayoutId() = if (settings.useDynamicColorsForWidget.value) {
+        R.layout.widget_dynamic_colors_theme
+    } else {
+        R.layout.widget_default_theme
     }
 }

--- a/modules/services/repositories/src/main/res/layout/widget.xml
+++ b/modules/services/repositories/src/main/res/layout/widget.xml
@@ -1,12 +1,8 @@
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/widget_frame"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="72dp"
-    android:background="@drawable/widget_background"
-    android:layoutDirection="ltr"
-    android:clickable="true"
-    android:focusable="true"
-    android:theme="@style/PCWidgetTheme">
+    tools:parentTag="android.widget.FrameLayout">
 
     <FrameLayout
         android:id="@+id/widget_empty_player"
@@ -153,4 +149,4 @@
         </LinearLayout>
     </FrameLayout>
 
-</FrameLayout>
+</merge>

--- a/modules/services/repositories/src/main/res/layout/widget_default_theme.xml
+++ b/modules/services/repositories/src/main/res/layout/widget_default_theme.xml
@@ -1,0 +1,13 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_frame"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/widget_background"
+    android:layoutDirection="ltr"
+    android:clickable="true"
+    android:focusable="true"
+    android:theme="@style/PCWidgetDefaultTheme">
+
+    <include layout="@layout/widget" />
+
+</FrameLayout>

--- a/modules/services/repositories/src/main/res/layout/widget_dynamic_colors_theme.xml
+++ b/modules/services/repositories/src/main/res/layout/widget_dynamic_colors_theme.xml
@@ -1,0 +1,13 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_frame"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/widget_background"
+    android:layoutDirection="ltr"
+    android:clickable="true"
+    android:focusable="true"
+    android:theme="@style/PCWidgetDynamicColorsTheme">
+
+    <include layout="@layout/widget" />
+
+</FrameLayout>

--- a/modules/services/repositories/src/main/res/values-v31/styles.xml
+++ b/modules/services/repositories/src/main/res/values-v31/styles.xml
@@ -1,4 +1,4 @@
 <resources>
     <!-- Do not override any color attribute. -->
-    <style name="PCWidgetTheme" parent="Theme.Material3.DynamicColors.DayNight" />
+    <style name="PCWidgetDynamicColorsTheme" parent="Theme.Material3.DynamicColors.DayNight" />
 </resources>

--- a/modules/services/repositories/src/main/res/values/styles.xml
+++ b/modules/services/repositories/src/main/res/values/styles.xml
@@ -1,5 +1,7 @@
 <resources>
-    <style name="PCWidgetTheme" parent="Theme.Material3.DynamicColors.DayNight">
+    <style name="PCWidgetDynamicColorsTheme" parent="PCWidgetDefaultTheme"/>
+
+    <style name="PCWidgetDefaultTheme">
         <item name="colorPrimaryContainer">#66000000</item>
         <item name="colorOnPrimaryContainer">#ffffff</item>
     </style>

--- a/modules/services/repositories/src/main/res/values/styles.xml
+++ b/modules/services/repositories/src/main/res/values/styles.xml
@@ -2,7 +2,7 @@
     <style name="PCWidgetDynamicColorsTheme" parent="PCWidgetDefaultTheme"/>
 
     <style name="PCWidgetDefaultTheme">
-        <item name="colorPrimaryContainer">#66000000</item>
+        <item name="colorPrimaryContainer">#000000</item>
         <item name="colorOnPrimaryContainer">#ffffff</item>
     </style>
 </resources>

--- a/modules/services/repositories/src/main/res/xml/widget.xml
+++ b/modules/services/repositories/src/main/res/xml/widget.xml
@@ -3,7 +3,7 @@
     android:minResizeWidth="220dp"
     android:minHeight="40dp"
     android:updatePeriodMillis="1000"
-    android:initialLayout="@layout/widget"
+    android:initialLayout="@layout/widget_default_theme"
     android:previewImage="@drawable/widget_preview"
     android:resizeMode="horizontal">
 </appwidget-provider>


### PR DESCRIPTION
## Description

This adds a setting to enable widget dynamic colors for Android 12 and above. It is off by default.

## Testing Instructions

#### Test.1 Android 12 and above

1. Fresh install the app
2. Long press the app icon
3. Tap Widgets
4. Drag the widget to the home screen
5. ✅ Notice that the widget colors remain the same as before
6. Open the app
7. Go to `Profile` -> `Settings` -> `Appearance`
8. Scroll down
9. ✅ Notice that you see a setting to enable widget dynamic colors
10. Toggle the switch switch to enable widget dynamic colors
11. ✅ Notice that you see in logs `Tracked: settings_appearance_use_dynamic_colors_widget_toggled, Properties: {"enabled":true,`
12. Return to the home screen where the widget was added
13. ✅ Notice that the widget has dynamic colors based on the wallpaper
14. ✅ Notice that play, skip actions work as before
15. Go back to `Profile` -> `Settings` -> `Appearance`
16.  Toggle the switch switch to disable widget dynamic colors
17.  ✅ Notice that you see in logs `Tracked: settings_appearance_use_dynamic_colors_widget_toggled, Properties: {"enabled":false,`
18. Return to the home screen where the widget was added
19. ✅ Notice that the widget now has default colors 

#### Test.2 Below Android 12

1. Fresh install the app
2. Long press the app icon
3. Tap Widgets
4. Drag the widget to the home screen
5. ✅ Notice that the widget colors remain the same as before
6. Open the app
7. Go to `Profile` -> `Settings` -> `Appearance`
8. Scroll down
9. ✅ Notice that you do not see any setting to enable widget dynamic colors


#### Test.3 Migration from 7.53 

1. Fresh install the app from 7.53 release tag
2. Long press the app icon
3. Tap Widgets
4. Drag the widget to the home screen
5. ✅ Notice that the widget has default colors
6. Install the app from this branch
7. ✅ Notice that the widget still has default colors

## Screenshots or Screencast 

Before (7.53) |  Now (default) | Now (dynamic colors) | Now (below Android 12)
-----|------|------|----
<img width="300" src="https://github.com/Automattic/pocket-casts-android/assets/1405144/4d066042-b06a-4d15-84af-b258a1559a6d"/> | <img width="300" src="https://github.com/Automattic/pocket-casts-android/assets/1405144/31536133-f18e-44f3-96cf-2d972985ca2d"/> | <img width="300" src="https://github.com/Automattic/pocket-casts-android/assets/1405144/1b05b539-6b28-41c6-be90-9d19d1bec0f6"/> | <img width="300" src="https://github.com/Automattic/pocket-casts-android/assets/1405144/b8e64e84-dc06-415a-8bb4-06bc3df0c4ea"/>


Appearance (Android 12 and above) |  Appearance (below)
-----|------
<img width="200" src="https://github.com/Automattic/pocket-casts-android/assets/1405144/12b2efe5-6d4a-4f03-a01b-c3d013cd12ec"/> | <img width="200" src="https://github.com/Automattic/pocket-casts-android/assets/1405144/1dd7a272-1fbe-4d22-876c-cae23dd03b26"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
