### PR TITLE
Fix large bitmap crash

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -37,6 +37,7 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
+import au.com.shiftyjelly.pocketcasts.ui.images.CoilManager
 import au.com.shiftyjelly.pocketcasts.ui.images.PodcastImageLoaderThemed
 import au.com.shiftyjelly.pocketcasts.ui.images.ThemedImageTintTransformation
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -53,6 +54,7 @@ import coil.load
 import coil.request.Disposable
 import coil.request.ErrorResult
 import coil.request.ImageRequest
+import coil.size.Scale
 import coil.size.Size
 import coil.transform.RoundedCornersTransformation
 import com.airbnb.lottie.LottieAnimationView
@@ -437,7 +439,8 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
 
             val imageBuilder: ImageRequest.Builder.() -> Unit = {
                 error(IR.drawable.defaultartwork_dark)
-                size(Size.ORIGINAL)
+                scale(Scale.FIT)
+                size(CoilManager.getMaxImageSize(imageView))
                 transformations(RoundedCornersTransformation(imageLoader.radiusPx.toFloat()), ThemedImageTintTransformation(imageView.context))
             }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -37,7 +37,6 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.images.CoilManager
 import au.com.shiftyjelly.pocketcasts.ui.images.PodcastImageLoaderThemed
 import au.com.shiftyjelly.pocketcasts.ui.images.ThemedImageTintTransformation
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -440,7 +439,6 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
             val imageBuilder: ImageRequest.Builder.() -> Unit = {
                 error(IR.drawable.defaultartwork_dark)
                 scale(Scale.FIT)
-                size(CoilManager.getMaxImageSize(imageView))
                 transformations(RoundedCornersTransformation(imageLoader.radiusPx.toFloat()), ThemedImageTintTransformation(imageView.context))
             }
 

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/images/CoilManager.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/images/CoilManager.kt
@@ -1,14 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.ui.images
 
-import android.widget.ImageView
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import coil.ImageLoader
 import coil.annotation.ExperimentalCoilApi
-import coil.size.Size
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.math.max
 
 @Singleton
 class CoilManager @Inject constructor(val imageLoader: ImageLoader) {
@@ -28,14 +25,5 @@ class CoilManager @Inject constructor(val imageLoader: ImageLoader) {
     fun clearAll() {
         imageLoader.memoryCache?.clear()
         imageLoader.diskCache?.clear()
-    }
-
-    companion object {
-        private const val MAX_IMAGE_SIZE_IN_PX = 2500
-
-        fun getMaxImageSize(imageView: ImageView) = Size(
-            max(imageView.width, MAX_IMAGE_SIZE_IN_PX),
-            max(imageView.height, MAX_IMAGE_SIZE_IN_PX)
-        )
     }
 }

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/images/CoilManager.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/images/CoilManager.kt
@@ -1,11 +1,14 @@
 package au.com.shiftyjelly.pocketcasts.ui.images
 
+import android.widget.ImageView
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import coil.ImageLoader
 import coil.annotation.ExperimentalCoilApi
+import coil.size.Size
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.max
 
 @Singleton
 class CoilManager @Inject constructor(val imageLoader: ImageLoader) {
@@ -25,5 +28,14 @@ class CoilManager @Inject constructor(val imageLoader: ImageLoader) {
     fun clearAll() {
         imageLoader.memoryCache?.clear()
         imageLoader.diskCache?.clear()
+    }
+
+    companion object {
+        private const val MAX_IMAGE_SIZE_IN_PX = 2500
+
+        fun getMaxImageSize(imageView: ImageView) = Size(
+            max(imageView.width, MAX_IMAGE_SIZE_IN_PX),
+            max(imageView.height, MAX_IMAGE_SIZE_IN_PX)
+        )
     }
 }


### PR DESCRIPTION
## Description

> [!WARNING]  
> Targets release/7.54

This prevents large bitmap crash while loading bitmap using Coil by [restricting image size](https://rb.gy/0zlgiu). It can be further improved by adding an interceptor that handles large bitmaps appropriately but I do not want to bring too many changes to a release branch freezing tomorrow.

Relevant Sentry report: https://a8c.sentry.io/share/issue/6d0da9c8e4764e39b3beca1368381184/

The problem it seems is due to setting [Size.ORIGINAL](https://github.com/Automattic/pocket-casts-android/blob/main/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt#L440) while loading episode artwork from URL which may return a large image. `Size.ORIGINAL` uses unrestricted image dimension, `Size(Dimension.Undefined, Dimension.Undefined)` causing a crash if the bitmap is too large.

I'm targeting the release branch since this issue is only seen in the beta version, and users who experience it may notice it repeatedly while the episode remains selected.

Fixes #1664

## Testing Instructions

#### Reproduce crash

1. Checkout `7.54-rc-5` tag (`git checkout tags/7.54-rc-5 -b 7.54-rc-5`)
2. Open podcast https://pca.st/c8lcat3q in the app
3. Play an episode from the podcast (`12 - Twisted Games`) (this loads image of size 5400x5400)
4. Open player
5. ❌  Notice that the app crashes

#### Test fix

1. Checkout this branch
2. Repeat steps 2-4 above
3. ✅ Notice that the image loads correctly and the app does not crash 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
