### PR TITLE
Sync headphones actions settings

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsFragment.kt
@@ -102,7 +102,7 @@ class HeadphoneControlsSettingsFragment : BaseFragment() {
             onNextActionSave = { viewModel.onNextActionSave(it) },
             onPreviousActionSave = { viewModel.onPreviousActionSave(it) },
             onConfirmationSoundSave = { newValue ->
-                settings.headphoneControlsPlayBookmarkConfirmationSound.set(newValue, needsSync = false)
+                settings.headphoneControlsPlayBookmarkConfirmationSound.set(newValue, needsSync = true)
                 if (newValue) {
                     playbackManager.playTone()
                 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
@@ -81,7 +81,7 @@ class HeadphoneControlsSettingsPageViewModel @Inject constructor(
 
     fun onNextActionSave(action: HeadphoneAction) {
         if (action.canSave()) {
-            settings.headphoneControlsNextAction.set(action, needsSync = false)
+            settings.headphoneControlsNextAction.set(action, needsSync = true)
             trackHeadphoneAction(action, AnalyticsEvent.SETTINGS_HEADPHONE_CONTROLS_NEXT_CHANGED)
         } else {
             _state.update { it.copy(startUpsellFromSource = UpsellSourceAction.NEXT) }
@@ -90,7 +90,7 @@ class HeadphoneControlsSettingsPageViewModel @Inject constructor(
 
     fun onPreviousActionSave(action: HeadphoneAction) {
         if (action.canSave()) {
-            settings.headphoneControlsPreviousAction.set(action, needsSync = false)
+            settings.headphoneControlsPreviousAction.set(action, needsSync = true)
             trackHeadphoneAction(action, AnalyticsEvent.SETTINGS_HEADPHONE_CONTROLS_PREVIOUS_CHANGED)
         } else {
             _state.update { it.copy(startUpsellFromSource = UpsellSourceAction.PREVIOUS) }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/HeadphoneAction.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/HeadphoneAction.kt
@@ -11,12 +11,35 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-enum class HeadphoneAction(val analyticsValue: String) {
-    ADD_BOOKMARK("add_bookmark"),
-    SKIP_BACK("skip_back"),
-    SKIP_FORWARD("skip_forward"),
-    NEXT_CHAPTER("next_chapter"),
-    PREVIOUS_CHAPTER("previous_chapter"),
+enum class HeadphoneAction(
+    val analyticsValue: String,
+    val serverId: Int,
+) {
+    ADD_BOOKMARK(
+        analyticsValue = "add_bookmark",
+        serverId = 0,
+    ),
+    SKIP_BACK(
+        analyticsValue = "skip_back",
+        serverId = 1,
+    ),
+    SKIP_FORWARD(
+        analyticsValue = "skip_forward",
+        serverId = 2,
+    ),
+    NEXT_CHAPTER(
+        analyticsValue = "next_chapter",
+        serverId = 3,
+    ),
+    PREVIOUS_CHAPTER(
+        analyticsValue = "previous_chapter",
+        serverId = 4,
+    ),
+    ;
+
+    companion object {
+        fun fromServerId(id: Int) = entries.find { it.serverId == id }
+    }
 }
 
 class HeadphoneActionUserSetting(

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -59,6 +59,9 @@ data class ChangedNamedSettings(
     @field:Json(name = "notificationActions") val notificationSettingActions: NamedChangedSettingString? = null,
     @field:Json(name = "playerShelf") val playerShelfItems: NamedChangedSettingString? = null,
     @field:Json(name = "showArtworkOnLockScreen") val showArtworkOnLockScreen: NamedChangedSettingBool? = null,
+    @field:Json(name = "headphoneControlsNextAction") val headphoneControlsNextAction: NamedChangedSettingInt? = null,
+    @field:Json(name = "headphoneControlsPreviousAction") val headphoneControlsPreviousAction: NamedChangedSettingInt? = null,
+    @field:Json(name = "headphoneControlsPlayBookmarkConfirmationSound") val headphoneControlsPlayBookmarkConfirmationSound: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -14,6 +14,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingS
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveInactiveSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoPlaySource
 import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
+import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
 import au.com.shiftyjelly.pocketcasts.preferences.model.NewEpisodeNotificationAction
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.PodcastGridLayoutType
@@ -204,6 +205,19 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         modifiedAt = modifiedAt,
                     )
                 },
+                headphoneControlsNextAction = settings.headphoneControlsNextAction.getSyncSetting(lastSyncTime) { setting, modifiedAt ->
+                    NamedChangedSettingInt(
+                        value = setting.serverId,
+                        modifiedAt = modifiedAt,
+                    )
+                },
+                headphoneControlsPreviousAction = settings.headphoneControlsPreviousAction.getSyncSetting(lastSyncTime) { setting, modifiedAt ->
+                    NamedChangedSettingInt(
+                        value = setting.serverId,
+                        modifiedAt = modifiedAt,
+                    )
+                },
+                headphoneControlsPlayBookmarkConfirmationSound = settings.headphoneControlsPlayBookmarkConfirmationSound.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
             ),
         )
 
@@ -455,6 +469,21 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "showArtworkOnLockScreen" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.showArtworkOnLockScreen,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "headphoneControlsNextAction" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.headphoneControlsNextAction,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { HeadphoneAction.fromServerId(it) ?: HeadphoneAction.SKIP_FORWARD },
+                    )
+                    "headphoneControlsPreviousAction" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.headphoneControlsPreviousAction,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { HeadphoneAction.fromServerId(it) ?: HeadphoneAction.SKIP_BACK },
+                    )
+                    "headphoneControlsPlayBookmarkConfirmationSound" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.headphoneControlsPlayBookmarkConfirmationSound,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the global settings for headphone controls.

## Testing Instructions

> [!note]
> You need to test this with staging because changes aren't deployed to production, yet.
> 
> To test on staging use the `debug` variant instead of the `debugProd` one.

> [!note]
> I added these tests before staging got fixed with podcasts API. I think they are sufficient but you can test with the real feature as well instead of just checking settings.

### Setting sync

### Previous action

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`Headphone controls`.
4. D1: Change `Previous action` to `Skip forward`.
5. D1: Sync the device in the `Profile`.
6. D2: Sync the device in the `Profile`.
7. D2: Go to `Profile`/`Settings (cog icon)`/`Headphone controls`.
8. D2: Make sure that `Previous action` is set to `Skip forward`.

### Next action

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`Headphone controls`.
4. D1: Change `Next action` to `Skip back`.
5. D1: Sync the device in the `Profile`.
6. D2: Sync the device in the `Profile`.
7. D2: Go to `Profile`/`Settings (cog icon)`/`Headphone controls`.
8. D2: Make sure that `Next action` is set to `Skip back`.

### Bookmark confirmation sound


> [!note]
> You need to test it with a Paton account.

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`Headphone controls`.
4. D1: Change `Next action` to `Add bookmark`.
5. D1: Toggle `Bookmark confirmation sound` to `OFF`.
6. D1: Sync the device in the `Profile`.
7. D2: Sync the device in the `Profile`.
8. D2: Go to `Profile`/`Settings (cog icon)`/`Headphone controls`.
9. D2: Make sure that `Bookmark confirmation sound` is set to `OFF`.
10. D2: Toggle `Bookmark confirmation sound` to `ON`.
11. D2: Sync the device in the `Profile`.
12. D1: Sync the device in the `Profile`.
13. D1: Go to `Profile`/`Settings (cog icon)`/`Headphone controls`.
14. D1: Make sure that `Bookmark confirmation sound` is set to `ON`.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
