### PR TITLE
PR Checks: Improve Draft PR workflow

### DIFF
--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -2,10 +2,12 @@ name: ☢️ Danger
 
 on:
   pull_request:
-    types: [opened, synchronize, edited, review_requested, review_request_removed, labeled, unlabeled, milestoned, demilestoned]
+    types: [opened, reopened, ready_for_review, synchronize, edited, labeled, unlabeled, milestoned, demilestoned]
 
 jobs:
   dangermattic:
+    # runs on draft PRs only for opened / synchronize events
+    if: ${{ (github.event.pull_request.draft == false) || (github.event.pull_request.draft == true && contains(fromJSON('["opened", "synchronize"]'), github.event.action)) }}
     uses: Automattic/dangermattic/.github/workflows/reusable-run-danger.yml@v1.0.0
     secrets:
-      github-token: ${{ secrets.DANGERMATTIC_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+      github-token: ${{ secrets.DANGERMATTIC_GITHUB_TOKEN }}

--- a/Dangerfile
+++ b/Dangerfile
@@ -7,7 +7,7 @@ rubocop.lint(files: [], force_exclusion: true, inline_comment: true, fail_on_inl
 
 manifest_pr_checker.check_gemfile_lock_updated
 
-# skip remaining checks if we're during the release process
+# skip remaining checks if we're in a release-process PR
 if github.pr_labels.include?('releases')
   message('This PR has the `releases` label: some checks will be skipped.')
   return
@@ -19,8 +19,11 @@ pr_size_checker.check_diff_size(max_size: 500)
 
 android_unit_test_checker.check_missing_tests
 
-# skip remaining checks if we have a Draft PR
-return if github.pr_draft?
+# skip remaining checks if the PR is still a Draft
+if github.pr_draft?
+  message('This PR is still a Draft: some checks will be skipped.')
+  return
+end
 
 labels_checker.check(
   do_not_merge_labels: ['do not merge'],

--- a/Dangerfile
+++ b/Dangerfile
@@ -13,22 +13,21 @@ if github.pr_labels.include?('releases')
   return
 end
 
-labels_checker.check(
-  do_not_merge_labels: ['do not merge'],
-  required_labels: [//],
-  required_labels_error: 'PR requires at least one label.'
-)
-
 view_changes_checker.check
 
 pr_size_checker.check_diff_size(max_size: 500)
 
 android_unit_test_checker.check_missing_tests
 
+# skip remaining checks if we have a Draft PR
+return if github.pr_draft?
+
+labels_checker.check(
+  do_not_merge_labels: ['do not merge'],
+  required_labels: [//],
+  required_labels_error: 'PR requires at least one label.'
+)
+
 milestone_checker.check_milestone_due_date(days_before_due: 2)
 
 warn('PR is classed as Work in Progress') if github_utils.wip_feature?
-
-unless github_utils.requested_reviewers? || github.pr_draft?
-  warn("No reviewers have been set for this PR yet. Please request a review from **@\u2060Automattic/pocket-casts-android**.")
-end


### PR DESCRIPTION
Based on some [changes](https://github.com/Automattic/pocket-casts-ios/pull/1418#discussion_r1484240656) we implemented in the Pocket Casts iOS repo, I'm porting them here as well.
The changes basically some optimizations when running against a Draft PR, avoiding running some of the checks.