### PR TITLE
Allow Danger to run on forked repos using GITHUB_TOKEN

### DIFF
--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -8,4 +8,4 @@ jobs:
   dangermattic:
     uses: Automattic/dangermattic/.github/workflows/reusable-run-danger.yml@trunk
     secrets:
-      github-token: ${{ secrets.DANGERMATTIC_GITHUB_TOKEN }}
+      github-token: ${{ secrets.DANGERMATTIC_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Our Danger configuration isn't passed to the GitHub Action runner when a workflow is triggered from a forked repository.
This PR solves this problem by allowing GitHub's own `GITHUB_TOKEN` to be used for running Danger on forked repos.

See https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow
