### PR TITLE
Add report violation option

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -35,6 +35,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
+import au.com.shiftyjelly.pocketcasts.ui.extensions.openUrl
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.images.PodcastImageLoaderThemed
 import au.com.shiftyjelly.pocketcasts.ui.images.ThemedImageTintTransformation
@@ -190,6 +191,10 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         binding.bookmark.setOnClickListener {
             trackShelfAction(ShelfItem.Bookmark.analyticsValue)
             onAddBookmarkClick(OnboardingUpgradeSource.BOOKMARKS_SHELF_ACTION)
+        }
+        binding.report?.setOnClickListener {
+            trackShelfAction(ShelfItem.Report.analyticsValue)
+            openUrl(settings.getReportViolationUrl())
         }
         binding.videoView.playbackManager = playbackManager
         binding.videoView.setOnClickListener { onFullScreenVideoClick() }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -155,6 +155,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
             ShelfItem.Archive.id to binding.archive,
             ShelfItem.Download.id to binding.download,
             ShelfItem.Bookmark.id to binding.bookmark,
+            ShelfItem.Report.id to binding.report,
         )
         viewModel.trimmedShelfLive.observe(viewLifecycleOwner) {
             val visibleItems = it.first.subList(0, 4).map { it.id }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
@@ -172,6 +172,9 @@ class ShelfBottomSheet : BaseDialogFragment() {
             ShelfItem.Download -> {
                 Timber.e("Unexpected click on ShelfItem.Download")
             }
+            is ShelfItem.Report -> {
+                Timber.e("ShelfItem.report is not implemented")
+            }
         }
         analyticsTracker.track(
             AnalyticsEvent.PLAYER_SHELF_ACTION_TAPPED,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
@@ -17,12 +17,14 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentShelfBottomSheetBinding
 import au.com.shiftyjelly.pocketcasts.player.view.ShelfFragment.Companion.AnalyticsProp
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.ChromeCastAnalytics
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.R
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
+import au.com.shiftyjelly.pocketcasts.ui.extensions.openUrl
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.views.extensions.applyColor
@@ -41,6 +43,8 @@ class ShelfBottomSheet : BaseDialogFragment() {
     @Inject lateinit var chromeCastAnalytics: ChromeCastAnalytics
 
     @Inject lateinit var playbackManager: PlaybackManager
+
+    @Inject lateinit var settings: Settings
 
     override val statusBarColor: StatusBarColor? = null
 
@@ -173,7 +177,7 @@ class ShelfBottomSheet : BaseDialogFragment() {
                 Timber.e("Unexpected click on ShelfItem.Download")
             }
             is ShelfItem.Report -> {
-                Timber.e("ShelfItem.report is not implemented")
+                openUrl(settings.getReportViolationUrl())
             }
         }
         analyticsTracker.track(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfItem.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfItem.kt
@@ -7,6 +7,8 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.player.R
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.views.R as VR
@@ -22,6 +24,9 @@ object ShelfItems {
         add(ShelfItem.Played)
         add(ShelfItem.Bookmark)
         add(ShelfItem.Archive)
+        if (FeatureFlag.isEnabled(Feature.REPORT_VIOLATION)) {
+            add(ShelfItem.Report)
+        }
     }
     private val items = itemsList.associateBy { it.id }
 
@@ -144,5 +149,14 @@ sealed class ShelfItem(
         shownWhen = Shown.Always,
         tier = SubscriptionTier.NONE,
         analyticsValue = "download",
+    )
+
+    object Report : ShelfItem(
+        id = "report",
+        title = { LR.string.report },
+        subtitle = LR.string.report_subtitle,
+        iconRes = { IR.drawable.ic_flag },
+        shownWhen = Shown.Always,
+        analyticsValue = "report",
     )
 }

--- a/modules/features/player/src/main/res/layout/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout/adapter_player_header.xml
@@ -444,6 +444,13 @@
                     style="@style/shelf_item" />
 
                 <ImageButton
+                    android:id="@+id/report"
+                    android:contentDescription="@string/report"
+                    app:srcCompat="@drawable/ic_flag"
+                    app:tint="?attr/player_contrast_03"
+                    style="@style/shelf_item" />
+
+                <ImageButton
                     android:id="@+id/playerActions"
                     android:layout_width="0dp"
                     android:layout_height="48dp"

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -895,6 +895,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         when (item.itemId) {
             R.id.share -> share()
             R.id.report -> {
+                analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_REPORT_TAPPED)
                 openUrl(settings.getReportViolationUrl())
             }
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -63,6 +63,8 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.images.CoilManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
@@ -565,6 +567,10 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         binding.toolbar.let {
             it.inflateMenu(R.menu.podcast_menu)
             it.setOnMenuItemClickListener(this)
+
+            val reportMenuItem = it.menu.findItem(R.id.report)
+            reportMenuItem.isVisible = FeatureFlag.isEnabled(Feature.REPORT_VIOLATION)
+
             it.setNavigationOnClickListener {
                 @Suppress("DEPRECATION")
                 activity?.onBackPressed()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -58,6 +58,7 @@ import au.com.shiftyjelly.pocketcasts.servers.ServerManager
 import au.com.shiftyjelly.pocketcasts.settings.HeadphoneControlsSettingsFragment
 import au.com.shiftyjelly.pocketcasts.settings.SettingsFragment
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
+import au.com.shiftyjelly.pocketcasts.ui.extensions.openUrl
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.images.CoilManager
@@ -893,6 +894,9 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
     override fun onMenuItemClick(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.share -> share()
+            R.id.report -> {
+                openUrl(settings.getReportViolationUrl())
+            }
         }
         return true
     }

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
@@ -32,7 +32,7 @@
             android:minHeight="?android:attr/actionBarSize"
             android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
             app:navigationIcon="@drawable/ic_arrow_back_24dp"
-            app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+            app:popupTheme="@style/LightPopupTheme" />
 
         <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
             android:id="@+id/multiSelectEpisodesToolbar"

--- a/modules/features/podcasts/src/main/res/menu/podcast_menu.xml
+++ b/modules/features/podcasts/src/main/res/menu/podcast_menu.xml
@@ -13,4 +13,10 @@
         app:showAsAction="ifRoom"
         android:title="@string/share_podcast" />
 
+    <item
+        android:id="@+id/report"
+        android:icon="@drawable/ic_flag"
+        app:showAsAction="never"
+        android:title="@string/report" />
+
 </menu>

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -220,6 +220,7 @@ enum class AnalyticsEvent(val key: String) {
     PODCASTS_SCREEN_SORT_ORDER_CHANGED("podcasts_screen_sort_order_changed"),
     PODCASTS_SCREEN_EPISODE_GROUPING_CHANGED("podcasts_screen_episode_grouping_changed"),
     PODCASTS_SCREEN_TAB_TAPPED("podcasts_screen_tab_tapped"),
+    PODCAST_SCREEN_REPORT_TAPPED("podcast_screen_report_tapped"),
 
     /* Podcast Settings */
     PODCAST_SETTINGS_FEED_ERROR_TAPPED("podcast_settings_feed_error_tapped"),

--- a/modules/services/images/src/main/res/drawable/ic_flag.xml
+++ b/modules/services/images/src/main/res/drawable/ic_flag.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M15,6a2,2 0,0 0,-2 -2H5v17h2v-7h5a2,2 0,0 0,2 2h6V6h-5z"/>
+</vector>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -153,6 +153,8 @@
     <string name="go_to_top">Go to top</string>
     <string name="go_to_bottom">Go to bottom</string>
     <string name="submit">Submit</string>
+    <string name="report">Report</string>
+    <string name="report_subtitle">Report inappropriate content</string>
     <string name="widget">Widget</string>
 
     <string name="multiselect_actions_shown">Shortcut in toolbar</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -308,6 +308,7 @@ interface Settings {
     fun getPeriodicSaveTimeMs(): Long
     fun getPodcastSearchDebounceMs(): Long
     fun getEpisodeSearchDebounceMs(): Long
+    fun getReportViolationUrl(): String
     val podcastGroupingDefault: UserSetting<PodcastGrouping>
 
     val marketingOptIn: UserSetting<Boolean>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -854,6 +854,10 @@ class SettingsImpl @Inject constructor(
         return getRemoteConfigLong(FirebaseConfig.EPISODE_SEARCH_DEBOUNCE_MS)
     }
 
+    override fun getReportViolationUrl(): String {
+        return firebaseRemoteConfig.getString(FirebaseConfig.REPORT_VIOLATION_URL)
+    }
+
     private fun getRemoteConfigLong(key: String): Long {
         val value = firebaseRemoteConfig.getLong(key)
         return if (value == 0L) (FirebaseConfig.defaults[key] as? Long ?: 0L) else value

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/extensions/Fragment.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/extensions/Fragment.kt
@@ -1,0 +1,14 @@
+package au.com.shiftyjelly.pocketcasts.ui.extensions
+
+import android.content.Intent
+import android.net.Uri
+import androidx.fragment.app.Fragment
+import timber.log.Timber
+
+fun Fragment.openUrl(url: String) {
+    try {
+        this.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+    } catch (e: Exception) {
+        Timber.e(e)
+    }
+}

--- a/modules/services/ui/src/main/res/values/themes.xml
+++ b/modules/services/ui/src/main/res/values/themes.xml
@@ -1880,4 +1880,9 @@
         <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 
+    <style name="LightPopupTheme" parent="ThemeOverlay.AppCompat.Light">
+        <item name="android:backgroundTint">@android:color/white</item>
+        <item name="android:elevation">0dp</item>
+    </style>
+
 </resources>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
@@ -7,6 +7,7 @@ object FirebaseConfig {
     const val PODCAST_SEARCH_DEBOUNCE_MS = "podcast_search_debounce_ms"
     const val EPISODE_SEARCH_DEBOUNCE_MS = "episode_search_debounce_ms"
     const val CLOUD_STORAGE_LIMIT = "custom_storage_limit_gb"
+    const val REPORT_VIOLATION_URL = "report_violation_url"
     val defaults = mapOf(
         PERIODIC_SAVE_TIME_MS to 60000L,
         PODCAST_SEARCH_DEBOUNCE_MS to 2000L,

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -35,6 +35,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),
+    REPORT_VIOLATION(
+        key = "report_violation",
+        title = "Report Violation",
+        defaultValue = false,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = true,
+        hasDevToggle = false,
+    ),
     ;
 
     companion object {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.utils.featureflag.providers
 
+import au.com.shiftyjelly.pocketcasts.utils.config.FirebaseConfig
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.MAX_PRIORITY
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.RemoteFeatureProvider
@@ -12,8 +13,12 @@ class FirebaseRemoteFeatureProvider @Inject constructor(
 ) : RemoteFeatureProvider {
     override val priority: Int = MAX_PRIORITY
 
-    override fun isEnabled(feature: Feature): Boolean =
-        firebaseRemoteConfig.getBoolean(feature.key)
+    override fun isEnabled(feature: Feature) = when (feature) {
+        Feature.REPORT_VIOLATION -> firebaseRemoteConfig
+            .getString(FirebaseConfig.REPORT_VIOLATION_URL)
+            .isNotEmpty()
+        else -> firebaseRemoteConfig.getBoolean(feature.key)
+    }
 
     override fun hasFeature(feature: Feature) =
         feature.hasFirebaseRemoteFlag

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
@@ -14,9 +14,10 @@ class FirebaseRemoteFeatureProvider @Inject constructor(
     override val priority: Int = MAX_PRIORITY
 
     override fun isEnabled(feature: Feature) = when (feature) {
-        Feature.REPORT_VIOLATION -> firebaseRemoteConfig
-            .getString(FirebaseConfig.REPORT_VIOLATION_URL)
-            .isNotEmpty()
+        Feature.REPORT_VIOLATION ->
+            firebaseRemoteConfig
+                .getString(FirebaseConfig.REPORT_VIOLATION_URL)
+                .isNotEmpty()
         else -> firebaseRemoteConfig.getBoolean(feature.key)
     }
 


### PR DESCRIPTION
## Description

This adds a report violation option in the app behind a feature flag that depends on a non-empty URL in the Firebase Console - remote config.
(Internal ref: pdeCcb-4aS-p2#comment-3197)

> [!WARNING] 
> Targets 7.56 (If it is difficult to include it in today's code-freeze, feel free to include it in the next beta)

## Testing Instructions

1. Edit minimum fetch interval to 5s in `FirebaseModule` inside the app
2. Install the `release build` variant
2. Open a podcast
3. ✅ Notice that there is no report option on the top tool bar
4. Play an episode
5. Go to Player screen
6. Tap more menu on the bottom shelf
7. ✅ Notice that there is no report option 
8. Open Firebase Console and edit `report_violation_url` remote config to any valid URL for the android app
9. Restart the app
10. Open a podcast
11. ✅ Notice that there is a report option on the top tool bar
12. Tap on the report option
13. ✅ Notice that 
     - it opens the URL provided in the Firebase Console - remote config 
     - displays `podcast_screen_report_tapped` in logs
15. Play an episode
16. Go to Player screen
17. Tap more menu in the bottom shelf
18. ✅ Notice it has a report option as the last option
19. Tap on the report option
20. ✅ Notice that 
     - it opens the URL provided in the Firebase Console - remote config 
     - displays `player_shelf_action_tapped` in logs for `report` action
22. Rearrange the report option to the top item so that it appears in the bottom shelf on the Player screen
23. From the bottom shelf on the Player screen , again tap report option
24. ✅ Notice that 
      - it opens the URL provided in the Firebase Console - remote config 
      -  displays `player_shelf_action_tapped` in logs for `report` action

Important **: Open Firebase Console and edit `report_violation_url` remote config to an empty string. This will disable the report option in the app.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
