### PR TITLE
Remove BOOKMARKS_ENABLED feature flag

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkFeatureControlTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkFeatureControlTest.kt
@@ -1,0 +1,31 @@
+package au.com.shiftyjelly.pocketcasts.repositories.bookmark
+
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
+import junit.framework.TestCase.assertFalse
+import org.junit.Before
+import org.junit.Test
+
+class BookmarkFeatureControlTest {
+
+    private lateinit var bookmarkFeatureControl: BookmarkFeatureControl
+
+    @Before
+    fun setup() {
+        bookmarkFeatureControl = BookmarkFeatureControl()
+    }
+
+    @Test
+    fun shouldBeAvailableForPatronSubscription() {
+        assert(bookmarkFeatureControl.isAvailable(UserTier.Patron))
+    }
+
+    @Test
+    fun shouldBeAvailableForPlusSubscription() {
+        assert(bookmarkFeatureControl.isAvailable(UserTier.Plus))
+    }
+
+    @Test
+    fun shouldNotBeAvailable() {
+        assertFalse(bookmarkFeatureControl.isAvailable(UserTier.Free))
+    }
+}

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -18,8 +18,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
 import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServerManager
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toIsoString
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
 import java.net.HttpURLConnection
 import java.util.Date
 import java.util.concurrent.TimeUnit
