### PR TITLE
Display Episode Artwork In Miniplayer, Notification & Widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 *   Bug Fixes:
     *   Fixed starring episode from full-screen player does not prevent episode from being archived
         ([#1735](https://github.com/Automattic/pocket-casts-android/pull/1735))
+*   New features:
+    *   Display episode artwork from podcast feed on Mini-player, Notification & Widget.
+        ([#1658](https://github.com/Automattic/pocket-casts-android/pull/1558))
 
 7.56
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 *   Updates:
     *   Warn when switching to metered network if warn before using data setting is enabled
         ([#1640](https://github.com/Automattic/pocket-casts-android/pull/1640))
+    *   Display episode artwork from podcast feed on Mini-player, Notification & Widget.
+        ([#1599](https://github.com/Automattic/pocket-casts-android/pull/1599))
 *   Bug Fixes:
     *   Fixed starring episode from full-screen player does not prevent episode from being archived
         ([#1735](https://github.com/Automattic/pocket-casts-android/pull/1735))

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -16,9 +16,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.player.databinding.ViewMiniPlayerBinding
-import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getUrlForArtwork
-import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImageLoader
 import au.com.shiftyjelly.pocketcasts.repositories.images.into
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
@@ -30,7 +28,6 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
-import coil.ImageLoader
 import coil.load
 import coil.request.Disposable
 import coil.request.ErrorResult

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -7,31 +7,62 @@ import android.os.Parcelable
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
+import android.widget.ImageView
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.player.databinding.ViewMiniPlayerBinding
+import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
+import au.com.shiftyjelly.pocketcasts.repositories.extensions.getUrlForArtwork
+import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImageLoader
 import au.com.shiftyjelly.pocketcasts.repositories.images.into
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.images.PodcastImageLoaderThemed
+import au.com.shiftyjelly.pocketcasts.ui.images.ThemedImageTintTransformation
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import coil.ImageLoader
+import coil.load
+import coil.request.Disposable
+import coil.request.ErrorResult
+import coil.request.ImageRequest
+import coil.size.Size
+import coil.transform.RoundedCornersTransformation
 import com.airbnb.lottie.LottieDrawable
 import com.airbnb.lottie.LottieProperty
 import com.airbnb.lottie.SimpleColorFilter
 import com.airbnb.lottie.model.KeyPath
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import java.io.File
+import kotlin.coroutines.CoroutineContext
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) : FrameLayout(context, attrs) {
+class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
+    FrameLayout(context, attrs), CoroutineScope {
 
-    private val inflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
-    private val binding = DataBindingUtil.inflate<ViewMiniPlayerBinding>(inflater, R.layout.view_mini_player, this, true)
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.Main
+
+    private val inflater =
+        context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+    private val binding = DataBindingUtil.inflate<ViewMiniPlayerBinding>(
+        inflater,
+        R.layout.view_mini_player,
+        this,
+        true
+    )
     private var playing = false
     private val stringPause: String = context.resources.getString(LR.string.pause)
     private val stringPlay: String = context.resources.getString(LR.string.play)
@@ -112,9 +143,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
     fun setUpNext(upNextState: UpNextQueue.State, theme: Theme) {
         if (upNextState is UpNextQueue.State.Loaded) {
             if (binding.episode?.uuid != upNextState.episode.uuid) {
-                val imageLoader = PodcastImageLoaderThemed(context)
-                imageLoader.radiusPx = 2.dpToPx(context.resources.displayMetrics)
-                imageLoader.smallPlaceholder().load(upNextState.episode).into(binding.artwork)
+                loadArtwork(upNextState.podcast, upNextState.episode)
             }
 
             binding.episode = upNextState.episode
@@ -193,6 +222,91 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
             drawable.frame = if (isPlaying) 0 else 10
         }
         button.contentDescription = if (isPlaying) stringPause else stringPlay
+    }
+
+    private fun loadArtwork(podcast: Podcast?, episode: BaseEpisode) {
+        val imageLoader = PodcastImageLoaderThemed(context)
+        val imageView = binding.artwork
+        imageLoader.radiusPx = 2.dpToPx(context.resources.displayMetrics)
+
+        val artwork = getEpisodeArtwork(episode)
+        if (artwork == Artwork.None && podcast?.uuid != null) {
+            loadPodcastArtwork(imageLoader, podcast)
+        } else {
+            loadEpisodeArtwork(artwork, imageView, imageLoader)?.let { disposable ->
+                launch {
+                    // If episode artwork fails to load, then load podcast artwork
+                    val result = disposable.job.await()
+                    if (result is ErrorResult && podcast?.uuid != null) {
+                        loadPodcastArtwork(imageLoader, podcast)
+                    }
+                }
+            }
+        }
+    }
+
+    private var loadedPodcastUuid: String? = null
+    private fun loadPodcastArtwork(
+        imageLoader: PodcastImageLoaderThemed,
+        podcast: Podcast,
+    ) {
+        if (loadedPodcastUuid == podcast.uuid) return
+        val imageView = binding.artwork
+        imageLoader.smallPlaceholder().loadPodcastUuid(podcast.uuid).into(imageView)
+        loadedPodcastUuid = podcast.uuid
+    }
+
+    private var loadedEpisodeArtwork: Artwork? = null
+    private fun loadEpisodeArtwork(
+        artwork: Artwork,
+        imageView: ImageView,
+        imageLoader: PodcastImageLoaderThemed
+    ): Disposable? {
+        if (artwork is Artwork.None || loadedEpisodeArtwork == artwork) return null
+        imageView.imageTintList = null
+
+        val imageBuilder: ImageRequest.Builder.() -> Unit = {
+            error(au.com.shiftyjelly.pocketcasts.images.R.drawable.defaultartwork_dark)
+            size(Size.ORIGINAL)
+            transformations(
+                RoundedCornersTransformation(imageLoader.radiusPx.toFloat()),
+                ThemedImageTintTransformation(imageView.context)
+            )
+        }
+        loadedEpisodeArtwork = artwork
+        return when (artwork) {
+            is Artwork.Path -> {
+                imageView.load(data = File(artwork.path), builder = imageBuilder)
+            }
+            is Artwork.Url -> {
+                imageView.load(data = artwork.url, builder = imageBuilder)
+            }
+            else -> {
+                null
+            }
+        }
+    }
+
+    companion object {
+        private fun getEpisodeArtwork(episode: BaseEpisode): Artwork {
+            val showNotesImageUrl = (episode as? PodcastEpisode)?.imageUrl
+            return if (showNotesImageUrl != null) {
+                Artwork.Url(showNotesImageUrl)
+            } else if (episode is UserEpisode) {
+                val artworkUrl = episode.getUrlForArtwork(themeIsDark = true)
+                if (artworkUrl.startsWith("/")) {
+                    Artwork.Path(artworkUrl)
+                } else {
+                    Artwork.Url(artworkUrl)
+                }
+            } else Artwork.None
+        }
+    }
+
+    sealed class Artwork {
+        data class Url(val url: String) : Artwork()
+        data class Path(val path: String) : Artwork()
+        object None : Artwork()
     }
 
     interface OnMiniPlayerClicked {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -38,12 +38,12 @@ import com.airbnb.lottie.LottieDrawable
 import com.airbnb.lottie.LottieProperty
 import com.airbnb.lottie.SimpleColorFilter
 import com.airbnb.lottie.model.KeyPath
+import java.io.File
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
-import java.io.File
-import kotlin.coroutines.CoroutineContext
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
@@ -58,7 +58,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
         inflater,
         R.layout.view_mini_player,
         this,
-        true
+        true,
     )
     private var playing = false
     private val stringPause: String = context.resources.getString(LR.string.pause)
@@ -256,7 +256,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
     private fun loadEpisodeArtwork(
         artwork: Artwork,
         imageView: ImageView,
-        imageLoader: PodcastImageLoaderThemed
+        imageLoader: PodcastImageLoaderThemed,
     ): Disposable? {
         if (artwork is Artwork.None || loadedEpisodeArtwork == artwork) return null
         imageView.imageTintList = null
@@ -266,7 +266,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
             scale(Scale.FIT)
             transformations(
                 RoundedCornersTransformation(imageLoader.radiusPx.toFloat()),
-                ThemedImageTintTransformation(imageView.context)
+                ThemedImageTintTransformation(imageView.context),
             )
         }
         loadedEpisodeArtwork = artwork
@@ -296,7 +296,9 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
                 } else {
                     Artwork.Url(artworkUrl)
                 }
-            } else Artwork.None
+            } else {
+                Artwork.None
+            }
         }
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -142,9 +142,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
 
     fun setUpNext(upNextState: UpNextQueue.State, theme: Theme) {
         if (upNextState is UpNextQueue.State.Loaded) {
-            if (binding.episode?.uuid != upNextState.episode.uuid) {
-                loadArtwork(upNextState.podcast, upNextState.episode)
-            }
+            loadArtwork(upNextState.podcast, upNextState.episode)
 
             binding.episode = upNextState.episode
             binding.podcast = upNextState.podcast
@@ -254,6 +252,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
         val imageView = binding.artwork
         imageLoader.smallPlaceholder().loadPodcastUuid(podcast.uuid).into(imageView)
         loadedPodcastUuid = podcast.uuid
+        loadedEpisodeArtwork = null
     }
 
     private var loadedEpisodeArtwork: Artwork? = null
@@ -274,6 +273,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
             )
         }
         loadedEpisodeArtwork = artwork
+        loadedPodcastUuid = null
         return when (artwork) {
             is Artwork.Path -> {
                 imageView.load(data = File(artwork.path), builder = imageBuilder)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -32,7 +32,7 @@ import coil.load
 import coil.request.Disposable
 import coil.request.ErrorResult
 import coil.request.ImageRequest
-import coil.size.Size
+import coil.size.Scale
 import coil.transform.RoundedCornersTransformation
 import com.airbnb.lottie.LottieDrawable
 import com.airbnb.lottie.LottieProperty
@@ -263,7 +263,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
 
         val imageBuilder: ImageRequest.Builder.() -> Unit = {
             error(au.com.shiftyjelly.pocketcasts.images.R.drawable.defaultartwork_dark)
-            size(Size.ORIGINAL)
+            scale(Scale.FIT)
             transformations(
                 RoundedCornersTransformation(imageLoader.radiusPx.toFloat()),
                 ThemedImageTintTransformation(imageView.context)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
@@ -128,13 +128,12 @@ open class PodcastImageLoader(
         episode: PodcastEpisode,
         coroutineScope: CoroutineScope,
     ) {
-        val loadPodcastImage: () -> ImageRequest = {
+        val loadPodcastImage: () -> Unit = {
             // If episode artwork image fails, try podcast image
             val imageRequest = loadPodcastImageForEpisode(episode)
             if (size != null) imageRequest.size(size)
-            if (target != null) imageRequest.target(target)
+            if (target != null) imageRequest.target(target).build()
             else imageRequest.into(imageView!!)
-            imageRequest.build()
         }
 
         if (episode.imageUrl != null) {
@@ -149,14 +148,12 @@ open class PodcastImageLoader(
                 when (disposable.job.await()) {
                     is SuccessResult -> { /* do nothing */ }
                     is ErrorResult -> {
-                        val podcastRequest = loadPodcastImage()
-                        podcastRequest.context.imageLoader.enqueue(podcastRequest)
+                        loadPodcastImage()
                     }
                 }
             }
         } else {
-            val podcastRequest = loadPodcastImage()
-            podcastRequest.context.imageLoader.enqueue(podcastRequest)
+            loadPodcastImage()
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
@@ -128,12 +128,13 @@ open class PodcastImageLoader(
         episode: PodcastEpisode,
         coroutineScope: CoroutineScope,
     ) {
-        val loadPodcastImage: () -> Unit = {
+        val loadPodcastImage: () -> ImageRequest = {
             // If episode artwork image fails, try podcast image
             val imageRequest = loadPodcastImageForEpisode(episode)
             if (size != null) imageRequest.size(size)
-            if (target != null) imageRequest.target(target).build()
+            if (target != null) imageRequest.target(target)
             else imageRequest.into(imageView!!)
+            imageRequest.build()
         }
 
         if (episode.imageUrl != null) {
@@ -148,12 +149,14 @@ open class PodcastImageLoader(
                 when (disposable.job.await()) {
                     is SuccessResult -> { /* do nothing */ }
                     is ErrorResult -> {
-                        loadPodcastImage()
+                        val podcastRequest = loadPodcastImage()
+                        podcastRequest.context.imageLoader.enqueue(podcastRequest)
                     }
                 }
             }
         } else {
-            loadPodcastImage()
+            val podcastRequest = loadPodcastImage()
+            podcastRequest.context.imageLoader.enqueue(podcastRequest)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
@@ -140,6 +140,7 @@ open class PodcastImageLoader(
             val imageBuilder = ImageRequest.Builder(context).data(episode.imageUrl)
             if (size != null) imageBuilder.size(size)
             if (target != null) imageBuilder.target(target)
+            if (imageView != null) imageBuilder.into(imageView)
             val imageRequest = imageBuilder.build()
 
             val disposable = imageRequest.context.imageLoader.enqueue(imageRequest)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
@@ -132,8 +132,11 @@ open class PodcastImageLoader(
             // If episode artwork image fails, try podcast image
             val imageRequest = loadPodcastImageForEpisode(episode)
             if (size != null) imageRequest.size(size)
-            if (target != null) imageRequest.target(target)
-            else imageRequest.into(imageView!!)
+            if (target != null) {
+                imageRequest.target(target)
+            } else {
+                imageRequest.into(imageView!!)
+            }
             imageRequest.build()
         }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -400,14 +400,9 @@ class MediaSessionManager(
         mediaSession.setMetadata(nowPlaying)
 
         if (settings.showArtworkOnLockScreen.value) {
-            if (Util.isAutomotive(context)) {
-                val bitmapUri = AutoConverter.getBitmapUriForPodcast(podcast, episode, context)?.toString()
-                nowPlayingBuilder = nowPlayingBuilder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM_ART_URI, bitmapUri)
-                nowPlayingBuilder = nowPlayingBuilder.putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_ICON_URI, bitmapUri)
-            } else {
-                val bitmap = AutoConverter.getBitmapForPodcast(podcast, false, context)
-                nowPlayingBuilder = nowPlayingBuilder.putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, bitmap)
-            }
+            val bitmapUri = AutoConverter.getBitmapUriForPodcast(podcast, episode, context)?.toString()
+            nowPlayingBuilder = nowPlayingBuilder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM_ART_URI, bitmapUri)
+            if (Util.isAutomotive(context)) nowPlayingBuilder = nowPlayingBuilder.putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_ICON_URI, bitmapUri)
 
             val nowPlayingWithArtwork = nowPlayingBuilder.build()
             Timber.i("MediaSession metadata. With artwork.")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/AutoConverter.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/AutoConverter.kt
@@ -132,7 +132,9 @@ object AutoConverter {
     }
 
     fun getBitmapUriForPodcast(podcast: Podcast?, episode: BaseEpisode?, context: Context): Uri? {
-        val url = if (episode is UserEpisode) {
+        val url = if (episode is PodcastEpisode && (!episode.imageUrl.isNullOrBlank())) {
+            episode.imageUrl
+        } else if (episode is UserEpisode) {
             // the artwork for user uploaded episodes are stored on each episode
             episode.artworkUrl
         } else {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
@@ -24,8 +24,8 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.getLaunchActivityPendingI
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import timber.log.Timber
 import javax.inject.Inject
+import timber.log.Timber
 import kotlin.coroutines.CoroutineContext
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
@@ -22,11 +22,11 @@ import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getLaunchActivityPendingIntent
 import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import javax.inject.Inject
 import timber.log.Timber
-import kotlin.coroutines.CoroutineContext
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 
 class WidgetManagerImpl @Inject constructor(
@@ -191,7 +191,7 @@ class WidgetManagerImpl @Inject constructor(
                 target = target,
                 size = 128,
                 episode = playingEpisode,
-                coroutineScope = this
+                coroutineScope = this,
             )
         } else if (playingEpisode is UserEpisode) {
             imageLoader.smallPlaceholder().loadForTarget(playingEpisode, 128, target)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
@@ -22,15 +22,20 @@ import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getLaunchActivityPendingIntent
 import dagger.hilt.android.qualifiers.ApplicationContext
-import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import timber.log.Timber
+import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 
 class WidgetManagerImpl @Inject constructor(
     private val settings: Settings,
     private val podcastManager: PodcastManager,
     @ApplicationContext private val context: Context,
-) : WidgetManager {
+) : WidgetManager, CoroutineScope {
+
+    override val coroutineContext: CoroutineContext get() = Dispatchers.IO
 
     private var remoteViewsLayoutId: Int = getRemoteViewsLayoutId()
 
@@ -180,7 +185,15 @@ class WidgetManagerImpl @Inject constructor(
             R.id.widget_artwork,
         )
         val imageLoader = PodcastImageLoader(context = context, isDarkTheme = true, transformations = emptyList())
-        if (playingEpisode is UserEpisode) {
+        if (playingEpisode is PodcastEpisode) {
+            imageLoader.smallPlaceholder().loadEpisodeArtworkInto(
+                imageView = null,
+                target = target,
+                size = 128,
+                episode = playingEpisode,
+                coroutineScope = this
+            )
+        } else if (playingEpisode is UserEpisode) {
             imageLoader.smallPlaceholder().loadForTarget(playingEpisode, 128, target)
         } else if (podcast != null) {
             imageLoader.smallPlaceholder().loadForTarget(podcast, 128, target)


### PR DESCRIPTION
## Description
In #1599 , we added episode artwork to the full-screen player and the episode details screen, and we now want to use it in more places in the app. See #1608 for more details. I've added artwork in MiniPlayer, Notification and Widget. 

## Testing Instructions

**Testing the Miniplayer, Notification & Widget**
1. Fresh install the app
2. Open up the podcast screen for "Darknet Diaries"
3. Open the episode details page for an episode and see the artwork of episode.
4. When network connection active or inactive, observe the Miniplayer, Notification & Widget artwork loaded from episode if successfully loads, If fails, automatically load the artwork of podcast.

## Screenshots or Screencast 
![00ecb5ad-3f03-4283-b175-20c70ed7b9c9](https://github.com/Automattic/pocket-casts-android/assets/64830777/8715cce7-ab9d-4157-a710-b4cd62f9c61b)
![83676f7d-99ca-42dd-b3f3-63b34d745a74](https://github.com/Automattic/pocket-casts-android/assets/64830777/d55e6534-133f-4cf5-9653-eb408db27bc8)
![a1d5d5f9-7004-4431-aa94-f165092a0ff5](https://github.com/Automattic/pocket-casts-android/assets/64830777/c06c798d-7b4b-470f-b334-82a570dee911)

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
