### PR TITLE
Sync grid layout setting

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
@@ -46,7 +46,7 @@ class PodcastsOptionsDialog(
                     descriptionId = LR.string.podcasts_layout_large_grid,
                     isOn = { settings.podcastGridLayout.value == PodcastGridLayoutType.LARGE_ARTWORK },
                     click = {
-                        settings.podcastGridLayout.set(PodcastGridLayoutType.LARGE_ARTWORK, needsSync = false)
+                        settings.podcastGridLayout.set(PodcastGridLayoutType.LARGE_ARTWORK, needsSync = true)
                         trackTapOnModalOption(ModalOption.LAYOUT)
                         trackLayoutChanged(PodcastGridLayoutType.LARGE_ARTWORK)
                     },
@@ -56,7 +56,7 @@ class PodcastsOptionsDialog(
                     descriptionId = LR.string.podcasts_layout_small_grid,
                     isOn = { settings.podcastGridLayout.value == PodcastGridLayoutType.SMALL_ARTWORK },
                     click = {
-                        settings.podcastGridLayout.set(PodcastGridLayoutType.SMALL_ARTWORK, needsSync = false)
+                        settings.podcastGridLayout.set(PodcastGridLayoutType.SMALL_ARTWORK, needsSync = true)
                         trackTapOnModalOption(ModalOption.LAYOUT)
                         trackLayoutChanged(PodcastGridLayoutType.SMALL_ARTWORK)
                     },
@@ -66,7 +66,7 @@ class PodcastsOptionsDialog(
                     descriptionId = LR.string.podcasts_layout_list_view,
                     isOn = { settings.podcastGridLayout.value == PodcastGridLayoutType.LIST_VIEW },
                     click = {
-                        settings.podcastGridLayout.set(PodcastGridLayoutType.LIST_VIEW, needsSync = false)
+                        settings.podcastGridLayout.set(PodcastGridLayoutType.LIST_VIEW, needsSync = true)
                         trackTapOnModalOption(ModalOption.LAYOUT)
                         trackLayoutChanged(PodcastGridLayoutType.LIST_VIEW)
                     },

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/PodcastGridLayoutType.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/PodcastGridLayoutType.kt
@@ -1,14 +1,20 @@
 package au.com.shiftyjelly.pocketcasts.preferences.model
 
-enum class PodcastGridLayoutType(val id: Int, val analyticsValue: String) {
-    LARGE_ARTWORK(id = 0, analyticsValue = "large_artwork"),
-    SMALL_ARTWORK(id = 1, analyticsValue = "small_artwork"),
-    LIST_VIEW(id = 2, analyticsValue = "list"),
+enum class PodcastGridLayoutType(
+    val id: Int,
+    val serverId: Int,
+    val analyticsValue: String,
+) {
+    LARGE_ARTWORK(id = 0, serverId = 0, analyticsValue = "large_artwork"),
+    SMALL_ARTWORK(id = 1, serverId = 1, analyticsValue = "small_artwork"),
+    LIST_VIEW(id = 2, serverId = 2, analyticsValue = "list"),
     ;
 
     companion object {
         val default = LARGE_ARTWORK
-        fun fromLayoutId(id: Int) =
-            PodcastGridLayoutType.values().find { it.id == id } ?: default
+
+        fun fromLayoutId(id: Int) = entries.find { it.id == id } ?: default
+
+        fun fromServerId(serverId: Int) = entries.find { it.serverId == serverId } ?: default
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -19,6 +19,7 @@ data class NamedSettingsSettings(
 data class ChangedNamedSettings(
     @field:Json(name = "skipForward") val skipForward: NamedChangedSettingInt? = null,
     @field:Json(name = "skipBack") val skipBack: NamedChangedSettingInt? = null,
+    @field:Json(name = "gridLayout") val gridLayout: NamedChangedSettingInt? = null,
     @field:Json(name = "gridOrder") val gridOrder: NamedChangedSettingInt? = null,
     @field:Json(name = "marketingOptIn") val marketingOptIn: NamedChangedSettingBool? = null,
     @field:Json(name = "freeGiftAcknowledgement") val freeGiftAcknowledgement: NamedChangedSettingBool? = null,

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveInactiveSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.PodcastGridLayoutType
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -74,6 +75,12 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         modifiedAt = modifiedAt,
                     )
                 },
+                gridLayout = settings.podcastGridLayout.getSyncSetting { type, modifiedAt ->
+                    NamedChangedSettingInt(
+                        value = type.serverId,
+                        modifiedAt = modifiedAt,
+                    )
+                },
                 marketingOptIn = settings.marketingOptIn.getSyncSetting(::NamedChangedSettingBool),
                 skipBack = settings.skipBackInSecs.getSyncSetting(::NamedChangedSettingInt),
                 skipForward = settings.skipForwardInSecs.getSyncSetting(::NamedChangedSettingInt),
@@ -116,6 +123,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                             val serverId = (changedSettingResponse.value as? Number)?.toInt()
                             PodcastsSortType.fromServerId(serverId)
                         },
+                    )
+                    "gridLayout" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.podcastGridLayout,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let(PodcastGridLayoutType::fromServerId),
                     )
                     "marketingOptIn" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,


### PR DESCRIPTION
## Description

Continuation of the sync settings project. This PR adds syncing of the podcasts grid layout.

## Testing Instructions

1. Have two devices D1 and D2.
2. Sign in on both devices with the same account that is subscribed to some podcasts.
4. Sync both devices by going to the Profile tap and tapping `Refresh now` at the bottom.
5. D1: Go to the Podcasts tab.
6. D1: Open the overflow menu.
7. D1: Select the list layout (the one to the right).
8. D1: Sync the device in the Profile tab.
9. D2: Sync the device in the Profile tab.
10. D2: Go to the Podcasts tab. You should see items displayed using the list layout.
11. D2: Open the overflow menu.
12. D2: Select the small grid layout (the one in the middle).
13. D2: Sync the device in the Profile tab.
14. D1: Sync the device in the Profile tab.
15. D1: Go to the Podcasts tab. You should see items displayed using the small grid layout.
16. D1: Select the big grid layout (the one to the left).
17. D1: Sync the device in the Profile tab.
18. D2: Sync the device in the Profile tab.
19. D2: Go to the Podcasts tab. You should see items displayed using the big grid layout.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
