### PR TITLE
 Sync episode grouping podcast setting

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -391,7 +391,7 @@ class PodcastAdapter(
         podcast: Podcast,
         context: Context,
     ) {
-        val grouping = podcast.podcastGrouping
+        val grouping = podcast.grouping
         val groupingFunction = grouping.sortFunction
         val episodesPlusLimit: MutableList<Any> = episodes.toMutableList()
         if (episodeLimit != null && episodeLimitIndex != null && groupingFunction == null) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -322,7 +322,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
     }
 
     private val showGroupingOptions = {
-        val selected = viewModel.podcast.value?.podcastGrouping ?: PodcastGrouping.None
+        val selected = viewModel.podcast.value?.grouping ?: PodcastGrouping.None
         var dialog = OptionsDialog()
         PodcastGrouping.All.forEach { grouping ->
             dialog = dialog.addCheckedOption(titleId = grouping.groupName, checked = grouping == selected, click = { viewModel.updatePodcastGrouping(grouping) })
@@ -397,7 +397,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
     }
 
     private fun selectedGroupStringId(): Int {
-        return viewModel.podcast.value?.podcastGrouping?.groupName ?: PodcastGrouping.None.groupName
+        return viewModel.podcast.value?.grouping?.groupName ?: PodcastGrouping.None.groupName
     }
 
     private fun selectedSortOrderStringId(): Int {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -171,7 +171,7 @@ class PodcastViewModel
             .loadEpisodesAndBookmarks(episodeManager, bookmarkManager, settings)
             .doOnNext {
                 if (it is UiState.Loaded) {
-                    val groups = it.podcast.podcastGrouping.formGroups(it.episodes, it.podcast, resources)
+                    val groups = it.podcast.grouping.formGroups(it.episodes, it.podcast, resources)
                     groupedEpisodes.postValue(groups)
                 } else {
                     groupedEpisodes.postValue(emptyList())
@@ -629,7 +629,7 @@ private fun Flowable<CombinedEpisodeAndBookmarkData>.loadEpisodesAndBookmarks(
         Flowable.combineLatest(
             episodeManager.observeEpisodesByPodcastOrderedRx(podcast)
                 .map {
-                    val sortFunction = podcast.podcastGrouping.sortFunction
+                    val sortFunction = podcast.grouping.sortFunction
                     if (sortFunction != null) {
                         it.sortedByDescending(sortFunction)
                     } else {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/PodcastGroupingTypeConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/PodcastGroupingTypeConverter.kt
@@ -1,0 +1,16 @@
+package au.com.shiftyjelly.pocketcasts.models.converter
+
+import androidx.room.TypeConverter
+import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
+
+class PodcastGroupingTypeConverter {
+    @TypeConverter
+    fun toTrimMode(value: Int?): PodcastGrouping {
+        return value?.let { PodcastGrouping.All.getOrNull(it) } ?: PodcastGrouping.None
+    }
+
+    @TypeConverter
+    fun toInt(value: PodcastGrouping?): Int {
+        return value?.let { PodcastGrouping.All.indexOf(it) } ?: 0
+    }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/PodcastGroupingTypeConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/PodcastGroupingTypeConverter.kt
@@ -5,12 +5,12 @@ import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 
 class PodcastGroupingTypeConverter {
     @TypeConverter
-    fun toTrimMode(value: Int?): PodcastGrouping {
-        return value?.let { PodcastGrouping.All.getOrNull(it) } ?: PodcastGrouping.None
+    fun fromInt(value: Int?): PodcastGrouping {
+        return value?.let { PodcastGrouping.fromIndex(it) } ?: PodcastGrouping.None
     }
 
     @TypeConverter
     fun toInt(value: PodcastGrouping?): Int {
-        return value?.let { PodcastGrouping.All.indexOf(it) } ?: 0
+        return value?.index ?: PodcastGrouping.None.index
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -21,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.models.converter.EpisodePlayingStatusConve
 import au.com.shiftyjelly.pocketcasts.models.converter.EpisodeStatusEnumConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.EpisodesSortTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.PodcastAutoUpNextConverter
+import au.com.shiftyjelly.pocketcasts.models.converter.PodcastGroupingTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.PodcastLicensingEnumConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.PodcastsSortTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.SafeDateTypeConverter
@@ -90,6 +91,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
     UserEpisodeServerStatusConverter::class,
     AutoArchiveAfterPlayingTypeConverter::class,
     AutoArchiveInactiveTypeConverter::class,
+    PodcastGroupingTypeConverter::class,
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun podcastDao(): PodcastDao

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveInactive
+import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
@@ -350,10 +351,10 @@ abstract class PodcastDao {
     abstract fun countEpisodesInPodcastWithStatus(podcastUuid: String, episodeStatus: EpisodeStatusEnum): Int
 
     @Query("UPDATE podcasts SET grouping = :grouping WHERE uuid = :uuid")
-    abstract fun updateGrouping(grouping: Int, uuid: String)
+    abstract fun updateGrouping(grouping: PodcastGrouping, uuid: String)
 
     @Query("UPDATE podcasts SET grouping = :grouping WHERE subscribed = 1")
-    abstract fun updatePodcastGroupingForAll(grouping: Int)
+    abstract fun updatePodcastGroupingForAll(grouping: PodcastGrouping)
 
     @Query("UPDATE podcasts SET start_from = :startFromSecs, skip_last = :skipLastSecs, folder_uuid = :folderUuid, sort_order = :sortPosition, added_date = :addedDate WHERE uuid = :uuid")
     abstract suspend fun updateSyncData(uuid: String, startFromSecs: Int, skipLastSecs: Int, folderUuid: String?, sortPosition: Int, addedDate: Date)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -350,11 +350,11 @@ abstract class PodcastDao {
     @Query("SELECT COUNT(*) FROM podcast_episodes WHERE podcast_id = :podcastUuid AND episode_status = :episodeStatus")
     abstract fun countEpisodesInPodcastWithStatus(podcastUuid: String, episodeStatus: EpisodeStatusEnum): Int
 
-    @Query("UPDATE podcasts SET grouping = :grouping WHERE uuid = :uuid")
-    abstract fun updateGrouping(grouping: PodcastGrouping, uuid: String)
+    @Query("UPDATE podcasts SET grouping = :grouping, grouping_modified = :modified, sync_status = 0 WHERE uuid = :uuid")
+    abstract fun updateGrouping(grouping: PodcastGrouping, uuid: String, modified: Date = Date())
 
-    @Query("UPDATE podcasts SET grouping = :grouping WHERE subscribed = 1")
-    abstract fun updatePodcastGroupingForAll(grouping: PodcastGrouping)
+    @Query("UPDATE podcasts SET grouping = :grouping, grouping_modified = :modified, sync_status = 0 WHERE subscribed = 1")
+    abstract fun updatePodcastGroupingForAll(grouping: PodcastGrouping, modified: Date = Date())
 
     @Query("UPDATE podcasts SET start_from = :startFromSecs, skip_last = :skipLastSecs, folder_uuid = :folderUuid, sort_order = :sortPosition, added_date = :addedDate WHERE uuid = :uuid")
     abstract suspend fun updateSyncData(uuid: String, startFromSecs: Int, skipLastSecs: Int, folderUuid: String?, sortPosition: Int, addedDate: Date)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
@@ -80,7 +80,7 @@ data class Podcast(
     @ColumnInfo(name = "auto_archive_episode_limit_modified") var autoArchiveEpisodeLimitModified: Date? = null,
     @ColumnInfo(name = "estimated_next_episode") var estimatedNextEpisode: Date? = null,
     @ColumnInfo(name = "episode_frequency") var episodeFrequency: String? = null,
-    @ColumnInfo(name = "grouping") var grouping: Int = PodcastGrouping.All.indexOf(PodcastGrouping.None),
+    @ColumnInfo(name = "grouping") var grouping: PodcastGrouping = PodcastGrouping.None,
     @ColumnInfo(name = "grouping_modified") var groupingModified: Date? = null,
     @ColumnInfo(name = "skip_last") var skipLastSecs: Int = 0,
     @ColumnInfo(name = "skip_last_modified") var skipLastModified: Date? = null,
@@ -144,9 +144,6 @@ data class Podcast(
 
     val isNotSynced: Boolean
         get() = syncStatus == SYNC_STATUS_NOT_SYNCED
-
-    val podcastGrouping: PodcastGrouping
-        get() = PodcastGrouping.All[grouping]
 
     val isSilenceRemoved: Boolean
         get() = trimMode != TrimMode.OFF

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PodcastGrouping.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PodcastGrouping.kt
@@ -122,7 +122,7 @@ sealed class PodcastGrouping(
      * @return A pair of episodes and their group indexes
      */
     open fun formGroups(episodes: List<PodcastEpisode>, podcast: Podcast, resources: Resources): List<List<PodcastEpisode>> {
-        val reversedSort = podcast.podcastGrouping is Season &&
+        val reversedSort = podcast.grouping is Season &&
             podcast.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_DATE_DESC
         val sortFunction = this.sortFunction ?: return listOf(episodes)
         val groups = mutableListOf<MutableList<PodcastEpisode>>()

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PodcastGrouping.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PodcastGrouping.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 sealed class PodcastGrouping(
     @StringRes val groupName: Int,
+    val index: Int,
     val serverId: Int,
     val sortFunction: ((PodcastEpisode) -> Int)?,
 ) {
@@ -18,13 +19,16 @@ sealed class PodcastGrouping(
         val All
             get() = listOf(None, Downloaded, Unplayed, Season, Starred)
 
-        fun fromServerId(id: Int) = All.find { it.serverId == id } ?: None
+        fun fromServerId(id: Int) = All.find { it.serverId == id }
+
+        fun fromIndex(index: Int) = All.find { it.index == index }
     }
 
     abstract fun groupTitles(index: Int, context: Context): String
 
     data object None : PodcastGrouping(
         groupName = LR.string.none,
+        index = 0,
         serverId = 0,
         sortFunction = null,
     ) {
@@ -35,6 +39,7 @@ sealed class PodcastGrouping(
 
     data object Downloaded : PodcastGrouping(
         groupName = LR.string.podcast_group_downloaded,
+        index = 1,
         serverId = 1,
         sortFunction = { if (it.isDownloaded || it.isDownloading || it.isQueued) 0 else 1 },
     ) {
@@ -51,6 +56,7 @@ sealed class PodcastGrouping(
 
     data object Unplayed : PodcastGrouping(
         groupName = LR.string.podcast_group_unplayed,
+        index = 2,
         serverId = 2,
         sortFunction = { if (it.isUnplayed || it.isInProgress) 0 else 1 },
     ) {
@@ -67,6 +73,7 @@ sealed class PodcastGrouping(
 
     data object Season : PodcastGrouping(
         groupName = LR.string.podcast_group_season,
+        index = 3,
         serverId = 3,
         sortFunction = { getSeasonGroupId(it) },
     ) {
@@ -101,6 +108,7 @@ sealed class PodcastGrouping(
 
     data object Starred : PodcastGrouping(
         groupName = LR.string.profile_navigation_starred,
+        index = 4,
         serverId = 4,
         sortFunction = { if (it.isStarred) 0 else 1 },
     ) {

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/converter/PodcastGroupingTypeConverterTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/converter/PodcastGroupingTypeConverterTest.kt
@@ -34,7 +34,7 @@ class PodcastGroupingTypeConverterTest {
             4 to PodcastGrouping.Starred,
         )
 
-        val databaseValues = List(5) { it to converter.toPodcastGrouping(it) }.toMap()
+        val databaseValues = List(PodcastGrouping.All.size) { it to converter.fromInt(it) }.toMap()
 
         assertEquals(expected, databaseValues)
     }
@@ -48,14 +48,14 @@ class PodcastGroupingTypeConverterTest {
 
     @Test
     fun `decode null value`() {
-        val grouping = converter.toPodcastGrouping(null)
+        val grouping = converter.fromInt(null)
 
         assertEquals(PodcastGrouping.None, grouping)
     }
 
     @Test
     fun `decode unknown value`() {
-        val grouping = converter.toPodcastGrouping(Int.MIN_VALUE)
+        val grouping = converter.fromInt(Int.MIN_VALUE)
 
         assertEquals(PodcastGrouping.None, grouping)
     }

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/converter/PodcastGroupingTypeConverterTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/converter/PodcastGroupingTypeConverterTest.kt
@@ -1,0 +1,62 @@
+package au.com.shiftyjelly.pocketcasts.models.converter
+
+import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PodcastGroupingTypeConverterTest {
+    private val converter = PodcastGroupingTypeConverter()
+
+    @Test
+    fun `podcast groupings are encoded correctly`() {
+        val expected = mapOf(
+            PodcastGrouping.None to 0,
+            PodcastGrouping.Downloaded to 1,
+            PodcastGrouping.Unplayed to 2,
+            PodcastGrouping.Season to 3,
+            PodcastGrouping.Starred to 4,
+        )
+
+        val databaseValues = PodcastGrouping.All.associateWith { grouping ->
+            converter.toInt(grouping)
+        }
+
+        assertEquals(expected, databaseValues)
+    }
+
+    @Test
+    fun `podcast groupings are decoded correctly`() {
+        val expected = mapOf(
+            0 to PodcastGrouping.None,
+            1 to PodcastGrouping.Downloaded,
+            2 to PodcastGrouping.Unplayed,
+            3 to PodcastGrouping.Season,
+            4 to PodcastGrouping.Starred,
+        )
+
+        val databaseValues = List(5) { it to converter.toPodcastGrouping(it) }.toMap()
+
+        assertEquals(expected, databaseValues)
+    }
+
+    @Test
+    fun `encode null value`() {
+        val databaseValue = converter.toInt(null)
+
+        assertEquals(0, databaseValue)
+    }
+
+    @Test
+    fun `decode null value`() {
+        val grouping = converter.toPodcastGrouping(null)
+
+        assertEquals(PodcastGrouping.None, grouping)
+    }
+
+    @Test
+    fun `decode unknown value`() {
+        val grouping = converter.toPodcastGrouping(Int.MIN_VALUE)
+
+        assertEquals(PodcastGrouping.None, grouping)
+    }
+}

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -974,8 +974,8 @@ class SettingsImpl @Inject constructor(
             sharedPrefKey = "default_podcast_grouping",
             defaultValue = default,
             sharedPrefs = sharedPreferences,
-            fromInt = { PodcastGrouping.All.getOrNull(it) ?: default },
-            toInt = { PodcastGrouping.All.indexOf(it) },
+            fromInt = { PodcastGrouping.fromIndex(it) ?: default },
+            toInt = { it.index },
         )
     }
 

--- a/modules/services/protobuf/src/main/proto/sync_api.proto
+++ b/modules/services/protobuf/src/main/proto/sync_api.proto
@@ -78,6 +78,7 @@ message PodcastSettings {
   Int32Setting auto_archive_played = 12;
   Int32Setting auto_archive_inactive = 13;
   Int32Setting auto_archive_episode_limit = 14;
+  Int32Setting episode_grouping = 15;
 }
 
 message SyncUserEpisode {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1323,7 +1323,7 @@ open class PlaybackManager @Inject constructor(
         val episodes = episodeManager
             .findEpisodesByPodcastOrdered(podcast)
 
-        val modifiedEpisodes = when (podcast.podcastGrouping) {
+        val modifiedEpisodes = when (podcast.grouping) {
             PodcastGrouping.None,
             PodcastGrouping.Season,
             PodcastGrouping.Starred,
@@ -1350,7 +1350,7 @@ open class PlaybackManager @Inject constructor(
                 }
         }
 
-        return podcast.podcastGrouping
+        return podcast.grouping
             .formGroups(modifiedEpisodes, podcast, application.resources)
             .flatten()
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -502,11 +502,11 @@ class PodcastManagerImpl @Inject constructor(
     }
 
     override fun updateGrouping(podcast: Podcast, grouping: PodcastGrouping) {
-        podcastDao.updateGrouping(PodcastGrouping.All.indexOf(grouping), podcast.uuid)
+        podcastDao.updateGrouping(grouping, podcast.uuid)
     }
 
     override fun updateGroupingForAll(grouping: PodcastGrouping) {
-        podcastDao.updatePodcastGroupingForAll(PodcastGrouping.All.indexOf(grouping))
+        podcastDao.updatePodcastGroupingForAll(grouping)
     }
 
     override suspend fun markAllPodcastsUnsynced() {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -5,7 +5,6 @@ import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
@@ -129,7 +128,7 @@ class SubscribeManager @Inject constructor(
         // set subscribed to true and update the sync status
         val updateObservable = podcastDao.updateSubscribedRx(subscribed = true, uuid = podcastUuid)
             .andThen(podcastDao.updateSyncStatusRx(syncStatus = if (sync) Podcast.SYNC_STATUS_NOT_SYNCED else Podcast.SYNC_STATUS_SYNCED, uuid = podcastUuid))
-            .andThen(Completable.fromAction { podcastDao.updateGrouping(PodcastGrouping.All.indexOf(settings.podcastGroupingDefault.value), podcastUuid) })
+            .andThen(Completable.fromAction { podcastDao.updateGrouping(settings.podcastGroupingDefault.value, podcastUuid) })
             .andThen(rxCompletable { podcastDao.updateShowArchived(podcastUuid, settings.showArchivedDefault.value) })
         // return the final podcast
         val findObservable = podcastDao.findByUuidRx(podcastUuid)
@@ -143,7 +142,7 @@ class SubscribeManager @Inject constructor(
                 // mark sync status
                 podcast.syncStatus = if (sync) Podcast.SYNC_STATUS_NOT_SYNCED else Podcast.SYNC_STATUS_SYNCED
                 podcast.isSubscribed = subscribed
-                podcast.grouping = PodcastGrouping.All.indexOf(settings.podcastGroupingDefault.value)
+                podcast.grouping = settings.podcastGroupingDefault.value
                 podcast.showArchived = settings.showArchivedDefault.value
             }
         // add the podcast

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -915,7 +915,7 @@ class PodcastSyncProcess(
         podcastSync.autoArchiveInactiveModified?.let { podcast.autoArchiveInactiveModified = it }
         podcastSync.autoArchiveEpisodeLimit?.let { podcast.autoArchiveEpisodeLimit = it }
         podcastSync.autoArchiveEpisodeLimitModified?.let { podcast.autoArchiveEpisodeLimitModified = it }
-        podcastSync.episodeGrouping?.let { podcast.grouping = PodcastGrouping.fromServerId(it) }
+        podcastSync.episodeGrouping?.let { podcast.grouping = PodcastGrouping.fromServerId(it) ?: PodcastGrouping.None }
         podcastSync.episodeGroupingModified?.let { podcast.groupingModified = it }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveInactive
+import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.to.StatsBundle
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
@@ -914,6 +915,8 @@ class PodcastSyncProcess(
         podcastSync.autoArchiveInactiveModified?.let { podcast.autoArchiveInactiveModified = it }
         podcastSync.autoArchiveEpisodeLimit?.let { podcast.autoArchiveEpisodeLimit = it }
         podcastSync.autoArchiveEpisodeLimitModified?.let { podcast.autoArchiveEpisodeLimitModified = it }
+        podcastSync.episodeGrouping?.let { podcast.grouping = PodcastGrouping.fromServerId(it) }
+        podcastSync.episodeGroupingModified?.let { podcast.groupingModified = it }
     }
 
     fun importEpisode(episodeSync: SyncUpdateResponse.EpisodeSync): Maybe<PodcastEpisode> {
@@ -1124,6 +1127,12 @@ class PodcastSyncProcess(
                             value = int32Value { value = podcast.autoArchiveEpisodeLimit ?: 0 }
                             modifiedAt = timestamp {
                                 seconds = podcast.autoArchiveEpisodeLimitModified?.timeSecs() ?: lastSyncTime.epochSecond
+                            }
+                        }
+                        episodeGrouping = int32Setting {
+                            value = int32Value { value = podcast.grouping.serverId }
+                            modifiedAt = timestamp {
+                                seconds = podcast.groupingModified?.timeSecs() ?: lastSyncTime.epochSecond
                             }
                         }
                     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -5,6 +5,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveInactive
+import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -316,6 +317,7 @@ class PodcastSyncProcessTest {
         autoArchiveAfterPlaying: AutoArchiveAfterPlaying = AutoArchiveAfterPlaying.Never,
         autoArchiveInactive: AutoArchiveInactive = AutoArchiveInactive.Never,
         autoArchiveEpisodeLimit: Int = 0,
+        podcastGrouping: PodcastGrouping = PodcastGrouping.None,
     ) = mock<Podcast> {
         on { this.addedDate } doReturn Date(addedDateSinceEpoch.toMillis())
         on { this.folderUuid } doReturn folderUuid
@@ -333,6 +335,7 @@ class PodcastSyncProcessTest {
         on { this.autoArchiveAfterPlaying } doReturn autoArchiveAfterPlaying
         on { this.autoArchiveInactive } doReturn autoArchiveInactive
         on { this.autoArchiveEpisodeLimit } doReturn autoArchiveEpisodeLimit
+        on { this.grouping } doReturn podcastGrouping
     }
 
     private fun mockPodcastEpisode(

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -372,7 +372,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "episodeGrouping" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.podcastGroupingDefault,
-                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let(PodcastGrouping::fromServerId),
+                        newSettingValue = (changedSettingResponse.value as? Number)?.toInt()?.let { PodcastGrouping.fromIndex(it) ?: PodcastGrouping.None },
                     )
                     "keepScreenAwake" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponse.kt
@@ -24,6 +24,7 @@ import com.pocketcasts.service.api.autoStartFromOrNull
 import com.pocketcasts.service.api.bookmarkOrNull
 import com.pocketcasts.service.api.dateAddedOrNull
 import com.pocketcasts.service.api.durationOrNull
+import com.pocketcasts.service.api.episodeGroupingOrNull
 import com.pocketcasts.service.api.episodeOrNull
 import com.pocketcasts.service.api.episodesSortOrderOrNull
 import com.pocketcasts.service.api.folderOrNull
@@ -88,6 +89,8 @@ data class SyncUpdateResponse(
         var autoArchiveInactiveModified: Date? = null,
         var autoArchiveEpisodeLimit: Int? = null,
         var autoArchiveEpisodeLimitModified: Date? = null,
+        var episodeGrouping: Int? = null,
+        var episodeGroupingModified: Date? = null,
     ) {
         companion object {
             fun fromSyncUserPodcast(syncUserPodcast: SyncUserPodcast): PodcastSync =
@@ -124,6 +127,8 @@ data class SyncUpdateResponse(
                     autoArchiveInactiveModified = syncUserPodcast.settings.autoArchiveInactiveOrNull?.modifiedAt?.toDate(),
                     autoArchiveEpisodeLimit = syncUserPodcast.settings.autoArchiveEpisodeLimitOrNull?.value?.value,
                     autoArchiveEpisodeLimitModified = syncUserPodcast.settings.autoArchiveEpisodeLimitOrNull?.modifiedAt?.toDate(),
+                    episodeGrouping = syncUserPodcast.settings.episodeGroupingOrNull?.value?.value,
+                    episodeGroupingModified = syncUserPodcast.settings.episodesSortOrderOrNull?.modifiedAt?.toDate(),
                 )
         }
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastViewModel.kt
@@ -48,7 +48,7 @@ class PodcastViewModel @Inject constructor(
                 episodeManager.observeEpisodesByPodcastOrderedRx(it)
                     .asFlow()
                     .map { podcastEpisodes ->
-                        val sortFunction = podcast.podcastGrouping.sortFunction
+                        val sortFunction = podcast.grouping.sortFunction
                         if (sortFunction != null) {
                             podcastEpisodes.sortedByDescending(sortFunction)
                         } else {


### PR DESCRIPTION
## Description

One of the settings listed for sync project #1739. This PR adds syncing to the podcast setting for grouping episodes.

I also added a converter for `PodcastGrouping` type so it is recognized by the database and we can use it directly.

## Testing Instructions

> [!note]
> You need to test this with staging because changes aren't deployed to production, yet.
> 
> To test on staging use the `debug` variant instead of the `debugProd` one.

1. Have two devices D1 and D2.
2. Sign in with an account and have multiple podcasts added.
3. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
4. D1: Go to `Podcasts` and open a podcast.
5. D1: Tap on `Overflow menu (three dots)`.
6. D1: Change `Group episodes` setting.
7. D1: Sync the device in the `Profile`.
8. D2: Sync the device in the `Profile`.
9. D2: Go to the same podcast that you've just edited.
10. D2: Notice that episode grouping is synced.
11. D2: Go to `Profile`/`Settings (cog icon)`/`General`.
12. D2: Switch `Podcast episode grouping` setting.
13. D2: Go to any podcast in `Podcasts` tab.
14. D2: Tap on `Overflow menu (three dots)`.
15. D2: Change `Group episodes` setting.
17. D2: Sync the device in the `Profile`.
18. D1: Sync the device in the `Profile`.
19. D1: Check podcasts. All of them except the one from step 13 should show archived episodes.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
