### PR TITLE
Deselect Chapters - Display checkboxes

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
@@ -49,7 +49,6 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 fun ChapterRow(
     state: ChaptersViewModel.ChapterState,
-    selected: Boolean,
     onSelectionChange: (Boolean, Chapter) -> Unit,
     onClick: () -> Unit,
     onUrlClick: () -> Unit,
@@ -81,8 +80,10 @@ fun ChapterRow(
         ) {
             if (FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS)) {
                 Checkbox(
-                    checked = selected,
-                    onCheckedChange = { selected -> onSelectionChange(selected, chapter) },
+                    checked = state.chapter.selected,
+                    onCheckedChange = { selected ->
+                        onSelectionChange(selected, chapter)
+                    },
                     modifier = Modifier
                         .padding(start = 16.dp),
                 )
@@ -173,21 +174,18 @@ fun ChapterRowPreview() {
         Column {
             ChapterRow(
                 state = ChaptersViewModel.ChapterState.Played(chapter = chapter),
-                selected = true,
                 onSelectionChange = { _, _ -> },
                 onClick = {},
                 onUrlClick = {},
             )
             ChapterRow(
                 state = ChaptersViewModel.ChapterState.Playing(chapter = chapter, progress = 0.5f),
-                selected = false,
                 onSelectionChange = { _, _ -> },
                 onClick = {},
                 onUrlClick = {},
             )
             ChapterRow(
                 state = ChaptersViewModel.ChapterState.NotPlayed(chapter = chapter),
-                selected = false,
                 onSelectionChange = { _, _ -> },
                 onClick = {},
                 onUrlClick = {},

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
@@ -17,11 +17,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Checkbox
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -40,6 +40,8 @@ import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -75,6 +77,15 @@ fun ChapterRow(
                 .clickable { onClick() }
                 .padding(horizontal = 12.dp),
         ) {
+            if (FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS)) {
+                Checkbox(
+                    checked = false,
+                    onCheckedChange = null,
+                    modifier = Modifier
+                        .padding(start = 16.dp),
+                )
+                Spacer(Modifier.width(8.dp))
+            }
             TextH50(
                 text = chapter.index.toString(),
                 color = textColor,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
@@ -49,6 +49,8 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 fun ChapterRow(
     state: ChaptersViewModel.ChapterState,
+    selected: Boolean,
+    onSelectionChange: (Boolean, Chapter) -> Unit,
     onClick: () -> Unit,
     onUrlClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -79,8 +81,8 @@ fun ChapterRow(
         ) {
             if (FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS)) {
                 Checkbox(
-                    checked = false,
-                    onCheckedChange = null,
+                    checked = selected,
+                    onCheckedChange = { selected -> onSelectionChange(selected, chapter) },
                     modifier = Modifier
                         .padding(start = 16.dp),
                 )
@@ -171,16 +173,22 @@ fun ChapterRowPreview() {
         Column {
             ChapterRow(
                 state = ChaptersViewModel.ChapterState.Played(chapter = chapter),
+                selected = true,
+                onSelectionChange = { _, _ -> },
                 onClick = {},
                 onUrlClick = {},
             )
             ChapterRow(
                 state = ChaptersViewModel.ChapterState.Playing(chapter = chapter, progress = 0.5f),
+                selected = false,
+                onSelectionChange = { _, _ -> },
                 onClick = {},
                 onUrlClick = {},
             )
             ChapterRow(
                 state = ChaptersViewModel.ChapterState.NotPlayed(chapter = chapter),
+                selected = false,
+                onSelectionChange = { _, _ -> },
                 onClick = {},
                 onUrlClick = {},
             )

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -69,6 +69,8 @@ class ChaptersFragment : BaseFragment() {
                     ChaptersPage(
                         lazyListState = lazyListState,
                         chapters = uiState.chapters,
+                        isSelected = { uiState.isSelected(it) },
+                        onSelectionChange = { selected, chapter -> chaptersViewModel.onSelectionChange(selected, chapter) },
                         onChapterClick = ::onChapterClick,
                         onUrlClick = ::onUrlClick,
                         backgroundColor = uiState.backgroundColor,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -69,7 +69,6 @@ class ChaptersFragment : BaseFragment() {
                     ChaptersPage(
                         lazyListState = lazyListState,
                         chapters = uiState.chapters,
-                        isSelected = { uiState.isSelected(it) },
                         onSelectionChange = { selected, chapter -> chaptersViewModel.onSelectionChange(selected, chapter) },
                         onChapterClick = ::onChapterClick,
                         onUrlClick = ::onUrlClick,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -12,13 +12,13 @@ import androidx.compose.material.Surface
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rxjava2.subscribeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
@@ -49,7 +49,7 @@ class ChaptersFragment : BaseFragment() {
             AppTheme(Theme.ThemeType.DARK) {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
 
-                val uiState by chaptersViewModel.uiState.subscribeAsState(chaptersViewModel.defaultUiState)
+                val uiState by chaptersViewModel.uiState.collectAsStateWithLifecycle()
                 val lazyListState = rememberLazyListState()
                 this@ChaptersFragment.lazyListState = lazyListState
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
@@ -19,7 +19,6 @@ import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 fun ChaptersPage(
     lazyListState: LazyListState,
     chapters: List<ChaptersViewModel.ChapterState>,
-    isSelected: (Chapter) -> Boolean,
     onSelectionChange: (Boolean, Chapter) -> Unit,
     onChapterClick: (Chapter, Boolean) -> Unit,
     onUrlClick: (String) -> Unit,
@@ -36,7 +35,6 @@ fun ChaptersPage(
         itemsIndexed(chapters, key = { _, state -> state.chapter.index }) { index, state ->
             ChapterRow(
                 state = state,
-                selected = isSelected(state.chapter),
                 onSelectionChange = onSelectionChange,
                 onClick = { onChapterClick(state.chapter, state is ChaptersViewModel.ChapterState.Playing) },
                 onUrlClick = { onUrlClick(state.chapter.url.toString()) },

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
@@ -19,6 +19,8 @@ import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 fun ChaptersPage(
     lazyListState: LazyListState,
     chapters: List<ChaptersViewModel.ChapterState>,
+    isSelected: (Chapter) -> Boolean,
+    onSelectionChange: (Boolean, Chapter) -> Unit,
     onChapterClick: (Chapter, Boolean) -> Unit,
     onUrlClick: (String) -> Unit,
     backgroundColor: Color,
@@ -34,6 +36,8 @@ fun ChaptersPage(
         itemsIndexed(chapters, key = { _, state -> state.chapter.index }) { index, state ->
             ChapterRow(
                 state = state,
+                selected = isSelected(state.chapter),
+                onSelectionChange = onSelectionChange,
                 onClick = { onChapterClick(state.chapter, state is ChaptersViewModel.ChapterState.Playing) },
                 onUrlClick = { onUrlClick(state.chapter.url.toString()) },
             )

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapter.kt
@@ -10,6 +10,7 @@ data class Chapter(
     val imagePath: String? = null,
     val mimeType: String? = null,
     var index: Int = 0,
+    val selected: Boolean = false,
 ) {
 
     val isImagePresent: Boolean


### PR DESCRIPTION
Part of #1807 

## Description

This displays placeholder checkboxes for chapters (UI will be fine-tuned later).

## Testing Instructions

#### Test.1 Feature Enabled
1. Open podcast https://pca.st/upgrade
2. Play an episode from the podcast
3. Open full-screen player
4. Go to the `Chapters` tab
5. Notice that checkboxes are shown for chapters
6. Notice that you can select/unselect chapters (values are not persisted though)


#### Test.2 Feature Disabled

1. Go to `Profile` -> `Settings` -> `Beta features`
2. Set `Deselect Chapters` toggle to off
3. Kill the app and reopen
4. Repeat steps 1-4 from Test.1 
5. Notice that checkboxes are not shown for chapters

## Screenshots or Screencast 

Feature enabled

https://github.com/Automattic/pocket-casts-android/assets/1405144/6e4a4e2a-0aea-4899-8c37-e94ca268d062

Feature disabled
<img width=320 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/f41377f0-b15b-411e-bb44-904eea44c5a0"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
