### PR TITLE
Sync play over notifications setting

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
@@ -145,7 +145,7 @@ class NotificationsSettingsFragment :
                 ?.let { PlayOverNotificationSetting.fromPreferenceString(it) }
                 ?: throw IllegalStateException("Invalid value for play over notification preference: $newValue")
 
-            settings.playOverNotification.set(playOverNotificationSetting, needsSync = false)
+            settings.playOverNotification.set(playOverNotificationSetting, needsSync = true)
             changePlayOverNotificationSummary()
 
             analyticsTracker.track(

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/PlayOverNotificationSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/PlayOverNotificationSetting.kt
@@ -5,22 +5,26 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 enum class PlayOverNotificationSetting(
     val preferenceInt: Int,
+    val serverId: Int,
     @StringRes val titleRes: Int,
     val analyticsString: String,
 ) {
     NEVER(
-        titleRes = LR.string.settings_notification_play_over_never,
         preferenceInt = 2,
+        serverId = 0,
+        titleRes = LR.string.settings_notification_play_over_never,
         analyticsString = "never",
     ),
     DUCK(
-        titleRes = LR.string.settings_notification_play_over_duck,
         preferenceInt = 1,
+        serverId = 2,
+        titleRes = LR.string.settings_notification_play_over_duck,
         analyticsString = "duck",
     ),
     ALWAYS(
-        titleRes = LR.string.settings_notification_play_over_always,
         preferenceInt = 0,
+        serverId = 1,
+        titleRes = LR.string.settings_notification_play_over_always,
         analyticsString = "always",
     ),
     ;
@@ -29,10 +33,12 @@ enum class PlayOverNotificationSetting(
         fun fromPreferenceString(stringValue: String): PlayOverNotificationSetting {
             try {
                 val intValue = stringValue.toInt()
-                return values().first { it.preferenceInt == intValue }
+                return entries.first { it.preferenceInt == intValue }
             } catch (e: Exception) {
                 throw IllegalStateException("Unknown play over notification setting: $stringValue")
             }
         }
+
+        fun fromServerId(id: Int) = entries.find { it.serverId == id } ?: NEVER
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -41,6 +41,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "autoPlayEnabled") val autoPlayEnabled: NamedChangedSettingBool? = null,
     @field:Json(name = "hideNotificationOnPause") val hideNotificationOnPause: NamedChangedSettingBool? = null,
     @field:Json(name = "playUpNextOnTap") val playUpNextOnTap: NamedChangedSettingBool? = null,
+    @field:Json(name = "playOverNotifications") val playOverNotifications: NamedChangedSettingInt? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveInactiveSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.PodcastGridLayoutType
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
@@ -127,6 +128,12 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 autoPlayEnabled = settings.autoPlayNextEpisodeOnEmpty.getSyncSetting(::NamedChangedSettingBool),
                 hideNotificationOnPause = settings.hideNotificationOnPause.getSyncSetting(::NamedChangedSettingBool),
                 playUpNextOnTap = settings.tapOnUpNextShouldPlay.getSyncSetting(::NamedChangedSettingBool),
+                playOverNotifications = settings.playOverNotification.getSyncSetting { mode, modifiedAt ->
+                    NamedChangedSettingInt(
+                        value = mode.serverId,
+                        modifiedAt = modifiedAt,
+                    )
+                },
             ),
         )
 
@@ -276,6 +283,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.tapOnUpNextShouldPlay,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "playOverNotifications" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.playOverNotification,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let(PlayOverNotificationSetting::fromServerId),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")
                 }


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the global settings for playing podcasts over notifications.

## Testing Instructions

### Setting sync

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Play your queue.
4. D2: Go to `Profile`/`Settings (cog icon)`/`Notifications`.
5. D2: Change `Play over notifications` to `Duck volume`.
6. D2: Sync the device in the `Profile`.
7. D1: Sync the device in the `Profile`.
8. D1: Open an app that can trigger audio notifications. For example you can use Google Maps and start navigation.
9. D1: Once you hear notifications form a different app a podcast should play with lower volume and then come back to a default loudness.
10. D2: Go to `Profile`/`Settings (cog icon)`/`Notifications`.
11. D2: Change `Play over notifications` to `Always`.
12. D2: Sync the device in the `Profile`.
13. D1: Sync the device in the `Profile`.
14. D1: Trigger another audio notification. The podcast volume should not drop at all.
15. D2:  Go to `Profile`/`Settings (cog icon)`/`Notifications`.
16. D2: Change `Play over notifications` to `Always`.
17. D2: Sync the device in the `Profile`.
18. D1: Sync the device in the `Profile`.
19. D1: Trigger another audio notification. The podcast volume should drop and come back again after the notification sound is over.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
