### PR TITLE
Sync warn on metered network setting

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
@@ -159,7 +159,7 @@ class StorageSettingsViewModel
     }
 
     private fun onStorageDataWarningCheckedChange(isChecked: Boolean) {
-        settings.warnOnMeteredNetwork.set(isChecked, needsSync = false)
+        settings.warnOnMeteredNetwork.set(isChecked, needsSync = true)
         updateMobileDataWarningState()
     }
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -44,6 +44,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "playOverNotifications") val playOverNotifications: NamedChangedSettingInt? = null,
     @field:Json(name = "autoUpNextLimit") val autoUpNextLimit: NamedChangedSettingInt? = null,
     @field:Json(name = "autoUpNextLimitReached") val autoUpNextLimitReached: NamedChangedSettingInt? = null,
+    @field:Json(name = "warnDataUsage") val warnDataUsage: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -142,6 +142,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         modifiedAt = modifiedAt,
                     )
                 },
+                warnDataUsage = settings.warnOnMeteredNetwork.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -306,6 +307,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.autoAddUpNextLimitBehaviour,
                         newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let(AutoAddUpNextLimitBehaviour::fromServerId),
+                    )
+                    "warnDataUsage" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.warnOnMeteredNetwork,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")
                 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsViewModel.kt
@@ -59,16 +59,24 @@ class SettingsViewModel @Inject constructor(
                     _state.update { it.copy(refreshState = refreshState) }
                 }
         }
+        viewModelScope.launch {
+            settings.warnOnMeteredNetwork.flow.collectLatest { warnOnMeteredNetwork ->
+                _state.update { it.copy(showDataWarning = warnOnMeteredNetwork) }
+            }
+        }
+        viewModelScope.launch {
+            settings.backgroundRefreshPodcasts.flow.collectLatest { refreshInBackground ->
+                _state.update { it.copy(refreshInBackground = refreshInBackground) }
+            }
+        }
     }
 
     fun setWarnOnMeteredNetwork(warnOnMeteredNetwork: Boolean) {
-        settings.warnOnMeteredNetwork.set(warnOnMeteredNetwork, needsSync = false)
-        _state.update { it.copy(showDataWarning = warnOnMeteredNetwork) }
+        settings.warnOnMeteredNetwork.set(warnOnMeteredNetwork, needsSync = true)
     }
 
     fun setRefreshPodcastsInBackground(isChecked: Boolean) {
         settings.backgroundRefreshPodcasts.set(isChecked, needsSync = false)
-        _state.update { it.copy(refreshInBackground = isChecked) }
     }
 
     fun signOut() {


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the global setting for warning on metered networks. This setting can be changed in multiple ways: Phone app and WearOS app.

## Testing prerequisites

To test wear OS you need either a physical device or prepare the app so you can use it with the wearOS emulator.

Build the *release* version of the app with this condition inverted.

```diff
--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -30,7 +30,7 @@ enum class Feature(
     SETTINGS_SYNC(
         key = "settings_sync",
         title = "Settings Sync",
-        defaultValue = BuildConfig.DEBUG,
+        defaultValue = !BuildConfig.DEBUG,
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,

```

## Testing Instructions

Each test requires two devices to check syncing. Sync process looks as follows.

1. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
2. Change the setting on the device 1.
3. Refresh settings on the device 1.
4. Refresh settings on the device 2.
5. Check settings on the device 2.

### Phone app

The setting is placed in `Profile`/`Settings (cog icon)`/`Storage & data use`/`Warn before using data`. When this setting is enabled and you are using metered network you should be able to trigger these popups when playing or downloading an episode.

| Download | Playback |
| - | - |
| ![Screenshot_20240131_133726](https://github.com/Automattic/pocket-casts-android/assets/30936061/505aee5d-1cc0-4166-b485-c39523d9edd1) | ![Screenshot_20240131_133705](https://github.com/Automattic/pocket-casts-android/assets/30936061/d7f89400-ef63-4caf-b811-30eb0d516587) |

> [!note]
> Playback popup won't appear again for the same episode once it's been played. However it will stop playing if during the playback you'll switch from a not metered to a metered network.

### WearOS app

The setting is placed in `Settings`/`Metered data warning`. When this setting is enabled and you are using metered network you should be able to trigger these popups when playing or downloading an episode.

| Download | Playback |
| - | - |
| ![Screenshot_20240131_133253](https://github.com/Automattic/pocket-casts-android/assets/30936061/1ab367da-69a7-42db-9f3f-9d61c461cd0b) | ![Screenshot_20240131_132730](https://github.com/Automattic/pocket-casts-android/assets/30936061/6f49b5e2-3f1c-4139-95af-5fbb82df5395) |

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
