### PR TITLE
Sync hide playback notification setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 *   Bug Fixes:
     *   Fixed starring episode from full-screen player does not prevent episode from being archived
         ([#1735](https://github.com/Automattic/pocket-casts-android/pull/1735))
+    *   Fixed "Hide playback notification on pause" setting not representing its state correctly
+        ([#1769](https://github.com/Automattic/pocket-casts-android/pull/1769))
 
 7.56
 -----

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
@@ -117,7 +117,7 @@ class NotificationsSettingsFragment :
 
         hidePlaybackNotificationsPreference?.setOnPreferenceChangeListener { _, newValue ->
             val newBool = (newValue as? Boolean) ?: throw IllegalStateException("Invalid value for hide notification on pause preference: $newValue")
-            settings.hideNotificationOnPause.set(newBool, needsSync = false)
+            settings.hideNotificationOnPause.set(newBool, needsSync = true)
             analyticsTracker.track(
                 AnalyticsEvent.SETTINGS_NOTIFICATIONS_HIDE_PLAYBACK_NOTIFICATION_ON_PAUSE,
                 mapOf("enabled" to newBool),
@@ -368,6 +368,7 @@ class NotificationsSettingsFragment :
         super.onResume()
         setupEnabledNotifications()
         setupNotificationVibrate()
+        setupHidePlaybackNotifications()
         setupPlayOverNotifications()
     }
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -39,6 +39,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "showArchived") val showArchived: NamedChangedSettingBool? = null,
     @field:Json(name = "intelligentResumption") val intelligentResumption: NamedChangedSettingBool? = null,
     @field:Json(name = "autoPlayEnabled") val autoPlayEnabled: NamedChangedSettingBool? = null,
+    @field:Json(name = "hideNotificationOnPause") val hideNotificationOnPause: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -125,6 +125,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 showArchived = settings.showArchivedDefault.getSyncSetting(::NamedChangedSettingBool),
                 intelligentResumption = settings.intelligentPlaybackResumption.getSyncSetting(::NamedChangedSettingBool),
                 autoPlayEnabled = settings.autoPlayNextEpisodeOnEmpty.getSyncSetting(::NamedChangedSettingBool),
+                hideNotificationOnPause = settings.hideNotificationOnPause.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -263,6 +264,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "autoPlayEnabled" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.autoPlayNextEpisodeOnEmpty,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "hideNotificationOnPause" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.hideNotificationOnPause,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the global settings for showing/hiding playback notification.

There was also a bug where the state of the setting was not represented correctly because we didn't call the setup method. I didn't find an issue for that which makes me think that probably not a lot of people use this feature. But, hey… 🤷‍♂️ 

## Testing Instructions

### Setting sync

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`Notifications`.
4. D1: Toggle `Hide playback notification on pause` to `ON`.
5. D1: Sync the device in the `Profile`.
6. D2: Sync the device in the `Profile`.
7. D2: Play an episode.
8. D2: Open notifications center and pause an episode. The notification should disappear.
9. D1: Toggle `Hide playback notification on pause` to `OFF`.
10. D1: Sync the device in the `Profile`.
11. D2: Sync the device in the `Profile`.
12. D2: Play an episode.
13. D2: Open notifications center and pause an episode. The notification should stay.

> [!note]
> This setting doesn't apply retroactively. If the episode was paused while the setting was `ON` it won't hide automatically when the setting is synced to `OFF`. It needs re-triggering the play/pause cycle.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
