### PR TITLE
Sync intelligent playback setting

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -277,7 +277,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                 AnalyticsEvent.SETTINGS_GENERAL_INTELLIGENT_PLAYBACK_TOGGLED,
                                 mapOf("enabled" to it),
                             )
-                            settings.intelligentPlaybackResumption.set(it, needsSync = false)
+                            settings.intelligentPlaybackResumption.set(it, needsSync = true)
                         },
                     )
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -37,6 +37,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "keepScreenAwake") val keepScreenAwake: NamedChangedSettingBool? = null,
     @field:Json(name = "openPlayer") val openPlayerAutomatically: NamedChangedSettingBool? = null,
     @field:Json(name = "showArchived") val showArchived: NamedChangedSettingBool? = null,
+    @field:Json(name = "intelligentResumption") val intelligentResumption: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -123,6 +123,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 keepScreenAwake = settings.keepScreenAwake.getSyncSetting(::NamedChangedSettingBool),
                 openPlayerAutomatically = settings.openPlayerAutomatically.getSyncSetting(::NamedChangedSettingBool),
                 showArchived = settings.showArchivedDefault.getSyncSetting(::NamedChangedSettingBool),
+                intelligentResumption = settings.intelligentPlaybackResumption.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -251,6 +252,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "showArchived" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.showArchivedDefault,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "intelligentResumption" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.intelligentPlaybackResumption,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the global settings for the intelligent playback.

Intelligent playback rules are defined as follows.

```kotlin
when (paused time since now) {
  in (5 minutes)..(1 hour) -> 10 seconds
  in (1 hours)..(24 hours) -> 15 seconds
  in (24 hours)..(infinity) -> 30 seconds
  else -> 0 seconds
}
```

## Testing Instructions

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`General`.
4. D1: Toggle `Intelligent playback resumption` to `ON`.
5. D1: Sync the device in the `Profile`.
6. D2: Sync the device in the `Profile`.
7. D2: Play an episode.
8. D2: Pause an episode and note the time that it was paused at.
9. D2: Wait for some time defined for intelligent playback rules.
10. D2: Resume playback and notice that the playback went back in time as per the rules.
11. D2: Pause and resume playback. There should be no time jumps.
12. D2: Go to `Profile`/`Settings (cog icon)`/`General`.
13. D2: Toggle `Intelligent playback resumption` to `OFF`.
14. D2: Sync the device in the `Profile`.
15. D1: Sync the device in the `Profile`.
16. D1: Play an episode.
17. D1: Pause an episode and note the time that it was paused at.
18. D1: Wait for some time defined for intelligent playback rules.
19. D1: Resume playback and notice no time jumps.
20. D1: Pause and resume playback. There should be no time jumps.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
