### PR TITLE
Streamline FileStorage

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -38,9 +38,6 @@ abstract class EpisodeDao {
     abstract fun observeCount(query: SupportSQLiteQuery): Flowable<Int>
 
     @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")
-    abstract fun findByUuidSync(uuid: String): PodcastEpisode?
-
-    @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")
     abstract suspend fun findByUuid(uuid: String): PodcastEpisode?
 
     @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.kt
@@ -14,6 +14,8 @@ import java.io.File
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.reactive.asFlow
 import timber.log.Timber
 
 @Singleton
@@ -177,7 +179,7 @@ open class FileStorage @Inject constructor(
                     .updateEpisodesWithNewFilePaths(episodesManager)
 
                 // Move episodes
-                episodesManager.observeDownloadedEpisodes().blockingFirst()
+                episodesManager.observeDownloadedEpisodes().asFlow().first()
                     .onEach { episode -> LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Found downloaded episode ${episode.title}") }
                     .matchWithDownloadedFilePaths()
                     .filterNotExistingFiles()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.kt
@@ -158,7 +158,7 @@ open class FileStorage @Inject constructor(
         }
     }
 
-    fun moveStorage(oldDir: File, newDir: File, episodesManager: EpisodeManager) {
+    suspend fun moveStorage(oldDir: File, newDir: File, episodesManager: EpisodeManager) {
         try {
             val oldPocketCastsDir = File(oldDir, "PocketCasts")
             if (oldPocketCastsDir.exists() && oldPocketCastsDir.isDirectory) {
@@ -202,9 +202,8 @@ open class FileStorage @Inject constructor(
 
     private fun List<Pair<File, String>>.filterInvalidFileNames() = filter { (_, fileName) -> fileName.length >= UUID_LENGTH }
 
-    @Suppress("DEPRECATION")
-    private fun List<Pair<File, String>>.findMatchingEpisodes(episodeManager: EpisodeManager) = mapNotNull { (file, fileName) ->
-        episodeManager.findByUuidSync(fileName)?.let { episode -> file to episode }
+    private suspend fun List<Pair<File, String>>.findMatchingEpisodes(episodeManager: EpisodeManager) = mapNotNull { (file, fileName) ->
+        episodeManager.findByUuid(fileName)?.let { episode -> file to episode }
     }
 
     private fun List<Pair<File, PodcastEpisode>>.deleteExistingFiles() = onEach { (_, episode) ->

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.kt
@@ -185,15 +185,11 @@ open class FileStorage @Inject constructor(
 
                 val oldCustomFilesDir = getOrCreateDir(oldPocketCastsDir, DIR_CUSTOM_EPISODES)
                 val newCustomFilesDir = getOrCreateDir(newPocketCastsDir, DIR_CUSTOM_EPISODES)
-                if (oldCustomFilesDir.exists()) {
-                    moveDir(oldCustomFilesDir, newCustomFilesDir)
-                }
+                moveDir(oldCustomFilesDir, newCustomFilesDir)
 
                 val oldNetworkImageDir = getOrCreateDir(oldPocketCastsDir, DIR_NETWORK_IMAGES)
                 val newNetworkImageDir = getOrCreateDir(newPocketCastsDir, DIR_NETWORK_IMAGES)
-                if (newNetworkImageDir.exists()) {
-                    moveDir(oldNetworkImageDir, newNetworkImageDir)
-                }
+                moveDir(oldNetworkImageDir, newNetworkImageDir)
             } else {
                 LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, "Old directory did not exist")
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.kt
@@ -68,12 +68,12 @@ open class FileStorage @Inject constructor(
     }
 
     private fun getOrCreateDir(parentDir: File, name: String): File = File(parentDir, name + File.separator).also { dir ->
-        createDir(dir)
+        dir.mkdirs()
         addNoMediaFile(dir)
     }
 
     fun getOrCreateStorageDir(): File? = getOrCreateBaseStorageDir()?.let { dir ->
-        File(dir, "PocketCasts" + File.separator).also(::createDir)
+        File(dir, "PocketCasts" + File.separator).also(File::mkdirs)
     }
 
     fun getOrCreateBaseStorageDir(): File? = settings.getStorageChoice()?.let(::getOrCreateBaseStorageDir)
@@ -91,8 +91,6 @@ open class FileStorage @Inject constructor(
     } else {
         File(choice)
     }
-
-    private fun createDir(dir: File): File = dir.also(File::mkdirs)
 
     private fun addNoMediaFile(dir: File) {
         if (!dir.exists()) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.kt
@@ -13,7 +13,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import java.io.IOException
 import javax.inject.Inject
-import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.filter
@@ -22,7 +21,6 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.reactive.asFlow
 import timber.log.Timber
 
-@Singleton
 open class FileStorage @Inject constructor(
     val settings: Settings,
     @ApplicationContext val context: Context,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -28,9 +28,6 @@ interface EpisodeManager {
     suspend fun findByUuid(uuid: String): PodcastEpisode?
 
     @Deprecated("Use findByUuid suspended function instead")
-    fun findByUuidSync(uuid: String): PodcastEpisode?
-
-    @Deprecated("Use findByUuid suspended function instead")
     fun findByUuidRx(uuid: String): Maybe<PodcastEpisode>
 
     fun observeByUuid(uuid: String): Flow<PodcastEpisode>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -91,10 +91,6 @@ class EpisodeManagerImpl @Inject constructor(
         episodeDao.findByUuid(uuid)
 
     @Deprecated("Use findByUuid suspended method instead")
-    override fun findByUuidSync(uuid: String): PodcastEpisode? =
-        episodeDao.findByUuidSync(uuid)
-
-    @Deprecated("Use findByUuid suspended method instead")
     override fun findByUuidRx(uuid: String): Maybe<PodcastEpisode> =
         episodeDao.findByUuidRx(uuid)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -592,7 +592,7 @@ class PodcastSyncProcess(
         return Completable.fromAction {
             val firstSync = settings.isFirstSyncRun()
             if (firstSync) {
-                fileStorage.fixBrokenFiles(episodeManager)
+                runBlocking { fileStorage.fixBrokenFiles(episodeManager) }
                 settings.setFirstSyncRun(false)
             }
         }


### PR DESCRIPTION
## Description

This is a follow-up to #1668. It improves migrated code. Some highlights:
* Long methods got separated into smaller named methods.
* Use suspending methods instead of deprecated sync methods to interact with `EpisodeManager`.
* `FileStorage` is no longer a singleton as it is not stateful.

## Testing Instructions

Generally, perform tests related to downloading podcasts. You should test this on devices pre and post Android 10. On Android 10+ you can simply test downloading, going into airplane mode, and checking if listening works as expected. On earlier Android versions you can check if you can move downloaded files between different storage choices. [This comment](https://github.com/Automattic/pocket-casts-android/pull/1668#pullrequestreview-1809946229) can be helpful with possible test scenarios.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
