### PR TITLE
Sync filters when basic settings change

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterViewModel.kt
@@ -88,6 +88,7 @@ class CreateFilterViewModel @Inject constructor(
         playlist.title = filterName.value ?: ""
         playlist.iconId = Playlist.calculateCombinedIconId(colorIndex, iconIndex)
         playlist.draft = false
+        playlist.syncStatus = Playlist.SYNC_STATUS_NOT_SYNCED
 
         // If in filter creation flow a filter is not being updated by the user,
         // there are no user updated playlist properties
@@ -119,6 +120,7 @@ class CreateFilterViewModel @Inject constructor(
         launch {
             playlist.value?.let { playlist ->
                 playlist.autoDownload = autoDownload
+
                 val userPlaylistUpdate = if (isAutoDownloadSwitchInitialized) {
                     userChangedAutoDownload.recordUserChange()
                     UserPlaylistUpdate(


### PR DESCRIPTION
## Description

Changes to the name, color, and icon of a filter did not trigger a need to sync the filter.

Closes #1721

## Testing Instructions

1. Have an account with at least one filter.
2. Have to devices D1 and D2.
3. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
4. D1: Go to `Filter`/`<YOUR_FILTER>`/`Overflow menu (three dots)`/`Filter settings`.
5. D1: Change the name of the filter.
6. D1: Go back.
7. D1: Sync the device in the `Profile`.
8. D2: Sync the device in the `Profile`.
9. D2: Go to `Filter` and notice that your filter changed the name.
10. D2: Go to `<YOUR_FILTER>`/`Overflow menu (three dots)`/`Filter settings`.
11. D2: Change the color of your filter.
12. D2: Go back.
13. D2: Sync the device in the `Profile`.
14. D1: Sync the device in the `Profile`.
15. D1: Go to `Filter` and notice that your filter change the color.
16. D1: Go to `<YOUR_FILTER>`/`Overflow menu (three dots)`/`Filter settings`.
17. D1: Change the icon of your filter.
18. D1: Go back.
19. D1: Sync the device in the `Profile`.
20. D2: Sync the device in the `Profile`.
21. D2: Go to `Filter` and notice that your filter changed the icon.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
