### PR TITLE
Improve handling of whether a setting should be synced

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/preferences/UserSettingTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/preferences/UserSettingTest.kt
@@ -38,38 +38,25 @@ class UserSettingTest {
     }
 
     @Test
-    fun keepsSyncEvenWithModificationNotRequiringSync() {
+    fun doesNotSyncAfterModificationNotRequiringSync() {
         val userSetting = getUserSetting()
 
         // first set requires sync
         userSetting.set("first_value", needsSync = true)
 
         // second set does not require sync
-        val newValue = "second_value"
         userSetting.set("second_value", needsSync = false)
-
-        assertWillSync(userSetting, newValue)
-    }
-
-    @Test
-    fun clearsSync() {
-        val userSetting = getUserSetting()
-
-        userSetting.set("new_value", needsSync = true)
-        userSetting.doesNotNeedSync()
 
         assertWillNotSync(userSetting)
     }
 
-    fun assertWillSync(userSetting: UserSetting.StringPref, expected: String) {
-        assertNotNull(userSetting.getModifiedAtServerString())
+    private fun assertWillSync(userSetting: UserSetting.StringPref, expected: String) {
         assertNotNull(userSetting.getModifiedAt())
         val result = userSetting.getSyncSetting { value, _ -> value }
         assertEquals(expected, result)
     }
 
     private fun assertWillNotSync(userSetting: UserSetting.StringPref) {
-        assertNull(userSetting.getModifiedAtServerString())
         assertNull(userSetting.getModifiedAt())
         val result = userSetting.getSyncSetting { _, _ -> Unit }
         assertNull(result)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -14,14 +14,10 @@ abstract class UserSetting<T>(
 
     private val modifiedAtKey = "${sharedPrefKey}ModifiedAt"
 
-    fun getModifiedAtServerString(): String? = sharedPrefs.getString(modifiedAtKey, null)
+    private fun getModifiedAtServerString(): String? = sharedPrefs.getString(modifiedAtKey, null)
 
     fun getModifiedAt(): Instant? = tryOrNull {
         getModifiedAtServerString()?.let { Instant.parse(it) }
-    }
-
-    fun doesNotNeedSync() {
-        updateModifiedAtServerString(null)
     }
 
     // Returns the value to sync if sync is needed. Returns null if sync is not needed.
@@ -58,31 +54,26 @@ abstract class UserSetting<T>(
 
     protected abstract fun persist(value: T, commit: Boolean)
 
-    fun set(value: T, commit: Boolean = false, needsSync: Boolean = false) {
+    open fun set(value: T, commit: Boolean = false, needsSync: Boolean = false) {
         persist(value, commit)
         _flow.value = value
-
-        if (needsSync) {
-            updateModifiedAtServerString()
-        }
+        val modifiedAt = if (needsSync) Instant.now().toString() else null
+        updateModifiedAtServerString(modifiedAt)
     }
 
-    private fun updateModifiedAtServerString(modifiedAt: String? = Instant.now().toString()) {
-        val valueToPersist = if (modifiedAt == null) {
-            // Allow persisting of nulls
-            null
-        } else {
+    // A null parameter reflects a setting that does not need to be synced
+    private fun updateModifiedAtServerString(modifiedAt: String?) {
+        if (modifiedAt != null) {
             val parsable = tryOrNull { Instant.parse(modifiedAt) } != null
             if (!parsable) {
+                // Only persist the string if it is parsable
                 LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot set invalid modified at server string: $modifiedAt")
                 return
             }
-            // Only persist the string if it is parsable
-            modifiedAt
         }
 
         sharedPrefs.edit().run {
-            putString(modifiedAtKey, valueToPersist)
+            putString(modifiedAtKey, modifiedAt)
             apply()
         }
     }
@@ -299,6 +290,7 @@ abstract class UserSetting<T>(
     ) {
         override fun get(): T = initialValue
         override fun persist(value: T, commit: Boolean) {}
+        override fun set(value: T, commit: Boolean, needsSync: Boolean) {}
     }
 }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -26,7 +26,6 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.FileImageUploadData
 import au.com.shiftyjelly.pocketcasts.servers.sync.FilePost
 import au.com.shiftyjelly.pocketcasts.servers.sync.FilesResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.NamedSettingsCaller
-import au.com.shiftyjelly.pocketcasts.servers.sync.NamedSettingsRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.NamedSettingsResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.PodcastEpisodesResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.PodcastListResponse
@@ -397,10 +396,13 @@ class SyncManagerImpl @Inject constructor(
             syncServerManager.loadStats(token)
         }
 
-    override suspend fun namedSettings(request: NamedSettingsRequest): NamedSettingsResponse =
-        getCacheTokenOrLogin { token ->
-            syncServerManager.namedSettings(request, token)
-        }
+    @Suppress("DEPRECATION")
+    @Deprecated("This method can be removed when the sync settings feature flag is removed")
+    override suspend fun namedSettings(
+        request: au.com.shiftyjelly.pocketcasts.servers.sync.NamedSettingsRequest,
+    ): NamedSettingsResponse = getCacheTokenOrLogin { token ->
+        syncServerManager.namedSettings(request, token)
+    }
 
     override suspend fun changedNamedSettings(request: ChangedNamedSettingsRequest): ChangedNamedSettingsResponse =
         getCacheTokenOrLogin { token ->

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -113,8 +113,7 @@ class UserManagerImpl @Inject constructor(
                     userEpisodeManager.removeCloudStatusFromFiles(playbackManager)
                 }
 
-                settings.marketingOptIn.set(false)
-                settings.marketingOptIn.doesNotNeedSync()
+                settings.marketingOptIn.set(false, needsSync = false)
                 settings.setEndOfYearShowModal(true)
 
                 analyticsTracker.track(

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -6,6 +6,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
+@Deprecated("This class can be removed when the sync settings feature flag is removed")
 data class NamedSettingsSettings(
     @field:Json(name = "skipForward") val skipForward: Int? = null,
     @field:Json(name = "skipBack") val skipBack: Int? = null,
@@ -25,6 +26,8 @@ data class NamedChangedSettingInt(
     @field:Json(name = "modified_at") val modifiedAt: String,
 )
 
+@Suppress("DEPRECATION")
+@Deprecated("This class can be removed when the sync settings feature flag is removed")
 @JsonClass(generateAdapter = true)
 data class NamedSettingsRequest(
     @field:Json(name = "m") val m: String = "Android",
@@ -62,6 +65,9 @@ data class ChangedSettingResponse(
 )
 
 interface NamedSettingsCaller {
-    suspend fun namedSettings(request: NamedSettingsRequest): NamedSettingsResponse
+    @Deprecated("This method can be removed when the sync settings feature flag is removed")
+    suspend fun namedSettings(
+        @Suppress("DEPRECATION") request: NamedSettingsRequest,
+    ): NamedSettingsResponse
     suspend fun changedNamedSettings(request: ChangedNamedSettingsRequest): ChangedNamedSettingsResponse
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -18,11 +18,21 @@ data class NamedSettingsSettings(
 @JsonClass(generateAdapter = true)
 data class ChangedNamedSettings(
     @field:Json(name = "skipForward") val skipForward: NamedChangedSettingInt? = null,
+    @field:Json(name = "skipBack") val skipBack: NamedChangedSettingInt? = null,
+    @field:Json(name = "gridOrder") val gridOrder: NamedChangedSettingInt? = null,
+    @field:Json(name = "marketingOptIn") val marketingOptIn: NamedChangedSettingBool? = null,
+    @field:Json(name = "freeGiftAcknowledgement") val freeGiftAcknowledgement: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)
 data class NamedChangedSettingInt(
     @field:Json(name = "value") val value: Int,
+    @field:Json(name = "modified_at") val modifiedAt: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class NamedChangedSettingBool(
+    @field:Json(name = "value") val value: Boolean,
     @field:Json(name = "modified_at") val modifiedAt: String,
 )
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServer.kt
@@ -61,6 +61,8 @@ interface SyncServer {
     suspend fun updatePassword(@Header("Authorization") authorization: String, @Body request: UpdatePasswordRequest): LoginTokenResponse
 
     @POST("/user/named_settings/update")
+    @Suppress("DEPRECATION")
+    @Deprecated("This method can be removed when the sync settings feature flag is removed")
     suspend fun namedSettings(@Header("Authorization") authorization: String, @Body request: NamedSettingsRequest): NamedSettingsResponse
 
     @POST("/user/named_settings/update")

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
@@ -116,6 +116,8 @@ open class SyncServerManager @Inject constructor(
     fun validatePromoCode(code: String): Single<PromoCodeResponse> =
         server.validatePromoCode(PromoCodeRequest(code))
 
+    @Suppress("DEPRECATION")
+    @Deprecated("This method can be removed when the sync settings feature flag is removed")
     suspend fun namedSettings(request: NamedSettingsRequest, token: AccessToken): NamedSettingsResponse =
         server.namedSettings(addBearer(token), request)
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -54,17 +54,57 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 return
             }
 
-            val request = ChangedNamedSettingsRequest(
-                changedSettings = ChangedNamedSettings(
-                    skipForward = settings.skipForwardInSecs.getSyncSetting(::NamedChangedSettingInt),
-                ),
-            )
+            val request = changedNamedSettingsRequest(settings)
             val response = namedSettingsCall.changedNamedSettings(request)
-            for ((key, value) in response) {
+            processChangedNameSettingsResponse(response, settings)
+        }
+
+        private fun changedNamedSettingsRequest(settings: Settings) = ChangedNamedSettingsRequest(
+            changedSettings = ChangedNamedSettings(
+                skipForward = settings.skipForwardInSecs.getSyncSetting(::NamedChangedSettingInt),
+                skipBack = settings.skipBackInSecs.getSyncSetting(::NamedChangedSettingInt),
+                gridOrder = settings.podcastsSortType.getSyncSetting { podcastSortType, modifiedAt ->
+                    NamedChangedSettingInt(
+                        value = podcastSortType.serverId,
+                        modifiedAt = modifiedAt,
+                    )
+                },
+                marketingOptIn = settings.marketingOptIn.getSyncSetting(::NamedChangedSettingBool),
+                freeGiftAcknowledgement = settings.freeGiftAcknowledged.getSyncSetting(::NamedChangedSettingBool),
+            ),
+        )
+
+        private fun processChangedNameSettingsResponse(response: ChangedNamedSettingsResponse, settings: Settings) {
+            for ((key, changedSettingResponse) in response) {
                 when (key) {
-                    "skipForward" -> updateSettingIfPossible(value, settings.skipForwardInSecs) {
-                        (it.value as? Number)?.toInt()
-                    }
+                    "skipForward" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.skipForwardInSecs,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt(),
+                    )
+                    "skipBack" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.skipBackInSecs,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt(),
+                    )
+                    "gridOrder" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.podcastsSortType,
+                        newSettingValue = run {
+                            val serverId = (changedSettingResponse.value as? Number)?.toInt()
+                            PodcastsSortType.fromServerId(serverId)
+                        },
+                    )
+                    "marketingOptIn" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.marketingOptIn,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "freeGiftAcknowledgement" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.freeGiftAcknowledged,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
                 }
             }
         }
@@ -72,10 +112,9 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
         private fun <T> updateSettingIfPossible(
             changedSettingResponse: ChangedSettingResponse,
             setting: UserSetting<T>,
-            transformToValue: (ChangedSettingResponse) -> T?,
+            newSettingValue: T?,
         ) {
-            val value = transformToValue(changedSettingResponse)
-            if (value == null) {
+            if (newSettingValue == null) {
                 LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Invalid ${setting.sharedPrefKey} value: ${changedSettingResponse.value}")
                 return
             }
@@ -104,7 +143,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
             }
 
             setting.set(
-                value = value,
+                value = newSettingValue,
                 needsSync = false,
             )
         }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -97,9 +97,9 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
 
             val localModifiedAt = setting.getModifiedAt()
             // Don't exit early if we don't have a local modifiedAt time since
-            // we don't know the local value is newew than the server value.
+            // we don't know the local value is newer than the server value.
             if (localModifiedAt != null && localModifiedAt.isAfter(serverModifiedAtInstant)) {
-                Timber.i("Not syncing ${setting.sharedPrefKey} from the server because setting was modified more recently locally")
+                Timber.i("Not syncing ${setting.sharedPrefKey} value of $newSettingValue from the server because setting was modified more recently locally")
                 return
             }
 
@@ -109,6 +109,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
             )
         }
 
+        @Suppress("DEPRECATION")
         @Deprecated("This can be removed when Feature.SETTINGS_SYNC flag is removed")
         private suspend fun oldSyncSettings(
             settings: Settings,

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -30,15 +30,6 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 return Result.failure()
             }
 
-            listOf(
-                settings.freeGiftAcknowledged,
-                settings.marketingOptIn,
-                settings.podcastsSortType,
-                settings.skipBackInSecs,
-                settings.skipForwardInSecs,
-            ).forEach {
-                it.doesNotNeedSync()
-            }
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Settings synced")
 
             return Result.success()


### PR DESCRIPTION
## Description
This PR improves how we determine/set whether a setting should be synced.

Previously, when updating a value and saying it did not need to be synced with something like `.set(value = 1, needsSync = false)`, we were leaving the modifiedAt value (which indicates sync is needed if it is not `null`). This meant that if you called `.set(value = 1, needsSync = true)` and then immediately called (`.set(value = 2, needsSync = false)` the setting of the value to `2` would not overwrite the modifiedAt value and the setting would be synced during the next incremental sync. 

This is a problem, but I think it's just a theoretical problem at this point because I can't think of any way a user could actually get into this scenario. Still improving this handling feels like the thing to do because it feels like a gotcha that will catch us at some point. For that reason, this PR updates this so that calling the method with `needsSync = false` sets the `modifiedAt` value to `null`, ensuring that the setting will not be synced. 

In addition to avoiding the possible syncing of values that should not have been synced, this change also means that we no longer need `.doesNotNeedSync` to be called to ensure that nothing gets synced from a particular setting because the set method's `needsSync` parameter now takes care of this.

> [!WARNING]
> This PR builds on top of https://github.com/Automattic/pocket-casts-android/pull/1693.

## Testing Instructions

### 1. Handles settings that should be synced
1. Ensure that the settings sync feature flag is toggled on
1. Tap the refresh button on the Profile tab to make sure all settings are up-to-date
2. Tap the account button on the Profile tab
3. Change the newsletter toggle
4. Tap the refresh button on the Profile tab
5. Check the logs and verify that the call to the `/named_settings/update` endpoint includes the newsletter toggle change, i.e., it includes something like `"changed_settings":{"marketingOptIn":{"value":true,"modified_at":"2024-01-12T16:52:57.552Z"}`
6. Tap the refresh button the Profile tab again
7. Verify that the call to the `/named_settings/update` endpoint does not include any changes, i.e., it includes `"changed_settings: {}"`

### 2. Handles settings that should not be synced

Currently I don't think there's a good way to take a setting that can be synced and force a change that we do not want to get synced without signing out of the app so, for this test, you need to build the app with this change so that toggling the newsletter should no longer get synced:

``` diff
diff --git a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
index 7bea787cb..99661eabc 100644
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
@@ -107,7 +107,7 @@ class AccountDetailsViewModel
             AnalyticsEvent.NEWSLETTER_OPT_IN_CHANGED,
             mapOf(SOURCE_KEY to NewsletterSource.PROFILE.analyticsValue, ENABLED_KEY to isChecked),
         )
-        settings.marketingOptIn.set(isChecked, needsSync = true)
+        settings.marketingOptIn.set(isChecked, needsSync = false)
     }
 
     override fun onCleared() {
```

1. Build and install the app with ⬆️that⬆️  change.
2. Ensure that the settings sync feature flag is toggled on
3. Tap the refresh button on the Profile tab to make sure all settings are up-to-date
4. Tap the account button on the Profile tab
5. Change the newsletter toggle
6. Tap the refresh button on the Profile tab
7. Verify that the call to the `/named_settings/update` endpoint does not include any changes, i.e., it includes `"changed_settings: {}"`

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews