### PR TITLE
Sync auto play setting

### DIFF
--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -64,7 +64,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
         preferenceAutoPlay.apply {
             isChecked = settings.autoPlayNextEpisodeOnEmpty.value
             setOnPreferenceChangeListener { _, newValue ->
-                settings.autoPlayNextEpisodeOnEmpty.set(newValue as Boolean, needsSync = false)
+                settings.autoPlayNextEpisodeOnEmpty.set(newValue as Boolean, needsSync = true)
                 true
             }
         }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -308,7 +308,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                 AnalyticsEvent.SETTINGS_GENERAL_AUTOPLAY_TOGGLED,
                                 mapOf("enabled" to it),
                             )
-                            settings.autoPlayNextEpisodeOnEmpty.set(it, needsSync = false)
+                            settings.autoPlayNextEpisodeOnEmpty.set(it, needsSync = true)
                         },
                     )
                 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -38,6 +38,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "openPlayer") val openPlayerAutomatically: NamedChangedSettingBool? = null,
     @field:Json(name = "showArchived") val showArchived: NamedChangedSettingBool? = null,
     @field:Json(name = "intelligentResumption") val intelligentResumption: NamedChangedSettingBool? = null,
+    @field:Json(name = "autoPlayEnabled") val autoPlayEnabled: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -124,6 +124,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 openPlayerAutomatically = settings.openPlayerAutomatically.getSyncSetting(::NamedChangedSettingBool),
                 showArchived = settings.showArchivedDefault.getSyncSetting(::NamedChangedSettingBool),
                 intelligentResumption = settings.intelligentPlaybackResumption.getSyncSetting(::NamedChangedSettingBool),
+                autoPlayEnabled = settings.autoPlayNextEpisodeOnEmpty.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -257,6 +258,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "intelligentResumption" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.intelligentPlaybackResumption,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "autoPlayEnabled" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.autoPlayNextEpisodeOnEmpty,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the global settings for the queue auto play.

## Testing Instructions

### Setting sync

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`General`.
4. D1: Toggle `Autoplay` to `ON`.
5. D1: Sync the device in the `Profile`.
6. D2: Sync the device in the `Profile`.
7. D2: Make sure that your queue is empty and play an episode.
8. D2: Scroll the timestamp near the end and let the episode finish.
9. D2: A next episode should start playing automatically.
10. D2: Clear the playback.
11. D2: Go to `Profile`/`Settings (cog icon)`/`General`.
12. D2: Toggle `Autoplay` to `OFF`.
13. D2: Sync the device in the `Profile`.
14. D1: Sync the device in the `Profile`.
15. D1: Make sure that your queue is empty and play an episode.
16. D1: Scroll the timestamp near the end and let the episode finish.
17. D1: Nothing should play after the episode finishes.
18. You can test this with Android Auto as well.

### New install

1. Have two devices D1 and D2. D2 should not have app installed yet.
2. D1: Go to `Profile`/`Settings (cog icon)`/`General`. 
3. D1: Toggle `Autoplay` to `OFF`.
4. D1: Sync the device in the Profile.
5. D2: Install the app.
6. D2: Sign in to the device with the same account as on D1.
7. D2: Go to `Profile`/`Settings (cog icon)`/`General`. 
8. D2: `Autoplay` should be turned `OFF`.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
