### PR TITLE
Intro offer: Update user eligibility

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
@@ -106,7 +106,7 @@ class CreateAccountViewModel
                             .mapNotNull {
                                 Subscription.fromProductDetails(
                                     productDetails = it,
-                                    isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(SubscriptionMapper.mapProductIdToTier(it.productId)),
+                                    isOfferEligible = subscriptionManager.isOfferEligible(SubscriptionMapper.mapProductIdToTier(it.productId)),
                                 )
                             }
                         subscriptionManager.getDefaultSubscription(subscriptions)?.let { updateSubscription(it) }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
@@ -64,7 +64,7 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
                         is ProductDetailsState.Loaded -> productDetails.productDetails.mapNotNull { productDetailsState ->
                             Subscription.fromProductDetails(
                                 productDetails = productDetailsState,
-                                isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(
+                                isOfferEligible = subscriptionManager.isOfferEligible(
                                     SubscriptionMapper.mapProductIdToTier(productDetailsState.productId),
                                 ),
                             )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -61,7 +61,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
                         is ProductDetailsState.Loaded -> productDetails.productDetails.mapNotNull { productDetailsState ->
                             Subscription.fromProductDetails(
                                 productDetails = productDetailsState,
-                                isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(
+                                isOfferEligible = subscriptionManager.isOfferEligible(
                                     SubscriptionMapper.mapProductIdToTier(productDetailsState.productId),
                                 ),
                             )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
@@ -53,12 +53,11 @@ class ProfileUpgradeBannerViewModel @Inject constructor(
                     val subscriptions = (productDetailsState as? ProductDetailsState.Loaded)
                         ?.productDetails
                         ?.mapNotNull { details ->
-                            val isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(
-                                SubscriptionMapper.mapProductIdToTier(details.productId),
-                            )
                             Subscription.fromProductDetails(
                                 productDetails = details,
-                                isFreeTrialEligible = isFreeTrialEligible,
+                                isOfferEligible = subscriptionManager.isOfferEligible(
+                                    SubscriptionMapper.mapProductIdToTier(details.productId),
+                                ),
                             )
                         } ?: emptyList()
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
@@ -52,7 +52,7 @@ class AccountDetailsViewModel
                 .mapNotNull {
                     Subscription.fromProductDetails(
                         productDetails = it,
-                        isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(
+                        isOfferEligible = subscriptionManager.isOfferEligible(
                             SubscriptionMapper.mapProductIdToTier(it.productId),
                         ),
                     )

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -118,8 +118,8 @@ sealed interface Subscription {
         const val TRIAL_OFFER_ID = "plus-yearly-trial-30days"
         const val INTRO_OFFER_ID = "testyearlyintropricingoffer"
 
-        fun fromProductDetails(productDetails: ProductDetails, isFreeTrialEligible: Boolean): Subscription? {
-            val subscription = SubscriptionMapper.map(productDetails, isFreeTrialEligible)
+        fun fromProductDetails(productDetails: ProductDetails, isOfferEligible: Boolean): Subscription? {
+            val subscription = SubscriptionMapper.map(productDetails, isOfferEligible)
             return if (FeatureFlag.isEnabled(Feature.INTRO_PLUS_OFFER_ENABLED) && subscription is Trial) null else subscription
         }
     }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -116,7 +116,7 @@ sealed interface Subscription {
         const val PATRON_YEARLY_PRODUCT_ID = "com.pocketcasts.yearly.patron"
         const val SUBSCRIPTION_TEST_PRODUCT_ID = "com.pocketcasts.plus.testfreetrialoffer"
         const val TRIAL_OFFER_ID = "plus-yearly-trial-30days"
-        const val INTRO_OFFER_ID = "testyearlyintropricingoffer"
+        const val INTRO_OFFER_ID = "testyearlyintropricingoffer-newusers"
 
         fun fromProductDetails(productDetails: ProductDetails, isOfferEligible: Boolean): Subscription? {
             val subscription = SubscriptionMapper.map(productDetails, isOfferEligible)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
@@ -12,8 +12,8 @@ import java.time.Period
 import java.time.format.DateTimeParseException
 
 object SubscriptionMapper {
-    fun map(productDetails: ProductDetails, isFreeTrialEligible: Boolean): Subscription? {
-        val matchingSubscriptionOfferDetails = if (isFreeTrialEligible) {
+    fun map(productDetails: ProductDetails, isOfferEligible: Boolean): Subscription? {
+        val matchingSubscriptionOfferDetails = if (isOfferEligible) {
             productDetails
                 .subscriptionOfferDetails
                 ?.filter { it.offerSubscriptionPricingPhase != null } // get SubscriptionOfferDetails with offers

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -33,7 +33,7 @@ interface SubscriptionManager {
     fun launchBillingFlow(activity: Activity, productDetails: ProductDetails, offerToken: String)
     fun getCachedStatus(): SubscriptionStatus?
     fun clearCachedStatus()
-    fun isFreeTrialEligible(tier: Subscription.SubscriptionTier): Boolean
+    fun isOfferEligible(tier: Subscription.SubscriptionTier): Boolean
     fun updateFreeTrialEligible(tier: Subscription.SubscriptionTier, eligible: Boolean)
     fun getDefaultSubscription(
         subscriptions: List<Subscription>,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -34,7 +34,8 @@ interface SubscriptionManager {
     fun getCachedStatus(): SubscriptionStatus?
     fun clearCachedStatus()
     fun isOfferEligible(tier: Subscription.SubscriptionTier): Boolean
-    fun updateFreeTrialEligible(tier: Subscription.SubscriptionTier, eligible: Boolean)
+    fun updateFreeTrialOfferEligible(tier: Subscription.SubscriptionTier, eligible: Boolean)
+    fun updateIntroOfferEligible(hasCurrentSubscription: Boolean)
     fun getDefaultSubscription(
         subscriptions: List<Subscription>,
         tier: Subscription.SubscriptionTier? = null,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -399,7 +399,7 @@ class SubscriptionManagerImpl @Inject constructor(
         subscriptionStatus.accept(Optional.empty())
     }
 
-    override fun isFreeTrialEligible(tier: Subscription.SubscriptionTier): Boolean {
+    override fun isOfferEligible(tier: Subscription.SubscriptionTier): Boolean {
         return if (FeatureFlag.isEnabled(Feature.INTRO_PLUS_OFFER_ENABLED)) true else freeTrialEligible[tier] ?: true
     }
 
@@ -439,7 +439,7 @@ class SubscriptionManagerImpl @Inject constructor(
                 is ProductDetailsState.Loaded -> productDetails.productDetails.mapNotNull { productDetailsState ->
                     Subscription.fromProductDetails(
                         productDetails = productDetailsState,
-                        isFreeTrialEligible = isFreeTrialEligible(
+                        isOfferEligible = isOfferEligible(
                             mapProductIdToTier(productDetailsState.productId),
                         ),
                     )


### PR DESCRIPTION
This is part of: #1728

## Description
- This PR implements the user eligibility offer for intro plus offer
```
The offer should be shown to any user that never had this subscription before (this case is com.pocketcasts.plus.testfreetrialoffer) or Plus activated (lifetime members).
```

## Testing Instructions
- git apply [patch](https://github.com/Automattic/pocket-casts-android/files/14036750/new_patch.patch)
- Have the In-app billing sandbox setup

### 1 Intro offer
#### 1.1 Free account

1. Have `Feature.INTRO_PLUS_OFFER_ENABLED.defaultValue` set to `true`.
2. Log in with a free account
3. Profile -> Account
4. You should see the Intro offer ✅

#### 1.2 Plus account
1. Have `Feature.INTRO_PLUS_OFFER_ENABLED.defaultValue` set to `true`.
2. Log in with a plus account
3. Profile -> Account
4. You should not see the Intro offer ✅

#### 1.3 Lifetime member
1. Have `Feature.INTRO_PLUS_OFFER_ENABLED.defaultValue` set to `true`.
2. Log in with lifetime member account
3. Profile -> Account
4. You should not see the Intro offer ✅

### 2. Trial offer

### 2.1 Fresh account
1. Have `Feature.INTRO_PLUS_OFFER_ENABLED.defaultValue` set to `false`.
2. Log in with a free account that never had a subscription before
3. Profile -> Account
4. You should see the trial offer ✅

### 2.2 Fresh account
1. Have `Feature.INTRO_PLUS_OFFER_ENABLED.defaultValue` set to `false`.
2. Log in with a free account already had a subscription before
3. Profile -> Account
4. You should see not the trial offer ✅

## Screenshots or Screencast 

<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/8d1e7e10-0bca-42f0-8b4b-c006b72fa1e3" height="500">


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews

