### PR TITLE
Update Bookmarks Plus benefits

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
@@ -24,7 +24,7 @@ enum class PlusUpgradeFeatureItem(
     ),
     Folders(
         image = IR.drawable.ic_folders,
-        title = LR.string.onboarding_plus_feature_folders_title,
+        title = LR.string.onboarding_plus_feature_folders_and_bookmarks_title,
     ),
     CloudStorage(
         image = IR.drawable.ic_cloud_storage,

--- a/modules/services/localization/src/main/res/values-ar/strings.xml
+++ b/modules/services/localization/src/main/res/values-ar/strings.xml
@@ -272,7 +272,7 @@ Language: ar
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">كل شيء تحبه بشأن Pocket Casts، إلى جانب المزيد</string>
     <string name="onboarding_plus_feature_desktop_apps_title">تطبيقات سطح المكتب</string>
     <string name="onboarding_plus_feature_desktop_apps_text">يمكنك الاستماع في مزيد من الأماكن من خلال تطبيقاتنا التي تعمل بنظامَي التشغيل Windows وmacOS وتطبيقات الويب.</string>
-    <string name="onboarding_plus_feature_folders_title">المجلدات</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">المجلدات</string>
     <string name="onboarding_plus_feature_folders_text">يمكنك تنظيم حلقات البودكاست الخاصة بك في المجلدات وحافظ عليها قيد المزامنة عبر كل أجهزتك.</string>
     <string name="onboarding_plus_feature_cloud_storage_text">ارفع ملفاتك إلى مساحة التخزين على السحابة واجعلها متوافرة في كل مكان.</string>
     <string name="onboarding_plus_feature_themes_icons_title">القوالب والأيقونات</string>

--- a/modules/services/localization/src/main/res/values-de/strings.xml
+++ b/modules/services/localization/src/main/res/values-de/strings.xml
@@ -334,7 +334,7 @@ Language: de
     <string name="onboarding_plus_feature_cloud_storage_text">Lade deine Dateien in den Cloud-Speicher. Dann kannst du von überall aus darauf zugreifen.</string>
     <string name="onboarding_plus_feature_cloud_storage_title">20 GB Cloud-Speicher</string>
     <string name="onboarding_plus_feature_folders_text">Verwalte deine Podcasts in Ordnern und halte sie auf all deinen Geräten synchron.</string>
-    <string name="onboarding_plus_feature_folders_title">Ordner</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">Ordner</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Mit unseren Windows-, macOS- und Web-Apps kannst du deine Inhalte auf beliebigen Geräten anhören.</string>
     <string name="onboarding_plus_feature_desktop_apps_title">Desktop-Apps</string>
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">Alles, was du an Pocket Casts liebst, und noch viel mehr</string>

--- a/modules/services/localization/src/main/res/values-en-rGB/strings.xml
+++ b/modules/services/localization/src/main/res/values-en-rGB/strings.xml
@@ -279,7 +279,7 @@ Language: en_GB
     <string name="plus_trial_duration_free_trial">%s free trial</string>
     <string name="end_of_year_stories_failed">Unable to load your end of year stories, check your internet connection.</string>
     <string name="onboarding_plus_feature_folders_text">Organise your podcasts in folders and keep them in sync across all your devices.</string>
-    <string name="onboarding_plus_feature_folders_title">Folders</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">Folders</string>
     <string name="onboarding_plus_feature_themes_icons_text">Fly your true colours. Exclusive icons and themes for the Plus club only.</string>
     <string name="onboarding_plus_feature_themes_icons_title">Themes &amp; Icons</string>
     <string name="onboarding_plus_feature_cloud_storage_text">Upload your files to cloud storage and have them available everywhere.</string>

--- a/modules/services/localization/src/main/res/values-es-rMX/strings.xml
+++ b/modules/services/localization/src/main/res/values-es-rMX/strings.xml
@@ -334,7 +334,7 @@ Language: es
     <string name="onboarding_plus_feature_cloud_storage_text">Carga tus archivos en el almacenamiento en la nube para que estén disponibles desde cualquier lugar.</string>
     <string name="onboarding_plus_feature_cloud_storage_title">Almacenamiento en la nube de 20 GB</string>
     <string name="onboarding_plus_feature_folders_text">Organiza tus pódcast en carpetas y mantenlos sincronizados en todos tus dispositivos.</string>
-    <string name="onboarding_plus_feature_folders_title">Carpetas</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">Carpetas</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Escucha pódcast en más lugares con nuestras aplicaciones para Windows, macOs y web.</string>
     <string name="onboarding_plus_feature_desktop_apps_title">Aplicaciones para ordenador</string>
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">Todo lo que te encanta de Pocket Casts y mucho más</string>

--- a/modules/services/localization/src/main/res/values-es/strings.xml
+++ b/modules/services/localization/src/main/res/values-es/strings.xml
@@ -334,7 +334,7 @@ Language: es
     <string name="onboarding_plus_feature_cloud_storage_text">Carga tus archivos en el almacenamiento en la nube para que estén disponibles desde cualquier lugar.</string>
     <string name="onboarding_plus_feature_cloud_storage_title">Almacenamiento en la nube de 20 GB</string>
     <string name="onboarding_plus_feature_folders_text">Organiza tus pódcast en carpetas y mantenlos sincronizados en todos tus dispositivos.</string>
-    <string name="onboarding_plus_feature_folders_title">Carpetas</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">Carpetas</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Escucha pódcast en más lugares con nuestras aplicaciones para Windows, macOs y web.</string>
     <string name="onboarding_plus_feature_desktop_apps_title">Aplicaciones para ordenador</string>
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">Todo lo que te encanta de Pocket Casts y mucho más</string>

--- a/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
@@ -334,7 +334,7 @@ Language: fr
     <string name="onboarding_plus_feature_cloud_storage_text">Chargez vos fichiers dans le stockage Cloud afin de pouvoir y accéder n’importe où.</string>
     <string name="onboarding_plus_feature_cloud_storage_title">20 Go de stockage Cloud</string>
     <string name="onboarding_plus_feature_folders_text">Organisez vos podcasts dans des dossiers et synchronisez-les sur tous vos appareils.</string>
-    <string name="onboarding_plus_feature_folders_title">Dossiers</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">Dossiers</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Écoutez vos podcasts partout grâce à nos applications Windows, macOS et Web.</string>
     <string name="onboarding_plus_feature_desktop_apps_title">Applications de bureau</string>
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">Tout ce que vous aimez chez Pocket Casts, et bien plus encore</string>

--- a/modules/services/localization/src/main/res/values-fr/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr/strings.xml
@@ -334,7 +334,7 @@ Language: fr
     <string name="onboarding_plus_feature_cloud_storage_text">Chargez vos fichiers dans le stockage Cloud afin de pouvoir y accéder n’importe où.</string>
     <string name="onboarding_plus_feature_cloud_storage_title">20 Go de stockage Cloud</string>
     <string name="onboarding_plus_feature_folders_text">Organisez vos podcasts dans des dossiers et synchronisez-les sur tous vos appareils.</string>
-    <string name="onboarding_plus_feature_folders_title">Dossiers</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">Dossiers</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Écoutez vos podcasts partout grâce à nos applications Windows, macOS et Web.</string>
     <string name="onboarding_plus_feature_desktop_apps_title">Applications de bureau</string>
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">Tout ce que vous aimez chez Pocket Casts, et bien plus encore</string>

--- a/modules/services/localization/src/main/res/values-it/strings.xml
+++ b/modules/services/localization/src/main/res/values-it/strings.xml
@@ -334,7 +334,7 @@ Language: it
     <string name="onboarding_plus_feature_cloud_storage_text">Carica i tuoi file sull\'archiviazione su cloud e rendili disponibili per qualsiasi postazione.</string>
     <string name="onboarding_plus_feature_cloud_storage_title">20 GB di archiviazione su cloud</string>
     <string name="onboarding_plus_feature_folders_text">Organizza i tuoi podcast in cartelle e sincronizzali su tutti i dispositivi.</string>
-    <string name="onboarding_plus_feature_folders_title">Cartelle</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">Cartelle</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Ascolta da più postazioni con le app per Windows, macOS e web.</string>
     <string name="onboarding_plus_feature_desktop_apps_title">App per desktop</string>
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">Tutto ciò che ti piace di Pocket Casts e molto altro</string>

--- a/modules/services/localization/src/main/res/values-ja/strings.xml
+++ b/modules/services/localization/src/main/res/values-ja/strings.xml
@@ -334,7 +334,7 @@ Language: ja_JP
     <string name="onboarding_plus_feature_cloud_storage_text">ファイルをクラウドストレージにアップロードしてどこからでも利用できるようにします。</string>
     <string name="onboarding_plus_feature_cloud_storage_title">20GB のクラウドストレージ</string>
     <string name="onboarding_plus_feature_folders_text">ポッドキャストをフォルダーに整理し、すべてのデバイス間で同期させます。</string>
-    <string name="onboarding_plus_feature_folders_title">フォルダー</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">フォルダー</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Pocket Casts の Windows 版、macOS 版、ウェブ版アプリでさらに多くの場所で聞きましょう。</string>
     <string name="onboarding_plus_feature_desktop_apps_title">デスクトップアプリ</string>
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">お気に入りの Pocket Casts の機能に加え、さらなる機能を利用できます</string>

--- a/modules/services/localization/src/main/res/values-ko/strings.xml
+++ b/modules/services/localization/src/main/res/values-ko/strings.xml
@@ -334,7 +334,7 @@ Language: ko_KR
     <string name="onboarding_plus_feature_cloud_storage_text">파일을 클라우드 저장 공간으로 업로드하고 어디에서나 사용할 수 있습니다.</string>
     <string name="onboarding_plus_feature_cloud_storage_title">클라우드 저장 공간 20GB</string>
     <string name="onboarding_plus_feature_folders_text">팟캐스트를 폴더로 정리하고 모든 기기에서 동기화 상태를 유지하세요.</string>
-    <string name="onboarding_plus_feature_folders_title">폴더</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">폴더</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Windows, macOS 및 웹 앱으로 더 많은 곳에서 청취하세요.</string>
     <string name="onboarding_plus_feature_desktop_apps_title">데스크톱 앱</string>
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">Pocket Casts에 대해 좋아하는 모든 것 이상</string>

--- a/modules/services/localization/src/main/res/values-nb/strings.xml
+++ b/modules/services/localization/src/main/res/values-nb/strings.xml
@@ -271,7 +271,7 @@ Language: nb_NO
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">Alt du liker med Pocket Casts, pluss mye mer</string>
     <string name="onboarding_plus_feature_desktop_apps_title">Skrivebordsapper</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Lytt på flere steder med appene våre for Windows, macOS og nett.</string>
-    <string name="onboarding_plus_feature_folders_title">Mapper</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">Mapper</string>
     <string name="onboarding_plus_feature_folders_text">Ordne podcastene i mapper og synkroniser dem mellom alle enhetene dine.</string>
     <string name="onboarding_plus_feature_cloud_storage_text">Last opp filene til skylageret, slik at du har dem tilgjengelig overalt.</string>
     <string name="onboarding_plus_feature_themes_icons_title">Temaer og ikoner</string>

--- a/modules/services/localization/src/main/res/values-nl/strings.xml
+++ b/modules/services/localization/src/main/res/values-nl/strings.xml
@@ -334,7 +334,7 @@ Language: nl
     <string name="onboarding_plus_feature_cloud_storage_text">Wanneer je je bestanden naar een cloudopslag uploadt, zijn ze overal beschikbaar.</string>
     <string name="onboarding_plus_feature_cloud_storage_title">20 GB cloudopslag</string>
     <string name="onboarding_plus_feature_folders_text">Organiseer je podcasts in mappen en synchroniseer ze op al je apparaten.</string>
-    <string name="onboarding_plus_feature_folders_title">Mappen</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">Mappen</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Luister overal met onze apps voor Windows en macOS en de online apps.</string>
     <string name="onboarding_plus_feature_desktop_apps_title">Desktop-apps</string>
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">Alles wat je geweldig vindt aan Pocket Casts en meer</string>

--- a/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
+++ b/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
@@ -334,7 +334,7 @@ Language: pt_BR
     <string name="onboarding_plus_feature_cloud_storage_text">Faça upload dos seus arquivos na nuvem para acessá-los em qualquer lugar.</string>
     <string name="onboarding_plus_feature_cloud_storage_title">20 GB de armazenamento na nuvem</string>
     <string name="onboarding_plus_feature_folders_text">Organize seus podcasts em pastas e mantenha a sincronização em todos os seus dispositivos.</string>
-    <string name="onboarding_plus_feature_folders_title">Pastas</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">Pastas</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Ouça seus podcasts em mais lugares com os apps para Windows, macOS e Web.</string>
     <string name="onboarding_plus_feature_desktop_apps_title">Aplicativos para desktop</string>
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">Tudo o que você adora no Pocket Casts e muito mais</string>

--- a/modules/services/localization/src/main/res/values-ru/strings.xml
+++ b/modules/services/localization/src/main/res/values-ru/strings.xml
@@ -334,7 +334,7 @@ Language: ru
     <string name="onboarding_plus_feature_cloud_storage_text">Загрузите файлы в облачное хранилище и пользуйтесь ими, где бы вы ни находились.</string>
     <string name="onboarding_plus_feature_cloud_storage_title">Облачное хранилище объемом 20 ГБ</string>
     <string name="onboarding_plus_feature_folders_text">Распределите подкасты по папкам и синхронизируйте их на всех устройствах.</string>
-    <string name="onboarding_plus_feature_folders_title">Папки</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">Папки</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Слушайте подкасты везде: в приложениях для Windows, macOS и веб-приложении.</string>
     <string name="onboarding_plus_feature_desktop_apps_title">Приложения для настольных систем</string>
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">Всё, что вам нравится в Pocket Casts, и ещё больше</string>

--- a/modules/services/localization/src/main/res/values-sv/strings.xml
+++ b/modules/services/localization/src/main/res/values-sv/strings.xml
@@ -334,7 +334,7 @@ Language: sv_SE
     <string name="onboarding_plus_feature_cloud_storage_text">Ladda upp dina filer till molnlagringen och ha dem tillgängliga överallt.</string>
     <string name="onboarding_plus_feature_cloud_storage_title">20 GB molnlagring</string>
     <string name="onboarding_plus_feature_folders_text">Organisera dina podcasts i mappar och håll dem synkroniserade på alla dina enheter.</string>
-    <string name="onboarding_plus_feature_folders_title">Mappar</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">Mappar</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Lyssna på fler med våra Windows-, macOS- och webbappar.</string>
     <string name="onboarding_plus_feature_desktop_apps_title">Dator-appar</string>
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">Allt du älskar med Pocket Casts och mer därtill</string>

--- a/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
@@ -334,7 +334,7 @@ Language: zh_TW
     <string name="onboarding_plus_feature_cloud_storage_text">將你的檔案上傳至雲端儲存空間，隨時隨地使用。</string>
     <string name="onboarding_plus_feature_cloud_storage_title">20 GB 雲端儲存空間</string>
     <string name="onboarding_plus_feature_folders_text">在資料夾中整理你的 Podcast，並同步到所有裝置。</string>
-    <string name="onboarding_plus_feature_folders_title">資料夾</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">資料夾</string>
     <string name="onboarding_plus_feature_desktop_apps_text">透過我們的 Windows、macOS 和網頁應用程式，享受更多元的收聽方式。</string>
     <string name="onboarding_plus_feature_desktop_apps_title">桌面應用程式</string>
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">包含所有你喜愛的 Pocket Casts 功能，以及更多好康</string>

--- a/modules/services/localization/src/main/res/values-zh/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh/strings.xml
@@ -334,7 +334,7 @@ Language: zh_CN
     <string name="onboarding_plus_feature_cloud_storage_text">将文件上传到云存储空间，在任何地方都能访问这些文件。</string>
     <string name="onboarding_plus_feature_cloud_storage_title">20GB 云存储空间</string>
     <string name="onboarding_plus_feature_folders_text">将播客整理到文件夹中，让它们在所有设备中保持同步。</string>
-    <string name="onboarding_plus_feature_folders_title">文件夹</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">文件夹</string>
     <string name="onboarding_plus_feature_desktop_apps_text">借助我们的 Windows、macOS 和 Web 应用程序，在更多位置收听播客。</string>
     <string name="onboarding_plus_feature_desktop_apps_title">桌面应用程序</string>
     <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">您喜欢的 Pocket Casts 的一切，还有更多内容</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1702,7 +1702,7 @@
     <string name="onboarding_plus_features_title" translatable="false">@string/onboarding_upgrade_everything_you_love_about_pocket_casts_plus</string>
     <string name="onboarding_plus_feature_desktop_apps_title">Desktop Apps &amp; web apps</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Listen in more places with our Windows, macOS, and Web apps.</string>
-    <string name="onboarding_plus_feature_folders_title">Folders</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">Folders</string>
     <string name="onboarding_plus_feature_folders_text">Organize your podcasts in folders and keep them in sync across all your devices.</string>
     <string name="onboarding_plus_feature_cloud_storage_title">20GB Cloud Storage</string>
     <string name="onboarding_plus_feature_cloud_storage_text">Upload your files to cloud storage and have them available everywhere.</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1700,7 +1700,7 @@
     <string name="onboarding_patron_feature_gratitude_title" translatable="false">@string/onboarding_plus_feature_gratitude_title</string>
     <string name="onboarding_patron_subscribe">Subscribe to Pocket&#160;Casts Patron</string>
     <string name="onboarding_plus_features_title" translatable="false">@string/onboarding_upgrade_everything_you_love_about_pocket_casts_plus</string>
-    <string name="onboarding_plus_feature_desktop_apps_title">Desktop Apps</string>
+    <string name="onboarding_plus_feature_desktop_apps_title">Desktop Apps &amp; web apps</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Listen in more places with our Windows, macOS, and Web apps.</string>
     <string name="onboarding_plus_feature_folders_title">Folders</string>
     <string name="onboarding_plus_feature_folders_text">Organize your podcasts in folders and keep them in sync across all your devices.</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1702,7 +1702,7 @@
     <string name="onboarding_plus_features_title" translatable="false">@string/onboarding_upgrade_everything_you_love_about_pocket_casts_plus</string>
     <string name="onboarding_plus_feature_desktop_apps_title">Desktop Apps &amp; web apps</string>
     <string name="onboarding_plus_feature_desktop_apps_text">Listen in more places with our Windows, macOS, and Web apps.</string>
-    <string name="onboarding_plus_feature_folders_and_bookmarks_title">Folders</string>
+    <string name="onboarding_plus_feature_folders_and_bookmarks_title">Folders &amp; Bookmarks</string>
     <string name="onboarding_plus_feature_folders_text">Organize your podcasts in folders and keep them in sync across all your devices.</string>
     <string name="onboarding_plus_feature_cloud_storage_title">20GB Cloud Storage</string>
     <string name="onboarding_plus_feature_cloud_storage_text">Upload your files to cloud storage and have them available everywhere.</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1706,7 +1706,7 @@
     <string name="onboarding_plus_feature_folders_text">Organize your podcasts in folders and keep them in sync across all your devices.</string>
     <string name="onboarding_plus_feature_cloud_storage_title">20GB Cloud Storage</string>
     <string name="onboarding_plus_feature_cloud_storage_text">Upload your files to cloud storage and have them available everywhere.</string>
-    <string name="onboarding_plus_feature_watch_playback">Watch Playback</string>
+    <string name="onboarding_plus_feature_watch_playback">Apple Watch &amp; Wear OS apps</string>
     <string name="onboarding_plus_feature_extra_themes_icons_title">Extra Themes &amp; App Icons</string>
     <string name="onboarding_plus_feature_themes_icons_title">Themes &amp; Icons</string>
     <string name="onboarding_plus_feature_themes_icons_text">Fly your true colors. Exclusive icons and themes for the Plus club only.</string>


### PR DESCRIPTION
## Description
- This PR updates the `Folders` benefit to `Folders & Bookmarks`, `Desktop` to `Desktop & web apps` and `Watch Playback` to `Apple Watch & Wear OS apps`
- Renamed `onboarding_plus_feature_folders_title` to `onboarding_plus_feature_folders_bookmarks_title`

## Testing Instructions
- Apply the [update_plus_benefits.patch](https://github.com/Automattic/pocket-casts-android/files/13918564/update_plus_benefits.patch)
- Log in with a free account
- Play an episode
- Click on the 3 dots
- Try to Bookmark
- You should be able to see the Up sell modal with the updated benefits

## Screenshots or Screencast 
<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/ac3c7d2f-4e53-4f98-b376-d17036d6b592" height="600">



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
