### PR TITLE
Sync media notification actions setting

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/MediaNotificationControlsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/MediaNotificationControlsFragment.kt
@@ -139,7 +139,7 @@ class MediaNotificationControlsFragment : BaseFragment(), MediaActionTouchCallba
                     ShowCustomMediaActionsSettingsRow(
                         shouldShowCustomMediaActions = settings.customMediaActionsVisibility.flow.collectAsState().value,
                         onShowCustomMediaActionsToggled = { showCustomActions ->
-                            settings.customMediaActionsVisibility.set(showCustomActions, needsSync = false)
+                            settings.customMediaActionsVisibility.set(showCustomActions, needsSync = true)
                             updateMediaActionsVisibility(showCustomActions)
                         },
                     )
@@ -282,7 +282,7 @@ class MediaNotificationControlsFragment : BaseFragment(), MediaActionTouchCallba
         // Reset mediaActionMove now that we've tracked it
         mediaActionMove = null
 
-        settings.mediaControlItems.set(items.filterIsInstance<Settings.MediaNotificationControls>(), needsSync = false)
+        settings.mediaControlItems.set(items.filterIsInstance<Settings.MediaNotificationControls>(), needsSync = true)
     }
 }
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -156,8 +156,12 @@ interface Settings {
         LONG_SHORT,
     }
 
