### PR TITLE
Fix native share url handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.56
 -----
-
+*   Bug Fixes:
+    *   Fixed incorrect podcast loading below the correct one on opening native podcast share url
+        ([#1696](https://github.com/Automattic/pocket-casts-android/pull/1696))
 
 7.55
 -----

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -169,6 +169,7 @@ class MainActivity :
     companion object {
         private const val INITIAL_KEY = "initial"
         private const val SOURCE_KEY = "source"
+        private const val SOCIAL_SHARE_PATH = "/social/share/show"
         init {
             AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
         }
@@ -1278,6 +1279,7 @@ class MainActivity :
                     return
                 } else if (IntentUtil.isNativeShareLink(intent)) {
                     openNativeSharingUrl(intent)
+                    return
                 }
 
                 val scheme = intent.scheme
@@ -1418,10 +1420,14 @@ class MainActivity :
 
     @Suppress("DEPRECATION")
     private fun openSharingUrl(intent: Intent) {
-        val url = intent.data?.path ?: return
+        var sharePath = intent.data?.path ?: return
+        // Prepend social share path to native sharing path
+        if (intent.data?.pathSegments?.size == 1) {
+            sharePath = "$SOCIAL_SHARE_PATH$sharePath"
+        }
         val dialog = android.app.ProgressDialog.show(this, getString(LR.string.loading), getString(LR.string.please_wait), true)
         serverManager.getSharedItemDetails(
-            url,
+            sharePath,
             object : ServerCallback<au.com.shiftyjelly.pocketcasts.models.to.Share> {
                 override fun dataReturned(result: au.com.shiftyjelly.pocketcasts.models.to.Share?) {
                     UiUtil.hideProgressDialog(dialog)
@@ -1474,10 +1480,13 @@ class MainActivity :
     @Suppress("DEPRECATION")
     private fun openNativeSharingUrl(intent: Intent) {
         val urlSegments = intent.data?.pathSegments ?: return
-        if (urlSegments.size < 2) return
+        if (urlSegments.size < 2) {
+            openSharingUrl(intent)
+            return
+        }
 
         when (urlSegments[0]) {
-            "podcast" -> openPodcastUrl(urlSegments[1])
+            "podcast" -> openPodcastUrl(IntentUtil.getUrl(intent))
             "episode" -> openEpisodeDialog(
                 episodeUuid = urlSegments[1],
                 source = EpisodeViewSource.SHARE,


### PR DESCRIPTION
## Description

This fixes native share URL handling. 
(Internal Ref: p1704359709586349-slack-C02A333D8LQ)

There were three issues while handling native URLs with scheme `pca.st`:

1. `openNativeSharingUrl(...)` passed podcast UUID instead of the URL to `openPodcastUrl(...)`. `openPodcastUrl(...)` internally called `serverManager.searchForPodcasts(url, ....)`, and returned a wrong podcast with UUID. 
2. After calling `openNativeSharingUrl(...)`, there was no `return` statement, so it also executed `openPodcastUrl(IntentUtil.getUrl(intent))` which opened the correct podcast on top of the wrong podcast.
3. `openNativeSharingUrl(...)` did not handle native share URLs with a single path segment (e.g. https://pca.st/yaoi883d). 

To fix these, I: 
- added a return statement at line 1282
- passed URL instead of UUID to `openNativeSharingUrl(...)` at line 1489
- if the native share URL has a single path segment, call `openSharingUrl(...)`, prepended social share path (`/social/share/show`). 
   👀 I'm not sure if it's right to hard-code this path, but I found one instance in the iOS app where this path is hard-coded [here](https://github.com/Automattic/pocket-casts-ios/blob/trunk/podcasts/AppDelelgate%2BSiriShortcuts.swift#L35).

## Testing Instructions

1. Add `pca.st` to open by default links in app info
2. ✅ Check that native share URLs in the following formats open correctly:
- Podcast URL: https://pca.st/podcast/2f837270-4a8c-013a-d6b5-0acc26574db2
- URLs having a single-path segment 
    - https://pca.st/yaoi883d (for episode)
    - https://pca.st/sysk (for podcast)
3. ✅ Tapping back should not take you to wrong podcast or episode


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack