### PR TITLE
Intro offer: Remove test subscription product ID and update intro offer id

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -114,7 +114,6 @@ sealed interface Subscription {
         const val PLUS_YEARLY_PRODUCT_ID = "$PLUS_PRODUCT_BASE.yearly"
         const val PATRON_MONTHLY_PRODUCT_ID = "com.pocketcasts.monthly.patron"
         const val PATRON_YEARLY_PRODUCT_ID = "com.pocketcasts.yearly.patron"
-        const val SUBSCRIPTION_TEST_PRODUCT_ID = "com.pocketcasts.plus.testfreetrialoffer"
         const val TRIAL_OFFER_ID = "plus-yearly-trial-30days"
         const val INTRO_OFFER_ID = "testyearlyintropricingoffer-newusers"
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
@@ -4,7 +4,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_YEARLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_MONTHLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_YEARLY_PRODUCT_ID
-import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.SUBSCRIPTION_TEST_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.android.billingclient.api.ProductDetails
@@ -145,7 +144,7 @@ object SubscriptionMapper {
         }
 
     fun mapProductIdToTier(productId: String) = when (productId) {
-        in listOf(PLUS_MONTHLY_PRODUCT_ID, PLUS_YEARLY_PRODUCT_ID, SUBSCRIPTION_TEST_PRODUCT_ID) -> SubscriptionTier.PLUS
+        in listOf(PLUS_MONTHLY_PRODUCT_ID, PLUS_YEARLY_PRODUCT_ID) -> SubscriptionTier.PLUS
         in listOf(PATRON_MONTHLY_PRODUCT_ID, PATRON_YEARLY_PRODUCT_ID) -> SubscriptionTier.PATRON
         else -> SubscriptionTier.UNKNOWN
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -477,23 +477,23 @@ data class FreeTrial(
 )
 
 private fun SubscriptionStatusResponse.toStatus(): SubscriptionStatus {
-    val originalPlatform = SubscriptionPlatform.values().getOrNull(platform) ?: SubscriptionPlatform.NONE
+    val originalPlatform = SubscriptionPlatform.entries.getOrNull(platform) ?: SubscriptionPlatform.NONE
 
     val subs = subscriptions?.map { it.toSubscription() } ?: emptyList()
     subs.getOrNull(index)?.isPrimarySubscription = true // Mark the subscription that the server says is the main one
     return if (paid == 0) {
         SubscriptionStatus.Free(expiryDate, giftDays, originalPlatform, subs)
     } else {
-        val freq = SubscriptionFrequency.values().getOrNull(frequency) ?: SubscriptionFrequency.NONE
-        val enumType = SubscriptionType.values().getOrNull(type) ?: SubscriptionType.NONE
+        val freq = SubscriptionFrequency.entries.getOrNull(frequency) ?: SubscriptionFrequency.NONE
+        val enumType = SubscriptionType.entries.getOrNull(type) ?: SubscriptionType.NONE
         val enumTier = SubscriptionTier.fromString(tier, enumType)
         SubscriptionStatus.Paid(expiryDate ?: Date(), autoRenewing, giftDays, freq, originalPlatform, subs, enumType, enumTier, index)
     }
 }
 
 private fun SubscriptionResponse.toSubscription(): SubscriptionStatus.Subscription {
-    val enumType = SubscriptionType.values().getOrNull(type) ?: SubscriptionType.NONE
+    val enumType = SubscriptionType.entries.getOrNull(type) ?: SubscriptionType.NONE
     val enumTier = SubscriptionTier.fromString(tier, enumType)
-    val freq = SubscriptionFrequency.values().getOrNull(frequency) ?: SubscriptionFrequency.NONE
+    val freq = SubscriptionFrequency.entries.getOrNull(frequency) ?: SubscriptionFrequency.NONE
     return SubscriptionStatus.Subscription(enumType, enumTier, freq, expiryDate, autoRenewing, updateUrl)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -9,7 +9,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_YEARLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_MONTHLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_YEARLY_PRODUCT_ID
-import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.SUBSCRIPTION_TEST_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper.mapProductIdToTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
@@ -23,8 +22,6 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionPurchaseRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionStatusResponse
 import au.com.shiftyjelly.pocketcasts.utils.Optional
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag.isEnabled
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.AcknowledgePurchaseResponseListener
@@ -181,14 +178,6 @@ class SubscriptionManagerImpl @Inject constructor(
                         .setProductType(BillingClient.ProductType.SUBS)
                         .build(),
                 )
-                if (isEnabled(Feature.INTRO_PLUS_OFFER_ENABLED)) {
-                    add(
-                        QueryProductDetailsParams.Product.newBuilder()
-                            .setProductId(SUBSCRIPTION_TEST_PRODUCT_ID)
-                            .setProductType(BillingClient.ProductType.SUBS)
-                            .build(),
-                    )
-                }
             }
 
         val params = QueryProductDetailsParams.newBuilder()


### PR DESCRIPTION
Project: #1728

We are preparing for landing 🚀 

## Description
- Removes the test subscription product ID that was used during the development of this feature -> 6e63c2ad714e8eba90635c1e54ff61db4bad6a9f
- Fixes a warm -> 5b5039d60e3f8359e242fed35d99075d5a342c92


### TODO

- [ ] Once @emilylaguna sets the intro offer in PROD, I will update the [intro offer ID](https://github.com/Automattic/pocket-casts-android/blob/0afaee9d5f9d686a7efe2fcef8c92766d9efeebb/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt#L119) on this pull request.
- [ ] Update the Milestone to the same as iOS

### Notes
- To enable this feature we can set the `intro_plus_offer_enabled` Feature flag in Firebase to `true`


## Screenshots
|Upgrade modal | Profile banner update | Upgrade account banner |
| --- | --- | --- |
| ![Upgrade modal](https://github.com/Automattic/pocket-casts-android/assets/42220351/4708c2db-4d4c-4a01-9be4-d4570ea1c036) | ![Profile banner update](https://github.com/Automattic/pocket-casts-android/assets/42220351/d591c74d-fbc8-4269-8cd0-9f3c98a3f850) | ![Upgrade account banner](https://github.com/Automattic/pocket-casts-android/assets/42220351/ae418368-f445-4997-8c94-51a541f02506) |
