### PR TITLE
Sync auto add files to queue settings

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
@@ -33,7 +33,7 @@ class CloudSettingsViewModel @Inject constructor(
     }
 
     fun setAddToUpNext(enabled: Boolean) {
-        settings.cloudAddToUpNext.set(enabled, needsSync = false)
+        settings.cloudAddToUpNext.set(enabled, needsSync = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_FILES_AUTO_ADD_UP_NEXT_TOGGLED,
             mapOf("enabled" to enabled),

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -49,6 +49,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "privacyAnalytics") val collectAnalytics: NamedChangedSettingBool? = null,
     @field:Json(name = "privacyCrashReports") val sendCrashReports: NamedChangedSettingBool? = null,
     @field:Json(name = "privacyLinkAccount") val linkCrashReportsToUser: NamedChangedSettingBool? = null,
+    @field:Json(name = "filesAutoUpNext") val addFileToUpNextAutomatically: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -147,6 +147,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 collectAnalytics = settings.collectAnalytics.getSyncSetting(::NamedChangedSettingBool),
                 sendCrashReports = settings.sendCrashReports.getSyncSetting(::NamedChangedSettingBool),
                 linkCrashReportsToUser = settings.linkCrashReportsToUser.getSyncSetting(::NamedChangedSettingBool),
+                addFileToUpNextAutomatically = settings.cloudAddToUpNext.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -335,6 +336,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "privacyLinkAccount" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.linkCrashReportsToUser,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "filesAutoUpNext" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.cloudAddToUpNext,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing of the global settings for auto adding cloud files to the queue.

## Testing Instructions

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Files`/`Overflow menu (three dots)`/`File settings`.
4. D1: Toggle `Auto add to Up Next` setting to `ON`.
5. D1: Sync the device in the `Profile`.
6. D2: Sync the device in the `Profile`.
7. D2: Go to `Profile`/`Files`
8. D2: Add a file. It should be added automatically to queue.
9. D2: Got to `Overflow menu (three dots)`/`File settings`.
10. D2: Toggle `Auto add to Up Next` setting to `OFF`.
11. D2: Sync the device in the `Profile`.
12. D1: Sync the device in the `Profile`.
13. D1: Go to `Profile`/`Files`.
14. D1: Add a file. It shouldn't be added automatically to queue.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
