### PR TITLE
Use correct setting when changing auto play preference

### DIFF
--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -64,7 +64,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
 
     private fun setupAutoPlay() {
         preferenceAutoPlay.setOnPreferenceChangeListener { _, newValue ->
-            settings.autoShowPlayed.set(newValue as Boolean, needsSync = false)
+            settings.autoPlayNextEpisodeOnEmpty.set(newValue as Boolean, needsSync = true)
             true
         }
         settings.autoPlayNextEpisodeOnEmpty.flow


### PR DESCRIPTION
## Description

We had a bug on automotive. We updated a wrong setting when `Auto play` preference was changed.

## Testing Instructions

1. Sign in to Automotive app.
2. Go to Settings.
3. Toggle `Auto Play` setting.
4. Go back to the main screen.
5. Go back to Settings.
6. `Auto Play` setting should keep its value.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
