### PR TITLE
Sync collecting privacy analytics setting

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTracker.kt
@@ -35,7 +35,7 @@ object AnalyticsTracker {
 
     fun setSendUsageStats(send: Boolean) {
         if (send != getSendUsageStats()) {
-            settings.collectAnalytics.set(send, needsSync = false)
+            settings.collectAnalytics.set(send, needsSync = true)
             if (!send) {
                 trackers.forEach { it.clearAllData() }
             }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -46,6 +46,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "autoUpNextLimitReached") val autoUpNextLimitReached: NamedChangedSettingInt? = null,
     @field:Json(name = "warnDataUsage") val warnDataUsage: NamedChangedSettingBool? = null,
     @field:Json(name = "notifications") val showPodcastNotifications: NamedChangedSettingBool? = null,
+    @field:Json(name = "privacyAnalytics") val collectAnalytics: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -144,6 +144,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 },
                 warnDataUsage = settings.warnOnMeteredNetwork.getSyncSetting(::NamedChangedSettingBool),
                 showPodcastNotifications = settings.notifyRefreshPodcast.getSyncSetting(::NamedChangedSettingBool),
+                collectAnalytics = settings.collectAnalytics.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -317,6 +318,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "notifications" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.notifyRefreshPodcast,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "privacyAnalytics" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.collectAnalytics,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing of the global settings for collecting Firebase events.

## Testing Instructions

I was not able to create a reliable test that would really see integration with the Firebase. We could test it with a proxy but I think it would be an overkill. Logs should suffice given that the single entry point for logging analytics is here.

https://github.com/Automattic/pocket-casts-android/blob/700c4f25137fa9f2ecdb34d17b1ccdf8a95eea9f/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/FirebaseAnalyticsTracker.kt#L263-L269

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. Have the Logcat opened for D2 with this filter `package:au.com.shiftyjelly.pocketcasts.debug message:"Analytic event"`.
4. D1: Go to `Profile`/`Setting (cog icon)`/`Privacy`.
5. D1: Toggle `Analytics` setting to `ON`.
6. D1: Sync the device in the `Profile`.
7. D2: Sync the device in the `Profile`.
8. D2: Clear the Logcat.
9. D2: Switch between different tabs.
10. D2: There should be no entries in the Logcat.
11. D1: Go to `Profile`/,Profile`/`Setting (cog icon)`/`Privacy`.
12. D1: Toggle `Analytics` setting to `OFF`.
13. D1: Sync the device in the `Profile`.
14. D2: Sync the device in the `Profile`.
15. D2: Clear the Logcat.
16. D2: Switch between different tabs.
17. D2: You should see in the Logcat entries related to opening different tabs.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
