### PR TITLE
Update tracking source

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -205,6 +205,8 @@ private fun Content(
                 OnboardingUpgradeSource.BOOKMARKS,
                 OnboardingUpgradeSource.HEADPHONE_CONTROLS_SETTINGS,
                 OnboardingUpgradeSource.END_OF_YEAR,
+                OnboardingUpgradeSource.BOOKMARKS_SHELF_ACTION,
+                OnboardingUpgradeSource.OVERFLOW_MENU,
                 OnboardingUpgradeSource.UNKNOWN,
                 -> false
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -194,19 +194,19 @@ private fun Content(
                 ?: throw IllegalStateException("upgradeSource not set")
 
             val userCreatedNewAccount = when (upgradeSource) {
+                OnboardingUpgradeSource.ACCOUNT_DETAILS,
                 OnboardingUpgradeSource.APPEARANCE,
+                OnboardingUpgradeSource.BOOKMARKS,
+                OnboardingUpgradeSource.BOOKMARKS_SHELF_ACTION,
+                OnboardingUpgradeSource.END_OF_YEAR,
                 OnboardingUpgradeSource.FILES,
                 OnboardingUpgradeSource.FOLDERS,
+                OnboardingUpgradeSource.HEADPHONE_CONTROLS_SETTINGS,
                 OnboardingUpgradeSource.LOGIN,
+                OnboardingUpgradeSource.OVERFLOW_MENU,
                 OnboardingUpgradeSource.PLUS_DETAILS,
                 OnboardingUpgradeSource.PROFILE,
-                OnboardingUpgradeSource.ACCOUNT_DETAILS,
                 OnboardingUpgradeSource.SETTINGS,
-                OnboardingUpgradeSource.BOOKMARKS,
-                OnboardingUpgradeSource.HEADPHONE_CONTROLS_SETTINGS,
-                OnboardingUpgradeSource.END_OF_YEAR,
-                OnboardingUpgradeSource.BOOKMARKS_SHELF_ACTION,
-                OnboardingUpgradeSource.OVERFLOW_MENU,
                 OnboardingUpgradeSource.UNKNOWN,
                 -> false
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -205,6 +205,7 @@ private fun Content(
                 OnboardingUpgradeSource.BOOKMARKS,
                 OnboardingUpgradeSource.HEADPHONE_CONTROLS_SETTINGS,
                 OnboardingUpgradeSource.END_OF_YEAR,
+                OnboardingUpgradeSource.UNKNOWN,
                 -> false
 
                 OnboardingUpgradeSource.RECOMMENDATIONS -> true

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -58,6 +58,7 @@ fun OnboardingUpgradeFlow(
                 mainSheetViewModel.onClickSubscribe(
                     activity = activity,
                     flow = flow,
+                    source = source,
                     onComplete = onProceed,
                 )
             }
@@ -127,6 +128,7 @@ fun OnboardingUpgradeFlow(
                                 mainSheetViewModel.onClickSubscribe(
                                     activity = activity,
                                     flow = flow,
+                                    source = source,
                                     onComplete = onProceed,
                                 )
                             } else {
@@ -148,6 +150,7 @@ fun OnboardingUpgradeFlow(
                         bottomSheetViewModel.onClickSubscribe(
                             activity = activity,
                             flow = flow,
+                            source = source,
                             onComplete = onProceed,
                         )
                     } else {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -90,14 +90,14 @@ fun OnboardingUpgradeFlow(
             ModalBottomSheetValue.Hidden -> {
                 // Don't fire event when initially loading the screen and both current and target are "Hidden"
                 if (sheetState.currentValue == ModalBottomSheetValue.Expanded) {
-                    bottomSheetViewModel.onSelectPaymentFrequencyDismissed(flow)
+                    bottomSheetViewModel.onSelectPaymentFrequencyDismissed(flow, source)
                     if (flow is OnboardingFlow.PlusAccountUpgrade) {
                         mainSheetViewModel.onDismiss(flow, source)
                         onBackPressed()
                     }
                 }
             }
-            ModalBottomSheetValue.Expanded -> bottomSheetViewModel.onSelectPaymentFrequencyShown(flow)
+            ModalBottomSheetValue.Expanded -> bottomSheetViewModel.onSelectPaymentFrequencyShown(flow, source)
             else -> {}
         }
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -65,17 +65,13 @@ fun OnboardingUpgradeFlow(
         }
     }
 
-    val startInExpandedState =
-        // Only start with expanded state if there are any subscriptions
+    val startSelectPaymentFrequencyInExpandedState =
+        // Only start with expanded state if there are any subscriptions and payment frequency selection is needed
         hasSubscriptions && (
-            // The hidden state is shown as the first screen in the Upsell flow, so when we return
-            // to this screen after login/signup we want to immediately expand the purchase bottom sheet.
-            (userSignedInOrSignedUpInUpsellFlow) ||
-                // User already indicated they want to upgrade, so go straight to purchase modal
-                flow is OnboardingFlow.PlusAccountUpgradeNeedsLogin ||
+            flow is OnboardingFlow.PlusAccountUpgradeNeedsLogin ||
                 flow is OnboardingFlow.PlusAccountUpgrade
             )
-    val initialValue = if (startInExpandedState) {
+    val initialValue = if (startSelectPaymentFrequencyInExpandedState) {
         ModalBottomSheetValue.Expanded
     } else {
         ModalBottomSheetValue.Hidden

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
@@ -98,6 +98,7 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
     fun onClickSubscribe(
         activity: Activity,
         flow: OnboardingFlow,
+        source: OnboardingUpgradeSource,
         onComplete: () -> Unit,
     ) {
         (state.value as? Loaded)?.let { loadedState ->
@@ -106,7 +107,11 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
 
             analyticsTracker.track(
                 AnalyticsEvent.SELECT_PAYMENT_FREQUENCY_NEXT_BUTTON_TAPPED,
-                mapOf(flowKey to flow.analyticsValue, selectedSubscriptionKey to subscription.productDetails.productId),
+                mapOf(
+                    flowKey to flow.analyticsValue,
+                    sourceKey to source.analyticsValue,
+                    selectedSubscriptionKey to subscription.productDetails.productId,
+                ),
             )
 
             viewModelScope.launch {
@@ -180,6 +185,7 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
     companion object {
         const val flowKey = "flow"
         const val selectedSubscriptionKey = "product"
+        const val sourceKey = "source"
     }
 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
@@ -168,17 +168,29 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
         }
     }
 
-    fun onSelectPaymentFrequencyShown(flow: OnboardingFlow) {
+    fun onSelectPaymentFrequencyShown(
+        flow: OnboardingFlow,
+        source: OnboardingUpgradeSource,
+    ) {
         analyticsTracker.track(
             AnalyticsEvent.SELECT_PAYMENT_FREQUENCY_SHOWN,
-            mapOf(flowKey to flow.analyticsValue),
+            mapOf(
+                flowKey to flow.analyticsValue,
+                sourceKey to source.analyticsValue,
+            ),
         )
     }
 
-    fun onSelectPaymentFrequencyDismissed(flow: OnboardingFlow) {
+    fun onSelectPaymentFrequencyDismissed(
+        flow: OnboardingFlow,
+        source: OnboardingUpgradeSource,
+    ) {
         analyticsTracker.track(
             AnalyticsEvent.SELECT_PAYMENT_FREQUENCY_DISMISSED,
-            mapOf(flowKey to flow.analyticsValue),
+            mapOf(
+                flowKey to flow.analyticsValue,
+                sourceKey to source.analyticsValue,
+            ),
         )
     }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -46,7 +46,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
     private val _state: MutableStateFlow<OnboardingUpgradeFeaturesState> = MutableStateFlow(OnboardingUpgradeFeaturesState.Loading)
     val state: StateFlow<OnboardingUpgradeFeaturesState> = _state
 
-    private val source = savedStateHandle.get<OnboardingUpgradeSource>("source")
+    private val source = savedStateHandle.get<OnboardingUpgradeSource>("source") ?: OnboardingUpgradeSource.UNKNOWN
     private val showPatronOnly = savedStateHandle.get<Boolean>("show_patron_only")
 
     init {
@@ -170,6 +170,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
     fun onClickSubscribe(
         activity: Activity,
         flow: OnboardingFlow,
+        source: OnboardingUpgradeSource,
         onComplete: () -> Unit,
     ) {
         (state.value as? OnboardingUpgradeFeaturesState.Loaded)?.let { loadedState ->
@@ -184,7 +185,11 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
             currentSubscription?.let { subscription ->
                 analyticsTracker.track(
                     AnalyticsEvent.SELECT_PAYMENT_FREQUENCY_NEXT_BUTTON_TAPPED,
-                    mapOf(OnboardingUpgradeBottomSheetViewModel.flowKey to flow.analyticsValue, OnboardingUpgradeBottomSheetViewModel.selectedSubscriptionKey to subscription.productDetails.productId),
+                    mapOf(
+                        OnboardingUpgradeBottomSheetViewModel.flowKey to flow.analyticsValue,
+                        OnboardingUpgradeBottomSheetViewModel.sourceKey to source.analyticsValue,
+                        OnboardingUpgradeBottomSheetViewModel.selectedSubscriptionKey to subscription.productDetails.productId,
+                    ),
                 )
 
                 viewModelScope.launch {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -194,7 +194,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         }
         binding.bookmark.setOnClickListener {
             trackShelfAction(ShelfItem.Bookmark.analyticsValue)
-            onAddBookmarkClick()
+            onAddBookmarkClick(OnboardingUpgradeSource.BOOKMARKS_SHELF_ACTION)
         }
         binding.videoView.playbackManager = playbackManager
         binding.videoView.setOnClickListener { onFullScreenVideoClick() }
@@ -499,18 +499,17 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         viewModel.starToggle()
     }
 
-    fun onAddBookmarkClick() {
+    fun onAddBookmarkClick(source: OnboardingUpgradeSource) {
         if (Feature.isUserEntitled(Feature.BOOKMARKS_ENABLED, settings.userTier)) {
             viewModel.buildBookmarkArguments { arguments ->
                 activityLauncher.launch(arguments.getIntent(requireContext()))
             }
         } else {
-            startUpsellFlow()
+            startUpsellFlow(source)
         }
     }
 
-    private fun startUpsellFlow() {
-        val source = OnboardingUpgradeSource.HEADPHONE_CONTROLS_SETTINGS
+    private fun startUpsellFlow(source: OnboardingUpgradeSource) {
         val onboardingFlow = OnboardingFlow.Upsell(
             source = source,
             showPatronOnly = Feature.BOOKMARKS_ENABLED.tier == FeatureTier.Patron ||

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
@@ -20,6 +20,7 @@ import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.ChromeCastAnalytics
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.R
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
@@ -166,7 +167,7 @@ class ShelfBottomSheet : BaseDialogFragment() {
                 playerViewModel.archiveCurrentlyPlaying(resources)?.show(parentFragmentManager, "archive")
             }
             is ShelfItem.Bookmark -> {
-                (parentFragment as? PlayerHeaderFragment)?.onAddBookmarkClick()
+                (parentFragment as? PlayerHeaderFragment)?.onAddBookmarkClick(OnboardingUpgradeSource.OVERFLOW_MENU)
             }
             ShelfItem.Download -> {
                 Timber.e("Unexpected click on ShelfItem.Download")

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
@@ -1,19 +1,19 @@
 package au.com.shiftyjelly.pocketcasts.settings.onboarding
 
 enum class OnboardingUpgradeSource(val analyticsValue: String) {
+    ACCOUNT_DETAILS("account_details"),
     APPEARANCE("appearance"),
+    BOOKMARKS("bookmarks"),
+    BOOKMARKS_SHELF_ACTION("bookmarks_shelf_action"),
+    END_OF_YEAR("end_of_year"),
     FILES("files"),
     FOLDERS("folders"),
+    HEADPHONE_CONTROLS_SETTINGS("headphone_controls_settings"),
     LOGIN("login"),
+    OVERFLOW_MENU("overflow_menu"),
     PLUS_DETAILS("plus_details"),
     PROFILE("profile"),
-    ACCOUNT_DETAILS("account_details"),
     RECOMMENDATIONS("recommendations"),
     SETTINGS("settings"),
-    BOOKMARKS("bookmarks"),
-    END_OF_YEAR("end_of_year"),
-    HEADPHONE_CONTROLS_SETTINGS("headphone_controls_settings"),
-    BOOKMARKS_SHELF_ACTION("bookmarks_shelf_action"),
-    OVERFLOW_MENU("overflow_menu"),
     UNKNOWN("unknown"),
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
@@ -13,4 +13,5 @@ enum class OnboardingUpgradeSource(val analyticsValue: String) {
     BOOKMARKS("bookmarks"),
     END_OF_YEAR("end_of_year"),
     HEADPHONE_CONTROLS_SETTINGS("headphone_controls_settings"),
+    UNKNOWN("unknown"),
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
@@ -13,5 +13,7 @@ enum class OnboardingUpgradeSource(val analyticsValue: String) {
     BOOKMARKS("bookmarks"),
     END_OF_YEAR("end_of_year"),
     HEADPHONE_CONTROLS_SETTINGS("headphone_controls_settings"),
+    BOOKMARKS_SHELF_ACTION("bookmarks_shelf_action"),
+    OVERFLOW_MENU("overflow_menu"),
     UNKNOWN("unknown"),
 }


### PR DESCRIPTION
## Description

This PR
- Adds a source for the following analytics events (internal ref: p1705339364325069/1705194590.257499-slack-C04DL33V5J7):
    `select_payment_frequency_next_button_tapped`
    `select_payment_frequency_shown`
    `select_payment_frequency_dismissed`
- Adds two upsell flow sources:  `overflow_menu`, `bookmarks_shelf_action` 
- Fixes select payment frequency screen display (it should not be shown except from the account details upgrade/ renew/ start free trial view pager where payment frequency needs to be selected) (dc672ef605cbffbcefc300950d5071cbeb9be82f) as the payment frequency (monthly/ yearly) is already selected on the upsell screen. Seems like the condition was slightly modified while removing `PATRON_ENABLED` feature flag here: https://github.com/Automattic/pocket-casts-android/pull/1681/files#diff-395e9a1b2f03fba797cb040bccba5736e2d5ee8a64644f333f7c33faf01bf166L74-R72. 

## Testing Instructions

#### Test source added for `select_payment_frequency_next_button_tapped`

🗒️ `source` was already passed to the upsell flow for `plus_promotion_shown`, it is now also set for the `select_payment_frequency_next_button_tapped` event. 

1. Launch the app as a logged-out user
2. Go to `Podcasts` tab
3. Tap locked folder icon
4. Tap the subscribe/ start free trial button at the bottom of the screen
5. ✅ Notice in logs that `select_payment_frequency_next_button_tapped, Properties: {"flow":"plus_upsell","source":"folders"` is shown 

[Optionally, test for other sources mentioned in [this sheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing)]

#### Test source added for `select_payment_frequency_shown`/ `select_payment_frequency_dismissed`

🗒️ `select_payment_frequency_shown` is shown only from the account details upgrade/ renew/ start free trial view pager where payment frequency needs to be selected.

1. Launch the app as a Plus user with less than 30 days expiry
2. Go to `Profile` -> `Account`
3. Tap subscribe/ start free trial button 
4. ✅ Notice that select payment frequency popup is shown
5. ✅ Notice in logs that `select_payment_frequency_shown, Properties: {"flow":"plus_account_upgrade", "source":"profile"` is shown
7. Dismiss the pop up by tapping outside it
8. ✅ Notice in logs that `select_payment_frequency_dismissed Properties: {"flow":"plus_account_upgrade", "source":"profile"` is shown

#### Test sources `overflow_menu` and `bookmarks_shelf_action`

1. Fresh install the app
2. Play an episode
3. Open full screen player
4. Tap overflow menu in the bottom shelf
5. Tap `Add bookmark` in the `More actions` bottom sheet
7. ✅ Notice in logs that `plus_promotion_shown, Properties: {"flow":"plus_upsell","source":"overflow_menu"` is shown
8. Dismiss the view
9.  ✅ Notice in logs that  `plus_promotion_dismissed, Properties: {"flow":"plus_upsell","source":"overflow_menu",` is shown
10. Tap overflow menu on the bottom shelf again
11. Edit actions to bring `Add bookmark` to the main shelf
12. Dismiss the `More actions` view and tap `Add bookmark` from the main shelf
13. ✅ Notice in logs that `Tracked: plus_promotion_shown, Properties: {"flow":"plus_upsell","source":"bookmarks_shelf_action"` is shown

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack