### PR TITLE
Sync crash reporting settings

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperPage.kt
@@ -1,7 +1,19 @@
 package au.com.shiftyjelly.pocketcasts.settings.developer
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.outlined.BugReport
@@ -11,15 +23,25 @@ import androidx.compose.material.icons.outlined.EditCalendar
 import androidx.compose.material.icons.outlined.HomeRepairService
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
+import au.com.shiftyjelly.pocketcasts.compose.components.FormField
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRow
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import io.sentry.Sentry
+import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -33,6 +55,9 @@ fun DeveloperPage(
     onTriggerUpdateEpisodeDetails: () -> Unit,
     onTriggerResetEoYModalProfileBadge: () -> Unit,
 ) {
+    var openCrashMessageDialog by remember { mutableStateOf(false) }
+    var crashMessage by remember { mutableStateOf("Test crash") }
+
     Column(modifier = modifier) {
         ThemedTopAppBar(
             title = stringResource(LR.string.settings_developer),
@@ -40,11 +65,25 @@ fun DeveloperPage(
         )
         ShowkaseSetting(onClick = onShowkaseClick)
         ForceRefreshSetting(onClick = onForceRefreshClick)
-        SendCrashSetting()
+        SendCrashSetting(
+            crashMessage = crashMessage,
+            onLongClick = { openCrashMessageDialog = true },
+        )
         TriggerNotificationSetting(onClick = onTriggerNotificationClick)
         DeleteFirstEpisodeSetting(onClick = onDeleteFirstEpisodeClick)
         TriggerUpdateEpisodeDetails(onClick = onTriggerUpdateEpisodeDetails)
         EndOfYear(onClick = onTriggerResetEoYModalProfileBadge)
+
+        if (openCrashMessageDialog) {
+            CrashMessageDialog(
+                initialMessage = crashMessage,
+                onDismiss = { openCrashMessageDialog = false },
+                onConfirm = { message ->
+                    openCrashMessageDialog = false
+                    crashMessage = message
+                },
+            )
+        }
     }
 }
 
@@ -75,17 +114,79 @@ private fun ForceRefreshSetting(
 }
 
 @Composable
+@OptIn(ExperimentalFoundationApi::class)
 private fun SendCrashSetting(
+    crashMessage: String,
+    onLongClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     SettingRow(
         primaryText = "Report a crash",
         secondaryText = "Send an exception to Sentry",
         icon = rememberVectorPainter(Icons.Outlined.BugReport),
-        modifier = modifier.clickable {
-            Sentry.captureException(Exception("Test crash"))
-        },
+        modifier = modifier.combinedClickable(
+            onClick = {
+                Sentry.captureException(Exception(crashMessage))
+                Timber.d("Test crash message: \"$crashMessage\"")
+            },
+            onLongClick = onLongClick,
+        ),
     )
+}
+
+@Composable
+private fun CrashMessageDialog(
+    initialMessage: String,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var message by remember { mutableStateOf(initialMessage) }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Card(
+            modifier = modifier
+                .wrapContentWidth()
+                .wrapContentHeight()
+                .padding(16.dp),
+            shape = RoundedCornerShape(16.dp),
+        ) {
+            Column(
+                modifier = Modifier
+                    .wrapContentHeight()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                TextH30(
+                    text = "Use a custom crash message",
+                    modifier = Modifier.padding(16.dp),
+                )
+                FormField(
+                    value = message,
+                    placeholder = "Crash message",
+                    onValueChange = { message = it },
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(
+                        onClick = { onDismiss() },
+                        modifier = Modifier.padding(8.dp),
+                    ) {
+                        Text("Dismiss")
+                    }
+                    TextButton(
+                        onClick = { onConfirm(message) },
+                        modifier = Modifier.padding(8.dp),
+                    ) {
+                        Text("Confirm")
+                    }
+                }
+            }
+        }
+    }
 }
 
 @Composable
