### PR TITLE
Add content type to playback events

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -135,6 +135,7 @@ open class PlaybackManager @Inject constructor(
         private const val MAX_TIME_WITHOUT_FOCUS_FOR_RESUME_MINUTES = 30
         private const val MAX_TIME_WITHOUT_FOCUS_FOR_RESUME = (MAX_TIME_WITHOUT_FOCUS_FOR_RESUME_MINUTES * 60 * 1000).toLong()
         private const val PAUSE_TIMER_DELAY = ((MAX_TIME_WITHOUT_FOCUS_FOR_RESUME_MINUTES + 1) * 60 * 1000).toLong()
+        private const val CONTENT_TYPE_KEY = "content_type"
         private const val SOURCE_KEY = "source"
         private const val SEEK_TO_PERCENT_KEY = "seek_to_percent"
         private const val SEEK_FROM_PERCENT_KEY = "seek_from_percent"
@@ -2255,7 +2256,14 @@ open class PlaybackManager @Inject constructor(
             Timber.w("Found unknown playback source.")
         }
         if (!sourceView.skipTracking()) {
-            analyticsTracker.track(event, mapOf(SOURCE_KEY to sourceView.analyticsValue))
+            val contentType = if (getCurrentEpisode()?.isVideo == true) ContentType.VIDEO else ContentType.AUDIO
+            analyticsTracker.track(
+                event,
+                mapOf(
+                    SOURCE_KEY to sourceView.analyticsValue,
+                    CONTENT_TYPE_KEY to contentType.analyticsValue,
+                ),
+            )
         }
     }
 
@@ -2294,5 +2302,10 @@ open class PlaybackManager @Inject constructor(
 
     fun setNotificationPermissionChecker(notificationPermissionChecker: NotificationPermissionChecker) {
         this.notificationPermissionChecker = notificationPermissionChecker
+    }
+
+    private enum class ContentType(val analyticsValue: String) {
+        AUDIO("audio"),
+        VIDEO("video"),
     }
 }


### PR DESCRIPTION
## Description
This adds content type to playback events.
Internal Ref: p1706301363090919/1706229369.681599-slack-C02ATC80MUM

## Testing Instructions
1. Play an episode from `Ted Talks Daily (HD video)` containing video episodes
2. Notice in logs: `Tracked: playback_play, Properties: {...","content_type":"video",`
3. Play an episode from `The Daily`  containing audio episodes
4. Notice in logs: `Tracked: playback_play, Properties: {...","content_type":"audio",`

Notice that content-type is present for other playback events like: pause, skip_back, skip_forward, stop

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack