### PR TITLE
Sync bookmark sorting settings

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -213,7 +213,7 @@ class BookmarksViewModel
 
     fun changeSortOrder(order: BookmarksSortType) {
         if (order !is BookmarksSortTypeDefault) return
-        sourceView.mapToBookmarksSortTypeUserSetting().set(order, needsSync = false)
+        sourceView.mapToBookmarksSortTypeUserSetting().set(order, needsSync = true)
         analyticsTracker.track(
             AnalyticsEvent.BOOKMARKS_SORT_BY_CHANGED,
             mapOf(

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -393,7 +393,7 @@ class PodcastViewModel
 
     fun changeSortOrder(order: BookmarksSortType) {
         if (order !is BookmarksSortTypeForPodcast) return
-        settings.podcastBookmarksSortType.set(order, needsSync = false)
+        settings.podcastBookmarksSortType.set(order, needsSync = true)
         analyticsTracker.track(
             AnalyticsEvent.BOOKMARKS_SORT_BY_CHANGED,
             mapOf(

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/BookmarksSortTypeDefault.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/BookmarksSortTypeDefault.kt
@@ -12,18 +12,22 @@ private const val SORT_TYPE_TIMESTAMP = "timestamp"
 enum class BookmarksSortTypeDefault(
     override val labelId: Int,
     override val key: String,
+    val serverId: Int,
 ) : BookmarksSortType {
     DATE_ADDED_NEWEST_TO_OLDEST(
         labelId = R.string.bookmarks_sort_newest_to_oldest,
         key = SORT_TYPE_DATE_ADDED_NEWEST_TO_OLDEST,
+        serverId = 0,
     ),
     DATE_ADDED_OLDEST_TO_NEWEST(
         labelId = R.string.bookmarks_sort_oldest_to_newest,
         key = SORT_TYPE_DATE_ADDED_OLDEST_TO_NEWEST,
+        serverId = 1,
     ),
     TIMESTAMP(
         labelId = R.string.bookmarks_sort_timestamp,
         key = SORT_TYPE_TIMESTAMP,
+        serverId = 2,
     ),
     ;
 
@@ -36,9 +40,12 @@ enum class BookmarksSortTypeDefault(
         defaultValue = defaultValue,
         sharedPrefs = sharedPrefs,
         fromString = { str ->
-            BookmarksSortTypeDefault.values().find { it.key == str }
-                ?: defaultValue
+            BookmarksSortTypeDefault.entries.find { it.key == str } ?: defaultValue
         },
         toString = { it.key },
     )
+
+    companion object {
+        fun fromServerId(id: Int) = entries.find { it.serverId == id }
+    }
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/BookmarksSortTypeForPodcast.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/BookmarksSortTypeForPodcast.kt
@@ -12,18 +12,22 @@ private const val SORT_TYPE_EPISODE = "episode"
 enum class BookmarksSortTypeForPodcast(
     override val labelId: Int,
     override val key: String,
+    val serverId: Int,
 ) : BookmarksSortType {
     DATE_ADDED_NEWEST_TO_OLDEST(
         labelId = R.string.bookmarks_sort_newest_to_oldest,
         key = SORT_TYPE_DATE_ADDED_NEWEST_TO_OLDEST,
+        serverId = 0,
     ),
     DATE_ADDED_OLDEST_TO_NEWEST(
         labelId = R.string.bookmarks_sort_oldest_to_newest,
         key = SORT_TYPE_DATE_ADDED_OLDEST_TO_NEWEST,
+        serverId = 1,
     ),
     EPISODE(
         labelId = R.string.episode,
         key = SORT_TYPE_EPISODE,
+        serverId = 2,
     ),
     ;
 
@@ -36,9 +40,12 @@ enum class BookmarksSortTypeForPodcast(
         defaultValue = defaultValue,
         sharedPrefs = sharedPrefs,
         fromString = { str ->
-            BookmarksSortTypeForPodcast.values().find { it.key == str }
-                ?: defaultValue
+            BookmarksSortTypeForPodcast.entries.find { it.key == str } ?: defaultValue
         },
         toString = { it.key },
     )
+
+    companion object {
+        fun fromServerId(id: Int) = entries.find { it.serverId == id }
+    }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -62,6 +62,9 @@ data class ChangedNamedSettings(
     @field:Json(name = "headphoneControlsNextAction") val headphoneControlsNextAction: NamedChangedSettingInt? = null,
     @field:Json(name = "headphoneControlsPreviousAction") val headphoneControlsPreviousAction: NamedChangedSettingInt? = null,
     @field:Json(name = "headphoneControlsPlayBookmarkConfirmationSound") val headphoneControlsPlayBookmarkConfirmationSound: NamedChangedSettingBool? = null,
+    @field:Json(name = "episodeBookmarksSortType") val episodeBookmarksSortType: NamedChangedSettingInt? = null,
+    @field:Json(name = "playerBookmarksSortType") val playerBookmarksSortType: NamedChangedSettingInt? = null,
+    @field:Json(name = "podcastBookmarksSortType") val podcastBookmarksSortType: NamedChangedSettingInt? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -14,6 +14,8 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveAfterPlayingS
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoArchiveInactiveSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoPlaySource
 import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
+import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeDefault
+import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeForPodcast
 import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
 import au.com.shiftyjelly.pocketcasts.preferences.model.NewEpisodeNotificationAction
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
@@ -218,6 +220,24 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     )
                 },
                 headphoneControlsPlayBookmarkConfirmationSound = settings.headphoneControlsPlayBookmarkConfirmationSound.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
+                episodeBookmarksSortType = settings.episodeBookmarksSortType.getSyncSetting(lastSyncTime) { setting, modifiedAt ->
+                    NamedChangedSettingInt(
+                        value = setting.serverId,
+                        modifiedAt = modifiedAt,
+                    )
+                },
+                playerBookmarksSortType = settings.playerBookmarksSortType.getSyncSetting(lastSyncTime) { setting, modifiedAt ->
+                    NamedChangedSettingInt(
+                        value = setting.serverId,
+                        modifiedAt = modifiedAt,
+                    )
+                },
+                podcastBookmarksSortType = settings.podcastBookmarksSortType.getSyncSetting(lastSyncTime) { setting, modifiedAt ->
+                    NamedChangedSettingInt(
+                        value = setting.serverId,
+                        modifiedAt = modifiedAt,
+                    )
+                },
             ),
         )
 
@@ -485,6 +505,21 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.headphoneControlsPlayBookmarkConfirmationSound,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "episodeBookmarksSortType" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.episodeBookmarksSortType,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { BookmarksSortTypeDefault.fromServerId(it) ?: BookmarksSortTypeDefault.DATE_ADDED_NEWEST_TO_OLDEST },
+                    )
+                    "playerBookmarksSortType" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.playerBookmarksSortType,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { BookmarksSortTypeDefault.fromServerId(it) ?: BookmarksSortTypeDefault.DATE_ADDED_NEWEST_TO_OLDEST },
+                    )
+                    "podcastBookmarksSortType" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.podcastBookmarksSortType,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { BookmarksSortTypeForPodcast.fromServerId(it) ?: BookmarksSortTypeForPodcast.DATE_ADDED_NEWEST_TO_OLDEST },
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")
                 }


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the global settings for bookmark sorting options.

## Testing Instructions

> [!note]
> You need to test this with staging because changes aren't deployed to production, yet.
> 
> To test on staging use the `debug` variant instead of the `debugProd` one.

> [!note]
> You need to test it with a Patron account.

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
4. D1: Play an episode and create some bookmarks for it.
5. D1: Open the player.
6. D1: Go to `Bookmarks` tab.
7. D1: Tap on the `overflow menu (three dots)`.
8. D1: Change `Sort by` setting.
9. D1: Sync the device in the `Profile`.
10. D2: Sync the device in the `Profile`.
11. D2: Open the player.
12. D2: Go to `Bookmarks` tab.
13. D2: Check if the sorting setting is applied.
14. D2: Go to `Podcasts`.
15. D2: Select a podcast with bookmarks.
16. D2: Go to `Bookmarks` tab.
17. D2: Tap on the `overflow menu (three dots)`.
18. D2: Change `Sort by` setting.
19. D2: Sync the device in the `Profile`.
20. D1: Sync the device in the `Profile`.
21. D1: Go to `Podcasts`.
22. D1: Select a podcast with bookmarks.
23. D1: Go to `Bookmarks` tab.
24. D1: Check if the sorting setting is applied. Notice there is a bug when sorting by timestamps so you might need to check the setting directly. #1741
25. D1: Go back to `Podcasts` tab.
26. D1: Select an episode with bookmarks.
27. D1: Go to `Bookmarks` tab.
28. D1: Tap on the `overflow menu (three dots)`.
29. D1: Change `Sort by` setting.
30. D1: Sync the device in the `Profile`.
31. D2: Sync the device in the `Profile`.
32. D2: Go to `Podcasts`.
33. D2: Select an episode with bookmarks.
34. D2: Go to `Bookmarks` tab.
35. D2: Check if the sorting setting is applied.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
