### PR TITLE
Sync episode grouping setting

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -188,7 +188,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                     },
                                 ),
                             )
-                            settings.podcastGroupingDefault.set(it, needsSync = false)
+                            settings.podcastGroupingDefault.set(it, needsSync = true)
                             showSetAllGroupingDialog(it)
                         },
                     )

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PodcastGrouping.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PodcastGrouping.kt
@@ -9,21 +9,35 @@ import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping.Season.getSeason
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-sealed class PodcastGrouping(@StringRes val groupName: Int, val sortFunction: ((PodcastEpisode) -> Int)?) {
+sealed class PodcastGrouping(
+    @StringRes val groupName: Int,
+    val serverId: Int,
+    val sortFunction: ((PodcastEpisode) -> Int)?,
+) {
     companion object {
         val All
             get() = listOf(None, Downloaded, Unplayed, Season, Starred)
+
+        fun fromServerId(id: Int) = All.find { it.serverId == id } ?: None
     }
 
     abstract fun groupTitles(index: Int, context: Context): String
 
-    object None : PodcastGrouping(LR.string.none, null) {
+    data object None : PodcastGrouping(
+        groupName = LR.string.none,
+        serverId = 0,
+        sortFunction = null,
+    ) {
         override fun groupTitles(index: Int, context: Context): String {
             return context.getString(LR.string.none)
         }
     }
 
-    object Downloaded : PodcastGrouping(LR.string.podcast_group_downloaded, { if (it.isDownloaded || it.isDownloading || it.isQueued) 0 else 1 }) {
+    data object Downloaded : PodcastGrouping(
+        groupName = LR.string.podcast_group_downloaded,
+        serverId = 1,
+        sortFunction = { if (it.isDownloaded || it.isDownloading || it.isQueued) 0 else 1 },
+    ) {
         override fun groupTitles(index: Int, context: Context): String {
             return if (index == 0) {
                 context.getString(LR.string.podcast_group_downloaded)
@@ -35,7 +49,11 @@ sealed class PodcastGrouping(@StringRes val groupName: Int, val sortFunction: ((
         }
     }
 
-    object Unplayed : PodcastGrouping(LR.string.podcast_group_unplayed, { if (it.isUnplayed || it.isInProgress) 0 else 1 }) {
+    data object Unplayed : PodcastGrouping(
+        groupName = LR.string.podcast_group_unplayed,
+        serverId = 2,
+        sortFunction = { if (it.isUnplayed || it.isInProgress) 0 else 1 },
+    ) {
         override fun groupTitles(index: Int, context: Context): String {
             return if (index == 0) {
                 context.getString(LR.string.podcast_group_unplayed)
@@ -47,7 +65,11 @@ sealed class PodcastGrouping(@StringRes val groupName: Int, val sortFunction: ((
         }
     }
 
-    object Season : PodcastGrouping(LR.string.podcast_group_season, { getSeasonGroupId(it) }) {
+    data object Season : PodcastGrouping(
+        groupName = LR.string.podcast_group_season,
+        serverId = 3,
+        sortFunction = { getSeasonGroupId(it) },
+    ) {
         lateinit var groupTitlesList: List<String>
         override fun groupTitles(index: Int, context: Context): String {
             return groupTitlesList.getOrNull(index) ?: context.getString(LR.string.podcast_no_season)
@@ -77,7 +99,11 @@ sealed class PodcastGrouping(@StringRes val groupName: Int, val sortFunction: ((
             firstEpisode.season?.toInt()?.takeIf { season -> season > 0 } ?: 0
     }
 
-    object Starred : PodcastGrouping(LR.string.profile_navigation_starred, { if (it.isStarred) 0 else 1 }) {
+    data object Starred : PodcastGrouping(
+        groupName = LR.string.profile_navigation_starred,
+        serverId = 4,
+        sortFunction = { if (it.isStarred) 0 else 1 },
+    ) {
         override fun groupTitles(index: Int, context: Context): String {
             return if (index == 0) {
                 context.getString(LR.string.profile_navigation_starred)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -31,6 +31,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "volumeBoost") val volumeBoost: NamedChangedSettingBool? = null,
     @field:Json(name = "rowAction") val rowAction: NamedChangedSettingInt? = null,
     @field:Json(name = "upNextSwipe") val upNextSwipe: NamedChangedSettingInt? = null,
+    @field:Json(name = "episodeGrouping") val episodeGrouping: NamedChangedSettingInt? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.helper.BuildConfig
+import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -106,6 +107,12 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         modifiedAt = modifiedAt,
                     )
                 },
+                episodeGrouping = settings.podcastGroupingDefault.getSyncSetting { type, modifiedAt ->
+                    NamedChangedSettingInt(
+                        value = type.serverId,
+                        modifiedAt = modifiedAt,
+                    )
+                },
             ),
         )
 
@@ -202,6 +209,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.upNextSwipe,
                         newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let(Settings.UpNextAction::fromServerId),
+                    )
+                    "episodeGrouping" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.podcastGroupingDefault,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let(PodcastGrouping::fromServerId),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")
                 }


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the global settings for episode grouping.

## Testing Instructions

### ⚠️ Warning ⚠️ 

It can be confusing that sync setting does not apply automatically to podcasts that are on a device. This is by design. The setting on a synced device applies only to new podcasts. If users want to apply the grouping on a synced device they need to re-trigger the setting.

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`General`/`Podcast episode grouping`.
4. D1: Change the value of the setting. You can dismiss the popup about applying the setting to available podcasts.
5. D1: Sync the device in the `Profile`.
6. D2: Sync the device in the `Profile`.
7. D2: Subscribe to a new podcast.
8. D2: Open that podcast and check if episode grouping is what you set on D1.
9. Perform this test for each grouping mode.

---

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`General`/`Podcast episode grouping`.
4. D1: Change the value of the setting. You can dismiss the popup about applying the setting to available podcasts.
5. D1: Sync the device in the `Profile`.
6. D2: Sync the device in the `Profile`.
7. D2: Go to `Profile`/`Settings (cog icon)`/`General`/`Podcast episode grouping`.
8. D2: Confirm already selected grouping.
9. D2: Confirm that you want to apply changes to available podcasts.
10. D2: Open a podcast that you are already subscribed to.
11. D2: Check if the grouping is correctly applied.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
