### PR TITLE
Refactor names for User eligibility for Intro offer

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
@@ -106,7 +106,7 @@ class CreateAccountViewModel
                             .mapNotNull {
                                 Subscription.fromProductDetails(
                                     productDetails = it,
-                                    isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(SubscriptionMapper.mapProductIdToTier(it.productId)),
+                                    isOfferEligible = subscriptionManager.isOfferEligible(SubscriptionMapper.mapProductIdToTier(it.productId)),
                                 )
                             }
                         subscriptionManager.getDefaultSubscription(subscriptions)?.let { updateSubscription(it) }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
@@ -64,7 +64,7 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
                         is ProductDetailsState.Loaded -> productDetails.productDetails.mapNotNull { productDetailsState ->
                             Subscription.fromProductDetails(
                                 productDetails = productDetailsState,
-                                isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(
+                                isOfferEligible = subscriptionManager.isOfferEligible(
                                     SubscriptionMapper.mapProductIdToTier(productDetailsState.productId),
                                 ),
                             )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -61,7 +61,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
                         is ProductDetailsState.Loaded -> productDetails.productDetails.mapNotNull { productDetailsState ->
                             Subscription.fromProductDetails(
                                 productDetails = productDetailsState,
-                                isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(
+                                isOfferEligible = subscriptionManager.isOfferEligible(
                                     SubscriptionMapper.mapProductIdToTier(productDetailsState.productId),
                                 ),
                             )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
@@ -53,12 +53,11 @@ class ProfileUpgradeBannerViewModel @Inject constructor(
                     val subscriptions = (productDetailsState as? ProductDetailsState.Loaded)
                         ?.productDetails
                         ?.mapNotNull { details ->
-                            val isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(
-                                SubscriptionMapper.mapProductIdToTier(details.productId),
-                            )
                             Subscription.fromProductDetails(
                                 productDetails = details,
-                                isFreeTrialEligible = isFreeTrialEligible,
+                                isOfferEligible = subscriptionManager.isOfferEligible(
+                                    SubscriptionMapper.mapProductIdToTier(details.productId),
+                                ),
                             )
                         } ?: emptyList()
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
@@ -52,7 +52,7 @@ class AccountDetailsViewModel
                 .mapNotNull {
                     Subscription.fromProductDetails(
                         productDetails = it,
-                        isFreeTrialEligible = subscriptionManager.isFreeTrialEligible(
+                        isOfferEligible = subscriptionManager.isOfferEligible(
                             SubscriptionMapper.mapProductIdToTier(it.productId),
                         ),
                     )

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -116,10 +116,10 @@ sealed interface Subscription {
         const val PATRON_YEARLY_PRODUCT_ID = "com.pocketcasts.yearly.patron"
         const val SUBSCRIPTION_TEST_PRODUCT_ID = "com.pocketcasts.plus.testfreetrialoffer"
         const val TRIAL_OFFER_ID = "plus-yearly-trial-30days"
-        const val INTRO_OFFER_ID = "testyearlyintropricingoffer"
+        const val INTRO_OFFER_ID = "testyearlyintropricingoffer-newusers"
 
-        fun fromProductDetails(productDetails: ProductDetails, isFreeTrialEligible: Boolean): Subscription? {
-            val subscription = SubscriptionMapper.map(productDetails, isFreeTrialEligible)
+        fun fromProductDetails(productDetails: ProductDetails, isOfferEligible: Boolean): Subscription? {
+            val subscription = SubscriptionMapper.map(productDetails, isOfferEligible)
             return if (FeatureFlag.isEnabled(Feature.INTRO_PLUS_OFFER_ENABLED) && subscription is Trial) null else subscription
         }
     }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
@@ -12,8 +12,8 @@ import java.time.Period
 import java.time.format.DateTimeParseException
 
 object SubscriptionMapper {
-    fun map(productDetails: ProductDetails, isFreeTrialEligible: Boolean): Subscription? {
-        val matchingSubscriptionOfferDetails = if (isFreeTrialEligible) {
+    fun map(productDetails: ProductDetails, isOfferEligible: Boolean): Subscription? {
+        val matchingSubscriptionOfferDetails = if (isOfferEligible) {
             productDetails
                 .subscriptionOfferDetails
                 ?.filter { it.offerSubscriptionPricingPhase != null } // get SubscriptionOfferDetails with offers

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -33,8 +33,8 @@ interface SubscriptionManager {
     fun launchBillingFlow(activity: Activity, productDetails: ProductDetails, offerToken: String)
     fun getCachedStatus(): SubscriptionStatus?
     fun clearCachedStatus()
-    fun isFreeTrialEligible(tier: Subscription.SubscriptionTier): Boolean
-    fun updateFreeTrialEligible(tier: Subscription.SubscriptionTier, eligible: Boolean)
+    fun isOfferEligible(tier: Subscription.SubscriptionTier): Boolean
+    fun updateOfferEligible(tier: Subscription.SubscriptionTier, eligible: Boolean)
     fun getDefaultSubscription(
         subscriptions: List<Subscription>,
         tier: Subscription.SubscriptionTier? = null,


### PR DESCRIPTION
## Description
- Since we are going to use  the Google-determined eligibility for intro offer (the same one we have for trial offer) we already have the user eligibility implemented. 
- We are going to display the offer for users that never had this subscription before. This case is this subscription -> `com.pocketcasts.plus.testfreetrialoffer`, but in PRO could be an plus yearly subscription as an example.
- This PR includes just renames and the new subscription product id 

This is part of: https://github.com/Automattic/pocket-casts-android/issues/1728

## Testing Instructions
The user eligibility was already tested for trial offer, but if you want to test it again, I will describe some tests you could do:

**Prerequisites**

1. Setup in app billing sandbox
2. Have the `INTRO_PLUS_OFFER_ENABLED` feature flag with `defaultValue` set to `true`

#### Free account without purchase history

1. Install the release build on device.
3. Sign-in to Google Play with an account that does not have a purchase history. _Make sure it is the primary account in case you have more than one account._
4. Launch the app
5. The intro offer should be displayed in the upgrade banner and the account screen

#### Free account with purchase history

1. (Clean) Install the release build.
2. Sign-in to Google Play with an account that has a purchase history.  _Make sure it is the primary account in case you have more than one account._
4. Launch the app.
5. The intro offer should not be displayed in the upgrade banner and the account screen

#### Paid account

1. Sign into the app with an account having active purchase. 
2. Since the purchase is active, user is subscribed to the plan and products list is not shown.

#### Test.4 Plan expired

1. Sign into the app with an account having expired purchase. 
2. Relaunch the app.
4. Sign-out from the app.
6. Notice that intro offer not shown for the test subscription.
7. Sign into app.
8. Notice that intro offer is not shown for the test subscription.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews

