### PR TITLE
Sync podcast badges setting

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
@@ -130,7 +130,7 @@ class PodcastsOptionsDialog(
                 checked = badgeType == BadgeType.OFF,
                 click = {
                     val newBadgeType = BadgeType.OFF
-                    settings.podcastBadgeType.set(newBadgeType, needsSync = false)
+                    settings.podcastBadgeType.set(newBadgeType, needsSync = true)
                     trackBadgeChanged(newBadgeType)
                 },
             )
@@ -139,7 +139,7 @@ class PodcastsOptionsDialog(
                 checked = badgeType == BadgeType.ALL_UNFINISHED,
                 click = {
                     val newBadgeType = BadgeType.ALL_UNFINISHED
-                    settings.podcastBadgeType.set(newBadgeType, needsSync = false)
+                    settings.podcastBadgeType.set(newBadgeType, needsSync = true)
                     trackBadgeChanged(newBadgeType)
                 },
             )
@@ -148,7 +148,7 @@ class PodcastsOptionsDialog(
                 checked = badgeType == BadgeType.LATEST_EPISODE,
                 click = {
                     val newBadgeType = BadgeType.LATEST_EPISODE
-                    settings.podcastBadgeType.set(newBadgeType, needsSync = false)
+                    settings.podcastBadgeType.set(newBadgeType, needsSync = true)
                     trackBadgeChanged(newBadgeType)
                 },
             )

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/BadgeType.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/BadgeType.kt
@@ -6,23 +6,27 @@ import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 
 enum class BadgeType(
     internal val persistedInt: Int,
+    val serverId: Int,
     @StringRes val labelId: Int,
     val analyticsValue: String,
 ) {
     OFF(
         persistedInt = 0,
+        serverId = 0,
         labelId = R.string.podcasts_badges_off,
         analyticsValue = "off",
     ),
 
     LATEST_EPISODE(
         persistedInt = 1,
+        serverId = 1,
         labelId = R.string.podcasts_badges_only_latest_episode,
         analyticsValue = "only_latest_episode",
     ),
 
     ALL_UNFINISHED(
         persistedInt = 2,
+        serverId = 2,
         labelId = R.string.podcasts_badges_all_unfinished,
         analyticsValue = "unfinished_episodes",
     ),
@@ -37,5 +41,7 @@ enum class BadgeType(
                     LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Unknown persisted int for badge type: $value")
                     defaultValue
                 }
+
+        fun fromServerId(id: Int) = entries.find { it.serverId == id } ?: defaultValue
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -51,6 +51,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "privacyLinkAccount") val linkCrashReportsToUser: NamedChangedSettingBool? = null,
     @field:Json(name = "filesAutoUpNext") val addFileToUpNextAutomatically: NamedChangedSettingBool? = null,
     @field:Json(name = "theme") val theme: NamedChangedSettingInt? = null,
+    @field:Json(name = "badges") val podcastBadges: NamedChangedSettingInt? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -12,6 +12,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoAddUpNextLimitBehaviour
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveInactiveSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.PodcastGridLayoutType
 import au.com.shiftyjelly.pocketcasts.preferences.model.ThemeSetting
@@ -152,6 +153,12 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 theme = settings.theme.getSyncSetting { value, modifiedAt ->
                     NamedChangedSettingInt(
                         value = value.serverId,
+                        modifiedAt = modifiedAt,
+                    )
+                },
+                podcastBadges = settings.podcastBadgeType.getSyncSetting { type, modifiedAt ->
+                    NamedChangedSettingInt(
+                        value = type.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
@@ -354,6 +361,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.theme,
                         newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let(ThemeSetting::fromServerId),
+                    )
+                    "badges" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.podcastBadgeType,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let(BadgeType::fromServerId),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")
                 }


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing of the global settings for displaying podcast badges.

## Testing Instructions

To test this you should be subscribed to a mix of different podcasts. There should be unfinished episodes, new episodes that you didn't listen to, and so on. 

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Podcasts`/`Overflow menu (three dots)`.
4. D1: Select `Only latest episode` badge type.
5. D1: Sync the device in the `Profile`.
6. D2: Sync the device in the `Profile`.
7. D2: Go to `Podcasts`.
8. D2: Notice dotted badges on podcasts.
9. D2: Open `Overflow menu (three dots)`.
10. D2: Select `All unfinished` badge type.
11. D2: Sync the device in the `Profile`.
12. D1: Sync the device in the `Profile`.
13. D1: Go to `Podcasts`.
14. D1: Notice counted badges on podcasts.
15. D1: Open `Overflow menu (three dots`).
16. D1: Select `Off` badge type.
17. D1: Sync the device in the `Profile`.
18. D2: Sync the device in the `Profile`.
19. D2: Go to `Podcasts`.
20. D2: Notice no badges on podcasts.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
