### PR TITLE
Sync playback effects setting

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -605,7 +605,7 @@ class PlayerViewModel @Inject constructor(
             if (podcast.overrideGlobalEffects) {
                 podcastManager.updateEffects(podcast, effects)
             } else {
-                settings.globalPlaybackEffects.set(effects, needsSync = false)
+                settings.globalPlaybackEffects.set(effects, needsSync = true)
             }
             playbackManager.updatePlayerEffects(effects)
         }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
@@ -86,7 +86,7 @@ class ActionRunnerControlPlayback : TaskerPluginRunnerActionNoOutput<InputContro
         if (overrideGlobalEffects) {
             podcastManager.updateEffects(currentPodcast, playbackEffects)
         } else {
-            settings.globalPlaybackEffects.set(playbackEffects, needsSync = false)
+            settings.globalPlaybackEffects.set(playbackEffects, needsSync = true)
         }
         playbackManager.updatePlayerEffects(playbackEffects)
     }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/TrimMode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/TrimMode.kt
@@ -1,8 +1,16 @@
 package au.com.shiftyjelly.pocketcasts.models.type
 
-enum class TrimMode(val analyticsVale: String) {
-    OFF("off"),
-    LOW("mild"),
-    MEDIUM("medium"),
-    HIGH("mad_max"),
+enum class TrimMode(
+    val serverId: Int,
+    val analyticsVale: String,
+) {
+    OFF(serverId = 0, "off"),
+    LOW(serverId = 1, "mild"),
+    MEDIUM(serverId = 2, "medium"),
+    HIGH(serverId = 3, "mad_max"),
+    ;
+
+    companion object {
+        fun fromServerId(id: Int) = entries.find { it.serverId == id } ?: OFF
+    }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -755,7 +755,7 @@ class MediaSessionManager(
             // update global playback speed
             val effects = settings.globalPlaybackEffects.value
             effects.playbackSpeed = newSpeed
-            settings.globalPlaybackEffects.set(effects, needsSync = false)
+            settings.globalPlaybackEffects.set(effects, needsSync = true)
             playbackManager.updatePlayerEffects(effects = effects)
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -200,7 +200,7 @@ open class PlaybackManager @Inject constructor(
         bookmarkManager = bookmarkManager,
         applicationScope = applicationScope,
         bookmarkFeature = bookmarkFeature,
-        )
+    )
     var sleepAfterEpisode: Boolean = false
 
     var player: Player? = null
@@ -391,10 +391,10 @@ open class PlaybackManager @Inject constructor(
 
     private fun shouldWarnWhenSwitchingToMeteredConnection(episodeUUID: String): Boolean =
         settings.warnOnMeteredNetwork.value &&
-                lastWarnedPlayedEpisodeUuid != episodeUUID &&
-                (player is LocalPlayer) && // don't warn if chromecasting
-                isStreaming() &&
-                isPlaying()
+            lastWarnedPlayedEpisodeUuid != episodeUUID &&
+            (player is LocalPlayer) && // don't warn if chromecasting
+            isStreaming() &&
+            isPlaying()
 
     fun getPlaybackSpeed(): Double {
         return playbackStateRelay.blockingFirst().playbackSpeed
@@ -1557,10 +1557,10 @@ open class PlaybackManager @Inject constructor(
             playbackOnDevice
         } else {
             episode.isDownloaded &&
-                    playbackOnDevice &&
-                    episode.downloadedFilePath != null &&
-                    player != null &&
-                    episode.downloadedFilePath != player?.filePath
+                playbackOnDevice &&
+                episode.downloadedFilePath != null &&
+                player != null &&
+                episode.downloadedFilePath != player?.filePath
         }
 
         // if the player has a different media file path then it is changing

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -26,6 +26,9 @@ data class ChangedNamedSettings(
     @field:Json(name = "autoArchivePlayed") val autoArchiveAfterPlaying: NamedChangedSettingInt? = null,
     @field:Json(name = "autoArchiveInactive") val autoArchiveInactive: NamedChangedSettingInt? = null,
     @field:Json(name = "autoArchiveIncludesStarred") val autoArchiveIncludesStarred: NamedChangedSettingBool? = null,
+    @field:Json(name = "playbackSpeed") val playbackSpeed: NamedChangedSettingDouble? = null,
+    @field:Json(name = "trimSilence") val trimSilence: NamedChangedSettingInt? = null,
+    @field:Json(name = "volumeBoost") val volumeBoost: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)
@@ -37,6 +40,12 @@ data class NamedChangedSettingInt(
 @JsonClass(generateAdapter = true)
 data class NamedChangedSettingBool(
     @field:Json(name = "value") val value: Boolean,
+    @field:Json(name = "modified_at") val modifiedAt: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class NamedChangedSettingDouble(
+    @field:Json(name = "value") val value: Double,
     @field:Json(name = "modified_at") val modifiedAt: String,
 )
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -5,6 +5,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.helper.BuildConfig
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
+import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
@@ -84,6 +85,15 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 marketingOptIn = settings.marketingOptIn.getSyncSetting(::NamedChangedSettingBool),
                 skipBack = settings.skipBackInSecs.getSyncSetting(::NamedChangedSettingInt),
                 skipForward = settings.skipForwardInSecs.getSyncSetting(::NamedChangedSettingInt),
+                playbackSpeed = settings.globalPlaybackEffects.getSyncSetting { effects, modifiedAt ->
+                    NamedChangedSettingDouble(effects.playbackSpeed, modifiedAt)
+                },
+                trimSilence = settings.globalPlaybackEffects.getSyncSetting { effects, modifiedAt ->
+                    NamedChangedSettingInt(effects.trimMode.serverId, modifiedAt)
+                },
+                volumeBoost = settings.globalPlaybackEffects.getSyncSetting { effects, modifiedAt ->
+                    NamedChangedSettingBool(effects.isVolumeBoosted, modifiedAt)
+                },
             ),
         )
 
@@ -143,6 +153,33 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.skipForwardInSecs,
                         newSettingValue = (changedSettingResponse.value as? Number)?.toInt(),
+                    )
+                    "playbackSpeed" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.globalPlaybackEffects,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toDouble()?.let { newValue ->
+                            settings.globalPlaybackEffects.value.apply {
+                                playbackSpeed = newValue
+                            }
+                        },
+                    )
+                    "trimSilence" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.globalPlaybackEffects,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { newValue ->
+                            settings.globalPlaybackEffects.value.apply {
+                                trimMode = TrimMode.fromServerId(newValue)
+                            }
+                        },
+                    )
+                    "volumeBoost" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.globalPlaybackEffects,
+                        newSettingValue = (changedSettingResponse.value as? Boolean)?.let { newValue ->
+                            settings.globalPlaybackEffects.value.apply {
+                                isVolumeBoosted = newValue
+                            }
+                        },
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")
                 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsViewModel.kt
@@ -66,7 +66,7 @@ class EffectsViewModel
         val effects = effectsData.toEffects()
         viewModelScope.launch {
             playbackManager.updatePlayerEffects(effects)
-            settings.globalPlaybackEffects.set(effects, needsSync = false)
+            settings.globalPlaybackEffects.set(effects, needsSync = true)
         }
     }
 


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the global playback effects. This setting can be changed in multiple ways: Phone app, Notification center, WearOS app, Tasker app.

## Testing prerequisites

Each test requires two devices to check syncing. Sync process looks as follows.

1. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
2. Change the setting on the device 1.
3. Refresh settings on the device 1.
4. Refresh settings on the device 2.
5. Check settings on the device 2.

### Phone app

Settings configuration can be reached by playing a podcast, opening the player, and then opening playback effects. You need to make sure that those are global settings. If settings are local to podcast you'll see a banner at the bottom that allows to `Clear` the settings.

![Screenshot_20240126-125633](https://github.com/Automattic/pocket-casts-android/assets/30936061/991e251a-7b7c-4a97-9fbc-98c9bf79eca5)

### Notification center

You can change the playback speed from the notification center. Play a podcast and open notification center. I'm not sure since which version it is available. I tested with Android 14.

![Screenshot_20240126-125622](https://github.com/Automattic/pocket-casts-android/assets/30936061/da8d358c-e4a2-4f32-8ddc-6798ade69e3b)

### WearOS app

If you have a physical device you should be able to test it without any issues. If you don't you can test it with an emulator but it'll require some work.

Build the *release* version of the app with this condition inverted.

```diff
--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -30,7 +30,7 @@ enum class Feature(
     SETTINGS_SYNC(
         key = "settings_sync",
         title = "Settings Sync",
-        defaultValue = BuildConfig.DEBUG,
+        defaultValue = !BuildConfig.DEBUG,
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,

```

1. Have a phone with non A8C account (managed profiles don't work with emulators). This account should have also a Pocket Casts Plus account.
2. Create a wearOS emulator and pair it with the phone.
3. Install **release** versions of the app on both the phone and the wear device.
4. Sign in to the Pocket Casts app using Google sign in. You should be ready to test now.

To be able to control playback effects from the device you need to play an episode. After that you need to enter the player screen where you'll see a playback effects icon.

| Player | Effects | Settings sync |
| - | - | - |
| ![Screenshot_20240126_121809](https://github.com/Automattic/pocket-casts-android/assets/30936061/2df43655-b6a2-4a1d-8902-65e5aa90b688) | ![Screenshot_20240126_121840](https://github.com/Automattic/pocket-casts-android/assets/30936061/e0d6ef2b-16e1-47d5-b4c9-f3719dd4d787) | ![Screenshot_20240126_121854](https://github.com/Automattic/pocket-casts-android/assets/30936061/97026409-3d81-4590-aa00-e21da35da0f8) |

### Tasker app

This is an external app that you can expense and download from the [Play Store](https://play.google.com/store/apps/details?id=net.dinglisch.android.taskerm). We support it via plugin. Once you have the app create the following tasks and play them (you can use different values).

![Screenshot_20240126-125646](https://github.com/Automattic/pocket-casts-android/assets/30936061/16e4ced6-d1ed-40c1-a4a5-aeb5c89258a0)

## Testing Instructions

I won't provide step by step testing instructions. Basically test that playback effects sync correctly using different methods that I described. Test each setting separately, combinations of some, and all of them. If you want a more comprehensive guide on how to test syncing check, for example, [this PR](https://github.com/Automattic/pocket-casts-android/pull/1736).

I found a bug with the notifications center not displaying speeds below `1x` - #1745.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
