### PR TITLE
Sync keep awake and open player settings

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.reactive.asFlow
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -92,7 +93,7 @@ class MainActivityViewModel
             Timber.d("Updated playback state from ${it.lastChangeFrom} is playing ${it.isPlaying}")
         }
         .toFlowable(BackpressureStrategy.LATEST)
-    val playbackState = playbackStateRx.toLiveData()
+    val playbackState = playbackStateRx.asFlow()
 
     val signInState: LiveData<SignInState> = userManager.getSignInState().toLiveData()
     val isSignedIn: Boolean

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -266,7 +266,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                 AnalyticsEvent.SETTINGS_GENERAL_OPEN_PLAYER_AUTOMATICALLY_TOGGLED,
                                 mapOf("enabled" to it),
                             )
-                            settings.openPlayerAutomatically.set(it, needsSync = false)
+                            settings.openPlayerAutomatically.set(it, needsSync = true)
                         },
                     )
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -255,7 +255,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                 AnalyticsEvent.SETTINGS_GENERAL_KEEP_SCREEN_AWAKE_TOGGLED,
                                 mapOf("enabled" to it),
                             )
-                            settings.keepScreenAwake.set(it, needsSync = false)
+                            settings.keepScreenAwake.set(it, needsSync = true)
                         },
                     )
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -35,6 +35,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "mediaActionsOrder") val mediaActionsOrder: NamedChangedSettingString? = null,
     @field:Json(name = "episodeGrouping") val episodeGrouping: NamedChangedSettingInt? = null,
     @field:Json(name = "keepScreenAwake") val keepScreenAwake: NamedChangedSettingBool? = null,
+    @field:Json(name = "openPlayer") val openPlayerAutomatically: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -34,6 +34,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "mediaActions") val showCustomMediaActions: NamedChangedSettingBool? = null,
     @field:Json(name = "mediaActionsOrder") val mediaActionsOrder: NamedChangedSettingString? = null,
     @field:Json(name = "episodeGrouping") val episodeGrouping: NamedChangedSettingInt? = null,
+    @field:Json(name = "keepScreenAwake") val keepScreenAwake: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -121,6 +121,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     )
                 },
                 keepScreenAwake = settings.keepScreenAwake.getSyncSetting(::NamedChangedSettingBool),
+                openPlayerAutomatically = settings.openPlayerAutomatically.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -239,6 +240,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "keepScreenAwake" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.keepScreenAwake,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "openPlayer" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.openPlayerAutomatically,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -120,6 +120,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         modifiedAt = modifiedAt,
                     )
                 },
+                keepScreenAwake = settings.keepScreenAwake.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -234,6 +235,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.podcastGroupingDefault,
                         newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let(PodcastGrouping::fromServerId),
+                    )
+                    "keepScreenAwake" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.keepScreenAwake,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")
                 }


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the global settings for keep the screen awake why player is opened and opening player automatically when playing a new episode.

## Testing Instructions

### Keep screen awake

1. Have two devices D1 and D2.
2. In the device settings set screen timeout setting to the lowest possible. For me on Pixel 6 it is 15 seconds.
3. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
4. D1: Go to `Profile`/`Settings (cog icon)`/`General`.
5. D1: Toggle `Keep screen awake` to `ON`.
6. D1: Sync the device in the `Profile`.
7. D2: Sync the device in the `Profile`.
8. D2: Play an episode and open the player.
9. D2: Wait for the amount of time set in the second step. Screen should not go black.
10. D2: Minimize the player.
11. D2: Wait for the amount of time set in the second step. Screen should go black.
12. D2: Go to `Profile`/`Settings (cog icon)`/`General`.
13. D2: Toggle `Keep screen awake` to `OFF`.
14. D2: Sync the device in the `Profile`.
15. D1: Sync the device in the `Profile`.
16. D1: Play an episode and open the player.
17. D1: Wait for the amount of time set in the second step. Screen should go black.
18. D1: Minimize the player.
19. D1: Wait for the amount of time set in the second step. Screen should go black.
20. Set the device settings for the screen timeout to whatever you want.

### Open player automatically

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`General`.
4. D1: Toggle `Open player automatically` to `ON`.
5. D1: Sync the device in the `Profile`.
6.D2: Sync the device in the `Profile`.
7. D2: Play an episode. Player should open automatically.
8. D2: Minimize the player and play a different episode. Player should open automatically.
9. D2: Go to `Profile`/`Settings (cog icon)`/`General`.
10. D2: Toggle `Open player automatically` to `OFF`.
11. D2: Sync the device in the `Profile`.
12. D1: Sync the device in the `Profile`.
13. D1: Play an episode. Player should not open automatically.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