-    sealed class MediaNotificationControls(@StringRes val controlName: Int, @DrawableRes val iconRes: Int, val key: String) {
-
+    sealed class MediaNotificationControls(
+        @StringRes val controlName: Int,
+        @DrawableRes val iconRes: Int,
+        val key: String,
+        val serverId: String,
+    ) {
         companion object {
             val All
                 get() = listOf(PlaybackSpeed, Star, MarkAsPlayed, PlayNext, Archive)
@@ -174,17 +178,51 @@ interface Settings {
             fun itemForId(id: String): MediaNotificationControls? {
                 return items[id]
             }
+
+            fun fromServerId(id: String) = All.find { it.serverId == id }
         }
 
-        object Archive : MediaNotificationControls(LR.string.archive, IR.drawable.ic_archive, ARCHIVE_KEY)
+        init {
+            // We use comma as a delimiter when syncing list of these settings
+            require(!serverId.contains(',')) {
+                "Media notification control server ID cannot contain a comma"
+            }
+        }
 
-        object MarkAsPlayed : MediaNotificationControls(LR.string.mark_as_played, IR.drawable.ic_markasplayed, MARK_AS_PLAYED_KEY)
+        data object Archive : MediaNotificationControls(
+            controlName = LR.string.archive,
+            iconRes = IR.drawable.ic_archive,
+            key = ARCHIVE_KEY,
+            serverId = "archive",
+        )
 
-        object PlayNext : MediaNotificationControls(LR.string.play_next, com.google.android.gms.cast.framework.R.drawable.cast_ic_mini_controller_skip_next, PLAY_NEXT_KEY)
+        data object MarkAsPlayed : MediaNotificationControls(
+            controlName = LR.string.mark_as_played,
+            iconRes = IR.drawable.ic_markasplayed,
+            key = MARK_AS_PLAYED_KEY,
+            serverId = "mark_as_played",
+        )
 
-        object PlaybackSpeed : MediaNotificationControls(LR.string.playback_speed, IR.drawable.auto_1x, PLAYBACK_SPEED_KEY)
+        data object PlayNext : MediaNotificationControls(
+            controlName = LR.string.play_next,
+            iconRes = com.google.android.gms.cast.framework.R.drawable.cast_ic_mini_controller_skip_next,
+            key = PLAY_NEXT_KEY,
+            serverId = "play_next",
+        )
 
-        object Star : MediaNotificationControls(LR.string.star, IR.drawable.ic_star, STAR_KEY)
+        data object PlaybackSpeed : MediaNotificationControls(
+            controlName = LR.string.playback_speed,
+            iconRes = IR.drawable.auto_1x,
+            key = PLAYBACK_SPEED_KEY,
+            serverId = "playback_speed",
+        )
+
+        data object Star : MediaNotificationControls(
+            controlName = LR.string.star,
+            iconRes = IR.drawable.ic_star,
+            key = STAR_KEY,
+            serverId = "star",
+        )
     }
 
     val selectPodcastSortTypeObservable: Observable<PodcastsSortType>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -125,7 +125,7 @@ open class PlaybackManager @Inject constructor(
     private val bookmarkManager: BookmarkManager,
     private val showNotesManager: ShowNotesManager,
     bookmarkFeature: BookmarkFeatureControl,
-    private val playbackManagerNetworkWatcher: PlaybackManagerNetworkWatcher,
+    private val playbackManagerNetworkWatcherFactory: PlaybackManagerNetworkWatcher.Factory,
     @ApplicationScope private val applicationScope: CoroutineScope,
 ) : FocusManager.FocusChangeListener, AudioNoisyManager.AudioBecomingNoisyListener, CoroutineScope {
 
@@ -219,6 +219,7 @@ open class PlaybackManager @Inject constructor(
         upNextQueue.setup()
         mediaSessionManager.startObserving()
         updatePausedPlaybackState()
+        val playbackManagerNetworkWatcher = playbackManagerNetworkWatcherFactory.create(::onSwitchedToMeteredConnection)
 
         launch {
             castManager.startSessionListener(object : CastManager.SessionListener {
@@ -234,10 +235,8 @@ open class PlaybackManager @Inject constructor(
                     castReconnected()
                 }
             })
+            playbackManagerNetworkWatcher.observeConnection()
         }
-        playbackManagerNetworkWatcher.initialize(
-            onSwitchToMeteredConnection = ::onSwitchedToMeteredConnection,
-        )
     }
 
     fun getCurrentEpisode(): BaseEpisode? {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManagerNetworkWatcherTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManagerNetworkWatcherTest.kt
@@ -3,45 +3,44 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
 import android.net.NetworkCapabilities
-import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import junit.framework.TestCase.assertEquals
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.TestCoroutineScheduler
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
-import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 
-@RunWith(MockitoJUnitRunner::class)
+@ExperimentalCoroutinesApi
 class PlaybackManagerNetworkWatcherTest {
+    private val inputNetworkCapabilities = MutableStateFlow<NetworkCapabilities?>(null)
+    private var numTimesCalledOnSwitchToMeteredConnection = 0
 
-    @get:Rule
-    val coroutineRule = MainCoroutineRule()
-
-    @Mock private lateinit var networkConnectionWatcher: NetworkConnectionWatcher
-    private lateinit var playbackManagerNetworkWatcher: PlaybackManagerNetworkWatcher
+    private val networkConnectionWatcher = object : NetworkConnectionWatcher {
+        override val networkCapabilities = inputNetworkCapabilities
+    }
+    private val playbackManagerNetworkWatcher = PlaybackManagerNetworkWatcher(
+        networkConnectionWatcher = networkConnectionWatcher,
+        onSwitchToMeteredConnection = { numTimesCalledOnSwitchToMeteredConnection++ },
+    )
 
     @Test
     fun `handles switch to metered connection`() = runTest {
         val isMeteredCapabilities = listOf(false, true)
-        val timesCalled = getSwitchToMeteredCalls(backgroundScope, testScheduler, isMeteredCapabilities)
-        assertEquals(1, timesCalled)
+        runNetworkMetering(isMeteredCapabilities)
+        assertEquals(1, numTimesCalledOnSwitchToMeteredConnection)
     }
 
     @Test
     fun `does not record switch if always on metered`() = runTest {
         val isMeteredCapabilities = listOf(true, true, true)
-        val timesCalled = getSwitchToMeteredCalls(backgroundScope, testScheduler, isMeteredCapabilities)
-        assertEquals(0, timesCalled)
+        runNetworkMetering(isMeteredCapabilities)
+        assertEquals(0, numTimesCalledOnSwitchToMeteredConnection)
     }
 
     @Test
@@ -51,37 +50,16 @@ class PlaybackManagerNetworkWatcherTest {
             true, true, true, false, false, true, // second switch to metered
             true, // not a switch to metered because was already metered
         )
-        val timesCalled = getSwitchToMeteredCalls(backgroundScope, testScheduler, isMeteredCapabilities)
-        assertEquals(2, timesCalled)
+        runNetworkMetering(isMeteredCapabilities)
+        assertEquals(2, numTimesCalledOnSwitchToMeteredConnection)
     }
 
-    private fun getSwitchToMeteredCalls(
-        backgroundScope: CoroutineScope,
-        testScheduler: TestCoroutineScheduler,
-        list: List<Boolean>,
-    ): Int {
-        // initialize NetworkConnectionWatcher mock
-        val mutableNetworkCapabilitiesFlow = MutableStateFlow<NetworkCapabilities?>(null)
-        whenever(networkConnectionWatcher.networkCapabilities)
-            .thenReturn(mutableNetworkCapabilitiesFlow)
-
-        playbackManagerNetworkWatcher = PlaybackManagerNetworkWatcher(
-            applicationScope = CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
-            networkConnectionWatcher = networkConnectionWatcher,
-        )
-
-        var numTimesCalledOnSwitchToMeteredConnection = 0
-        playbackManagerNetworkWatcher.initialize(
-            onSwitchToMeteredConnection = { numTimesCalledOnSwitchToMeteredConnection++ },
-        )
-
-        list.forEach { isMetered ->
-            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-                mutableNetworkCapabilitiesFlow.value = networkCapabilities(isMetered)
-            }
+    private suspend fun TestScope.runNetworkMetering(meteredChanges: List<Boolean>) {
+        backgroundScope.launch(Dispatchers.Unconfined) {
+            playbackManagerNetworkWatcher.observeConnection()
         }
 
-        return numTimesCalledOnSwitchToMeteredConnection
+        inputNetworkCapabilities.emitAll(meteredChanges.map(::networkCapabilities).asFlow())
     }
 
     private fun networkCapabilities(isMetered: Boolean) = mock<NetworkCapabilities> {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -31,6 +31,8 @@ data class ChangedNamedSettings(
     @field:Json(name = "volumeBoost") val volumeBoost: NamedChangedSettingBool? = null,
     @field:Json(name = "rowAction") val rowAction: NamedChangedSettingInt? = null,
     @field:Json(name = "upNextSwipe") val upNextSwipe: NamedChangedSettingInt? = null,
+    @field:Json(name = "mediaActions") val showCustomMediaActions: NamedChangedSettingBool? = null,
+    @field:Json(name = "mediaActionsOrder") val mediaActionsOrder: NamedChangedSettingString? = null,
     @field:Json(name = "episodeGrouping") val episodeGrouping: NamedChangedSettingInt? = null,
 )
 
@@ -49,6 +51,12 @@ data class NamedChangedSettingBool(
 @JsonClass(generateAdapter = true)
 data class NamedChangedSettingDouble(
     @field:Json(name = "value") val value: Double,
+    @field:Json(name = "modified_at") val modifiedAt: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class NamedChangedSettingString(
+    @field:Json(name = "value") val value: String,
     @field:Json(name = "modified_at") val modifiedAt: String,
 )
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -227,7 +227,8 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         setting = settings.mediaControlItems,
                         newSettingValue = (changedSettingResponse.value as? String)
                             ?.split(',')
-                            ?.mapNotNull(Settings.MediaNotificationControls::fromServerId),
+                            ?.mapNotNull(Settings.MediaNotificationControls::fromServerId)
+                            ?.appendMissingControls(),
                     )
                     "episodeGrouping" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
@@ -328,3 +329,5 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
         return run(settings, namedSettingsCaller)
     }
 }
+
+private fun List<Settings.MediaNotificationControls>.appendMissingControls() = this + (Settings.MediaNotificationControls.All - this)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -113,6 +113,13 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         modifiedAt = modifiedAt,
                     )
                 },
+                showCustomMediaActions = settings.customMediaActionsVisibility.getSyncSetting(::NamedChangedSettingBool),
+                mediaActionsOrder = settings.mediaControlItems.getSyncSetting { items, modifiedAt ->
+                    NamedChangedSettingString(
+                        value = items.joinToString(separator = ",", transform = Settings.MediaNotificationControls::serverId),
+                        modifiedAt = modifiedAt,
+                    )
+                },
             ),
         )
 
@@ -209,6 +216,18 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.upNextSwipe,
                         newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let(Settings.UpNextAction::fromServerId),
+                    )
+                    "mediaActions" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.customMediaActionsVisibility,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "mediaActionsOrder" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.mediaControlItems,
+                        newSettingValue = (changedSettingResponse.value as? String)
+                            ?.split(',')
+                            ?.mapNotNull(Settings.MediaNotificationControls::fromServerId),
                     )
                     "episodeGrouping" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the global media notification actions.

