### PR TITLE
Fix blinking artwork

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -67,6 +67,7 @@ import javax.inject.Inject
 import kotlin.math.abs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import okhttp3.Headers.Companion.headersOf
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -368,6 +369,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
 
             val imageBuilder: ImageRequest.Builder.() -> Unit = {
                 error(IR.drawable.defaultartwork_dark)
+                headers(headersOf("User-Agent", Settings.USER_AGENT_POCKETCASTS_SERVER))
                 scale(Scale.FIT)
                 transformations(RoundedCornersTransformation(imageLoader.radiusPx.toFloat()), ThemedImageTintTransformation(imageView.context))
             }


### PR DESCRIPTION
## Description

This fixes blinking artwork for podcast: https://pca.st/cna84b64. 
Internal ref: p1705637991454989-slack-C02A333D8LQ 

There might be other podcasts as well showing this behavior, it'll be good to include it in a 7.56 release candidate.  

Loading certain episode artwork using `Coil` results in `HTTP 403` error. As a result, it loads the fallback podcast artwork repeatedly ignoring [this check](https://github.com/Automattic/pocket-casts-android/blob/main/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt#L362) to skip fetching artwork if it is already displayed. 

It seems an issue with `Coil` and adding a user-agent header resolves the 403 HTTP issue:
https://stackoverflow.com/a/74861860/193545
https://rb.gy/cixtzb

## Testing Instructions
1. Install the app
2. Play episode from podcast: https://pca.st/cna84b64
3. Notice that it loads episode artwork and it doesn't blink
4. Switch to `Details` tab and back to `Now Playing` tab
5. Notice that the artwork remains visible

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/12aa045e-6492-4012-838f-6bebb88e6382


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack