### PR TITLE
Set label for close button in up next screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 *   Bug Fixes:
     *   Improve handling of user files on watch
         ([#1638](https://github.com/Automattic/pocket-casts-android/pull/1638))
-
+    *   Fixed an issue with a missing accessibility label for the 'Up Next' screen
+        ([#1657](https://github.com/Automattic/pocket-casts-android/pull/1662))
 7.54
 -----
 

--- a/modules/features/player/src/main/res/layout/fragment_upnext.xml
+++ b/modules/features/player/src/main/res/layout/fragment_upnext.xml
@@ -18,6 +18,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="?attr/secondary_ui_01"
+            app:navigationContentDescription="@string/close"
             app:navigationIcon="@drawable/ic_close" />
         <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
             android:id="@+id/multiSelectToolbar"


### PR DESCRIPTION
## Description
This PR improves accessibility by adding a 'Close' label description to an unlabeled button

Fixes #1657 

## Testing Instructions

1. Start TalkBack: https://support.google.com/accessibility/android/answer/6007100?hl=en
2. Open Pocket Casts.
3. Queue some episodes to play next
4. On the player near the bottom of the screen, just above the tabs, select the Up Next button near the right edge of the screen to open the Up Next screen

**Expected behavior**: When you tap on the X button the `TalkBack` must say `Close button`

## Screenshots

| Up Next Queue | Up Next Screen |
|--------|--------|
| <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/08e5e1e1-4397-4986-9f34-91c4ecf0e251" height="400"> | <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/4fcd805e-280a-48fa-8cfd-c8aaa919a9c7" height="400"> | 









## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
