### PR TITLE
Sample ForegroundServiceStartNotAllowedException

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -137,6 +137,13 @@ class PocketCastsApplication : Application(), Configuration.Provider {
         SentryAndroid.init(this) { options ->
             options.dsn = if (settings.sendCrashReports.value) settings.getSentryDsn() else ""
             options.setTag(SentryHelper.GLOBAL_TAG_APP_PLATFORM, AppPlatform.MOBILE.value)
+            options.setTracesSampler { context ->
+                return@setTracesSampler if (context.transactionContext.name == "PlaybackStateChangedWithNotification") {
+                    0.2
+                } else {
+                    1.0
+                }
+            }
         }
 
         // Link email to Sentry crash reports only if the user has opted in


### PR DESCRIPTION
## Description
This samples `ForegroundServiceStartNotAllowedException` in Sentry.

Relevant Sentry docs
[Setting a Sampling Function](https://docs.sentry.io/platforms/android/configuration/sampling/#setting-a-sampling-function)
[Connect Errors with Spans](https://docs.sentry.io/platforms/java/performance/instrumentation/custom-instrumentation/#connect-errors-with-spans)

## Testing Instructions
TODO

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