## Testing Instructions

1. Have two devices D1 and D2 that can display custom notification actions.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`General`/`Media notification controls`.
4. D1: Toggle the setting. If the setting is enabled reorder the actions.  
5. D1: Sync the device in the `Profile`.
6. D2: Sync the device in the `Profile`.
7. D2: Play an episode.
8. D2: Open notifications center and notice that your custom actions are applied according to settings.
9. D2: Go to `Profile`/`Settings (cog icon)`/`General`/`Media notification controls` and notice that settings are in sync with D1.
10. Test this the other way around by syncing from D2 to D1. Try testing each action individually and combinations of them as well.

---

I'm not sure the best way to test a0d057247c9d6e3c700aaf7623de5aeea682e6be. 

1. Have two devices. D1 with the app from this branch and D2 with the app with [this patch](https://github.com/Automattic/pocket-casts-android/files/14095114/media-sync.patch). 
2. D2: Go to `Profile`/`Settings (cog icon)`/`General`/`Media notification controls`.
3. D2: Toggle the setting. If the setting is enabled reorder the actions.  
4. D2: Sync the device in the `Profile`.
5. D1: Sync the device in the `Profile`.
6. D1: The `Archive` action should be at the bottom in `Media notification controls`.

## Screenshots or Screencast 

Notification center:

![Untitled 2](https://github.com/Automattic/pocket-casts-android/assets/30936061/33c86150-5e22-4146-b247-9cb041a025f0)

Notification actions setting:

![Screenshot_20240129-160451](https://github.com/Automattic/pocket-casts-android/assets/30936061/5f0029ed-30e9-4a67-8cae-826954b7e334)

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
