### PR TITLE
Sync show archived setting

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -205,7 +205,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                     },
                                 ),
                             )
-                            settings.showArchivedDefault.set(it, needsSync = false)
+                            settings.showArchivedDefault.set(it, needsSync = true)
                             showSetAllArchiveDialog(it)
                         },
                     )

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -36,6 +36,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "episodeGrouping") val episodeGrouping: NamedChangedSettingInt? = null,
     @field:Json(name = "keepScreenAwake") val keepScreenAwake: NamedChangedSettingBool? = null,
     @field:Json(name = "openPlayer") val openPlayerAutomatically: NamedChangedSettingBool? = null,
+    @field:Json(name = "showArchived") val showArchived: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -122,6 +122,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 },
                 keepScreenAwake = settings.keepScreenAwake.getSyncSetting(::NamedChangedSettingBool),
                 openPlayerAutomatically = settings.openPlayerAutomatically.getSyncSetting(::NamedChangedSettingBool),
+                showArchived = settings.showArchivedDefault.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -245,6 +246,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "openPlayer" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.openPlayerAutomatically,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "showArchived" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.showArchivedDefault,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the global settings for showing archived episodes.

## Testing Instructions

### ⚠️ Warning ⚠️ 

It can be confusing that sync setting does not apply automatically to podcasts that are on a device. This is by design. The setting on a synced device applies only to new podcasts. If users want to apply it on a synced device they need to re-trigger the setting.

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`General`/`Show archived`.
4. D1: Change the value to `Show`. You can dismiss the popup about applying the setting to available podcasts.
5. D1: Sync the device in the `Profile`.
6. D2: Sync the device in the `Profile`.
7. D2: Subscribe to a new podcast.
8. D2: Open that podcast and check if archived episodes are show in the episode listing.
9. D2: Go to `Profile`/`Settings (cog icon)`/`General`/`Show archived`.
10. D2: Change the value to `Hide`.
11. D2: Sync the device in the `Profile`.
12. D1: Sync the device in the `Profile`.
13. D1: Subscribe to a new podcast.
14. D1: Open that podcast and check if archived episodes are hidden in the episode listing.

---

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`General`/`Show archived`.
4. D1: Change the value of the setting. You can dismiss the popup about applying the setting to available podcasts.
5. D1: Sync the device in the `Profile`.
6. D2: Sync the device in the `Profile`.
7. D2: Go to `Profile`/`Settings (cog icon)`/`General`/`Show archived`.
8. D2: Confirm already selected setting.
9. D2: Confirm that you want to apply changes to available podcasts.
15. D2: Open a podcast that you are already subscribed to.
16. D2: Check if displaying archived is correctly applied.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
