### PR TITLE
Revert "Remove Gradle Wrapper Validation GitHub workflow"

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,10 @@
+name: "Validate Gradle Wrapper"
+on: [push, pull_request]
+
+jobs:
+  validation:
+    name: "Validation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
This reverts https://github.com/Automattic/pocket-casts-android/pull/1683.

At first, the Gradle Wrapper Validation check in both Buildkite and GitHub Actions seemed redundant, specially given GHAs were completely disabled for this repo. But comparing to other repos and discussing with the team, we consider a good idea to have this additional safety layer.

So this PR will add back the Gradle Wrapper Validation, now with the proper Actions configuration.

### Testing
Just make sure CI is green and the Gradle Wrapper Validation workflow runs successfully on GitHub Actions as well.