### PR TITLE
Make trial logic generic for offers

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateAccountFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateAccountFragment.kt
@@ -84,7 +84,13 @@ class CreateAccountFragment : BaseFragment() {
                     val subscription = subscriptionManager.getDefaultSubscription(state.list)
                     val plusLabel = when (subscription) {
                         is Subscription.Simple, null -> binding.root.resources.getString(LR.string.pocket_casts_plus)
-                        is Subscription.WithTrial -> binding.root.resources.getString(LR.string.pocket_casts_plus_short)
+                        is Subscription.WithOffer -> {
+                            if (subscription.isTrial()) {
+                                binding.root.resources.getString(LR.string.pocket_casts_plus_short)
+                            } else {
+                                binding.root.resources.getString(LR.string.pocket_casts_plus)
+                            }
+                        }
                     }
                     binding.lblPlus.text = plusLabel
 
@@ -101,18 +107,22 @@ class CreateAccountFragment : BaseFragment() {
                                         horizontalAlignment = Alignment.End,
                                         emphasized = emphasized,
                                     )
-                                    is Subscription.WithTrial -> {
-                                        val res = LocalContext.current.resources
-                                        val primaryText = stringResource(
-                                            LR.string.plus_trial_duration_free,
-                                            subscription.trialPricingPhase.periodValuePlural(res),
-                                        )
-                                        ProductAmountView(
-                                            primaryText = primaryText,
-                                            secondaryText = subscription.recurringPricingPhase.thenPriceSlashPeriod(res),
-                                            horizontalAlignment = Alignment.End,
-                                            emphasized = emphasized,
-                                        )
+                                    is Subscription.WithOffer -> {
+                                        if (subscription.isTrial()) {
+                                            val res = LocalContext.current.resources
+                                            val primaryText = stringResource(
+                                                LR.string.plus_trial_duration_free,
+                                                subscription.trialPricingPhase.periodValuePlural(res),
+                                            )
+                                            ProductAmountView(
+                                                primaryText = primaryText,
+                                                secondaryText = subscription.recurringPricingPhase.thenPriceSlashPeriod(
+                                                    res,
+                                                ),
+                                                horizontalAlignment = Alignment.End,
+                                                emphasized = emphasized,
+                                            )
+                                        }
                                     }
                                     null -> { /* show nothing */ }
                                 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateAccountFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateAccountFragment.kt
@@ -112,7 +112,7 @@ class CreateAccountFragment : BaseFragment() {
                                             val res = LocalContext.current.resources
                                             val primaryText = stringResource(
                                                 LR.string.plus_trial_duration_free,
-                                                subscription.trialPricingPhase.periodValuePlural(res),
+                                                subscription.offerPricingPhase.periodValuePlural(res),
                                             )
                                             ProductAmountView(
                                                 primaryText = primaryText,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateAccountFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateAccountFragment.kt
@@ -84,13 +84,9 @@ class CreateAccountFragment : BaseFragment() {
                     val subscription = subscriptionManager.getDefaultSubscription(state.list)
                     val plusLabel = when (subscription) {
                         is Subscription.Simple, null -> binding.root.resources.getString(LR.string.pocket_casts_plus)
-                        is Subscription.WithOffer -> {
-                            if (subscription.isTrial()) {
-                                binding.root.resources.getString(LR.string.pocket_casts_plus_short)
-                            } else {
-                                binding.root.resources.getString(LR.string.pocket_casts_plus)
-                            }
-                        }
+                        is Subscription.Trial -> { binding.root.resources.getString(LR.string.pocket_casts_plus_short) }
+                        is Subscription.Intro -> { binding.root.resources.getString(LR.string.pocket_casts_plus) }
+                        else -> { binding.root.resources.getString(LR.string.pocket_casts_plus) }
                     }
                     binding.lblPlus.text = plusLabel
 
@@ -107,24 +103,23 @@ class CreateAccountFragment : BaseFragment() {
                                         horizontalAlignment = Alignment.End,
                                         emphasized = emphasized,
                                     )
-                                    is Subscription.WithOffer -> {
-                                        if (subscription.isTrial()) {
-                                            val res = LocalContext.current.resources
-                                            val primaryText = stringResource(
-                                                LR.string.plus_trial_duration_free,
-                                                subscription.offerPricingPhase.periodValuePlural(res),
-                                            )
-                                            ProductAmountView(
-                                                primaryText = primaryText,
-                                                secondaryText = subscription.recurringPricingPhase.thenPriceSlashPeriod(
-                                                    res,
-                                                ),
-                                                horizontalAlignment = Alignment.End,
-                                                emphasized = emphasized,
-                                            )
-                                        }
+                                    is Subscription.Trial -> {
+                                        val res = LocalContext.current.resources
+                                        val primaryText = stringResource(
+                                            LR.string.plus_trial_duration_free,
+                                            subscription.offerPricingPhase.periodValuePlural(res),
+                                        )
+                                        ProductAmountView(
+                                            primaryText = primaryText,
+                                            secondaryText = subscription.recurringPricingPhase.thenPriceSlashPeriod(
+                                                res,
+                                            ),
+                                            horizontalAlignment = Alignment.End,
+                                            emphasized = emphasized,
+                                        )
                                     }
                                     null -> { /* show nothing */ }
+                                    else -> { /* show nothing */ }
                                 }
                             }
                         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateFrequencyAdapter.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateFrequencyAdapter.kt
@@ -67,17 +67,16 @@ class CreateFrequencyAdapter(
                     when (subscription) {
                         is Subscription.Simple ->
                             ProductAmountView(subscription.recurringPricingPhase.formattedPrice)
-                        is Subscription.WithOffer -> {
-                            if (subscription.isTrial()) {
-                                val res = LocalContext.current.resources
-                                ProductAmountView(
-                                    primaryText = subscription.offerPricingPhase.numPeriodFree(res),
-                                    secondaryText = subscription.recurringPricingPhase.thenPriceSlashPeriod(
-                                        res,
-                                    ),
-                                )
-                            }
+                        is Subscription.Trial -> {
+                            val res = LocalContext.current.resources
+                            ProductAmountView(
+                                primaryText = subscription.offerPricingPhase.numPeriodFree(res),
+                                secondaryText = subscription.recurringPricingPhase.thenPriceSlashPeriod(
+                                    res,
+                                ),
+                            )
                         }
+                        else -> {}
                     }
                 }
             }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateFrequencyAdapter.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateFrequencyAdapter.kt
@@ -67,12 +67,16 @@ class CreateFrequencyAdapter(
                     when (subscription) {
                         is Subscription.Simple ->
                             ProductAmountView(subscription.recurringPricingPhase.formattedPrice)
-                        is Subscription.WithTrial -> {
-                            val res = LocalContext.current.resources
-                            ProductAmountView(
-                                primaryText = subscription.trialPricingPhase.numPeriodFree(res),
-                                secondaryText = subscription.recurringPricingPhase.thenPriceSlashPeriod(res),
-                            )
+                        is Subscription.WithOffer -> {
+                            if (subscription.isTrial()) {
+                                val res = LocalContext.current.resources
+                                ProductAmountView(
+                                    primaryText = subscription.trialPricingPhase.numPeriodFree(res),
+                                    secondaryText = subscription.recurringPricingPhase.thenPriceSlashPeriod(
+                                        res,
+                                    ),
+                                )
+                            }
                         }
                     }
                 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateFrequencyAdapter.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateFrequencyAdapter.kt
@@ -71,7 +71,7 @@ class CreateFrequencyAdapter(
                             if (subscription.isTrial()) {
                                 val res = LocalContext.current.resources
                                 ProductAmountView(
-                                    primaryText = subscription.trialPricingPhase.numPeriodFree(res),
+                                    primaryText = subscription.offerPricingPhase.numPeriodFree(res),
                                     secondaryText = subscription.recurringPricingPhase.thenPriceSlashPeriod(
                                         res,
                                     ),

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateFrequencyFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateFrequencyFragment.kt
@@ -89,7 +89,7 @@ class CreateFrequencyFragment : BaseFragment() {
                     title = subscription.productDetails.title,
                     price = subscription.recurringPricingPhase.pricingPhase.priceAmountMicros * 1_000_000.0,
                     currency = subscription.recurringPricingPhase.pricingPhase.priceCurrencyCode,
-                    isFreeTrial = (subscription as? Subscription.WithOffer)?.isTrial() ?: false,
+                    isFreeTrial = (subscription is Subscription.Trial),
                 )
                 it.findNavController().navigate(R.id.action_createFrequencyFragment_to_createTOSFragment)
             }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateFrequencyFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateFrequencyFragment.kt
@@ -89,7 +89,7 @@ class CreateFrequencyFragment : BaseFragment() {
                     title = subscription.productDetails.title,
                     price = subscription.recurringPricingPhase.pricingPhase.priceAmountMicros * 1_000_000.0,
                     currency = subscription.recurringPricingPhase.pricingPhase.priceCurrencyCode,
-                    isFreeTrial = subscription is Subscription.WithTrial,
+                    isFreeTrial = (subscription as? Subscription.WithOffer)?.isTrial() ?: false,
                 )
                 it.findNavController().navigate(R.id.action_createFrequencyFragment_to_createTOSFragment)
             }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreatePayNowFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreatePayNowFragment.kt
@@ -79,7 +79,7 @@ class CreatePayNowFragment : BaseFragment() {
                             )
                             is Subscription.WithOffer -> if (subscription.isTrial()) {
                                 ProductAmountView(
-                                    primaryText = subscription.trialPricingPhase.numPeriodFree(res),
+                                    primaryText = subscription.offerPricingPhase.numPeriodFree(res),
                                     secondaryText = subscription.recurringPricingPhase.thenPriceSlashPeriod(res),
                                     horizontalAlignment = Alignment.CenterHorizontally,
                                 )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreatePayNowFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreatePayNowFragment.kt
@@ -77,13 +77,14 @@ class CreatePayNowFragment : BaseFragment() {
                                 primaryText = subscription.recurringPricingPhase.priceSlashPeriod(res),
                                 horizontalAlignment = Alignment.CenterHorizontally,
                             )
-                            is Subscription.WithOffer -> if (subscription.isTrial()) {
+                            is Subscription.Trial -> {
                                 ProductAmountView(
                                     primaryText = subscription.offerPricingPhase.numPeriodFree(res),
                                     secondaryText = subscription.recurringPricingPhase.thenPriceSlashPeriod(res),
                                     horizontalAlignment = Alignment.CenterHorizontally,
                                 )
                             }
+                            else -> {}
                         }
                     }
                 }
@@ -168,7 +169,8 @@ class CreatePayNowFragment : BaseFragment() {
             mainLayout.visibility = View.VISIBLE
             btnSubmit.text = getString(
                 when (subscription) {
-                    is Subscription.WithOffer -> if (subscription.isTrial()) { LR.string.profile_start_free_trial } else LR.string.profile_confirm
+                    is Subscription.Trial -> LR.string.profile_start_free_trial
+                    is Subscription.Intro -> LR.string.profile_confirm
                     is Subscription.Simple -> LR.string.profile_confirm
                 },
             )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreatePayNowFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreatePayNowFragment.kt
@@ -77,11 +77,13 @@ class CreatePayNowFragment : BaseFragment() {
                                 primaryText = subscription.recurringPricingPhase.priceSlashPeriod(res),
                                 horizontalAlignment = Alignment.CenterHorizontally,
                             )
-                            is Subscription.WithTrial -> ProductAmountView(
-                                primaryText = subscription.trialPricingPhase.numPeriodFree(res),
-                                secondaryText = subscription.recurringPricingPhase.thenPriceSlashPeriod(res),
-                                horizontalAlignment = Alignment.CenterHorizontally,
-                            )
+                            is Subscription.WithOffer -> if (subscription.isTrial()) {
+                                ProductAmountView(
+                                    primaryText = subscription.trialPricingPhase.numPeriodFree(res),
+                                    secondaryText = subscription.recurringPricingPhase.thenPriceSlashPeriod(res),
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                )
+                            }
                         }
                     }
                 }
@@ -166,7 +168,7 @@ class CreatePayNowFragment : BaseFragment() {
             mainLayout.visibility = View.VISIBLE
             btnSubmit.text = getString(
                 when (subscription) {
-                    is Subscription.WithTrial -> LR.string.profile_start_free_trial
+                    is Subscription.WithOffer -> if (subscription.isTrial()) { LR.string.profile_start_free_trial } else LR.string.profile_confirm
                     is Subscription.Simple -> LR.string.profile_confirm
                 },
             )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
@@ -44,8 +44,8 @@ import au.com.shiftyjelly.pocketcasts.compose.bottomsheet.Pill
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.localization.R
+import au.com.shiftyjelly.pocketcasts.models.type.OfferSubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
-import au.com.shiftyjelly.pocketcasts.models.type.TrialSubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import java.util.Locale
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -107,7 +107,7 @@ fun OnboardingUpgradeBottomSheet(
 
                         val text = subscription.recurringPricingPhase.pricePerPeriod(resources)
                         val topText = subscription
-                            .trialPricingPhase
+                            .offerPricingPhase
                             ?.numPeriodFreeTrial(resources)
                             ?.uppercase(Locale.getDefault())
 
@@ -139,7 +139,7 @@ fun OnboardingUpgradeBottomSheet(
                     }
             }
 
-            val descriptionText = state.selectedSubscription.trialPricingPhase.let { trialPhase ->
+            val descriptionText = state.selectedSubscription.offerPricingPhase.let { trialPhase ->
                 if (trialPhase != null) {
                     stringResource(
                         LR.string.onboarding_plus_recurring_after_free_trial,
@@ -188,7 +188,7 @@ fun OnboardingUpgradeBottomSheet(
 
             UpgradeRowButton(
                 primaryText = stringResource(
-                    if (state.selectedSubscription.trialPricingPhase != null) {
+                    if (state.selectedSubscription.offerPricingPhase != null) {
                         LR.string.onboarding_plus_start_free_trial_and_subscribe
                     } else {
                         LR.string.subscribe
@@ -236,9 +236,9 @@ private val animationSpec = tween<IntSize>(
 )
 
 private fun recurringAfterString(
-    trialSubscriptionPricingPhase: TrialSubscriptionPricingPhase,
+    offerSubscriptionPricingPhase: OfferSubscriptionPricingPhase,
     res: Resources,
-) = "${trialSubscriptionPricingPhase.numPeriodFreeTrial(res)} (${trialSubscriptionPricingPhase.trialEnd()})"
+) = "${offerSubscriptionPricingPhase.numPeriodFreeTrial(res)} (${offerSubscriptionPricingPhase.trialEnd()})"
 
 fun SubscriptionTier.toSubscribeTitle() = when (this) {
     SubscriptionTier.PLUS -> R.string.onboarding_plus_subscribe

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -333,6 +333,8 @@ private fun UpgradeButton(
         is Subscription.Simple -> stringResource(LR.string.subscribe_to, shortName)
         is Subscription.WithOffer -> if (subscription.isTrial()) {
             stringResource(LR.string.trial_start)
+        } else if (subscription.isIntroOffer()) {
+            "TODO"
         } else {
             stringResource(LR.string.subscribe_to, shortName)
         }
@@ -341,6 +343,8 @@ private fun UpgradeButton(
         is Subscription.Simple -> subscription.recurringPricingPhase.pricePerPeriod(resources)
         is Subscription.WithOffer -> if (subscription.isTrial()) {
             subscription.tryFreeThenPricePerPeriod(resources)
+        } else if (subscription.isIntroOffer()) {
+            "TODO"
         } else {
             subscription.recurringPricingPhase.pricePerPeriod(resources)
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -331,11 +331,19 @@ private fun UpgradeButton(
     val shortName = resources.getString(button.shortNameRes)
     val primaryText = when (subscription) {
         is Subscription.Simple -> stringResource(LR.string.subscribe_to, shortName)
-        is Subscription.WithTrial -> stringResource(LR.string.trial_start)
+        is Subscription.WithOffer -> if (subscription.isTrial()) {
+            stringResource(LR.string.trial_start)
+        } else {
+            stringResource(LR.string.subscribe_to, shortName)
+        }
     }
     val secondaryText = when (subscription) {
         is Subscription.Simple -> subscription.recurringPricingPhase.pricePerPeriod(resources)
-        is Subscription.WithTrial -> subscription.tryFreeThenPricePerPeriod(resources)
+        is Subscription.WithOffer -> if (subscription.isTrial()) {
+            subscription.tryFreeThenPricePerPeriod(resources)
+        } else {
+            subscription.recurringPricingPhase.pricePerPeriod(resources)
+        }
     }
     Box(
         contentAlignment = Alignment.BottomCenter,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -331,23 +331,14 @@ private fun UpgradeButton(
     val shortName = resources.getString(button.shortNameRes)
     val primaryText = when (subscription) {
         is Subscription.Simple -> stringResource(LR.string.subscribe_to, shortName)
-        is Subscription.WithOffer -> if (subscription.isTrial()) {
-            stringResource(LR.string.trial_start)
-        } else if (subscription.isIntroOffer()) {
-            "TODO"
-        } else {
-            stringResource(LR.string.subscribe_to, shortName)
-        }
+        is Subscription.Trial -> { stringResource(LR.string.trial_start) }
+        is Subscription.Intro -> { "TODO" }
+        else -> { stringResource(LR.string.subscribe_to, shortName) }
     }
     val secondaryText = when (subscription) {
         is Subscription.Simple -> subscription.recurringPricingPhase.pricePerPeriod(resources)
-        is Subscription.WithOffer -> if (subscription.isTrial()) {
-            subscription.tryFreeThenPricePerPeriod(resources)
-        } else if (subscription.isIntroOffer()) {
-            "TODO"
-        } else {
-            subscription.recurringPricingPhase.pricePerPeriod(resources)
-        }
+        is Subscription.Trial, is Subscription.Intro -> { subscription.tryFreeThenPricePerPeriod(resources) }
+        else -> { subscription.recurringPricingPhase.pricePerPeriod(resources) }
     }
     Box(
         contentAlignment = Alignment.BottomCenter,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -132,7 +132,11 @@ private fun FeatureCard(
             UpgradeButton.PlanType.SUBSCRIBE -> {
                 when (button.subscription) {
                     is Subscription.Simple -> stringResource(LR.string.subscribe_to, stringResource(button.shortNameRes))
-                    is Subscription.WithTrial -> stringResource(LR.string.trial_start)
+                    is Subscription.WithOffer -> if ((button.subscription as Subscription.WithOffer).isTrial()) {
+                        stringResource(LR.string.trial_start)
+                    } else {
+                        stringResource(LR.string.subscribe_to, stringResource(button.shortNameRes))
+                    }
                 }
             }
             UpgradeButton.PlanType.UPGRADE -> stringResource(LR.string.upgrade_to, stringResource(button.shortNameRes))

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -132,11 +132,9 @@ private fun FeatureCard(
             UpgradeButton.PlanType.SUBSCRIBE -> {
                 when (button.subscription) {
                     is Subscription.Simple -> stringResource(LR.string.subscribe_to, stringResource(button.shortNameRes))
-                    is Subscription.WithOffer -> if ((button.subscription as Subscription.WithOffer).isTrial()) {
-                        stringResource(LR.string.trial_start)
-                    } else {
-                        stringResource(LR.string.subscribe_to, stringResource(button.shortNameRes))
-                    }
+                    is Subscription.Trial -> { stringResource(LR.string.trial_start) }
+                    is Subscription.Intro -> { stringResource(LR.string.subscribe_to, stringResource(button.shortNameRes)) }
+                    else -> { stringResource(LR.string.subscribe_to, stringResource(button.shortNameRes)) }
                 }
             }
             UpgradeButton.PlanType.UPGRADE -> stringResource(LR.string.upgrade_to, stringResource(button.shortNameRes))

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
@@ -62,7 +62,7 @@ class CreateAccountViewModel
                     it // return full product id for new products
                 }
             } ?: TracksAnalyticsTracker.INVALID_OR_NULL_VALUE
-            val isFreeTrial = (subscription as? Subscription.WithOffer)?.isTrial() ?: false
+            val isFreeTrial = (subscription is Subscription.Trial)
 
             val analyticsProperties = mapOf(
                 PRODUCT_KEY to productKey,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
@@ -62,7 +62,7 @@ class CreateAccountViewModel
                     it // return full product id for new products
                 }
             } ?: TracksAnalyticsTracker.INVALID_OR_NULL_VALUE
-            val isFreeTrial = subscription is Subscription.WithTrial
+            val isFreeTrial = (subscription as? Subscription.WithOffer)?.isTrial() ?: false
 
             val analyticsProperties = mapOf(
                 PRODUCT_KEY to productKey,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
@@ -10,9 +10,9 @@ import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomS
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetState.NoSubscriptions
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.models.type.OfferSubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
-import au.com.shiftyjelly.pocketcasts.models.type.TrialSubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.PurchaseEvent
@@ -46,9 +46,9 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
     private val _state = MutableStateFlow<OnboardingUpgradeBottomSheetState>(Loading)
     val state: StateFlow<OnboardingUpgradeBottomSheetState> = _state
         .map {
-            // If selected subscription has trialPricingPhase, update mostRecentlySelectedTrialPhase
-            (it as? Loaded)?.selectedSubscription?.trialPricingPhase?.let { trialPhase ->
-                it.copy(mostRecentlySelectedTrialPhase = trialPhase)
+            // If selected subscription has offerPricingPhase, update mostRecentlySelectedOfferPhase
+            (it as? Loaded)?.selectedSubscription?.offerPricingPhase?.let { offerPhase ->
+                it.copy(mostRecentlySelectedOfferPhase = offerPhase)
             } ?: it
         }.stateIn(viewModelScope, SharingStarted.Lazily, _state.value)
 
@@ -207,12 +207,12 @@ sealed class OnboardingUpgradeBottomSheetState {
     data class Loaded constructor(
         val subscriptions: List<Subscription>, // This list should never be empty
         val selectedSubscription: Subscription,
-        // Need to retain the most recently selected trial phase so that information is still available as
-        // it animates out of view after a subscription without a trial phase is selected
-        val mostRecentlySelectedTrialPhase: TrialSubscriptionPricingPhase? = null,
+        // Need to retain the most recently selected offer phase so that information is still available as
+        // it animates out of view after a subscription without a offer phase is selected
+        val mostRecentlySelectedOfferPhase: OfferSubscriptionPricingPhase? = null,
         val purchaseFailed: Boolean = false,
     ) : OnboardingUpgradeBottomSheetState() {
-        val showTrialInfo = selectedSubscription.trialPricingPhase != null
+        val showTrialInfo = selectedSubscription.offerPricingPhase != null
         val upgradeButton = selectedSubscription.toUpgradeButton()
         init {
             if (subscriptions.isEmpty()) {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -8,7 +8,7 @@ import com.android.billingclient.api.ProductDetails
 sealed interface Subscription {
     val tier: SubscriptionTier
     val recurringPricingPhase: RecurringSubscriptionPricingPhase
-    val trialPricingPhase: TrialSubscriptionPricingPhase?
+    val offerPricingPhase: OfferSubscriptionPricingPhase?
     val productDetails: ProductDetails
     val offerToken: String
     val shortTitle: String
@@ -17,14 +17,14 @@ sealed interface Subscription {
     fun numFreeThenPricePerPeriod(res: Resources): String?
     fun tryFreeThenPricePerPeriod(res: Resources): String?
 
-    // Simple subscriptions do not have a trial phase
+    // Simple subscriptions do not have a offer phase
     class Simple(
         override val tier: SubscriptionTier,
         override val recurringPricingPhase: RecurringSubscriptionPricingPhase,
         override val productDetails: ProductDetails,
         override val offerToken: String,
     ) : Subscription {
-        override val trialPricingPhase = null
+        override val offerPricingPhase = null
         override fun numFreeThenPricePerPeriod(res: Resources): String? = null
         override fun tryFreeThenPricePerPeriod(res: Resources): String? = null
     }
@@ -32,7 +32,7 @@ sealed interface Subscription {
     class WithOffer(
         override val tier: SubscriptionTier,
         override val recurringPricingPhase: RecurringSubscriptionPricingPhase,
-        override val trialPricingPhase: TrialSubscriptionPricingPhase, // override to not be nullable
+        override val offerPricingPhase: OfferSubscriptionPricingPhase, // override to not be nullable
         override val productDetails: ProductDetails,
         override val offerToken: String,
     ) : Subscription {
@@ -43,7 +43,7 @@ sealed interface Subscription {
             }
             return res.getString(
                 stringRes,
-                trialPricingPhase.periodValuePlural(res),
+                offerPricingPhase.periodValuePlural(res),
                 recurringPricingPhase.formattedPrice,
             )
         }
@@ -55,7 +55,7 @@ sealed interface Subscription {
             }
             return res.getString(
                 stringRes,
-                trialPricingPhase.periodValuePlural(res),
+                offerPricingPhase.periodValuePlural(res),
                 recurringPricingPhase.formattedPrice,
             )
         }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -62,12 +62,12 @@ sealed interface Subscription {
 
         fun isTrial(): Boolean {
             return this.productDetails.subscriptionOfferDetails?.any {
-                it.offerId == TRIAL_OFFER_ID && (recurringPricingPhase is SubscriptionPricingPhase.Months)
+                it.offerId == TRIAL_OFFER_ID
             } ?: false
         }
         fun isIntroOffer(): Boolean {
             return this.productDetails.subscriptionOfferDetails?.any {
-                it.offerId == INTRO_OFFER_ID && (recurringPricingPhase is SubscriptionPricingPhase.Years)
+                it.offerId == INTRO_OFFER_ID
             } ?: false
         }
     }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -82,6 +82,7 @@ sealed interface Subscription {
         const val PLUS_YEARLY_PRODUCT_ID = "$PLUS_PRODUCT_BASE.yearly"
         const val PATRON_MONTHLY_PRODUCT_ID = "com.pocketcasts.monthly.patron"
         const val PATRON_YEARLY_PRODUCT_ID = "com.pocketcasts.yearly.patron"
+        const val SUBSCRIPTION_TEST_PRODUCT_ID = "com.pocketcasts.plus.testfreetrialoffer"
 
         fun fromProductDetails(productDetails: ProductDetails, isFreeTrialEligible: Boolean): Subscription? =
             SubscriptionMapper.map(productDetails, isFreeTrialEligible)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -29,7 +29,7 @@ sealed interface Subscription {
         override fun tryFreeThenPricePerPeriod(res: Resources): String? = null
     }
 
-    class WithTrial(
+    class WithOffer(
         override val tier: SubscriptionTier,
         override val recurringPricingPhase: RecurringSubscriptionPricingPhase,
         override val trialPricingPhase: TrialSubscriptionPricingPhase, // override to not be nullable
@@ -59,6 +59,17 @@ sealed interface Subscription {
                 recurringPricingPhase.formattedPrice,
             )
         }
+
+        fun isTrial(): Boolean {
+            return this.productDetails.subscriptionOfferDetails?.any {
+                it.offerId == TRIAL_OFFER_ID && (recurringPricingPhase is SubscriptionPricingPhase.Months)
+            } ?: false
+        }
+        fun isIntroOffer(): Boolean {
+            return this.productDetails.subscriptionOfferDetails?.any {
+                it.offerId == INTRO_OFFER_ID && (recurringPricingPhase is SubscriptionPricingPhase.Years)
+            } ?: false
+        }
     }
 
     enum class SubscriptionTier {
@@ -83,6 +94,8 @@ sealed interface Subscription {
         const val PATRON_MONTHLY_PRODUCT_ID = "com.pocketcasts.monthly.patron"
         const val PATRON_YEARLY_PRODUCT_ID = "com.pocketcasts.yearly.patron"
         const val SUBSCRIPTION_TEST_PRODUCT_ID = "com.pocketcasts.plus.testfreetrialoffer"
+        const val INTRO_OFFER_ID = "testyearlyintropricingoffer"
+        const val TRIAL_OFFER_ID = "plus-yearly-trial-30days"
 
         fun fromProductDetails(productDetails: ProductDetails, isFreeTrialEligible: Boolean): Subscription? =
             SubscriptionMapper.map(productDetails, isFreeTrialEligible)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
@@ -16,13 +16,13 @@ object SubscriptionMapper {
         val matchingSubscriptionOfferDetails = if (isFreeTrialEligible) {
             productDetails
                 .subscriptionOfferDetails
-                ?.filter { it.trialSubscriptionPricingPhase != null } // get SubscriptionOfferDetails with trial offers
+                ?.filter { it.offerSubscriptionPricingPhase != null } // get SubscriptionOfferDetails with trial offers
                 ?.ifEmpty { productDetails.subscriptionOfferDetails } // if no trial offers, return all offers
                 ?: productDetails.subscriptionOfferDetails // if null, return all offers
         } else {
             productDetails
                 .subscriptionOfferDetails
-                ?.filter { it.trialSubscriptionPricingPhase == null } // Take the first if there are multiple SubscriptionOfferDetails without trial offers
+                ?.filter { it.offerSubscriptionPricingPhase == null } // Take the first if there are multiple SubscriptionOfferDetails without trial offers
         } ?: emptyList()
 
         // TODO handle multiple matching SubscriptionOfferDetails
@@ -34,7 +34,7 @@ object SubscriptionMapper {
         return relevantSubscriptionOfferDetails
             ?.recurringSubscriptionPricingPhase
             ?.let { recurringPricingPhase ->
-                val trialPricingPhase = relevantSubscriptionOfferDetails.trialSubscriptionPricingPhase
+                val trialPricingPhase = relevantSubscriptionOfferDetails.offerSubscriptionPricingPhase
                 if (trialPricingPhase == null) {
                     Subscription.Simple(
                         tier = mapProductIdToTier(productDetails.productId),
@@ -46,7 +46,7 @@ object SubscriptionMapper {
                     Subscription.WithOffer(
                         tier = mapProductIdToTier(productDetails.productId),
                         recurringPricingPhase = recurringPricingPhase,
-                        trialPricingPhase = trialPricingPhase,
+                        offerPricingPhase = trialPricingPhase,
                         productDetails = productDetails,
                         offerToken = relevantSubscriptionOfferDetails.offerToken,
                     )
@@ -75,7 +75,7 @@ object SubscriptionMapper {
             }
         }
 
-    private val ProductDetails.SubscriptionOfferDetails.trialSubscriptionPricingPhase: TrialSubscriptionPricingPhase?
+    private val ProductDetails.SubscriptionOfferDetails.offerSubscriptionPricingPhase: OfferSubscriptionPricingPhase?
         get() = trialSubscriptionPricingPhases().run {
             when (size) {
                 0 -> null
@@ -94,7 +94,7 @@ object SubscriptionMapper {
         subscriptionPricingPhases<RecurringSubscriptionPricingPhase>(SubscriptionPricingPhase.Type.RECURRING)
 
     private fun ProductDetails.SubscriptionOfferDetails.trialSubscriptionPricingPhases() =
-        subscriptionPricingPhases<TrialSubscriptionPricingPhase>(SubscriptionPricingPhase.Type.TRIAL)
+        subscriptionPricingPhases<OfferSubscriptionPricingPhase>(SubscriptionPricingPhase.Type.TRIAL)
 
     private inline fun <reified T : SubscriptionPricingPhase> ProductDetails.SubscriptionOfferDetails.subscriptionPricingPhases(
         phaseType: SubscriptionPricingPhase.Type,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
@@ -43,15 +43,30 @@ object SubscriptionMapper {
                         offerToken = relevantSubscriptionOfferDetails.offerToken,
                     )
                 } else {
-                    Subscription.WithOffer(
-                        tier = mapProductIdToTier(productDetails.productId),
-                        recurringPricingPhase = recurringPricingPhase,
-                        offerPricingPhase = offerPricingPhase,
-                        productDetails = productDetails,
-                        offerToken = relevantSubscriptionOfferDetails.offerToken,
-                    )
+                    if (isTrial(productDetails)) {
+                        Subscription.Trial(
+                            tier = mapProductIdToTier(productDetails.productId),
+                            recurringPricingPhase = recurringPricingPhase,
+                            offerPricingPhase = offerPricingPhase,
+                            productDetails = productDetails,
+                            offerToken = relevantSubscriptionOfferDetails.offerToken,
+                        )
+                    } else {
+                        Subscription.Intro(
+                            tier = mapProductIdToTier(productDetails.productId),
+                            recurringPricingPhase = recurringPricingPhase,
+                            offerPricingPhase = offerPricingPhase,
+                            productDetails = productDetails,
+                            offerToken = relevantSubscriptionOfferDetails.offerToken,
+                        )
+                    }
                 }
             }
+    }
+    private fun isTrial(productDetails: ProductDetails): Boolean {
+        return productDetails.subscriptionOfferDetails?.any {
+            it.offerId == Subscription.TRIAL_OFFER_ID
+        } ?: false
     }
 
     private val ProductDetails.SubscriptionOfferDetails.recurringSubscriptionPricingPhase: RecurringSubscriptionPricingPhase?

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
@@ -4,6 +4,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_YEARLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_MONTHLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_YEARLY_PRODUCT_ID
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.SUBSCRIPTION_TEST_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.android.billingclient.api.ProductDetails
@@ -42,7 +43,7 @@ object SubscriptionMapper {
                         offerToken = relevantSubscriptionOfferDetails.offerToken,
                     )
                 } else {
-                    Subscription.WithTrial(
+                    Subscription.WithOffer(
                         tier = mapProductIdToTier(productDetails.productId),
                         recurringPricingPhase = recurringPricingPhase,
                         trialPricingPhase = trialPricingPhase,
@@ -122,7 +123,7 @@ object SubscriptionMapper {
         }
 
     fun mapProductIdToTier(productId: String) = when (productId) {
-        in listOf(PLUS_MONTHLY_PRODUCT_ID, PLUS_YEARLY_PRODUCT_ID) -> SubscriptionTier.PLUS
+        in listOf(PLUS_MONTHLY_PRODUCT_ID, PLUS_YEARLY_PRODUCT_ID, SUBSCRIPTION_TEST_PRODUCT_ID) -> SubscriptionTier.PLUS
         in listOf(PATRON_MONTHLY_PRODUCT_ID, PATRON_YEARLY_PRODUCT_ID) -> SubscriptionTier.PATRON
         else -> SubscriptionTier.UNKNOWN
     }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionPricingPhase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionPricingPhase.kt
@@ -53,11 +53,11 @@ sealed interface SubscriptionPricingPhase {
         "$periodValue ${res.getString(periodResSingular)}"
     fun phaseType(): Type = pricingPhase.subscriptionPricingPhaseType
 
-    enum class Type { TRIAL, RECURRING, UNKNOWN }
+    enum class Type { OFFER, RECURRING, UNKNOWN }
 
     private val ProductDetails.PricingPhase.subscriptionPricingPhaseType: Type
         get() = when (recurrenceMode) {
-            ProductDetails.RecurrenceMode.FINITE_RECURRING -> Type.TRIAL
+            ProductDetails.RecurrenceMode.FINITE_RECURRING -> Type.OFFER
             ProductDetails.RecurrenceMode.INFINITE_RECURRING -> Type.RECURRING
             else -> {
                 LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, "Unable to determine SubscriptionPricingPhase.Type")
@@ -120,8 +120,8 @@ sealed interface SubscriptionPricingPhase {
         override val chronoUnit = ChronoUnit.DAYS
 
         init {
-            if (phaseType() != Type.TRIAL) {
-                LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, "Got a phase type of ${phaseType()} for a Days phase, which only extends TrialSubscriptionPricingPhase")
+            if (phaseType() != Type.OFFER) {
+                LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, "Got a phase type of ${phaseType()} for a Days phase, which only extends OfferSubscriptionPricingPhase")
             }
         }
     }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionPricingPhase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionPricingPhase.kt
@@ -12,7 +12,7 @@ import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.time.temporal.ChronoUnit
 
-sealed interface TrialSubscriptionPricingPhase : SubscriptionPricingPhase {
+sealed interface OfferSubscriptionPricingPhase : SubscriptionPricingPhase {
     val chronoUnit: ChronoUnit
 
     // i.e., 14 days free
@@ -68,7 +68,7 @@ sealed interface SubscriptionPricingPhase {
     class Years(
         override val pricingPhase: ProductDetails.PricingPhase,
         private val period: Period,
-    ) : RecurringSubscriptionPricingPhase, TrialSubscriptionPricingPhase {
+    ) : RecurringSubscriptionPricingPhase, OfferSubscriptionPricingPhase {
         override val periodValue = period.years
         override val chronoUnit = ChronoUnit.YEARS
         override val periodResSingular = R.string.plus_year
@@ -90,7 +90,7 @@ sealed interface SubscriptionPricingPhase {
     class Months(
         override val pricingPhase: ProductDetails.PricingPhase,
         private val period: Period,
-    ) : RecurringSubscriptionPricingPhase, TrialSubscriptionPricingPhase {
+    ) : RecurringSubscriptionPricingPhase, OfferSubscriptionPricingPhase {
 
         override val periodResSingular = R.string.plus_month
         override val periodResPlural = R.string.months_plural
@@ -113,7 +113,7 @@ sealed interface SubscriptionPricingPhase {
     class Days(
         override val pricingPhase: ProductDetails.PricingPhase,
         private val period: Period,
-    ) : TrialSubscriptionPricingPhase {
+    ) : OfferSubscriptionPricingPhase {
         override val periodResSingular = R.string.plus_day
         override val periodResPlural = R.string.days_plural
         override val periodValue = period.days

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -413,7 +413,7 @@ class SubscriptionManagerImpl @Inject constructor(
         val withOffers = tierSubscriptions.filterIsInstance<Subscription.WithOffer>()
 
         return withOffers.find {
-            it.recurringPricingPhase is SubscriptionPricingPhase.Months // trial is available for monthly only
+            it.recurringPricingPhase is SubscriptionPricingPhase.Months
         } ?: tierSubscriptions.firstOrNull {
             when (subscriptionFrequency) {
                 SubscriptionFrequency.MONTHLY -> it.recurringPricingPhase is SubscriptionPricingPhase.Months

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -448,7 +448,7 @@ class SubscriptionManagerImpl @Inject constructor(
             emit(
                 FreeTrial(
                     subscriptionTier = subscriptionTier,
-                    exists = defaultSubscription?.trialPricingPhase != null,
+                    exists = defaultSubscription?.offerPricingPhase != null,
                 ),
             )
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_YEARLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_MONTHLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_YEARLY_PRODUCT_ID
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.SUBSCRIPTION_TEST_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper.mapProductIdToTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
@@ -175,6 +176,12 @@ class SubscriptionManagerImpl @Inject constructor(
                 add(
                     QueryProductDetailsParams.Product.newBuilder()
                         .setProductId(PATRON_YEARLY_PRODUCT_ID)
+                        .setProductType(BillingClient.ProductType.SUBS)
+                        .build(),
+                )
+                add(
+                    QueryProductDetailsParams.Product.newBuilder()
+                        .setProductId(SUBSCRIPTION_TEST_PRODUCT_ID)
                         .setProductType(BillingClient.ProductType.SUBS)
                         .build(),
                 )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -410,10 +410,9 @@ class SubscriptionManagerImpl @Inject constructor(
         val subscriptionFrequency = frequency ?: SubscriptionFrequency.YEARLY
 
         val tierSubscriptions = subscriptions.filter { it.tier == subscriptionTier }
-        val trialsIfPresent = tierSubscriptions
-            .filterIsInstance<Subscription.WithTrial>()
+        val withOffers = tierSubscriptions.filterIsInstance<Subscription.WithOffer>()
 
-        return trialsIfPresent.find {
+        return withOffers.find {
             it.recurringPricingPhase is SubscriptionPricingPhase.Months // trial is available for monthly only
         } ?: tierSubscriptions.firstOrNull {
             when (subscriptionFrequency) {


### PR DESCRIPTION
## Description
- This PR does a little refactor for subscriptions with an offer. Currently we have only trial subscription and we want to support another type of offer
- This prepared for an update on the upgrade subscription page. In the next PR I will implement the UI, but for now I replaced the offer strings with `TODO`

## Screenshot
<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/66bd7215-8715-455a-bfcd-894502236e18" height="500">

## Testing
git apply [release.patch](https://github.com/Automattic/pocket-casts-android/files/13998087/release.patch)

1. Run the app and login in with a free account that never had a subscription
2. Go to `Podcasts` tab
3. Click on folders
**4. You should see the TODO text on the upgrade Button for Plus/Yearly plan** 


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews

