### PR TITLE
Android 14 - Add foreground service media playback permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
     <uses-permission android:name="com.android.vending.BILLING" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 


### PR DESCRIPTION
## Description
This adds foreground service media playback permission as part of Android 14 target SDK changes. 

## Testing Instructions
1. Temporarily change `targetSdkVersion` to 34 in `dependencies.gradle.kts`
2. Install the app
3. Play an episode
4. Notice that 
    - the episode plays fine
    - media notification is displayed in the notification drawer
    - there is no log complaining of missing FGS media playback permission:
       `Playback: attempted startForeground for state: 6, but that threw an exception we caught: java.lang.SecurityException: Starting FGS with type mediaPlayback callerApp=ProcessRecord{fcfd6af 29813:au.com.shiftyjelly.pocketcasts.debug/u0a1490} targetSDK=34 requires permissions: all of the permissions allOf=true [android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK]` 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
