### PR TITLE
Plus promotion login

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/OnboardingFlowComposableTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/OnboardingFlowComposableTest.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivity
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingFlowComposable
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingNavRoute
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingExitInfo
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -33,7 +34,7 @@ class OnboardingFlowComposableTest {
     fun setupAppNavHost(
         flow: OnboardingFlow,
         signInState: SignInState = mock(),
-        exitOnboarding: () -> Unit = {},
+        exitOnboarding: (OnboardingExitInfo) -> Unit = {},
         completeOnboardingToDiscover: () -> Unit = {},
     ) {
         composeTestRule.activity.setContent {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -251,7 +251,7 @@ class MainActivity :
             }
             OnboardingFinish.DoneShowPlusPromotion -> {
                 settings.setHasDoneInitialOnboarding()
-                OnboardingLauncher.openOnboardingFlow(this, OnboardingFlow.Upsell(OnboardingUpgradeSource.LOGIN))
+                OnboardingLauncher.openOnboardingFlow(this, OnboardingFlow.Upsell(OnboardingUpgradeSource.LOGIN_PLUS_PROMOTION))
             }
             null -> {
                 Timber.e("Unexpected null result from onboarding activity")

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -108,6 +108,7 @@ import au.com.shiftyjelly.pocketcasts.servers.ServerManager
 import au.com.shiftyjelly.pocketcasts.servers.discover.PodcastSearch
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewFragment
 import au.com.shiftyjelly.pocketcasts.ui.MainActivityViewModel.NavigationState
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
@@ -247,6 +248,10 @@ class MainActivity :
             OnboardingFinish.DoneGoToDiscover -> {
                 settings.setHasDoneInitialOnboarding()
                 openTab(VR.id.navigation_discover)
+            }
+            OnboardingFinish.DoneShowPlusPromotion -> {
+                settings.setHasDoneInitialOnboarding()
+                OnboardingLauncher.openOnboardingFlow(this, OnboardingFlow.Upsell(OnboardingUpgradeSource.LOGIN))
             }
             null -> {
                 Timber.e("Unexpected null result from onboarding activity")

--- a/modules/features/account/build.gradle.kts
+++ b/modules/features/account/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation(project(":modules:services:ui"))
     implementation(project(":modules:services:utils"))
     implementation(project(":modules:services:views"))
+    testImplementation(project(":modules:services:sharedtest"))
 
     // android libs
     implementation(libs.horologist.auth.data.phone)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
@@ -5,12 +5,14 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.core.content.IntentCompat
 import androidx.core.view.WindowCompat
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContract.OnboardingFinish
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingActivityViewModel
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -25,6 +27,8 @@ class OnboardingActivity : AppCompatActivity() {
 
     @Inject lateinit var userManager: UserManager
 
+    private val viewModel: OnboardingActivityViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // Make content edge-to-edge
@@ -33,6 +37,9 @@ class OnboardingActivity : AppCompatActivity() {
         setContent {
             val signInState = userManager.getSignInState().asFlow().collectAsState(null)
             val currentSignInState = signInState.value
+
+            val finishState = viewModel.finishState.collectAsState(null)
+            finishState.value?.let { finishWithResult(it) }
 
             if (currentSignInState != null) {
                 val onboardingFlow = remember(savedInstanceState) {
@@ -46,7 +53,7 @@ class OnboardingActivity : AppCompatActivity() {
                 OnboardingFlowComposable(
                     theme = theme.activeTheme,
                     flow = onboardingFlow,
-                    exitOnboarding = { finishWithResult(OnboardingFinish.Done) },
+                    exitOnboarding = { viewModel.onExitOnboarding(it) },
                     completeOnboardingToDiscover = { finishWithResult(OnboardingFinish.DoneGoToDiscover) },
                     signInState = currentSignInState,
                 )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivityContract.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivityContract.kt
@@ -20,6 +20,7 @@ class OnboardingActivityContract : ActivityResultContract<Intent, OnboardingActi
     enum class OnboardingFinish {
         Done,
         DoneGoToDiscover,
+        DoneShowPlusPromotion,
     }
 
     companion object {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -15,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations.Onboard
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeFlow
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingExitInfo
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -24,7 +25,7 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.getSerializableCompat
 fun OnboardingFlowComposable(
     theme: Theme.ThemeType,
     flow: OnboardingFlow,
-    exitOnboarding: () -> Unit,
+    exitOnboarding: (OnboardingExitInfo) -> Unit,
     completeOnboardingToDiscover: () -> Unit,
     signInState: SignInState,
     navController: NavHostController = rememberNavController(),
@@ -56,7 +57,7 @@ fun OnboardingFlowComposable(
 private fun Content(
     theme: Theme.ThemeType,
     flow: OnboardingFlow,
-    exitOnboarding: () -> Unit,
+    exitOnboarding: (OnboardingExitInfo) -> Unit,
     completeOnboardingToDiscover: () -> Unit,
     signInState: SignInState,
     navController: NavHostController,
@@ -89,7 +90,7 @@ private fun Content(
         onboardingRecommendationsFlowGraph(
             theme = theme,
             flow = flow,
-            onBackPressed = exitOnboarding,
+            onBackPressed = { exitOnboarding(OnboardingExitInfo()) },
             onComplete = {
                 navController.navigate(
                     if (signInState.isSignedInAsPlusOrPatron) {
@@ -118,13 +119,13 @@ private fun Content(
                         -> {
                             val popped = navController.popBackStack()
                             if (!popped) {
-                                exitOnboarding()
+                                exitOnboarding(OnboardingExitInfo())
                             }
                         }
 
                         OnboardingFlow.InitialOnboarding,
                         OnboardingFlow.LoggedOut,
-                        -> exitOnboarding()
+                        -> exitOnboarding(OnboardingExitInfo())
                     }
                 },
                 onSignUpClicked = { navController.navigate(OnboardingNavRoute.createFreeAccount) },
@@ -162,7 +163,7 @@ private fun Content(
             OnboardingForgotPasswordPage(
                 theme = theme,
                 onBackPressed = { navController.popBackStack() },
-                onCompleted = exitOnboarding,
+                onCompleted = { exitOnboarding(OnboardingExitInfo()) },
             )
         }
 
@@ -221,7 +222,7 @@ private fun Content(
                     if (userCreatedNewAccount) {
                         navController.popBackStack()
                     } else {
-                        exitOnboarding()
+                        exitOnboarding(OnboardingExitInfo())
                     }
                 },
                 onNeedLogin = { navController.navigate(OnboardingNavRoute.logInOrSignUp) },
@@ -229,7 +230,7 @@ private fun Content(
                     if (userCreatedNewAccount) {
                         navController.navigate(OnboardingNavRoute.welcome)
                     } else {
-                        exitOnboarding()
+                        exitOnboarding(OnboardingExitInfo())
                     }
                 },
             )
@@ -240,13 +241,13 @@ private fun Content(
                 activeTheme = theme,
                 flow = flow,
                 isSignedInAsPlusOrPatron = signInState.isSignedInAsPlusOrPatron,
-                onDone = exitOnboarding,
+                onDone = { exitOnboarding(OnboardingExitInfo()) },
                 onContinueToDiscover = completeOnboardingToDiscover,
                 onImportTapped = { navController.navigate(OnboardingImportFlow.route) },
                 onBackPressed = {
                     // Don't allow navigation back to the upgrade screen after the user upgrades
                     if (signInState.isSignedInAsPlusOrPatron) {
-                        exitOnboarding()
+                        exitOnboarding(OnboardingExitInfo())
                     } else {
                         navController.popBackStack()
                     }
@@ -258,13 +259,12 @@ private fun Content(
 
 private fun onLoginToExistingAccount(
     flow: OnboardingFlow,
-    exitOnboarding: () -> Unit,
+    exitOnboarding: (OnboardingExitInfo) -> Unit,
     navController: NavHostController,
 ) {
     when (flow) {
-        OnboardingFlow.InitialOnboarding,
-        OnboardingFlow.LoggedOut,
-        -> exitOnboarding()
+        OnboardingFlow.InitialOnboarding -> exitOnboarding(OnboardingExitInfo())
+        OnboardingFlow.LoggedOut -> exitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = true))
 
         is OnboardingFlow.PlusAccountUpgrade,
         is OnboardingFlow.PatronAccountUpgrade,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -204,6 +204,7 @@ private fun Content(
                 OnboardingUpgradeSource.FOLDERS,
                 OnboardingUpgradeSource.HEADPHONE_CONTROLS_SETTINGS,
                 OnboardingUpgradeSource.LOGIN,
+                OnboardingUpgradeSource.LOGIN_PLUS_PROMOTION,
                 OnboardingUpgradeSource.OVERFLOW_MENU,
                 OnboardingUpgradeSource.PLUS_DETAILS,
                 OnboardingUpgradeSource.PROFILE,
@@ -263,8 +264,9 @@ private fun onLoginToExistingAccount(
     navController: NavHostController,
 ) {
     when (flow) {
-        OnboardingFlow.InitialOnboarding -> exitOnboarding(OnboardingExitInfo())
-        OnboardingFlow.LoggedOut -> exitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = true))
+        OnboardingFlow.InitialOnboarding,
+        OnboardingFlow.LoggedOut,
+        -> exitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = true))
 
         is OnboardingFlow.PlusAccountUpgrade,
         is OnboardingFlow.PatronAccountUpgrade,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModel.kt
@@ -1,0 +1,61 @@
+package au.com.shiftyjelly.pocketcasts.account.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContract.OnboardingFinish
+import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingExitInfo
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.reactive.asFlow
+
+@HiltViewModel
+class OnboardingActivityViewModel @Inject constructor(
+    private val userManager: UserManager,
+) : ViewModel() {
+
+    private var showPlusPromotionForFreeUserFlow = MutableStateFlow(false)
+
+    private val _finishState = MutableSharedFlow<OnboardingFinish>()
+    val finishState = _finishState.asSharedFlow()
+
+    init {
+        viewModelScope.launch {
+            combine(
+                showPlusPromotionForFreeUserFlow,
+                userManager.getSignInState().asFlow(),
+            ) { showPlusPromotionForFreeUser, signInState ->
+                if (showPlusPromotionForFreeUser) {
+                    // subscriptionStatus is null just after sign in, so we need to wait for it to be set
+                    // before we can finish the onboarding flow to show plus promotion for a free user
+                    (signInState as? SignInState.SignedIn)?.subscriptionStatus?.let { status ->
+                        showPlusPromotionForFreeUserFlow.value = false
+                        if (status is SubscriptionStatus.Free) {
+                            _finishState.emit(OnboardingFinish.DoneShowPlusPromotion)
+                        } else {
+                            _finishState.emit(OnboardingFinish.Done)
+                        }
+                    }
+                }
+            }.stateIn(viewModelScope)
+        }
+    }
+
+    fun onExitOnboarding(exitInfo: OnboardingExitInfo) {
+        if (exitInfo.showPlusPromotionForFreeUser) {
+            showPlusPromotionForFreeUserFlow.value = true
+        } else {
+            viewModelScope.launch {
+                _finishState.emit(OnboardingFinish.Done)
+            }
+        }
+    }
+}

--- a/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModelTest.kt
+++ b/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModelTest.kt
@@ -1,0 +1,78 @@
+package au.com.shiftyjelly.pocketcasts.account.viewmodel
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContract.OnboardingFinish
+import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingExitInfo
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import io.reactivex.Flowable
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(MockitoJUnitRunner::class)
+class OnboardingActivityViewModelTest {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    @Mock
+    private lateinit var userManager: UserManager
+
+    @Mock
+    private lateinit var paidSubscriptionStatus: SubscriptionStatus.Paid
+
+    @Mock
+    private lateinit var freeSubscriptionStatus: SubscriptionStatus.Free
+
+    private lateinit var viewModel: OnboardingActivityViewModel
+
+    @Test
+    fun `given showPlusPromotionForFreeUser is false, when exit onboarding, then finish with Done`() = runTest {
+        initViewModel()
+
+        viewModel.finishState.test {
+            viewModel.onExitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = false))
+            assert(awaitItem() == OnboardingFinish.Done)
+        }
+    }
+
+    @Test
+    fun `given showPlusPromotionForFreeUser is true and free user, when exit onboarding, then finish with DoneShowPlusPromotion`() = runTest {
+        initViewModel(freeSubscriptionStatus)
+
+        viewModel.finishState.test {
+            viewModel.onExitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = true))
+            assert(awaitItem() == OnboardingFinish.DoneShowPlusPromotion)
+        }
+    }
+
+    @Test
+    fun `given showPlusPromotionForFreeUser is true and paid user, when exit onboarding, then finish with Done`() = runTest {
+        initViewModel(paidSubscriptionStatus)
+
+        viewModel.finishState.test {
+            viewModel.onExitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = true))
+            assert(awaitItem() == OnboardingFinish.Done)
+        }
+    }
+
+    private fun initViewModel(subscriptionStatus: SubscriptionStatus = mock<SubscriptionStatus>()) {
+        whenever(userManager.getSignInState()).thenReturn(
+            Flowable.just(
+                SignInState.SignedIn(email = "", subscriptionStatus = subscriptionStatus),
+            ),
+        )
+        viewModel = OnboardingActivityViewModel(
+            userManager = userManager,
+        )
+    }
+}

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingExitInfo.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingExitInfo.kt
@@ -1,0 +1,5 @@
+package au.com.shiftyjelly.pocketcasts.settings.onboarding
+
+data class OnboardingExitInfo(
+    val showPlusPromotionForFreeUser: Boolean = false,
+)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
@@ -9,7 +9,8 @@ enum class OnboardingUpgradeSource(val analyticsValue: String) {
     FILES("files"),
     FOLDERS("folders"),
     HEADPHONE_CONTROLS_SETTINGS("headphone_controls_settings"),
-    LOGIN("login"),
+    LOGIN("login"), // for login from within upsell screen
+    LOGIN_PLUS_PROMOTION("login_plus_promotion"), // for login from outside upsell screen
     OVERFLOW_MENU("overflow_menu"),
     PLUS_DETAILS("plus_details"),
     PROFILE("profile"),


### PR DESCRIPTION
## Description
This displays plus promotion after login for free account to match iOS behavior.

(Internal ref: p1705270282607759-slack-C028JAG44VD)

## Testing Instructions

0. Fresh install release build

#### Test.1 Login Free user (Initial Onboarding)
1. From the login and sign-up screen, tap `Log in `
2. Enter email/ pwd for a free user and log in
3. ✅ Notice that you see upsell screen 
4. Sign out and clear app storage
5. Restart the app
6. Login using Google for a free user 
7. ✅ Notice that you see upsell screen 

#### Test.2 Login Paid user (Initial Onboarding)
1. Repeat steps from Test.1 for paid user
2. ✅ Notice that you do not see upsell screen 

#### Test.3 Login Free user from Profile tab
1. Launch the app
2. Go to `Profile` tab
3. Tap `Set up account`
4. Tap `Log in `
5. Enter email/ pwd for a free user and log in
6. ✅ Notice that you see upsell screen
7. Dismiss the upsell screen and sign out
8. Repeat steps 2-3
9. Login using Google for a free user 
10. ✅ Notice that you see upsell screen

#### Test.4 Login Paid user from Profile tab
1. Repeat steps from Test.3 for paid user
2. ✅ Notice that you do not see upsell screen 

#### Test.5 Exit Login without entering details
1. Launch the app
2. Go to `Profile` tab
3. Tap `Set up account`
4. Tap `Log in`
5. From the Log in screen, tap back button
6. Press close on the login or sign up screen
19. ✅ Notice that login or sign up screen is closed

## Screenshots or Screencast 


**Free User**

https://github.com/Automattic/pocket-casts-android/assets/1405144/9dd10597-e029-4d32-b41d-9f5d5d536141

**Paid User**

https://github.com/Automattic/pocket-casts-android/assets/1405144/67e93c3b-cb34-4497-9d74-31feca0b67cb


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack

