### PR TITLE
Sync system theme settings

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -420,7 +420,7 @@ class MainActivity :
 
         mediaRouter = MediaRouter.getInstance(this)
 
-        ThemeSettingObserver(theme, settings.theme, settings.useSystemTheme, this).observeThemeChanges()
+        ThemeSettingObserver(this, theme, settings.themeReconfigurationEvents).observeThemeChanges()
     }
 
     private fun resetEoYBadgeIfNeeded() {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -420,7 +420,7 @@ class MainActivity :
 
         mediaRouter = MediaRouter.getInstance(this)
 
-        ThemeSettingObserver(theme, settings.theme, this).observeThemeChanges()
+        ThemeSettingObserver(theme, settings.theme, settings.useSystemTheme, this).observeThemeChanges()
     }
 
     private fun resetEoYBadgeIfNeeded() {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/ThemeSettingObserver.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/ThemeSettingObserver.kt
@@ -4,31 +4,20 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
-import au.com.shiftyjelly.pocketcasts.preferences.model.ThemeSetting
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
 class ThemeSettingObserver(
-    private val theme: Theme,
-    private val themeSetting: UserSetting<ThemeSetting>,
-    private val useSystemTheme: UserSetting<Boolean>,
     private val appCompatActivity: AppCompatActivity,
+    private val theme: Theme,
+    private val themeChangeRequests: Flow<Unit>,
 ) {
     fun observeThemeChanges() {
         appCompatActivity.lifecycleScope.launch {
             appCompatActivity.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                launch {
-                    themeSetting.flow.collectLatest { themeSetting ->
-                        theme.updateTheme(appCompatActivity, Theme.ThemeType.fromThemeSetting(themeSetting))
-                    }
-                }
-                launch {
-                    useSystemTheme.flow.filter { it }.collectLatest { _ ->
-                        theme.setupThemeForConfig(appCompatActivity, appCompatActivity.resources.configuration)
-                    }
+                themeChangeRequests.collect {
+                    theme.setupThemeForConfig(appCompatActivity, appCompatActivity.resources.configuration)
                 }
             }
         }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/ThemeSettingObserver.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/ThemeSettingObserver.kt
@@ -8,18 +8,27 @@ import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.ThemeSetting
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 
 class ThemeSettingObserver(
     private val theme: Theme,
     private val themeSetting: UserSetting<ThemeSetting>,
+    private val useSystemTheme: UserSetting<Boolean>,
     private val appCompatActivity: AppCompatActivity,
 ) {
     fun observeThemeChanges() {
         appCompatActivity.lifecycleScope.launch {
             appCompatActivity.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                themeSetting.flow.collectLatest { themeSetting ->
-                    theme.updateTheme(appCompatActivity, Theme.ThemeType.fromThemeSetting(themeSetting))
+                launch {
+                    themeSetting.flow.collectLatest { themeSetting ->
+                        theme.updateTheme(appCompatActivity, Theme.ThemeType.fromThemeSetting(themeSetting))
+                    }
+                }
+                launch {
+                    useSystemTheme.flow.filter { it }.collectLatest { _ ->
+                        theme.setupThemeForConfig(appCompatActivity, appCompatActivity.resources.configuration)
+                    }
                 }
             }
         }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -28,6 +28,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.ThemeSetting
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import io.reactivex.Observable
 import java.util.Date
+import kotlinx.coroutines.flow.Flow
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -502,4 +503,14 @@ interface Settings {
     val useDarkUpNextTheme: UserSetting<Boolean>
 
     val useDynamicColorsForWidget: UserSetting<Boolean>
+
+    // We need to have a trigger for requesting theme changes.
+    // It is needed because during the sync we apply updates
+    // to individual theme settings one by one.
+    //
+    // If we were to react to them this way and not as a whole
+    // it might lead to side effects such us resetting following
+    // system dark mode.
+    val themeReconfigurationEvents: Flow<Unit>
+    fun requestThemeReconfiguration()
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -58,6 +58,9 @@ import javax.crypto.spec.PBEKeySpec
 import javax.crypto.spec.PBEParameterSpec
 import javax.inject.Inject
 import kotlin.math.max
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import timber.log.Timber
 
 class SettingsImpl @Inject constructor(
@@ -1327,4 +1330,12 @@ class SettingsImpl @Inject constructor(
         defaultValue = false,
         sharedPrefs = sharedPreferences,
     )
+
+    private val _themeReconfigurationEvents = MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_LATEST)
+    override val themeReconfigurationEvents: Flow<Unit>
+        get() = _themeReconfigurationEvents
+
+    override fun requestThemeReconfiguration() {
+        _themeReconfigurationEvents.tryEmit(Unit)
+    }
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ThemeSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ThemeSetting.kt
@@ -64,6 +64,6 @@ enum class ThemeSetting(
     )
 
     companion object {
-        fun fromServerId(id: Int) = entries.find { it.serverId == id } ?: LIGHT
+        fun fromServerId(id: Int) = entries.find { it.serverId == id }
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -68,6 +68,9 @@ data class ChangedNamedSettings(
     @field:Json(name = "useDarkUpNextTheme") val useDarkUpNextTheme: NamedChangedSettingBool? = null,
     @field:Json(name = "useDynamicColorsForWidget") val useDynamicColorsForWidget: NamedChangedSettingBool? = null,
     @field:Json(name = "filesSortOrder") val filesSortOrder: NamedChangedSettingInt? = null,
+    @field:Json(name = "darkThemePreference") val darkThemePreference: NamedChangedSettingInt? = null,
+    @field:Json(name = "lightThemePreference") val lightThemePreference: NamedChangedSettingInt? = null,
+    @field:Json(name = "useSystemTheme") val useSystemTheme: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -246,6 +246,19 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         modifiedAt = modifiedAt,
                     )
                 },
+                darkThemePreference = settings.darkThemePreference.getSyncSetting(lastSyncTime) { value, modifiedAt ->
+                    NamedChangedSettingInt(
+                        value = value.serverId,
+                        modifiedAt = modifiedAt,
+                    )
+                },
+                lightThemePreference = settings.lightThemePreference.getSyncSetting(lastSyncTime) { value, modifiedAt ->
+                    NamedChangedSettingInt(
+                        value = value.serverId,
+                        modifiedAt = modifiedAt,
+                    )
+                },
+                useSystemTheme = settings.useSystemTheme.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
             ),
         )
 
@@ -543,6 +556,21 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.cloudSortOrder,
                         newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { Settings.CloudSortOrder.fromServerId(it) ?: Settings.CloudSortOrder.NEWEST_OLDEST },
+                    )
+                    "darkThemePreference" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.darkThemePreference,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { ThemeSetting.fromServerId(it) ?: ThemeSetting.DARK },
+                    )
+                    "lightThemePreference" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.lightThemePreference,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { ThemeSetting.fromServerId(it) ?: ThemeSetting.LIGHT },
+                    )
+                    "useSystemTheme" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.useSystemTheme,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")
                 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -267,6 +267,8 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
             settings: Settings,
             response: ChangedNamedSettingsResponse,
         ) {
+            var isThemeChanged = false
+
             for ((key, changedSettingResponse) in response) {
                 when (key) {
                     "autoArchiveInactive" -> updateSettingIfPossible(
@@ -467,7 +469,22 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.theme,
                         newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { ThemeSetting.fromServerId(it) ?: ThemeSetting.LIGHT },
-                    )
+                    ).also { isThemeChanged = it != null || isThemeChanged }
+                    "darkThemePreference" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.darkThemePreference,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { ThemeSetting.fromServerId(it) ?: ThemeSetting.DARK },
+                    ).also { isThemeChanged = it != null || isThemeChanged }
+                    "lightThemePreference" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.lightThemePreference,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { ThemeSetting.fromServerId(it) ?: ThemeSetting.LIGHT },
+                    ).also { isThemeChanged = it != null || isThemeChanged }
+                    "useSystemTheme" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.useSystemTheme,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    ).also { isThemeChanged = it != null || isThemeChanged }
                     "badges" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.podcastBadgeType,
@@ -557,23 +574,12 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         setting = settings.cloudSortOrder,
                         newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { Settings.CloudSortOrder.fromServerId(it) ?: Settings.CloudSortOrder.NEWEST_OLDEST },
                     )
-                    "darkThemePreference" -> updateSettingIfPossible(
-                        changedSettingResponse = changedSettingResponse,
-                        setting = settings.darkThemePreference,
-                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { ThemeSetting.fromServerId(it) ?: ThemeSetting.DARK },
-                    )
-                    "lightThemePreference" -> updateSettingIfPossible(
-                        changedSettingResponse = changedSettingResponse,
-                        setting = settings.lightThemePreference,
-                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { ThemeSetting.fromServerId(it) ?: ThemeSetting.LIGHT },
-                    )
-                    "useSystemTheme" -> updateSettingIfPossible(
-                        changedSettingResponse = changedSettingResponse,
-                        setting = settings.useSystemTheme,
-                        newSettingValue = (changedSettingResponse.value as? Boolean),
-                    )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")
                 }
+            }
+
+            if (isThemeChanged) {
+                settings.requestThemeReconfiguration()
             }
         }
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -453,7 +453,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "theme" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.theme,
-                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let(ThemeSetting::fromServerId),
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { ThemeSetting.fromServerId(it) ?: ThemeSetting.LIGHT },
                     )
                     "badges" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
