### PR TITLE
ci: submit Gradle dependencies to GH dependency graph

### DIFF
--- a/.github/workflows/submit-gradle-dependencies.yml
+++ b/.github/workflows/submit-gradle-dependencies.yml
@@ -1,0 +1,23 @@
+name: Submit dependencies to GitHub Dependency Graph
+on:
+  push:
+    branches:
+      - main
+      - release/*
+permissions:
+  contents: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Setup Gradle to generate and submit dependency graphs
+        uses: gradle/gradle-build-action@v2
+        with:
+          dependency-graph: generate-and-submit
+      - name: Generate the dependency graph which will be submitted post-job
+        run: ./gradlew :app:dependencies


### PR DESCRIPTION
## Description

This PR adds a GitHub Actions job to send Gradle/Maven dependencies to Github Dependency Graph for each push to `main` or `release/*` branch.

By sending those dependencies, we allow Dependabot to scan whether dependencies we use are affected by known vulnerabilities.

Soon, those metrics will be available to visualize on Apps Metrics ([link](https://metrics.a8c-ci.services/grafana/d/f2131a73-89a3-48b9-8d3b-ecc1456347ac/dependabot-security-alerts?orgId=1)).

More about this project can be found internally at paaHJt-5Tn-p2

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
I verified correctness on [my fork](https://github.com/wzieba/pocket-casts-android). This PR is also a twin of PRs working in other repositories, which are fine. I think manual testing is not necessary.