### PR TITLE
Player: Episode artwork - add image ratio constraint

### DIFF
--- a/modules/features/player/src/main/res/layout/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout/adapter_player_header.xml
@@ -36,6 +36,7 @@
                 android:visibility="@{viewModel.isPodcastArtworkVisible()}"
                 android:clickable="true"
                 android:scaleType="fitCenter"
+                app:layout_constraintDimensionRatio="1:1"
                 app:layout_constraintBottom_toTopOf="@+id/episodeTitle"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## Description
As part of this PR: https://github.com/Automattic/pocket-casts-android/pull/1665 we added a `Scale.FIT` while loading episode artwork to prevent large bitmap OOM error. 

`coil.size.Scale.FIT`

> Fit the image to the view so that both dimensions (width and height) of the image will be equal to or less than the corresponding dimension of the view.

With the `Scale.FIT`, the width and height of the image should be equal to or less than the corresponding dimension of the view. However, the image spreads beyond the view width.

This is also reported here:

https://pocketcastsbeta.slack.com/archives/C013F9S9C2W/p1704702825434209 

To fix this, I added an aspect ratio constraint for the image view. I think it is safe to include this constraint as it is also applied to the landscape layout loading the same image URL.

Before applying the fix I also tried adding [precision.EXACT](https://rb.gy/pds2o9) but it made no difference. 

Let me know if you can think of a better way to address it. 


## Testing Instructions
1. Fresh install the app
2. Open episode https://pca.st/e3LI in the app
3. Open player
4. Notice that the image has 1:1 aspect ratio

## Screenshots or Screencast 

Before | After
----|-----
![image](https://github.com/Automattic/pocket-casts-android/assets/1405144/d767bff9-fce9-4df8-986c-42020d01017a)| ![image](https://github.com/Automattic/pocket-casts-android/assets/1405144/570110d4-6e52-483b-8064-474c9d191ae3)





## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