@@ -281,15 +281,15 @@ class Theme @Inject constructor(private val settings: Settings) {
         ThemeType.fromThemeSetting(settings.lightThemePreference.value)
 
     private fun setPreferredDarkThemeToPreferences(theme: ThemeType) {
-        settings.darkThemePreference.set(theme.themeSetting, needsSync = false)
+        settings.darkThemePreference.set(theme.themeSetting, needsSync = true)
     }
 
     private fun setPreferredLightThemeToPreferences(theme: ThemeType) {
-        settings.lightThemePreference.set(theme.themeSetting, needsSync = false)
+        settings.lightThemePreference.set(theme.themeSetting, needsSync = true)
     }
 
     fun setUseSystemTheme(value: Boolean, activity: AppCompatActivity?) {
-        settings.useSystemTheme.set(value, commit = true, needsSync = false)
+        settings.useSystemTheme.set(value, commit = true, needsSync = true)
 
         if (value && activity != null) {
             setupThemeForConfig(activity, activity.resources.configuration)

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
@@ -253,7 +253,7 @@ class Theme @Inject constructor(private val settings: Settings) {
 
             updateTheme(activity, theme)
         } else {
-            updateTheme(activity, activeTheme)
+            updateTheme(activity, getThemeFromPreferences())
         }
     }
 


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the global settings for system theme controls.

## Testing Instructions

> [!note]
> You need to test this with staging because changes aren't deployed to production, yet.
> 
> To test on staging use the `debug` variant instead of the `debugProd` one.

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`Appearance`.
4. D1: Toggle `Use Android Light/Dark Mode` to `OFF`.
5. D1: Sync the device in the `Profile`.
6. D2: Sync the device in the `Profile`.
7. D2: Notice that the app doesn't follow Android's Light/Dark Mode.
8. D2: Go to `Profile`/`Settings (cog icon)`/`Appearance`.
9. D2: Set `Classic` theme (this will trigger default light theme setting).
10. D2: Set `Dark contrast` theme (this will trigger default dark theme setting).
11. D2: Toggle `Use Android Light/Dark Mode` to `ON`.
12. D2: Sync the device in the `Profile`.
13. D1: Sync the device in the `Profile`.
14. D1: Notice that the app follows Android's Light/Dark Mode and uses `Classic` and `Dark contrast` as themes.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
