### PR TITLE
Add tests for FileUtil

### DIFF
--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/FileUtil.java
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/FileUtil.java
@@ -8,14 +8,11 @@ import android.net.Uri;
 
 import androidx.annotation.NonNull;
 import androidx.core.content.FileProvider;
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.util.List;
 import timber.log.Timber;
@@ -54,41 +51,6 @@ public class FileUtil {
         } catch (Exception e) {
             Timber.e("Could not delete directory: " + e.getMessage());
         }
-    }
-
-    public static final String readAssetToString(Context context, String filename) throws IOException {
-        BufferedReader reader = null;
-        try {
-            reader = new BufferedReader(new InputStreamReader(context.getAssets().open(filename)));
-            StringBuilder html = new StringBuilder();
-            String line;
-            String newLine = "\n";
-            while((line = reader.readLine()) != null) {
-                html.append(line).append(newLine);
-            }
-            return html.toString();
-        }
-        catch (IOException e) {
-            Timber.e(e);
-            return null;
-        }
-        finally {
-            try { if (reader != null) { reader.close(); } } catch(Exception e) {}
-        }
-    }
-
-    public static final String readFileToString(File file) throws IOException {
-        FileReader fileReader = new FileReader(file);
-        BufferedReader reader = new BufferedReader(fileReader);
-        String line;
-        StringBuilder output = new StringBuilder((int)file.length());
-        String newLine = "\n";
-        while((line = reader.readLine()) != null) {
-            output.append(line).append(newLine);
-        }
-        try { fileReader.close(); } catch(Exception e) {}
-        try { reader.close(); } catch(Exception e) {}
-        return output.toString();
     }
 
     public static void readFileTo(File file, OutputStream out) throws IOException {
@@ -151,16 +113,6 @@ public class FileUtil {
         else {
             copyFile(srcDir, dstDir);
         }
-    }
-
-    public static String getFileExtension(File file) {
-        String fileName = file.getName();
-        if (fileName == null || fileName.length() == 0) return null;
-
-        int dotIndex = fileName.lastIndexOf(".");
-        if (dotIndex < 0) return null; //no dot in file name
-
-        return fileName.substring(dotIndex);
     }
 
     public static String getFileNameWithoutExtension(File file) {

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -118,6 +118,29 @@ class FileUtilTest {
         assertEquals("Files contents differ", file1.snapshot(), file2.snapshot())
     }
 
+    @Test
+    fun `directory is copied using copy function`() {
+        val dir1 = tempDir.newFolder().apply {
+            File(this, "file1").writeRandomBytes(100)
+            File(this, "file2").writeRandomBytes(200)
+            val innerDir = File(this, "inner").also(File::mkdirs)
+            File(innerDir, "file3").writeRandomBytes(300)
+        }
+        val dir2 = tempDir.newFolder()
+
+        FileUtil.copy(dir1, dir2)
+
+        val comparisonPairs = listOf(
+            File(dir1, "file1") to File(dir2, "file1"),
+            File(dir1, "file2") to File(dir2, "file2"),
+            File(File(dir1, "inner"), "file3") to File(File(dir2, "inner"), "file3"),
+        )
+        comparisonPairs.forEach { (srcFile, dstFile) ->
+            assertFalse("Original file has no content", srcFile.snapshot().size == 0)
+            assertEquals("Files contents differ", srcFile.snapshot(), dstFile.snapshot())
+        }
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -106,6 +106,18 @@ class FileUtilTest {
         assertEquals("Files contents differ", file1.snapshot(), file2.snapshot())
     }
 
+    @Test
+    fun `file is copied using copyFile function`() {
+        val file1 = tempDir.newFile().also { it.writeRandomBytes(100) }
+        val file2 = tempDir.newFile()
+        val originalSnapshot = file1.snapshot()
+
+        FileUtil.copyFile(file1, file2)
+
+        assertEquals("Original file has different content", originalSnapshot, file1.snapshot())
+        assertEquals("Files contents differ", file1.snapshot(), file2.snapshot())
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -269,6 +269,15 @@ class FileUtilTest {
         assertEquals("hello", fileName)
     }
 
+    @Test
+    fun `get file name without extension for a directory with a single dot`() {
+        val dir = tempDir.newFolder("hello.there")
+
+        val dirName = FileUtil.getFileNameWithoutExtension(dir)
+
+        assertEquals("hello", dirName)
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -287,6 +287,15 @@ class FileUtilTest {
         assertEquals("hello.there.", dirName)
     }
 
+    @Test
+    fun `get directory name without extension for a directory with no dots`() {
+        val dir = tempDir.newFolder("hello")
+
+        val dirName = FileUtil.getFileNameWithoutExtension(dir)
+
+        assertEquals("hello", dirName)
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -141,6 +141,29 @@ class FileUtilTest {
         }
     }
 
+    @Test
+    fun `directory is copied using copyDirectory function`() {
+        val dir1 = tempDir.newFolder().apply {
+            File(this, "file1").writeRandomBytes(100)
+            File(this, "file2").writeRandomBytes(200)
+            val innerDir = File(this, "inner").also(File::mkdirs)
+            File(innerDir, "file3").writeRandomBytes(300)
+        }
+        val dir2 = tempDir.newFolder()
+
+        FileUtil.copyDirectory(dir1, dir2)
+
+        val comparisonPairs = listOf(
+                File(dir1, "file1") to File(dir2, "file1"),
+                File(dir1, "file2") to File(dir2, "file2"),
+                File(File(dir1, "inner"), "file3") to File(File(dir2, "inner"), "file3"),
+        )
+        comparisonPairs.forEach { (srcFile, dstFile) ->
+            assertFalse("Original file has no content", srcFile.snapshot().size == 0)
+            assertEquals("Files contents differ", srcFile.snapshot(), dstFile.snapshot())
+        }
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -278,6 +278,15 @@ class FileUtilTest {
         assertEquals("hello", dirName)
     }
 
+    @Test
+    fun `get directory name without extension for a directory with multiple dots`() {
+        val dir = tempDir.newFolder("hello.there..traveller")
+
+        val dirName = FileUtil.getFileNameWithoutExtension(dir)
+
+        assertEquals("hello.there.", dirName)
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -228,6 +228,20 @@ class FileUtilTest {
         assertEquals("$dir (Is a directory)", exception.message)
     }
 
+    @Test
+    fun `fail copying a directory to a file using copyDirectory function`() {
+        val file = tempDir.newFile()
+        val dir = tempDir.newFolder().apply {
+            File(this, "file").writeRandomBytes(100)
+        }
+
+        val exception = assertThrows(FileNotFoundException::class.java) {
+            FileUtil.copyDirectory(dir, file)
+        }
+
+        assertEquals("$file/file (Not a directory)", exception.message)
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -316,6 +316,17 @@ class FileUtilTest {
         assertEquals(0, size)
     }
 
+    @Test
+    fun `compute directory size with a non-empty file`() {
+        val dir = tempDir.newFolder().apply {
+            File(this, "file").writeRandomBytes(100)
+        }
+
+        val size = FileUtil.folderSize(dir)
+
+        assertEquals(100, size)
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.utils
 
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -14,6 +15,15 @@ class FileUtilTest {
 
         FileUtil.deleteFileByPath(file.path)
 
-        assertFalse("File $file is not deleted", file.exists())
+        assertFalse("File $file exists", file.exists())
+    }
+
+    @Test
+    fun `delete non existing file`() {
+        val file = tempDir.newFile()
+
+        FileUtil.deleteFileByPath(file.path + "test")
+
+        assertTrue("File $file does not exist", file.exists())
     }
 }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -327,6 +327,32 @@ class FileUtilTest {
         assertEquals(100, size)
     }
 
+    @Test
+    fun `compute directory size with complex structure`() {
+        val dir = tempDir.newFolder().apply {
+            File(this, "file1").writeRandomBytes(1)
+            File(this, "file2").writeRandomBytes(10)
+
+            File(this, "inner1").also(File::mkdirs).apply {
+                File(this, "file3").writeRandomBytes(100)
+
+                File(this, "inner2").also(File::mkdirs).apply {
+                    File(this, "file4").writeRandomBytes(1000)
+                    File(this, "file5").writeRandomBytes(10000)
+                }
+            }
+
+            File(this, "inner3").also(File::mkdirs).apply {
+                File(this, "file6").writeRandomBytes(100000)
+                File(this, "file7").writeRandomBytes(1000000)
+            }
+        }
+
+        val size = FileUtil.folderSize(dir)
+
+        assertEquals(1111111, size)
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.utils
 import java.io.File
 import kotlin.random.Random
 import okio.Buffer
-import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import okio.buffer
 import okio.sink
@@ -93,6 +92,18 @@ class FileUtilTest {
         FileUtil.readFileTo(file, Buffer().outputStream())
 
         assertEquals("Original file content was changed", originalSnapshot, file.snapshot())
+    }
+
+    @Test
+    fun `file is copied using copy function`() {
+        val file1 = tempDir.newFile().also { it.writeRandomBytes(100) }
+        val file2 = tempDir.newFile()
+        val originalSnapshot = file1.snapshot()
+
+        FileUtil.copy(file1, file2)
+
+        assertEquals("Original file has different content", originalSnapshot, file1.snapshot())
+        assertEquals("Files contents differ", file1.snapshot(), file2.snapshot())
     }
 
     private fun File.writeRandomBytes(count: Int) {

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -305,6 +305,17 @@ class FileUtilTest {
         assertEquals(0, size)
     }
 
+    @Test
+    fun `compute directory size with an empty file`() {
+        val dir = tempDir.newFolder().apply {
+            File(this, "file").also(File::createNewFile)
+        }
+
+        val size = FileUtil.folderSize(dir)
+
+        assertEquals(0, size)
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -260,6 +260,15 @@ class FileUtilTest {
         assertEquals("hello.there.", fileName)
     }
 
+    @Test
+    fun `get file name without extension for a file with no dots`() {
+        val file = tempDir.newFile("hello")
+
+        val fileName = FileUtil.getFileNameWithoutExtension(file)
+
+        assertEquals("hello", fileName)
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -353,6 +353,16 @@ class FileUtilTest {
         assertEquals(1111111, size)
     }
 
+    @Test
+    fun `do not compute size of a file`() {
+        val file = tempDir.newFile()
+        file.writeRandomBytes(1024)
+
+        val size = FileUtil.folderSize(file)
+
+        assertEquals(0, size)
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -190,6 +190,18 @@ class FileUtilTest {
         assertEquals("$dir (Is a directory)", exception.message)
     }
 
+    @Test
+    fun `fail copying file to a directory using copyDirectory function`() {
+        val file = tempDir.newFile()
+        val dir = tempDir.newFolder()
+
+        val exception = assertThrows(FileNotFoundException::class.java) {
+            FileUtil.copyDirectory(file, dir)
+        }
+
+        assertEquals("$dir (Is a directory)", exception.message)
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -216,6 +216,18 @@ class FileUtilTest {
         assertEquals("$file/file (Not a directory)", exception.message)
     }
 
+    @Test
+    fun `fail copying directory to a file using copyFile function`() {
+        val file = tempDir.newFile()
+        val dir = tempDir.newFolder()
+
+        val exception = assertThrows(FileNotFoundException::class.java) {
+            FileUtil.copyFile(dir, file)
+        }
+
+        assertEquals("$dir (Is a directory)", exception.message)
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -178,6 +178,18 @@ class FileUtilTest {
         assertEquals("$dir (Is a directory)", exception.message)
     }
 
+    @Test
+    fun `fail copying file to a directory using copyFile function`() {
+        val file = tempDir.newFile()
+        val dir = tempDir.newFolder()
+
+        val exception = assertThrows(FileNotFoundException::class.java) {
+            FileUtil.copyFile(file, dir)
+        }
+
+        assertEquals("$dir (Is a directory)", exception.message)
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -296,6 +296,15 @@ class FileUtilTest {
         assertEquals("hello", dirName)
     }
 
+    @Test
+    fun `compute empty directory size`() {
+        val dir = tempDir.newFolder()
+
+        val size = FileUtil.folderSize(dir)
+
+        assertEquals(0, size)
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -242,6 +242,15 @@ class FileUtilTest {
         assertEquals("$file/file (Not a directory)", exception.message)
     }
 
+    @Test
+    fun `get file name without extension for a file with a single dot`() {
+        val file = tempDir.newFile("hello.there")
+
+        val fileName = FileUtil.getFileNameWithoutExtension(file)
+
+        assertEquals("hello", fileName)
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -85,6 +85,16 @@ class FileUtilTest {
         assertEquals("File and output stream have different contents", file.snapshot(), outputBuffer.snapshot())
     }
 
+    @Test
+    fun `reading file to output stream does not delete file content`() {
+        val file = tempDir.newFile().also { it.writeRandomBytes(1024) }
+        val originalSnapshot = file.snapshot()
+
+        FileUtil.readFileTo(file, Buffer().outputStream())
+
+        assertEquals("Original file content was changed", originalSnapshot, file.snapshot())
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -53,4 +53,18 @@ class FileUtilTest {
             assertTrue("nomedia file $file does not exist", file.exists())
         }
     }
+
+    @Test
+    fun `delete files with nomedia extension when deleting directory contests`() {
+        val dir = tempDir.newFolder()
+        val contents = listOf(
+            File(dir, "test1.nomedia").also(File::createNewFile),
+            File(dir, "test2.nomedia").also(File::createNewFile),
+            File(dir, "test3.nomedia").also(File::createNewFile),
+        )
+
+        FileUtil.deleteDirectoryContents(dir.path)
+
+        assertFalse("At least one file still exists", contents.any(File::exists))
+    }
 }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -156,9 +156,9 @@ class FileUtilTest {
         FileUtil.copyDirectory(dir1, dir2)
 
         val comparisonPairs = listOf(
-                File(dir1, "file1") to File(dir2, "file1"),
-                File(dir1, "file2") to File(dir2, "file2"),
-                File(File(dir1, "inner"), "file3") to File(File(dir2, "inner"), "file3"),
+            File(dir1, "file1") to File(dir2, "file1"),
+            File(dir1, "file2") to File(dir2, "file2"),
+            File(File(dir1, "inner"), "file3") to File(File(dir2, "inner"), "file3"),
         )
         comparisonPairs.forEach { (srcFile, dstFile) ->
             assertFalse("Original file has no content", srcFile.snapshot().size == 0)
@@ -200,6 +200,20 @@ class FileUtilTest {
         }
 
         assertEquals("$dir (Is a directory)", exception.message)
+    }
+
+    @Test
+    fun `fail copying directory to a file using copy function`() {
+        val file = tempDir.newFile()
+        val dir = tempDir.newFolder().apply {
+            File(this, "file").writeRandomBytes(100)
+        }
+
+        val exception = assertThrows(FileNotFoundException::class.java) {
+            FileUtil.copy(dir, file)
+        }
+
+        assertEquals("$file/file (Not a directory)", exception.message)
     }
 
     private fun File.writeRandomBytes(count: Int) {

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -1,0 +1,19 @@
+package au.com.shiftyjelly.pocketcasts.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class FileUtilTest {
+    @get:Rule val tempDir = TemporaryFolder()
+
+    @Test
+    fun `delete existing file`() {
+        val file = tempDir.newFile()
+
+        FileUtil.deleteFileByPath(file.path)
+
+        assertFalse("File $file is not deleted", file.exists())
+    }
+}

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -41,4 +41,16 @@ class FileUtilTest {
 
         assertFalse("At least one file still exists", contents.any(File::exists))
     }
+
+    @Test
+    fun `keep nomedia file when deleting directory contents`() {
+        listOf(".nomedia", ".NOMEDIA", ".nOmEdIa").forEach { name ->
+            val dir = tempDir.newFolder()
+            val file = File(dir, name).also(File::createNewFile)
+
+            FileUtil.deleteDirectoryContents(dir.path)
+
+            assertTrue("nomedia file $file does not exist", file.exists())
+        }
+    }
 }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -251,6 +251,15 @@ class FileUtilTest {
         assertEquals("hello", fileName)
     }
 
+    @Test
+    fun `get file name without extension for a file with multiple dots`() {
+        val file = tempDir.newFile("hello.there..traveller")
+
+        val fileName = FileUtil.getFileNameWithoutExtension(file)
+
+        assertEquals("hello.there.", fileName)
+    }
+
     private fun File.writeRandomBytes(count: Int) {
         sink().buffer().use { it.write(Random.nextBytes(count)) }
     }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.utils
 
+import java.io.File
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -25,5 +26,19 @@ class FileUtilTest {
         FileUtil.deleteFileByPath(file.path + "test")
 
         assertTrue("File $file does not exist", file.exists())
+    }
+
+    @Test
+    fun `delete directory contents`() {
+        val dir = tempDir.newFolder()
+        val contents = listOf(
+            File(dir, "test1").also(File::createNewFile),
+            File(dir, "test2").also(File::createNewFile),
+            File(dir, "test3").also(File::createNewFile),
+        )
+
+        FileUtil.deleteDirectoryContents(dir.path)
+
+        assertFalse("At least one file still exists", contents.any(File::exists))
     }
 }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -1,6 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.utils
 
 import java.io.File
+import kotlin.random.Random
+import okio.Buffer
+import okio.ByteString
+import okio.ByteString.Companion.toByteString
+import okio.buffer
+import okio.sink
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -67,4 +74,20 @@ class FileUtilTest {
 
         assertFalse("At least one file still exists", contents.any(File::exists))
     }
+
+    @Test
+    fun `read file to output stream`() {
+        val file = tempDir.newFile().also { it.writeRandomBytes(1024) }
+        val outputBuffer = Buffer()
+
+        FileUtil.readFileTo(file, outputBuffer.outputStream())
+
+        assertEquals("File and output stream have different contents", file.snapshot(), outputBuffer.snapshot())
+    }
+
+    private fun File.writeRandomBytes(count: Int) {
+        sink().buffer().use { it.write(Random.nextBytes(count)) }
+    }
+
+    private fun File.snapshot() = readBytes().toByteString()
 }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/FileUtilTest.kt
@@ -4,10 +4,12 @@ import java.io.File
 import kotlin.random.Random
 import okio.Buffer
 import okio.ByteString.Companion.toByteString
+import okio.FileNotFoundException
 import okio.buffer
 import okio.sink
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -162,6 +164,18 @@ class FileUtilTest {
             assertFalse("Original file has no content", srcFile.snapshot().size == 0)
             assertEquals("Files contents differ", srcFile.snapshot(), dstFile.snapshot())
         }
+    }
+
+    @Test
+    fun `fail copying file to a directory using copy function`() {
+        val file = tempDir.newFile()
+        val dir = tempDir.newFolder()
+
+        val exception = assertThrows(FileNotFoundException::class.java) {
+            FileUtil.copy(file, dir)
+        }
+
+        assertEquals("$dir (Is a directory)", exception.message)
     }
 
     private fun File.writeRandomBytes(count: Int) {


### PR DESCRIPTION
## Description

This is a preparation PR for migrating [`FileUtil`](https://github.com/Automattic/pocket-casts-android/blob/61fe9bf02411dbb158ec838d2fc4834099e99a4b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/FileUtil.java) from Java to Kotlin. Since it is a utility class that is used in multiple areas of code I find it will be easier to verify correctness through automated tests rather than through manual checking of every possible functionality that uses this code.

Some tests seem a bit redundant like `copy()`/`copyFile()`/`copyDirectory()` but I did it to make migration easier. In the migration PR I'll probably make some of these function private and delete tests for them while also migrating code using it to use only a single `copy()` function.

I didn't test for nullability because at quick glace I can ignore it as Kotlin code already uses non null parameters. And if it doesn't I'll make it work using `?.` operator. I also didn't test Android specific stuff related to `Uri`. Since it is permission related and code is quite simple I'll just `go for it`™ during the migration.

## Testing Instructions

Code review my changes.

## Screenshots or Screencast 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
