### PR TITLE
Update Compose and Kotlin to the newest versions

### DIFF
--- a/base.gradle
+++ b/base.gradle
@@ -154,7 +154,6 @@ dependencies {
 //    debugImplementation libs.leakcanary
 //    debugProdImplementation libs.leakcanary
 
-    implementation libs.bundles.accompanist
     implementation libs.bundles.billing
     implementation libs.bundles.coroutines
     implementation libs.bundles.firebase

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,23 +14,17 @@
 #    https://github.com/google/horologist/blob/main/gradle/libs.versions.toml
 #    wear-compose = Wear Compose Version
 #    horologist = Horologist Version
-#
-# 4. Check the Compose and Accompanist versions are compatible.
-#    https://github.com/google/accompanist
-#    compose = Compose Version from compose-bom
-#    accompanist = Accompanist Version
 
 [versions]
 aboutlibraries = "10.5.0"
-accompanist = "0.30.1"
 # Android Gradle Plugin - https://developer.android.com/studio/releases/gradle-plugin
-android-application = "8.1.1"
+android-application = "8.2.2"
 billing = "6.0.1"
-coil = "2.2.1"
-compose = "2023.04.01" # uses compose version 1.4.2, see https://developer.android.com/jetpack/compose/bom/bom-mapping
+coil = "2.5.0"
+compose = "2024.02.00" # uses compose version 1.6.1, see https://developer.android.com/jetpack/compose/bom/bom-mapping
 # @keep
 # Compose to Kotlin Compatibility Map: https://developer.android.com/jetpack/androidx/releases/compose-kotlin
-compose-kotlin-compiler = "1.5.2"
+compose-kotlin-compiler = "1.5.9"
 coroutines = "1.6.4"
 espresso = "3.4.0"
 firebase = "30.5.0"
@@ -38,10 +32,10 @@ glide = "4.13.2"
 google-services = "4.3.14"
 hilt = "2.49"
 hilt-compiler = "1.1.0"
-horologist = "0.4.17"
-kotlin = "1.9.0"
+horologist = "0.5.21"
+kotlin = "1.9.22"
 kotlin-coroutines = "1.6.4"
-ksp = "1.9.0-1.0.13"
+ksp = "1.9.22-1.0.17"
 lifecycle = "2.6.0"
 lottie = "5.2.0"
 media3 = "1.0.2"
@@ -57,17 +51,13 @@ sentry = "6.28.0"
 sentry-plugin = "3.10.0"
 showkase = "1.0.2"
 test = "1.5.0"
-wear-compose = "1.2.1"
+wear-compose = "1.3.0"
 work = "2.8.1"
 
 [libraries]
 # About Libraries
 aboutLibraries-compose = "com.mikepenz:aboutlibraries-compose:10.5.0"
 aboutlibraries-core = { module = "com.mikepenz:aboutlibraries-core", version.ref = "aboutlibraries" }
-
-# Accompanist
-accompanist-flowlayout = { module = "com.google.accompanist:accompanist-flowlayout", version.ref = "accompanist" }
-accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
 
 # Billing
 billing = { module = "com.android.billingclient:billing", version.ref = "billing" }
@@ -90,7 +80,7 @@ compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-ui-util = { module = "androidx.compose.ui:ui-util" }
-compose-activity = "androidx.activity:activity-compose:1.5.1"
+compose-activity = "androidx.activity:activity-compose:1.8.2"
 compose-constraint = "androidx.constraintlayout:constraintlayout-compose:1.0.1"
 
 # Coroutines
@@ -104,7 +94,7 @@ coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", ve
 dagger-hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hilt-compiler" }
-hilt-navigation-compose = "androidx.hilt:hilt-navigation-compose:1.0.0"
+hilt-navigation-compose = "androidx.hilt:hilt-navigation-compose:1.1.0"
 hilt-work = "androidx.hilt:hilt-work:1.0.0"
 
 # Espresso
@@ -284,11 +274,6 @@ wear-tooling-preview = "androidx.wear:wear-tooling-preview:1.0.0"
 aboutlibraries = [
     "aboutlibraries-core",
     "aboutLibraries-compose"
-]
-
-accompanist = [
-    "accompanist-flowlayout",
-    "accompanist-systemuicontroller"
 ]
 
 billing = [

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.collectAsState
@@ -50,12 +51,17 @@ class OnboardingActivity : AppCompatActivity() {
                     theme.setupThemeForConfig(this, resources.configuration)
                 }
 
+                enableEdgeToEdge()
+
                 OnboardingFlowComposable(
                     theme = theme.activeTheme,
                     flow = onboardingFlow,
                     exitOnboarding = { viewModel.onExitOnboarding(it) },
                     completeOnboardingToDiscover = { finishWithResult(OnboardingFinish.DoneGoToDiscover) },
                     signInState = currentSignInState,
+                    onUpdateSystemBars = { value ->
+                        enableEdgeToEdge(value.statusBarStyle, value.navigationBarStyle)
+                    },
                 )
             }
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingCreateAccountPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingCreateAccountPage.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding
 
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -19,6 +20,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -28,6 +30,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingCreateAccountViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
+import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.EmailAndPasswordFields
@@ -36,7 +39,6 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -44,11 +46,11 @@ internal fun OnboardingCreateAccountPage(
     theme: Theme.ThemeType,
     onBackPressed: () -> Unit,
     onAccountCreated: () -> Unit,
+    onUpdateSystemBars: (SystemBarsStyles) -> Unit,
 ) {
     val viewModel = hiltViewModel<OnboardingCreateAccountViewModel>()
     val state by viewModel.stateFlow.collectAsState()
 
-    val systemUiController = rememberSystemUiController()
     val pocketCastsTheme = MaterialTheme.theme
 
     CallOnce {
@@ -56,11 +58,16 @@ internal fun OnboardingCreateAccountPage(
     }
 
     LaunchedEffect(Unit) {
-        systemUiController.apply {
-            // Use secondaryUI01 so the status bar matches the ThemedTopAppBar
-            setStatusBarColor(pocketCastsTheme.colors.secondaryUi01, darkIcons = !theme.defaultLightIcons)
-            setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
-        }
+        // Use secondaryUI01 so the status bar matches the ThemedTopAppBar
+        val statusBar = SystemBarStyle.auto(
+            pocketCastsTheme.colors.secondaryUi01.toArgb(),
+            pocketCastsTheme.colors.secondaryUi01.toArgb(),
+        ) { theme.darkTheme }
+        val navigationBar = SystemBarStyle.auto(
+            Color.Transparent.toArgb(),
+            Color.Transparent.toArgb(),
+        ) { theme.darkTheme }
+        onUpdateSystemBars(SystemBarsStyles(statusBar, navigationBar))
     }
 
     BackHandler {
@@ -152,6 +159,7 @@ private fun OnboardingCreateAccountPagePreview(
             theme = themeType,
             onBackPressed = {},
             onAccountCreated = {},
+            onUpdateSystemBars = {},
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -14,6 +14,7 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations.Onboard
 import au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations.OnboardingRecommendationsFlow.onboardingRecommendationsFlowGraph
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeFlow
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingExitInfo
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
@@ -28,26 +29,29 @@ fun OnboardingFlowComposable(
     exitOnboarding: (OnboardingExitInfo) -> Unit,
     completeOnboardingToDiscover: () -> Unit,
     signInState: SignInState,
+    onUpdateSystemBars: (SystemBarsStyles) -> Unit,
     navController: NavHostController = rememberNavController(),
 ) {
     if (flow is OnboardingFlow.PlusAccountUpgrade) {
         Content(
-            theme = theme,
+            theme,
             flow = flow,
             exitOnboarding = exitOnboarding,
             completeOnboardingToDiscover = completeOnboardingToDiscover,
             signInState = signInState,
             navController = navController,
+            onUpdateSystemBars = onUpdateSystemBars,
         )
     } else {
         AppThemeWithBackground(theme) {
             Content(
-                theme = theme,
+                theme,
                 flow = flow,
                 exitOnboarding = exitOnboarding,
                 completeOnboardingToDiscover = completeOnboardingToDiscover,
                 signInState = signInState,
                 navController = navController,
+                onUpdateSystemBars = onUpdateSystemBars,
             )
         }
     }
@@ -61,6 +65,7 @@ private fun Content(
     completeOnboardingToDiscover: () -> Unit,
     signInState: SignInState,
     navController: NavHostController,
+    onUpdateSystemBars: (SystemBarsStyles) -> Unit,
 ) {
     val startDestination = when (flow) {
         OnboardingFlow.LoggedOut,
@@ -85,10 +90,10 @@ private fun Content(
     }
 
     NavHost(navController, startDestination) {
-        importFlowGraph(theme, navController, flow)
+        importFlowGraph(theme, navController, flow, onUpdateSystemBars)
 
         onboardingRecommendationsFlowGraph(
-            theme = theme,
+            theme,
             flow = flow,
             onBackPressed = { exitOnboarding(OnboardingExitInfo()) },
             onComplete = {
@@ -101,6 +106,7 @@ private fun Content(
                 )
             },
             navController = navController,
+            onUpdateSystemBars = onUpdateSystemBars,
         )
 
         composable(OnboardingNavRoute.logInOrSignUp) {
@@ -137,6 +143,7 @@ private fun Content(
                         onLoginToExistingAccount(flow, exitOnboarding, navController)
                     }
                 },
+                onUpdateSystemBars = onUpdateSystemBars,
             )
         }
 
@@ -145,6 +152,7 @@ private fun Content(
                 theme = theme,
                 onBackPressed = { navController.popBackStack() },
                 onAccountCreated = onAccountCreated,
+                onUpdateSystemBars = onUpdateSystemBars,
             )
         }
 
@@ -156,6 +164,7 @@ private fun Content(
                     onLoginToExistingAccount(flow, exitOnboarding, navController)
                 },
                 onForgotPasswordTapped = { navController.navigate(OnboardingNavRoute.forgotPassword) },
+                onUpdateSystemBars = onUpdateSystemBars,
             )
         }
 
@@ -164,6 +173,7 @@ private fun Content(
                 theme = theme,
                 onBackPressed = { navController.popBackStack() },
                 onCompleted = { exitOnboarding(OnboardingExitInfo()) },
+                onUpdateSystemBars = onUpdateSystemBars,
             )
         }
 
@@ -235,12 +245,13 @@ private fun Content(
                         exitOnboarding(OnboardingExitInfo())
                     }
                 },
+                onUpdateSystemBars = onUpdateSystemBars,
             )
         }
 
         composable(OnboardingNavRoute.welcome) {
             OnboardingWelcomePage(
-                activeTheme = theme,
+                theme = theme,
                 flow = flow,
                 isSignedInAsPlusOrPatron = signInState.isSignedInAsPlusOrPatron,
                 onDone = { exitOnboarding(OnboardingExitInfo()) },
@@ -254,6 +265,7 @@ private fun Content(
                         navController.popBackStack()
                     }
                 },
+                onUpdateSystemBars = onUpdateSystemBars,
             )
         }
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingForgotPasswordPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingForgotPasswordPage.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding
 
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -22,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
@@ -33,6 +35,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingForgotPasswordViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
+import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.EmailField
@@ -41,8 +44,6 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
-import com.google.androidbrowserhelper.trusted.Utils.setStatusBarColor
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -50,6 +51,7 @@ fun OnboardingForgotPasswordPage(
     theme: Theme.ThemeType,
     onBackPressed: () -> Unit,
     onCompleted: () -> Unit,
+    onUpdateSystemBars: (SystemBarsStyles) -> Unit,
 ) {
     val viewModel = hiltViewModel<OnboardingForgotPasswordViewModel>()
     val state by viewModel.stateFlow.collectAsState()
@@ -68,7 +70,6 @@ fun OnboardingForgotPasswordPage(
         )
     }
 
