### PR TITLE
Update JDK to 17

### DIFF
--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModelTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModelTest.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.ui
 import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.localization.R
-import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -23,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import com.jakewharton.rxrelay2.BehaviorRelay
 import io.reactivex.Flowable
+import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
@@ -79,12 +79,11 @@ class MainActivityViewModelTest {
     lateinit var bookmark: Bookmark
 
     @Mock
-    lateinit var episode: BaseEpisode
-
-    @Mock
     lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     private lateinit var viewModel: MainActivityViewModel
+
+    private val episode = UserEpisode(uuid = TEST_EPISODE_UUID, publishedDate = Date())
 
     @Before
     fun setup() = runTest {
@@ -125,7 +124,6 @@ class MainActivityViewModelTest {
     @Test
     fun `given episode for bookmark is current playing, when bookmark viewed from notification, then bookmarks on player shown`() = runTest {
         whenever(bookmark.episodeUuid).thenReturn(TEST_EPISODE_UUID)
-        whenever(episode.uuid).thenReturn(TEST_EPISODE_UUID)
         whenever(bookmarkManager.findBookmark(anyString(), eq(false))).thenReturn(bookmark)
         whenever(playbackManager.getCurrentEpisode()).thenReturn(episode)
         initViewModel()
@@ -215,7 +213,7 @@ class MainActivityViewModelTest {
             Flowable.just(
                 SignInState.SignedIn(
                     email = "",
-                    subscriptionStatus = mock<SubscriptionStatus>(),
+                    subscriptionStatus = SubscriptionStatus.Free(),
                 ),
             ),
         )

--- a/base.gradle
+++ b/base.gradle
@@ -43,13 +43,15 @@ android {
         coreLibraryDesugaringEnabled true
     }
 
+    final javaVersion = JavaVersion.toVersion(libs.versions.java.get())
+
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility javaVersion
+        targetCompatibility javaVersion
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = javaVersion.toString()
         // disable Kotlin warnings for Coroutines, working with the annotation @OptIn(DelicateCoroutinesApi::class)
         freeCompilerArgs += [
             "-opt-in=kotlin.RequiresOptIn"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,6 +59,7 @@ showkase = "1.0.2"
 test = "1.5.0"
 wear-compose = "1.2.1"
 work = "2.8.1"
+java = "17"
 
 [libraries]
 # About Libraries

--- a/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModelTest.kt
+++ b/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModelTest.kt
@@ -4,10 +4,14 @@ import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContract.OnboardingFinish
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingExitInfo
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import io.reactivex.Flowable
+import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -15,7 +19,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 @RunWith(MockitoJUnitRunner::class)
@@ -27,17 +30,22 @@ class OnboardingActivityViewModelTest {
     @Mock
     private lateinit var userManager: UserManager
 
-    @Mock
-    private lateinit var paidSubscriptionStatus: SubscriptionStatus.Paid
-
-    @Mock
-    private lateinit var freeSubscriptionStatus: SubscriptionStatus.Free
-
     private lateinit var viewModel: OnboardingActivityViewModel
+
+    private val paidSubscriptionStatus = SubscriptionStatus.Paid(
+        expiry = Date(),
+        autoRenew = false,
+        index = 0,
+        platform = SubscriptionPlatform.GIFT,
+        tier = SubscriptionTier.PLUS,
+        type = SubscriptionType.PLUS,
+    )
+
+    private val freeSubscriptionStatus = SubscriptionStatus.Free()
 
     @Test
     fun `given showPlusPromotionForFreeUser is false, when exit onboarding, then finish with Done`() = runTest {
-        initViewModel()
+        initViewModel(freeSubscriptionStatus)
 
         viewModel.finishState.test {
             viewModel.onExitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = false))
@@ -65,7 +73,7 @@ class OnboardingActivityViewModelTest {
         }
     }
 
-    private fun initViewModel(subscriptionStatus: SubscriptionStatus = mock<SubscriptionStatus>()) {
+    private fun initViewModel(subscriptionStatus: SubscriptionStatus) {
         whenever(userManager.getSignInState()).thenReturn(
             Flowable.just(
                 SignInState.SignedIn(email = "", subscriptionStatus = subscriptionStatus),

--- a/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
+++ b/modules/features/endofyear/src/test/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesViewModelTest.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionMana
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.utils.FileUtilWrapper
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
+import java.util.Date
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -65,12 +66,11 @@ class StoriesViewModelTest {
     private lateinit var subscriptionManager: SubscriptionManager
 
     @Mock
-    private lateinit var cachedSubscriptionStatus: SubscriptionStatus
-
-    @Mock
     private lateinit var userSetting: UserSetting<SubscriptionStatus?>
 
     private lateinit var cachedSubscriptionStatusFlow: MutableStateFlow<SubscriptionStatus>
+
+    private val cachedSubscriptionStatus = SubscriptionStatus.Free()
 
     @Before
     fun setup() {
@@ -226,7 +226,7 @@ class StoriesViewModelTest {
             .thenReturn(UserTier.Plus)
         initViewModel(listOf(plusStory1))
 
-        cachedSubscriptionStatusFlow.value = mock()
+        cachedSubscriptionStatusFlow.value = cachedSubscriptionStatus.copy(expiry = Date())
 
         verifyBlocking(endOfYearManager, times(2)) { downloadListeningHistory(anyOrNull()) }
         verifyBlocking(endOfYearManager, times(2)) { loadStories() }
@@ -239,7 +239,7 @@ class StoriesViewModelTest {
             .thenReturn(UserTier.Free)
         initViewModel(listOf(plusStory1))
 
-        cachedSubscriptionStatusFlow.value = mock()
+        cachedSubscriptionStatusFlow.value = cachedSubscriptionStatus.copy(expiry = Date())
 
         verifyBlocking(endOfYearManager, times(1)) { downloadListeningHistory(anyOrNull()) }
         verifyBlocking(endOfYearManager, times(1)) { loadStories() }

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
@@ -4,8 +4,8 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
@@ -18,6 +18,7 @@ import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
+import java.util.Date
 import java.util.UUID
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
@@ -61,12 +62,6 @@ class BookmarksViewModelTest {
     private lateinit var multiSelectHelper: MultiSelectBookmarksHelper
 
     @Mock
-    private lateinit var episode: BaseEpisode
-
-    @Mock
-    private lateinit var cachedSubscriptionStatus: SubscriptionStatus
-
-    @Mock
     private lateinit var settings: Settings
 
     @Mock
@@ -82,7 +77,10 @@ class BookmarksViewModelTest {
     private lateinit var bookmarkFeature: BookmarkFeatureControl
 
     private lateinit var bookmarksViewModel: BookmarksViewModel
+
     private val episodeUuid = UUID.randomUUID().toString()
+    private val episode = UserEpisode(episodeUuid, publishedDate = Date())
+    private val cachedSubscriptionStatus = SubscriptionStatus.Free()
 
     @Before
     fun setUp() = runTest {

--- a/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModelTest.kt
+++ b/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModelTest.kt
@@ -7,7 +7,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryMa
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import java.util.UUID
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -48,20 +47,18 @@ class SearchViewModelTest {
     }
 
     @Test
-    fun `given podcast is subscribed, when podcast subscribe plus icon clicked, then podcast is subscribed`() =
-        runTest {
-            val uuid = UUID.randomUUID().toString()
-            viewModel.onSubscribeToPodcast(Podcast(uuid = uuid, isSubscribed = false))
+    fun `given podcast is subscribed, when podcast subscribe plus icon clicked, then podcast is subscribed`() {
+        val uuid = UUID.randomUUID().toString()
+        viewModel.onSubscribeToPodcast(Podcast(uuid = uuid, isSubscribed = false))
 
-            verify(podcastManager).subscribeToPodcast(podcastUuid = uuid, sync = true)
-        }
+        verify(podcastManager).subscribeToPodcast(podcastUuid = uuid, sync = true)
+    }
 
     @Test
-    fun `given podcast not subscribed, when podcast subscribe check icon clicked, then podcast remains subscribed`() =
-        runTest {
-            val uuid = UUID.randomUUID().toString()
-            viewModel.onSubscribeToPodcast(Podcast(uuid = uuid, isSubscribed = true))
+    fun `given podcast not subscribed, when podcast subscribe check icon clicked, then podcast remains subscribed`() {
+        val uuid = UUID.randomUUID().toString()
+        viewModel.onSubscribeToPodcast(Podcast(uuid = uuid, isSubscribed = true))
 
-            verify(podcastManager, never()).subscribeToPodcast(podcastUuid = uuid, sync = true)
-        }
+        verify(podcastManager, never()).subscribeToPodcast(podcastUuid = uuid, sync = true)
+    }
 }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -66,7 +66,6 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
         // Allow for widescale experimental APIs in Alpha libraries we build upon
         freeCompilerArgs += "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi"
     }


### PR DESCRIPTION
## Description

While working on automating proto generation in #1831 I encountered a problem with Java compatibility. This PR switches our Java target and compatibility versions to 17. I had to fix some of the tests because we were mocking final classes and it is no longer possible with newer versions of JDK. There are some discussions on Mockito project about it with potential solutions like switching to MockK. But I think it is much simpler, and better, to not mock unnecessary objects.

## Testing Instructions

CI checks should be enough. You can smoke test the apps.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
