### PR TITLE
Slumber Studios - What's New Full Flow

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,7 +20,7 @@
 # https://github.com/shiftyjelly/pocketcasts-android/issues/1656
 -keep class au.com.shiftyjelly.pocketcasts.core.player.** { *; }
 
--dontwarn au.com.shiftyjelly.pocketcasts.ui.R$style
+-dontwarn au.com.shiftyjelly.pocketcasts.*.R$style
 -dontwarn android.test.**
 -dontwarn org.junit.internal.runners.statements.**
 -dontwarn org.junit.rules.**

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,7 +20,6 @@
 # https://github.com/shiftyjelly/pocketcasts-android/issues/1656
 -keep class au.com.shiftyjelly.pocketcasts.core.player.** { *; }
 
--dontwarn au.com.shiftyjelly.pocketcasts.*.R$style
 -dontwarn android.test.**
 -dontwarn org.junit.internal.runners.statements.**
 -dontwarn org.junit.rules.**
@@ -172,6 +171,7 @@
 -dontwarn au.com.shiftyjelly.pocketcasts.*.R$id
 -dontwarn au.com.shiftyjelly.pocketcasts.*.R$layout
 -dontwarn au.com.shiftyjelly.pocketcasts.*.R$string
+-dontwarn au.com.shiftyjelly.pocketcasts.*.R$style
 -dontwarn au.com.shiftyjelly.pocketcasts.*.R$styleable
 -dontwarn com.google.android.material.R$attr
 -dontwarn com.google.android.material.R$dimen

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,6 +20,7 @@
 # https://github.com/shiftyjelly/pocketcasts-android/issues/1656
 -keep class au.com.shiftyjelly.pocketcasts.core.player.** { *; }
 
+-dontwarn au.com.shiftyjelly.pocketcasts.ui.R$style
 -dontwarn android.test.**
 -dontwarn org.junit.internal.runners.statements.**
 -dontwarn org.junit.rules.**

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -65,7 +65,9 @@ class WhatsNewFragment : BaseFragment() {
                                 AnalyticsEvent.WHATSNEW_CONFIRM_BUTTON_TAPPED,
                                 mapOf("version" to Settings.WHATS_NEW_VERSION_CODE),
                             )
-                            onClose()
+                            if (it.shouldCloseOnConfirm) {
+                                onClose()
+                            }
                             performConfirmAction(it)
                             confirmActionClicked = true
                         },

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
@@ -231,6 +231,7 @@ private fun Message(
         textStyleResId = UR.style.P40,
         gravity = Gravity.CENTER_HORIZONTAL,
         modifier = Modifier.padding(horizontal = 16.dp),
+        selectable = true,
     )
 }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
@@ -114,7 +114,7 @@ private fun WhatsNewPageLoaded(
             .clickable(
                 indication = null,
                 interactionSource = remember { MutableInteractionSource() },
-                onClick = performClose,
+                onClick = { if (!state.fullModel) performClose() },
             )
             .padding(if (state.fullModel) 0.dp else 16.dp)
             .fillMaxSize(),

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
@@ -37,10 +37,16 @@ class WhatsNewViewModel @Inject constructor(
     val navigationState = _navigationState.asSharedFlow()
 
     init {
-        if (FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_PROMO)) {
-            updateStateForSlumberStudiosPromo()
-        } else {
-            updateStateForBookmarks()
+        viewModelScope.launch {
+            settings.cachedSubscriptionStatus.flow
+                .stateIn(viewModelScope)
+                .collect {
+                    if (FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_PROMO)) {
+                        updateStateForSlumberStudiosPromo()
+                    } else {
+                        updateStateForBookmarks()
+                    }
+                }
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
@@ -133,7 +133,10 @@ class WhatsNewViewModel @Inject constructor(
                 is WhatsNewFeature.SlumberStudiosPromo -> if (currentState.feature.isUserEntitled) {
                     NavigationState.SlumberStudiosRedeemPromoCode
                 } else {
-                    NavigationState.StartUpsellFlow(OnboardingUpgradeSource.SLUMBER_STUDIOS)
+                    NavigationState.StartUpsellFlow(
+                        source = OnboardingUpgradeSource.SLUMBER_STUDIOS,
+                        shouldCloseOnConfirm = false,
+                    )
                 }
             }
             _navigationState.emit(target)
@@ -185,10 +188,15 @@ class WhatsNewViewModel @Inject constructor(
         )
     }
 
-    sealed class NavigationState {
+    sealed class NavigationState(
+        open val shouldCloseOnConfirm: Boolean = true,
+    ) {
         data object HeadphoneControlsSettings : NavigationState()
         data object FullScreenPlayerScreen : NavigationState()
-        data class StartUpsellFlow(val source: OnboardingUpgradeSource) : NavigationState()
-        data object SlumberStudiosRedeemPromoCode : NavigationState()
+        data class StartUpsellFlow(
+            val source: OnboardingUpgradeSource,
+            override val shouldCloseOnConfirm: Boolean = true,
+        ) : NavigationState()
+        data object SlumberStudiosRedeemPromoCode : NavigationState(shouldCloseOnConfirm = false)
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/text/HtmlText.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/text/HtmlText.kt
@@ -26,6 +26,7 @@ fun HtmlText(
     linkColor: Color = MaterialTheme.theme.colors.primaryInteractive01,
     maxLines: Int = Int.MAX_VALUE,
     lineSpacingMultiplier: Float = 1.4f,
+    selectable: Boolean = false,
     @StyleRes textStyleResId: Int = UR.style.H50,
 ) {
     AndroidView(
@@ -38,6 +39,7 @@ fun HtmlText(
                 setMaxLines(maxLines)
                 setTextColor(color.toArgb())
                 setLinkTextColor(linkColor.toArgb())
+                setTextIsSelectable(selectable)
                 movementMethod = LinkMovementMethod.getInstance()
             }
         },


### PR DESCRIPTION
## Description

This PR
- Prevents modal from closing when confirm action is tapped
- Updates layout after subscribing to Plus
- Makes text body selectable
- Prevents modal from accidental closing on layout tap (so that promo code can be copied)

## Testing Instructions

Prerequisite
- Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/14193646/patch-test-promo.patch)
- Release build
- License test account

1. Login with license test account having no plan linked with it (free user)
2. Force kill and relaunch the app
3. Slumber Studios - What's New should be shown
4. Tap `Subscribe to Plus`
5. Complete purchase flow
6. ✅ Notice that the text is updated on the modal and promo code is shown
7. Try to select the promo code
8. ✅ Notice that the text is selectable
9. Tap anywhere on the modal body
10. ✅ Notice that the modal is not dismissed

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/03adcb5c-7dc2-4905-9a3b-8a4bed4bdb91

I also tested the scenario when a user is not signed in and completes the purchase flow after login from what's new modal

https://github.com/Automattic/pocket-casts-android/assets/1405144/17e37bc8-5271-4276-a700-9175afaadb20


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