@@ -50,7 +48,6 @@ class PodcastSyncProcessTest {
     private lateinit var retrofit: Retrofit
     private lateinit var okhttpCache: Cache
     private lateinit var appDatabase: AppDatabase
-    private val featureFlagWrapper: FeatureFlagWrapper = mock()
 
     @Before
     fun setUp() {
@@ -61,8 +58,7 @@ class PodcastSyncProcessTest {
 
         appDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
 
-        whenever(featureFlagWrapper.isEnabled(Feature.BOOKMARKS_ENABLED)) doReturn true
-        val moshi = ServersModule.provideMoshiBuilder(featureFlagWrapper).build()
+        val moshi = ServersModule.provideMoshiBuilder().build()
         val okHttpClient = OkHttpClient.Builder().build()
         retrofit = ServersModule.provideRetrofit(baseUrl = mockWebServer.url("/").toString(), okHttpClient = okHttpClient, moshi = moshi)
         okhttpCache = ServersModule.provideCache(folder = "TestCache", context = context)
@@ -140,6 +136,7 @@ class PodcastSyncProcessTest {
 
             val syncProcess = PodcastSyncProcess(
                 context = context,
+                applicationScope = CoroutineScope(Dispatchers.Default),
                 settings = settings,
                 episodeManager = episodeManager,
                 podcastManager = podcastManager,
@@ -153,8 +150,6 @@ class PodcastSyncProcessTest {
                 subscriptionManager = mock(),
                 folderManager = folderManager,
                 syncManager = syncManager,
-                featureFlagWrapper = featureFlagWrapper,
-                applicationScope = CoroutineScope(Dispatchers.Default),
             )
 
             val response = MockResponse()

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/settings/advanced/AdvancedSettingsTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/settings/advanced/AdvancedSettingsTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.work.NetworkType
 import au.com.shiftyjelly.pocketcasts.preferences.SettingsImpl
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.squareup.moshi.Moshi
 import org.junit.Assert.assertEquals
@@ -26,6 +27,7 @@ class AdvancedSettingsTest {
             context = context,
             firebaseRemoteConfig = firebaseRemoteConfig,
             moshi = moshi,
+            bookmarkFeature = BookmarkFeatureControl(),
         )
 
         // Non-advanced settings

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkFeatureControlTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkFeatureControlTest.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.bookmark
 
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
-import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase
 import org.junit.Before
 import org.junit.Test
 
@@ -26,6 +26,6 @@ class BookmarkFeatureControlTest {
 
     @Test
     fun shouldNotBeAvailable() {
-        assertFalse(bookmarkFeatureControl.isAvailable(UserTier.Free))
+        TestCase.assertFalse(bookmarkFeatureControl.isAvailable(UserTier.Free))
     }
 }

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkFeatureControlTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkFeatureControlTest.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.bookmark
 
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
-import junit.framework.TestCase
+import junit.framework.TestCase.assertFalse
 import org.junit.Before
 import org.junit.Test
 
@@ -26,6 +26,6 @@ class BookmarkFeatureControlTest {
 
     @Test
     fun shouldNotBeAvailable() {
-        TestCase.assertFalse(bookmarkFeatureControl.isAvailable(UserTier.Free))
+        assertFalse(bookmarkFeatureControl.isAvailable(UserTier.Free))
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -36,8 +36,6 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.HasBackstack
 import au.com.shiftyjelly.pocketcasts.views.tour.TourStep
@@ -339,17 +337,11 @@ private class ViewPagerAdapter(fragmentManager: FragmentManager, lifecycle: Life
             newSections.add(Section.Chapters)
         }
 
-        if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-            newSections.add(Section.Bookmarks)
-        }
+        newSections.add(Section.Bookmarks)
 
         this.sections = newSections
 
-        if (hadNotes != hasNotes || hadChapters != hasChapters) {
-            return true
-        }
-
-        return false
+        return hadNotes != hasNotes || hadChapters != hasChapters
     }
 
     override fun getItemId(position: Int): Long {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -30,6 +30,7 @@ import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarkActivityContr
 import au.com.shiftyjelly.pocketcasts.player.view.video.VideoActivity
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.images.into
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -42,7 +43,6 @@ import au.com.shiftyjelly.pocketcasts.ui.images.ThemedImageTintTransformation
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.extensions.updateColor
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -88,6 +88,8 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
     @Inject lateinit var warningsHelper: WarningsHelper
 
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
+
+    @Inject lateinit var bookmarkFeature: BookmarkFeatureControl
 
     lateinit var imageLoader: PodcastImageLoaderThemed
     private val viewModel: PlayerViewModel by activityViewModels()
@@ -499,7 +501,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
     }
 
     fun onAddBookmarkClick() {
-        if (Feature.isUserEntitled(Feature.BOOKMARKS_ENABLED, settings.userTier)) {
+        if (bookmarkFeature.isAvailable(settings.userTier)) {
             viewModel.buildBookmarkArguments { arguments ->
                 activityLauncher.launch(arguments.getIntent(requireContext()))
             }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -43,7 +43,6 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.extensions.updateColor
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -510,11 +509,8 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
     }
 
     private fun startUpsellFlow() {
-        val source = OnboardingUpgradeSource.HEADPHONE_CONTROLS_SETTINGS
         val onboardingFlow = OnboardingFlow.Upsell(
-            source = source,
-            showPatronOnly = Feature.BOOKMARKS_ENABLED.tier == FeatureTier.Patron ||
-                Feature.BOOKMARKS_ENABLED.isCurrentlyExclusiveToPatron(),
+            source = OnboardingUpgradeSource.HEADPHONE_CONTROLS_SETTINGS,
         )
         OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -30,7 +30,6 @@ import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarkActivityContr
 import au.com.shiftyjelly.pocketcasts.player.view.video.VideoActivity
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.images.into
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -43,6 +42,7 @@ import au.com.shiftyjelly.pocketcasts.ui.images.ThemedImageTintTransformation
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.extensions.updateColor
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfItem.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfItem.kt
@@ -21,7 +21,6 @@ object ShelfItems {
         add(ShelfItem.Cast)
         add(ShelfItem.Played)
         add(ShelfItem.Bookmark)
-
         add(ShelfItem.Archive)
     }
     private val items = itemsList.associateBy { it.id }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfItem.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfItem.kt
@@ -7,8 +7,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.player.R
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.views.R as VR
@@ -22,9 +20,8 @@ object ShelfItems {
         add(ShelfItem.Podcast)
         add(ShelfItem.Cast)
         add(ShelfItem.Played)
-        if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-            add(ShelfItem.Bookmark)
-        }
+        add(ShelfItem.Bookmark)
+
         add(ShelfItem.Archive)
     }
     private val items = itemsList.associateBy { it.id }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
@@ -30,8 +30,6 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
 import au.com.shiftyjelly.pocketcasts.views.R
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -190,11 +188,8 @@ class BookmarksFragment : BaseFragment() {
     }
 
     private fun onUpgradeClicked() {
-        val source = OnboardingUpgradeSource.BOOKMARKS
         val onboardingFlow = OnboardingFlow.Upsell(
-            source = source,
-            showPatronOnly = Feature.BOOKMARKS_ENABLED.tier == FeatureTier.Patron ||
-                Feature.BOOKMARKS_ENABLED.isCurrentlyExclusiveToPatron(),
+            source = OnboardingUpgradeSource.BOOKMARKS,
         )
         OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellViewModel.kt
@@ -8,11 +8,6 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.FreeTrial
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.EarlyAccessState
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureWrapper
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersion.Companion.comparedToEarlyPatronAccess
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersionWrapper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,39 +20,20 @@ import kotlinx.coroutines.launch
 class UpsellViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val subscriptionManager: SubscriptionManager,
-    feature: FeatureWrapper,
-    private val releaseVersion: ReleaseVersionWrapper,
 ) : ViewModel() {
 
     private val _state: MutableStateFlow<UiState> = MutableStateFlow(UiState.Loading)
     val state: StateFlow<UiState> = _state
 
     init {
-        val bookmarksFeature = feature.bookmarksFeature
-        val patronExclusiveAccessRelease = (bookmarksFeature.tier as? FeatureTier.Plus)?.patronExclusiveAccessRelease
-
-        val isReleaseCandidate = releaseVersion.currentReleaseVersion.releaseCandidate != null
-        val relativeToEarlyPatronAccess = patronExclusiveAccessRelease?.let {
-            releaseVersion.currentReleaseVersion.comparedToEarlyPatronAccess(it)
-        }
-        val availableForFeatureTier = when (relativeToEarlyPatronAccess) {
-            null -> bookmarksFeature.tier
-            EarlyAccessState.Before,
-            EarlyAccessState.During,
-            -> if (isReleaseCandidate) bookmarksFeature.tier else FeatureTier.Patron
-
-            EarlyAccessState.After -> bookmarksFeature.tier
-        }
-        val subscriptionTier = availableForFeatureTier.toSubscriptionTier()
-
         viewModelScope.launch {
-            subscriptionManager.freeTrialForSubscriptionTierFlow(subscriptionTier)
+            subscriptionManager.freeTrialForSubscriptionTierFlow(SubscriptionTier.PLUS)
                 .stateIn(this)
                 .collect { freeTrial ->
                     _state.update {
                         UiState.Loaded(
                             freeTrial = freeTrial,
-                            showEarlyAccessMessage = bookmarksFeature.isCurrentlyExclusiveToPatron(releaseVersion),
+                            showEarlyAccessMessage = false,
                         )
                     }
                 }
@@ -71,14 +47,8 @@ class UpsellViewModel @Inject constructor(
         )
     }
 
-    private fun FeatureTier.toSubscriptionTier() = when (this) {
-        FeatureTier.Patron -> SubscriptionTier.PATRON
-        is FeatureTier.Plus -> SubscriptionTier.PLUS
-        FeatureTier.Free -> SubscriptionTier.UNKNOWN
-    }
-
     sealed class UiState {
-        object Loading : UiState()
+        data object Loading : UiState()
         data class Loaded(
             val freeTrial: FreeTrial,
             val showEarlyAccessMessage: Boolean,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -17,14 +17,13 @@ import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.NoBookmark
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortType
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeDefault
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureWrapper
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
@@ -55,7 +54,7 @@ class BookmarksViewModel
     private val settings: Settings,
     private val playbackManager: PlaybackManager,
     private val theme: Theme,
-    private val feature: FeatureWrapper,
+    private val bookmarkFeature: BookmarkFeatureControl,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
@@ -160,7 +159,7 @@ class BookmarksViewModel
                     settings.cachedSubscriptionStatus.flow,
                 ) { bookmarks, isMultiSelecting, selectedList, cachedSubscriptionStatus ->
                     val userTier = (cachedSubscriptionStatus as? SubscriptionStatus.Paid)?.tier?.toUserTier() ?: UserTier.Free
-                    _uiState.value = if (!feature.isUserEntitled(Feature.BOOKMARKS_ENABLED, userTier)) {
+                    _uiState.value = if (!bookmarkFeature.isAvailable(userTier)) {
                         UiState.Upsell(sourceView)
                     } else if (bookmarks.isEmpty()) {
                         UiState.Empty(sourceView)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -17,13 +17,13 @@ import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.NoBookmark
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortType
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeDefault
-import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -42,8 +42,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Util
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.helper.CloudDeleteHelper
@@ -207,12 +205,11 @@ class PlayerViewModel @Inject constructor(
             // Add missing bookmark item if the feature flag is enabled
             val updatedList = when {
                 list.contains(ShelfItem.Bookmark.id) -> list
-                FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) -> {
+                else -> {
                     list.toMutableList().apply {
                         add(list.size - 1, ShelfItem.Bookmark.id)
                     }
                 }
-                else -> list
             }
             updatedList.mapNotNull { id ->
                 ShelfItems.itemForId(id)

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellViewModelTest.kt
@@ -1,24 +1,19 @@
 package au.com.shiftyjelly.pocketcasts.player.view.bookmark.components
 
-import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.FreeTrial
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureWrapper
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersion
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersionWrapper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -33,154 +28,19 @@ class UpsellViewModelTest {
 
     private lateinit var upsellViewModel: UpsellViewModel
 
-    private val betaEarlyAccessRelease = ReleaseVersion(7, 50, null, 1)
-    private val productionEarlyAccessRelease = ReleaseVersion(7, 50)
-    private val betaFullAccessRelease = ReleaseVersion(7, 51, null, 1)
-    private val productionFullAccessRelease = ReleaseVersion(7, 51)
-
-    /* Early Access Availability */
-    // Current Release                   | Beta         | Production
-    // ----------------------------------|--------------|--------------
-    // Beta Early Access Release         | Plus Users   | N/A
-    // Production Early Access Release   | Plus Users   | Patron Users
-    // Beta Full Access Release          | Plus Users   | Plus Users
-    // Production Full Access Release    | Plus Users   | Plus Users
     @Test
-    fun `given patron exclusive feature, when beta release, feature available to Plus`() {
-        initViewModel(
-            currentRelease = betaEarlyAccessRelease,
-            patronExclusiveAccessRelease = productionEarlyAccessRelease,
-        )
+    fun `given a trial for subscription PLUS, early access message not shown`() {
+        whenever(subscriptionManager.freeTrialForSubscriptionTierFlow(Subscription.SubscriptionTier.PLUS))
+            .thenReturn(flowOf(FreeTrial(subscriptionTier = Subscription.SubscriptionTier.PLUS)))
 
-        val state = upsellViewModel.state.value as UpsellViewModel.UiState.Loaded
-        assertTrue(state.freeTrial.subscriptionTier == SubscriptionTier.PLUS)
-    }
-
-    @Test
-    fun `given patron exclusive feature, when production early access release, feature available to Patron`() {
-        initViewModel(
-            currentRelease = productionEarlyAccessRelease,
-            patronExclusiveAccessRelease = productionEarlyAccessRelease,
-        )
-
-        val state = upsellViewModel.state.value as UpsellViewModel.UiState.Loaded
-        assertTrue(state.freeTrial.subscriptionTier == SubscriptionTier.PATRON)
-    }
-
-    @Test
-    fun `given not a patron exclusive feature, when production release, feature available to Plus`() {
-        initViewModel(
-            currentRelease = productionEarlyAccessRelease,
-            patronExclusiveAccessRelease = null,
-        )
-
-        val state = upsellViewModel.state.value as UpsellViewModel.UiState.Loaded
-        assertTrue(state.freeTrial.subscriptionTier == SubscriptionTier.PLUS)
-    }
-
-    @Test
-    fun `given not a patron exclusive feature, when beta full access release, feature available to Plus`() {
-        initViewModel(
-            currentRelease = betaFullAccessRelease,
-            patronExclusiveAccessRelease = productionEarlyAccessRelease,
-        )
-
-        val state = upsellViewModel.state.value as UpsellViewModel.UiState.Loaded
-        assertTrue(state.freeTrial.subscriptionTier == SubscriptionTier.PLUS)
-    }
-
-    @Test
-    fun `given not a patron exclusive feature, when production full access release, feature available to Plus`() {
-        initViewModel(
-            currentRelease = productionFullAccessRelease,
-            patronExclusiveAccessRelease = productionEarlyAccessRelease,
-        )
-
-        val state = upsellViewModel.state.value as UpsellViewModel.UiState.Loaded
-        assertTrue(state.freeTrial.subscriptionTier == SubscriptionTier.PLUS)
-    }
-
-    /* Early Access Message */
-    @Test
-    fun `given not a patron exclusive feature, when beta release, early access message not shown`() {
-        initViewModel(
-            currentRelease = betaEarlyAccessRelease,
-            patronExclusiveAccessRelease = productionEarlyAccessRelease,
-        )
-
-        val state = upsellViewModel.state.value as UpsellViewModel.UiState.Loaded
-        assertFalse(state.showEarlyAccessMessage)
-    }
-
-    @Test
-    fun `given patron exclusive feature, when production early access release, early access message shown`() {
-        val releaseVersionMock = mock<ReleaseVersionWrapper>().apply {
-            doReturn(productionEarlyAccessRelease).whenever(this).currentReleaseVersion
-        }
-
-        val bookmarksFeatureMock = mock<Feature>().apply {
-            doReturn(FeatureTier.Plus(productionEarlyAccessRelease)).whenever(this).tier
-            doReturn(true).whenever(this).isCurrentlyExclusiveToPatron(releaseVersionMock)
-        }
-        initViewModel(
-            currentRelease = productionEarlyAccessRelease,
-            patronExclusiveAccessRelease = productionEarlyAccessRelease,
-            releaseVersionMock = releaseVersionMock,
-            bookmarksFeatureMock = bookmarksFeatureMock,
-        )
-
-        val state = upsellViewModel.state.value as UpsellViewModel.UiState.Loaded
-        assertTrue(state.showEarlyAccessMessage)
-    }
-
-    @Test
-    fun `given not a patron exclusive feature, when beta full access release, early access message not shown`() {
-        initViewModel(
-            currentRelease = betaFullAccessRelease,
-            patronExclusiveAccessRelease = productionEarlyAccessRelease,
-        )
-
-        val state = upsellViewModel.state.value as UpsellViewModel.UiState.Loaded
-        assertFalse(state.showEarlyAccessMessage)
-    }
-
-    @Test
-    fun `given not a patron exclusive feature, when production full access release, early access message not shown`() {
-        initViewModel(
-            currentRelease = productionFullAccessRelease,
-            patronExclusiveAccessRelease = productionEarlyAccessRelease,
-        )
-
-        val state = upsellViewModel.state.value as UpsellViewModel.UiState.Loaded
-        assertFalse(state.showEarlyAccessMessage)
-    }
-
-    private fun initViewModel(
-        currentRelease: ReleaseVersion,
-        patronExclusiveAccessRelease: ReleaseVersion?,
-        bookmarksFeatureMock: Feature? = null,
-        releaseVersionMock: ReleaseVersionWrapper? = null,
-    ) {
-        whenever(subscriptionManager.freeTrialForSubscriptionTierFlow(SubscriptionTier.PATRON))
-            .thenReturn(flowOf(FreeTrial(subscriptionTier = SubscriptionTier.PATRON)))
-
-        whenever(subscriptionManager.freeTrialForSubscriptionTierFlow(SubscriptionTier.PLUS))
-            .thenReturn(flowOf(FreeTrial(subscriptionTier = SubscriptionTier.PLUS)))
-
-        val bookmarksFeature = bookmarksFeatureMock ?: mock<Feature>().apply {
-            doReturn(FeatureTier.Plus(patronExclusiveAccessRelease)).whenever(this).tier
-        }
-        val releaseVersion = releaseVersionMock ?: mock<ReleaseVersionWrapper>().apply {
-            doReturn(currentRelease).whenever(this).currentReleaseVersion
-        }
-        val feature = mock<FeatureWrapper>().apply {
-            doReturn(bookmarksFeature).whenever(this).bookmarksFeature
-        }
         upsellViewModel = UpsellViewModel(
-            analyticsTracker = mock(),
-            feature = feature,
-            releaseVersion = releaseVersion,
+            analyticsTracker = mock<AnalyticsTrackerWrapper>(),
             subscriptionManager = subscriptionManager,
         )
+
+        val state = upsellViewModel.state.value as UpsellViewModel.UiState.Loaded
+
+        assertFalse(state.showEarlyAccessMessage)
+        assertEquals(Subscription.SubscriptionTier.PLUS, state.freeTrial.subscriptionTier)
     }
 }

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
@@ -10,13 +10,13 @@ import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeDefault
-import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import java.util.UUID
 import junit.framework.TestCase.assertFalse

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
@@ -10,14 +10,13 @@ import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeDefault
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureWrapper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import java.util.UUID
 import junit.framework.TestCase.assertFalse
@@ -33,9 +32,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -77,10 +76,10 @@ class BookmarksViewModelTest {
     private lateinit var theme: Theme
 
     @Mock
-    private lateinit var feature: FeatureWrapper
+    private lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     @Mock
-    private lateinit var analyticsTracker: AnalyticsTrackerWrapper
+    private lateinit var bookmarkFeature: BookmarkFeatureControl
 
     private lateinit var bookmarksViewModel: BookmarksViewModel
     private val episodeUuid = UUID.randomUUID().toString()
@@ -91,7 +90,7 @@ class BookmarksViewModelTest {
         whenever(userSetting.flow).thenReturn(MutableStateFlow(cachedSubscriptionStatus))
         whenever(settings.cachedSubscriptionStatus).thenReturn(userSetting)
         whenever(episodeManager.findEpisodeByUuid(episodeUuid)).thenReturn(episode)
-        whenever(feature.isUserEntitled(eq(Feature.BOOKMARKS_ENABLED), anyOrNull())).thenReturn(true)
+        whenever(bookmarkFeature.isAvailable(anyOrNull())).thenReturn(true)
         whenever(bookmarkManager.findEpisodeBookmarksFlow(episode, BookmarksSortTypeDefault.TIMESTAMP)).thenReturn(flowOf(emptyList()))
         val playerBookmarksSortType = mock<UserSetting<BookmarksSortTypeDefault>> {
             on { flow } doReturn MutableStateFlow(BookmarksSortTypeDefault.TIMESTAMP)
@@ -103,6 +102,7 @@ class BookmarksViewModelTest {
             .thenReturn(MutableLiveData<List<Bookmark>>().apply { value = emptyList() })
 
         bookmarksViewModel = BookmarksViewModel(
+            analyticsTracker = analyticsTracker,
             bookmarkManager = bookmarkManager,
             episodeManager = episodeManager,
             podcastManager = podcastManager,
@@ -110,33 +110,14 @@ class BookmarksViewModelTest {
             settings = settings,
             playbackManager = playbackManager,
             theme = theme,
-            feature = feature,
+            bookmarkFeature = bookmarkFeature,
             ioDispatcher = UnconfinedTestDispatcher(),
-            analyticsTracker = analyticsTracker,
         )
     }
 
-    /*@Test
-    fun `given no bookmarks, when bookmarks loaded, then Empty state shown`() = runTest {
-        whenever(bookmarkManager.findEpisodeBookmarksFlow(episode)).thenReturn(flowOf(emptyList()))
-
-        bookmarksViewModel.loadBookmarks(episodeUuid)
-
-        assertTrue(bookmarksViewModel.uiState.value is BookmarksViewModel.UiState.Empty)
-    }
-
-    @Test
-    fun `given bookmarks present, when bookmarks loaded, then Loaded state shown`() = runTest {
-        whenever(bookmarkManager.findEpisodeBookmarksFlow(episode)).thenReturn(flowOf(listOf(mock())))
-
-        bookmarksViewModel.loadBookmarks(episodeUuid)
-
-        assertTrue(bookmarksViewModel.uiState.value is BookmarksViewModel.UiState.Loaded)
-    }*/
-
     @Test
     fun `given feature not available, when bookmarks loaded, then Upsell state shown`() = runTest {
-        whenever(feature.isUserEntitled(eq(Feature.BOOKMARKS_ENABLED), anyOrNull())).thenReturn(false)
+        whenever(bookmarkFeature.isAvailable(any())).thenReturn(false)
 
         bookmarksViewModel.loadBookmarks(episodeUuid, SourceView.PLAYER)
 
@@ -145,7 +126,7 @@ class BookmarksViewModelTest {
 
     @Test
     fun `given feature available, when bookmarks loaded, then Upsell state not shown`() = runTest {
-        whenever(feature.isUserEntitled(eq(Feature.BOOKMARKS_ENABLED), anyOrNull())).thenReturn(true)
+        whenever(bookmarkFeature.isAvailable(any())).thenReturn(true)
 
         bookmarksViewModel.loadBookmarks(episodeUuid, SourceView.PLAYER)
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -31,8 +31,6 @@ import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -196,11 +194,9 @@ class EpisodeContainerFragment :
 
         viewPager.adapter = adapter
 
-        if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-            TabLayoutMediator(tabLayout, viewPager, true) { tab, position ->
-                tab.setText(adapter.pageTitle(position))
-            }.attach()
-        }
+        TabLayoutMediator(tabLayout, viewPager, true) { tab, position ->
+            tab.setText(adapter.pageTitle(position))
+        }.attach()
 
         viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
             override fun onPageScrollStateChanged(state: Int) {
@@ -265,14 +261,12 @@ class EpisodeContainerFragment :
             get() = sections.indexOf(Section.Bookmarks)
 
         private sealed class Section(@StringRes val titleRes: Int) {
-            object Details : Section(LR.string.details)
-            object Bookmarks : Section(LR.string.bookmarks)
+            data object Details : Section(LR.string.details)
+            data object Bookmarks : Section(LR.string.bookmarks)
         }
 
         private var sections = mutableListOf<Section>(Section.Details).apply {
-            if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-                add(Section.Bookmarks)
-            }
+            add(Section.Bookmarks)
         }.toList()
 
         override fun getItemId(position: Int): Long {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -58,8 +58,6 @@ import au.com.shiftyjelly.pocketcasts.ui.images.PodcastImageLoaderThemed
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.extensions.hide
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.extensions.toggleVisibility
@@ -414,9 +412,7 @@ class PodcastAdapter(
         }
         val content = mutableListOf<Any>().apply {
             add(Podcast())
-            if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-                add(TabsHeader(PodcastTab.EPISODES, onTabClicked))
-            }
+            add(TabsHeader(PodcastTab.EPISODES, onTabClicked))
             add(
                 EpisodeHeader(
                     showingArchived = showingArchived,
@@ -468,53 +464,51 @@ class PodcastAdapter(
         context: Context,
     ) {
         val content = mutableListOf<Any>().apply {
-            if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-                add(Podcast())
-                add(TabsHeader(PodcastTab.BOOKMARKS, onTabClicked))
+            add(Podcast())
+            add(TabsHeader(PodcastTab.BOOKMARKS, onTabClicked))
 
-                if (!bookmarksAvailable) {
-                    add(BookmarkUpsell)
-                } else if (searchTerm.isEmpty() && bookmarks.isEmpty()) {
-                    add(NoBookmarkMessage)
-                } else {
+            if (!bookmarksAvailable) {
+                add(BookmarkUpsell)
+            } else if (searchTerm.isEmpty() && bookmarks.isEmpty()) {
+                add(NoBookmarkMessage)
+            } else {
+                add(
+                    BookmarkHeader(
+                        bookmarksCount = bookmarks.size,
+                        searchTerm = searchTerm,
+                        onSearchFocus = onSearchFocus,
+                        onSearchQueryChanged = onSearchQueryChanged,
+                        onOptionsClicked = onBookmarksOptionsClicked,
+                    ),
+                )
+                if (searchTerm.isNotEmpty() && bookmarks.isEmpty()) {
                     add(
-                        BookmarkHeader(
-                            bookmarksCount = bookmarks.size,
-                            searchTerm = searchTerm,
-                            onSearchFocus = onSearchFocus,
-                            onSearchQueryChanged = onSearchQueryChanged,
-                            onOptionsClicked = onBookmarksOptionsClicked,
+                        NoResultsMessage(
+                            title = context.getString(LR.string.podcast_no_bookmarks_found),
+                            bodyText = context.getString(LR.string.podcast_no_bookmarks_matching),
+                            showButton = false,
                         ),
                     )
-                    if (searchTerm.isNotEmpty() && bookmarks.isEmpty()) {
-                        add(
-                            NoResultsMessage(
-                                title = context.getString(LR.string.podcast_no_bookmarks_found),
-                                bodyText = context.getString(LR.string.podcast_no_bookmarks_matching),
-                                showButton = false,
-                            ),
-                        )
-                    } else {
-                        addAll(
-                            bookmarks.map {
-                                BookmarkItemData(
-                                    bookmark = it,
-                                    onBookmarkPlayClicked = onBookmarkPlayClicked,
-                                    onBookmarkRowLongPress = onBookmarkRowLongPress,
-                                    onBookmarkRowClick = { bookmark, adapterPosition ->
-                                        multiSelectBookmarksHelper.toggle(bookmark)
-                                        notifyItemChanged(adapterPosition)
-                                    },
-                                    isMultiSelecting = { multiSelectBookmarksHelper.isMultiSelecting },
-                                    isSelected = { bookmark ->
-                                        multiSelectBookmarksHelper.isSelected(
-                                            bookmark,
-                                        )
-                                    },
-                                )
-                            },
-                        )
-                    }
+                } else {
+                    addAll(
+                        bookmarks.map {
+                            BookmarkItemData(
+                                bookmark = it,
+                                onBookmarkPlayClicked = onBookmarkPlayClicked,
+                                onBookmarkRowLongPress = onBookmarkRowLongPress,
+                                onBookmarkRowClick = { bookmark, adapterPosition ->
+                                    multiSelectBookmarksHelper.toggle(bookmark)
+                                    notifyItemChanged(adapterPosition)
+                                },
+                                isMultiSelecting = { multiSelectBookmarksHelper.isMultiSelecting },
+                                isSelected = { bookmark ->
+                                    multiSelectBookmarksHelper.isSelected(
+                                        bookmark,
+                                    )
+                                },
+                            )
+                        },
+                    )
                 }
             }
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -63,8 +63,6 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.images.CoilManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
@@ -660,14 +658,12 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         super.onViewCreated(view, savedInstanceState)
         binding?.setupMultiSelect()
 
-        if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-            viewLifecycleOwner.lifecycleScope.launch {
-                viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                    viewModel.multiSelectBookmarksHelper.showEditBookmarkPage
-                        .collect { show ->
-                            if (show) onEditBookmarkClick()
-                        }
-                }
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.multiSelectBookmarksHelper.showEditBookmarkPage
+                    .collect { show ->
+                        if (show) onEditBookmarkClick()
+                    }
             }
         }
     }
@@ -680,9 +676,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
     private fun FragmentPodcastBinding.setupMultiSelect() {
         viewModel.multiSelectEpisodesHelper.setUp(multiSelectEpisodesToolbar)
-        if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-            viewModel.multiSelectBookmarksHelper.setUp(multiSelectBookmarksToolbar)
-        }
+        viewModel.multiSelectBookmarksHelper.setUp(multiSelectBookmarksToolbar)
     }
 
     fun <T> MultiSelectHelper<T>.setUp(multiSelectToolbar: MultiSelectToolbar) {
@@ -868,9 +862,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         itemTouchHelper = null
 
         viewModel.multiSelectEpisodesHelper.cleanup()
-        if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-            viewModel.multiSelectBookmarksHelper.cleanup()
-        }
+        viewModel.multiSelectBookmarksHelper.cleanup()
 
         super.onDestroyView()
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkUpsellViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkUpsellViewHolder.kt
@@ -16,8 +16,6 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
 
 class BookmarkUpsellViewHolder(
     private val composeView: ComposeView,
@@ -32,11 +30,8 @@ class BookmarkUpsellViewHolder(
                     style = MessageViewColors.Default,
                     sourceView = sourceView,
                     onClick = {
-                        val source = OnboardingUpgradeSource.BOOKMARKS
                         val onboardingFlow = OnboardingFlow.Upsell(
-                            source = source,
-                            showPatronOnly = Feature.BOOKMARKS_ENABLED.tier == FeatureTier.Patron ||
-                                Feature.BOOKMARKS_ENABLED.isCurrentlyExclusiveToPatron(),
+                            source = OnboardingUpgradeSource.BOOKMARKS,
                         )
                         OnboardingLauncher.openOnboardingFlow(context.getActivity(), onboardingFlow)
                     },

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/EpisodeListBookmarkViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/EpisodeListBookmarkViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/EpisodeListBookmarkViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/EpisodeListBookmarkViewModel.kt
@@ -4,8 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -19,6 +18,7 @@ import kotlinx.coroutines.launch
 class EpisodeListBookmarkViewModel
 @Inject constructor(
     private val settings: Settings,
+    private val bookmarkFeature: BookmarkFeatureControl,
 ) : ViewModel() {
 
     private var _stateFlow: MutableStateFlow<State> = MutableStateFlow(State())
@@ -31,8 +31,7 @@ class EpisodeListBookmarkViewModel
                     _stateFlow.update { state ->
                         val userTier = (cachedSubscriptionStatus as? SubscriptionStatus.Paid)?.tier?.toUserTier() ?: UserTier.Free
                         state.copy(
-                            isBookmarkFeatureAvailable = FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) &&
-                                Feature.isUserEntitled(Feature.BOOKMARKS_ENABLED, userTier),
+                            isBookmarkFeatureAvailable = bookmarkFeature.isAvailable(userTier),
                         )
                     }
                 }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheetFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheetFragment.kt
@@ -222,7 +222,6 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
                 }
 
                 val layoutBookmark = binding.layoutBookmark
-                layoutBookmark.isVisible = true
                 layoutBookmark.setOnClickListener {
                     dialog?.dismiss()
                     viewModel.trackOptionTapped(CloudBottomSheetViewModel.BOOKMARKS)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheetFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheetFragment.kt
@@ -43,8 +43,6 @@ import au.com.shiftyjelly.pocketcasts.ui.images.PodcastImageLoaderThemed
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.Network
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.helper.CloudDeleteHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.WarningsHelper
@@ -224,7 +222,7 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
                 }
 
                 val layoutBookmark = binding.layoutBookmark
-                layoutBookmark.isVisible = FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)
+                layoutBookmark.isVisible = true
                 layoutBookmark.setOnClickListener {
                     dialog?.dismiss()
                     viewModel.trackOptionTapped(CloudBottomSheetViewModel.BOOKMARKS)

--- a/modules/features/profile/src/main/res/layout/bottom_sheet_cloud_file.xml
+++ b/modules/features/profile/src/main/res/layout/bottom_sheet_cloud_file.xml
@@ -216,8 +216,7 @@
         android:paddingStart="24dp"
         android:paddingEnd="24dp"
         android:paddingTop="8dp"
-        android:paddingBottom="8dp"
-        android:visibility="gone">
+        android:paddingBottom="8dp">
         <ImageView
             android:id="@+id/imgIconBookmark"
             android:layout_width="24dp"

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsFragment.kt
@@ -41,8 +41,6 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -268,11 +266,8 @@ class HeadphoneControlsSettingsFragment : BaseFragment() {
     }
 
     private fun startUpsellFlow() {
-        val source = OnboardingUpgradeSource.HEADPHONE_CONTROLS_SETTINGS
         val onboardingFlow = OnboardingFlow.Upsell(
-            source = source,
-            showPatronOnly = Feature.BOOKMARKS_ENABLED.tier == FeatureTier.Patron ||
-                Feature.BOOKMARKS_ENABLED.isCurrentlyExclusiveToPatron(),
+            source = OnboardingUpgradeSource.HEADPHONE_CONTROLS_SETTINGS,
         )
         OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
@@ -10,7 +10,7 @@ import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
-import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
@@ -42,9 +42,9 @@ class HeadphoneControlsSettingsPageViewModel @Inject constructor(
                     _state.update { state ->
                         state.copy(
                             isAddBookmarkEnabled = isAddBookmarkEnabled,
-                            addBookmarkIconId = addBookmarkIconId
+                            addBookmarkIconId = R.drawable.ic_plus
                                 .takeIf { !isAddBookmarkEnabled },
-                            addBookmarkIconColor = addBookmarkIconColor
+                            addBookmarkIconColor = SubscriptionTierColor.plusGold
                                 .takeIf { !isAddBookmarkEnabled } ?: SubscriptionTierColor.plusGold,
                         )
                     }
@@ -130,12 +130,6 @@ class HeadphoneControlsSettingsPageViewModel @Inject constructor(
         val addBookmarkIconId: Int? = null,
         val addBookmarkIconColor: Color = SubscriptionTierColor.plusGold,
     )
-
-    private val addBookmarkIconId
-        get() = R.drawable.ic_plus
-
-    private val addBookmarkIconColor: Color
-        get() = SubscriptionTierColor.plusGold
 
     enum class UpsellSourceAction {
         PREVIOUS,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
@@ -11,8 +11,6 @@ import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -134,18 +132,10 @@ class HeadphoneControlsSettingsPageViewModel @Inject constructor(
     )
 
     private val addBookmarkIconId
-        get() = when (Feature.BOOKMARKS_ENABLED.tier) {
-            is FeatureTier.Plus -> R.drawable.ic_plus
-            is FeatureTier.Free -> null
-            else -> null
-        }
+        get() = R.drawable.ic_plus
 
-    private val addBookmarkIconColor
-        get() = when (Feature.BOOKMARKS_ENABLED.tier) {
-            is FeatureTier.Plus -> SubscriptionTierColor.plusGold
-            is FeatureTier.Free -> null
-            else -> null
-        }
+    private val addBookmarkIconColor: Color
+        get() = SubscriptionTierColor.plusGold
 
     enum class UpsellSourceAction {
         PREVIOUS,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragmentPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragmentPage.kt
@@ -30,8 +30,6 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSourc
 import au.com.shiftyjelly.pocketcasts.settings.privacy.PrivacyFragment
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BatteryRestrictionsSettingsFragment
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -92,9 +90,7 @@ fun SettingsFragmentPage(
             AutoArchiveRow(onClick = { openFragment(AutoArchiveFragment()) })
             AutoDownloadRow(onClick = { openFragment(AutoDownloadSettingsFragment.newInstance()) })
             AutoAddToUpNextRow(onClick = { openFragment(AutoAddSettingsFragment()) })
-            if (FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-                HeadphoneControlsRow(onClick = { openFragment(HeadphoneControlsSettingsFragment()) })
-            }
+            HeadphoneControlsRow(onClick = { openFragment(HeadphoneControlsSettingsFragment()) })
             ImportAndExportOpmlRow(onClick = { openFragment(ExportSettingsFragment()) })
             AdvancedRow(onClick = { openFragment(AdvancedSettingsFragment()) })
             PrivacyRow(onClick = { openFragment(PrivacyFragment()) })

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragmentPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragmentPage.kt
@@ -108,7 +108,7 @@ private fun DeveloperRow(onClick: () -> Unit) {
             MaterialTheme.theme.colors.gradient03A,
             MaterialTheme.theme.colors.gradient03E,
         ),
-        modifier = rowModifier(onClick),
+        modifier = Modifier.rowModifier(onClick),
     )
 }
 
@@ -121,7 +121,7 @@ private fun BetaFeatures(onClick: () -> Unit) {
             MaterialTheme.theme.colors.gradient03A,
             MaterialTheme.theme.colors.gradient03E,
         ),
-        modifier = rowModifier(onClick),
+        modifier = Modifier.rowModifier(onClick),
     )
 }
 
@@ -134,7 +134,7 @@ private fun BatteryOptimizationRow(onClick: () -> Unit) {
             MaterialTheme.theme.colors.gradient03A,
             MaterialTheme.theme.colors.gradient03E,
         ),
-        modifier = rowModifier(onClick),
+        modifier = Modifier.rowModifier(onClick),
     )
 }
 
@@ -147,7 +147,7 @@ private fun PlusRow(onClick: () -> Unit) {
             MaterialTheme.theme.colors.gradient01A,
             MaterialTheme.theme.colors.gradient01E,
         ),
-        modifier = rowModifier(onClick),
+        modifier = Modifier.rowModifier(onClick),
     )
 }
 
@@ -156,7 +156,7 @@ private fun GeneralRow(onClick: () -> Unit) {
     SettingRow(
         primaryText = stringResource(LR.string.settings_title_playback),
         icon = painterResource(IR.drawable.ic_profile_settings),
-        modifier = rowModifier(onClick),
+        modifier = Modifier.rowModifier(onClick),
     )
 }
 
@@ -165,7 +165,7 @@ private fun NotificationRow(onClick: () -> Unit) {
     SettingRow(
         primaryText = stringResource(LR.string.settings_title_notifications),
         icon = painterResource(SR.drawable.settings_notifications),
-        modifier = rowModifier(onClick),
+        modifier = Modifier.rowModifier(onClick),
     )
 }
 
@@ -175,7 +175,7 @@ private fun AppearanceRow(isSignedInAsPlusOrPatron: Boolean, onClick: () -> Unit
         primaryText = stringResource(LR.string.settings_title_appearance),
         icon = painterResource(SR.drawable.settings_appearance),
         primaryTextEndDrawable = if (isSignedInAsPlusOrPatron) null else IR.drawable.ic_plus,
-        modifier = rowModifier(onClick),
+        modifier = Modifier.rowModifier(onClick),
     )
 }
 
@@ -184,7 +184,7 @@ private fun StorageAndDataUseRow(onClick: () -> Unit) {
     SettingRow(
         primaryText = stringResource(LR.string.settings_title_storage),
         icon = painterResource(SR.drawable.settings_storage),
-        modifier = rowModifier(onClick),
+        modifier = Modifier.rowModifier(onClick),
     )
 }
 
@@ -193,7 +193,7 @@ private fun AutoArchiveRow(onClick: () -> Unit) {
     SettingRow(
         primaryText = stringResource(LR.string.settings_title_auto_archive),
         icon = painterResource(SR.drawable.settings_auto_archive),
-        modifier = rowModifier(onClick),
+        modifier = Modifier.rowModifier(onClick),
     )
 }
 
@@ -202,7 +202,7 @@ private fun AutoDownloadRow(onClick: () -> Unit) {
     SettingRow(
         primaryText = stringResource(LR.string.settings_title_auto_download),
         icon = painterResource(SR.drawable.settings_auto_download),
-        modifier = rowModifier(onClick),
+        modifier = Modifier.rowModifier(onClick),
     )
 }
 
@@ -211,7 +211,7 @@ private fun AutoAddToUpNextRow(onClick: () -> Unit) {
     SettingRow(
         primaryText = stringResource(LR.string.settings_title_auto_add_to_up_next),
         icon = painterResource(IR.drawable.ic_upnext_playlast),
-        modifier = rowModifier(onClick),
+        modifier = Modifier.rowModifier(onClick),
     )
 }
 
@@ -220,7 +220,7 @@ private fun HeadphoneControlsRow(onClick: () -> Unit) {
     SettingRow(
         primaryText = stringResource(LR.string.settings_title_headphone_controls),
         icon = painterResource(IR.drawable.ic_headphone),
-        modifier = rowModifier(onClick),
+        modifier = Modifier.rowModifier(onClick),
     )
 }
 
@@ -229,7 +229,7 @@ private fun ImportAndExportOpmlRow(onClick: () -> Unit) {
     SettingRow(
         primaryText = stringResource(LR.string.settings_title_import_export),
         icon = painterResource(SR.drawable.settings_import_export),
-        modifier = rowModifier(onClick),
+        modifier = Modifier.rowModifier(onClick),
     )
 }
 
@@ -238,7 +238,7 @@ private fun PrivacyRow(onClick: () -> Unit) {
     SettingRow(
         primaryText = stringResource(LR.string.settings_title_privacy),
         icon = painterResource(SR.drawable.whatsnew_privacy),
-        modifier = rowModifier(onClick),
+        modifier = Modifier.rowModifier(onClick),
     )
 }
 
@@ -247,7 +247,7 @@ private fun AboutRow(onClick: () -> Unit) {
     SettingRow(
         primaryText = stringResource(LR.string.settings_title_about),
         icon = painterResource(SR.drawable.settings_about),
-        modifier = rowModifier(onClick),
+        modifier = Modifier.rowModifier(onClick),
     )
 }
 
@@ -256,12 +256,12 @@ private fun AdvancedRow(onClick: () -> Unit) {
     SettingRow(
         primaryText = stringResource(LR.string.settings_title_advanced),
         icon = painterResource(SR.drawable.settings_advanced),
-        modifier = rowModifier(onClick),
+        modifier = Modifier.rowModifier(onClick),
     )
 }
 
-private fun rowModifier(onClick: () -> Unit) =
-    Modifier
+fun Modifier.rowModifier(onClick: () -> Unit): Modifier =
+    this
         .clickable { onClick() }
         .padding(vertical = 6.dp)
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -27,8 +27,6 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewViewModel.NavigationState
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -114,11 +112,8 @@ class WhatsNewFragment : BaseFragment() {
     }
 
     private fun startUpsellFlow() {
-        val source = OnboardingUpgradeSource.BOOKMARKS
         val onboardingFlow = OnboardingFlow.Upsell(
-            source = source,
-            showPatronOnly = Feature.BOOKMARKS_ENABLED.tier == FeatureTier.Patron ||
-                Feature.BOOKMARKS_ENABLED.isCurrentlyExclusiveToPatron(),
+            source = OnboardingUpgradeSource.BOOKMARKS,
         )
         OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
@@ -5,14 +5,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.EarlyAccessState
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureWrapper
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersion.Companion.comparedToEarlyPatronAccess
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersionWrapper
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -29,9 +24,7 @@ class WhatsNewViewModel @Inject constructor(
     private val playbackManager: PlaybackManager,
     private val subscriptionManager: SubscriptionManager,
     private val settings: Settings,
-    private val releaseVersion: ReleaseVersionWrapper,
-    private val feature: FeatureWrapper,
-    featureFlag: FeatureFlagWrapper,
+    private val bookmarkFeature: BookmarkFeatureControl,
 ) : ViewModel() {
     private val _state: MutableStateFlow<UiState> = MutableStateFlow(UiState.Loading)
     val state = _state.asStateFlow()
@@ -40,20 +33,12 @@ class WhatsNewViewModel @Inject constructor(
     val navigationState = _navigationState.asSharedFlow()
 
     init {
-        val isBookmarksEnabled = featureFlag.isEnabled(feature.bookmarksFeature)
-        if (isBookmarksEnabled) {
-            updateStateForBookmarks()
-        } else {
-            _state.value = UiState.Loaded(
-                feature = WhatsNewFeature.AutoPlay,
-                tier = UserTier.Free,
-            )
-        }
+        updateStateForBookmarks()
     }
 
     private fun updateStateForBookmarks() {
         val userTier = settings.userTier
-        val isUserEntitled = feature.isUserEntitled(feature.bookmarksFeature, userTier)
+        val isUserEntitled = bookmarkFeature.isAvailable(userTier)
         if (isUserEntitled) {
             _state.value = UiState.Loaded(
                 feature = bookmarksFeature(isUserEntitled = true),
@@ -61,12 +46,7 @@ class WhatsNewViewModel @Inject constructor(
             )
         } else {
             viewModelScope.launch {
-                val availableForFeatureTier = if (feature.bookmarksFeature.isCurrentlyExclusiveToPatron(releaseVersion)) {
-                    FeatureTier.Patron
-                } else {
-                    feature.bookmarksFeature.tier
-                }
-                val subscriptionTier = availableForFeatureTier.toSubscriptionTier()
+                val subscriptionTier = Subscription.SubscriptionTier.PLUS
 
                 subscriptionManager
                     .freeTrialForSubscriptionTierFlow(subscriptionTier)
@@ -92,7 +72,7 @@ class WhatsNewViewModel @Inject constructor(
     ): WhatsNewFeature.Bookmarks {
         val currentEpisode = playbackManager.getCurrentEpisode()
         return WhatsNewFeature.Bookmarks(
-            title = titleResId(),
+            title = LR.string.whats_new_bookmarks_title,
             message = if (isUserEntitled) LR.string.whats_new_bookmarks_body else LR.string.bookmarks_upsell_instructions,
             confirmButtonTitle = if (currentEpisode == null) LR.string.whats_new_bookmarks_enable_now_button else LR.string.whats_new_bookmarks_try_now_button,
             hasFreeTrial = trialExists,
@@ -100,31 +80,6 @@ class WhatsNewViewModel @Inject constructor(
             subscriptionTier = subscriptionTier,
         )
     }
-
-    private fun titleResId(): Int {
-        val bookmarksFeature = feature.bookmarksFeature
-        val patronExclusiveAccessRelease = (bookmarksFeature.tier as? FeatureTier.Plus)?.patronExclusiveAccessRelease
-
-        val isReleaseCandidate = releaseVersion.currentReleaseVersion.releaseCandidate != null
-        val relativeToEarlyPatronAccess = patronExclusiveAccessRelease?.let {
-            releaseVersion.currentReleaseVersion.comparedToEarlyPatronAccess(it)
-        }
-
-        val showJoinBeta = when (relativeToEarlyPatronAccess) {
-            EarlyAccessState.Before,
-            EarlyAccessState.During,
-            -> isReleaseCandidate
-            EarlyAccessState.After -> false
-            null -> false
-        }
-
-        return if (showJoinBeta) {
-            LR.string.whats_new_boomarks_join_beta_testing_title
-        } else {
-            LR.string.whats_new_bookmarks_title
-        }
-    }
-
     fun onConfirm() {
         viewModelScope.launch {
             val currentState = state.value as? UiState.Loaded ?: return@launch
@@ -145,14 +100,8 @@ class WhatsNewViewModel @Inject constructor(
         }
     }
 
-    private fun FeatureTier.toSubscriptionTier() = when (this) {
-        is FeatureTier.Patron -> Subscription.SubscriptionTier.PATRON
-        is FeatureTier.Plus -> Subscription.SubscriptionTier.PLUS
-        is FeatureTier.Free -> Subscription.SubscriptionTier.UNKNOWN
-    }
-
     sealed class UiState {
-        object Loading : UiState()
+        data object Loading : UiState()
         data class Loaded(
             val feature: WhatsNewFeature,
             val tier: UserTier,
@@ -165,7 +114,7 @@ class WhatsNewViewModel @Inject constructor(
         @StringRes open val confirmButtonTitle: Int,
         @StringRes val closeButtonTitle: Int? = null,
     ) {
-        object AutoPlay : WhatsNewFeature(
+        data object AutoPlay : WhatsNewFeature(
             title = LR.string.whats_new_autoplay_title,
             message = LR.string.whats_new_autoplay_body,
             confirmButtonTitle = LR.string.whats_new_autoplay_enable_button,
@@ -187,9 +136,9 @@ class WhatsNewViewModel @Inject constructor(
     }
 
     sealed class NavigationState {
-        object PlaybackSettings : NavigationState()
-        object HeadphoneControlsSettings : NavigationState()
-        object FullScreenPlayerScreen : NavigationState()
-        object StartUpsellFlow : NavigationState()
+        data object PlaybackSettings : NavigationState()
+        data object HeadphoneControlsSettings : NavigationState()
+        data object FullScreenPlayerScreen : NavigationState()
+        data object StartUpsellFlow : NavigationState()
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
@@ -7,6 +7,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
+import au.com.shiftyjelly.pocketcasts.utils.earlyaccess.EarlyAccessStrings
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -72,7 +73,7 @@ class WhatsNewViewModel @Inject constructor(
     ): WhatsNewFeature.Bookmarks {
         val currentEpisode = playbackManager.getCurrentEpisode()
         return WhatsNewFeature.Bookmarks(
-            title = LR.string.whats_new_bookmarks_title,
+            title = EarlyAccessStrings.getAppropriateTextResource(LR.string.whats_new_bookmarks_title),
             message = if (isUserEntitled) LR.string.whats_new_bookmarks_body else LR.string.bookmarks_upsell_instructions,
             confirmButtonTitle = if (currentEpisode == null) LR.string.whats_new_bookmarks_enable_now_button else LR.string.whats_new_bookmarks_try_now_button,
             hasFreeTrial = trialExists,

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/whatsnew/WhatsNewViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/whatsnew/WhatsNewViewModelTest.kt
@@ -4,17 +4,12 @@ import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.FreeTrial
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewViewModel
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureWrapper
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersion
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersionWrapper
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -25,8 +20,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -45,166 +38,55 @@ class WhatsNewViewModelTest {
     @Mock
     lateinit var subscriptionManager: SubscriptionManager
 
+    @Mock
+    lateinit var bookmarkFeature: BookmarkFeatureControl
+
     private lateinit var viewModel: WhatsNewViewModel
 
-    private val betaEarlyAccessRelease = ReleaseVersion(7, 50, null, 1)
-    private val productionEarlyAccessRelease = ReleaseVersion(7, 50)
-    private val betaFullAccessRelease = ReleaseVersion(7, 51, null, 1)
-    private val productionFullAccessRelease = ReleaseVersion(7, 51)
-
-    /* Title */
     @Test
-    fun `given plus user, when beta early access release, then join beta testing title shown`() = runTest {
-        whenever(settings.userTier).thenReturn(UserTier.Plus)
+    fun `given plus user, then bookmarks are here title shown`() =
+        runTest {
+            whenever(settings.userTier).thenReturn(UserTier.Plus)
 
-        initViewModel(
-            currentRelease = betaEarlyAccessRelease,
-            patronExclusiveAccessRelease = productionEarlyAccessRelease,
-        )
+            initViewModel()
 
-        viewModel.state.test {
-            assertTrue((awaitItem() as WhatsNewViewModel.UiState.Loaded).feature.title == LR.string.whats_new_boomarks_join_beta_testing_title)
+            viewModel.state.test {
+                assertTrue((awaitItem() as WhatsNewViewModel.UiState.Loaded).feature.title == R.string.whats_new_bookmarks_title)
+            }
         }
-    }
 
     @Test
-    fun `given patron user, when beta early access release, then join beta testing title shown`() = runTest {
-        whenever(settings.userTier).thenReturn(UserTier.Patron)
+    fun `given patron user, then bookmarks are here title shown`() =
+        runTest {
+            whenever(settings.userTier).thenReturn(UserTier.Patron)
+            initViewModel()
 
-        initViewModel(
-            currentRelease = betaEarlyAccessRelease,
-            patronExclusiveAccessRelease = productionEarlyAccessRelease,
-        )
-
-        viewModel.state.test {
-            assertTrue((awaitItem() as WhatsNewViewModel.UiState.Loaded).feature.title == LR.string.whats_new_boomarks_join_beta_testing_title)
+            viewModel.state.test {
+                assertTrue((awaitItem() as WhatsNewViewModel.UiState.Loaded).feature.title == R.string.whats_new_bookmarks_title)
+            }
         }
-    }
 
     @Test
-    fun `given plus user, when prod early access release, then bookmarks are here title shown`() = runTest {
-        whenever(settings.userTier).thenReturn(UserTier.Plus)
+    fun `given free user, then bookmarks are here title shown`() =
+        runTest {
+            whenever(settings.userTier).thenReturn(UserTier.Free)
 
-        initViewModel(
-            currentRelease = productionEarlyAccessRelease,
-            patronExclusiveAccessRelease = productionEarlyAccessRelease,
-        )
+            initViewModel()
 
-        viewModel.state.test {
-            assertTrue((awaitItem() as WhatsNewViewModel.UiState.Loaded).feature.title == R.string.whats_new_bookmarks_title)
+            viewModel.state.test {
+                assertTrue((awaitItem() as WhatsNewViewModel.UiState.Loaded).feature.title == LR.string.whats_new_bookmarks_title)
+            }
         }
-    }
 
-    @Test
-    fun `given patron user, when prod early access release, then bookmarks are here title shown`() = runTest {
-        whenever(settings.userTier).thenReturn(UserTier.Patron)
-        initViewModel(
-            currentRelease = productionEarlyAccessRelease,
-            patronExclusiveAccessRelease = productionEarlyAccessRelease,
-        )
-
-        viewModel.state.test {
-            assertTrue((awaitItem() as WhatsNewViewModel.UiState.Loaded).feature.title == R.string.whats_new_bookmarks_title)
-        }
-    }
-
-    @Test
-    fun `given plus user, when beta full access release, then bookmarks are here title shown`() = runTest {
-        whenever(settings.userTier).thenReturn(UserTier.Plus)
-
-        initViewModel(
-            currentRelease = betaFullAccessRelease,
-            patronExclusiveAccessRelease = productionEarlyAccessRelease,
-        )
-
-        viewModel.state.test {
-            assertTrue((awaitItem() as WhatsNewViewModel.UiState.Loaded).feature.title == R.string.whats_new_bookmarks_title)
-        }
-    }
-
-    @Test
-    fun `given patron user, when beta full access release, then bookmarks are here title shown`() = runTest {
-        whenever(settings.userTier).thenReturn(UserTier.Patron)
-
-        initViewModel(
-            currentRelease = betaFullAccessRelease,
-            patronExclusiveAccessRelease = productionEarlyAccessRelease,
-        )
-
-        viewModel.state.test {
-            assertTrue((awaitItem() as WhatsNewViewModel.UiState.Loaded).feature.title == R.string.whats_new_bookmarks_title)
-        }
-    }
-
-    @Test
-    fun `given free user, when prod full access release, then bookmarks are here title shown`() = runTest {
-        whenever(settings.userTier).thenReturn(UserTier.Free)
-
-        initViewModel(
-            currentRelease = productionFullAccessRelease,
-            patronExclusiveAccessRelease = productionEarlyAccessRelease,
-        )
-
-        viewModel.state.test {
-            assertTrue((awaitItem() as WhatsNewViewModel.UiState.Loaded).feature.title == LR.string.whats_new_bookmarks_title)
-        }
-    }
-
-    @Test
-    fun `given plus user, when prod full access release, then bookmarks are here title shown`() = runTest {
-        whenever(settings.userTier).thenReturn(UserTier.Plus)
-
-        initViewModel(
-            currentRelease = productionFullAccessRelease,
-            patronExclusiveAccessRelease = productionEarlyAccessRelease,
-        )
-
-        viewModel.state.test {
-            assertTrue((awaitItem() as WhatsNewViewModel.UiState.Loaded).feature.title == R.string.whats_new_bookmarks_title)
-        }
-    }
-
-    @Test
-    fun `given patron user, when prod full access release, then bookmarks are here title shown`() = runTest {
-        whenever(settings.userTier).thenReturn(UserTier.Patron)
-
-        initViewModel(
-            currentRelease = productionFullAccessRelease,
-            patronExclusiveAccessRelease = productionEarlyAccessRelease,
-        )
-
-        viewModel.state.test {
-            assertTrue((awaitItem() as WhatsNewViewModel.UiState.Loaded).feature.title == R.string.whats_new_bookmarks_title)
-        }
-    }
-
-    private fun initViewModel(
-        currentRelease: ReleaseVersion,
-        patronExclusiveAccessRelease: ReleaseVersion?,
-    ) {
+    private fun initViewModel() {
         whenever(subscriptionManager.freeTrialForSubscriptionTierFlow(Subscription.SubscriptionTier.PLUS))
             .thenReturn(flowOf(FreeTrial(subscriptionTier = Subscription.SubscriptionTier.PLUS)))
-
-        val releaseVersion = mock<ReleaseVersionWrapper>().apply {
-            doReturn(currentRelease).whenever(this).currentReleaseVersion
-        }
-        val bookmarksFeature = mock<Feature>().apply {
-            doReturn(FeatureTier.Plus(patronExclusiveAccessRelease)).whenever(this).tier
-        }
-        val feature = mock<FeatureWrapper>().apply {
-            doReturn(bookmarksFeature).whenever(this).bookmarksFeature
-        }
-
-        val featureFlag = mock<FeatureFlagWrapper>()
-        whenever(featureFlag.isEnabled(feature.bookmarksFeature)).thenReturn(true)
 
         viewModel = WhatsNewViewModel(
             playbackManager = playbackManager,
             subscriptionManager = subscriptionManager,
             settings = settings,
-            releaseVersion = releaseVersion,
-            feature = feature,
-            featureFlag = featureFlag,
+            bookmarkFeature = bookmarkFeature,
         )
     }
 }

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/whatsnew/WhatsNewViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/whatsnew/WhatsNewViewModelTest.kt
@@ -4,12 +4,12 @@ import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.FreeTrial
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewViewModel
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf

--- a/modules/services/localization/src/main/res/values-de/strings.xml
+++ b/modules/services/localization/src/main/res/values-de/strings.xml
@@ -45,7 +45,6 @@ Language: de
     <string name="podcast_submit_rating_no_internet">Keine Internetverbindung gefunden. Bitte stelle eine Internetverbindung her, um eine Bewertung abzugeben.</string>
     <string name="podcast_rate">%s bewerten</string>
     <string name="submit">Übermitteln</string>
-    <string name="whats_new_boomarks_join_beta_testing_title">Sei beim Testen der Beta-Version der Lesezeichen dabei!</string>
     <string name="whats_new_bookmarks_try_now_button">Jetzt testen</string>
     <string name="whats_new_bookmarks_title">Die Lesezeichen sind da!</string>
     <string name="bookmarks_upsell_instructions_early_access">Profitiere mit Pocket Casts Patron von frühzeitigem Zugriff auf diese Funktion und speichere Zeitstempel für deine Lieblingsfolgen. Bald für Plus-Abonnenten verfügbar.</string>

--- a/modules/services/localization/src/main/res/values-es-rMX/strings.xml
+++ b/modules/services/localization/src/main/res/values-es-rMX/strings.xml
@@ -45,7 +45,6 @@ Language: es
     <string name="podcast_submit_rating_no_internet">No se ha encontrado ninguna conexión a Internet. Conéctate a Internet para enviar una valoración.</string>
     <string name="podcast_rate">Puntúa %s</string>
     <string name="submit">Enviar</string>
-    <string name="whats_new_boomarks_join_beta_testing_title">Únete a nosotros en las pruebas beta de marcadores.</string>
     <string name="whats_new_bookmarks_try_now_button">Probar ahora</string>
     <string name="whats_new_bookmarks_title">Ya están aquí los marcadores.</string>
     <string name="bookmarks_upsell_instructions_early_access">Obtén acceso anticipado a esta función con Pocket Casts Patron y guarda las marcas de tiempo de tus episodios favoritos. Disponible próximamente para los suscriptores Plus.</string>

--- a/modules/services/localization/src/main/res/values-es/strings.xml
+++ b/modules/services/localization/src/main/res/values-es/strings.xml
@@ -45,7 +45,6 @@ Language: es
     <string name="podcast_submit_rating_no_internet">No se ha encontrado ninguna conexión a Internet. Conéctate a Internet para enviar una valoración.</string>
     <string name="podcast_rate">Puntúa %s</string>
     <string name="submit">Enviar</string>
-    <string name="whats_new_boomarks_join_beta_testing_title">Únete a nosotros en las pruebas beta de marcadores.</string>
     <string name="whats_new_bookmarks_try_now_button">Probar ahora</string>
     <string name="whats_new_bookmarks_title">Ya están aquí los marcadores.</string>
     <string name="bookmarks_upsell_instructions_early_access">Obtén acceso anticipado a esta función con Pocket Casts Patron y guarda las marcas de tiempo de tus episodios favoritos. Disponible próximamente para los suscriptores Plus.</string>

--- a/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
@@ -45,7 +45,6 @@ Language: fr
     <string name="podcast_submit_rating_no_internet">Aucune connexion Internet détectée. Veuillez vous connecter à Internet pour envoyer une note.</string>
     <string name="podcast_rate">Évaluer %s</string>
     <string name="submit">Envoyer</string>
-    <string name="whats_new_boomarks_join_beta_testing_title">Rejoignez-nous pour le bêta-test des favoris !</string>
     <string name="whats_new_bookmarks_try_now_button">Essayer maintenant</string>
     <string name="whats_new_bookmarks_title">Les favoris sont là !</string>
     <string name="bookmarks_upsell_instructions_early_access">Bénéficiez d’un accès anticipé à cette fonctionnalité avec Pocket Casts Patron et enregistrez les horodatages de vos épisodes favoris. Bientôt disponible pour les abonnés Plus.</string>

--- a/modules/services/localization/src/main/res/values-fr/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr/strings.xml
@@ -45,7 +45,6 @@ Language: fr
     <string name="podcast_submit_rating_no_internet">Aucune connexion Internet détectée. Veuillez vous connecter à Internet pour envoyer une note.</string>
     <string name="podcast_rate">Évaluer %s</string>
     <string name="submit">Envoyer</string>
-    <string name="whats_new_boomarks_join_beta_testing_title">Rejoignez-nous pour le bêta-test des favoris !</string>
     <string name="whats_new_bookmarks_try_now_button">Essayer maintenant</string>
     <string name="whats_new_bookmarks_title">Les favoris sont là !</string>
     <string name="bookmarks_upsell_instructions_early_access">Bénéficiez d’un accès anticipé à cette fonctionnalité avec Pocket Casts Patron et enregistrez les horodatages de vos épisodes favoris. Bientôt disponible pour les abonnés Plus.</string>

--- a/modules/services/localization/src/main/res/values-it/strings.xml
+++ b/modules/services/localization/src/main/res/values-it/strings.xml
@@ -45,7 +45,6 @@ Language: it
     <string name="podcast_submit_rating_no_internet">Nessuna connessione a Internet trovata. Connettiti a Internet per inviare una valutazione.</string>
     <string name="podcast_rate">Valuta %s</string>
     <string name="submit">Invia</string>
-    <string name="whats_new_boomarks_join_beta_testing_title">Unisciti a noi per il beta test della funzionalità dei segnalibri.</string>
     <string name="whats_new_bookmarks_try_now_button">Prova ora</string>
     <string name="whats_new_bookmarks_title">I segnalibri sono disponibili.</string>
     <string name="bookmarks_upsell_instructions_early_access">Ottieni l\'accesso anticipato a questa funzionalità con Pocket Casts Patron e salva le date e le ore dei tuoi episodi preferiti. Presto disponibile per gli abbonati a Plus.</string>

--- a/modules/services/localization/src/main/res/values-ja/strings.xml
+++ b/modules/services/localization/src/main/res/values-ja/strings.xml
@@ -45,7 +45,6 @@ Language: ja_JP
     <string name="podcast_submit_rating_no_internet">インターネット接続が見つかりません。 評価を送信するにはインターネットに接続してください。</string>
     <string name="podcast_rate">%s を評価する</string>
     <string name="submit">送信</string>
-    <string name="whats_new_boomarks_join_beta_testing_title">ブックマークのベータテストに参加してください !</string>
     <string name="whats_new_bookmarks_try_now_button">今すぐ試す</string>
     <string name="whats_new_bookmarks_title">ブックマークはこちら !</string>
     <string name="bookmarks_upsell_instructions_early_access">お早めに Pocket Casts Patron でこの機能にアクセスすると、お気に入りのエピソードのタイムスタンプを保存できます。 まもなく Plus にご登録の皆さまもご利用いただけるようになります。</string>

--- a/modules/services/localization/src/main/res/values-ko/strings.xml
+++ b/modules/services/localization/src/main/res/values-ko/strings.xml
@@ -45,7 +45,6 @@ Language: ko_KR
     <string name="podcast_submit_rating_no_internet">인터넷에 연결되지 않았습니다. 인터넷에 연결한 다음 평가를 제출하세요.</string>
     <string name="podcast_rate">%s 평가</string>
     <string name="submit">제출</string>
-    <string name="whats_new_boomarks_join_beta_testing_title">북마크에 대한 베타 테스트에 참여하세요!</string>
     <string name="whats_new_bookmarks_try_now_button">지금 시도</string>
     <string name="whats_new_bookmarks_title">북마크는 여기 있습니다!</string>
     <string name="bookmarks_upsell_instructions_early_access">Pocket Casts Patron으로 이 기능을 미리 이용해 보고 좋아하는 에피소드의 타임스탬프를 저장하세요. 곧 Plus 구독자가 이용할 수 있습니다.</string>

--- a/modules/services/localization/src/main/res/values-nl/strings.xml
+++ b/modules/services/localization/src/main/res/values-nl/strings.xml
@@ -45,7 +45,6 @@ Language: nl
     <string name="podcast_submit_rating_no_internet">Geen internetverbinding gevonden. Maak verbinding met het internet om een beoordeling in te dienen.</string>
     <string name="podcast_rate">Tarief %s</string>
     <string name="submit">Verzenden</string>
-    <string name="whats_new_boomarks_join_beta_testing_title">Doe mee met de betatests voor bladwijzers!</string>
     <string name="whats_new_bookmarks_try_now_button">Probeer het nu</string>
     <string name="whats_new_bookmarks_title">De bladwijzers zijn er!</string>
     <string name="bookmarks_upsell_instructions_early_access">Krijg vroegtijdige toegang tot deze functie met Pocket Casts Patron en sla tijdstempels op van je favoriete afleveringen. Binnenkort beschikbaar voor Plus-abonnees.</string>

--- a/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
+++ b/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
@@ -45,7 +45,6 @@ Language: pt_BR
     <string name="podcast_submit_rating_no_internet">Sem conexão com a Internet. Conecte-se à Internet para enviar a avaliação.</string>
     <string name="podcast_rate">Avalie o %s</string>
     <string name="submit">Enviar</string>
-    <string name="whats_new_boomarks_join_beta_testing_title">Junte-se a nós na versão beta dos favoritos!</string>
     <string name="whats_new_bookmarks_try_now_button">Experimentar agora</string>
     <string name="whats_new_bookmarks_title">Chegaram os favoritos!</string>
     <string name="bookmarks_upsell_instructions_early_access">Obtenha o Pocket Casts Patron para receber acesso antecipado a esta funcionalidade e salvar a data/hora dos seus episódios favoritos. Disponível para assinantes do Plus em breve.</string>

--- a/modules/services/localization/src/main/res/values-ru/strings.xml
+++ b/modules/services/localization/src/main/res/values-ru/strings.xml
@@ -45,7 +45,6 @@ Language: ru
     <string name="podcast_submit_rating_no_internet">Отсутствует подключение к Интернету. Чтобы отправить оценку, подключитесь к Интернету.</string>
     <string name="podcast_rate">Оцените %s</string>
     <string name="submit">Отправить</string>
-    <string name="whats_new_boomarks_join_beta_testing_title">Примите участие в бета-тестировании закладок!</string>
     <string name="whats_new_bookmarks_try_now_button">Попробовать</string>
     <string name="whats_new_bookmarks_title">Закладки уже готовы!</string>
     <string name="bookmarks_upsell_instructions_early_access">Получите ранний доступ к этой и многим другим функциям с Pocket Casts Patron и сохраняйте отметки времени понравившихся вам эпизодов. Уже скоро станет доступным для подписчиков Plus.</string>

--- a/modules/services/localization/src/main/res/values-sv/strings.xml
+++ b/modules/services/localization/src/main/res/values-sv/strings.xml
@@ -45,7 +45,6 @@ Language: sv_SE
     <string name="podcast_submit_rating_no_internet">Ingen internetanslutning hittades. Anslut till internet för att lämna ett betyg.</string>
     <string name="podcast_rate">Omdöme %s</string>
     <string name="submit">Skicka</string>
-    <string name="whats_new_boomarks_join_beta_testing_title">Var med och betatesta bokmärken!</string>
     <string name="whats_new_bookmarks_try_now_button">Testa nu</string>
     <string name="whats_new_bookmarks_title">Bokmärkena är här!</string>
     <string name="bookmarks_upsell_instructions_early_access">Få tidig åtkomst till den här funktionen med Pocket Casts Patron och spara tidsstämplar för dina favoritavsnitt. Snart tillgänglig för Plus-prenumeranter.</string>

--- a/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
@@ -45,7 +45,6 @@ Language: zh_TW
     <string name="podcast_submit_rating_no_internet">找不到網際網路連線。 若要提交評分，請先連線至網際網路。</string>
     <string name="podcast_rate">為 %s 評分</string>
     <string name="submit">提交</string>
-    <string name="whats_new_boomarks_join_beta_testing_title">加入我們的書籤 Beta 測試！</string>
     <string name="whats_new_bookmarks_try_now_button">立即試試</string>
     <string name="whats_new_bookmarks_title">書籤登場！</string>
     <string name="bookmarks_upsell_instructions_early_access">利用 Pocket Casts Patron 搶先體驗此功能，還能儲存所愛單集的時間戳記。 即將開放 Plus 訂閱者使用。</string>

--- a/modules/services/localization/src/main/res/values-zh/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh/strings.xml
@@ -45,7 +45,6 @@ Language: zh_CN
     <string name="podcast_submit_rating_no_internet">未发现互联网连接。 请连接到互联网，以提交评级。</string>
     <string name="podcast_rate">评分 %s</string>
     <string name="submit">提交</string>
-    <string name="whats_new_boomarks_join_beta_testing_title">加入我们的书签 Beta 测试！</string>
     <string name="whats_new_bookmarks_try_now_button">立即试用</string>
     <string name="whats_new_bookmarks_title">书签在这里！</string>
     <string name="bookmarks_upsell_instructions_early_access">通过 Pocket Casts Patron 尽早使用此功能，并保存收藏剧集的时间戳。 即将面向 Plus 订阅用户推出。</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1415,7 +1415,6 @@
     <string name="whats_new_bookmarks_body" translatable="false">@string/bookmarks_create_instructions</string>
     <string name="whats_new_bookmarks_enable_now_button">Enable it now</string>
     <string name="whats_new_bookmarks_try_now_button">Try it now</string>
-    <string name="whats_new_boomarks_join_beta_testing_title">Join us in the beta testing for bookmarks!</string>
 
     <!-- Errors -->
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -40,6 +40,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.ThemeSetting
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.config.FirebaseConfig
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.jakewharton.rxrelay2.BehaviorRelay
@@ -63,6 +64,7 @@ class SettingsImpl @Inject constructor(
     @ApplicationContext private val context: Context,
     private val firebaseRemoteConfig: FirebaseRemoteConfig,
     private val moshi: Moshi,
+    private val bookmarkFeature: BookmarkFeatureControl,
 ) : Settings {
 
     companion object {
@@ -905,6 +907,7 @@ class SettingsImpl @Inject constructor(
         defaultAction = HeadphoneAction.SKIP_FORWARD,
         sharedPrefs = sharedPreferences,
         subscriptionStatusFlow = cachedSubscriptionStatus.flow,
+        bookmarkFeature = bookmarkFeature,
     )
 
     override val headphoneControlsPreviousAction = HeadphoneActionUserSetting(
@@ -912,6 +915,7 @@ class SettingsImpl @Inject constructor(
         defaultAction = HeadphoneAction.SKIP_BACK,
         sharedPrefs = sharedPreferences,
         subscriptionStatusFlow = cachedSubscriptionStatus.flow,
+        bookmarkFeature = bookmarkFeature,
     )
 
     override val headphoneControlsPlayBookmarkConfirmationSound = UserSetting.BoolPref(

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/HeadphoneAction.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/HeadphoneAction.kt
@@ -3,8 +3,6 @@ package au.com.shiftyjelly.pocketcasts.preferences.model
 import android.content.SharedPreferences
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -32,9 +30,7 @@ class HeadphoneActionUserSetting(
     fromInt = {
         val userTier = (subscriptionStatusFlow.value as? SubscriptionStatus.Paid)?.tier?.toUserTier()
             ?: UserTier.Free
-        val isAddBookmarkEnabled =
-            FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) &&
-                Feature.isUserEntitled(Feature.BOOKMARKS_ENABLED, userTier)
+        val isAddBookmarkEnabled = userTier == UserTier.Patron || userTier == UserTier.Plus
         val nextAction = HeadphoneAction.values()[it]
         if (nextAction == HeadphoneAction.ADD_BOOKMARK && !isAddBookmarkEnabled) {
             defaultAction

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/HeadphoneAction.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/HeadphoneAction.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.preferences.model
 import android.content.SharedPreferences
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -23,6 +24,7 @@ class HeadphoneActionUserSetting(
     defaultAction: HeadphoneAction,
     sharedPrefs: SharedPreferences,
     subscriptionStatusFlow: StateFlow<SubscriptionStatus?>,
+    bookmarkFeature: BookmarkFeatureControl,
 ) : UserSetting.PrefFromInt<HeadphoneAction>(
     sharedPrefKey = sharedPrefKey,
     defaultValue = defaultAction,
@@ -30,9 +32,8 @@ class HeadphoneActionUserSetting(
     fromInt = {
         val userTier = (subscriptionStatusFlow.value as? SubscriptionStatus.Paid)?.tier?.toUserTier()
             ?: UserTier.Free
-        val isAddBookmarkEnabled = userTier == UserTier.Patron || userTier == UserTier.Plus
-        val nextAction = HeadphoneAction.values()[it]
-        if (nextAction == HeadphoneAction.ADD_BOOKMARK && !isAddBookmarkEnabled) {
+        val nextAction = HeadphoneAction.entries[it]
+        if (nextAction == HeadphoneAction.ADD_BOOKMARK && !bookmarkFeature.isAvailable(userTier)) {
             defaultAction
         } else {
             nextAction

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkFeatureControl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkFeatureControl.kt
@@ -6,6 +6,10 @@ import javax.inject.Singleton
 
 @Singleton
 class BookmarkFeatureControl @Inject constructor() {
-    fun isAvailable(userTier: UserTier): Boolean =
-        userTier == UserTier.Patron || userTier == UserTier.Plus
+    fun isAvailable(userTier: UserTier): Boolean {
+        return when (userTier) {
+            UserTier.Plus, UserTier.Patron -> true
+            UserTier.Free -> false
+        }
+    }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkFeatureControl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkFeatureControl.kt
@@ -1,0 +1,11 @@
+package au.com.shiftyjelly.pocketcasts.repositories.bookmark
+
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class BookmarkFeatureControl @Inject constructor() {
+    fun isAvailable(userTier: UserTier): Boolean =
+        userTier == UserTier.Patron || userTier == UserTier.Plus
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkHelper.kt
@@ -19,6 +19,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.NotificationBroadcastRec
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isAppForeground
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.images.R as IR

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkHelper.kt
@@ -19,8 +19,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.NotificationBroadcastRec
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isAppForeground
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -30,6 +28,7 @@ class BookmarkHelper @Inject constructor(
     private val playbackManager: PlaybackManager,
     private val bookmarkManager: BookmarkManager,
     private val settings: Settings,
+    private val bookmarkFeature: BookmarkFeatureControl,
 ) {
     suspend fun handleAddBookmarkAction(
         context: Context,
@@ -75,8 +74,7 @@ class BookmarkHelper @Inject constructor(
     }
 
     private fun shouldAllowAddBookmark() =
-        FeatureFlag.isEnabled(Feature.BOOKMARKS_ENABLED) &&
-            Feature.isUserEntitled(Feature.BOOKMARKS_ENABLED, settings.userTier)
+        bookmarkFeature.isAvailable(settings.userTier)
 }
 
 private fun buildAndShowNotification(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -27,7 +27,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationControls
 import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
 import au.com.shiftyjelly.pocketcasts.preferences.model.LastPlayedList
-import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkHelper
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.auto.AutoConverter
@@ -39,6 +38,7 @@ import au.com.shiftyjelly.pocketcasts.utils.Optional
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getLaunchActivityPendingIntent
 import au.com.shiftyjelly.pocketcasts.utils.extensions.roundedSpeed
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import io.reactivex.Completable
 import io.reactivex.Observable

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -27,6 +27,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationControls
 import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
 import au.com.shiftyjelly.pocketcasts.preferences.model.LastPlayedList
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkHelper
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.auto.AutoConverter
@@ -71,6 +72,7 @@ class MediaSessionManager(
     val context: Context,
     val episodeAnalytics: EpisodeAnalytics,
     val bookmarkManager: BookmarkManager,
+    val bookmarkFeature: BookmarkFeatureControl,
     applicationScope: CoroutineScope,
 ) : CoroutineScope {
     companion object {
@@ -142,6 +144,7 @@ class MediaSessionManager(
             playbackManager,
             bookmarkManager,
             settings,
+            bookmarkFeature,
         )
 
         connect()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -35,7 +35,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.UserEpisodeServerStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
 import au.com.shiftyjelly.pocketcasts.repositories.R
-import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
@@ -63,6 +62,7 @@ import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isPositive
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.jakewharton.rxrelay2.BehaviorRelay
 import com.jakewharton.rxrelay2.Relay

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -35,6 +35,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.UserEpisodeServerStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
 import au.com.shiftyjelly.pocketcasts.repositories.R
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
@@ -123,6 +124,7 @@ open class PlaybackManager @Inject constructor(
     private val cloudFilesManager: CloudFilesManager,
     private val bookmarkManager: BookmarkManager,
     private val showNotesManager: ShowNotesManager,
+    bookmarkFeature: BookmarkFeatureControl,
     @ApplicationScope private val applicationScope: CoroutineScope,
 ) : FocusManager.FocusChangeListener, AudioNoisyManager.AudioBecomingNoisyListener, CoroutineScope {
 
@@ -196,6 +198,7 @@ open class PlaybackManager @Inject constructor(
         episodeAnalytics = episodeAnalytics,
         bookmarkManager = bookmarkManager,
         applicationScope = applicationScope,
+        bookmarkFeature = bookmarkFeature,
     )
     var sleepAfterEpisode: Boolean = false
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -46,7 +46,6 @@ import au.com.shiftyjelly.pocketcasts.servers.ServerManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManagerImpl
 import au.com.shiftyjelly.pocketcasts.servers.sync.exception.RefreshTokenExpiredException
 import au.com.shiftyjelly.pocketcasts.utils.Network
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.EntryPoint
 import dagger.hilt.EntryPoints
@@ -85,7 +84,6 @@ class RefreshPodcastsThread(
         fun notificationHelper(): NotificationHelper
         fun userManager(): UserManager
         fun syncManager(): SyncManager
-        fun featureFlagWrapper(): FeatureFlagWrapper
     }
 
     @Volatile
@@ -257,7 +255,6 @@ class RefreshPodcastsThread(
             subscriptionManager = entryPoint.subscriptionManager(),
             folderManager = entryPoint.folderManager(),
             syncManager = entryPoint.syncManager(),
-            featureFlagWrapper = entryPoint.featureFlagWrapper(),
         )
         val startTime = SystemClock.elapsedRealtime()
         val syncCompletable = sync.run()
@@ -680,6 +677,6 @@ class RefreshPodcastsThread(
 }
 
 private sealed class AddToUpNext {
-    object Next : AddToUpNext()
-    object Last : AddToUpNext()
+    data object Next : AddToUpNext()
+    data object Last : AddToUpNext()
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -479,7 +479,7 @@ class RefreshPodcastsThread(
             val phoneActions = mutableListOf<NotificationCompat.Action>()
             val wearActions = mutableListOf<NotificationCompat.Action>()
 
-            for (action in NewEpisodeNotificationAction.values()) {
+            for (action in NewEpisodeNotificationAction.entries) {
                 if (userActions.contains(action)) {
                     intentId++
                     val label = context.resources.getString(action.labelId)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -705,7 +705,7 @@ class PodcastSyncProcess(
 
     private fun importPodcast(sync: SyncUpdateResponse.PodcastSync): Maybe<Podcast> {
         val uuid = sync.uuid
-        if (uuid == null || uuid.isNullOrBlank()) {
+        if (uuid.isNullOrBlank()) {
             return Maybe.empty()
         }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -33,8 +33,6 @@ import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.parseIsoDate
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toIsoString
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import io.reactivex.Completable
 import io.reactivex.Maybe
@@ -70,7 +68,6 @@ class PodcastSyncProcess(
     var subscriptionManager: SubscriptionManager,
     var folderManager: FolderManager,
     var syncManager: SyncManager,
-    var featureFlagWrapper: FeatureFlagWrapper,
 ) : CoroutineScope {
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
@@ -222,9 +219,6 @@ class PodcastSyncProcess(
     }
 
     private suspend fun downloadAndImportBookmarks() {
-        if (!featureFlagWrapper.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-            return
-        }
         val bookmarks = syncManager.getBookmarks()
         importBookmarks(bookmarks)
     }
@@ -513,9 +507,6 @@ class PodcastSyncProcess(
     }
 
     private fun uploadBookmarksChanges(records: JSONArray) {
-        if (!featureFlagWrapper.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-            return
-        }
         try {
             val bookmarks = bookmarkManager.findBookmarksToSync()
             bookmarks.forEach { bookmark ->
@@ -643,9 +634,6 @@ class PodcastSyncProcess(
     }
 
     private suspend fun importBookmarks(bookmarks: List<Bookmark>) {
-        if (!featureFlagWrapper.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-            return
-        }
         for (bookmark in bookmarks) {
             importBookmark(bookmark)
         }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
@@ -20,7 +20,6 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
 import au.com.shiftyjelly.pocketcasts.servers.sync.update.SyncUpdateResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.update.SyncUpdateResponseParser
 import au.com.shiftyjelly.pocketcasts.utils.Util
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
 import dagger.Module
@@ -120,10 +119,10 @@ class ServersModule {
                 .build()
         }
 
-        fun provideMoshiBuilder(featureFlagWrapper: FeatureFlagWrapper = FeatureFlagWrapper()): Moshi.Builder {
+        fun provideMoshiBuilder(): Moshi.Builder {
             return Moshi.Builder()
                 .add(Date::class.java, Rfc3339DateJsonAdapter().nullSafe())
-                .add(SyncUpdateResponse::class.java, SyncUpdateResponseParser(featureFlagWrapper))
+                .add(SyncUpdateResponse::class.java, SyncUpdateResponseParser())
                 .add(EpisodePlayingStatus::class.java, EpisodePlayingStatusMoshiAdapter())
                 .add(PodcastsSortType::class.java, PodcastsSortTypeMoshiAdapter())
                 .add(AccessToken::class.java, AccessToken.Adapter)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
@@ -13,7 +13,6 @@ import au.com.shiftyjelly.pocketcasts.servers.extensions.nextIntOrDefault
 import au.com.shiftyjelly.pocketcasts.servers.extensions.nextIntOrNull
 import au.com.shiftyjelly.pocketcasts.servers.extensions.nextStringOrNull
 import au.com.shiftyjelly.pocketcasts.utils.extensions.parseIsoDate
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.JsonAdapter
@@ -91,11 +90,7 @@ class SyncUpdateResponseParser(
             "UserFolder" -> readFolder(reader, response)
             "UserPodcast" -> readPodcast(reader, response)
             "UserEpisode" -> readEpisode(reader, response)
-            "UserBookmark" -> if (featureFlagWrapper.isEnabled(Feature.BOOKMARKS_ENABLED)) {
-                readBookmark(reader, response)
-            } else {
-                reader.skipValue()
-            }
+            "UserBookmark" -> readBookmark(reader, response)
             null -> throw Exception("No type found for field")
             else -> reader.skipValue()
         }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
@@ -13,7 +13,6 @@ import au.com.shiftyjelly.pocketcasts.servers.extensions.nextIntOrDefault
 import au.com.shiftyjelly.pocketcasts.servers.extensions.nextIntOrNull
 import au.com.shiftyjelly.pocketcasts.servers.extensions.nextStringOrNull
 import au.com.shiftyjelly.pocketcasts.utils.extensions.parseIsoDate
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
@@ -26,9 +25,7 @@ import okhttp3.ResponseBody.Companion.toResponseBody
 import retrofit2.HttpException
 import retrofit2.Response
 
-class SyncUpdateResponseParser(
-    private val featureFlagWrapper: FeatureFlagWrapper,
-) : JsonAdapter<SyncUpdateResponse>() {
+class SyncUpdateResponseParser : JsonAdapter<SyncUpdateResponse>() {
 
     @ToJson
     override fun toJson(writer: JsonWriter, value: SyncUpdateResponse?) {}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/earlyaccess/EarlyAccessHelper.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/earlyaccess/EarlyAccessHelper.kt
@@ -1,0 +1,30 @@
+package au.com.shiftyjelly.pocketcasts.utils.earlyaccess
+
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.EarlyAccessState
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersion.Companion.comparedToEarlyPatronAccess
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersionWrapper
+
+object EarlyAccessHelper {
+    fun getAvailableForFeatureTier(
+        feature: Feature,
+        releaseVersion: ReleaseVersionWrapper = ReleaseVersionWrapper(),
+    ): FeatureTier {
+        val patronExclusiveAccessRelease =
+            (feature.tier as? FeatureTier.Plus)?.patronExclusiveAccessRelease
+
+        val isReleaseCandidate = releaseVersion.currentReleaseVersion.releaseCandidate != null
+        val relativeToEarlyPatronAccess = patronExclusiveAccessRelease?.let {
+            releaseVersion.currentReleaseVersion.comparedToEarlyPatronAccess(it)
+        }
+        return when (relativeToEarlyPatronAccess) {
+            null -> feature.tier
+            EarlyAccessState.Before,
+            EarlyAccessState.During,
+            -> if (isReleaseCandidate) feature.tier else FeatureTier.Patron
+
+            EarlyAccessState.After -> feature.tier
+        }
+    }
+}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/earlyaccess/EarlyAccessStrings.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/earlyaccess/EarlyAccessStrings.kt
@@ -1,0 +1,44 @@
+package au.com.shiftyjelly.pocketcasts.utils.earlyaccess
+
+import androidx.annotation.StringRes
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.EarlyAccessState
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersion.Companion.comparedToEarlyPatronAccess
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersionWrapper
+
+object EarlyAccessStrings {
+    fun getAppropriateTextResource(
+        @StringRes titleRes: Int,
+        @StringRes joinBetaRes: Int? = null,
+        earlyAccessFeature: Feature? = null,
+        releaseVersion: ReleaseVersionWrapper = ReleaseVersionWrapper(),
+    ): Int {
+        if (earlyAccessFeature == null || joinBetaRes == null) {
+            return titleRes
+        } else {
+            val patronExclusiveAccessRelease =
+                (earlyAccessFeature.tier as? FeatureTier.Plus)?.patronExclusiveAccessRelease
+
+            val isReleaseCandidate = releaseVersion.currentReleaseVersion.releaseCandidate != null
+            val relativeToEarlyPatronAccess = patronExclusiveAccessRelease?.let {
+                releaseVersion.currentReleaseVersion.comparedToEarlyPatronAccess(it)
+            }
+
+            val showJoinBeta = when (relativeToEarlyPatronAccess) {
+                EarlyAccessState.Before,
+                EarlyAccessState.During,
+                -> isReleaseCandidate
+
+                EarlyAccessState.After -> false
+                null -> false
+            }
+
+            return if (showJoinBeta) {
+                joinBetaRes
+            } else {
+                titleRes
+            }
+        }
+    }
+}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/BookmarkFeatureControl.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/BookmarkFeatureControl.kt
@@ -1,6 +1,5 @@
-package au.com.shiftyjelly.pocketcasts.repositories.bookmark
+package au.com.shiftyjelly.pocketcasts.utils.featureflag
 
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -84,6 +84,23 @@ enum class Feature(
             }
         }
     }
+
+    // Please do not delete this method because sometimes we need it
+    fun isCurrentlyExclusiveToPatron(
+        releaseVersion: ReleaseVersionWrapper = ReleaseVersionWrapper(),
+    ): Boolean {
+        val isReleaseCandidate = releaseVersion.currentReleaseVersion.releaseCandidate != null
+        val relativeToEarlyAccessState = (this.tier as? FeatureTier.Plus)?.patronExclusiveAccessRelease?.let {
+            releaseVersion.currentReleaseVersion.comparedToEarlyPatronAccess(it)
+        }
+        return when (relativeToEarlyAccessState) {
+            null -> false
+            EarlyAccessState.Before,
+            EarlyAccessState.During,
+            -> !isReleaseCandidate
+            EarlyAccessState.After -> false
+        }
+    }
 }
 
 // It would be nice to be able to use Subscription.SubscriptionTier here, but that's in the

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -19,16 +19,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = false,
         hasDevToggle = false,
     ),
-    BOOKMARKS_ENABLED(
-        key = "bookmarks_enabled",
-        title = "Bookmarks",
-        defaultValue = true,
-        tier = FeatureTier.Plus(
-            patronExclusiveAccessRelease = ReleaseVersion(major = 7, minor = 52),
-        ),
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     GIVE_RATINGS(
         key = "give_ratings",
         title = "Give Ratings",
@@ -46,22 +36,6 @@ enum class Feature(
         hasDevToggle = true,
     ),
     ;
-
-    fun isCurrentlyExclusiveToPatron(
-        releaseVersion: ReleaseVersionWrapper = ReleaseVersionWrapper(),
-    ): Boolean {
-        val isReleaseCandidate = releaseVersion.currentReleaseVersion.releaseCandidate != null
-        val relativeToEarlyAccessState = (this.tier as? FeatureTier.Plus)?.patronExclusiveAccessRelease?.let {
-            releaseVersion.currentReleaseVersion.comparedToEarlyPatronAccess(it)
-        }
-        return when (relativeToEarlyAccessState) {
-            null -> false
-            EarlyAccessState.Before,
-            EarlyAccessState.During,
-            -> !isReleaseCandidate
-            EarlyAccessState.After -> false
-        }
-    }
 
     companion object {
 
@@ -121,7 +95,7 @@ enum class UserTier {
 }
 
 sealed class FeatureTier {
-    object Patron : FeatureTier()
+    data object Patron : FeatureTier()
     class Plus(val patronExclusiveAccessRelease: ReleaseVersion?) : FeatureTier()
-    object Free : FeatureTier()
+    data object Free : FeatureTier()
 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/FeatureWrapper.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/FeatureWrapper.kt
@@ -1,8 +1,0 @@
-package au.com.shiftyjelly.pocketcasts.utils.featureflag
-
-import javax.inject.Inject
-
-class FeatureWrapper @Inject constructor() {
-    fun isUserEntitled(feature: Feature, userTier: UserTier) = Feature.isUserEntitled(feature, userTier)
-    val bookmarksFeature = Feature.BOOKMARKS_ENABLED
-}

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/earlyaccess/EarlyAccessHelperTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/earlyaccess/EarlyAccessHelperTest.kt
@@ -1,0 +1,85 @@
+package au.com.shiftyjelly.pocketcasts.utils.earlyaccess
+
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersion
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersionWrapper
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class EarlyAccessHelperTest {
+    private val betaEarlyAccessRelease = ReleaseVersion(7, 50, null, 1)
+    private val productionEarlyAccessRelease = ReleaseVersion(7, 50)
+    private val betaFullAccessRelease = ReleaseVersion(7, 51, null, 1)
+    private val productionFullAccessRelease = ReleaseVersion(7, 51)
+
+    /* Early Access Availability */
+    // Current Release                   | Beta         | Production
+    // ----------------------------------|--------------|--------------
+    // Beta Early Access Release         | Plus Users   | N/A
+    // Production Early Access Release   | Plus Users   | Patron Users
+    // Beta Full Access Release          | Plus Users   | Plus Users
+    // Production Full Access Release    | Plus Users   | Plus Users
+    @Test
+    fun `given patron exclusive feature, when beta release, feature available to Plus`() {
+        val featureTier = getFeatureTier(
+            currentRelease = betaEarlyAccessRelease,
+            patronExclusiveAccessRelease = productionEarlyAccessRelease,
+        )
+        assertTrue(featureTier is FeatureTier.Plus)
+    }
+
+    @Test
+    fun `given patron exclusive feature, when production early access release, feature available to Patron`() {
+        val featureTier = getFeatureTier(
+            currentRelease = productionEarlyAccessRelease,
+            patronExclusiveAccessRelease = productionEarlyAccessRelease,
+        )
+        assertTrue(featureTier is FeatureTier.Patron)
+    }
+
+    @Test
+    fun `given not a patron exclusive feature, when production release, feature available to Plus`() {
+        val featureTier = getFeatureTier(
+            currentRelease = productionEarlyAccessRelease,
+            patronExclusiveAccessRelease = null,
+        )
+        assertTrue(featureTier is FeatureTier.Plus)
+    }
+
+    @Test
+    fun `given not a patron exclusive feature, when beta full access release, feature available to Plus`() {
+        val featureTier = getFeatureTier(
+            currentRelease = betaFullAccessRelease,
+            patronExclusiveAccessRelease = productionEarlyAccessRelease,
+        )
+        assertTrue(featureTier is FeatureTier.Plus)
+    }
+
+    @Test
+    fun `given not a patron exclusive feature, when production full access release, feature available to Plus`() {
+        val featureTier = getFeatureTier(
+            currentRelease = productionFullAccessRelease,
+            patronExclusiveAccessRelease = productionEarlyAccessRelease,
+        )
+        assertTrue(featureTier is FeatureTier.Plus)
+    }
+
+    private fun getFeatureTier(
+        currentRelease: ReleaseVersion,
+        patronExclusiveAccessRelease: ReleaseVersion?,
+    ): FeatureTier {
+        val releaseVersion = mock<ReleaseVersionWrapper>().apply {
+            Mockito.doReturn(currentRelease).whenever(this).currentReleaseVersion
+        }
+        val feature = mock<Feature>().apply {
+            Mockito.doReturn(FeatureTier.Plus(patronExclusiveAccessRelease)).whenever(this).tier
+            Mockito.doReturn(true).whenever(this).defaultValue
+        }
+
+        return EarlyAccessHelper.getAvailableForFeatureTier(feature, releaseVersion)
+    }
+}

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/earlyaccess/EarlyAccessStringsTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/earlyaccess/EarlyAccessStringsTest.kt
@@ -1,0 +1,102 @@
+package au.com.shiftyjelly.pocketcasts.utils.earlyaccess
+
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersion
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersionWrapper
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+import org.mockito.Mockito.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class EarlyAccessStringsTest {
+
+    private val betaEarlyAccessRelease = ReleaseVersion(7, 50, null, 1)
+    private val productionEarlyAccessRelease = ReleaseVersion(7, 50)
+    private val betaFullAccessRelease = ReleaseVersion(7, 51, null, 1)
+    private val productionFullAccessRelease = ReleaseVersion(7, 51)
+
+    private val titleRes = 1
+    private val joinBetaRes = 2
+
+    @Test
+    fun `given join beta resource null, then default resource is shown`() {
+        val resource =
+            EarlyAccessStrings.getAppropriateTextResource(titleRes = titleRes, joinBetaRes = null)
+        assertEquals(titleRes, resource)
+    }
+
+    @Test
+    fun `given feature null, then default resource is shown`() {
+        val resource = EarlyAccessStrings.getAppropriateTextResource(
+            titleRes = titleRes,
+            earlyAccessFeature = null,
+        )
+        assertEquals(titleRes, resource)
+    }
+
+    @Test
+    fun `when beta early access release, then join beta testing title shown`() {
+        val resource = getEarlyAccessString(
+            titleRes = titleRes,
+            joinBetaRes = joinBetaRes,
+            currentRelease = betaEarlyAccessRelease,
+            patronExclusiveAccessRelease = productionEarlyAccessRelease,
+        )
+
+        assertEquals(joinBetaRes, resource)
+    }
+
+    @Test
+    fun `when prod early access release, then default resource is shown`() {
+        val resource = getEarlyAccessString(
+            titleRes = titleRes,
+            joinBetaRes = joinBetaRes,
+            currentRelease = productionEarlyAccessRelease,
+            patronExclusiveAccessRelease = productionEarlyAccessRelease,
+        )
+
+        assertEquals(titleRes, resource)
+    }
+
+    @Test
+    fun `when beta full access release, then default resource is shown`() {
+        val resource = getEarlyAccessString(
+            titleRes = titleRes,
+            joinBetaRes = joinBetaRes,
+            currentRelease = betaFullAccessRelease,
+            patronExclusiveAccessRelease = productionEarlyAccessRelease,
+        )
+
+        assertEquals(titleRes, resource)
+    }
+
+    @Test
+    fun `when prod full access release, then default resource is shown`() {
+        val resource = getEarlyAccessString(
+            titleRes = titleRes,
+            joinBetaRes = joinBetaRes,
+            currentRelease = productionFullAccessRelease,
+            patronExclusiveAccessRelease = productionEarlyAccessRelease,
+        )
+
+        assertEquals(titleRes, resource)
+    }
+    private fun getEarlyAccessString(
+        titleRes: Int,
+        joinBetaRes: Int? = null,
+        currentRelease: ReleaseVersion,
+        patronExclusiveAccessRelease: ReleaseVersion?,
+    ): Int {
+        val releaseVersion = mock<ReleaseVersionWrapper>().apply {
+            doReturn(currentRelease).whenever(this).currentReleaseVersion
+        }
+        val feature = mock<Feature>().apply {
+            doReturn(FeatureTier.Plus(patronExclusiveAccessRelease)).whenever(this).tier
+            doReturn(true).whenever(this).defaultValue
+        }
+
+        return EarlyAccessStrings.getAppropriateTextResource(titleRes, joinBetaRes, feature, releaseVersion)
+    }
+}

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/BookmarkFeatureControlTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/BookmarkFeatureControlTest.kt
@@ -1,6 +1,5 @@
-package au.com.shiftyjelly.pocketcasts.repositories.bookmark
+package au.com.shiftyjelly.pocketcasts.utils.featureflag
 
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import junit.framework.TestCase.assertFalse
 import org.junit.Before
 import org.junit.Test


### PR DESCRIPTION
## Description
- Removes `BOOKMARKS_ENABLED` feature flag
- Removes early access logic for Bookmark feature
- Creates `BookmarkFeatureControl` to handle the feature's availability depending on the user's subscription
- Deletes `strings.xml` that we don't need anymore
- Clean up `WhatsNew` flow
- ⚠️ I need special attention for review: 4b17b2eb3aa53442e055300aa9d1faa50e21992b, b22960c8564a64fa7d8fd067ef07c06682bcd812 and e6b49f3eaa9752da3a77c5cd56274afbf97b9968 because I was not 100% what is the expected behavior for WhatsNew flow 

Closes #1688

## Testing In
git apply [debug.patch](https://github.com/Automattic/pocket-casts-android/files/13933869/debug.patchx) and run the app in `debug`

### 1 Testing with Patron or Plus user

#### 1.1 Headphone controls
-  Log in with a patron/plus user account
-  Go to Profile -> Settings -> Headphone controls -> Next Action
- [ ]  You should be able to add bookmark
-  Try with Previous action too
- [ ]  You should be able to add bookmark

#### 1.2 Podcast episode
- Play a podcast episode
- Click on the 3 dots of the menu
-  [ ]  You should be able to add bookmark
- In the same screen of the episode, click on the `Bookmarks` tab at the top
- [ ]  You should be able to see the bookmarks

#### 1.3 Podcast episode list
- Open an podcast episode list
- You will see the tabs at the top: `Episodes` and `Bookmarks`
- Click on Bookmarks
- [ ]  You should be able to see the bookmarks

### 2 Testing with free user

#### 2.1 Headphone controls
-  Log in with a patron/plus user account
-  Go to Profile -> Settings -> Headphone controls -> Next Action
- [ ]  You should not be able to add bookmark
- [ ]  The `Add bookmark` button must have an icon to indicates to upgrade to premium account
-  Try with Previous action too
- [ ]  You should not be able to add bookmark
- [ ]  The `Add bookmark` button must have an icon to indicates to upgrade to premium account

#### 2.2 Podcast episode
- Play a podcast episode
- Click on the 3 dots of the menu
-  [ ]  You should not be able to add bookmark
- In the same screen of the episode, click on the `Bookmarks` tab at the top
- [ ]  You should see the UpSell asking you to upgrade your account

#### 2.3 Podcast episode list
- Open an podcast episode list
- You will see the tabs at the top: `Episodes` and `Bookmarks`
- Click on Bookmarks
- [ ]  You should see the UpSell asking you to upgrade your account

#### 3 What's new modal

### 3.1 Free user existing account
- Uninstall the app 
- Increase the `Settings.WHATS_NEW_VERSION_CODE`
- Build and run the app again
- Log in with an existing free account
- [ ]  You should see the Bookmarks what's new modal with an button to upgrade your account like this:

<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/0a4d4dcf-eb35-47da-93eb-f86724bf38e2" height="400">

### 3.2 Patron/Plus user existing account
- Uninstall the app 
- Increase the `Settings.WHATS_NEW_VERSION_CODE`
- Build and run the app again
- Log in with an existing Patron/Plus account
- [ ]  You should see the Bookmarks what's new modal with an try button like this:

<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/5b3a7e7f-535b-476d-b4da-b635d3f826a0" height="400">

### 3.3 New account
- Uninstall the app 
- Increase the `Settings.WHATS_NEW_VERSION_CODE`
- Build and run the app again
- Create a new account
- [ ] You should not see the what's new modal


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack


I would appreciate your inputs since you worked on this feature @ashiagr 🙏
