### PR TITLE
Cherry pick #1726 and #1742

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/OnboardingFlowComposableTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/OnboardingFlowComposableTest.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivity
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingFlowComposable
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingNavRoute
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingExitInfo
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -33,7 +34,7 @@ class OnboardingFlowComposableTest {
     fun setupAppNavHost(
         flow: OnboardingFlow,
         signInState: SignInState = mock(),
-        exitOnboarding: () -> Unit = {},
+        exitOnboarding: (OnboardingExitInfo) -> Unit = {},
         completeOnboardingToDiscover: () -> Unit = {},
     ) {
         composeTestRule.activity.setContent {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -108,6 +108,7 @@ import au.com.shiftyjelly.pocketcasts.servers.ServerManager
 import au.com.shiftyjelly.pocketcasts.servers.discover.PodcastSearch
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewFragment
 import au.com.shiftyjelly.pocketcasts.ui.MainActivityViewModel.NavigationState
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
@@ -247,6 +248,10 @@ class MainActivity :
             OnboardingFinish.DoneGoToDiscover -> {
                 settings.setHasDoneInitialOnboarding()
                 openTab(VR.id.navigation_discover)
+            }
+            OnboardingFinish.DoneShowPlusPromotion -> {
+                settings.setHasDoneInitialOnboarding()
+                OnboardingLauncher.openOnboardingFlow(this, OnboardingFlow.Upsell(OnboardingUpgradeSource.LOGIN_PLUS_PROMOTION))
             }
             null -> {
                 Timber.e("Unexpected null result from onboarding activity")

--- a/modules/features/account/build.gradle.kts
+++ b/modules/features/account/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation(project(":modules:services:ui"))
     implementation(project(":modules:services:utils"))
     implementation(project(":modules:services:views"))
+    testImplementation(project(":modules:services:sharedtest"))
 
     // android libs
     implementation(libs.horologist.auth.data.phone)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
@@ -5,12 +5,14 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.core.content.IntentCompat
 import androidx.core.view.WindowCompat
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContract.OnboardingFinish
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingActivityViewModel
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -25,6 +27,8 @@ class OnboardingActivity : AppCompatActivity() {
 
     @Inject lateinit var userManager: UserManager
 
+    private val viewModel: OnboardingActivityViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // Make content edge-to-edge
@@ -33,6 +37,9 @@ class OnboardingActivity : AppCompatActivity() {
         setContent {
             val signInState = userManager.getSignInState().asFlow().collectAsState(null)
             val currentSignInState = signInState.value
+
+            val finishState = viewModel.finishState.collectAsState(null)
+            finishState.value?.let { finishWithResult(it) }
 
             if (currentSignInState != null) {
                 val onboardingFlow = remember(savedInstanceState) {
@@ -46,7 +53,7 @@ class OnboardingActivity : AppCompatActivity() {
                 OnboardingFlowComposable(
                     theme = theme.activeTheme,
                     flow = onboardingFlow,
-                    exitOnboarding = { finishWithResult(OnboardingFinish.Done) },
+                    exitOnboarding = { viewModel.onExitOnboarding(it) },
                     completeOnboardingToDiscover = { finishWithResult(OnboardingFinish.DoneGoToDiscover) },
                     signInState = currentSignInState,
                 )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivityContract.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivityContract.kt
@@ -20,6 +20,7 @@ class OnboardingActivityContract : ActivityResultContract<Intent, OnboardingActi
     enum class OnboardingFinish {
         Done,
         DoneGoToDiscover,
+        DoneShowPlusPromotion,
     }
 
     companion object {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -15,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations.Onboard
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeFlow
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingExitInfo
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -24,7 +25,7 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.getSerializableCompat
 fun OnboardingFlowComposable(
     theme: Theme.ThemeType,
     flow: OnboardingFlow,
-    exitOnboarding: () -> Unit,
+    exitOnboarding: (OnboardingExitInfo) -> Unit,
     completeOnboardingToDiscover: () -> Unit,
     signInState: SignInState,
     navController: NavHostController = rememberNavController(),
@@ -56,7 +57,7 @@ fun OnboardingFlowComposable(
 private fun Content(
     theme: Theme.ThemeType,
     flow: OnboardingFlow,
-    exitOnboarding: () -> Unit,
+    exitOnboarding: (OnboardingExitInfo) -> Unit,
     completeOnboardingToDiscover: () -> Unit,
     signInState: SignInState,
     navController: NavHostController,
@@ -89,7 +90,7 @@ private fun Content(
         onboardingRecommendationsFlowGraph(
             theme = theme,
             flow = flow,
-            onBackPressed = exitOnboarding,
+            onBackPressed = { exitOnboarding(OnboardingExitInfo()) },
             onComplete = {
                 navController.navigate(
                     if (signInState.isSignedInAsPlusOrPatron) {
@@ -118,13 +119,13 @@ private fun Content(
                         -> {
                             val popped = navController.popBackStack()
                             if (!popped) {
-                                exitOnboarding()
+                                exitOnboarding(OnboardingExitInfo())
                             }
                         }
 
                         OnboardingFlow.InitialOnboarding,
                         OnboardingFlow.LoggedOut,
-                        -> exitOnboarding()
+                        -> exitOnboarding(OnboardingExitInfo())
                     }
                 },
                 onSignUpClicked = { navController.navigate(OnboardingNavRoute.createFreeAccount) },
@@ -162,7 +163,7 @@ private fun Content(
             OnboardingForgotPasswordPage(
                 theme = theme,
                 onBackPressed = { navController.popBackStack() },
-                onCompleted = exitOnboarding,
+                onCompleted = { exitOnboarding(OnboardingExitInfo()) },
             )
         }
 
@@ -203,6 +204,7 @@ private fun Content(
                 OnboardingUpgradeSource.FOLDERS,
                 OnboardingUpgradeSource.HEADPHONE_CONTROLS_SETTINGS,
                 OnboardingUpgradeSource.LOGIN,
+                OnboardingUpgradeSource.LOGIN_PLUS_PROMOTION,
                 OnboardingUpgradeSource.OVERFLOW_MENU,
                 OnboardingUpgradeSource.PLUS_DETAILS,
                 OnboardingUpgradeSource.PROFILE,
@@ -221,7 +223,7 @@ private fun Content(
                     if (userCreatedNewAccount) {
                         navController.popBackStack()
                     } else {
-                        exitOnboarding()
+                        exitOnboarding(OnboardingExitInfo())
                     }
                 },
                 onNeedLogin = { navController.navigate(OnboardingNavRoute.logInOrSignUp) },
@@ -229,7 +231,7 @@ private fun Content(
                     if (userCreatedNewAccount) {
                         navController.navigate(OnboardingNavRoute.welcome)
                     } else {
-                        exitOnboarding()
+                        exitOnboarding(OnboardingExitInfo())
                     }
                 },
             )
@@ -240,13 +242,13 @@ private fun Content(
                 activeTheme = theme,
                 flow = flow,
                 isSignedInAsPlusOrPatron = signInState.isSignedInAsPlusOrPatron,
-                onDone = exitOnboarding,
+                onDone = { exitOnboarding(OnboardingExitInfo()) },
                 onContinueToDiscover = completeOnboardingToDiscover,
                 onImportTapped = { navController.navigate(OnboardingImportFlow.route) },
                 onBackPressed = {
                     // Don't allow navigation back to the upgrade screen after the user upgrades
                     if (signInState.isSignedInAsPlusOrPatron) {
-                        exitOnboarding()
+                        exitOnboarding(OnboardingExitInfo())
                     } else {
                         navController.popBackStack()
                     }
@@ -258,13 +260,13 @@ private fun Content(
 
 private fun onLoginToExistingAccount(
     flow: OnboardingFlow,
-    exitOnboarding: () -> Unit,
+    exitOnboarding: (OnboardingExitInfo) -> Unit,
     navController: NavHostController,
 ) {
     when (flow) {
         OnboardingFlow.InitialOnboarding,
         OnboardingFlow.LoggedOut,
-        -> exitOnboarding()
+        -> exitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = true))
 
         is OnboardingFlow.PlusAccountUpgrade,
         is OnboardingFlow.PatronAccountUpgrade,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModel.kt
@@ -1,0 +1,61 @@
+package au.com.shiftyjelly.pocketcasts.account.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContract.OnboardingFinish
+import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingExitInfo
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.reactive.asFlow
+
+@HiltViewModel
+class OnboardingActivityViewModel @Inject constructor(
+    private val userManager: UserManager,
+) : ViewModel() {
+
+    private var showPlusPromotionForFreeUserFlow = MutableStateFlow(false)
+
+    private val _finishState = MutableSharedFlow<OnboardingFinish>()
+    val finishState = _finishState.asSharedFlow()
+
+    init {
+        viewModelScope.launch {
+            combine(
+                showPlusPromotionForFreeUserFlow,
+                userManager.getSignInState().asFlow(),
+            ) { showPlusPromotionForFreeUser, signInState ->
+                if (showPlusPromotionForFreeUser) {
+                    // subscriptionStatus is null just after sign in, so we need to wait for it to be set
+                    // before we can finish the onboarding flow to show plus promotion for a free user
+                    (signInState as? SignInState.SignedIn)?.subscriptionStatus?.let { status ->
+                        showPlusPromotionForFreeUserFlow.value = false
+                        if (status is SubscriptionStatus.Free) {
+                            _finishState.emit(OnboardingFinish.DoneShowPlusPromotion)
+                        } else {
+                            _finishState.emit(OnboardingFinish.Done)
+                        }
+                    }
+                }
+            }.stateIn(viewModelScope)
+        }
+    }
+
+    fun onExitOnboarding(exitInfo: OnboardingExitInfo) {
+        if (exitInfo.showPlusPromotionForFreeUser) {
+            showPlusPromotionForFreeUserFlow.value = true
+        } else {
+            viewModelScope.launch {
+                _finishState.emit(OnboardingFinish.Done)
+            }
+        }
+    }
+}

--- a/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModelTest.kt
+++ b/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModelTest.kt
@@ -1,0 +1,78 @@
+package au.com.shiftyjelly.pocketcasts.account.viewmodel
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContract.OnboardingFinish
+import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingExitInfo
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import io.reactivex.Flowable
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(MockitoJUnitRunner::class)
+class OnboardingActivityViewModelTest {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    @Mock
+    private lateinit var userManager: UserManager
+
+    @Mock
+    private lateinit var paidSubscriptionStatus: SubscriptionStatus.Paid
+
+    @Mock
+    private lateinit var freeSubscriptionStatus: SubscriptionStatus.Free
+
+    private lateinit var viewModel: OnboardingActivityViewModel
+
+    @Test
+    fun `given showPlusPromotionForFreeUser is false, when exit onboarding, then finish with Done`() = runTest {
+        initViewModel()
+
+        viewModel.finishState.test {
+            viewModel.onExitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = false))
+            assert(awaitItem() == OnboardingFinish.Done)
+        }
+    }
+
+    @Test
+    fun `given showPlusPromotionForFreeUser is true and free user, when exit onboarding, then finish with DoneShowPlusPromotion`() = runTest {
+        initViewModel(freeSubscriptionStatus)
+
+        viewModel.finishState.test {
+            viewModel.onExitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = true))
+            assert(awaitItem() == OnboardingFinish.DoneShowPlusPromotion)
+        }
+    }
+
+    @Test
+    fun `given showPlusPromotionForFreeUser is true and paid user, when exit onboarding, then finish with Done`() = runTest {
+        initViewModel(paidSubscriptionStatus)
+
+        viewModel.finishState.test {
+            viewModel.onExitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = true))
+            assert(awaitItem() == OnboardingFinish.Done)
+        }
+    }
+
+    private fun initViewModel(subscriptionStatus: SubscriptionStatus = mock<SubscriptionStatus>()) {
+        whenever(userManager.getSignInState()).thenReturn(
+            Flowable.just(
+                SignInState.SignedIn(email = "", subscriptionStatus = subscriptionStatus),
+            ),
+        )
+        viewModel = OnboardingActivityViewModel(
+            userManager = userManager,
+        )
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -43,6 +43,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
+import au.com.shiftyjelly.pocketcasts.utils.images.RoundedCornersTransformation
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.extensions.updateColor
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -54,7 +55,6 @@ import coil.request.ErrorResult
 import coil.request.ImageRequest
 import coil.size.Scale
 import coil.size.Size
-import coil.transform.RoundedCornersTransformation
 import com.airbnb.lottie.LottieAnimationView
 import com.airbnb.lottie.LottieProperty
 import com.airbnb.lottie.SimpleColorFilter

--- a/modules/features/player/src/main/res/layout/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout/adapter_player_header.xml
@@ -36,7 +36,6 @@
                 android:visibility="@{viewModel.isPodcastArtworkVisible()}"
                 android:clickable="true"
                 android:scaleType="fitCenter"
-                app:layout_constraintDimensionRatio="1:1"
                 app:layout_constraintBottom_toTopOf="@+id/episodeTitle"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingExitInfo.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingExitInfo.kt
@@ -1,0 +1,5 @@
+package au.com.shiftyjelly.pocketcasts.settings.onboarding
+
+data class OnboardingExitInfo(
+    val showPlusPromotionForFreeUser: Boolean = false,
+)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
@@ -9,7 +9,8 @@ enum class OnboardingUpgradeSource(val analyticsValue: String) {
     FILES("files"),
     FOLDERS("folders"),
     HEADPHONE_CONTROLS_SETTINGS("headphone_controls_settings"),
-    LOGIN("login"),
+    LOGIN("login"), // for login from within upsell screen
+    LOGIN_PLUS_PROMOTION("login_plus_promotion"), // for login from outside upsell screen
     OVERFLOW_MENU("overflow_menu"),
     PLUS_DETAILS("plus_details"),
     PROFILE("profile"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageLoader.kt
@@ -9,13 +9,13 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getUrlForArtwork
+import au.com.shiftyjelly.pocketcasts.utils.images.RoundedCornersTransformation
 import coil.imageLoader
 import coil.request.CachePolicy
 import coil.request.ErrorResult
 import coil.request.ImageRequest
 import coil.request.SuccessResult
 import coil.size.Size
-import coil.transform.RoundedCornersTransformation
 import coil.transform.Transformation
 import java.io.File
 import kotlinx.coroutines.CoroutineScope

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/images/RoundedCornersTransformation.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/images/RoundedCornersTransformation.kt
@@ -1,0 +1,107 @@
+package au.com.shiftyjelly.pocketcasts.utils.images
+import android.graphics.Bitmap
+import android.graphics.BitmapShader
+import android.graphics.Color
+import android.graphics.Matrix
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.PorterDuff
+import android.graphics.RectF
+import android.graphics.Shader
+import androidx.annotation.Px
+import androidx.core.graphics.applyCanvas
+import androidx.core.graphics.createBitmap
+import coil.decode.DecodeUtils
+import coil.size.Scale
+import coil.size.Size
+import coil.transform.Transformation
+
+/**
+ *
+ * This is a modified version of the RoundedCornersTransformation class from Coil,
+ * altered to remove cropping to the target's size and prevent scaling issues.
+ *
+ * https://github.com/coil-kt/coil/issues/421#issuecomment-640133205
+ * https://github.com/Automattic/pocket-casts-android/issues/1719
+ */
+
+class RoundedCornersTransformation(
+    @Px private val topLeft: Float = 0f,
+    @Px private val topRight: Float = 0f,
+    @Px private val bottomLeft: Float = 0f,
+    @Px private val bottomRight: Float = 0f,
+) : Transformation {
+
+    constructor(@Px radius: Float) : this(radius, radius, radius, radius)
+
+    init {
+        require(topLeft >= 0 && topRight >= 0 && bottomLeft >= 0 && bottomRight >= 0) {
+            "All radii must be >= 0."
+        }
+    }
+
+    override val cacheKey = "${javaClass.name}-$topLeft,$topRight,$bottomLeft,$bottomRight"
+
+    override suspend fun transform(input: Bitmap, size: Size): Bitmap {
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
+
+        // Do not crop to target's size to avoid scaling issues.
+        // https://github.com/coil-kt/coil/issues/421#issuecomment-640133205
+        val (outputWidth, outputHeight) = input.width to input.height
+
+        val output = createBitmap(outputWidth, outputHeight, input.config)
+        output.applyCanvas {
+            drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR)
+
+            val matrix = Matrix()
+            val multiplier = DecodeUtils.computeSizeMultiplier(
+                srcWidth = input.width,
+                srcHeight = input.height,
+                dstWidth = outputWidth,
+                dstHeight = outputHeight,
+                scale = Scale.FILL,
+            ).toFloat()
+            val dx = (outputWidth - multiplier * input.width) / 2
+            val dy = (outputHeight - multiplier * input.height) / 2
+            matrix.setTranslate(dx, dy)
+            matrix.preScale(multiplier, multiplier)
+
+            val shader = BitmapShader(input, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
+            shader.setLocalMatrix(matrix)
+            paint.shader = shader
+
+            val radii = floatArrayOf(
+                topLeft,
+                topLeft,
+                topRight,
+                topRight,
+                bottomRight,
+                bottomRight,
+                bottomLeft,
+                bottomLeft,
+            )
+            val rect = RectF(0f, 0f, width.toFloat(), height.toFloat())
+            val path = Path().apply { addRoundRect(rect, radii, Path.Direction.CW) }
+            drawPath(path, paint)
+        }
+
+        return output
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return other is RoundedCornersTransformation &&
+            topLeft == other.topLeft &&
+            topRight == other.topRight &&
+            bottomLeft == other.bottomLeft &&
+            bottomRight == other.bottomRight
+    }
+
+    override fun hashCode(): Int {
+        var result = topLeft.hashCode()
+        result = 31 * result + topRight.hashCode()
+        result = 31 * result + bottomLeft.hashCode()
+        result = 31 * result + bottomRight.hashCode()
+        return result
+    }
+}


### PR DESCRIPTION
## Description

This cherry picks changes from #1726 and #1742 to `release/7.56`.

#1726  is included to match iOS in terms of plus promotion display when this experiment is conducted next month: pdeCcb-4mW-p2
#1742 is included to fix an important aspect ratio issue. 

## Testing Instructions
PRs are already tested. Make sure that commits are cherry-picked correctly.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack