### PR TITLE
Fix artwork aspect ratio

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -38,6 +38,7 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSourc
 import au.com.shiftyjelly.pocketcasts.ui.extensions.openUrl
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.images.PodcastImageLoaderThemed
+import au.com.shiftyjelly.pocketcasts.ui.images.RoundedCornersTransformation
 import au.com.shiftyjelly.pocketcasts.ui.images.ThemedImageTintTransformation
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
@@ -54,7 +55,6 @@ import coil.request.ErrorResult
 import coil.request.ImageRequest
 import coil.size.Scale
 import coil.size.Size
-import coil.transform.RoundedCornersTransformation
 import com.airbnb.lottie.LottieAnimationView
 import com.airbnb.lottie.LottieProperty
 import com.airbnb.lottie.SimpleColorFilter

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -38,12 +38,12 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSourc
 import au.com.shiftyjelly.pocketcasts.ui.extensions.openUrl
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.images.PodcastImageLoaderThemed
-import au.com.shiftyjelly.pocketcasts.ui.images.RoundedCornersTransformation
 import au.com.shiftyjelly.pocketcasts.ui.images.ThemedImageTintTransformation
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
+import au.com.shiftyjelly.pocketcasts.utils.images.RoundedCornersTransformation
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.extensions.updateColor
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment

--- a/modules/features/player/src/main/res/layout/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout/adapter_player_header.xml
@@ -36,7 +36,6 @@
                 android:visibility="@{viewModel.isPodcastArtworkVisible()}"
                 android:clickable="true"
                 android:scaleType="fitCenter"
-                app:layout_constraintDimensionRatio="1:1"
                 app:layout_constraintBottom_toTopOf="@+id/episodeTitle"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
@@ -9,13 +9,13 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getUrlForArtwork
+import au.com.shiftyjelly.pocketcasts.utils.images.RoundedCornersTransformation
 import coil.imageLoader
 import coil.request.CachePolicy
 import coil.request.ErrorResult
 import coil.request.ImageRequest
 import coil.request.SuccessResult
 import coil.size.Size
-import coil.transform.RoundedCornersTransformation
 import coil.transform.Transformation
 import java.io.File
 import kotlinx.coroutines.CoroutineScope

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/images/RoundedCornersTransformation.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/images/RoundedCornersTransformation.kt
@@ -1,0 +1,132 @@
+package au.com.shiftyjelly.pocketcasts.ui.images
+import android.graphics.Bitmap
+import android.graphics.BitmapShader
+import android.graphics.Color
+import android.graphics.Matrix
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.PorterDuff
+import android.graphics.RectF
+import android.graphics.Shader
+import androidx.annotation.Px
+import androidx.core.graphics.applyCanvas
+import androidx.core.graphics.createBitmap
+import coil.decode.DecodeUtils
+import coil.size.Dimension
+import coil.size.Scale
+import coil.size.Size
+import coil.size.isOriginal
+import coil.size.pxOrElse
+import coil.transform.Transformation
+
+import kotlin.math.roundToInt
+
+/**
+ * A [Transformation] that crops the image to fit the target's dimensions and rounds the corners of
+ * the image.
+ *
+ * If you're using Jetpack Compose, use `Modifier.clip(RoundedCornerShape(radius))` instead of this
+ * transformation as it's more efficient.
+ *
+ * @param topLeft The radius for the top left corner.
+ * @param topRight The radius for the top right corner.
+ * @param bottomLeft The radius for the bottom left corner.
+ * @param bottomRight The radius for the bottom right corner.
+ */
+
+class RoundedCornersTransformation(
+    @Px private val topLeft: Float = 0f,
+    @Px private val topRight: Float = 0f,
+    @Px private val bottomLeft: Float = 0f,
+    @Px private val bottomRight: Float = 0f
+) : Transformation {
+
+    constructor(@Px radius: Float) : this(radius, radius, radius, radius)
+
+    init {
+        require(topLeft >= 0 && topRight >= 0 && bottomLeft >= 0 && bottomRight >= 0) {
+            "All radii must be >= 0."
+        }
+    }
+
+    override val cacheKey = "${javaClass.name}-$topLeft,$topRight,$bottomLeft,$bottomRight"
+
+    override suspend fun transform(input: Bitmap, size: Size): Bitmap {
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
+
+        val (outputWidth, outputHeight) = calculateOutputSize(input, size)
+
+        val output = createBitmap(outputWidth, outputHeight, input.config)
+        output.applyCanvas {
+            drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR)
+
+            val matrix = Matrix()
+            val multiplier = DecodeUtils.computeSizeMultiplier(
+                srcWidth = input.width,
+                srcHeight = input.height,
+                dstWidth = outputWidth,
+                dstHeight = outputHeight,
+                scale = Scale.FILL
+            ).toFloat()
+            val dx = (outputWidth - multiplier * input.width) / 2
+            val dy = (outputHeight - multiplier * input.height) / 2
+            matrix.setTranslate(dx, dy)
+            matrix.preScale(multiplier, multiplier)
+
+            val shader = BitmapShader(input, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
+            shader.setLocalMatrix(matrix)
+            paint.shader = shader
+
+            val radii = floatArrayOf(
+                topLeft, topLeft,
+                topRight, topRight,
+                bottomRight, bottomRight,
+                bottomLeft, bottomLeft,
+            )
+            val rect = RectF(0f, 0f, width.toFloat(), height.toFloat())
+            val path = Path().apply { addRoundRect(rect, radii, Path.Direction.CW) }
+            drawPath(path, paint)
+        }
+
+        return output
+    }
+
+    private fun calculateOutputSize(input: Bitmap, size: Size): Pair<Int, Int> {
+        if (size.isOriginal) {
+            return input.width to input.height
+        }
+
+        val (dstWidth, dstHeight) = size
+        if (dstWidth is Dimension.Pixels && dstHeight is Dimension.Pixels) {
+            return dstWidth.px to dstHeight.px
+        }
+
+        val multiplier = DecodeUtils.computeSizeMultiplier(
+            srcWidth = input.width,
+            srcHeight = input.height,
+            dstWidth = size.width.pxOrElse { Int.MIN_VALUE },
+            dstHeight = size.height.pxOrElse { Int.MIN_VALUE },
+            scale = Scale.FILL
+        )
+        val outputWidth = (multiplier * input.width).roundToInt()
+        val outputHeight = (multiplier * input.height).roundToInt()
+        return outputWidth to outputHeight
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return other is RoundedCornersTransformation &&
+            topLeft == other.topLeft &&
+            topRight == other.topRight &&
+            bottomLeft == other.bottomLeft &&
+            bottomRight == other.bottomRight
+    }
+
+    override fun hashCode(): Int {
+        var result = topLeft.hashCode()
+        result = 31 * result + topRight.hashCode()
+        result = 31 * result + bottomLeft.hashCode()
+        result = 31 * result + bottomRight.hashCode()
+        return result
+    }
+}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/images/RoundedCornersTransformation.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/images/RoundedCornersTransformation.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.ui.images
+package au.com.shiftyjelly.pocketcasts.utils.images
 import android.graphics.Bitmap
 import android.graphics.BitmapShader
 import android.graphics.Color


