### PR TITLE
Adding incremental sync of episodes with the new endpoint

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/EpisodePlayingStatus.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/EpisodePlayingStatus.kt
@@ -10,6 +10,12 @@ enum class EpisodePlayingStatus {
     COMPLETED,
     ;
 
+    fun toInt(): Int = when (this) {
+        NOT_PLAYED -> 1
+        IN_PROGRESS -> 2
+        COMPLETED -> 3
+    }
+
     companion object {
         fun fromInt(n: Int) =
             when (n) {

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/EpisodePlayingStatusTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/EpisodePlayingStatusTest.kt
@@ -1,0 +1,14 @@
+package au.com.shiftyjelly.pocketcasts.models.type
+
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+
+class EpisodePlayingStatusTest {
+
+    @Test
+    fun `to-from int round trip`() {
+        EpisodePlayingStatus.values().forEach {
+            assertEquals(it, EpisodePlayingStatus.fromInt(it.toInt()))
+        }
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -1,0 +1,211 @@
+package au.com.shiftyjelly.pocketcasts.repositories.sync
+
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
+import java.time.Duration
+import java.util.Date
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+class PodcastSyncProcessTest {
+
+    @Test
+    fun podcastToRecord() {
+        val addedDateSinceEpoch = Duration.ofSeconds(123)
+        val podcastMock = mock<Podcast> {
+            on { addedDate } doReturn Date(addedDateSinceEpoch.toMillis())
+            on { folderUuid } doReturn "folderUuid"
+            on { uuid } doReturn "uuid"
+            on { startFromSecs } doReturn 11
+            on { skipLastSecs } doReturn 22
+            on { sortPosition } doReturn 3
+        }
+
+        val record = PodcastSyncProcess.toRecord(podcastMock).podcast
+
+        assertEquals(addedDateSinceEpoch.seconds, record.dateAdded.seconds)
+        assertEquals("folderUuid", record.folderUuid.value)
+        assertEquals("uuid", record.uuid)
+        assertEquals(11, record.settings.autoStartFrom.value.value)
+        assertEquals(22, record.settings.autoSkipLast.value.value)
+    }
+
+    @Test
+    fun podcastToRecord_subscribed() {
+        val podcastMock = mock<Podcast> {
+            on { folderUuid } doReturn "folderUuid"
+            on { uuid } doReturn "uuid"
+            on { isSubscribed } doReturn true
+        }
+
+        val record = PodcastSyncProcess.toRecord(podcastMock).podcast
+
+        assertFalse(record.isDeleted.value)
+        assertTrue(record.subscribed.value)
+    }
+
+    @Test
+    fun podcastToRecord_unsubscribed() {
+        val podcastMock = mock<Podcast> {
+            on { folderUuid } doReturn "folderUuid"
+            on { uuid } doReturn "uuid"
+            on { isSubscribed } doReturn false
+        }
+        val record = PodcastSyncProcess.toRecord(podcastMock).podcast
+
+        assertTrue(record.isDeleted.value)
+        assertFalse(record.subscribed.value)
+    }
+
+    @Test
+    fun podcastEpisodeToRecord_hasFields() {
+        val podcastEpisodeMock = mock<PodcastEpisode> {
+            on { uuid } doReturn "uuid"
+            on { podcastUuid } doReturn "podcastUuid"
+
+            on { playingStatusModified } doReturn 111
+            on { playingStatus } doReturn EpisodePlayingStatus.IN_PROGRESS
+
+            on { playedUpToModified } doReturn 333
+            on { playedUpTo } doReturn 12.0
+
+            on { durationModified } doReturn 444
+            on { duration } doReturn 13.0
+        }
+
+        val record = PodcastSyncProcess.toRecord(podcastEpisodeMock).episode
+
+        assertEquals("uuid", record.uuid)
+        assertEquals("podcastUuid", record.podcastUuid)
+
+        assertEquals(111, record.playingStatusModified.value)
+        assertEquals(EpisodePlayingStatus.IN_PROGRESS.toInt(), record.playingStatus.value)
+
+        assertEquals(333, record.playedUpToModified.value)
+        assertEquals(12, record.playedUpTo.value)
+
+        assertEquals(444, record.durationModified.value)
+        assertEquals(13, record.duration.value)
+    }
+
+    @Test
+    fun podcastEpisodeToRecord_missingFields() {
+        val podcastEpisodeMock = mock<PodcastEpisode> {
+            on { uuid } doReturn "uuid"
+            on { podcastUuid } doReturn "podcastUuid"
+
+            on { playingStatusModified } doReturn null
+            on { playedUpToModified } doReturn null
+            on { durationModified } doReturn null
+        }
+
+        val record = PodcastSyncProcess.toRecord(podcastEpisodeMock).episode
+
+        assertFalse(record.hasPlayingStatus())
+        assertFalse(record.hasPlayedUpTo())
+        assertFalse(record.hasDuration())
+    }
+
+    @Test
+    fun podcastEpisodeToRecord_starred() {
+        val podcastEpisodeMock = mock<PodcastEpisode> {
+            on { uuid } doReturn "uuid"
+            on { podcastUuid } doReturn "podcastUuid"
+            on { playingStatusModified } doReturn null // avoids NPE
+
+            on { starredModified } doReturn 123
+            on { isStarred } doReturn true
+        }
+
+        val record = PodcastSyncProcess.toRecord(podcastEpisodeMock).episode
+
+        assertEquals(123, record.starredModified.value)
+        assertTrue(record.starred.value)
+    }
+
+    @Test
+    fun podcastEpisodeToRecord_notStarred() {
+        val podcastEpisodeMock = mock<PodcastEpisode> {
+            on { uuid } doReturn "uuid"
+            on { podcastUuid } doReturn "podcastUuid"
+            on { playingStatusModified } doReturn null // avoids NPE
+
+            on { starredModified } doReturn 222
+            on { isStarred } doReturn false
+        }
+
+        val record = PodcastSyncProcess.toRecord(podcastEpisodeMock).episode
+
+        assertEquals(222, record.starredModified.value)
+        assertFalse(record.starred.value)
+    }
+
+    @Test
+    fun podcastEpisodeToRecord_starredNotModified() {
+        val podcastEpisodeMock = mock<PodcastEpisode> {
+            on { uuid } doReturn "uuid"
+            on { podcastUuid } doReturn "podcastUuid"
+            on { playingStatusModified } doReturn null // avoids NPE
+
+            on { starredModified } doReturn null
+        }
+
+        val record = PodcastSyncProcess.toRecord(podcastEpisodeMock).episode
+
+        assertFalse(record.hasStarred())
+    }
+
+    @Test
+    fun podcastEpisodeToRecord_archived() {
+        val podcastEpisodeMock = mock<PodcastEpisode> {
+            on { uuid } doReturn "uuid"
+            on { podcastUuid } doReturn "podcastUuid"
+            on { playingStatusModified } doReturn null // avoids NPE
+
+            on { archivedModified } doReturn 123
+            on { isArchived } doReturn true
+        }
+
+        val record = PodcastSyncProcess.toRecord(podcastEpisodeMock).episode
+
+        assertEquals(123, record.isDeletedModified.value)
+        assertTrue(record.isDeleted.value)
+    }
+
+    @Test
+    fun podcastEpisodeToRecord_notArchived() {
+        val podcastEpisodeMock = mock<PodcastEpisode> {
+            on { uuid } doReturn "uuid"
+            on { podcastUuid } doReturn "podcastUuid"
+            on { playingStatusModified } doReturn null // avoids NPE
+
+            on { archivedModified } doReturn 222
+            on { isArchived } doReturn false
+        }
+
+        val record = PodcastSyncProcess.toRecord(podcastEpisodeMock).episode
+
+        assertEquals(222, record.isDeletedModified.value)
+        assertFalse(record.isDeleted.value)
+    }
+
+    @Test
+    fun podcastEpisodeToRecord_archivedNotModified() {
+        val podcastEpisodeMock = mock<PodcastEpisode> {
+            on { uuid } doReturn "uuid"
+            on { podcastUuid } doReturn "podcastUuid"
+            on { playingStatusModified } doReturn null // avoids NPE
+
+            on { archivedModified } doReturn null
+        }
+
+        val record = PodcastSyncProcess.toRecord(podcastEpisodeMock).episode
+
+        assertFalse(record.hasIsDeleted())
+    }
+}


### PR DESCRIPTION
## Description
This is a follow-up to #1703 that updates the new sync call (`/user/sync/update`) to sync episode information. This new call will take the place of the current "/sync/update" call. 

Before this PR, the information that was being synced in the old call that the new call is also syncing is for:

- podcasts

The information that was not _yet_ being synced by the new call is:

- episodes
- folder
- filters
- bookmarks
- stats

This PR is adding syncing of **episode** data to the new call.

## Testing Instructions

For all these tests you will need to:
1. Install the app on two devices
2. Log into the same Pocket Casts account on both devices
3.  Turn on sync settings under Profile → ⚙️ → Beta features → Settings Sync

### 1. Syncs playing status
1. Device 1:
    1. Select an episode you have not interacted with before and mark that episode as played from the episode details screen.
    2. Tap the refresh button on the Profile tab
2. Device 2:
    1. Tap the refresh button on the Profile tab
    2. Verify that the episode details screen for the episode you marked as played on Device 1 shows the episode as played

### 2. Syncs played up to
1. Device 1:
    1. Begin playing an episode
    2. Skip to somewhere in the middle of the episode. Remember this episode and the position playback is at in the episode
    3. Begin playing some other episode
    5. Tap the refresh button on the Profile tab
2. Device 2:
    1. Tap the refresh button on the Profile tab
    2. Begin playing the episode that you remembered the playback position for
    3. Observe that it begins playing at the same position the episode had on Device 1

### 3. Syncs star status
1. Device 1:
    1. Star an episode
    5. Tap the refresh button on the Profile tab
4. Device 2:
    1. Tap the refresh button on the Profile tab
    4. Verify that the episode you starred on Device 1 is now starred
    7. Unstar the episode
    1. Tap the refresh button on the Profile tab
5. Device 1:
    1. Tap the refresh button on the Profile tab
    4. Verify that the episode is no longer starred

### 4. Syncs archive status
1. Device 1:
    1. Archive an episode
    2. Tap the refresh button on the Profile tab
2. Device 2:
    1. Tap the refresh button on the Profile tab
    2. Verify that the episode you archived on Device 1 is now archived
    5. Unarchive the episode
    1. Tap the refresh button on the Profile tab
5. Device 1:
    1. Tap the refresh button on the Profile tab
    2. Verify that the episode is no longer archived

### 5. Syncs duration

There isn't a good way to manipulate this from the app's UI, so we'll manipulate and inspect the databases in this test.

1. Device 1:
    1. Using the database inspector, change the `duration` field to be different and the `durationModified` field to be the current seconds since the epoch for one episode of a podcast you are subscribed to
    2. Tap the refresh button on the Profile tab
2. Device 2:
    1. Tap the refresh button on the Profile tab
    2. Verify that the episode now reflects the changed duration from Device 1 on the podcast screen

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [X] Any jetpack compose components I added or changed are covered by compose previews
