### PR TITLE
Sentry set sample rate for errors

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -137,6 +137,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
         SentryAndroid.init(this) { options ->
             options.dsn = if (settings.sendCrashReports.value) settings.getSentryDsn() else ""
             options.setTag(SentryHelper.GLOBAL_TAG_APP_PLATFORM, AppPlatform.MOBILE.value)
+            options.sampleRate = 0.3
         }
 
         // Link email to Sentry crash reports only if the user has opted in


### PR DESCRIPTION
## Description
This sets a sample rate (0.3) for errors in Sentry.
Internal Ref: p1706544857589869-slack-C028JAG44VD

## Testing Instructions

1. Comment `if (isDebug)` condition in `SettingsFragmentPage` so that `DeveloperRow` is visible for the release build
2. Install release build
3. Go to `Profile` -> `Settings` -> `Developer`
4. Tap `Report a crash` 10 times
5. Open `Sentry`
6. Select the release in Sentry set in `versions.properties`
7. Look for `Exception: Test crash` and open in `Discover`
8. ✅ Notice that 3 instances are recorded recently (0.3 x 10)

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack