### PR TITLE
Use last sync time as a default modified at timestamp

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/preferences/UserSettingTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/preferences/UserSettingTest.kt
@@ -2,6 +2,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import java.time.Instant
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertNull
@@ -52,13 +53,13 @@ class UserSettingTest {
 
     private fun assertWillSync(userSetting: UserSetting.StringPref, expected: String) {
         assertNotNull(userSetting.getModifiedAt())
-        val result = userSetting.getSyncSetting { value, _ -> value }
+        val result = userSetting.getSyncSetting(Instant.EPOCH) { value, _ -> value }
         assertEquals(expected, result)
     }
 
     private fun assertWillNotSync(userSetting: UserSetting.StringPref) {
         assertNull(userSetting.getModifiedAt())
-        val result = userSetting.getSyncSetting { _, _ -> Unit }
+        val result = userSetting.getSyncSetting(Instant.EPOCH) { _, _ -> Unit }
         assertNull(result)
     }
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -22,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureProvider
 import java.net.HttpURLConnection
+import java.time.Instant
 import java.util.Date
 import java.util.concurrent.TimeUnit
 import junit.framework.TestCase.assertEquals
@@ -223,7 +224,7 @@ class PodcastSyncProcessTest {
                 )
             mockWebServer.enqueue(response)
 
-            val lastModified = System.currentTimeMillis().toString()
+            val lastModified = Instant.ofEpochMilli(System.currentTimeMillis())
 
             syncProcess.performIncrementalSync(lastModified)
                 .doOnError {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -21,8 +21,8 @@ abstract class UserSetting<T>(
     }
 
     // Returns the value to sync if sync is needed. Returns null if sync is not needed.
-    fun <U> getSyncSetting(f: (T, String) -> U): U? {
-        val modifiedAtServerString = getModifiedAtServerString()
+    fun <U> getSyncSetting(lastSyncTime: Instant, f: (T, String) -> U): U? {
+        val modifiedAtServerString = getModifiedAtServerString() ?: lastSyncTime.takeIf { it != Instant.EPOCH }?.toString()
         // Only need to sync if modifiedAtServerString is not null
         return if (modifiedAtServerString != null) {
             f(value, modifiedAtServerString)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -33,6 +33,7 @@ import io.reactivex.Completable
 import io.reactivex.Maybe
 import io.reactivex.Single
 import java.io.File
+import java.time.Instant
 import retrofit2.Response
 
 interface SyncManager : NamedSettingsCaller, AccountStatusInfo {
@@ -84,7 +85,7 @@ interface SyncManager : NamedSettingsCaller, AccountStatusInfo {
     fun getPodcastEpisodes(podcastUuid: String): Single<PodcastEpisodesResponse>
 
     @Deprecated("This should no longer be used once the SETTINGS_SYNC feature flag is removed/permanently-enabled. Use userSyncUpdate instead.")
-    fun syncUpdate(data: String, lastModified: String): Single<au.com.shiftyjelly.pocketcasts.servers.sync.update.SyncUpdateResponse>
+    fun syncUpdate(data: String, lastSyncTime: Instant): Single<au.com.shiftyjelly.pocketcasts.servers.sync.update.SyncUpdateResponse>
 
     suspend fun userSyncUpdate(request: SyncUpdateRequest): SyncUpdateResponse
     fun episodeSync(request: EpisodeSyncRequest): Completable

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -52,6 +52,7 @@ import io.reactivex.Maybe
 import io.reactivex.Single
 import java.io.File
 import java.net.HttpURLConnection
+import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.rx2.rxSingle
@@ -348,11 +349,11 @@ class SyncManagerImpl @Inject constructor(
 // Sync
 
     @Deprecated("This should no longer be used once the SETTINGS_SYNC feature flag is removed/permanently-enabled.")
-    override fun syncUpdate(data: String, lastModified: String): Single<au.com.shiftyjelly.pocketcasts.servers.sync.update.SyncUpdateResponse> =
+    override fun syncUpdate(data: String, lastSyncTime: Instant): Single<au.com.shiftyjelly.pocketcasts.servers.sync.update.SyncUpdateResponse> =
         getEmail()?.let { email ->
             getCacheTokenOrLoginRxSingle { token ->
                 @Suppress("DEPRECATION")
-                syncServerManager.syncUpdate(email, data, lastModified, token)
+                syncServerManager.syncUpdate(email, data, lastSyncTime, token)
             }
         } ?: Single.error(Exception("Not logged in"))
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -8,6 +8,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import java.time.Duration
+import java.time.Instant
 import java.util.Date
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -48,6 +49,7 @@ class PodcastSyncProcessTest {
                 trimMode = TrimMode.HIGH,
                 isVolumeBoosted = true,
             ),
+            Instant.now(),
         ).podcast
 
         assertEquals(addedDateSinceEpoch.seconds, record.dateAdded.seconds)
@@ -67,6 +69,7 @@ class PodcastSyncProcessTest {
     fun podcastToRecord_subscribed() {
         val record = PodcastSyncProcess.toRecord(
             mockPodcast(isSubscribed = true),
+            Instant.now(),
         ).podcast
 
         assertFalse(record.isDeleted.value)
@@ -77,6 +80,7 @@ class PodcastSyncProcessTest {
     fun podcastToRecord_unsubscribed() {
         val record = PodcastSyncProcess.toRecord(
             mockPodcast(isSubscribed = false),
+            Instant.now(),
         ).podcast
 
         assertTrue(record.isDeleted.value)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
@@ -33,6 +33,7 @@ import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Single
 import java.io.File
+import java.time.Instant
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -126,13 +127,13 @@ open class SyncServerManager @Inject constructor(
         server.namedSettings(addBearer(token), request)
 
     @Deprecated("This should no longer be used once the SETTINGS_SYNC feature flag is removed/permanently-enabled.")
-    fun syncUpdate(email: String, data: String, lastModified: String, token: AccessToken): Single<au.com.shiftyjelly.pocketcasts.servers.sync.update.SyncUpdateResponse> {
+    fun syncUpdate(email: String, data: String, lastSyncTime: Instant, token: AccessToken): Single<au.com.shiftyjelly.pocketcasts.servers.sync.update.SyncUpdateResponse> {
         val fields = mutableMapOf(
             "email" to email,
             "token" to token.value,
             "data" to data,
             "device_utc_time_ms" to System.currentTimeMillis().toString(),
-            "last_modified" to lastModified,
+            "last_modified" to lastSyncTime.toString(),
         )
         addDeviceFields(fields)
 


### PR DESCRIPTION
## Description

This PR uses last sync timestamp as a default modification timestamp when the value of a setting modification timestamp is unknown. We do this because we want to make sure that all settings sync when the feature is enabled. Otherwise users would have to re-trigger all of the settings one by one.

Closes #1762 

## Testing Instructions

1. Have two devices D1 and D2.
2. D1: Install the app from c86132a18ae6eebe67b65ccde33f46e9173c7dd1.
3. D1: Sign up with a new account.
4. D1: Subscribe to any podcast.
5. D1: Go to this podcast settings.
6. D1: Enable notifications for this podcast.
7. D1: Set custom playback effects for this podcast.
8. D1: Go to the global settings in the profile.
9. D1: Go to `General`.
10. D1: Change `Row action` setting.
11. D1: Change `Up Next swipe` setting.
12. D1: Change `Podcast episode grouping` setting.
13. D1: Change `Media notification controls` setting`.
14. D1: Go back to general settings and open `Notifications`.
15. D1: Change `Play over notifications` setting.
16. D1: Sync the device in the profile.
17. D1: Close the app.
18. D1: Update the app with the one from this branch.
19. D1: Sync the device in the profile.
20. D1: Make sure that all of the settings that you changed are still applied.
21. D2: Install the app from this branch.
22. D2: Sign in with the same account as in step 3.
23. D2: Sync the device in the profile.
24. D2: Check if all of the setting that you changed applied (both podcast and global settings).

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
