### PR TITLE
Sync cloud files sorting order setting

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -270,7 +270,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         }
         multiSelectHelper.listener = object : MultiSelectHelper.Listener<BaseEpisode> {
             override fun multiSelectSelectAll() {
-                val episodes = viewModel.cloudFilesList.value
+                val episodes = viewModel.uiState.value?.userEpisodes
                 if (episodes != null) {
                     multiSelectHelper.selectAllInList(episodes)
                     adapter.notifyDataSetChanged()
@@ -279,7 +279,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             }
 
             override fun multiSelectSelectNone() {
-                val episodes = viewModel.cloudFilesList.value
+                val episodes = viewModel.uiState.value?.userEpisodes
                 if (episodes != null) {
                     multiSelectHelper.deselectAllInList(episodes)
                     adapter.notifyDataSetChanged()
@@ -288,7 +288,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             }
 
             override fun multiSelectSelectAllUp(multiSelectable: BaseEpisode) {
-                val episodes = viewModel.cloudFilesList.value
+                val episodes = viewModel.uiState.value?.userEpisodes
                 if (episodes != null) {
                     val startIndex = episodes.indexOf(multiSelectable)
                     if (startIndex > -1) {
@@ -301,7 +301,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             }
 
             override fun multiSelectSelectAllDown(multiSelectable: BaseEpisode) {
-                val episodes = viewModel.cloudFilesList.value
+                val episodes = viewModel.uiState.value?.userEpisodes
                 if (episodes != null) {
                     val startIndex = episodes.indexOf(multiSelectable)
                     if (startIndex > -1) {
@@ -314,7 +314,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             }
 
             override fun multiDeselectAllBelow(multiSelectable: BaseEpisode) {
-                val cloudFiles = viewModel.cloudFilesList.value
+                val cloudFiles = viewModel.uiState.value?.userEpisodes
                 if (cloudFiles != null) {
                     val startIndex = cloudFiles.indexOf(multiSelectable)
                     if (startIndex > -1) {
@@ -326,7 +326,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             }
 
             override fun multiDeselectAllAbove(multiSelectable: BaseEpisode) {
-                val cloudFiles = viewModel.cloudFilesList.value
+                val cloudFiles = viewModel.uiState.value?.userEpisodes
                 if (cloudFiles != null) {
                     val startIndex = cloudFiles.indexOf(multiSelectable)
                     if (startIndex > -1) {
@@ -386,10 +386,6 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                 titleId = LR.string.episode_sort_newest_to_oldest,
                 click = {
                     viewModel.changeSort(Settings.CloudSortOrder.NEWEST_OLDEST)
-                    analyticsTracker.track(
-                        AnalyticsEvent.UPLOADED_FILES_SORT_BY_CHANGED,
-                        mapOf(SORT_BY to SortOrder.NEWEST_TO_OLDEST.analyticsValue),
-                    )
                 },
                 checked = (viewModel.getSortOrder() == Settings.CloudSortOrder.NEWEST_OLDEST),
             )
@@ -397,10 +393,6 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                 titleId = LR.string.episode_sort_oldest_to_newest,
                 click = {
                     viewModel.changeSort(Settings.CloudSortOrder.OLDEST_NEWEST)
-                    analyticsTracker.track(
-                        AnalyticsEvent.UPLOADED_FILES_SORT_BY_CHANGED,
-                        mapOf(SORT_BY to SortOrder.OLDEST_TO_NEWEST.analyticsValue),
-                    )
                 },
                 checked = (viewModel.getSortOrder() == Settings.CloudSortOrder.OLDEST_NEWEST),
             )
@@ -408,10 +400,6 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                 titleId = LR.string.podcasts_sort_by_title,
                 click = {
                     viewModel.changeSort(Settings.CloudSortOrder.A_TO_Z)
-                    analyticsTracker.track(
-                        AnalyticsEvent.UPLOADED_FILES_SORT_BY_CHANGED,
-                        mapOf(SORT_BY to SortOrder.TITLE_A_TO_Z.analyticsValue),
-                    )
                 },
                 checked = (viewModel.getSortOrder() == Settings.CloudSortOrder.A_TO_Z),
             )
@@ -425,12 +413,6 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         } else {
             false
         }
-    }
-
-    enum class SortOrder(val analyticsValue: String) {
-        NEWEST_TO_OLDEST("newest_to_oldest"),
-        OLDEST_TO_NEWEST("oldest_to_newest"),
-        TITLE_A_TO_Z("title_a_to_z"),
     }
 
     companion object {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.profile.cloud
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.asFlow
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.toLiveData
 import androidx.lifecycle.viewModelScope
@@ -19,6 +18,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -35,7 +35,7 @@ class CloudFilesViewModel @Inject constructor(
 
     val accountUsage = userEpisodeManager.observeAccountUsage().toLiveData()
     val signInState = userManager.getSignInState().toLiveData()
-    val cloudFilesList = cloudFilesManager.cloudFilesList
+    val cloudFilesList = cloudFilesManager.sortedCloudFiles
 
     data class UiState(
         val userEpisodes: List<UserEpisode> = emptyList(),
@@ -46,7 +46,7 @@ class CloudFilesViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             combine(
-                cloudFilesManager.cloudFilesList.asFlow(),
+                cloudFilesManager.sortedCloudFiles,
                 bookmarkManager.findUserEpisodesBookmarksFlow(),
             ) { cloudFiles, bookmarks ->
                 val cloudFilesWithBookmarkInfo = cloudFiles.map { file ->
@@ -59,32 +59,38 @@ class CloudFilesViewModel @Inject constructor(
     }
 
     fun refreshFiles(userInitiated: Boolean) {
-        if (userInitiated) {
-            analyticsTracker.track(
-                AnalyticsEvent.PULLED_TO_REFRESH,
-                mapOf(
-                    "source" to when (cloudFilesManager.cloudFilesList.value?.isEmpty()) {
-                        true -> "no_files"
-                        false -> "files"
-                        else -> "unknown"
-                    },
-                ),
-            )
+        viewModelScope.launch {
+            if (userInitiated) {
+                analyticsTracker.track(
+                    AnalyticsEvent.PULLED_TO_REFRESH,
+                    mapOf(
+                        "source" to when (cloudFilesManager.sortedCloudFiles.firstOrNull()?.isEmpty()) {
+                            true -> "no_files"
+                            false -> "files"
+                            else -> "unknown"
+                        },
+                    ),
+                )
+            }
         }
         userEpisodeManager.syncFilesInBackground(playbackManager)
     }
 
     fun changeSort(sortOrder: Settings.CloudSortOrder) {
-        settings.setCloudSortOrder(sortOrder)
-        cloudFilesManager.sortOrderRelay.accept(sortOrder)
+        analyticsTracker.track(
+            AnalyticsEvent.UPLOADED_FILES_SORT_BY_CHANGED,
+            mapOf(SORT_BY to sortOrder.analyticsValue),
+        )
+        settings.cloudSortOrder.set(sortOrder, needsSync = true)
     }
 
     fun getSortOrder(): Settings.CloudSortOrder {
-        return cloudFilesManager.sortOrderRelay.value ?: settings.getCloudSortOrder()
+        return settings.cloudSortOrder.value
     }
 
     companion object {
         private const val ACTION_KEY = "action"
         private const val SOURCE_KEY = "source"
+        private const val SORT_BY = "sort_by"
     }
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -149,13 +149,39 @@ interface Settings {
         }
     }
 
-    enum class CloudSortOrder {
-        NEWEST_OLDEST,
-        OLDEST_NEWEST,
-        A_TO_Z,
-        Z_TO_A,
-        SHORT_LONG,
-        LONG_SHORT,
+    enum class CloudSortOrder(
+        val analyticsValue: String,
+        val serverId: Int,
+    ) {
+        NEWEST_OLDEST(
+            analyticsValue = "newest_to_oldest",
+            serverId = 0,
+        ),
+        OLDEST_NEWEST(
+            analyticsValue = "oldest_to_newest",
+            serverId = 1,
+        ),
+        A_TO_Z(
+            analyticsValue = "title_a_to_z",
+            serverId = 2,
+        ),
+        Z_TO_A(
+            analyticsValue = "title_z_to_a",
+            serverId = 3,
+        ),
+        SHORT_LONG(
+            analyticsValue = "shortest_to_longest",
+            serverId = 4,
+        ),
+        LONG_SHORT(
+            analyticsValue = "longest_to_shortest",
+            serverId = 5,
+        ),
+        ;
+
+        companion object {
+            fun fromServerId(id: Int) = entries.find { it.serverId == id }
+        }
     }
 
     sealed class MediaNotificationControls(
@@ -362,8 +388,7 @@ interface Settings {
 
     val freeGiftAcknowledged: UserSetting<Boolean>
 
-    fun setCloudSortOrder(sortOrder: CloudSortOrder)
-    fun getCloudSortOrder(): CloudSortOrder
+    val cloudSortOrder: UserSetting<CloudSortOrder>
     val cloudAddToUpNext: UserSetting<Boolean>
     val deleteLocalFileAfterPlaying: UserSetting<Boolean>
     val deleteCloudFileAfterPlaying: UserSetting<Boolean>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -976,13 +976,13 @@ class SettingsImpl @Inject constructor(
         )
     }
 
-    override fun setCloudSortOrder(sortOrder: Settings.CloudSortOrder) {
-        setInt("cloud_sort_order", sortOrder.ordinal)
-    }
-
-    override fun getCloudSortOrder(): Settings.CloudSortOrder {
-        return Settings.CloudSortOrder.values().getOrNull(getInt("cloud_sort_order", 0)) ?: Settings.CloudSortOrder.NEWEST_OLDEST
-    }
+    override val cloudSortOrder = UserSetting.PrefFromInt(
+        sharedPrefKey = "cloud_sort_order",
+        defaultValue = Settings.CloudSortOrder.NEWEST_OLDEST,
+        sharedPrefs = sharedPreferences,
+        fromInt = { ordinal -> Settings.CloudSortOrder.entries.find { it.ordinal == ordinal } ?: Settings.CloudSortOrder.NEWEST_OLDEST },
+        toInt = Settings.CloudSortOrder::ordinal,
+    )
 
     override val cloudAddToUpNext = UserSetting.BoolPref(
         sharedPrefKey = "cloudUpNext",

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/CloudFilesManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/CloudFilesManager.kt
@@ -1,17 +1,16 @@
 package au.com.shiftyjelly.pocketcasts.repositories.file
 
-import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
-import com.jakewharton.rxrelay2.BehaviorRelay
-import io.reactivex.BackpressureStrategy
 import javax.inject.Inject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.reactive.asFlow
 
 class CloudFilesManager @Inject constructor(
-    private val settings: Settings,
+    settings: Settings,
     private val userEpisodeManager: UserEpisodeManager,
 ) {
-    val sortOrderRelay = BehaviorRelay.create<Settings.CloudSortOrder>().apply { accept(settings.getCloudSortOrder()) }
-    val sortedCloudFiles = sortOrderRelay.toFlowable(BackpressureStrategy.LATEST).switchMap { userEpisodeManager.observeUserEpisodesSorted(it) }
-    val cloudFilesList = sortedCloudFiles.toLiveData()
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val sortedCloudFiles = settings.cloudSortOrder.flow.flatMapLatest { userEpisodeManager.observeUserEpisodesSorted(it).asFlow() }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1285,7 +1285,7 @@ open class PlaybackManager @Inject constructor(
     private suspend fun autoSelectNextEpisode(): BaseEpisode? {
         val allEpisodes: List<BaseEpisode> = when (val autoSource = settings.lastAutoPlaySource.value) {
             is AutoPlaySource.Downloads -> episodeManager.observeDownloadEpisodes().asFlow().firstOrNull()
-            is AutoPlaySource.Files -> cloudFilesManager.cloudFilesList.asFlow().firstOrNull()
+            is AutoPlaySource.Files -> cloudFilesManager.sortedCloudFiles.firstOrNull()
             is AutoPlaySource.Starred -> episodeManager.observeStarredEpisodes().asFlow().firstOrNull()
             // First check if it is a podcast uuid, then check if it is from a filter
             is AutoPlaySource.PodcastOrFilter -> podcastManager.findPodcastByUuid(autoSource.uuid)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -67,6 +67,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "podcastBookmarksSortType") val podcastBookmarksSortType: NamedChangedSettingInt? = null,
     @field:Json(name = "useDarkUpNextTheme") val useDarkUpNextTheme: NamedChangedSettingBool? = null,
     @field:Json(name = "useDynamicColorsForWidget") val useDynamicColorsForWidget: NamedChangedSettingBool? = null,
+    @field:Json(name = "filesSortOrder") val filesSortOrder: NamedChangedSettingInt? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -240,6 +240,12 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 },
                 useDarkUpNextTheme = settings.useDarkUpNextTheme.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
                 useDynamicColorsForWidget = settings.useDynamicColorsForWidget.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
+                filesSortOrder = settings.cloudSortOrder.getSyncSetting(lastSyncTime) { setting, modifiedAt ->
+                    NamedChangedSettingInt(
+                        value = setting.serverId,
+                        modifiedAt = modifiedAt,
+                    )
+                },
             ),
         )
 
@@ -532,6 +538,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.useDynamicColorsForWidget,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "filesSortOrder" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.cloudSortOrder,
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { Settings.CloudSortOrder.fromServerId(it) ?: Settings.CloudSortOrder.NEWEST_OLDEST },
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")
                 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesViewModel.kt
@@ -14,6 +14,6 @@ class FilesViewModel @Inject constructor(
 ) : ViewModel() {
 
     val userEpisodes = userEpisodeManager
-        .observeUserEpisodesSorted(settings.getCloudSortOrder())
+        .observeUserEpisodesSorted(settings.cloudSortOrder.value)
         .asFlow()
 }


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the global settings for cloud files sorting order.

I had to refactor and change old code a bit because migrating to `UserSetting` from `get()/set()` functions removed a need for a `BehaviorRelay` and we can use `Flow` instead.

I also removed redundant `SortOrder` from `CloudFilesFragment` and moved missing properties to `Settings.CloudSortOrder`.

## Testing Instructions

> [!note]
> You need to test this with staging because changes aren't deployed to production, yet.
> 
> To test on staging use the `debug` variant instead of the `debugProd` one.

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Add some custom files in `Profile`/`Files`.
4. D2: Go to `Files`/`Overflow menu (three dots)`/`Sort by`.
5. D2: Change sorting order.
6. D2: Sync the device in the `Profile`.
7. D1: Sync the device in the `Profile`.
8. D1: Go to `Files`.
9. D1: Notice that the sorting order setting is applied.
10. Repeat this test with different sorting orders.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
