### PR TITLE
Fix: Total time remaining incorrectly displayed for some languages when device large font sizes are set

### DIFF
--- a/modules/features/player/src/main/res/layout/adapter_up_next_footer.xml
+++ b/modules/features/player/src/main/res/layout/adapter_up_next_footer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
         <variable name="totalTime" type="String" />
@@ -10,42 +10,50 @@
 
     <LinearLayout
         android:id="@+id/upNextFooter"
-        android:layout_height="wrap_content"
         android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <LinearLayout
-            android:layout_height="wrap_content"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:orientation="horizontal">
+            android:layout_height="match_parent"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="16dp">
+
+            <androidx.constraintlayout.helper.widget.Flow
+                android:layout_width="match_parent"
+                android:orientation="horizontal"
+                android:layout_height="wrap_content"
+                app:constraint_referenced_ids="lblUpNextTime,btnClear"
+                app:flow_wrapMode="chain"
+                app:flow_horizontalStyle="spread_inside"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
                 android:id="@+id/lblUpNextTime"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:layout_gravity="center_vertical"
-                android:layout_marginStart="16dp"
-                android:ellipsize="start"
                 style="@style/P60"
-                android:textColor="?attr/primary_text_02"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
                 android:text="@{totalTime}"
-                android:layout_marginEnd="16dp"
+                android:textColor="?attr/primary_text_02"
                 tools:text="23 min." />
 
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnClear"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_gravity="center_vertical"
                 android:enabled="@{episodeCount > 0}"
                 android:text="@string/player_up_next_clear_queue"
-                android:layout_marginEnd="8dp"
-                android:layout_gravity="end|center_vertical"
                 android:textColor="@color/player_button_text_color" />
 
-        </LinearLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <LinearLayout
             android:background="@drawable/up_next_card"


### PR DESCRIPTION
## Description
- The total time remaining string in Up Next was not being displayed correctly for some languages when device has large font size set.
- The solution I implemented was to use 
- See the attached screenshot in #1635 to observe the issue with `androidx.constraintlayout.helper.widget.Flow`, which is not aligning the items horizontally when there is available space; otherwise, it aligns them vertically.

Fixes #1635

## Testing Instructions
- Play around different languages and device font size. I will also depending on the size of the device that you are testing
- You should not see 'Total time remaining' and `Clear queue` with a line break. If they do not fit within the available space, `Total time remaining` should be positioned above `Clear queue`

## Screenshots or Screencast 

| English with large font size | English with normal font size | Spanish with normal font size |
|--------|--------|--------|
|<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/97c808bf-9743-4de7-b0ae-0ee13d74870c" alt="english_large" width="200"> |<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/e5de3dce-f5e6-4996-8c57-cc33eb9476bb" alt="english_normal" width="200"> |<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/53a4db29-40ec-4c5b-bd76-9dfaafa0efd2" alt="spanish_normal" width="200"> | 


| German with large font size | German with normal font size |
|--------|--------|
|<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/a6130dc8-6310-4b1b-ade2-4fa858d55474" alt="german_large" width="200"> |<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/c0cf5ac0-0872-43cf-84b9-1305970d306b" alt="german_normal" width="200"> | 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
