### PR TITLE
Sync up next swipe setting

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -169,7 +169,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                     },
                                 ),
                             )
-                            settings.upNextSwipe.set(it, needsSync = false)
+                            settings.upNextSwipe.set(it, needsSync = true)
                         },
                     )
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -137,9 +137,14 @@ interface Settings {
         BOOKMARK(21483650),
     }
 
-    enum class UpNextAction {
-        PLAY_NEXT,
-        PLAY_LAST,
+    enum class UpNextAction(val serverId: Int) {
+        PLAY_NEXT(serverId = 0),
+        PLAY_LAST(serverId = 1),
+        ;
+
+        companion object {
+            fun fromServerId(id: Int) = entries.find { it.serverId == id } ?: PLAY_NEXT
+        }
     }
 
     enum class CloudSortOrder {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -27,6 +27,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "autoArchiveInactive") val autoArchiveInactive: NamedChangedSettingInt? = null,
     @field:Json(name = "autoArchiveIncludesStarred") val autoArchiveIncludesStarred: NamedChangedSettingBool? = null,
     @field:Json(name = "rowAction") val rowAction: NamedChangedSettingInt? = null,
+    @field:Json(name = "upNextSwipe") val upNextSwipe: NamedChangedSettingInt? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -90,6 +90,12 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         modifiedAt = modifiedAt,
                     )
                 },
+                upNextSwipe = settings.upNextSwipe.getSyncSetting { action, modifiedAt ->
+                    NamedChangedSettingInt(
+                        value = action.serverId,
+                        modifiedAt = modifiedAt,
+                    )
+                },
             ),
         )
 
@@ -154,6 +160,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.streamingMode,
                         newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { it == 0 },
+                    )
+                    "upNextSwipe" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.upNextSwipe,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let(Settings.UpNextAction::fromServerId),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")
                 }


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the global settings for swiping episodes.

## Testing Instructions

1. Have to devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`General`/`Up Next swipe`.
4. D1: Change the value of `Up Next swipe` to `Play last`.  
5. D1: Sync the device in the `Profile`.
6. D2: Sync the device in the `Profile`.
7. D2: Open a podcast.
8. D2: Swipe an episode that is not in your queue all the way to the right. It should be added to the bottom of the queue.
9. D2: Go to `Profile`/`Settings (cog icon)`/`General`/`Up Next swipe`.
10. D2: Change the value of `Up Next swipe` to `Play next`.
11. D2: Sync the device in the `Profile`.
12. D1: Sync the device in the `Profile`.
13. D1: Open a podcast.
14. D1: Swipe an episode that is not in your queue all the way to the right. It should be added to the top of the queue.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
