### PR TITLE
Improve bluetooth skipping behavior (Pixel A-series buds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
         ([#1735](https://github.com/Automattic/pocket-casts-android/pull/1735))
     *   Fixed "Hide playback notification on pause" setting not representing its state correctly
         ([#1769](https://github.com/Automattic/pocket-casts-android/pull/1769))
+    *   Improved skipping behavior from bluetooth device 
+        ([#1818](https://github.com/Automattic/pocket-casts-android/pull/1818))
 
 7.56
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -2044,9 +2044,9 @@ open class PlaybackManager @Inject constructor(
         }
 
         val currentTimeSecs = currentTimeMs.toDouble() / 1000.0
-        LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Saved time in database %.3f", currentTimeSecs)
         episodeManager.updatePlayedUpTo(episode, currentTimeSecs, false)
         episodeManager.updatePlaybackInteractionDate(episode)
+        LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Saved time in database %.3f", currentTimeSecs)
 
         statsManager.persistTimes()
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1728,6 +1728,7 @@ open class PlaybackManager @Inject constructor(
             }
         }
 
+        var posUpdatedOnPlayerReset = false
         // We want to make sure we get the current position at the last possible moment before changing/resetting the player
         val currentPositionMs = if (
             isPlayerSwitchRequired() ||
@@ -1744,6 +1745,7 @@ open class PlaybackManager @Inject constructor(
                     // This helps avoid having the audio jump "back" a second or so when the currently playing episode
                     // is downloaded.
                     episodeManager.updatePlayedUpTo(episode, playerPositionSeconds, forceUpdate = true)
+                    posUpdatedOnPlayerReset = true
                 }
 
                 resetPlayer()
@@ -1811,7 +1813,7 @@ open class PlaybackManager @Inject constructor(
             if (sameEpisode && currentPositionMs != null) {
                 player?.seekToTimeMs(currentPositionMs)
             }
-            play(sourceView)
+            play(sourceView, posUpdatedOnPlayerReset)
         } else {
             player?.load(episode.playedUpToMs)
             onPlayerPaused()
@@ -1906,10 +1908,17 @@ open class PlaybackManager @Inject constructor(
         return PendingIntent.getBroadcast(context, intentId, intent, PendingIntent.FLAG_UPDATE_CURRENT.or(PendingIntent.FLAG_IMMUTABLE))
     }
 
-    private suspend fun play(sourceView: SourceView = SourceView.UNKNOWN) {
+    private suspend fun play(
+        sourceView: SourceView = SourceView.UNKNOWN,
+        posUpdatedOnPlayerReset: Boolean = false,
+    ) {
         val episode = getCurrentEpisode()?.let {
-            // Make sure we have the most up-to-date episode instance
-            episodeManager.findEpisodeByUuid(it.uuid)
+            if (posUpdatedOnPlayerReset) {
+                // Retrieves latest episode instance to address potential audio skip back issue (PR#1510)
+                episodeManager.findEpisodeByUuid(it.uuid) ?: it
+            } else {
+                it
+            }
         }
         if (episode == null || player == null) {
             return


### PR DESCRIPTION
## Description

This improves Bluetooth skipping behavior noticed particularly on Pixel A-series buds since last few releases. 

> [!Warning]
> Targets release/7.57

I opted to target the release branch because the changeset is minor, we still have a week before the next release, and it resolves a painful problem experienced by some customers. Let me know if you think otherwise.

In PR #1510, we saved the latest playback position in the database before resetting the player and retrieved it using the `PlaybackManager`'s suspended `play(...`) method. This addressed a potential audio skipping issue after streaming media had been downloaded.
However, this introduced a side effect: when skipping from a Bluetooth device, the subsequent play command might retrieve the episode from a state before the new position (resulting from the skip) was saved in the database. We tried to mitigate the race condition in PR #1620.   

We still received a few reports of intermittent skipping issues, particularly on [Pixel A-series buds](https://forums.pocketcasts.com/forums/topic/skip-function-from-bluetooth-device-not-working-properly-beta-7-52-rc-2-9162/page/2/?view=all#post-2665).

Logs when the issue is reproducible:

```
I 12/2 13:00:34 Event from Media Session to play. Controller: com.google.android.googlequicksearchbox pid: 17689 uid: 10151
I 12/2 13:00:34 PlaybackService seekToTimeMsInternal 1143.112 
I 12/2 13:00:34 LocalPlayer seekToToTimeMs 1143.112
I 12/2 13:00:34 LocalPlayer onSeekComplete 1143.112
I 12/2 13:00:34 Executing queued command: play
I 12/2 13:00:34 Saved time in database 1143.112
I 12/2 13:00:34 Trying to gain audio focus
I 12/2 13:00:34 Audio focus gained
I 12/2 13:00:34 Play 1143.112 System Player. Episode 4 - Breaking Their Silence Downloaded: false, Downloading: false, Audio: true, File: https://sphinx.acast.com/p/open/s/6585f23688f900001625890c/e/65bfbc06b0da970016b355c3/media.mp3, EpisodeUuid: 229cba9a-2734-4d2a-9cab-234304d86e6a, PodcastUuid: de6ba1d0-9132-013c-9fe5-0acc26574db2
I 12/2 13:00:34 startForeground state: 6
I 12/2 13:00:35 Event from Media Session to pause. Controller: com.google.android.googlequicksearchbox pid: 17689 uid: 10151
I 12/2 13:00:35 Executing queued command: pause
I 12/2 13:00:35 Giving up audio focus
I 12/2 13:00:35 Giving up audio focus. Request granted
I 12/2 13:00:35 Paused - Not transient
I 12/2 13:00:35 Saved time in database 1143.531
I 12/2 13:00:35 stopForeground state: 2 (update notification)
I 12/2 13:00:35 Event from Media Session to skip forwards. Controller: com.google.android.googlequicksearchbox pid: 17689 uid: 10151
I 12/2 13:00:35 Executing queued command: skip forwards
I 12/2 13:00:35 Event from Media Session to play. Controller: com.google.android.googlequicksearchbox pid: 17689 uid: 10151
I 12/2 13:00:35 Skip forward tapped
I 12/2 13:00:35 PlaybackService seekToTimeMsInternal 1203.531 
I 12/2 13:00:35 LocalPlayer seekToToTimeMs 1203.531
I 12/2 13:00:35 LocalPlayer onSeekComplete 1203.531
I 12/2 13:00:35 Saved time in database 1203.531
I 12/2 13:00:35 Executing queued command: play
I 12/2 13:00:35 Trying to gain audio focus
I 12/2 13:00:35 Audio focus gained
I 12/2 13:00:35 Play 1143.112 System Player. Episode 4 - Breaking Their Silence Downloaded: false, Downloading: false, Audio: true, File: https://sphinx.acast.com/p/open/s/6585f23688f900001625890c/e/65bfbc06b0da970016b355c3/media.mp3, EpisodeUuid: 229cba9a-2734-4d2a-9cab-234304d86e6a, PodcastUuid: de6ba1d0-9132-013c-9fe5-0acc26574db2
I 12/2 13:00:35 LocalPlayer onSeekComplete 1143.112
I 12/2 13:00:35 Saved time in database 1143.112
```

Notice how Play executes from an old state in the database after the seek is complete.
`I 12/2 13:00:35 LocalPlayer onSeekComplete 1203.531`
`I 12/2 13:00:35 Play 1143.112 System Player. Episode 4 - Breaking Their Silence Downloaded: false, Downloading: false, Audio: true`

Also, notice how the log displays that the time is saved in the database after skip completes, yet a previous playback position is picked later
`I 12/2 13:00:35 Saved time in database 1203.531`
`I 12/2 13:00:35 Play 1143.112 System Player. Episode 4 - Breaking Their Silence Downloaded: false, Downloading: false, Audio: true`


This PR mitigates the issue by re-fetching the episode from the database within the `play(...`) method, but only if the method is invoked from `loadCurrentEpisode(...)` at the time when the playback position is updated in the database before the player resets. At all other times, it maintains the behavior that existed before PR #1510, continuing to play from the current episode's playback position.

In https://github.com/Automattic/pocket-casts-android/pull/1818/commits/1284b9efc61eed29a1e6e7cbce502551be02c9f0, the log position is updated to better reflect when a playback position is actually saved in the database.

## Testing Instructions

It might be difficult to recreate the race condition, so I've included before and after videos for skip commands from Pixel A-series buds. It might be sufficient to review only the code changes.

## Screenshots or Screencast 

Before (Notice a glitch at episode playback position 19:03):

https://github.com/Automattic/pocket-casts-android/assets/1405144/c4f7daed-5ff2-4a04-bb91-031269e641d7

After:

https://github.com/Automattic/pocket-casts-android/assets/1405144/7ada4a29-8505-43e1-96f8-d79471c514a9

<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack