### PR TITLE
Fix Incorrect playback speed shown on the media notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
         ([#1638](https://github.com/Automattic/pocket-casts-android/pull/1638))
     *   Fixed an issue with a missing accessibility label for the 'Up Next' screen
         ([#1657](https://github.com/Automattic/pocket-casts-android/pull/1662))
+    *   Fixed an issue with incorrect playback speed shown on the media notification
+        ([#1648](https://github.com/Automattic/pocket-casts-android/pull/1666))
 7.54
 -----
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
@@ -26,15 +26,14 @@ import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.images.PodcastImageLoaderThemed
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
-import au.com.shiftyjelly.pocketcasts.utils.extensions.clipToRange
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+import au.com.shiftyjelly.pocketcasts.utils.extensions.roundedSpeed
 import au.com.shiftyjelly.pocketcasts.views.extensions.applyColor
 import au.com.shiftyjelly.pocketcasts.views.extensions.updateTint
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import com.google.android.material.button.MaterialButtonToggleGroup
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlin.math.round
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @AndroidEntryPoint
@@ -158,8 +157,7 @@ class EffectsFragment : BaseDialogFragment(), CompoundButton.OnCheckedChangeList
     private fun changePlaybackSpeed(effects: PlaybackEffects, podcast: Podcast, amount: Double) {
         val binding = binding ?: return
 
-        // val speed = (amount.clipToRange(0.5, 3.0) * 10.0).toInt() / 10.0
-        val speed = round(amount.clipToRange(0.5, 3.0) * 10.0) / 10.0
+        val speed = amount.roundedSpeed()
         effects.playbackSpeed = speed
         updatedSpeed = speed
         binding.playbackSpeedString = String.format("%.1fx", effects.playbackSpeed)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
@@ -11,7 +11,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.utils.extensions.clipToRange
+import au.com.shiftyjelly.pocketcasts.utils.extensions.roundedSpeed
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineScope
@@ -19,7 +19,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
-import kotlin.math.round
 
 @HiltViewModel
 class PodcastEffectsViewModel
@@ -89,9 +88,7 @@ class PodcastEffectsViewModel
 
     private fun changePlaybackSpeed(speed: Double) {
         val podcast = this.podcast.value ?: return
-        val clippedToRangeSpeed = speed.clipToRange(0.5, 3.0)
-        // to stop the issue 1.2000000000000002
-        val roundedSpeed = round(clippedToRangeSpeed * 10.0) / 10.0
+        val roundedSpeed = speed.roundedSpeed()
         podcastManager.updatePlaybackSpeed(podcast, roundedSpeed)
         updatedSpeed = roundedSpeed
         if (shouldUpdatePlaybackManager()) {

--- a/modules/features/taskerplugin/build.gradle.kts
+++ b/modules/features/taskerplugin/build.gradle.kts
@@ -29,5 +29,6 @@ dependencies {
     implementation(project(":modules:services:views"))
     implementation(project(":modules:services:images"))
     implementation(project(":modules:services:preferences"))
+    implementation(project(":modules:services:utils"))
     implementation("com.joaomgcd:taskerpluginlibrary:0.4.6")
 }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
@@ -8,12 +8,12 @@ import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.playbackManager
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.podcastManager
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.settings
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.nullIfEmpty
+import au.com.shiftyjelly.pocketcasts.utils.extensions.roundedSpeed
 import com.joaomgcd.taskerpluginlibrary.action.TaskerPluginRunnerActionNoOutput
 import com.joaomgcd.taskerpluginlibrary.input.TaskerInput
 import com.joaomgcd.taskerpluginlibrary.runner.TaskerPluginResult
 import com.joaomgcd.taskerpluginlibrary.runner.TaskerPluginResultError
 import com.joaomgcd.taskerpluginlibrary.runner.TaskerPluginResultSucess
-import kotlin.math.round
 
 private const val ERROR_NO_COMMAND_PROVIDED = 1
 private const val ERROR_INVALIUD_COMMAND_PROVIDED = 2
@@ -56,9 +56,7 @@ class ActionRunnerControlPlayback : TaskerPluginRunnerActionNoOutput<InputContro
             InputControlPlayback.PlaybackCommand.SetPlaybackSpeed -> {
                 val speed = input.regular.playbackSpeed?.toDoubleOrNull() ?: return TaskerPluginResultError(ERROR_INVALID_PLAYBACK_SPEED_PROVIDED, context.getString(R.string.playback_speed_not_valid, input.regular.playbackSpeed))
 
-                val clippedToRangeSpeed = speed.coerceIn(0.5, 3.0)
-                val roundedSpeed = round(clippedToRangeSpeed * 10.0) / 10.0
-                context.updateEffects { playbackSpeed = roundedSpeed }
+                context.updateEffects { playbackSpeed = speed.roundedSpeed() }
             }
             InputControlPlayback.PlaybackCommand.SetTrimSilenceMode -> {
                 val trimSilenceMode = input.regular.trimSilenceModeEnum ?: return TaskerPluginResultError(ERROR_INVALID_TRIM_SILENCE_MODE_PROVIDED, context.getString(R.string.trim_silence_mode_not_valid, input.regular.trimSilenceMode))

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -37,6 +37,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getLaunchActivityPendingIntent
+import au.com.shiftyjelly.pocketcasts.utils.extensions.roundedSpeed
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import io.reactivex.Completable
 import io.reactivex.Observable
@@ -425,7 +426,7 @@ class MediaSessionManager(
                 MediaNotificationControls.PlayNext -> addCustomAction(stateBuilder, APP_ACTION_PLAY_NEXT, "Play next", com.google.android.gms.cast.framework.R.drawable.cast_ic_mini_controller_skip_next)
                 MediaNotificationControls.PlaybackSpeed -> {
                     if (playbackManager.isAudioEffectsAvailable()) {
-                        val currentSpeed = playbackState.playbackSpeed
+                        val currentSpeed = playbackState.playbackSpeed.roundedSpeed()
                         val drawableId = when {
                             currentSpeed <= 1 -> IR.drawable.auto_1x
                             currentSpeed == 1.1 -> IR.drawable.auto_1_1x

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/Double.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/Double.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.utils.extensions
 
-import kotlin.math.max
-import kotlin.math.min
+import kotlin.math.round
 
-fun Double.clipToRange(minimum: Double, maximum: Double): Double {
-    return min(max(minimum, this), maximum)
-}
+/**
+ * This is to prevent the issue of having speed values such as 1.2000000000000002
+ */
+fun Double.roundedSpeed(): Double = round(this.coerceIn(0.5, 3.0) * 10.0) / 10.0

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/DoubleTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/DoubleTest.kt
@@ -1,0 +1,40 @@
+package au.com.shiftyjelly.pocketcasts.utils.featureflag
+
+import au.com.shiftyjelly.pocketcasts.utils.extensions.roundedSpeed
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+
+class DoubleTest {
+
+    @Test
+    fun `roundedSpeed rounds correctly`() {
+        assertEquals(1.2, 1.19.roundedSpeed())
+        assertEquals(2.8, 2.75.roundedSpeed())
+        assertEquals(1.2, 1.2000000000000002.roundedSpeed())
+    }
+
+    @Test
+    fun `roundedSpeed respects lower boundary`() {
+        assertEquals(0.5, 0.1.roundedSpeed())
+    }
+
+    @Test
+    fun `roundedSpeed respects upper boundary`() {
+        assertEquals(3.0, 5.0.roundedSpeed())
+    }
+
+    @Test
+    fun `roundedSpeed works within boundaries`() {
+        assertEquals(2.0, 2.0.roundedSpeed())
+    }
+
+    @Test
+    fun `roundedSpeed adjusts below lower boundary`() {
+        assertEquals(0.5, 0.4.roundedSpeed())
+    }
+
+    @Test
+    fun `roundedSpeed adjusts above upper boundary`() {
+        assertEquals(3.0, 3.5.roundedSpeed())
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsViewModel.kt
@@ -6,7 +6,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.utils.extensions.clipToRange
+import au.com.shiftyjelly.pocketcasts.utils.extensions.roundedSpeed
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -15,7 +15,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlow
 import javax.inject.Inject
-import kotlin.math.round
 
 @HiltViewModel
 class EffectsViewModel
@@ -49,10 +48,7 @@ class EffectsViewModel
     private fun changePlaybackSpeed(speed: Double) {
         val currentState = state.value as? State.Loaded ?: return
         val effects = currentState.playbackEffects
-        val clippedToRangeSpeed = speed.clipToRange(0.5, 3.0)
-        // to stop the issue 1.2000000000000002
-        val roundedSpeed = round(clippedToRangeSpeed * 10.0) / 10.0
-        effects.playbackSpeed = roundedSpeed
+        effects.playbackSpeed = speed.roundedSpeed()
         saveEffects(effects)
     }
 


### PR DESCRIPTION
## Description
- We noticed an issue where an incorrect value was displayed in the media notification after changing the playback speed value and restarting the app. This issue was caused by not rounding the speed value. As a result, the default value (1x) was always returned instead of the correct one. This PR addresses this problem by implementing rounding for the speed value.
- Also this PR extracts the rounding logic to an extension function and replace it in order to avoid code duplication

Fixes #1648

## Testing Instructions

1. Play an episode
2. Open full-screen player
3. Tap the effects option on the bottom shelf
4. Change playback speed
5. ✅ Notice that media notification displays the correct playback speed
6. Force stop the app
7. Reopen the app
8. Play the last episode. _You don't need to wait for the episode actual starts. Right after tapping on playing button you can check the media notification._

**Expected behavior**: media notification displays the correct playback speed.

## Screenshots or Screencast 
| Before | After |
|--------|--------|
| https://github.com/Automattic/pocket-casts-android/assets/1405144/2b3d4641-9124-4feb-9077-b82f6d5e58a2 | [Screen_recording_20240104_110103.webm](https://github.com/Automattic/pocket-casts-android/assets/42220351/92fb801e-292f-4055-8308-40f3e078a732) | 


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
