### PR TITLE
Intro offer: Update upgrade plus modal

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.account.components
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -13,7 +14,9 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
@@ -56,9 +59,12 @@ fun ProductAmountVerticalText(
 
 @Composable
 fun ProductAmountHorizontalText(
-    primaryText: String? = null,
-    secondaryText: String? = null,
-    lineThroughSecondaryText: Boolean = true,
+    price: String? = null,
+    priceTextFontSize: TextUnit = 22.sp,
+    originalPrice: String? = null,
+    period: String? = null,
+    originalPriceFontSize: TextUnit = 13.sp,
+    lineThroughOriginalPrice: Boolean = true,
     hasBackgroundAlwaysWhite: Boolean = false,
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
     modifier: Modifier = Modifier,
@@ -67,9 +73,10 @@ fun ProductAmountHorizontalText(
         modifier = modifier,
         verticalAlignment = verticalAlignment,
     ) {
-        if (primaryText != null) {
+        if (price != null) {
             TextH30(
-                text = primaryText,
+                text = price,
+                fontSize = priceTextFontSize,
                 color =
                 if (hasBackgroundAlwaysWhite) {
                     Color.Black
@@ -79,14 +86,27 @@ fun ProductAmountHorizontalText(
             )
         }
 
+        if (period != null) {
+            TextP60(
+                text = period,
+                fontSize = originalPriceFontSize,
+                color = MaterialTheme.theme.colors.primaryText02,
+                modifier = modifier.padding(start = 4.dp),
+                style = TextStyle(
+                    textDecoration = if (lineThroughOriginalPrice) TextDecoration.LineThrough else TextDecoration.None,
+                ),
+            )
+        }
+
         Spacer(modifier = Modifier.width(4.dp))
 
-        if (secondaryText != null) {
+        if (originalPrice != null) {
             TextP60(
-                text = secondaryText,
+                text = originalPrice,
+                fontSize = originalPriceFontSize,
                 color = MaterialTheme.theme.colors.primaryText02,
                 style = TextStyle(
-                    textDecoration = if (lineThroughSecondaryText) TextDecoration.LineThrough else TextDecoration.None,
+                    textDecoration = if (lineThroughOriginalPrice) TextDecoration.LineThrough else TextDecoration.None,
                 ),
             )
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
@@ -92,9 +92,6 @@ fun ProductAmountHorizontalText(
                 fontSize = originalPriceFontSize,
                 color = MaterialTheme.theme.colors.primaryText02,
                 modifier = modifier.padding(start = 4.dp),
-                style = TextStyle(
-                    textDecoration = if (lineThroughOriginalPrice) TextDecoration.LineThrough else TextDecoration.None,
-                ),
             )
         }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
@@ -147,10 +147,21 @@ fun OnboardingUpgradeBottomSheet(
 
             val descriptionText = state.selectedSubscription.offerPricingPhase.let { offerPhase ->
                 if (offerPhase != null) {
-                    stringResource(
-                        LR.string.onboarding_plus_recurring_after_free_trial,
-                        recurringAfterString(offerPhase, resources),
-                    )
+                    if (selectedSubscription is Subscription.Intro) {
+                        stringResource(
+                            LR.string.onboarding_plus_recurring_after_intro_offer,
+                            recurringAfterIntroString(
+                                offerPhase,
+                                state.selectedSubscription.recurringPricingPhase,
+                                resources,
+                            ),
+                        )
+                    } else {
+                        stringResource(
+                            LR.string.onboarding_plus_recurring_after_free_trial,
+                            recurringAfterTrialString(offerPhase, resources),
+                        )
+                    }
                 } else {
                     val firstLine = stringResource(state.selectedSubscription.recurringPricingPhase.renews)
                     val secondLine = stringResource(LR.string.onboarding_plus_can_be_canceled_at_any_time)
@@ -235,10 +246,16 @@ private val animationSpec = tween<IntSize>(
     easing = EaseInOut,
 )
 
-private fun recurringAfterString(
+private fun recurringAfterTrialString(
     offerSubscriptionPricingPhase: OfferSubscriptionPricingPhase,
     res: Resources,
-) = "${offerSubscriptionPricingPhase.numPeriodOffer(res)} (${offerSubscriptionPricingPhase.offerEnd()})"
+) = "${offerSubscriptionPricingPhase.numPeriodOffer(res, isTrial = true)} (${offerSubscriptionPricingPhase.offerEnd()})"
+private fun recurringAfterIntroString(
+    offerSubscriptionPricingPhase: OfferSubscriptionPricingPhase,
+    recurringSubscriptionPricingPhase: RecurringSubscriptionPricingPhase,
+    res: Resources,
+): String =
+    "${recurringSubscriptionPricingPhase.formattedPrice} ${res.getString(LR.string.onboarding_plus_recurring_after_intro_offer_sufix)} (${offerSubscriptionPricingPhase.offerEnd()})"
 
 fun SubscriptionTier.toSubscribeTitle() = when (this) {
     SubscriptionTier.PLUS -> R.string.onboarding_plus_subscribe

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
@@ -45,6 +45,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.type.OfferSubscriptionPricingPhase
+import au.com.shiftyjelly.pocketcasts.models.type.RecurringSubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
@@ -106,7 +107,11 @@ fun OnboardingUpgradeBottomSheet(
                         // as the user changes selections.
                         val interactionSource = remember(subscription) { MutableInteractionSource() }
 
-                        val text = subscription.recurringPricingPhase.pricePerPeriod(resources)
+                        val price = when (subscription) {
+                            is Subscription.Intro -> (subscription.offerPricingPhase as RecurringSubscriptionPricingPhase).pricePerPeriod(resources)
+                            else -> subscription.recurringPricingPhase.pricePerPeriod(resources)
+                        }
+
                         val topText = when (subscription) {
                             is Subscription.WithOffer -> subscription.badgeOfferText(resources).uppercase(Locale.getDefault())
                             else -> null
@@ -119,7 +124,7 @@ fun OnboardingUpgradeBottomSheet(
 
                             if (subscription == state.selectedSubscription) {
                                 OutlinedRowButton(
-                                    text = text,
+                                    text = price,
                                     topText = topText,
                                     subscriptionTier = subscriptionTier,
                                     brush = subscriptionTier.toOutlinedButtonBrush(),
@@ -129,7 +134,7 @@ fun OnboardingUpgradeBottomSheet(
                                 )
                             } else {
                                 UnselectedOutlinedRowButton(
-                                    text = text,
+                                    text = price,
                                     topText = topText,
                                     subscriptionTier = subscriptionTier,
                                     onClick = { viewModel.updateSelectedSubscription(subscription) },

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -26,6 +26,8 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.pager.PageSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -36,6 +38,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
@@ -63,6 +68,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalPagerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.components.StyledToggle
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.images.OfferBadge
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
@@ -72,6 +78,9 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSourc
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+private const val MAX_OFFER_BADGE_TEXT_LENGTH = 23
+private const val MIN_SCREEN_WIDTH_FOR_HORIZONTAL_DISPLAY = 400
 
 @Composable
 internal fun OnboardingUpgradeFeaturesPage(
@@ -297,22 +306,69 @@ private fun FeatureCard(
         Column(
             modifier = Modifier.padding(24.dp),
         ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 12.dp),
-                contentAlignment = Alignment.TopStart,
-            ) {
-                SubscriptionBadge(
-                    iconRes = card.iconRes,
-                    shortNameRes = card.shortNameRes,
-                    backgroundColor = Color.Black,
-                    textColor = Color.White,
-                )
+            var offerBadgeTextLength by remember { mutableStateOf(MAX_OFFER_BADGE_TEXT_LENGTH) }
+            val screenWidth = LocalConfiguration.current.screenWidthDp
+            val displayInHorizontal = screenWidth >= MIN_SCREEN_WIDTH_FOR_HORIZONTAL_DISPLAY && offerBadgeTextLength <= MAX_OFFER_BADGE_TEXT_LENGTH
+
+            if (displayInHorizontal) {
+                Row(
+                    horizontalArrangement = Arrangement.Start,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 12.dp),
+                ) {
+                    SubscriptionBadge(
+                        iconRes = card.iconRes,
+                        shortNameRes = card.shortNameRes,
+                        backgroundColor = Color.Black,
+                        textColor = Color.White,
+                        modifier = Modifier
+                            .wrapContentWidth()
+                            .wrapContentHeight(),
+                    )
+
+                    if (subscription is Subscription.WithOffer) {
+                        val offerText = subscription.badgeOfferText(LocalContext.current.resources)
+                        offerBadgeTextLength = offerText.length
+                        OfferBadge(
+                            text = offerText,
+                            backgroundColor = upgradeButton.backgroundColorRes,
+                            textColor = upgradeButton.textColorRes,
+                            modifier = Modifier.padding(start = 4.dp),
+                        )
+                    }
+                }
+            } else {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 8.dp),
+                ) {
+                    SubscriptionBadge(
+                        iconRes = card.iconRes,
+                        shortNameRes = card.shortNameRes,
+                        backgroundColor = Color.Black,
+                        textColor = Color.White,
+                        modifier = Modifier
+                            .wrapContentWidth()
+                            .wrapContentHeight(),
+                    )
+
+                    if (subscription is Subscription.WithOffer) {
+                        val offerText = subscription.badgeOfferText(LocalContext.current.resources)
+                        offerBadgeTextLength = offerText.length
+                        OfferBadge(
+                            text = offerText,
+                            backgroundColor = upgradeButton.backgroundColorRes,
+                            textColor = upgradeButton.textColorRes,
+                            modifier = Modifier.padding(top = 4.dp),
+                        )
+                    }
+                }
             }
 
             Column {
-                SubscriptionPriceSection(subscription, upgradeButton, hasBackgroundAlwaysWhite = true)
+                SubscriptionProductAmountHorizontal(subscription, hasBackgroundAlwaysWhite = true)
 
                 Spacer(modifier = Modifier.padding(vertical = 4.dp))
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -24,8 +24,10 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradeFeatu
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.ProfileUpgradeBannerViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.ProfileUpgradeBannerViewModel.State
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalPagerWrapper
+import au.com.shiftyjelly.pocketcasts.compose.images.OfferBadge
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -95,7 +97,7 @@ private fun FeatureCard(
         modifier = modifier.padding(horizontal = 16.dp),
     ) {
         Row(
-            horizontalArrangement = Arrangement.SpaceBetween,
+            horizontalArrangement = Arrangement.Start,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 12.dp),
@@ -104,12 +106,20 @@ private fun FeatureCard(
                 iconRes = card.iconRes,
                 shortNameRes = card.shortNameRes,
             )
+
+            if (button.subscription is Subscription.WithOffer) {
+                OfferBadge(
+                    text = (button.subscription as Subscription.WithOffer).badgeOfferText(LocalContext.current.resources),
+                    backgroundColor = button.backgroundColorRes,
+                    textColor = button.textColorRes,
+                    modifier = Modifier.padding(start = 4.dp),
+                )
+            }
         }
 
         Column {
-            SubscriptionPriceSection(
+            SubscriptionProductAmountHorizontal(
                 subscription = button.subscription,
-                upgradeButton = button,
             )
 
             card.featureItems.forEach {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionPriceSection.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionPriceSection.kt
@@ -20,15 +20,16 @@ fun SubscriptionPriceSection(
     if (subscription is Subscription.WithOffer) {
         if (subscription is Subscription.Intro) {
             ProductAmountHorizontalText(
-                primaryText = subscription.offerPricingPhase.priceSlashPeriod(LocalContext.current.resources),
-                secondaryText = subscription.recurringPricingPhase.priceSlashPeriod(LocalContext.current.resources),
+                price = subscription.offerPricingPhase.pricingPhase.formattedPrice,
+                period = subscription.offerPricingPhase.slashPeriod(LocalContext.current.resources),
+                originalPrice = subscription.recurringPricingPhase.priceSlashPeriod(LocalContext.current.resources),
                 hasBackgroundAlwaysWhite = hasBackgroundAlwaysWhite,
             )
         } else if (subscription is Subscription.Trial) {
             ProductAmountHorizontalText(
-                primaryText = subscription.recurringPricingPhase.formattedPrice,
-                secondaryText = subscription.recurringPricingPhase.slashPeriod(LocalContext.current.resources),
-                lineThroughSecondaryText = false,
+                price = subscription.recurringPricingPhase.formattedPrice,
+                originalPrice = subscription.recurringPricingPhase.slashPeriod(LocalContext.current.resources),
+                lineThroughOriginalPrice = false,
                 hasBackgroundAlwaysWhite = hasBackgroundAlwaysWhite,
             )
         }
@@ -42,9 +43,9 @@ fun SubscriptionPriceSection(
         )
     } else if (subscription is Subscription.Simple) {
         ProductAmountHorizontalText(
-            primaryText = subscription.recurringPricingPhase.formattedPrice,
-            secondaryText = subscription.recurringPricingPhase.slashPeriod(LocalContext.current.resources),
-            lineThroughSecondaryText = false,
+            price = subscription.recurringPricingPhase.formattedPrice,
+            originalPrice = subscription.recurringPricingPhase.slashPeriod(LocalContext.current.resources),
+            lineThroughOriginalPrice = false,
             hasBackgroundAlwaysWhite = hasBackgroundAlwaysWhite,
         )
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionProductAmountHorizontal.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionProductAmountHorizontal.kt
@@ -7,15 +7,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.account.components.ProductAmountHorizontalText
-import au.com.shiftyjelly.pocketcasts.compose.images.OfferBadge
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 
 @Composable
-fun SubscriptionPriceSection(
+fun SubscriptionProductAmountHorizontal(
     subscription: Subscription,
-    upgradeButton: UpgradeButton,
-    hasBackgroundAlwaysWhite: Boolean = false,
     modifier: Modifier = Modifier,
+    hasBackgroundAlwaysWhite: Boolean = false,
 ) {
     if (subscription is Subscription.WithOffer) {
         if (subscription is Subscription.Intro) {
@@ -35,12 +33,6 @@ fun SubscriptionPriceSection(
         }
 
         Spacer(modifier = modifier.padding(vertical = 4.dp))
-
-        OfferBadge(
-            text = subscription.badgeOfferText(LocalContext.current.resources),
-            backgroundColor = upgradeButton.backgroundColorRes,
-            textColor = upgradeButton.textColorRes,
-        )
     } else if (subscription is Subscription.Simple) {
         ProductAmountHorizontalText(
             price = subscription.recurringPricingPhase.formattedPrice,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
@@ -284,12 +284,14 @@ fun TextP60(
     textAlign: TextAlign? = null,
     maxLines: Int = Int.MAX_VALUE,
     fontWeight: FontWeight? = null,
+    fontSize: TextUnit? = null,
     style: TextStyle = TextStyle(),
 ) {
+    val fontSizeUpdated = fontSize ?: 13.sp
     Text(
         text = text,
         color = color,
-        fontSize = 13.sp,
+        fontSize = fontSizeUpdated,
         lineHeight = 15.sp,
         letterSpacing = 0.sp,
         maxLines = maxLines,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -128,7 +128,7 @@ fun SubscriptionBadgeForTier(
 fun OfferBadge(
     text: String,
     modifier: Modifier = Modifier,
-    fontSize: TextUnit = 14.sp,
+    fontSize: TextUnit = 11.sp,
     padding: Dp = 4.dp,
     backgroundColor: Int,
     textColor: Int,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
@@ -128,7 +129,7 @@ fun SubscriptionBadgeForTier(
 fun OfferBadge(
     text: String,
     modifier: Modifier = Modifier,
-    fontSize: TextUnit = 11.sp,
+    fontSize: TextUnit = 14.sp,
     padding: Dp = 4.dp,
     backgroundColor: Int,
     textColor: Int,
@@ -139,12 +140,13 @@ fun OfferBadge(
         modifier = modifier,
     ) {
         Row(
-            modifier = Modifier
+            modifier = modifier
                 .semantics(mergeDescendants = true) {}
                 .padding(horizontal = padding * 2, vertical = padding),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             TextH50(
+                textAlign = TextAlign.Center,
                 text = text.uppercase(),
                 color = colorResource(id = textColor),
                 fontSize = fontSize,

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1724,6 +1724,8 @@
     <string name="onboarding_plus_start_free_trial_and_subscribe">Start free trial &amp; subscribe</string>
     <string name="onboarding_plus_subscribe">Subscribe to Pocket&#160;Casts Plus</string>
     <string name="onboarding_plus_recurring_after_free_trial">Recurring payments will begin after your %s</string>
+    <string name="onboarding_plus_recurring_after_intro_offer">Recurring payment at %s</string>
+    <string name="onboarding_plus_recurring_after_intro_offer_sufix">after your first year</string>
     <string name="onboarding_plus_can_be_canceled_at_any_time">Can be canceled at any time.</string>
     <string name="onboarding_welcome_get_you_listening">Welcome, now let\'s get you listening!</string>
     <string name="onboarding_welcome_get_you_listening_plus">Thank you, now let\'s get you listening!</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -48,7 +48,7 @@ sealed interface Subscription {
         productDetails: ProductDetails,
         offerToken: String,
     ) : WithOffer(tier, recurringPricingPhase, offerPricingPhase, productDetails, offerToken) {
-        override fun badgeOfferText(res: Resources): String = offerPricingPhase.numPeriodOffer(res)
+        override fun badgeOfferText(res: Resources): String = offerPricingPhase.numPeriodOffer(res, isTrial = true)
 
         override fun numFreeThenPricePerPeriod(res: Resources): String {
             val stringRes = when (recurringPricingPhase) {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
@@ -6,8 +6,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_MO
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_YEARLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.SUBSCRIPTION_TEST_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.android.billingclient.api.ProductDetails
 import java.time.Period
@@ -146,10 +144,9 @@ object SubscriptionMapper {
             null
         }
 
-    fun mapProductIdToTier(productId: String) = when {
-        FeatureFlag.isEnabled(Feature.INTRO_PLUS_OFFER_ENABLED) && productId == SUBSCRIPTION_TEST_PRODUCT_ID -> SubscriptionTier.PLUS
-        productId in listOf(PLUS_MONTHLY_PRODUCT_ID, PLUS_YEARLY_PRODUCT_ID) -> SubscriptionTier.PLUS
-        productId in listOf(PATRON_MONTHLY_PRODUCT_ID, PATRON_YEARLY_PRODUCT_ID) -> SubscriptionTier.PATRON
+    fun mapProductIdToTier(productId: String) = when (productId) {
+        in listOf(PLUS_MONTHLY_PRODUCT_ID, PLUS_YEARLY_PRODUCT_ID, SUBSCRIPTION_TEST_PRODUCT_ID) -> SubscriptionTier.PLUS
+        in listOf(PATRON_MONTHLY_PRODUCT_ID, PATRON_YEARLY_PRODUCT_ID) -> SubscriptionTier.PATRON
         else -> SubscriptionTier.UNKNOWN
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionPricingPhase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionPricingPhase.kt
@@ -4,8 +4,6 @@ import android.content.res.Resources
 import androidx.annotation.StringRes
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.android.billingclient.api.ProductDetails
 import java.time.Period
@@ -22,11 +20,11 @@ sealed interface OfferSubscriptionPricingPhase : SubscriptionPricingPhase {
         res.getString(R.string.profile_amount_free, periodValuePlural(res))
 
     // i.e., 14 day offer
-    fun numPeriodOffer(res: Resources): String =
-        if (FeatureFlag.isEnabled(Feature.INTRO_PLUS_OFFER_ENABLED)) {
-            res.getString(R.string.plus_offer_duration, periodValueSingular(res))
-        } else {
+    fun numPeriodOffer(res: Resources, isTrial: Boolean): String =
+        if (isTrial) {
             res.getString(R.string.plus_trial_duration_free_trial, periodValueSingular(res))
+        } else {
+            res.getString(R.string.plus_offer_duration, periodValueSingular(res))
         }
 
     fun offerEnd(): String {


### PR DESCRIPTION
## Description
This PR does some UI updates:
1. Updates the size of the price displayed in the upgrade card
2. Updates the Recurring payment message
3. Updates the badges arrangement to be in horizontal 


## Testing Instructions
1. Setup in app billing sandbox
3. Have the `INTRO_PLUS_OFFER_ENABLED` feature flag with `defaultValue` set to `true`
4. Install the release build on device medium / large device
5. Sign-in to Google Play with an account that does not have a purchase history. Make sure it is the primary account in case you have more than one account.
6. Launch the app
7. Go to accounts -> See if the offer badge is displayed on the side of Plus badge
8. Click on `Subscribe to Plus` button -> Select the intro offer -> Check if the text matches with: `"Recurring payment at ${price} after your first year ({end date})"`
9. Go to Settings -> Pocket Casts Plus -> See if the offer badge is displayed on the side of Plus badge
10. Have the `INTRO_PLUS_OFFER_ENABLED` feature flag with `defaultValue` set to `false`
11. Install the release build on device.
12. Sign-in to Google Play with an account that does not have a purchase history. Make sure it is the primary account in case you have more than one account.
13. Launch the app
14. Go to accounts -> See if the offer badge is displayed on the side of Plus badge
15. Click on `Subscribe to Plus` button -> Select the intro offer -> Check if the text matches with: `Recurring payments will begin after your 1 month free trial ({end date})"`
16. Repeat the tests above with a small device. Depending on the size of the device or text the offer badge will be displayed below of plus badge

## Screenshots
|Upgrade modal | Profile banner update | Upgrade account banner |
| --- | --- | --- |
| ![Upgrade modal](https://github.com/Automattic/pocket-casts-android/assets/42220351/4708c2db-4d4c-4a01-9be4-d4570ea1c036) | ![Profile banner update](https://github.com/Automattic/pocket-casts-android/assets/42220351/d591c74d-fbc8-4269-8cd0-9f3c98a3f850) | ![Upgrade account banner](https://github.com/Automattic/pocket-casts-android/assets/42220351/ae418368-f445-4997-8c94-51a541f02506) |


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
