### PR TITLE
Sync show archived podcast setting

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -157,11 +157,11 @@ abstract class PodcastDao {
     @Query("UPDATE podcasts SET sync_status = :syncStatus WHERE uuid = :uuid")
     abstract fun updateSyncStatus(syncStatus: Int, uuid: String)
 
-    @Query("UPDATE podcasts SET show_archived = :showArchived WHERE uuid = :uuid")
-    abstract suspend fun updateShowArchived(uuid: String, showArchived: Boolean)
+    @Query("UPDATE podcasts SET show_archived = :showArchived, show_archived_modified = :modified, sync_status = 0 WHERE uuid = :uuid")
+    abstract suspend fun updateShowArchived(uuid: String, showArchived: Boolean, modified: Date = Date())
 
-    @Query("UPDATE podcasts SET show_archived = :showArchived")
-    abstract suspend fun updateAllShowArchived(showArchived: Boolean)
+    @Query("UPDATE podcasts SET show_archived = :showArchived, show_archived_modified = :modified, sync_status = 0")
+    abstract suspend fun updateAllShowArchived(showArchived: Boolean, modified: Date = Date())
 
     @Query("UPDATE podcasts SET folder_uuid = :folderUuid, sync_status = 0 WHERE uuid IN (:podcastUuids)")
     abstract suspend fun updateFolderUuid(folderUuid: String?, podcastUuids: List<String>)

--- a/modules/services/protobuf/src/main/proto/sync_api.proto
+++ b/modules/services/protobuf/src/main/proto/sync_api.proto
@@ -79,6 +79,7 @@ message PodcastSettings {
   Int32Setting auto_archive_inactive = 13;
   Int32Setting auto_archive_episode_limit = 14;
   Int32Setting episode_grouping = 15;
+  BoolSetting show_archived = 16;
 }
 
 message SyncUserEpisode {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -917,6 +917,8 @@ class PodcastSyncProcess(
         podcastSync.autoArchiveEpisodeLimitModified?.let { podcast.autoArchiveEpisodeLimitModified = it }
         podcastSync.episodeGrouping?.let { podcast.grouping = PodcastGrouping.fromServerId(it) ?: PodcastGrouping.None }
         podcastSync.episodeGroupingModified?.let { podcast.groupingModified = it }
+        podcastSync.showArchived?.let { podcast.showArchived = it }
+        podcastSync.showArchivedModified?.let { podcast.showNotificationsModified = it }
     }
 
     fun importEpisode(episodeSync: SyncUpdateResponse.EpisodeSync): Maybe<PodcastEpisode> {
@@ -1133,6 +1135,12 @@ class PodcastSyncProcess(
                             value = int32Value { value = podcast.grouping.serverId }
                             modifiedAt = timestamp {
                                 seconds = podcast.groupingModified?.timeSecs() ?: lastSyncTime.epochSecond
+                            }
+                        }
+                        showArchived = boolSetting {
+                            value = boolValue { value = podcast.showArchived }
+                            modifiedAt = timestamp {
+                                seconds = podcast.showArchivedModified?.timeSecs() ?: lastSyncTime.epochSecond
                             }
                         }
                     }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponse.kt
@@ -91,6 +91,8 @@ data class SyncUpdateResponse(
         var autoArchiveEpisodeLimitModified: Date? = null,
         var episodeGrouping: Int? = null,
         var episodeGroupingModified: Date? = null,
+        var showArchived: Boolean? = null,
+        var showArchivedModified: Date? = null,
     ) {
         companion object {
             fun fromSyncUserPodcast(syncUserPodcast: SyncUserPodcast): PodcastSync =
@@ -129,6 +131,8 @@ data class SyncUpdateResponse(
                     autoArchiveEpisodeLimitModified = syncUserPodcast.settings.autoArchiveEpisodeLimitOrNull?.modifiedAt?.toDate(),
                     episodeGrouping = syncUserPodcast.settings.episodeGroupingOrNull?.value?.value,
                     episodeGroupingModified = syncUserPodcast.settings.episodesSortOrderOrNull?.modifiedAt?.toDate(),
+                    showArchived = syncUserPodcast.settings.showArchived?.value?.value,
+                    showArchivedModified = syncUserPodcast.settings.showArchived?.modifiedAt?.toDate(),
                 )
         }
     }


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the podcast setting for showing archived episodes.

Closes #1739

## Testing Instructions

> [!note]
> You need to test this with staging because changes aren't deployed to production, yet.
> 
> To test on staging use the `debug` variant instead of the `debugProd` one.

1. Have two devices D1 and D2.
2. Sign in with an account and have multiple podcasts added.
3. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
4. D1: Go to `Podcasts` and open a podcast.
5. D1: Tap on `Show archived`. It should change to `Hide archived`.
6. D1: Sync the device in the `Profile`.
7. D2: Sync the device in the `Profile`.
8. D2: Go to the same podcast that you've just edited.
9. D2: Notice that the `Hide archived` action is shown and archived episodes are available in the list.
10. D2: Go to `Profile`/`Settings (cog icon)`/`General`.
11. D2: Switch `Show archived` to `Show` setting and confirm applying it to existing podcasts.
12. D2: Go to any podcast in `Podcasts` tab.
13. D2: Tap on `Hide archived`. It should change to `Show archived`.
14. D2: Sync the device in the `Profile`.
15. D1: Sync the device in the `Profile`.
16. D1: Check podcasts. All of them except the one from step 12 should show archived episodes.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
