### PR TITLE
Move Danger to GitHub Actions

### DIFF
--- a/.buildkite/commands/danger-pr-check.sh
+++ b/.buildkite/commands/danger-pr-check.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -eu
-
-echo "--- :rubygems: Setting up Gems"
-bundle install
-
-echo "--- Running Danger: PR Check"
-bundle exec danger --fail-on-errors=true --remove-previous-comments --danger_id=pr-check

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,21 +18,6 @@ steps:
 
   - group: "Linters"
     steps:
-      - label: "☢️ Danger - PR Check"
-        command: .buildkite/commands/danger-pr-check.sh
-        plugins:
-          - docker#v5.8.0:
-              image: "public.ecr.aws/docker/library/ruby:3.2.2"
-              propagate-environment: true
-              environment:
-                - "DANGER_GITHUB_API_TOKEN"
-        if: "build.pull_request.id != null"
-        agents:
-          queue: "default"
-        retry:
-          manual:
-            permit_on_passed: true
-
       - label: 'Lint'
         command: |
           echo "--- 🧹 Linting"

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -1,0 +1,11 @@
+name: ☢️ Danger
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited, review_requested, review_request_removed, labeled, unlabeled, milestoned, demilestoned]
+
+jobs:
+  dangermattic:
+    uses: Automattic/dangermattic/.github/workflows/reusable-run-danger.yml@iangmaia/danger-on-gha
+    secrets:
+      github-token: ${{ secrets.DANGERMATTIC_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR experiments moving the current Buildkite step setup to GitHub Actions (as discussed on paaHJt-5Qn-p2).

Running on Buildkite is still an option, but it would require a GitHub action (or an intermediate server) to forward to Buildkite Pull Request Events such as "labeled", "unlabeled", "milestoned" and so on. This was implemented as a prototype on https://github.com/woocommerce/woocommerce-android/pull/10385.

If we find problems using GitHub Actions, we can always revert this change and go back to Buildkite, as the setup works in general (just not as fast and as simple as GHA alone).

## How to test
Make sure CI is green and Danger runs on labels/milestones/reviewers changes as well as on code changes.