### PR DESCRIPTION
## Description

This fixes horizontal artwork aspect ratio by using a modified version of Coil's rounded corners image transformation that does not crop to the target size. 

I'm not yet fully sure that removing cropping to the target size during transformation can cause any issues. In Test.3, I tested loading a very large image and noticed that it didn't crash the app. 

Also, it seems another image loading library, [Glide does not crop to the target size](https://github.com/bumptech/glide/blob/master/library/src/main/java/com/bumptech/glide/load/resource/bitmap/TransformationUtils.java#L581) in rounded corner transformation.

Fixes #1719

## Testing Instructions

### Test.1 Horizontal Image
1. Play this episode with a horizontal artwork: https://pca.st/episode/c7bc3a08-17b7-48c8-b5b9-dbdfd63211f4
2. Open full-screen player
3. ✅ Notice that full artwork is shown maintaining its aspect ratio

### Test.2 Square Image
1. Play this episode with a square artwork: https://pca.st/episode/e548fdef-c912-4468-9594-34b492644107
2. Open full-screen player
3. ✅ Notice that full artwork is shown maintaining its aspect ratio

### Test.3 Large image
1. Play this episode with a very large artwork of size 5400 x 5400: https://pca.st/episode/c00fd075-ee5c-42a4-94e1-6b7afeb8ed1b
2. Open full-screen player
3. ✅ Notice that full artwork is shown maintaining its aspect ratio and the app does not crash

### Test.4 Small device
1. Repeat all above tests on a small device (5.2" 1080x1920)
2. ✅ Notice that all tests pass and no scrolling is required as reported here: p1706158031515139-slack-C02A333D8LQ

## Screenshots or Screencast 

Pixel 7
Horizontal | Square
---|---
<img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/a0e36351-72b6-4688-9724-4c6befcb15c9"/>| <img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/dd828947-85e3-4575-9511-7ca94f250a4f"/>

Small device (5.2" 1080x1920)
Horizontal | Square
---|---
 <img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/d53d1e3a-42c7-4cde-a1b9-fa6f3e1d54fb"/> | <img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/4ff959ea-0866-4f13-a996-4c319d7f1b91"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack