### PR TITLE
Slumber Studios - Add feature flag

### DIFF
--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
@@ -8,6 +8,7 @@ object FirebaseConfig {
     const val EPISODE_SEARCH_DEBOUNCE_MS = "episode_search_debounce_ms"
     const val CLOUD_STORAGE_LIMIT = "custom_storage_limit_gb"
     const val REPORT_VIOLATION_URL = "report_violation_url"
+    const val SLUMBER_STUDIOS_PROMO_CODE = "slumber_studios_promo_code"
     val defaults = mapOf(
         PERIODIC_SAVE_TIME_MS to 60000L,
         PODCAST_SEARCH_DEBOUNCE_MS to 2000L,

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -43,6 +43,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = false,
     ),
+    SLUMBER_STUDIOS_PROMO(
+        key = "slumber_studios_promo",
+        title = "Slumber Studios Promo",
+        defaultValue = false,
+        tier = FeatureTier.Plus(null),
+        hasFirebaseRemoteFlag = true,
+        hasDevToggle = false,
+    ),
     ;
 
     companion object {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
@@ -18,6 +18,10 @@ class FirebaseRemoteFeatureProvider @Inject constructor(
             firebaseRemoteConfig
                 .getString(FirebaseConfig.REPORT_VIOLATION_URL)
                 .isNotEmpty()
+        Feature.SLUMBER_STUDIOS_PROMO ->
+            firebaseRemoteConfig
+                .getString(FirebaseConfig.SLUMBER_STUDIOS_PROMO_CODE)
+                .isNotEmpty()
         else -> firebaseRemoteConfig.getBoolean(feature.key)
     }
 


### PR DESCRIPTION
## Description
This adds feature flag for Slumber Studios that depends on Firebase remote config `slumber_studios_promo_code` in the release build.

> [!WARNING]
> Targets 7.57

## Testing Instructions

#### Test.1 `slumber_studios_promo_code` is blank in `Firebase` remote config

1. `setMinimumFetchIntervalInSeconds` to 5L (5 secs) in `FirebaseModule`
2. Add a log statement at the end of `PocketCastsApplication.onCreate()` that prints `FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_PROMO)`
3. Install release build
4. Launch the app
5. ✅ Notice in logs that the feature flag for Slumber Studios is false

#### Test.2 `slumber_studios_promo_code` is not blank in `Firebase` remote config

1. Set a string value for `slumber_studios_promo_code` in `Firebase` remote config for Android app and publish changes
2. Kill the app
3. Restart the app
4. ✅ Notice in logs that the feature flag for Slumber Studios is true

Important (after tests are completed):
- Reset `slumber_studios_promo_code` in `Firebase` remote config for the Android app to a blank string and publish changes
- Uninstall the app that set minimum fetch interval to 5 secs

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
