### PR TITLE
Update UI with intro offer

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateAccountFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateAccountFragment.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.findNavController
-import au.com.shiftyjelly.pocketcasts.account.components.ProductAmountView
+import au.com.shiftyjelly.pocketcasts.account.components.ProductAmountVerticalText
 import au.com.shiftyjelly.pocketcasts.account.databinding.FragmentCreateAccountBinding
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.CreateAccountState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.CreateAccountViewModel
@@ -96,7 +96,7 @@ class CreateAccountFragment : BaseFragment() {
                             AppTheme(theme.activeTheme) {
                                 val emphasized = true
                                 when (subscription) {
-                                    is Subscription.Simple -> ProductAmountView(
+                                    is Subscription.Simple -> ProductAmountVerticalText(
                                         primaryText = subscription.recurringPricingPhase.formattedPrice,
                                         secondaryText = stringResource(subscription.recurringPricingPhase.perPeriod)
                                             .lowercase(Locale.getDefault()),
@@ -109,7 +109,7 @@ class CreateAccountFragment : BaseFragment() {
                                             LR.string.plus_trial_duration_free,
                                             subscription.offerPricingPhase.periodValuePlural(res),
                                         )
-                                        ProductAmountView(
+                                        ProductAmountVerticalText(
                                             primaryText = primaryText,
                                             secondaryText = subscription.recurringPricingPhase.thenPriceSlashPeriod(
                                                 res,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateFrequencyAdapter.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreateFrequencyAdapter.kt
@@ -6,7 +6,7 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.LocalContext
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.NO_POSITION
-import au.com.shiftyjelly.pocketcasts.account.components.ProductAmountView
+import au.com.shiftyjelly.pocketcasts.account.components.ProductAmountVerticalText
 import au.com.shiftyjelly.pocketcasts.account.databinding.AdapterFrequencyItemBinding
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.localization.helper.tryToLocalise
@@ -66,10 +66,10 @@ class CreateFrequencyAdapter(
                 AppTheme(activeTheme) {
                     when (subscription) {
                         is Subscription.Simple ->
-                            ProductAmountView(subscription.recurringPricingPhase.formattedPrice)
+                            ProductAmountVerticalText(subscription.recurringPricingPhase.formattedPrice)
                         is Subscription.Trial -> {
                             val res = LocalContext.current.resources
-                            ProductAmountView(
+                            ProductAmountVerticalText(
                                 primaryText = subscription.offerPricingPhase.numPeriodFree(res),
                                 secondaryText = subscription.recurringPricingPhase.thenPriceSlashPeriod(
                                     res,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreatePayNowFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/CreatePayNowFragment.kt
@@ -13,7 +13,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.findNavController
-import au.com.shiftyjelly.pocketcasts.account.components.ProductAmountView
+import au.com.shiftyjelly.pocketcasts.account.components.ProductAmountVerticalText
 import au.com.shiftyjelly.pocketcasts.account.databinding.FragmentCreatePaynowBinding
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.CreateAccountError
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.CreateAccountState
@@ -73,12 +73,12 @@ class CreatePayNowFragment : BaseFragment() {
                     AppTheme(theme.activeTheme) {
                         val res = LocalContext.current.resources
                         when (subscription) {
-                            is Subscription.Simple -> ProductAmountView(
+                            is Subscription.Simple -> ProductAmountVerticalText(
                                 primaryText = subscription.recurringPricingPhase.priceSlashPeriod(res),
                                 horizontalAlignment = Alignment.CenterHorizontally,
                             )
                             is Subscription.Trial -> {
-                                ProductAmountView(
+                                ProductAmountVerticalText(
                                     primaryText = subscription.offerPricingPhase.numPeriodFree(res),
                                     secondaryText = subscription.recurringPricingPhase.thenPriceSlashPeriod(res),
                                     horizontalAlignment = Alignment.CenterHorizontally,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
@@ -1,12 +1,18 @@
 package au.com.shiftyjelly.pocketcasts.account.components
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
@@ -16,7 +22,7 @@ import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 
 @Composable
-fun ProductAmountView(
+fun ProductAmountVerticalText(
     primaryText: String,
     secondaryText: String? = null,
     modifier: Modifier = Modifier,
@@ -47,13 +53,45 @@ fun ProductAmountView(
     }
 }
 
+@Composable
+fun ProductAmountHorizontalText(
+    primaryText: String? = null,
+    secondaryText: String? = null,
+    modifier: Modifier = Modifier,
+    verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = verticalAlignment,
+    ) {
+        if (primaryText != null) {
+            TextH30(
+                text = primaryText,
+                color = MaterialTheme.theme.colors.primaryText01,
+            )
+        }
+
+        Spacer(modifier = Modifier.width(4.dp))
+
+        if (secondaryText != null) {
+            TextP60(
+                text = secondaryText,
+                color = MaterialTheme.theme.colors.primaryText02,
+                style = TextStyle(
+                    textDecoration = TextDecoration.LineThrough,
+                ),
+            )
+        }
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun ProductAmountPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppTheme(themeType) {
-        ProductAmountView(
+        ProductAmountVerticalText(
             primaryText = "4 days free",
             secondaryText = "then $0.99 / month",
         )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
@@ -57,8 +57,9 @@ fun ProductAmountVerticalText(
 fun ProductAmountHorizontalText(
     primaryText: String? = null,
     secondaryText: String? = null,
-    modifier: Modifier = Modifier,
+    lineThroughSecondaryText: Boolean = true,
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
+    modifier: Modifier = Modifier,
 ) {
     Row(
         modifier = modifier,
@@ -78,7 +79,7 @@ fun ProductAmountHorizontalText(
                 text = secondaryText,
                 color = MaterialTheme.theme.colors.primaryText02,
                 style = TextStyle(
-                    textDecoration = TextDecoration.LineThrough,
+                    textDecoration = if (lineThroughSecondaryText) TextDecoration.LineThrough else TextDecoration.None,
                 ),
             )
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
@@ -58,6 +59,7 @@ fun ProductAmountHorizontalText(
     primaryText: String? = null,
     secondaryText: String? = null,
     lineThroughSecondaryText: Boolean = true,
+    hasBackgroundAlwaysWhite: Boolean = false,
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
     modifier: Modifier = Modifier,
 ) {
@@ -68,7 +70,12 @@ fun ProductAmountHorizontalText(
         if (primaryText != null) {
             TextH30(
                 text = primaryText,
-                color = MaterialTheme.theme.colors.primaryText01,
+                color =
+                if (hasBackgroundAlwaysWhite) {
+                    Color.Black
+                } else {
+                    MaterialTheme.theme.colors.primaryText01
+                },
             )
         }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -64,8 +63,10 @@ import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalPagerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.components.StyledToggle
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.images.OfferBadge
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
@@ -231,6 +232,7 @@ private fun UpgradeLayout(
 
                         FeatureCards(
                             state = state,
+                            upgradeButton = state.currentUpgradeButton,
                             onFeatureCardChanged = onFeatureCardChanged,
                         )
                     }
@@ -253,6 +255,7 @@ private fun UpgradeLayout(
 @Composable
 fun FeatureCards(
     state: OnboardingUpgradeFeaturesState.Loaded,
+    upgradeButton: UpgradeButton,
     onFeatureCardChanged: (Int) -> Unit,
 ) {
     val featureCardsState = state.featureCardsState
@@ -265,7 +268,9 @@ fun FeatureCards(
         contentPadding = PaddingValues(horizontal = 32.dp),
     ) { index, pagerHeight ->
         FeatureCard(
+            subscription = state.currentSubscription,
             card = featureCardsState.featureCards[index],
+            upgradeButton = upgradeButton,
             modifier = if (pagerHeight > 0) {
                 Modifier.height(pagerHeight.pxToDp(LocalContext.current).dp)
             } else {
@@ -278,6 +283,8 @@ fun FeatureCards(
 @Composable
 private fun FeatureCard(
     card: UpgradeFeatureCard,
+    upgradeButton: UpgradeButton,
+    subscription: Subscription,
     modifier: Modifier = Modifier,
 ) {
     Card(
@@ -306,6 +313,16 @@ private fun FeatureCard(
             }
 
             Column {
+                if (subscription is Subscription.WithOffer) {
+                    OfferBadge(
+                        shortNameRes = subscription.badgeOfferText(),
+                        backgroundColor = upgradeButton.backgroundColorRes,
+                        textColor = upgradeButton.textColorRes,
+                    )
+
+                    Spacer(modifier = Modifier.weight(2f))
+                }
+
                 card.featureItems.forEach {
                     UpgradeFeatureItem(it)
                 }
@@ -452,15 +469,3 @@ private fun Modifier.fadeBackground() = this
             drawContent()
         }
     }
-
-@Preview
-@Composable
-private fun OnboardingPlusFeatureCardPreview() {
-    FeatureCard(card = UpgradeFeatureCard.PLUS)
-}
-
-@Preview
-@Composable
-private fun OnboardingPatonFeatureCardPreview() {
-    FeatureCard(card = UpgradeFeatureCard.PATRON)
-}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -66,7 +66,6 @@ import au.com.shiftyjelly.pocketcasts.compose.components.StyledToggle
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
@@ -327,19 +326,9 @@ private fun UpgradeButton(
     onClickSubscribe: () -> Unit,
 ) {
     val resources = LocalContext.current.resources
-    val subscription = button.subscription
     val shortName = resources.getString(button.shortNameRes)
-    val primaryText = when (subscription) {
-        is Subscription.Simple -> stringResource(LR.string.subscribe_to, shortName)
-        is Subscription.Trial -> { stringResource(LR.string.trial_start) }
-        is Subscription.Intro -> { "TODO" }
-        else -> { stringResource(LR.string.subscribe_to, shortName) }
-    }
-    val secondaryText = when (subscription) {
-        is Subscription.Simple -> subscription.recurringPricingPhase.pricePerPeriod(resources)
-        is Subscription.Trial, is Subscription.Intro -> { subscription.tryFreeThenPricePerPeriod(resources) }
-        else -> { subscription.recurringPricingPhase.pricePerPeriod(resources) }
-    }
+    val primaryText = stringResource(LR.string.subscribe_to, shortName)
+
     Box(
         contentAlignment = Alignment.BottomCenter,
         modifier = Modifier.fadeBackground(),
@@ -347,13 +336,14 @@ private fun UpgradeButton(
         Column {
             UpgradeRowButton(
                 primaryText = primaryText,
-                secondaryText = secondaryText,
                 backgroundColor = colorResource(button.backgroundColorRes),
                 textColor = colorResource(button.textColorRes),
+                fontWeight = FontWeight.W500,
                 onClick = onClickSubscribe,
                 modifier = Modifier
+                    .fillMaxWidth()
                     .padding(horizontal = 20.dp, vertical = 24.dp)
-                    .fillMaxWidth(),
+                    .heightIn(min = 48.dp),
             )
             Spacer(
                 modifier = Modifier

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -53,7 +53,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import au.com.shiftyjelly.pocketcasts.account.components.ProductAmountHorizontalText
 import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradeFeatureItem
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.UpgradeRowButton
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
@@ -64,7 +63,6 @@ import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalPagerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.components.StyledToggle
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
-import au.com.shiftyjelly.pocketcasts.compose.images.OfferBadge
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
@@ -314,24 +312,7 @@ private fun FeatureCard(
             }
 
             Column {
-                if (subscription is Subscription.WithOffer) {
-                    ProductAmountHorizontalText(
-                        primaryText = subscription.offerPricingPhase.priceSlashPeriod(LocalContext.current.resources),
-                        secondaryText = subscription.recurringPricingPhase.priceSlashPeriod(LocalContext.current.resources),
-                    )
-
-                    Spacer(modifier = Modifier.padding(vertical = 4.dp))
-
-                    OfferBadge(
-                        shortNameRes = subscription.badgeOfferText(),
-                        backgroundColor = upgradeButton.backgroundColorRes,
-                        textColor = upgradeButton.textColorRes,
-                    )
-                } else if (subscription is Subscription.Simple) {
-                    ProductAmountHorizontalText(
-                        primaryText = subscription.recurringPricingPhase.priceSlashPeriod(LocalContext.current.resources),
-                    )
-                }
+                SubscriptionPriceSection(subscription, upgradeButton)
 
                 Spacer(modifier = Modifier.padding(vertical = 4.dp))
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import au.com.shiftyjelly.pocketcasts.account.components.ProductAmountHorizontalText
 import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradeFeatureItem
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.UpgradeRowButton
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
@@ -314,14 +315,25 @@ private fun FeatureCard(
 
             Column {
                 if (subscription is Subscription.WithOffer) {
+                    ProductAmountHorizontalText(
+                        primaryText = subscription.offerPricingPhase.priceSlashPeriod(LocalContext.current.resources),
+                        secondaryText = subscription.recurringPricingPhase.priceSlashPeriod(LocalContext.current.resources),
+                    )
+
+                    Spacer(modifier = Modifier.padding(vertical = 4.dp))
+
                     OfferBadge(
                         shortNameRes = subscription.badgeOfferText(),
                         backgroundColor = upgradeButton.backgroundColorRes,
                         textColor = upgradeButton.textColorRes,
                     )
-
-                    Spacer(modifier = Modifier.weight(2f))
+                } else if (subscription is Subscription.Simple) {
+                    ProductAmountHorizontalText(
+                        primaryText = subscription.recurringPricingPhase.priceSlashPeriod(LocalContext.current.resources),
+                    )
                 }
+
+                Spacer(modifier = Modifier.padding(vertical = 4.dp))
 
                 card.featureItems.forEach {
                     UpgradeFeatureItem(it)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -312,7 +312,7 @@ private fun FeatureCard(
             }
 
             Column {
-                SubscriptionPriceSection(subscription, upgradeButton)
+                SubscriptionPriceSection(subscription, upgradeButton, hasBackgroundAlwaysWhite = true)
 
                 Spacer(modifier = Modifier.padding(vertical = 4.dp))
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -18,12 +17,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradeFeatureItem
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.ProfileUpgradeBannerViewModel
@@ -31,9 +26,7 @@ import au.com.shiftyjelly.pocketcasts.account.viewmodel.ProfileUpgradeBannerView
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalPagerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
-import java.util.Locale
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -111,11 +104,14 @@ private fun FeatureCard(
                 iconRes = card.iconRes,
                 shortNameRes = card.shortNameRes,
             )
-
-            AmountView(button.subscription)
         }
 
         Column {
+            SubscriptionPriceSection(
+                subscription = button.subscription,
+                upgradeButton = button,
+            )
+
             card.featureItems.forEach {
                 UpgradeFeatureItem(
                     item = it,
@@ -129,15 +125,7 @@ private fun FeatureCard(
 
         val primaryText = when (button.planType) {
             UpgradeButton.PlanType.RENEW -> stringResource(LR.string.renew_your_subscription)
-            UpgradeButton.PlanType.SUBSCRIBE -> {
-                when (button.subscription) {
-                    is Subscription.Simple -> stringResource(LR.string.subscribe_to, stringResource(button.shortNameRes))
-                    is Subscription.Trial -> { stringResource(LR.string.trial_start) }
-                    is Subscription.Intro -> { stringResource(LR.string.subscribe_to, stringResource(button.shortNameRes)) }
-                    else -> { stringResource(LR.string.subscribe_to, stringResource(button.shortNameRes)) }
-                }
-            }
-            UpgradeButton.PlanType.UPGRADE -> stringResource(LR.string.upgrade_to, stringResource(button.shortNameRes))
+            UpgradeButton.PlanType.SUBSCRIBE, UpgradeButton.PlanType.UPGRADE -> { stringResource(LR.string.subscribe_to, stringResource(button.shortNameRes)) }
         }
         OnboardingUpgradeHelper.UpgradeRowButton(
             primaryText = primaryText,
@@ -150,27 +138,4 @@ private fun FeatureCard(
                 .heightIn(min = 48.dp),
         )
     }
-}
-
-@Composable
-private fun AmountView(
-    subscription: Subscription,
-) {
-    Text(
-        fontSize = 22.sp,
-        lineHeight = 30.sp,
-        color = MaterialTheme.theme.colors.primaryText01,
-        text = buildAnnotatedString {
-            withStyle(style = SpanStyle(fontWeight = FontWeight.W700)) {
-                append("${subscription.recurringPricingPhase.formattedPrice} ")
-            }
-
-            withStyle(style = SpanStyle(fontWeight = FontWeight.W400)) {
-                append(
-                    stringResource(subscription.recurringPricingPhase.perPeriod)
-                        .lowercase(Locale.getDefault()),
-                )
-            }
-        },
-    )
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionPriceSection.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionPriceSection.kt
@@ -14,6 +14,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 fun SubscriptionPriceSection(
     subscription: Subscription,
     upgradeButton: UpgradeButton,
+    hasBackgroundAlwaysWhite: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     if (subscription is Subscription.WithOffer) {
@@ -21,12 +22,14 @@ fun SubscriptionPriceSection(
             ProductAmountHorizontalText(
                 primaryText = subscription.offerPricingPhase.priceSlashPeriod(LocalContext.current.resources),
                 secondaryText = subscription.recurringPricingPhase.priceSlashPeriod(LocalContext.current.resources),
+                hasBackgroundAlwaysWhite = hasBackgroundAlwaysWhite,
             )
         } else if (subscription is Subscription.Trial) {
             ProductAmountHorizontalText(
                 primaryText = subscription.recurringPricingPhase.formattedPrice,
                 secondaryText = subscription.recurringPricingPhase.period(LocalContext.current.resources),
                 lineThroughSecondaryText = false,
+                hasBackgroundAlwaysWhite = hasBackgroundAlwaysWhite,
             )
         }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionPriceSection.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionPriceSection.kt
@@ -1,0 +1,47 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.account.components.ProductAmountHorizontalText
+import au.com.shiftyjelly.pocketcasts.compose.images.OfferBadge
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+
+@Composable
+fun SubscriptionPriceSection(
+    subscription: Subscription,
+    upgradeButton: UpgradeButton,
+    modifier: Modifier = Modifier,
+) {
+    if (subscription is Subscription.WithOffer) {
+        if (subscription is Subscription.Intro) {
+            ProductAmountHorizontalText(
+                primaryText = subscription.offerPricingPhase.priceSlashPeriod(LocalContext.current.resources),
+                secondaryText = subscription.recurringPricingPhase.priceSlashPeriod(LocalContext.current.resources),
+            )
+        } else if (subscription is Subscription.Trial) {
+            ProductAmountHorizontalText(
+                primaryText = subscription.recurringPricingPhase.formattedPrice,
+                secondaryText = subscription.recurringPricingPhase.period(LocalContext.current.resources),
+                lineThroughSecondaryText = false,
+            )
+        }
+
+        Spacer(modifier = modifier.padding(vertical = 4.dp))
+
+        OfferBadge(
+            shortNameRes = subscription.badgeOfferText(),
+            backgroundColor = upgradeButton.backgroundColorRes,
+            textColor = upgradeButton.textColorRes,
+        )
+    } else if (subscription is Subscription.Simple) {
+        ProductAmountHorizontalText(
+            primaryText = subscription.recurringPricingPhase.formattedPrice,
+            secondaryText = subscription.recurringPricingPhase.period(LocalContext.current.resources),
+            lineThroughSecondaryText = false,
+        )
+    }
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionPriceSection.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionPriceSection.kt
@@ -45,6 +45,7 @@ fun SubscriptionPriceSection(
             primaryText = subscription.recurringPricingPhase.formattedPrice,
             secondaryText = subscription.recurringPricingPhase.slashPeriod(LocalContext.current.resources),
             lineThroughSecondaryText = false,
+            hasBackgroundAlwaysWhite = hasBackgroundAlwaysWhite,
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionPriceSection.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionPriceSection.kt
@@ -27,7 +27,7 @@ fun SubscriptionPriceSection(
         } else if (subscription is Subscription.Trial) {
             ProductAmountHorizontalText(
                 primaryText = subscription.recurringPricingPhase.formattedPrice,
-                secondaryText = subscription.recurringPricingPhase.period(LocalContext.current.resources),
+                secondaryText = subscription.recurringPricingPhase.slashPeriod(LocalContext.current.resources),
                 lineThroughSecondaryText = false,
                 hasBackgroundAlwaysWhite = hasBackgroundAlwaysWhite,
             )
@@ -36,14 +36,14 @@ fun SubscriptionPriceSection(
         Spacer(modifier = modifier.padding(vertical = 4.dp))
 
         OfferBadge(
-            shortNameRes = subscription.badgeOfferText(),
+            text = subscription.badgeOfferText(LocalContext.current.resources),
             backgroundColor = upgradeButton.backgroundColorRes,
             textColor = upgradeButton.textColorRes,
         )
     } else if (subscription is Subscription.Simple) {
         ProductAmountHorizontalText(
             primaryText = subscription.recurringPricingPhase.formattedPrice,
-            secondaryText = subscription.recurringPricingPhase.period(LocalContext.current.resources),
+            secondaryText = subscription.recurringPricingPhase.slashPeriod(LocalContext.current.resources),
             lineThroughSecondaryText = false,
         )
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
@@ -21,7 +21,7 @@ enum class UpgradeFeatureCard(
         shortNameRes = LR.string.pocket_casts_plus_short,
         backgroundGlowsRes = R.drawable.upgrade_background_plus_glows,
         iconRes = IR.drawable.ic_plus,
-        featureItems = PlusUpgradeFeatureItem.values().toList(),
+        featureItems = PlusUpgradeFeatureItem.entries,
         subscriptionTier = SubscriptionTier.PLUS,
     ),
     PATRON(
@@ -29,7 +29,7 @@ enum class UpgradeFeatureCard(
         shortNameRes = LR.string.pocket_casts_patron_short,
         backgroundGlowsRes = R.drawable.upgrade_background_patron_glows,
         iconRes = IR.drawable.ic_patron,
-        featureItems = PatronUpgradeFeatureItem.values().toList(),
+        featureItems = PatronUpgradeFeatureItem.entries,
         subscriptionTier = SubscriptionTier.PATRON,
     ),
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/UpsellButtonTitle.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/UpsellButtonTitle.kt
@@ -3,13 +3,15 @@ package au.com.shiftyjelly.pocketcasts.compose.buttons
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun UpsellButtonTitle(
     tier: SubscriptionTier,
     hasFreeTrial: Boolean,
-) = if (hasFreeTrial) {
+) = if (hasFreeTrial && !FeatureFlag.isEnabled(Feature.INTRO_PLUS_OFFER_ENABLED)) {
     stringResource(LR.string.profile_start_free_trial)
 } else {
     stringResource(

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
@@ -88,6 +88,7 @@ fun TextH30(
     disableScale: Boolean = false,
     fontSize: TextUnit? = null,
     lineHeight: TextUnit = 21.sp,
+    style: TextStyle = TextStyle(),
 ) {
     val fontSizeUpdated = fontSize ?: 18.sp
     Text(
@@ -100,6 +101,7 @@ fun TextH30(
         fontWeight = fontWeight ?: FontWeight.W600,
         maxLines = maxLines,
         overflow = TextOverflow.Ellipsis,
+        style = style,
         modifier = modifier,
     )
 }
@@ -282,6 +284,7 @@ fun TextP60(
     textAlign: TextAlign? = null,
     maxLines: Int = Int.MAX_VALUE,
     fontWeight: FontWeight? = null,
+    style: TextStyle = TextStyle(),
 ) {
     Text(
         text = text,
@@ -293,6 +296,7 @@ fun TextP60(
         overflow = TextOverflow.Ellipsis,
         textAlign = textAlign,
         fontWeight = fontWeight,
+        style = style,
         modifier = modifier,
     )
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
@@ -120,6 +121,38 @@ fun SubscriptionBadgeForTier(
             },
         )
         SubscriptionTier.UNKNOWN -> Unit
+    }
+}
+
+@Composable
+fun OfferBadge(
+    @StringRes shortNameRes: Int,
+    modifier: Modifier = Modifier,
+    fontSize: TextUnit = 14.sp,
+    padding: Dp = 4.dp,
+    backgroundColor: Int,
+    textColor: Int,
+) {
+    Card(
+        shape = RoundedCornerShape(pillCornerRadiusInDp),
+        backgroundColor = colorResource(id = backgroundColor),
+        modifier = modifier,
+    ) {
+        Row(
+            modifier = Modifier
+                .semantics(mergeDescendants = true) {}
+                .padding(horizontal = padding * 2, vertical = padding),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TextH50(
+                text = stringResource(shortNameRes),
+                color = colorResource(id = textColor),
+                fontSize = fontSize,
+                lineHeight = fontSize,
+                modifier = Modifier
+                    .padding(start = padding),
+            )
+        }
     }
 }
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -145,7 +145,7 @@ fun OfferBadge(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             TextH50(
-                text = stringResource(shortNameRes),
+                text = stringResource(shortNameRes).uppercase(),
                 color = colorResource(id = textColor),
                 fontSize = fontSize,
                 lineHeight = fontSize,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -126,7 +126,7 @@ fun SubscriptionBadgeForTier(
 
 @Composable
 fun OfferBadge(
-    @StringRes shortNameRes: Int,
+    text: String,
     modifier: Modifier = Modifier,
     fontSize: TextUnit = 14.sp,
     padding: Dp = 4.dp,
@@ -145,7 +145,7 @@ fun OfferBadge(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             TextH50(
-                text = stringResource(shortNameRes).uppercase(),
+                text = text.uppercase(),
                 color = colorResource(id = textColor),
                 fontSize = fontSize,
                 lineHeight = fontSize,

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -980,10 +980,7 @@
     <string name="plus_per_month">%s per month</string>
     <string name="plus_per_year">%s per year</string>
     <string name="plus_slash_month">%s / month</string>
-    <string name="slash_month"> / month</string>
-    <string name="slash_day"> / day</string>
     <string name="plus_slash_year">%s / year</string>
-    <string name="slash_year"> / year</string>
     <string name="plus_then_slash_month">then %s / month</string>
     <string name="plus_then_slash_year">then %s / year</string>
     <string name="plus_trial_then_slash_month">%1$s free then %2$s / month</string>
@@ -1015,7 +1012,6 @@
     <string name="trial_start">Start my free trial</string>
     <string name="trial_then_per_month">Try %1$s, then %2$s per month</string>
     <string name="trial_then_per_year">Try %1$s, then %2$s per year</string>
-    <string name="one_month_free_trial_badge">1 month free trial</string>
 
     <!-- Intro Offer -->
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -980,7 +980,10 @@
     <string name="plus_per_month">%s per month</string>
     <string name="plus_per_year">%s per year</string>
     <string name="plus_slash_month">%s / month</string>
+    <string name="slash_month"> / month</string>
+    <string name="slash_day"> / day</string>
     <string name="plus_slash_year">%s / year</string>
+    <string name="slash_year"> / year</string>
     <string name="plus_then_slash_month">then %s / month</string>
     <string name="plus_then_slash_year">then %s / year</string>
     <string name="plus_trial_then_slash_month">%1$s free then %2$s / month</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1012,6 +1012,11 @@
     <string name="trial_start">Start my free trial</string>
     <string name="trial_then_per_month">Try %1$s, then %2$s per month</string>
     <string name="trial_then_per_year">Try %1$s, then %2$s per year</string>
+    <string name="one_month_free_trial_badge">1 month free trial</string>
+
+    <!-- Intro Offer -->
+
+    <string name="half_price_first_year">50% off your first year</string>
 
     <!-- Settings -->
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -2,6 +2,8 @@ package au.com.shiftyjelly.pocketcasts.models.type
 
 import android.content.res.Resources
 import au.com.shiftyjelly.pocketcasts.localization.R
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import com.android.billingclient.api.ProductDetails
 
@@ -116,7 +118,9 @@ sealed interface Subscription {
         const val TRIAL_OFFER_ID = "plus-yearly-trial-30days"
         const val INTRO_OFFER_ID = "testyearlyintropricingoffer"
 
-        fun fromProductDetails(productDetails: ProductDetails, isFreeTrialEligible: Boolean): Subscription? =
-            SubscriptionMapper.map(productDetails, isFreeTrialEligible)
+        fun fromProductDetails(productDetails: ProductDetails, isFreeTrialEligible: Boolean): Subscription? {
+            val subscription = SubscriptionMapper.map(productDetails, isFreeTrialEligible)
+            return if (FeatureFlag.isEnabled(Feature.INTRO_PLUS_OFFER_ENABLED) && subscription is Trial) null else subscription
+        }
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -114,6 +114,7 @@ sealed interface Subscription {
         const val PATRON_YEARLY_PRODUCT_ID = "com.pocketcasts.yearly.patron"
         const val SUBSCRIPTION_TEST_PRODUCT_ID = "com.pocketcasts.plus.testfreetrialoffer"
         const val TRIAL_OFFER_ID = "plus-yearly-trial-30days"
+        const val INTRO_OFFER_ID = "testyearlyintropricingoffer"
 
         fun fromProductDetails(productDetails: ProductDetails, isFreeTrialEligible: Boolean): Subscription? =
             SubscriptionMapper.map(productDetails, isFreeTrialEligible)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -36,7 +36,7 @@ sealed interface Subscription {
         override val productDetails: ProductDetails,
         override val offerToken: String,
     ) : Subscription {
-        abstract fun badgeOfferText(): Int
+        abstract fun badgeOfferText(res: Resources): String
     }
 
     class Trial(
@@ -46,7 +46,7 @@ sealed interface Subscription {
         productDetails: ProductDetails,
         offerToken: String,
     ) : WithOffer(tier, recurringPricingPhase, offerPricingPhase, productDetails, offerToken) {
-        override fun badgeOfferText(): Int = R.string.one_month_free_trial_badge
+        override fun badgeOfferText(res: Resources): String = offerPricingPhase.numPeriodFreeTrial(res)
 
         override fun numFreeThenPricePerPeriod(res: Resources): String {
             val stringRes = when (recurringPricingPhase) {
@@ -80,7 +80,7 @@ sealed interface Subscription {
         productDetails: ProductDetails,
         offerToken: String,
     ) : WithOffer(tier, recurringPricingPhase, offerPricingPhase, productDetails, offerToken) {
-        override fun badgeOfferText(): Int = R.string.half_price_first_year
+        override fun badgeOfferText(res: Resources): String = res.getString(R.string.half_price_first_year)
 
         override fun numFreeThenPricePerPeriod(res: Resources): String {
             return "TODO"

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -35,7 +35,9 @@ sealed interface Subscription {
         override val offerPricingPhase: OfferSubscriptionPricingPhase, // override to not be nullable
         override val productDetails: ProductDetails,
         override val offerToken: String,
-    ) : Subscription
+    ) : Subscription {
+        abstract fun badgeOfferText(): Int
+    }
 
     class Trial(
         tier: SubscriptionTier,
@@ -44,6 +46,8 @@ sealed interface Subscription {
         productDetails: ProductDetails,
         offerToken: String,
     ) : WithOffer(tier, recurringPricingPhase, offerPricingPhase, productDetails, offerToken) {
+        override fun badgeOfferText(): Int = R.string.one_month_free_trial_badge
+
         override fun numFreeThenPricePerPeriod(res: Resources): String {
             val stringRes = when (recurringPricingPhase) {
                 is SubscriptionPricingPhase.Years -> R.string.plus_trial_then_slash_year
@@ -76,6 +80,8 @@ sealed interface Subscription {
         productDetails: ProductDetails,
         offerToken: String,
     ) : WithOffer(tier, recurringPricingPhase, offerPricingPhase, productDetails, offerToken) {
+        override fun badgeOfferText(): Int = R.string.half_price_first_year
+
         override fun numFreeThenPricePerPeriod(res: Resources): String {
             return "TODO"
         }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
@@ -51,7 +51,7 @@ object SubscriptionMapper {
                             productDetails = productDetails,
                             offerToken = relevantSubscriptionOfferDetails.offerToken,
                         )
-                    } else {
+                    } else if (isIntro(productDetails)) {
                         Subscription.Intro(
                             tier = mapProductIdToTier(productDetails.productId),
                             recurringPricingPhase = recurringPricingPhase,
@@ -59,6 +59,8 @@ object SubscriptionMapper {
                             productDetails = productDetails,
                             offerToken = relevantSubscriptionOfferDetails.offerToken,
                         )
+                    } else {
+                        null
                     }
                 }
             }
@@ -66,6 +68,11 @@ object SubscriptionMapper {
     private fun isTrial(productDetails: ProductDetails): Boolean {
         return productDetails.subscriptionOfferDetails?.any {
             it.offerId == Subscription.TRIAL_OFFER_ID
+        } ?: false
+    }
+    private fun isIntro(productDetails: ProductDetails): Boolean {
+        return productDetails.subscriptionOfferDetails?.any {
+            it.offerId == Subscription.INTRO_OFFER_ID
         } ?: false
     }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionPricingPhase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionPricingPhase.kt
@@ -27,6 +27,14 @@ sealed interface OfferSubscriptionPricingPhase : SubscriptionPricingPhase {
         val end = chronoUnit.addTo(ZonedDateTime.now(), periodValue.toLong())
         return DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).format(end)
     }
+
+    override fun priceSlashPeriod(res: Resources): String {
+        return when (this) {
+            is SubscriptionPricingPhase.Years -> res.getString(R.string.plus_slash_year, this.formattedPrice)
+            is SubscriptionPricingPhase.Months -> res.getString(R.string.plus_slash_month, this.formattedPrice)
+            else -> { "" }
+        }
+    }
 }
 
 sealed interface RecurringSubscriptionPricingPhase : SubscriptionPricingPhase {
@@ -36,7 +44,7 @@ sealed interface RecurringSubscriptionPricingPhase : SubscriptionPricingPhase {
     val renews: Int
     val hint: Int?
     fun pricePerPeriod(res: Resources): String
-    fun priceSlashPeriod(res: Resources): String
+    override fun priceSlashPeriod(res: Resources): String
     fun thenPriceSlashPeriod(res: Resources): String
 }
 
@@ -52,6 +60,8 @@ sealed interface SubscriptionPricingPhase {
     fun periodValueSingular(res: Resources): String =
         "$periodValue ${res.getString(periodResSingular)}"
     fun phaseType(): Type = pricingPhase.subscriptionPricingPhaseType
+
+    fun priceSlashPeriod(res: Resources): String
 
     enum class Type { OFFER, RECURRING, UNKNOWN }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionPricingPhase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionPricingPhase.kt
@@ -63,6 +63,8 @@ sealed interface SubscriptionPricingPhase {
 
     fun priceSlashPeriod(res: Resources): String
 
+    fun period(res: Resources): String
+
     enum class Type { OFFER, RECURRING, UNKNOWN }
 
     private val ProductDetails.PricingPhase.subscriptionPricingPhaseType: Type
@@ -95,6 +97,9 @@ sealed interface SubscriptionPricingPhase {
 
         override fun thenPriceSlashPeriod(res: Resources): String =
             res.getString(R.string.plus_then_slash_year, pricingPhase.formattedPrice)
+
+        override fun period(res: Resources): String =
+            res.getString(R.string.slash_year)
     }
 
     class Months(
@@ -118,6 +123,9 @@ sealed interface SubscriptionPricingPhase {
 
         override fun thenPriceSlashPeriod(res: Resources): String =
             res.getString(R.string.plus_then_slash_month, pricingPhase.formattedPrice)
+
+        override fun period(res: Resources): String =
+            res.getString(R.string.slash_month)
     }
 
     class Days(
@@ -127,6 +135,10 @@ sealed interface SubscriptionPricingPhase {
         override val periodResSingular = R.string.plus_day
         override val periodResPlural = R.string.days_plural
         override val periodValue = period.days
+
+        override fun period(res: Resources): String =
+            res.getString(R.string.slash_day)
+
         override val chronoUnit = ChronoUnit.DAYS
 
         init {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionPricingPhase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionPricingPhase.kt
@@ -59,11 +59,11 @@ sealed interface SubscriptionPricingPhase {
         res.getStringPlural(periodValue, periodResSingular, periodResPlural)
     fun periodValueSingular(res: Resources): String =
         "$periodValue ${res.getString(periodResSingular)}"
+    fun slashPeriod(res: Resources): String =
+        "/ ${res.getString(periodResSingular)}"
     fun phaseType(): Type = pricingPhase.subscriptionPricingPhaseType
 
     fun priceSlashPeriod(res: Resources): String
-
-    fun period(res: Resources): String
 
     enum class Type { OFFER, RECURRING, UNKNOWN }
 
@@ -97,9 +97,6 @@ sealed interface SubscriptionPricingPhase {
 
         override fun thenPriceSlashPeriod(res: Resources): String =
             res.getString(R.string.plus_then_slash_year, pricingPhase.formattedPrice)
-
-        override fun period(res: Resources): String =
-            res.getString(R.string.slash_year)
     }
 
     class Months(
@@ -123,9 +120,6 @@ sealed interface SubscriptionPricingPhase {
 
         override fun thenPriceSlashPeriod(res: Resources): String =
             res.getString(R.string.plus_then_slash_month, pricingPhase.formattedPrice)
-
-        override fun period(res: Resources): String =
-            res.getString(R.string.slash_month)
     }
 
     class Days(
@@ -135,9 +129,6 @@ sealed interface SubscriptionPricingPhase {
         override val periodResSingular = R.string.plus_day
         override val periodResPlural = R.string.days_plural
         override val periodValue = period.days
-
-        override fun period(res: Resources): String =
-            res.getString(R.string.slash_day)
 
         override val chronoUnit = ChronoUnit.DAYS
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -399,7 +399,9 @@ class SubscriptionManagerImpl @Inject constructor(
         subscriptionStatus.accept(Optional.empty())
     }
 
-    override fun isFreeTrialEligible(tier: Subscription.SubscriptionTier) = freeTrialEligible[tier] ?: true
+    override fun isFreeTrialEligible(tier: Subscription.SubscriptionTier): Boolean {
+        return if (FeatureFlag.isEnabled(Feature.INTRO_PLUS_OFFER_ENABLED)) true else freeTrialEligible[tier] ?: true
+    }
 
     override fun updateFreeTrialEligible(tier: Subscription.SubscriptionTier, eligible: Boolean) {
         freeTrialEligible[tier] = eligible

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -23,6 +23,8 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionPurchaseRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionStatusResponse
 import au.com.shiftyjelly.pocketcasts.utils.Optional
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.AcknowledgePurchaseResponseListener
@@ -179,12 +181,14 @@ class SubscriptionManagerImpl @Inject constructor(
                         .setProductType(BillingClient.ProductType.SUBS)
                         .build(),
                 )
-                add(
-                    QueryProductDetailsParams.Product.newBuilder()
-                        .setProductId(SUBSCRIPTION_TEST_PRODUCT_ID)
-                        .setProductType(BillingClient.ProductType.SUBS)
-                        .build(),
-                )
+                if (FeatureFlag.isEnabled(Feature.INTRO_PLUS_OFFER_ENABLED)) {
+                    add(
+                        QueryProductDetailsParams.Product.newBuilder()
+                            .setProductId(SUBSCRIPTION_TEST_PRODUCT_ID)
+                            .setProductType(BillingClient.ProductType.SUBS)
+                            .build(),
+                    )
+                }
             }
 
         val params = QueryProductDetailsParams.newBuilder()

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -43,6 +43,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = false,
     ),
+    INTRO_PLUS_OFFER_ENABLED(
+        key = "intro_plus_offer_enabled",
+        title = "Intro Offer Plus",
+        defaultValue = true,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = true,
+        hasDevToggle = false,
+    ),
     ;
 
     companion object {


### PR DESCRIPTION
This is part of: #1728

## Description
This PR updates two screens with intro offer UI: Upgrade screen page and the Profile Page


## Testing
- git apply ~~[release.patch](https://github.com/Automattic/pocket-casts-android/files/13998087/release.patch)~~  [new_patch.patch](https://github.com/Automattic/pocket-casts-android/files/14036750/new_patch.patch)
- To be able to see offers make sure the `Feature.INTRO_PLUS_OFFER_ENABLED.defaultValue` is `true` to enable intro offer

### 1 Intro Offer

#### 1.1 Update screen

1. Run the app and login in with a free account that never had a subscription
2. Go to `Podcasts` tab
3. Click on folders

- [ ] You should see the `Subscribe to [Plus/Patron]` button
- [ ] You should see the plan price bellow the badge
- [ ] For the Plus offer you should the the half price and the recurring price (see screenshot section)

#### 1.2 Profile screen
1. Run the app and login in with a free account that never had a subscription
2. Go to `Profile` tab
- [ ] You should see the `Subscribe to [Plus/Patron]` button
- [ ] You should see the plan price bellow the badge
- [ ] For the Plus offer you should see the half price and the recurring price (see screenshot section)
- [ ] Click on `Subscribe to [Plus/Patron]` button -> You should see the upgrade bottom sheet with the correct labels for Intro and trial. Also the button needs to be `Subscribe to [Plus/Patron]` (see screenshot section)

### 2 Trial Offer
- Make sure the `Feature.INTRO_PLUS_OFFER_ENABLED.defaultValue` is `false` to disable intro offer and see trial offer

- [ ] Repeat the same steps from 1.1 and 1.2 and check if the trial offer matches with the screen from the screenshot section

### 3 UpSell

#### 3.1 Intro offer
1. Run the app and login in with a free account that never had a subscription
2. Make sure the `Feature.INTRO_PLUS_OFFER_ENABLED.defaultValue` is `true` to enable intro offer
3. Play a podcast
4. Go to Bookmarks tab
5. You should be able to see the Upsell button with `Upgrade to [plan]`

#### 3.2 Trial
1. Run the app and login in with a free account that never had a subscription
2. Make sure the `Feature.INTRO_PLUS_OFFER_ENABLED.defaultValue` is `false` to disable intro offer
3. Play a podcast
4. Go to Bookmarks tab
5. You should be able to see the Upsell button with `Start trial`


## Screenshots or Screencast 
| Intro Offer | Regular Plus | Intro Offer
|--------|--------|--------|
|<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/232ed2dd-c8da-459b-b1d1-9df03666ed35" height="500"> |<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/b5984c94-0523-4a81-b1ef-2097795bd1ba" height="500"> | <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/f4889a24-3a0f-44e9-8059-9daf9877d768" height="500">| 

| Trial Offer | Trial Offer |
|--------|--------|
| <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/d3c7191d-afa1-4749-a0f7-6639d7a19808" height="500"> |<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/56e41627-d07a-46ce-8e38-71b61e485018" height="500"> | 

| UpgradeBottomSheet |UpgradeBottomSheet |UpgradeBottomSheet with Intro disabled |
|--------|--------|--------|
|<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/04dd8e48-be24-4e21-99fc-3db6ec4469f3" height="500"> |<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/e7ecb940-7d00-4f04-aa1e-02c5cd915a31" height="500"> |<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/9eca4487-6bcb-41b8-a144-d0d92a566faf" height="500"> | 


| UpSell |
|--------|
|<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/f42efc8c-035d-492d-b196-a682d2fa820e" height="500"> | 


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
