### PR TITLE
Add remaining named settings that currently sync to new named settings sync call

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -26,7 +26,6 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.FileImageUploadData
 import au.com.shiftyjelly.pocketcasts.servers.sync.FilePost
 import au.com.shiftyjelly.pocketcasts.servers.sync.FilesResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.NamedSettingsCaller
-import au.com.shiftyjelly.pocketcasts.servers.sync.NamedSettingsRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.NamedSettingsResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.PodcastEpisodesResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.PodcastListResponse
@@ -397,10 +396,13 @@ class SyncManagerImpl @Inject constructor(
             syncServerManager.loadStats(token)
         }
 
-    override suspend fun namedSettings(request: NamedSettingsRequest): NamedSettingsResponse =
-        getCacheTokenOrLogin { token ->
-            syncServerManager.namedSettings(request, token)
-        }
+    @Suppress("DEPRECATION")
+    @Deprecated("This method can be removed when the sync settings feature flag is removed")
+    override suspend fun namedSettings(
+        request: au.com.shiftyjelly.pocketcasts.servers.sync.NamedSettingsRequest,
+    ): NamedSettingsResponse = getCacheTokenOrLogin { token ->
+        syncServerManager.namedSettings(request, token)
+    }
 
     override suspend fun changedNamedSettings(request: ChangedNamedSettingsRequest): ChangedNamedSettingsResponse =
         getCacheTokenOrLogin { token ->

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -6,6 +6,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
+@Deprecated("This class can be removed when the sync settings feature flag is removed")
 data class NamedSettingsSettings(
     @field:Json(name = "skipForward") val skipForward: Int? = null,
     @field:Json(name = "skipBack") val skipBack: Int? = null,
@@ -25,6 +26,8 @@ data class NamedChangedSettingInt(
     @field:Json(name = "modified_at") val modifiedAt: String,
 )
 
+@Suppress("DEPRECATION")
+@Deprecated("This class can be removed when the sync settings feature flag is removed")
 @JsonClass(generateAdapter = true)
 data class NamedSettingsRequest(
     @field:Json(name = "m") val m: String = "Android",
@@ -62,6 +65,9 @@ data class ChangedSettingResponse(
 )
 
 interface NamedSettingsCaller {
-    suspend fun namedSettings(request: NamedSettingsRequest): NamedSettingsResponse
+    @Deprecated("This method can be removed when the sync settings feature flag is removed")
+    suspend fun namedSettings(
+        @Suppress("DEPRECATION") request: NamedSettingsRequest,
+    ): NamedSettingsResponse
     suspend fun changedNamedSettings(request: ChangedNamedSettingsRequest): ChangedNamedSettingsResponse
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -18,11 +18,21 @@ data class NamedSettingsSettings(
 @JsonClass(generateAdapter = true)
 data class ChangedNamedSettings(
     @field:Json(name = "skipForward") val skipForward: NamedChangedSettingInt? = null,
+    @field:Json(name = "skipBack") val skipBack: NamedChangedSettingInt? = null,
+    @field:Json(name = "gridOrder") val gridOrder: NamedChangedSettingInt? = null,
+    @field:Json(name = "marketingOptIn") val marketingOptIn: NamedChangedSettingBool? = null,
+    @field:Json(name = "freeGiftAcknowledgement") val freeGiftAcknowledgement: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)
 data class NamedChangedSettingInt(
     @field:Json(name = "value") val value: Int,
+    @field:Json(name = "modified_at") val modifiedAt: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class NamedChangedSettingBool(
+    @field:Json(name = "value") val value: Boolean,
     @field:Json(name = "modified_at") val modifiedAt: String,
 )
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServer.kt
@@ -61,6 +61,8 @@ interface SyncServer {
     suspend fun updatePassword(@Header("Authorization") authorization: String, @Body request: UpdatePasswordRequest): LoginTokenResponse
 
     @POST("/user/named_settings/update")
+    @Suppress("DEPRECATION")
+    @Deprecated("This method can be removed when the sync settings feature flag is removed")
     suspend fun namedSettings(@Header("Authorization") authorization: String, @Body request: NamedSettingsRequest): NamedSettingsResponse
 
     @POST("/user/named_settings/update")

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
@@ -116,6 +116,8 @@ open class SyncServerManager @Inject constructor(
     fun validatePromoCode(code: String): Single<PromoCodeResponse> =
         server.validatePromoCode(PromoCodeRequest(code))
 
+    @Suppress("DEPRECATION")
+    @Deprecated("This method can be removed when the sync settings feature flag is removed")
     suspend fun namedSettings(request: NamedSettingsRequest, token: AccessToken): NamedSettingsResponse =
         server.namedSettings(addBearer(token), request)
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -54,17 +54,57 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 return
             }
 
-            val request = ChangedNamedSettingsRequest(
-                changedSettings = ChangedNamedSettings(
-                    skipForward = settings.skipForwardInSecs.getSyncSetting(::NamedChangedSettingInt),
-                ),
-            )
+            val request = changedNamedSettingsRequest(settings)
             val response = namedSettingsCall.changedNamedSettings(request)
-            for ((key, value) in response) {
+            processChangedNameSettingsResponse(response, settings)
+        }
+
+        private fun changedNamedSettingsRequest(settings: Settings) = ChangedNamedSettingsRequest(
+            changedSettings = ChangedNamedSettings(
+                skipForward = settings.skipForwardInSecs.getSyncSetting(::NamedChangedSettingInt),
+                skipBack = settings.skipBackInSecs.getSyncSetting(::NamedChangedSettingInt),
+                gridOrder = settings.podcastsSortType.getSyncSetting { podcastSortType, modifiedAt ->
+                    NamedChangedSettingInt(
+                        value = podcastSortType.serverId,
+                        modifiedAt = modifiedAt,
+                    )
+                },
+                marketingOptIn = settings.marketingOptIn.getSyncSetting(::NamedChangedSettingBool),
+                freeGiftAcknowledgement = settings.freeGiftAcknowledged.getSyncSetting(::NamedChangedSettingBool),
+            ),
+        )
+
+        private fun processChangedNameSettingsResponse(response: ChangedNamedSettingsResponse, settings: Settings) {
+            for ((key, changedSettingResponse) in response) {
                 when (key) {
-                    "skipForward" -> updateSettingIfPossible(value, settings.skipForwardInSecs) {
-                        (it.value as? Number)?.toInt()
-                    }
+                    "skipForward" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.skipForwardInSecs,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt(),
+                    )
+                    "skipBack" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.skipBackInSecs,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt(),
+                    )
+                    "gridOrder" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.podcastsSortType,
+                        newSettingValue = run {
+                            val serverId = (changedSettingResponse.value as? Number)?.toInt()
+                            PodcastsSortType.fromServerId(serverId)
+                        },
+                    )
+                    "marketingOptIn" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.marketingOptIn,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "freeGiftAcknowledgement" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.freeGiftAcknowledged,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
                 }
             }
         }
@@ -72,10 +112,9 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
         private fun <T> updateSettingIfPossible(
             changedSettingResponse: ChangedSettingResponse,
             setting: UserSetting<T>,
-            transformToValue: (ChangedSettingResponse) -> T?,
+            newSettingValue: T?,
         ) {
-            val value = transformToValue(changedSettingResponse)
-            if (value == null) {
+            if (newSettingValue == null) {
                 LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Invalid ${setting.sharedPrefKey} value: ${changedSettingResponse.value}")
                 return
             }
@@ -104,7 +143,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
             }
 
             setting.set(
-                value = value,
+                value = newSettingValue,
                 needsSync = false,
             )
         }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -97,9 +97,9 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
 
             val localModifiedAt = setting.getModifiedAt()
             // Don't exit early if we don't have a local modifiedAt time since
-            // we don't know the local value is newew than the server value.
+            // we don't know the local value is newer than the server value.
             if (localModifiedAt != null && localModifiedAt.isAfter(serverModifiedAtInstant)) {
-                Timber.i("Not syncing ${setting.sharedPrefKey} from the server because setting was modified more recently locally")
+                Timber.i("Not syncing ${setting.sharedPrefKey} value of $newSettingValue from the server because setting was modified more recently locally")
                 return
             }
 
@@ -109,6 +109,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
             )
         }
 
+        @Suppress("DEPRECATION")
         @Deprecated("This can be removed when Feature.SETTINGS_SYNC flag is removed")
         private suspend fun oldSyncSettings(
             settings: Settings,


### PR DESCRIPTION
## Description
This PR builds on https://github.com/Automattic/pocket-casts-android/pull/1690. That PR added the first named setting to sync using the new call, and this PR adds the remaining named settings that are currently being synced with the new call. With this change, the app is syncing the same data regardless of whether the sync setting feature flag is turned on or off.

This also adds a few more deprecation annotations for methods that we can remove when we remove the feature flag for this feature.

## Testing Instructions

For all these tests you will need to:
1. Install the app on two devices
2. Log into the same Pocket Casts account on both devices
3.  Turn on sync settings under Profile → ⚙️ → Beta features → Settings Sync

### 1. Skip back setting

1. Device 1: go to Profile → ⚙️ → General, and update the skip back time to a new value
2. Device 1: tap the refresh button on the profile screen
3. Device 2: tap the refresh button on the profile screen
4. Device 2: verify that the skip back time on this device is the new value you set on device 1

### 2. Newsletter

1. Device 1: go to Profile → Account, and tap switch the "Pocket Casts newsletter" toggle.
2. Device 1: tap the refresh button on the profile screen
3. Device 2: tap the refresh button on the profile screen
4. Device 2: verify that the newsletter toggle has the new value you set on device 1

### 3. Podcast sort

1. Device 1: Go to the podcast tab and tap on the three-dot overflow menu button
2. Device 1: Change how the podcasts are sorted
3. Device 1: tap the refresh button on the profile screen
4. Device 2: tap the refresh button on the profile screen
5. Device 2: go to the podcast tab, tap the three-dot overflow menu, and confirm the sort type is the new value you set on device 1

### 4. Free gift acknowledgement

I don't know a good way to test this without code changes, so this test requires a special build of the app that includes an added call to

``` kotlin
settings.freeGiftAcknowledged.set(value = [true/false], needsSync = true)
```

in `PocketCastApplication::onCreate`.

1. Device 1: Install a build of the app that sets freeGiftAcknowledged to --true-- in `PocketCastsApplication::onCreate` by adding the above line of code
2. Device 2: Install a build of the app that sets freeGiftAcknowledged to --false-- in `PocketCastsApplication::onCreate` by adding the above line of code
3. Device 1: force stop the app and reopen the app
4. Device 2: Wait a few seconds, force stop the app, and reopen the app
6. Device 2: Tap the refresh button on the profile screen
7. Device 2: Confirm that the device logs show a request to `/named_settings/update` that includes `changed_settings: { "freeGiftAcknowledgement": {"value": false, "modified_at": "2024-XX-XXTXX..."}`.
8. Device 1: Tap the refresh button on the profile screen
9. Device 1: Confirm that the device logs show a request to `/named_settings/update` that includes `changed_settings: { "freeGiftAcknowledgement": {"value": true, "modified_at": "2024-XX-XXTXX..."}`
10. Device 1: Confirm that the device logs show the response from the `/named_settings/update` call includes the `freeGiftAcknowledgement` setting with a `value` of `false`.
11. Device 1: Force stop the app, reopen the app, and tap refresh
12. Device 1: Confirm that the device logs show a call to `/named_settings/update` that includes `changed_settings: { "freeGiftAcknowledgement": {"value": true, "modified_at": "2024-XX-XXTXX..."}`
13. Device 2: Tap the refresh button
14. Device 2: Confirm that the device logs show the response from the `/named_settings/update` call includes the `freeGiftAcknowledgement` setting with a `value` of `true`.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews