### PR TITLE
Sync automotive settings

### DIFF
--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts
 
 import android.os.Bundle
-import android.view.View
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.EditTextPreference
 import androidx.preference.Preference
@@ -173,12 +172,10 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
     }
 
     private fun setupAbout() {
-        about.apply {
-            summary = getString(LR.string.settings_version, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE.toString())
-            setOnPreferenceClickListener {
-                (activity as? FragmentHostListener)?.addFragment(AutomotiveAboutFragment())
-                true
-            }
+        about.summary = getString(LR.string.settings_version, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE.toString())
+        about.setOnPreferenceClickListener {
+            (activity as? FragmentHostListener)?.addFragment(AutomotiveAboutFragment())
+            true
         }
     }
 }

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -58,8 +58,8 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
         setupAutoSubscribeToPlayed()
         setupAutoShowPlayed()
         setupSkipForward()
+        setupSkipBackward()
         setupRefreshNow()
-        changeSkipTitles()
         setupAbout()
     }
 
@@ -118,6 +118,25 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
             .launchIn(lifecycleScope)
     }
 
+    private fun setupSkipBackward() {
+        preferenceSkipBackward.setInputAsSeconds()
+        preferenceSkipBackward.setOnPreferenceChangeListener { _, newValue ->
+            val value = newValue.toString().toIntOrNull() ?: 0
+            if (value > 0) {
+                settings.skipBackInSecs.set(value, needsSync = true)
+                true
+            } else {
+                false
+            }
+        }
+        settings.skipBackInSecs.flow
+            .onEach {
+                preferenceSkipBackward.text = it.toString()
+                preferenceSkipBackward.summary = resources.getStringPluralSeconds(settings.skipBackInSecs.value)
+            }
+            .launchIn(lifecycleScope)
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun setupRefreshNow() {
         preferenceRefreshNow.setOnPreferenceClickListener {
@@ -153,21 +172,6 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
         preferenceRefreshNow.summary = status
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        preferenceSkipBackward.setOnPreferenceChangeListener { _, newValue ->
-            val value = newValue.toString().toIntOrNull() ?: 0
-            if (value > 0) {
-                settings.skipBackInSecs.set(value, needsSync = true)
-                changeSkipTitles()
-                true
-            } else {
-                false
-            }
-        }
-    }
-
     private fun setupAbout() {
         about.apply {
             summary = getString(LR.string.settings_version, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE.toString())
@@ -176,10 +180,5 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
                 true
             }
         }
-    }
-
-    private fun changeSkipTitles() {
-        val skipBackwardSummary = resources.getStringPluralSeconds(settings.skipBackInSecs.value)
-        preferenceSkipBackward.summary = skipBackwardSummary
     }
 }

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.toLiveData
 import androidx.preference.EditTextPreference
 import androidx.preference.Preference
@@ -22,6 +23,8 @@ import io.reactivex.Flowable
 import java.util.Date
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @AndroidEntryPoint
@@ -51,9 +54,22 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
         preferenceSkipBackward = findPreference(Settings.PREFERENCE_SKIP_BACKWARD)!!
         about = findPreference("about")!!
 
+        setupAutoPlay()
         changeSkipTitles()
         setupRefreshNow()
         setupAbout()
+    }
+
+    private fun setupAutoPlay() {
+        preferenceAutoPlay.apply {
+            setOnPreferenceChangeListener { _, newValue ->
+                settings.autoPlayNextEpisodeOnEmpty.set(newValue as Boolean, needsSync = true)
+                true
+            }
+        }
+        settings.autoPlayNextEpisodeOnEmpty.flow
+            .onEach { preferenceAutoPlay.isChecked = it }
+            .launchIn(lifecycleScope)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -55,6 +55,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
         about = findPreference("about")!!
 
         setupAutoPlay()
+        setupAutoSubscribeToPlayed()
         changeSkipTitles()
         setupRefreshNow()
         setupAbout()
@@ -69,6 +70,18 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
         }
         settings.autoPlayNextEpisodeOnEmpty.flow
             .onEach { preferenceAutoPlay.isChecked = it }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun setupAutoSubscribeToPlayed() {
+        preferenceAutoSubscribeToPlayed.apply {
+            setOnPreferenceChangeListener { _, newValue ->
+                settings.autoSubscribeToPlayed.set(newValue as Boolean, needsSync = false)
+                true
+            }
+        }
+        settings.autoSubscribeToPlayed.flow
+            .onEach { preferenceAutoSubscribeToPlayed.isChecked = it }
             .launchIn(lifecycleScope)
     }
 
@@ -115,15 +128,6 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
 
     override fun onResume() {
         super.onResume()
-
-
-        preferenceAutoSubscribeToPlayed.apply {
-            isChecked = settings.autoSubscribeToPlayed.value
-            setOnPreferenceChangeListener { _, newValue ->
-                settings.autoSubscribeToPlayed.set(newValue as Boolean, needsSync = false)
-                true
-            }
-        }
 
         preferenceAutoShowPlayed.apply {
             isChecked = settings.autoShowPlayed.value

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -63,11 +63,9 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
     }
 
     private fun setupAutoPlay() {
-        preferenceAutoPlay.apply {
-            setOnPreferenceChangeListener { _, newValue ->
-                settings.autoPlayNextEpisodeOnEmpty.set(newValue as Boolean, needsSync = true)
-                true
-            }
+        preferenceAutoPlay.setOnPreferenceChangeListener { _, newValue ->
+            settings.autoShowPlayed.set(newValue as Boolean, needsSync = false)
+            true
         }
         settings.autoPlayNextEpisodeOnEmpty.flow
             .onEach { preferenceAutoPlay.isChecked = it }
@@ -75,11 +73,9 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
     }
 
     private fun setupAutoSubscribeToPlayed() {
-        preferenceAutoSubscribeToPlayed.apply {
-            setOnPreferenceChangeListener { _, newValue ->
-                settings.autoSubscribeToPlayed.set(newValue as Boolean, needsSync = false)
-                true
-            }
+        preferenceAutoSubscribeToPlayed.setOnPreferenceChangeListener { _, newValue ->
+            settings.autoSubscribeToPlayed.set(newValue as Boolean, needsSync = false)
+            true
         }
         settings.autoSubscribeToPlayed.flow
             .onEach { preferenceAutoSubscribeToPlayed.isChecked = it }
@@ -87,11 +83,9 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
     }
 
     private fun setupAutoShowPlayed() {
-        preferenceAutoShowPlayed.apply {
-            setOnPreferenceChangeListener { _, newValue ->
-                settings.autoShowPlayed.set(newValue as Boolean, needsSync = false)
-                true
-            }
+        preferenceAutoShowPlayed.setOnPreferenceChangeListener { _, newValue ->
+            settings.autoShowPlayed.set(newValue as Boolean, needsSync = false)
+            true
         }
         settings.autoShowPlayed.flow
             .onEach { preferenceAutoShowPlayed.isChecked = it }

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -56,6 +56,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
 
         setupAutoPlay()
         setupAutoSubscribeToPlayed()
+        setupAutoShowPlayed()
         changeSkipTitles()
         setupRefreshNow()
         setupAbout()
@@ -82,6 +83,18 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
         }
         settings.autoSubscribeToPlayed.flow
             .onEach { preferenceAutoSubscribeToPlayed.isChecked = it }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun setupAutoShowPlayed() {
+        preferenceAutoShowPlayed.apply {
+            setOnPreferenceChangeListener { _, newValue ->
+                settings.autoShowPlayed.set(newValue as Boolean, needsSync = false)
+                true
+            }
+        }
+        settings.autoShowPlayed.flow
+            .onEach { preferenceAutoShowPlayed.isChecked = it }
             .launchIn(lifecycleScope)
     }
 
@@ -124,18 +137,6 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat(), Observe
         super.onDestroyView()
 
         refreshObservable?.removeObserver(this)
-    }
-
-    override fun onResume() {
-        super.onResume()
-
-        preferenceAutoShowPlayed.apply {
-            isChecked = settings.autoShowPlayed.value
-            setOnPreferenceChangeListener { _, newValue ->
-                settings.autoShowPlayed.set(newValue as Boolean, needsSync = false)
-                true
-            }
-        }
     }
 
     private fun setupAbout() {

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -74,7 +74,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
 
     private fun setupAutoSubscribeToPlayed() {
         preferenceAutoSubscribeToPlayed.setOnPreferenceChangeListener { _, newValue ->
-            settings.autoSubscribeToPlayed.set(newValue as Boolean, needsSync = false)
+            settings.autoSubscribeToPlayed.set(newValue as Boolean, needsSync = true)
             true
         }
         settings.autoSubscribeToPlayed.flow
@@ -84,7 +84,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
 
     private fun setupAutoShowPlayed() {
         preferenceAutoShowPlayed.setOnPreferenceChangeListener { _, newValue ->
-            settings.autoShowPlayed.set(newValue as Boolean, needsSync = false)
+            settings.autoShowPlayed.set(newValue as Boolean, needsSync = true)
             true
         }
         settings.autoShowPlayed.flow

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -374,7 +374,7 @@ class PodcastSyncProcess(
     private fun syncSettings(): Completable {
         return rxCompletable {
             val startTime = SystemClock.elapsedRealtime()
-            SyncSettingsTask.run(settings, syncManager)
+            SyncSettingsTask.run(context, settings, syncManager)
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Refresh - sync settings - ${String.format("%d ms", SystemClock.elapsedRealtime() - startTime)}")
         }
     }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -52,6 +52,8 @@ data class ChangedNamedSettings(
     @field:Json(name = "filesAutoUpNext") val addFileToUpNextAutomatically: NamedChangedSettingBool? = null,
     @field:Json(name = "theme") val theme: NamedChangedSettingInt? = null,
     @field:Json(name = "badges") val podcastBadges: NamedChangedSettingInt? = null,
+    @field:Json(name = "autoSubscribeToPlayed") val autoSubscribeToPlayed: NamedChangedSettingBool? = null,
+    @field:Json(name = "autoShowPlayed") val autoShowPlayed: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -16,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.PodcastGridLayoutType
 import au.com.shiftyjelly.pocketcasts.preferences.model.ThemeSetting
+import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -26,10 +27,14 @@ import timber.log.Timber
 
 class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) : CoroutineWorker(context, parameters) {
     companion object {
-        suspend fun run(settings: Settings, namedSettingsCall: NamedSettingsCaller): Result {
+        suspend fun run(
+            context: Context,
+            settings: Settings,
+            namedSettingsCall: NamedSettingsCaller,
+        ): Result {
             try {
                 if (FeatureFlag.isEnabled(Feature.SETTINGS_SYNC)) {
-                    syncSettings(settings, namedSettingsCall)
+                    syncSettings(context, settings, namedSettingsCall)
                 } else {
                     @Suppress("DEPRECATION")
                     oldSyncSettings(settings, namedSettingsCall)
@@ -45,6 +50,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
         }
 
         private suspend fun syncSettings(
+            context: Context,
             settings: Settings,
             namedSettingsCall: NamedSettingsCaller,
         ) {
@@ -54,12 +60,15 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 return
             }
 
-            val request = changedNamedSettingsRequest(settings)
+            val request = changedNamedSettingsRequest(context, settings)
             val response = namedSettingsCall.changedNamedSettings(request)
-            processChangedNameSettingsResponse(response, settings)
+            processChangedNameSettingsResponse(context, settings, response)
         }
 
-        private fun changedNamedSettingsRequest(settings: Settings) = ChangedNamedSettingsRequest(
+        private fun changedNamedSettingsRequest(
+            context: Context,
+            settings: Settings,
+        ) = ChangedNamedSettingsRequest(
             changedSettings = ChangedNamedSettings(
                 autoArchiveAfterPlaying = settings.autoArchiveAfterPlaying.getSyncSetting { autoArchiveAfterPlaying, modifiedAt ->
                     NamedChangedSettingInt(
@@ -162,12 +171,16 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         modifiedAt = modifiedAt,
                     )
                 },
-                autoShowPlayed = settings.autoShowPlayed.getSyncSetting(::NamedChangedSettingBool),
-                autoSubscribeToPlayed = settings.autoSubscribeToPlayed.getSyncSetting(::NamedChangedSettingBool),
+                autoShowPlayed = settings.autoShowPlayed.takeIf { Util.isAutomotive(context) }?.getSyncSetting(::NamedChangedSettingBool),
+                autoSubscribeToPlayed = settings.autoSubscribeToPlayed.takeIf { Util.isAutomotive(context) }?.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
-        private fun processChangedNameSettingsResponse(response: ChangedNamedSettingsResponse, settings: Settings) {
+        private fun processChangedNameSettingsResponse(
+            context: Context,
+            settings: Settings,
+            response: ChangedNamedSettingsResponse,
+        ) {
             for ((key, changedSettingResponse) in response) {
                 when (key) {
                     "autoArchiveInactive" -> updateSettingIfPossible(
@@ -359,16 +372,6 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         setting = settings.cloudAddToUpNext,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
-                    "autoShowPlayed" -> updateSettingIfPossible(
-                        changedSettingResponse = changedSettingResponse,
-                        setting = settings.autoShowPlayed,
-                        newSettingValue = (changedSettingResponse.value as? Boolean),
-                    )
-                    "autoSubscribeToPlayed" -> updateSettingIfPossible(
-                        changedSettingResponse = changedSettingResponse,
-                        setting = settings.autoSubscribeToPlayed,
-                        newSettingValue = (changedSettingResponse.value as? Boolean),
-                    )
                     "theme" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.theme,
@@ -378,6 +381,16 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.podcastBadgeType,
                         newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let(BadgeType::fromServerId),
+                    )
+                    "autoShowPlayed" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.autoShowPlayed,
+                        newSettingValue = (changedSettingResponse.value as? Boolean)?.takeIf { Util.isAutomotive(context = context) },
+                    )
+                    "autoSubscribeToPlayed" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.autoSubscribeToPlayed,
+                        newSettingValue = (changedSettingResponse.value as? Boolean)?.takeIf { Util.isAutomotive(context = context) },
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")
                 }
@@ -470,7 +483,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
     lateinit var namedSettingsCaller: NamedSettingsCaller
 
     override suspend fun doWork(): Result {
-        return run(settings, namedSettingsCaller)
+        return run(context, settings, namedSettingsCaller)
     }
 }
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -162,6 +162,8 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         modifiedAt = modifiedAt,
                     )
                 },
+                autoShowPlayed = settings.autoShowPlayed.getSyncSetting(::NamedChangedSettingBool),
+                autoSubscribeToPlayed = settings.autoSubscribeToPlayed.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -355,6 +357,16 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "filesAutoUpNext" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.cloudAddToUpNext,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "autoShowPlayed" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.autoShowPlayed,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "autoSubscribeToPlayed" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.autoSubscribeToPlayed,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     "theme" -> updateSettingIfPossible(


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing of the global settings specific to automotive app.

Syncing is done in 6eb8327ed7866b8890a18429af2b50c2c0f904a9. Other commits just clean up the code, switch to coroutines, and make the screen reactive to changes during sync.

## Testing Instructions

### Automotive subscribe syncing

1. Have two automotive devices D1 and D2.
2. Install `:automotive` app on them.
3. Make sure that both devices are synced before starting the test by refreshing apps in the settings.
4. D1: Go to `Settings (cog icon)`.
5. D1: Toggle `Subscribe to played podcasts` notification `ON`.
6. D1: Tap on `Refresh now`.
7. D2: Tap on `Refresh now`.
8. D2: Play a podcast that you're not subscribed to.
9. D2: Check `Podcasts` tab.
10. D2: Notice that you see that podcast there.
11. D2: Go to `Settings (cog icon)`.
12. D2: Toggle `Subscribe to played podcasts` notification `OFF`.
13. D2: Tap on `Refresh now`.
14. D1: Tap on `Refresh now`.
15. D1: Play a podcast that you're not subscribed to.
16. D1: Play a podcast that you're not subscribed to.
17. D1: Check `Podcasts` tab.
18. D1: Notice that the podcast you've just listened to isn't there.

### Android subscribe syncing

1. Have two devices D1 (automotive) and D2 (phone).
2. Install respective apps (`:automotive` and `:app`) on the devices.
3. Make sure that both devices are synced.
4. D1: Go to `Settings (cog icon)`.
5. D1: Toggle `Subscribe to played podcasts` notification `ON`.
6. D1: Tap on `Refresh now`.
7. D2: Go to `Profile` and tap on `Refresh now`.
8. D2: Play a podcast that you're not subscribed to.
9. D2: Check `Podcasts` tab.
10. D2: Notice that the podcast you've just listened to isn't there.

### Automotive show played syncing

> [!note]
> Before you start testing make sure that `Show archived` setting in the Android app is disabled.

1. Have an account with archived episodes.
2. Have two automotive devices D1 and D2.
3. Install `:automotive` app on them.
4. Make sure that both devices are synced before starting the test by refreshing apps in the settings.
5. D1: Go to `Settings (cog icon)`.
6. D1: Toggle `Show played episodes` notification `ON`.
7. D1: Tap on `Refresh now`.
8. D2: Tap on `Refresh now`.
9. D2: Open a podcast with archived episodes.
10. D2: You should see all episodes.
11. D2: Go to `Settings (cog icon)`.
12. D2: Toggle `Show played episodes` notification `OFF`.
13. D2: Tap on `Refresh now`.
14. D1: Tap on `Refresh now`.
15. D1: Open a podcast with archived episodes.
16. D1: You should not see archived episodes.

### Android show played syncing

> [!note]
> Before you start testing make sure that `Show archived` setting in the Android app is disabled.

1. Have two devices D1 (automotive) and D2 (phone).
2. Install respective apps (`:automotive` and `:app`) on the devices.
3. Make sure that both devices are synced.
4. D1: Go to `Settings (cog icon)`.
5. D1: Toggle `Show played episodes` notification `ON`.
6. D1: Tap on `Refresh now`.
7. D2: Go to `Profile` and tap on `Refresh now`.
8. D2: Open a podcast with archived episodes.
9. D2: You should not see archived episodes.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
