### PR TITLE
Close UpNext sheet whenever player sheet is closed

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -884,6 +884,14 @@ class MainActivity :
         return binding.playerBottomSheet.sheetBehavior?.state ?: BottomSheetBehavior.STATE_COLLAPSED
     }
 
+    override fun addPlayerBottomSheetCallback(callback: BottomSheetBehavior.BottomSheetCallback) {
+        binding.playerBottomSheet.sheetBehavior?.addBottomSheetCallback(callback)
+    }
+
+    override fun removePlayerBottomSheetCallback(callback: BottomSheetBehavior.BottomSheetCallback) {
+        binding.playerBottomSheet.sheetBehavior?.removeBottomSheetCallback(callback)
+    }
+
     override fun lockPlayerBottomSheet(locked: Boolean) {
         binding.playerBottomSheet.isDragEnabled = !locked
     }

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import dagger.hilt.android.AndroidEntryPoint
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.profile.R as PR
@@ -116,6 +117,10 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
     override fun getPlayerBottomSheetState(): Int {
         return 0
     }
+
+    override fun addPlayerBottomSheetCallback(callback: BottomSheetBehavior.BottomSheetCallback) = Unit
+
+    override fun removePlayerBottomSheetCallback(callback: BottomSheetBehavior.BottomSheetCallback) = Unit
 
     override fun openEpisodeDialog(
         episodeUuid: String?,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -66,6 +66,16 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
     val overrideTheme: Theme.ThemeType
         get() = if (settings.useDarkUpNextTheme.value) Theme.ThemeType.DARK else theme.activeTheme
 
+    private val closeUpNextCallback = object : BottomSheetBehavior.BottomSheetCallback() {
+        override fun onStateChanged(bottomSheet: View, newState: Int) {
+            if (newState in listOf(BottomSheetBehavior.STATE_COLLAPSED, BottomSheetBehavior.STATE_HIDDEN)) {
+                upNextBottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+            }
+        }
+
+        override fun onSlide(bottomSheet: View, slideOffset: Float) = Unit
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentPlayerContainerBinding.inflate(inflater, container, false)
         return binding?.root
@@ -73,6 +83,7 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        (activity as? FragmentHostListener)?.removePlayerBottomSheetCallback(closeUpNextCallback)
         binding = null
         bookmarksViewModel.multiSelectHelper.context = null
     }
@@ -92,6 +103,7 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
         // Having it gone from the beginning adds a small delay before it can be initially shown.
         binding.upNextFrameBottomSheet.doOnLayout {
             it.isGone = true
+            (activity as? FragmentHostListener)?.addPlayerBottomSheetCallback(closeUpNextCallback)
         }
         upNextBottomSheetBehavior = BottomSheetBehavior.from(binding.upNextFrameBottomSheet)
         upNextBottomSheetBehavior.addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.ui.helper
 import android.view.View
 import androidx.fragment.app.Fragment
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 
 interface FragmentHostListener {
     fun addFragment(fragment: Fragment, onTop: Boolean = false)
@@ -22,6 +23,8 @@ interface FragmentHostListener {
     fun showAccountUpgradeNow(autoSelectPlus: Boolean)
     fun updateStatusBar()
     fun getPlayerBottomSheetState(): Int
+    fun addPlayerBottomSheetCallback(callback: BottomSheetBehavior.BottomSheetCallback)
+    fun removePlayerBottomSheetCallback(callback: BottomSheetBehavior.BottomSheetCallback)
     fun openEpisodeDialog(episodeUuid: String?, source: EpisodeViewSource, podcastUuid: String?, forceDark: Boolean)
     fun lockPlayerBottomSheet(locked: Boolean)
     fun updateSystemColors()


### PR DESCRIPTION
## Description

Fixes an issue introduced in #1697. While removing the old behavior I wasn't aware that we can come back to the app without closing the "up next" queue and then the player directly. Changes in this PR address it.

I made a change below because it was simpler to have a nullable property in the callback instead of dealing 

```diff
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -56,7 +56,7 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
     private val bookmarksViewModel: BookmarksViewModel by viewModels()
 
-    lateinit var upNextBottomSheetBehavior: BottomSheetBehavior<View>
+    var upNextBottomSheetBehavior: BottomSheetBehavior<View>? = null

```

Fixes #1730

## Testing Instructions

1. Add an episode to up next queue.
2. Open the  player page.
3. Open the up next page (flinging or top right button).
4. Click on an episode in the queue (not the one that is currently playing).
5. A podcast description page should open.
6. Tap on a podcast name.
7. Everything including the queue and the player should hide and you should see the podcast listing.
8. You should be able to open the player by dragging the mini player.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
