### PR TITLE
Sync theme setting

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -419,6 +419,8 @@ class MainActivity :
         updateSystemColors()
 
         mediaRouter = MediaRouter.getInstance(this)
+
+        ThemeSettingObserver(theme, settings.theme, this).observeThemeChanges()
     }
 
     private fun resetEoYBadgeIfNeeded() {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/ThemeSettingObserver.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/ThemeSettingObserver.kt
@@ -1,0 +1,27 @@
+package au.com.shiftyjelly.pocketcasts.ui
+
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.ThemeSetting
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+class ThemeSettingObserver(
+    private val theme: Theme,
+    private val themeSetting: UserSetting<ThemeSetting>,
+    private val appCompatActivity: AppCompatActivity,
+) {
+    fun observeThemeChanges() {
+        appCompatActivity.lifecycleScope.launch {
+            appCompatActivity.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                themeSetting.flow.collectLatest { themeSetting ->
+                    theme.updateTheme(appCompatActivity, Theme.ThemeType.fromThemeSetting(themeSetting))
+                }
+            }
+        }
+    }
+}

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ThemeSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ThemeSetting.kt
@@ -3,17 +3,50 @@ package au.com.shiftyjelly.pocketcasts.preferences.model
 import android.content.SharedPreferences
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 
-enum class ThemeSetting(val id: String) {
-    LIGHT("light"),
-    DARK("dark"),
-    ROSE("rose"),
-    INDIGO("indigo"),
-    EXTRA_DARK("extraDark"),
-    DARK_CONTRAST("darkContrast"),
-    LIGHT_CONTRAST("lightContrast"),
-    ELECTRIC("electric"),
-    CLASSIC_LIGHT("classicLight"),
-    RADIOACTIVE("radioactive"),
+enum class ThemeSetting(
+    val id: String,
+    val serverId: Int,
+) {
+    LIGHT(
+        id = "light",
+        serverId = 0,
+    ),
+    DARK(
+        id = "dark",
+        serverId = 1,
+    ),
+    ROSE(
+        id = "rose",
+        serverId = 3,
+    ),
+    INDIGO(
+        id = "indigo",
+        serverId = 4,
+    ),
+    EXTRA_DARK(
+        id = "extraDark",
+        serverId = 2,
+    ),
+    DARK_CONTRAST(
+        id = "darkContrast",
+        serverId = 5,
+    ),
+    LIGHT_CONTRAST(
+        id = "lightContrast",
+        serverId = 6,
+    ),
+    ELECTRIC(
+        id = "electric",
+        serverId = 7,
+    ),
+    CLASSIC_LIGHT(
+        id = "classicLight",
+        serverId = 8,
+    ),
+    RADIOACTIVE(
+        id = "radioactive",
+        serverId = 9,
+    ),
     ;
 
     class UserSettingPref(
@@ -25,9 +58,12 @@ enum class ThemeSetting(val id: String) {
         defaultValue = defaultValue,
         sharedPrefs = sharedPrefs,
         fromString = { str ->
-            ThemeSetting.values().find { it.id == str }
-                ?: defaultValue
+            ThemeSetting.entries.find { it.id == str } ?: defaultValue
         },
         toString = { it.id },
     )
+
+    companion object {
+        fun fromServerId(id: Int) = entries.find { it.serverId == id } ?: LIGHT
+    }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -50,6 +50,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "privacyCrashReports") val sendCrashReports: NamedChangedSettingBool? = null,
     @field:Json(name = "privacyLinkAccount") val linkCrashReportsToUser: NamedChangedSettingBool? = null,
     @field:Json(name = "filesAutoUpNext") val addFileToUpNextAutomatically: NamedChangedSettingBool? = null,
+    @field:Json(name = "theme") val theme: NamedChangedSettingInt? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -14,6 +14,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingS
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveInactiveSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.PodcastGridLayoutType
+import au.com.shiftyjelly.pocketcasts.preferences.model.ThemeSetting
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -148,6 +149,12 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 sendCrashReports = settings.sendCrashReports.getSyncSetting(::NamedChangedSettingBool),
                 linkCrashReportsToUser = settings.linkCrashReportsToUser.getSyncSetting(::NamedChangedSettingBool),
                 addFileToUpNextAutomatically = settings.cloudAddToUpNext.getSyncSetting(::NamedChangedSettingBool),
+                theme = settings.theme.getSyncSetting { value, modifiedAt ->
+                    NamedChangedSettingInt(
+                        value = value.serverId,
+                        modifiedAt = modifiedAt,
+                    )
+                },
             ),
         )
 
@@ -342,6 +349,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.cloudAddToUpNext,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "theme" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.theme,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let(ThemeSetting::fromServerId),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")
                 }

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
@@ -271,7 +271,7 @@ class Theme @Inject constructor(private val settings: Settings) {
         ThemeType.fromThemeSetting(settings.theme.value)
 
     private fun setThemeToPreferences(theme: ThemeType) {
-        settings.theme.set(theme.themeSetting, needsSync = false)
+        settings.theme.set(theme.themeSetting, needsSync = true)
     }
 
     private fun getPreferredDarkThemeFromPreferences(): ThemeType =


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing of the global settings for the app theme.

## Testing Instructions

1. Have two devices D1 and D2.
2. On both devices disable `Profile`/`Setting (cog icon)`/`Appearance`/`Use Android Light/Dark Mode`. This setting is not synced and might be problematic during the test.
3. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
4. D1: Go to `Profile`/`Setting (cog icon)`/`Appearance`.
5. D1: Change the theme.
6. D1: Sync the device in the `Profile`.
7. D2: Sync the device in the `Profile`.
8. D2: Notice that theme changes. Screen might jump because applying theme in Pocket Casts recreates the Activity.
9. Test this with different themes.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
