### PR TITLE
Sync play up next item on tap setting

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -288,7 +288,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                 AnalyticsEvent.SETTINGS_GENERAL_PLAY_UP_NEXT_ON_TAP_TOGGLED,
                                 mapOf("enabled" to it),
                             )
-                            settings.tapOnUpNextShouldPlay.set(it, needsSync = false)
+                            settings.tapOnUpNextShouldPlay.set(it, needsSync = true)
                         },
                     )
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -40,6 +40,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "intelligentResumption") val intelligentResumption: NamedChangedSettingBool? = null,
     @field:Json(name = "autoPlayEnabled") val autoPlayEnabled: NamedChangedSettingBool? = null,
     @field:Json(name = "hideNotificationOnPause") val hideNotificationOnPause: NamedChangedSettingBool? = null,
+    @field:Json(name = "playUpNextOnTap") val playUpNextOnTap: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -126,6 +126,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 intelligentResumption = settings.intelligentPlaybackResumption.getSyncSetting(::NamedChangedSettingBool),
                 autoPlayEnabled = settings.autoPlayNextEpisodeOnEmpty.getSyncSetting(::NamedChangedSettingBool),
                 hideNotificationOnPause = settings.hideNotificationOnPause.getSyncSetting(::NamedChangedSettingBool),
+                playUpNextOnTap = settings.tapOnUpNextShouldPlay.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -269,6 +270,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "hideNotificationOnPause" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.hideNotificationOnPause,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "playUpNextOnTap" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.tapOnUpNextShouldPlay,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the global settings for tapping items in the queue.

## Testing Instructions

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`General`.
4. D1: Toggle `Play Up Next episode on tap` to `ON`.
5. D1: Sync the device in the `Profile`.
6. D2: Sync the device in the `Profile`.
7. D2: Add some episodes to the queue.
8. D2: Open the queue.
9. D2: Tap on an episode in the queue. It should move to the top and start playing.
10. D2: Long press an episode in the queue. It should open its details.
11. D2: Go to `Profile`/`Settings (cog icon)`/`General`.
12. D2: Toggle `Play Up Next episode on tap` to `OFF`.
13. D2: Sync the device in the `Profile`.
14. D1: Sync the device in the `Profile`.
15. D1: Add some episodes to the queue.
16. D1: Open the queue.
17. D1: Tap on an episode in the queue. It should open its details.
18. D1: Long press an episode in the queue. It should move to the top and start playing.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
