### PR TITLE
Fix starring episode from full-screen player does not prevent episode from being archived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.57
 -----
-
+*   Bug Fixes:
+    *   Fixed starring episode from full-screen player does not prevent episode from being archived
+        ([#1735](https://github.com/Automattic/pocket-casts-android/pull/1735))
 
 7.56
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -422,7 +422,8 @@ class EpisodeManagerImpl @Inject constructor(
     override suspend fun toggleStarEpisode(episode: PodcastEpisode, sourceView: SourceView) {
         // Retrieve the episode to make sure we have the latest starred status
         findByUuid(episode.uuid)?.let {
-            starEpisode(episode, !it.isStarred, sourceView)
+            episode.isStarred = !it.isStarred
+            starEpisode(episode, episode.isStarred, sourceView)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -406,9 +406,9 @@ class EpisodeManagerImpl @Inject constructor(
         episodeDao.updateStarred(starred, System.currentTimeMillis(), episode.uuid)
         val event =
             if (starred) {
-                AnalyticsEvent.EPISODE_UNSTARRED
-            } else {
                 AnalyticsEvent.EPISODE_STARRED
+            } else {
+                AnalyticsEvent.EPISODE_UNSTARRED
             }
         episodeAnalytics.trackEvent(event, sourceView, episode.uuid)
     }


### PR DESCRIPTION
## Description
This fixes an issue where starring an episode from a full-screen player does not prevent the episode from being archived.

## The Problem
When up next queue's current episode is starred, star status is updated for the episode in the database but the status is not updated for the in-memory up next queue's current episode.

Because of this, [on completion of the episode](https://github.com/Automattic/pocket-casts-android/blob/main/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt#L1115-L1127), when [star status is checked](https://github.com/Automattic/pocket-casts-android/blob/main/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt#L623) while checking if it should be archived, it returns a wrong value.

## The Solution
Up next queue's current episode starred status is updated when the full-screen player star button is toggled in  8802d870fc2be4a17cf8a70630254c68d6c926a4. 

I also noticed that the analytics value was incorrect when full-screen player star button was toggled. This is fixed in 0a8f4544c48d92522b823d2d2b3d694b7852f47c.

Fixes #1606

## Testing Instructions

Test.1 Episode not archived when `Include starred episodes` toggle is off for `Auto archive`

1. Launch the app
2. Go to `Profile` -> `Settings` -> `Auto archive`
3. Make sure that `Include starred episodes` toggle is set to off
4. Go to `Discover`
5. Open any podcast
6. Download an episode from the podcast
7. Play the download episode
8. Open full-screen player
9. Star the episode
10. ✅ Notice `episode_starred` is shown in logs
11. Drag the scrubber to the end of the episode to finish the episode
12. Go back to the podcast screen
13. ✅ Notice that the episode is completed but NOT archived (timestamp `00:41` in video, episode greyed out as it is completed but archived count at the top of episodes is 0)
14. Go to `Profile` -> `Downloads`
15. ✅ Notice that the download still exists

Test.2 Episode archived when `Include starred episodes` toggle is on for `Auto archive`

1. Launch the app
2. Go to `Profile` -> `Settings` -> `Auto archive`
3. Toggle `Include starred episodes` to on
4. Go to `Discover`
5. Open any podcast
6. Download an episode from the podcast
7. Play the download episode
8. Open full-screen player
9. Star the episode
10. Drag the scrubber to the end of the episode to finish the episode
11. Go back to the podcast screen
12. ✅ Notice that the episode is completed archived (timestamp `1:17` in video, archived episode not shownand archived count at the top of episodes is 1)
13. Go to `Profile` -> `Downloads`
14. ✅ Notice that the download does not exist for this episode


## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/2645863c-1569-4c96-9ef2-153dadab86a1


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
