### PR TITLE
Android14 - Specify foreground service types

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="com.android.vending.CHECK_LICENSE"/>
     <uses-permission android:name="com.android.vending.BILLING" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
@@ -519,6 +520,12 @@
         <service android:name="au.com.shiftyjelly.pocketcasts.repositories.sync.UpNextSyncJob"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="true"/>
+
+        <!-- Workers -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
 
         <receiver android:name="au.com.shiftyjelly.pocketcasts.repositories.playback.SleepTimerReceiver" />
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
@@ -1,8 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.repositories.download.task
 
 import android.content.Context
+import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
 import android.media.MediaExtractor
 import android.media.MediaFormat
+import android.os.Build
 import android.system.ErrnoException
 import android.system.OsConstants
 import android.util.Log
@@ -187,7 +189,15 @@ class DownloadEpisodeTask @AssistedInject constructor(
         val notification = downloadManager.getNotificationBuilder()
             .build()
 
-        return ForegroundInfo(NotificationId.DOWNLOADING.value, notification)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(
+                NotificationId.DOWNLOADING.value,
+                notification,
+                FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            )
+        } else {
+            ForegroundInfo(NotificationId.DOWNLOADING.value, notification)
+        }
     }
 
     private fun markAsRetry(e: Exception? = null) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
@@ -193,7 +193,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
             ForegroundInfo(
                 NotificationId.DOWNLOADING.value,
                 notification,
-                FOREGROUND_SERVICE_TYPE_DATA_SYNC
+                FOREGROUND_SERVICE_TYPE_DATA_SYNC,
             )
         } else {
             ForegroundInfo(NotificationId.DOWNLOADING.value, notification)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
@@ -3,7 +3,9 @@ package au.com.shiftyjelly.pocketcasts.repositories.opml
 import android.app.Notification
 import android.app.NotificationManager
 import android.content.Context
+import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
 import android.net.Uri
+import android.os.Build
 import android.widget.Toast
 import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
@@ -270,7 +272,15 @@ class OpmlImportTask @AssistedInject constructor(
      * Keep the job in the foreground with a notification
      */
     private fun createForegroundInfo(progress: Int, total: Int): ForegroundInfo {
-        return ForegroundInfo(Settings.NotificationId.OPML.value, buildNotification(progress, total))
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(
+                Settings.NotificationId.OPML.value,
+                buildNotification(progress, total),
+                FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            )
+        } else {
+            ForegroundInfo(Settings.NotificationId.OPML.value, buildNotification(progress, total))
+        }
     }
 
     private fun updateNotification(initialDatabaseCount: Int, podcastCount: Int) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
@@ -276,7 +276,7 @@ class OpmlImportTask @AssistedInject constructor(
             ForegroundInfo(
                 Settings.NotificationId.OPML.value,
                 buildNotification(progress, total),
-                FOREGROUND_SERVICE_TYPE_DATA_SYNC
+                FOREGROUND_SERVICE_TYPE_DATA_SYNC,
             )
         } else {
             ForegroundInfo(Settings.NotificationId.OPML.value, buildNotification(progress, total))


### PR DESCRIPTION
## Description

This PR specifies [foreground service types at runtime](https://developer.android.com/develop/background-work/background-tasks/persistent/how-to/long-running#specify-foreground-service-types-runtime) when calling `setForeground()` or `setForegroundAsync()` which is required if the app targets Android 14.

This is needed at two places, while
1. downloading episodes
2. importing OPML 

To get this working, I also had to [declare the foreground service type in the Android manifest](https://developer.android.com/develop/background-work/background-tasks/persistent/how-to/long-running#declare-foreground-service-types-manifest) for the long-running worker.

## Testing Instructions

Prerequisites: Change `targetSdkVersion` set to 34 in `dependencies.gradle.kts`

#### Test.1 - Download Episode

1. Install the app
2. Open any podcast -> episode
3. Tap `Download` button for the episode
4. ✅ Notice that the download task succeeds without any crash

** `setForegroundAsync(...)` is not called from `DownloadEpisodeTask` for the Wear OS app, so these changes do not apply to the Wear OS app.

```
if (!Util.isWearOs(context)) {
   setForegroundAsync(createForegroundInfo())
}
```

It would also be good to test the episode download on the Wear OS app.

#### Test.2 - Import OPML

1.  Install the app
2. Go to `Profile` -> `Settings` -> `Import & export OPML`
3. Tap `Save file` to export the OPML file to your storage
4. Tap `Select file` and import podcast from the OPML file saved above
6. ✅ Notice that OPML task succeeds without any crash

** Import/ export OPML feature is only available for phone app.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
