### PR TITLE
Adjust GitHub workflow reference to use Dangermattic's main branch

### DIFF
--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   dangermattic:
-    uses: Automattic/dangermattic/.github/workflows/reusable-run-danger.yml@iangmaia/danger-on-gha
+    uses: Automattic/dangermattic/.github/workflows/reusable-run-danger.yml@trunk
     secrets:
       github-token: ${{ secrets.DANGERMATTIC_GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Following up on https://github.com/Automattic/pocket-casts-android/pull/1667, this PR adjusts the GitHub workflow reference to use Dangermattic's main branch.