### PR TITLE
Sync dark up next theme setting

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
@@ -115,7 +115,7 @@ class SettingsAppearanceViewModel @Inject constructor(
     }
 
     fun updateUpNextDarkTheme(value: Boolean) {
-        settings.useDarkUpNextTheme.set(value, needsSync = false)
+        settings.useDarkUpNextTheme.set(value, needsSync = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_APPEARANCE_USE_DARK_UP_NEXT_TOGGLED,
             mapOf("enabled" to value),

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -65,6 +65,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "episodeBookmarksSortType") val episodeBookmarksSortType: NamedChangedSettingInt? = null,
     @field:Json(name = "playerBookmarksSortType") val playerBookmarksSortType: NamedChangedSettingInt? = null,
     @field:Json(name = "podcastBookmarksSortType") val podcastBookmarksSortType: NamedChangedSettingInt? = null,
+    @field:Json(name = "useDarkUpNextTheme") val useDarkUpNextTheme: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -238,6 +238,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         modifiedAt = modifiedAt,
                     )
                 },
+                useDarkUpNextTheme = settings.useDarkUpNextTheme.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
             ),
         )
 
@@ -520,6 +521,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.podcastBookmarksSortType,
                         newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { BookmarksSortTypeForPodcast.fromServerId(it) ?: BookmarksSortTypeForPodcast.DATE_ADDED_NEWEST_TO_OLDEST },
+                    )
+                    "useDarkUpNextTheme" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.useDarkUpNextTheme,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")
                 }


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the global settings for dark Up Next queue theme.

## Testing Instructions

> [!note]
> You need to test this with staging because changes aren't deployed to production, yet.
> 
> To test on staging use the `debug` variant instead of the `debugProd` one.

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
4. D1: Play an episode so that the mini player opens. You can pause playback after that.
5. D1: Go to `Profile`/`Settings (cog icon)`/`Appearance`.
6. D1: Change the theme to something light.
7. D1: Toggle `Use Dark Up Next Theme` setting `OFF`.
8. D1: Sync the device in the `Profile`.
9. D2: Sync the device in the `Profile`.
10. D2: Tap on the queue icon on the mini player.
11. D2: Up Next should open and use the app's theme.
12. D2: Go to `Profile`/`Settings (cog icon)`/`Appearance`.
13. D2: Toggle `Use Dark Up Next Theme` setting `ON`.
14. D2: Sync the device in the `Profile`.
15. D1: Sync the device in the `Profile`.
16. D1: Tap on the queue icon on the mini player.
17. D1: Up Next should open and use the dark theme.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
