### PR TITLE
Fix/sync skip last

### DIFF
--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponse.kt
@@ -25,6 +25,7 @@ import com.pocketcasts.service.api.episodesSortOrderOrNull
 import com.pocketcasts.service.api.folderOrNull
 import com.pocketcasts.service.api.folderUuidOrNull
 import com.pocketcasts.service.api.isDeletedOrNull
+import com.pocketcasts.service.api.notificationOrNull
 import com.pocketcasts.service.api.playbackEffectsOrNull
 import com.pocketcasts.service.api.playbackSpeedOrNull
 import com.pocketcasts.service.api.playedUpToOrNull
@@ -101,8 +102,8 @@ data class SyncUpdateResponse(
                     trimSilenceModified = syncUserPodcast.settings.trimSilenceOrNull?.modifiedAt?.toDate(),
                     useVolumeBoost = syncUserPodcast.settings.volumeBoostOrNull?.value?.value,
                     useVolumeBoostModified = syncUserPodcast.settings.volumeBoostOrNull?.modifiedAt?.toDate(),
-                    showNotifications = syncUserPodcast.settings.notification?.value?.value,
-                    showNotificationsModified = syncUserPodcast.settings.notification?.modifiedAt?.toDate(),
+                    showNotifications = syncUserPodcast.settings.notificationOrNull?.value?.value,
+                    showNotificationsModified = syncUserPodcast.settings.notificationOrNull?.modifiedAt?.toDate(),
                 )
         }
     }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponse.kt
@@ -15,6 +15,7 @@ import com.pocketcasts.service.api.SyncUserPlaylist
 import com.pocketcasts.service.api.SyncUserPodcast
 import com.pocketcasts.service.api.addToUpNextOrNull
 import com.pocketcasts.service.api.addToUpNextPositionOrNull
+import com.pocketcasts.service.api.autoSkipLastOrNull
 import com.pocketcasts.service.api.autoStartFromOrNull
 import com.pocketcasts.service.api.bookmarkOrNull
 import com.pocketcasts.service.api.dateAddedOrNull
@@ -86,8 +87,8 @@ data class SyncUpdateResponse(
                     dateAdded = syncUserPodcast.dateAddedOrNull?.toDate(),
                     startFromSecs = syncUserPodcast.settings.autoStartFromOrNull?.value?.value,
                     startFromModified = syncUserPodcast.settings.autoStartFromOrNull?.modifiedAt?.toDate(),
-                    skipLastSecs = syncUserPodcast.settings.autoStartFromOrNull?.value?.value,
-                    skipLastModified = syncUserPodcast.settings.autoStartFromOrNull?.modifiedAt?.toDate(),
+                    skipLastSecs = syncUserPodcast.settings.autoSkipLastOrNull?.value?.value,
+                    skipLastModified = syncUserPodcast.settings.autoSkipLastOrNull?.modifiedAt?.toDate(),
                     addToUpNext = syncUserPodcast.settings.addToUpNextOrNull?.value?.value,
                     addToUpNextModified = syncUserPodcast.settings.addToUpNextOrNull?.modifiedAt?.toDate(),
                     addToUpNextPosition = syncUserPodcast.settings.addToUpNextPositionOrNull?.value?.value,


### PR DESCRIPTION
## Description

There was a bug with a podcast skip last setting where we didn't use a correct value for mapping.

## Testing Instructions

1. Have two devices D1 and D2.
2. Sign in with an account a podcast added.
3. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
4. D1: Go to `Podcasts`/`Select a podcast`/`Settings (cog icon)`.
5. D1: Change the value of `Skip last`.
6. D1: Sync the device in the `Profile`.
7. D2: Sync the device in the `Profile`.
8. D2: Check that the podcast from step 4 has `Skip last` value synced.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