-    val systemUiController = rememberSystemUiController()
     val pocketCastsTheme = MaterialTheme.theme
 
     CallOnce {
@@ -77,10 +78,16 @@ fun OnboardingForgotPasswordPage(
 
     LaunchedEffect(Unit) {
         emailFocusRequester.requestFocus()
-        systemUiController.apply {
-            setStatusBarColor(pocketCastsTheme.colors.secondaryUi01, darkIcons = !theme.defaultLightIcons)
-            setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
-        }
+        // Use secondaryUI01 so the status bar matches the ThemedTopAppBar
+        val statusBar = SystemBarStyle.auto(
+            pocketCastsTheme.colors.secondaryUi01.toArgb(),
+            pocketCastsTheme.colors.secondaryUi01.toArgb(),
+        ) { theme.darkTheme }
+        val navigationBar = SystemBarStyle.auto(
+            Color.Transparent.toArgb(),
+            Color.Transparent.toArgb(),
+        ) { theme.darkTheme }
+        onUpdateSystemBars(SystemBarsStyles(statusBar, navigationBar))
     }
     BackHandler {
         viewModel.onBackPressed()
@@ -150,6 +157,7 @@ private fun OnboardingForgotPasswordPreview(
             theme = themeType,
             onBackPressed = {},
             onCompleted = {},
+            onUpdateSystemBars = {},
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding
 
 import android.content.res.Configuration
 import android.content.res.Configuration.ORIENTATION_LANDSCAPE
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Box
@@ -28,6 +29,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -49,6 +51,7 @@ import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
+import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowTextButton
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastCover
@@ -62,7 +65,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.ui.extensions.inLandscape
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -73,9 +75,9 @@ internal fun OnboardingLoginOrSignUpPage(
     onSignUpClicked: () -> Unit,
     onLoginClicked: () -> Unit,
     onContinueWithGoogleComplete: (GoogleSignInState) -> Unit,
+    onUpdateSystemBars: (SystemBarsStyles) -> Unit,
     viewModel: OnboardingLoginOrSignUpViewModel = hiltViewModel(),
 ) {
-    val systemUiController = rememberSystemUiController()
     val pocketCastsTheme = MaterialTheme.theme
 
     CallOnce {
@@ -83,10 +85,15 @@ internal fun OnboardingLoginOrSignUpPage(
     }
 
     LaunchedEffect(Unit) {
-        systemUiController.apply {
-            setStatusBarColor(pocketCastsTheme.colors.primaryUi01.copy(alpha = 0.9f), darkIcons = !theme.darkTheme)
-            setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
-        }
+        val statusBar = SystemBarStyle.auto(
+            pocketCastsTheme.colors.primaryUi01.copy(alpha = 0.9f).toArgb(),
+            pocketCastsTheme.colors.primaryUi01.copy(alpha = 0.9f).toArgb(),
+        ) { theme.darkTheme }
+        val navigationBar = SystemBarStyle.auto(
+            Color.Transparent.toArgb(),
+            Color.Transparent.toArgb(),
+        ) { theme.darkTheme }
+        onUpdateSystemBars(SystemBarsStyles(statusBar, navigationBar))
     }
 
     val onNavigationClick = {
@@ -325,6 +332,7 @@ private fun OnboardingLoginOrSignUpPagePreview(@PreviewParameter(ThemePreviewPar
             onSignUpClicked = {},
             onLoginClicked = {},
             onContinueWithGoogleComplete = {},
+            onUpdateSystemBars = {},
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding
 
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -23,6 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -32,6 +34,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingLogInViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
+import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.EmailAndPasswordFields
@@ -41,7 +44,6 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -50,8 +52,8 @@ internal fun OnboardingLoginPage(
     onBackPressed: () -> Unit,
     onLoginComplete: () -> Unit,
     onForgotPasswordTapped: () -> Unit,
+    onUpdateSystemBars: (SystemBarsStyles) -> Unit,
 ) {
-    val systemUiController = rememberSystemUiController()
     val pocketCastsTheme = MaterialTheme.theme
 
     val viewModel = hiltViewModel<OnboardingLogInViewModel>()
@@ -62,10 +64,16 @@ internal fun OnboardingLoginPage(
     }
 
     LaunchedEffect(Unit) {
-        systemUiController.apply {
-            setStatusBarColor(pocketCastsTheme.colors.secondaryUi01, darkIcons = !theme.defaultLightIcons)
-            setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
-        }
+        // Use secondaryUI01 so the status bar matches the ThemedTopAppBar
+        val statusBar = SystemBarStyle.auto(
+            pocketCastsTheme.colors.secondaryUi01.toArgb(),
+            pocketCastsTheme.colors.secondaryUi01.toArgb(),
+        ) { theme.darkTheme }
+        val navigationBar = SystemBarStyle.auto(
+            Color.Transparent.toArgb(),
+            Color.Transparent.toArgb(),
+        ) { theme.darkTheme }
+        onUpdateSystemBars(SystemBarsStyles(statusBar, navigationBar))
     }
     BackHandler {
         viewModel.onBackPressed()
@@ -156,6 +164,7 @@ private fun OnboardingLoginPage_Preview(
             onBackPressed = {},
             onLoginComplete = {},
             onForgotPasswordTapped = {},
+            onUpdateSystemBars = {},
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingWelcomePage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingWelcomePage.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding
 
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
@@ -36,6 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -47,6 +49,7 @@ import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingWelcomeState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingWelcomeViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
+import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.Confetti
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
@@ -58,24 +61,23 @@ import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun OnboardingWelcomePage(
-    activeTheme: Theme.ThemeType,
+    theme: Theme.ThemeType,
     flow: OnboardingFlow,
     isSignedInAsPlusOrPatron: Boolean,
     onDone: () -> Unit,
     onContinueToDiscover: () -> Unit,
     onImportTapped: () -> Unit,
     onBackPressed: () -> Unit,
+    onUpdateSystemBars: (SystemBarsStyles) -> Unit,
 ) {
     val viewModel = hiltViewModel<OnboardingWelcomeViewModel>()
     val state by viewModel.stateFlow.collectAsState()
 
-    val systemUiController = rememberSystemUiController()
     val pocketCastsTheme = MaterialTheme.theme
 
     CallOnce {
@@ -83,10 +85,15 @@ fun OnboardingWelcomePage(
     }
 
     LaunchedEffect(Unit) {
-        systemUiController.apply {
-            setStatusBarColor(pocketCastsTheme.colors.primaryUi01.copy(alpha = 0.9f), darkIcons = !activeTheme.darkTheme)
-            setNavigationBarColor(Color.Transparent, darkIcons = !activeTheme.darkTheme)
-        }
+        val statusBar = SystemBarStyle.auto(
+            pocketCastsTheme.colors.primaryUi01.copy(alpha = 0.9f).toArgb(),
+            pocketCastsTheme.colors.primaryUi01.copy(alpha = 0.9f).toArgb(),
+        ) { theme.darkTheme }
+        val navigationBar = SystemBarStyle.auto(
+            Color.Transparent.toArgb(),
+            Color.Transparent.toArgb(),
+        ) { theme.darkTheme }
+        onUpdateSystemBars(SystemBarsStyles(statusBar, navigationBar))
     }
 
     BackHandler {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/import/OnboardingImportFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/import/OnboardingImportFlow.kt
@@ -10,6 +10,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingImportViewModel
+import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -23,6 +24,7 @@ object OnboardingImportFlow {
         theme: Theme.ThemeType,
         navController: NavController,
         flow: OnboardingFlow,
+        onUpdateSystemBars: (SystemBarsStyles) -> Unit,
     ) {
         navigation(
             route = this@OnboardingImportFlow.route,
@@ -45,6 +47,7 @@ object OnboardingImportFlow {
                         viewModel.onImportDismissed(flow)
                         navController.popBackStack()
                     },
+                    onUpdateSystemBars = onUpdateSystemBars,
                 )
             }
 
@@ -69,6 +72,7 @@ object OnboardingImportFlow {
                         }
                     },
                     onBackPressed = { navController.popBackStack() },
+                    onUpdateSystemBars = onUpdateSystemBars,
                 )
             }
 
@@ -83,6 +87,7 @@ object OnboardingImportFlow {
                         stringResource(LR.string.onboarding_import_from_other_apps_step_2),
                     ),
                     onBackPressed = { navController.popBackStack() },
+                    onUpdateSystemBars = onUpdateSystemBars,
                 )
             }
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/import/OnboardingImportFrom.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/import/OnboardingImportFrom.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.import
 
+import androidx.activity.SystemBarStyle
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
@@ -18,6 +19,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextAlign
@@ -27,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
@@ -34,8 +37,6 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
-import com.google.androidbrowserhelper.trusted.Utils.setStatusBarColor
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 
 @Composable
@@ -48,12 +49,19 @@ fun OnboardingImportFrom(
     buttonText: String? = null,
     buttonClick: (() -> Unit)? = null,
     onBackPressed: () -> Unit,
+    onUpdateSystemBars: (SystemBarsStyles) -> Unit,
 ) {
-    rememberSystemUiController().apply {
-        // Use the secondaryUI01 so the status bar matches the ThemedTopAppBar
-        setStatusBarColor(MaterialTheme.theme.colors.secondaryUi01, darkIcons = !theme.defaultLightIcons)
-        setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
-    }
+    val pocketCastsTheme = MaterialTheme.theme
+    // Use secondaryUI01 so the status bar matches the ThemedTopAppBar
+    val statusBar = SystemBarStyle.auto(
+        pocketCastsTheme.colors.secondaryUi01.toArgb(),
+        pocketCastsTheme.colors.secondaryUi01.toArgb(),
+    ) { theme.darkTheme }
+    val navigationBar = SystemBarStyle.auto(
+        Color.Transparent.toArgb(),
+        Color.Transparent.toArgb(),
+    ) { theme.darkTheme }
+    onUpdateSystemBars(SystemBarsStyles(statusBar, navigationBar))
 
     Column(
         Modifier
@@ -160,6 +168,7 @@ private fun OnboardingImportFromPreview(
             buttonText = "A button",
             buttonClick = {},
             onBackPressed = {},
+            onUpdateSystemBars = {},
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/import/OnboardingImportStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/import/OnboardingImportStartPage.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.import
 
+import androidx.activity.SystemBarStyle
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -23,6 +24,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -30,6 +32,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
+import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
@@ -37,7 +40,6 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -48,8 +50,8 @@ fun OnboardingImportStartPage(
     onCastboxClicked: () -> Unit,
     onOtherAppsClicked: () -> Unit,
     onBackPressed: () -> Unit,
+    onUpdateSystemBars: (SystemBarsStyles) -> Unit,
 ) {
-    val systemUiController = rememberSystemUiController()
     val pocketCastsTheme = MaterialTheme.theme
 
     CallOnce {
@@ -57,11 +59,16 @@ fun OnboardingImportStartPage(
     }
 
     LaunchedEffect(Unit) {
-        systemUiController.apply {
-            // Use secondaryUI01 so the status bar matches the ThemedTopAppBar
-            setStatusBarColor(pocketCastsTheme.colors.secondaryUi01, darkIcons = !theme.defaultLightIcons)
-            setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
-        }
+        // Use secondaryUI01 so the status bar matches the ThemedTopAppBar
+        val statusBar = SystemBarStyle.auto(
+            pocketCastsTheme.colors.secondaryUi01.toArgb(),
+            pocketCastsTheme.colors.secondaryUi01.toArgb(),
+        ) { theme.darkTheme }
+        val navigationBar = SystemBarStyle.auto(
+            Color.Transparent.toArgb(),
+            Color.Transparent.toArgb(),
+        ) { theme.darkTheme }
+        onUpdateSystemBars(SystemBarsStyles(statusBar, navigationBar))
     }
 
     Column {
@@ -141,6 +148,7 @@ private fun OnboardingImportStartPagePreview(
             onCastboxClicked = {},
             onOtherAppsClicked = {},
             onBackPressed = {},
+            onUpdateSystemBars = {},
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import au.com.shiftyjelly.pocketcasts.account.onboarding.import.OnboardingImportFlow
 import au.com.shiftyjelly.pocketcasts.account.onboarding.import.OnboardingImportFlow.importFlowGraph
+import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Network
@@ -26,16 +27,17 @@ object OnboardingRecommendationsFlow {
         onBackPressed: () -> Unit,
         onComplete: () -> Unit,
         navController: NavController,
+        onUpdateSystemBars: (SystemBarsStyles) -> Unit,
     ) {
         navigation(
             route = this@OnboardingRecommendationsFlow.route,
             startDestination = start,
         ) {
-            importFlowGraph(theme, navController, flow)
+            importFlowGraph(theme, navController, flow, onUpdateSystemBars)
 
             composable(start) {
                 OnboardingRecommendationsStartPage(
-                    theme = theme,
+                    theme,
                     onImportClicked = { navController.navigate(OnboardingImportFlow.route) },
                     onSearch = with(LocalContext.current) {
                         {
@@ -52,12 +54,14 @@ object OnboardingRecommendationsFlow {
                     },
                     onBackPressed = onBackPressed,
                     onComplete = onComplete,
+                    onUpdateSystemBars = onUpdateSystemBars,
                 )
             }
             composable(search) {
                 OnboardingRecommendationsSearchPage(
                     theme = theme,
                     onBackPressed = { navController.popBackStack() },
+                    onUpdateSystemBars = onUpdateSystemBars,
                 )
             }
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchPage.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
 
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -28,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -35,33 +37,38 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastItem
 import au.com.shiftyjelly.pocketcasts.compose.components.SearchBar
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun OnboardingRecommendationsSearchPage(
     theme: Theme.ThemeType,
     onBackPressed: () -> Unit,
+    onUpdateSystemBars: (SystemBarsStyles) -> Unit,
 ) {
     val viewModel = hiltViewModel<OnboardingRecommendationsSearchViewModel>()
     val state by viewModel.state.collectAsState()
 
     val focusRequester = remember { FocusRequester() }
-    val systemUiController = rememberSystemUiController()
     val pocketCastsTheme = MaterialTheme.theme
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
-        systemUiController.apply {
-            // Use secondaryUI01 so the status bar matches the ThemedTopAppBar
-            setStatusBarColor(pocketCastsTheme.colors.secondaryUi01, darkIcons = !theme.defaultLightIcons)
-            setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
-        }
+        // Use secondaryUI01 so the status bar matches the ThemedTopAppBar
+        val statusBar = SystemBarStyle.auto(
+            pocketCastsTheme.colors.secondaryUi01.toArgb(),
+            pocketCastsTheme.colors.secondaryUi01.toArgb(),
+        ) { theme.darkTheme }
+        val navigationBar = SystemBarStyle.auto(
+            Color.Transparent.toArgb(),
+            Color.Transparent.toArgb(),
+        ) { theme.darkTheme }
+        onUpdateSystemBars(SystemBarsStyles(statusBar, navigationBar))
     }
 
     BackHandler {
@@ -140,6 +147,7 @@ private fun OnboardingRecommendationSearchPage_Preview(
         OnboardingRecommendationsSearchPage(
             theme = themeType,
             onBackPressed = {},
+            onUpdateSystemBars = {},
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPage.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
 
 import android.content.res.Configuration
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -31,6 +32,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
@@ -46,6 +48,7 @@ import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingRecommendation
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingRecommendationsStartPageViewModel.SectionId
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
+import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
 import au.com.shiftyjelly.pocketcasts.compose.components.SearchBarButton
@@ -60,7 +63,6 @@ import au.com.shiftyjelly.pocketcasts.compose.podcast.PodcastSubscribeImage
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -70,11 +72,11 @@ fun OnboardingRecommendationsStartPage(
     onSearch: () -> Unit,
     onBackPressed: () -> Unit,
     onComplete: () -> Unit,
+    onUpdateSystemBars: (SystemBarsStyles) -> Unit,
 ) {
     val viewModel = hiltViewModel<OnboardingRecommendationsStartPageViewModel>()
     val state by viewModel.state.collectAsState()
 
-    val systemUiController = rememberSystemUiController()
     val pocketCastsTheme = MaterialTheme.theme
 
     CallOnce {
@@ -82,10 +84,15 @@ fun OnboardingRecommendationsStartPage(
     }
 
     LaunchedEffect(Unit) {
-        systemUiController.apply {
-            setStatusBarColor(pocketCastsTheme.colors.primaryUi01.copy(alpha = 0.9f), darkIcons = !theme.darkTheme)
-            setNavigationBarColor(Color.Transparent, darkIcons = !theme.darkTheme)
-        }
+        val statusBar = SystemBarStyle.auto(
+            pocketCastsTheme.colors.primaryUi01.copy(alpha = 0.9f).toArgb(),
+            pocketCastsTheme.colors.primaryUi01.copy(alpha = 0.9f).toArgb(),
+        ) { theme.darkTheme }
+        val navigationBar = SystemBarStyle.auto(
+            Color.Transparent.toArgb(),
+            Color.Transparent.toArgb(),
+        ) { theme.darkTheme }
+        onUpdateSystemBars(SystemBarsStyles(statusBar, navigationBar))
     }
     BackHandler {
         viewModel.onBackPressed()

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
+import androidx.activity.SystemBarStyle
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -48,6 +49,7 @@ import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
@@ -64,6 +66,7 @@ import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeature
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesViewModel
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
+import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalPagerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.components.StyledToggle
@@ -76,7 +79,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private const val MAX_OFFER_BADGE_TEXT_LENGTH = 23
@@ -90,6 +92,7 @@ internal fun OnboardingUpgradeFeaturesPage(
     onClickSubscribe: () -> Unit,
     onNotNowPressed: () -> Unit,
     canUpgrade: Boolean,
+    onUpdateSystemBars: (SystemBarsStyles) -> Unit,
 ) {
     val viewModel = hiltViewModel<OnboardingUpgradeFeaturesViewModel>()
     val state by viewModel.state.collectAsState()
@@ -111,7 +114,7 @@ internal fun OnboardingUpgradeFeaturesPage(
     }
 
     val scrollState = rememberScrollState()
-    SetStatusBarBackground(scrollState)
+    SetStatusBarBackground(scrollState, onUpdateSystemBars)
 
     when (state) {
         is OnboardingUpgradeFeaturesState.Loading -> Unit // Do Nothing
@@ -420,8 +423,10 @@ private fun UpgradeButton(
 }
 
 @Composable
-private fun SetStatusBarBackground(scrollState: ScrollState) {
-    val systemUiController = rememberSystemUiController()
+private fun SetStatusBarBackground(
+    scrollState: ScrollState,
+    onUpdateSystemBars: (SystemBarsStyles) -> Unit,
+) {
     val hasScrolled = scrollState.value > 0
 
     val scrimAlpha: Float by animateFloatAsState(
@@ -431,16 +436,15 @@ private fun SetStatusBarBackground(scrollState: ScrollState) {
     )
 
     val statusBarBackground = if (scrimAlpha > 0) {
-        OnboardingUpgradeHelper.backgroundColor.copy(alpha = scrimAlpha)
+        OnboardingUpgradeHelper.backgroundColor.copy(alpha = scrimAlpha).toArgb()
     } else {
-        Color.Transparent
+        Color.Transparent.toArgb()
     }
 
     LaunchedEffect(statusBarBackground) {
-        systemUiController.apply {
-            setStatusBarColor(statusBarBackground, darkIcons = false)
-            setNavigationBarColor(Color.Transparent, darkIcons = false)
-        }
+        val statusBar = SystemBarStyle.dark(statusBarBackground)
+        val navigationBar = SystemBarStyle.dark(Color.Transparent.toArgb())
+        onUpdateSystemBars(SystemBarsStyles(statusBar, navigationBar))
     }
 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -22,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgra
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesViewModel
+import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
@@ -40,6 +41,7 @@ fun OnboardingUpgradeFlow(
     onBackPressed: () -> Unit,
     onNeedLogin: () -> Unit,
     onProceed: () -> Unit,
+    onUpdateSystemBars: (SystemBarsStyles) -> Unit,
 ) {
     val bottomSheetViewModel = hiltViewModel<OnboardingUpgradeBottomSheetViewModel>()
     val mainSheetViewModel = hiltViewModel<OnboardingUpgradeFeaturesViewModel>()
@@ -136,6 +138,7 @@ fun OnboardingUpgradeFlow(
                     },
                     onNotNowPressed = onProceed,
                     canUpgrade = hasSubscriptions,
+                    onUpdateSystemBars = onUpdateSystemBars,
                 )
             }
         },

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreatePodcastsPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreatePodcastsPage.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -37,7 +37,7 @@ fun ShareListCreatePodcastsPage(
                     enabled = state.selectedPodcasts.isNotEmpty(),
                 ) {
                     Icon(
-                        imageVector = Icons.Filled.ArrowForward,
+                        imageVector = Icons.AutoMirrored.Filled.ArrowForward,
                         contentDescription = stringResource(LR.string.next),
                     )
                 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
@@ -1,9 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.viewmodel
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.StarHalf
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.StarBorder
-import androidx.compose.material.icons.filled.StarHalf
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.ViewModel
@@ -129,7 +129,7 @@ class PodcastRatingsViewModel
 
     enum class Star(val icon: ImageVector) {
         FilledStar(Icons.Filled.Star),
-        HalfStar(Icons.Default.StarHalf),
+        HalfStar(Icons.AutoMirrored.Filled.StarHalf),
         BorderedStar(Icons.Filled.StarBorder),
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
@@ -14,7 +14,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.disposables.CompositeDisposable
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.take
@@ -121,7 +121,7 @@ class DeveloperViewModel
         disposables.clear()
     }
 
-    @OptIn(FlowPreview::class)
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun triggerUpdateEpisodeDetails() {
         viewModelScope.launch {
             try {

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/SystemBarsStyles.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/SystemBarsStyles.kt
@@ -1,0 +1,8 @@
+package au.com.shiftyjelly.pocketcasts.compose.bars
+
+import androidx.activity.SystemBarStyle
+
+class SystemBarsStyles(
+    val statusBarStyle: SystemBarStyle,
+    val navigationBarStyle: SystemBarStyle,
+)

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/ThemedTopAppBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/ThemedTopAppBar.kt
@@ -8,7 +8,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -27,7 +27,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 sealed class NavigationButton(val image: ImageVector, val contentDescription: Int) {
-    object Back : NavigationButton(image = Icons.Default.ArrowBack, contentDescription = LR.string.back)
+    object Back : NavigationButton(image = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = LR.string.back)
     object Close : NavigationButton(image = Icons.Default.Close, contentDescription = LR.string.close)
 }
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/AutoResizeText.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/AutoResizeText.kt
@@ -46,7 +46,7 @@ fun AutoResizeText(
     fontFamily: FontFamily? = null,
     letterSpacing: TextUnit = TextUnit.Unspecified,
     textDecoration: TextDecoration? = null,
-    textAlign: TextAlign? = null,
+    textAlign: TextAlign = TextAlign.Unspecified,
     contentAlignment: Alignment? = null,
     lineHeight: TextUnit = TextUnit.Unspecified,
     maxLines: Int = Int.MAX_VALUE,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/FolderColorPicker.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/FolderColorPicker.kt
@@ -2,6 +2,8 @@ package au.com.shiftyjelly.pocketcasts.compose.components
 
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.MaterialTheme
@@ -17,9 +19,9 @@ import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.buttons.CircleIconButton
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import com.google.accompanist.flowlayout.FlowRow
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun FolderColorPicker(selectedId: Int, onClick: (Int) -> Unit, modifier: Modifier = Modifier) {
     FlowRow(modifier = modifier.padding(start = 14.dp, top = 16.dp, end = 2.dp)) {

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
@@ -46,7 +46,7 @@ fun HorizontalPagerWrapper(
     contentPadding: PaddingValues = PaddingValues(0.dp),
     content: @Composable (Int, Int) -> Unit = { _, _ -> },
 ) {
-    val pagerState = rememberPagerState(initialPage = initialPage)
+    val pagerState = rememberPagerState(initialPage = initialPage) { pageCount }
 
     LaunchedEffect(pagerState) {
         snapshotFlow { pagerState.currentPage }.collect { index ->
@@ -57,7 +57,6 @@ fun HorizontalPagerWrapper(
     var pagerHeight by remember { mutableStateOf(0) }
     Column(modifier = modifier) {
         HorizontalPager(
-            pageCount = pageCount,
             state = pagerState,
             pageSize = pageSize,
             contentPadding = contentPadding,


### PR DESCRIPTION
## Description

This change updates:
* Kotlin to `1.9.22`.
* Compose to `1.6.1` using `2024.02.00` BOM
* Compose compiler to `1.5.9`
* AGP to `8.2.2`
* KSP to `1.9.22-1.0.17`
* And some other libraries like Horologist or Coil to follow the Compose updates

I also removed Accompanist library as APIs used by our app were deprecated and are now replaced by Compose equivalents. The biggest change is related to `com.google.accompanist.systemuicontroller.rememberSystemUiController()`. Instead we use `androidx.activity.enableEdgeToEdge()`. This cascaded in a lot of changes to the on-boarding UI.

## Testing Instructions

Main areas to test:
* Smoke test the app and image loading
* Test the on-boarding flow with different themes and check if status and navigation bars behave correctly when it comes to colors. [This](https://github.com/Automattic/pocket-casts-android/pull/656) might be a helpful PR.
* Smoke test the Wear OS app.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
