### PR TITLE
Update: Offer tracks

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
@@ -47,7 +47,10 @@ class CreateAccountViewModel
 
     companion object {
         private const val PRODUCT_KEY = "product"
-        private const val IS_FREE_TRIAL_KEY = "is_free_trial"
+        private const val OFFER_TYPE_KEY = "offer_type"
+        private const val OFFER_TYPE_NONE = "none"
+        private const val OFFER_TYPE_FREE_TRIAL = "free_trial"
+        private const val OFFER_TYPE_INTRO_OFFER = "intro_offer"
         private const val ERROR_CODE_KEY = "error_code"
         private const val SOURCE_KEY = "source"
         private const val ENABLED_KEY = "enabled"
@@ -62,11 +65,15 @@ class CreateAccountViewModel
                     it // return full product id for new products
                 }
             } ?: TracksAnalyticsTracker.INVALID_OR_NULL_VALUE
-            val isFreeTrial = (subscription is Subscription.Trial)
+            val offerType = when (subscription) {
+                is Subscription.Trial -> OFFER_TYPE_FREE_TRIAL
+                is Subscription.Intro -> OFFER_TYPE_INTRO_OFFER
+                else -> OFFER_TYPE_NONE
+            }
 
             val analyticsProperties = mapOf(
                 PRODUCT_KEY to productKey,
-                IS_FREE_TRIAL_KEY to isFreeTrial,
+                OFFER_TYPE_KEY to offerType,
             )
 
             when (purchaseEvent) {


### PR DESCRIPTION
This is part of: #1728 

## Description
- This small PR just updates the `purchase_successful`, `purchase_cancelled` and `purchase_failed` events to deprecate `is_free_trial ` property and includes `offer_type ` that can be `none`, `free_trial`, `intro_offer`
- This PR does have the layout updated. This change will be addressed in https://github.com/Automattic/pocket-casts-android/pull/1733

[Screen_recording_20240125_141613.webm](https://github.com/Automattic/pocket-casts-android/assets/42220351/340ae821-1291-4984-bad8-124c33646da6)

## Testing Instructions
- git apply [debug_build.patch](https://github.com/Automattic/pocket-casts-android/files/14055979/debug_build.patch)
- run in debug variant
- To see the credit card screen you need to have your email listed in `License testing`

### None offer_type
- Login with a free account
- Profile -> Account -> Subscribe to Plus -> Select a plan (not an offer) -> Back to App (you don't need to proceed with the account)
- Put a breakpoint in https://github.com/Automattic/pocket-casts-android/blob/1de83320e0af63e0570634e04e87498d569adf97/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt#L73 to check the properties we are sending
- For a simple subscription we should send `none` value for `offer_type `

### Free trial offer_type
- Login with a free account that did not have any subscription before or change the `SubscriptionManagerImpl.isFreeTrialEligible()` to always returns `true` to force offer eligibility
- Profile -> Account -> Subscribe to Plus -> Select a trial offer-> Back to App (you don't need to proceed with the account)
- Put a breakpoint in https://github.com/Automattic/pocket-casts-android/blob/1de83320e0af63e0570634e04e87498d569adf97/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt#L73 to check the properties we are sending
- For a trial subscription we should send `free_trial` value for `offer_type `

### Intro offer_type
- Go to `SubscriptionManagerImpl.loadProducts()` and delete the product `PLUS_YEARLY_PRODUCT_ID` from the list. Line: 165
- Login with a free account that did not have any subscription before or change the `SubscriptionManagerImpl.isFreeTrialEligible()` to always returns `true` to force offer eligibility
- Profile -> Account -> Subscribe to Plus -> Select a intro offer (select the yearly option since you can't see the badge for intro offer) -> Back to App (you don't need to proceed with the account)
- Put a breakpoint in https://github.com/Automattic/pocket-casts-android/blob/1de83320e0af63e0570634e04e87498d569adf97/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt#L73 to check the properties we are sending
- For a intro offer subscription we should send `intro_offer` value for `offer_type `


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews

