### PR TITLE
Slumber Studios - Full Modal What's new 

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -807,7 +807,6 @@ class MainActivity :
                     if (state.shouldShowWhatsNew) {
                         showBottomSheet(
                             fragment = WhatsNewFragment(),
-                            swipeEnabled = false,
                         )
                         viewModel.onWhatsNewShown()
                     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/SlumberStudiosHeader.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/SlumberStudiosHeader.kt
@@ -48,6 +48,7 @@ private const val PaddingTop = 80
 fun SlumberStudiosHeader(
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
+    fullModal: Boolean = true,
 ) {
     val width = LocalConfiguration.current.screenWidthDp - 48
     val size = width / slumberStudioImageResItems.size
@@ -62,7 +63,7 @@ fun SlumberStudiosHeader(
                 .fillMaxWidth()
                 .clipToBounds()
                 .height((size * 2 + PaddingTop).dp)
-                .padding(top = PaddingTop.dp),
+                .then(if (fullModal) Modifier else Modifier.padding(top = PaddingTop.dp)),
         ) {
             Row(
                 horizontalArrangement = Arrangement.Center,
@@ -92,10 +93,12 @@ fun SlumberStudiosHeader(
             }
         }
 
-        RowCloseButton(
-            onClose = onClose,
-            tintColor = if (MaterialTheme.theme.isLight) Color.Black else Color.White,
-        )
+        if (!fullModal) {
+            RowCloseButton(
+                onClose = onClose,
+                tintColor = if (MaterialTheme.theme.isLight) Color.Black else Color.White,
+            )
+        }
     }
 }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.bottomsheet.Pill
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowTextButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
@@ -128,9 +129,12 @@ private fun WhatsNewPageLoaded(
                 modifier = Modifier,
             ) {
                 if (state.fullModel) {
+                    Spacer(Modifier.height(8.dp))
+
+                    Pill()
+
                     Box(
                         modifier = Modifier
-                            .padding(top = 16.dp)
                             .align(Alignment.Start),
                     ) {
                         RowTextButton(

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
@@ -71,7 +71,7 @@ fun WhatsNewPage(
                         is WhatsNewFeature.SlumberStudiosPromo ->
                             SlumberStudiosHeader(
                                 onClose = onClose,
-                                fullModal = uiState.fullModel
+                                fullModal = uiState.fullModel,
                             )
                     }
                 },

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
@@ -52,6 +52,7 @@ class WhatsNewViewModel @Inject constructor(
                         promoCode = settings.getSlumberStudiosPromoCode(),
                         message = LR.string.whats_new_slumber_studios_body,
                     ),
+                    fullModel = true,
                     tier = userTier,
                 )
             }
@@ -62,6 +63,7 @@ class WhatsNewViewModel @Inject constructor(
                         message = LR.string.whats_new_slumber_studios_body_free_user,
                         isUserEntitled = false,
                     ),
+                    fullModel = true,
                     tier = userTier,
                 )
             }
@@ -143,6 +145,7 @@ class WhatsNewViewModel @Inject constructor(
         data class Loaded(
             val feature: WhatsNewFeature,
             val tier: UserTier,
+            val fullModel: Boolean = false,
         ) : UiState()
     }
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowOutlinedButton.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowOutlinedButton.kt
@@ -53,20 +53,21 @@ fun RowOutlinedButton(
     leadingIcon: Painter? = null,
     tintIcon: Boolean = true,
     onClick: () -> Unit,
+    fullWidth: Boolean = true,
 ) {
     Row(
         modifier = modifier
             .then(if (includePadding) Modifier.padding(16.dp) else Modifier)
-            .fillMaxWidth(),
+            .then(if (fullWidth) Modifier.fillMaxWidth() else Modifier),
     ) {
         OutlinedButton(
             onClick = { onClick() },
             shape = RoundedCornerShape(12.dp),
             border = border,
             colors = colors,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = if (fullWidth) Modifier.fillMaxWidth() else Modifier,
         ) {
-            Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
+            Box(if (fullWidth) Modifier.fillMaxWidth() else Modifier, contentAlignment = Alignment.CenterStart) {
                 RowOutlinedImage(
                     image = leadingIcon,
                     colors = colors,
@@ -75,7 +76,7 @@ fun RowOutlinedButton(
                 Row(
                     horizontalArrangement = Arrangement.Center,
                     verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = if (fullWidth) Modifier.fillMaxWidth() else Modifier,
                 ) {
                     RowOutlinedImage(
                         image = textIcon,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowTextButton.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowTextButton.kt
@@ -21,6 +21,7 @@ fun RowTextButton(
     fontSize: TextUnit? = null,
     tintIcon: Boolean = true,
     onClick: () -> Unit,
+    fullWidth: Boolean = true,
 ) {
     RowOutlinedButton(
         text = text,
@@ -32,6 +33,7 @@ fun RowTextButton(
         fontSize = fontSize,
         tintIcon = tintIcon,
         onClick = onClick,
+        fullWidth = fullWidth,
     )
 }
 


### PR DESCRIPTION
## Description
This converts Slumber Studios what's new to full modal.

## Testing Instructions
1. Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/14176680/patch_whats_new.patch)
2. Install debugProd build
3. Launch the app
4. ✅ Notice what's new for `Slumber Studios` promo is displayed in full modal
5. ✅ Swiping down should resize the modal
6. Tap Cancel
7.  ✅ Modal should dismiss

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/20eac4b0-5902-4425-b624-aeb438fc6b79

Landscape

<img width=500 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/00bc231b-3a91-4db3-b501-489c72863c9f"/>

Small screen

<img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/0afd6933-d742-4fc0-a7fd-6b1490930f28"/>


Since we're merging changes to a frozen branch, the modal can be converted to pop-up again by updating the fullModal variable in the view modal, in case it is needed

<img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/d0d0613c-cc16-4030-a3fd-2d2bfd841a98"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