@@ -166,5 +267,15 @@ private fun DeveloperPagePreview() {
         onDeleteFirstEpisodeClick = {},
         onTriggerUpdateEpisodeDetails = {},
         onTriggerResetEoYModalProfileBadge = {},
+    )
+}
+
+@Preview
+@Composable
+private fun CrashMessageDialogPreview() {
+    CrashMessageDialog(
+        initialMessage = "Test crash",
+        onDismiss = {},
+        onConfirm = {},
     )
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
@@ -41,6 +41,6 @@ class UserAnalyticsSettings @Inject constructor(
         val user = if (enabled) User().apply { email = syncManager.getEmail() } else null
         Sentry.setUser(user)
 
-        settings.linkCrashReportsToUser.set(enabled, needsSync = false)
+        settings.linkCrashReportsToUser.set(enabled, needsSync = true)
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
@@ -34,7 +34,7 @@ class UserAnalyticsSettings @Inject constructor(
         } else {
             SentryAndroid.init(context) { it.dsn = "" }
         }
-        settings.sendCrashReports.set(enabled, needsSync = false)
+        settings.sendCrashReports.set(enabled, needsSync = true)
     }
 
     fun updateLinkAccountSetting(enabled: Boolean) {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -48,6 +48,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "notifications") val showPodcastNotifications: NamedChangedSettingBool? = null,
     @field:Json(name = "privacyAnalytics") val collectAnalytics: NamedChangedSettingBool? = null,
     @field:Json(name = "privacyCrashReports") val sendCrashReports: NamedChangedSettingBool? = null,
+    @field:Json(name = "privacyLinkAccount") val linkCrashReportsToUser: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -47,6 +47,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "warnDataUsage") val warnDataUsage: NamedChangedSettingBool? = null,
     @field:Json(name = "notifications") val showPodcastNotifications: NamedChangedSettingBool? = null,
     @field:Json(name = "privacyAnalytics") val collectAnalytics: NamedChangedSettingBool? = null,
+    @field:Json(name = "privacyCrashReports") val sendCrashReports: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -145,6 +145,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 warnDataUsage = settings.warnOnMeteredNetwork.getSyncSetting(::NamedChangedSettingBool),
                 showPodcastNotifications = settings.notifyRefreshPodcast.getSyncSetting(::NamedChangedSettingBool),
                 collectAnalytics = settings.collectAnalytics.getSyncSetting(::NamedChangedSettingBool),
+                sendCrashReports = settings.sendCrashReports.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -323,6 +324,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "privacyAnalytics" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.collectAnalytics,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "privacyCrashReports" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.sendCrashReports,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -146,6 +146,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 showPodcastNotifications = settings.notifyRefreshPodcast.getSyncSetting(::NamedChangedSettingBool),
                 collectAnalytics = settings.collectAnalytics.getSyncSetting(::NamedChangedSettingBool),
                 sendCrashReports = settings.sendCrashReports.getSyncSetting(::NamedChangedSettingBool),
+                linkCrashReportsToUser = settings.linkCrashReportsToUser.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -329,6 +330,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "privacyCrashReports" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.sendCrashReports,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "privacyLinkAccount" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.linkCrashReportsToUser,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing of the global settings for enabling crash reports and linking user's account to those reports.

For easier testing I added setting custom messages to triggered crashes.

## Testing prerequisites

* This should be tested with a release version of the app.
* You must have the Sentry DSN property set. Otherwise crash reporting won't work and you'll see in the logs this message `WARNING: Sentry DSN gradle property 'pocketcastsSentryDsn' not found. Crash reporting won't work without this`.
* Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/14125118/developer.patch).

## Testing Instructions

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`Privacy`.
4. D1: Toggle `Crash reports` setting to `ON` and `Link your account to crashes` to `OFF`.
5. D1: Sync the device in the `Profile`.
6. D2: Sync the device in the `Profile`.
7. D2: Go to `Profile`/`Settings (cog icon)`/`Developer`.
8. D2: Long press `Report a crash` and set a custom message.
9. D2: Tap on `Report a crash` a couple of times. It is necessary because we use report sampling at 30%. Though not available on this branch, yet. Adding it here just in case this branch gets in sync with the sampling change.
10. Go to `Sentry`.
11. Select the release in Sentry set in `versions.properties`.
12. Look for an exception with your message and open it in `Discover`.
13. Make sure that your user data (like email) aren't attached to the exception.
14. D1: Go to `Profile`/`Settings (cog icon)`/`Privacy`.
15. D1: Toggle `Link your account to crashes` to `ON`.
16. D1: Sync the device in the `Profile`.
17. D2: Sync the device in the `Profile`.
18. D2: Go to `Profile`/`Settings (cog icon)`/`Developer`.
19. D2: Long press `Report a crash` and set a custom message.
20. D2: Tap on `Report a crash` a couple of times.
21. Go to `Sentry`.
22. Select the release in Sentry set in `versions.properties`.
23. Look for an exception with your message and open it in `Discover`.
24. Make sure that your user data (like email) is attached to the exception.
25. D1: Go to `Profile`/`Settings (cog icon)`/`Privacy`.
26. D1: Toggle `Crash reports` to `OFF`.
27. D1: Sync the device in the `Profile`.
28. D2: Sync the device in the `Profile`.
29. D2: Go to `Profile`/`Settings (cog icon)`/`Developer`.
30. D2: Long press `Report a crash` and set a custom message.
31. D2: Tap on `Report a crash` a couple of times.
32. Go to `Sentry`.
33. Select the release in Sentry set in `versions.properties`.
34. Make sure that the exception with the custom message isn't there.

## Screenshots or Screencast 

![Screenshot_20240201-130232](https://github.com/Automattic/pocket-casts-android/assets/30936061/cba92dab-9bcc-4a79-bb17-b181bb898825)

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack