### PR TITLE
Use epoch as a fallback modification timestamp

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/preferences/UserSettingTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/preferences/UserSettingTest.kt
@@ -1,77 +1,133 @@
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.platform.app.InstrumentationRegistry
+import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import java.time.Clock
 import java.time.Instant
+import java.time.ZoneId
 import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNotNull
-import junit.framework.TestCase.assertNull
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 
 class UserSettingTest {
+    private val sharedPrefs = InstrumentationRegistry
+        .getInstrumentation()
+        .targetContext
+        .getSharedPreferences("instrumentation_test_shared_prefs", Context.MODE_PRIVATE)
 
-    private val sharedPrefKey = "sharedPrefKey"
+    private val clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
+
+    private val userSetting = UserSetting.StringPref(
+        defaultValue = "default",
+        sharedPrefKey = "key",
+        sharedPrefs = sharedPrefs,
+    )
 
     @Before
     fun setUp() {
         // clear out test shared preferences so tests don't interfere with each other
-        getSharedPreferences().edit().clear().commit()
+        sharedPrefs.edit().clear().commit()
+    }
+
+    @Test
+    fun usesDefaultValue() {
+        assertEquals("default", userSetting.value)
     }
 
     @Test
     fun handlesSetWithoutSync() {
-        val userSetting = getUserSetting()
+        userSetting.set("new_value", clock = clock, needsSync = false)
 
-        userSetting.set("new_value", needsSync = false)
-
-        assertWillNotSync(userSetting)
+        assertEquals("new_value", userSetting.value)
+        assertEquals(Instant.EPOCH, userSetting.modifiedAt)
     }
 
     @Test
     fun handlesSetWithSync() {
-        val userSetting = getUserSetting()
+        userSetting.set("new_value", clock = clock, needsSync = true)
 
-        val newValue = "new_value"
-        userSetting.set(newValue, needsSync = true)
-
-        assertWillSync(userSetting, newValue)
+        assertEquals("new_value", userSetting.value)
+        assertEquals(clock.instant(), userSetting.modifiedAt)
     }
 
     @Test
     fun doesNotSyncAfterModificationNotRequiringSync() {
-        val userSetting = getUserSetting()
+        userSetting.set("first_value", clock = clock, needsSync = true)
+        userSetting.set("second_value", clock = clock, needsSync = false)
 
-        // first set requires sync
-        userSetting.set("first_value", needsSync = true)
-
-        // second set does not require sync
-        userSetting.set("second_value", needsSync = false)
-
-        assertWillNotSync(userSetting)
+        assertEquals("second_value", userSetting.value)
+        assertEquals(Instant.EPOCH, userSetting.modifiedAt)
     }
 
-    private fun assertWillSync(userSetting: UserSetting.StringPref, expected: String) {
-        assertNotNull(userSetting.getModifiedAt())
-        val result = userSetting.getSyncSetting(Instant.EPOCH) { value, _ -> value }
-        assertEquals(expected, result)
+    @Test
+    fun emitsValueUpdates() = runTest {
+        userSetting.flow.test {
+            assertEquals("default", awaitItem())
+
+            userSetting.set("new_value", needsSync = false)
+            assertEquals("new_value", awaitItem())
+
+            cancel()
+        }
     }
 
-    private fun assertWillNotSync(userSetting: UserSetting.StringPref) {
-        assertNull(userSetting.getModifiedAt())
-        val result = userSetting.getSyncSetting(Instant.EPOCH) { _, _ -> Unit }
-        assertNull(result)
-    }
-
-    private fun getUserSetting() = UserSetting.StringPref(
+    private class ReversingToSetting(
+        defaultValue: String,
+        sharedPrefKey: String,
+        sharedPrefs: SharedPreferences,
+    ) : UserSetting.PrefFromString<String>(
         sharedPrefKey = sharedPrefKey,
-        sharedPrefs = getSharedPreferences(),
-        defaultValue = "default",
+        defaultValue = defaultValue,
+        sharedPrefs = sharedPrefs,
+        toString = { it.reversed() },
+        fromString = { it },
     )
 
-    private fun getSharedPreferences(): SharedPreferences =
-        InstrumentationRegistry
-            .getInstrumentation()
-            .targetContext
-            .getSharedPreferences("instrumentation_test_shared_prefs", Context.MODE_PRIVATE)
+    @Test
+    fun usesCustomToConverter() {
+        val setting = ReversingToSetting(
+            defaultValue = "default",
+            sharedPrefKey = "key",
+            sharedPrefs = sharedPrefs,
+        )
+
+        assertEquals("default".reversed(), setting.value)
+
+        setting.set("new_value", clock = clock, needsSync = true)
+
+        assertEquals("new_value".reversed(), setting.value)
+        // Verify if converter doesn't jumble modification timestamp
+        assertEquals(clock.instant(), setting.modifiedAt)
+    }
+
+    private class ReversingFromSetting(
+        defaultValue: String,
+        sharedPrefKey: String,
+        sharedPrefs: SharedPreferences,
+    ) : UserSetting.PrefFromString<String>(
+        sharedPrefKey = sharedPrefKey,
+        defaultValue = defaultValue,
+        sharedPrefs = sharedPrefs,
+        toString = { it },
+        fromString = { it.reversed() },
+    )
+
+    @Test
+    fun usesCustomFromConverter() {
+        val setting = ReversingFromSetting(
+            defaultValue = "default",
+            sharedPrefKey = "key",
+            sharedPrefs = sharedPrefs,
+        )
+
+        assertEquals("default".reversed(), setting.value)
+
+        setting.set("new_value", clock = clock, needsSync = true)
+
+        assertEquals("new_value".reversed(), setting.value)
+        // Verify if converter doesn't jumble modification timestamp
+        assertEquals(clock.instant(), setting.modifiedAt)
+    }
 }

--- a/base.gradle
+++ b/base.gradle
@@ -243,6 +243,7 @@ dependencies {
     androidTestImplementation libs.room.testing
     androidTestImplementation libs.uiautomator
     androidTestImplementation libs.work.test
+    androidTestImplementation libs.turbine
 
     testImplementation libs.arch.core
     testImplementation libs.coroutines.test

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
@@ -110,7 +110,7 @@ class AppLifecycleObserverTest {
 
         verify(appLifecycleAnalytics).onNewApplicationInstall()
 
-        verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any())
+        verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
         verify(useUpNextDarkThemeSetting).set(false, needsSync = false)
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
     }
@@ -126,7 +126,7 @@ class AppLifecycleObserverTest {
 
         verify(appLifecycleAnalytics).onNewApplicationInstall()
 
-        verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any())
+        verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
         verify(useUpNextDarkThemeSetting).set(false, needsSync = false)
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
     }
@@ -143,7 +143,7 @@ class AppLifecycleObserverTest {
         verify(appLifecycleAnalytics).onApplicationUpgrade(VERSION_CODE_AFTER_FIRST_INSTALL)
 
         verify(appLifecycleAnalytics, never()).onNewApplicationInstall()
-        verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any())
-        verify(useUpNextDarkThemeSetting, never()).set(any(), any(), any())
+        verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
+        verify(useUpNextDarkThemeSetting, never()).set(any(), any(), any(), any())
     }
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.preferences
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import java.time.Clock
 import java.time.Instant
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,19 +17,16 @@ abstract class UserSetting<T>(
 
     private fun getModifiedAtServerString(): String? = sharedPrefs.getString(modifiedAtKey, null)
 
-    fun getModifiedAt(): Instant? = tryOrNull {
-        getModifiedAtServerString()?.let { Instant.parse(it) }
-    }
+    val modifiedAt get(): Instant = runCatching {
+        Instant.parse(getModifiedAtServerString())
+    }.getOrDefault(Instant.EPOCH)
 
-    // Returns the value to sync if sync is needed. Returns null if sync is not needed.
-    fun <U> getSyncSetting(lastSyncTime: Instant, f: (T, String) -> U): U? {
-        val modifiedAtServerString = getModifiedAtServerString() ?: lastSyncTime.takeIf { it != Instant.EPOCH }?.toString()
-        // Only need to sync if modifiedAtServerString is not null
-        return if (modifiedAtServerString != null) {
-            f(value, modifiedAtServerString)
-        } else {
-            null
-        }
+    /**
+     * Returns the value to sync. If sync is not needed or the modification timestamp is unknown
+     * it provides [Instant.EPOCH] as the modification timestamp.
+     */
+    fun <U> getSyncSetting(f: (T, Instant) -> U): U {
+        return f(value, modifiedAt)
     }
 
     // Returns the value to sync if sync is needed. Returns null if sync is not needed.
@@ -53,17 +51,22 @@ abstract class UserSetting<T>(
 
     protected abstract fun persist(value: T, commit: Boolean)
 
-    open fun set(value: T, commit: Boolean = false, needsSync: Boolean) {
+    open fun set(
+        value: T,
+        needsSync: Boolean,
+        commit: Boolean = false,
+        clock: Clock = Clock.systemUTC(),
+    ) {
         persist(value, commit)
         _flow.value = get()
-        val modifiedAt = if (needsSync) Instant.now().toString() else null
+        val modifiedAt = if (needsSync) Instant.now(clock).toString() else null
         updateModifiedAtServerString(modifiedAt)
     }
 
     // A null parameter reflects a setting that does not need to be synced
     private fun updateModifiedAtServerString(modifiedAt: String?) {
         if (modifiedAt != null) {
-            val parsable = tryOrNull { Instant.parse(modifiedAt) } != null
+            val parsable = runCatching { Instant.parse(modifiedAt) }.isSuccess
             if (!parsable) {
                 // Only persist the string if it is parsable
                 LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot set invalid modified at server string: $modifiedAt")
@@ -288,14 +291,7 @@ abstract class UserSetting<T>(
         sharedPrefs = sharedPrefs,
     ) {
         override fun get(): T = initialValue
-        override fun persist(value: T, commit: Boolean) {}
-        override fun set(value: T, commit: Boolean, needsSync: Boolean) {}
+        override fun persist(value: T, commit: Boolean) = Unit
+        override fun set(value: T, needsSync: Boolean, commit: Boolean, clock: Clock) = Unit
     }
 }
-
-private inline fun <T> tryOrNull(f: () -> T): T? =
-    try {
-        f()
-    } catch (e: Exception) {
-        null
-    }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -132,7 +132,7 @@ class PodcastSyncProcess(
             }
         }
         val syncUpNextObservable = downloadObservable
-            .andThen(syncSettings(lastSyncTime))
+            .andThen(syncSettings())
             .andThen(syncCloudFiles())
             .andThen(firstSyncChanges())
             .andThen(

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -11,7 +11,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import java.time.Duration
-import java.time.Instant
 import java.util.Date
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -52,7 +51,6 @@ class PodcastSyncProcessTest {
                 trimMode = TrimMode.HIGH,
                 isVolumeBoosted = true,
             ),
-            Instant.now(),
         ).podcast
 
         assertEquals(addedDateSinceEpoch.seconds, record.dateAdded.seconds)
@@ -72,7 +70,6 @@ class PodcastSyncProcessTest {
     fun podcastToRecord_subscribed() {
         val record = PodcastSyncProcess.toRecord(
             mockPodcast(isSubscribed = true),
-            Instant.now(),
         ).podcast
 
         assertFalse(record.isDeleted.value)
@@ -83,7 +80,6 @@ class PodcastSyncProcessTest {
     fun podcastToRecord_unsubscribed() {
         val record = PodcastSyncProcess.toRecord(
             mockPodcast(isSubscribed = false),
-            Instant.now(),
         ).podcast
 
         assertTrue(record.isDeleted.value)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/adapters/InstantAdapter.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/adapters/InstantAdapter.kt
@@ -1,0 +1,14 @@
+package au.com.shiftyjelly.pocketcasts.servers.adapters
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.time.Instant
+import java.util.Date
+
+internal class InstantAdapter {
+    @FromJson
+    fun fromJson(date: Date): Instant = date.toInstant()
+
+    @ToJson
+    fun toJson(instant: Instant): Date = Date.from(instant)
+}

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortTypeMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
 import au.com.shiftyjelly.pocketcasts.preferences.RefreshToken
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.servers.adapters.InstantAdapter
 import au.com.shiftyjelly.pocketcasts.servers.model.DisplayStyleMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyleMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.servers.model.ListTypeMoshiAdapter
@@ -121,6 +122,7 @@ class ServersModule {
 
         fun provideMoshiBuilder(): Moshi.Builder {
             return Moshi.Builder()
+                .add(InstantAdapter())
                 .add(Date::class.java, Rfc3339DateJsonAdapter().nullSafe())
                 .add(SyncUpdateResponse::class.java, SyncUpdateResponseParser())
                 .add(EpisodePlayingStatus::class.java, EpisodePlayingStatusMoshiAdapter())

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -4,6 +4,7 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.time.Instant
 
 @JsonClass(generateAdapter = true)
 @Deprecated("This class can be removed when the sync settings feature flag is removed")
@@ -76,25 +77,25 @@ data class ChangedNamedSettings(
 @JsonClass(generateAdapter = true)
 data class NamedChangedSettingInt(
     @field:Json(name = "value") val value: Int,
-    @field:Json(name = "modified_at") val modifiedAt: String,
+    @field:Json(name = "modified_at") val modifiedAt: Instant,
 )
 
 @JsonClass(generateAdapter = true)
 data class NamedChangedSettingBool(
     @field:Json(name = "value") val value: Boolean,
-    @field:Json(name = "modified_at") val modifiedAt: String,
+    @field:Json(name = "modified_at") val modifiedAt: Instant,
 )
 
 @JsonClass(generateAdapter = true)
 data class NamedChangedSettingDouble(
     @field:Json(name = "value") val value: Double,
-    @field:Json(name = "modified_at") val modifiedAt: String,
+    @field:Json(name = "modified_at") val modifiedAt: Instant,
 )
 
 @JsonClass(generateAdapter = true)
 data class NamedChangedSettingString(
     @field:Json(name = "value") val value: String,
-    @field:Json(name = "modified_at") val modifiedAt: String,
+    @field:Json(name = "modified_at") val modifiedAt: Instant,
 )
 
 @Suppress("DEPRECATION")

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -35,13 +35,12 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
     companion object {
         suspend fun run(
             context: Context,
-            lastSyncTime: Instant,
             settings: Settings,
             namedSettingsCall: NamedSettingsCaller,
         ): Result {
             try {
                 if (FeatureFlag.isEnabled(Feature.SETTINGS_SYNC)) {
-                    syncSettings(context, settings, namedSettingsCall, lastSyncTime)
+                    syncSettings(context, settings, namedSettingsCall)
                 } else {
                     @Suppress("DEPRECATION")
                     oldSyncSettings(settings, namedSettingsCall)
@@ -60,7 +59,6 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
             context: Context,
             settings: Settings,
             namedSettingsCall: NamedSettingsCaller,
-            lastSyncTime: Instant,
         ) {
             if (!FeatureFlag.isEnabled(Feature.SETTINGS_SYNC)) {
                 LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "syncSettings method should never be called if settings sync flag is not enabled")
@@ -68,197 +66,191 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 return
             }
 
-            val request = changedNamedSettingsRequest(context, lastSyncTime, settings)
+            val request = changedNamedSettingsRequest(context, settings)
             val response = namedSettingsCall.changedNamedSettings(request)
             processChangedNameSettingsResponse(context, settings, response)
         }
 
         private fun changedNamedSettingsRequest(
             context: Context,
-            lastSyncTime: Instant,
             settings: Settings,
         ) = ChangedNamedSettingsRequest(
             changedSettings = ChangedNamedSettings(
-                autoArchiveAfterPlaying = settings.autoArchiveAfterPlaying.getSyncSetting(lastSyncTime) { autoArchiveAfterPlaying, modifiedAt ->
+                autoArchiveAfterPlaying = settings.autoArchiveAfterPlaying.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
-                        value = autoArchiveAfterPlaying.serverId,
+                        value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                autoArchiveInactive = settings.autoArchiveInactive.getSyncSetting(lastSyncTime) { AutoArchiveInactive, modifiedAt ->
+                autoArchiveInactive = settings.autoArchiveInactive.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
-                        value = AutoArchiveInactive.serverId,
+                        value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                autoArchiveIncludesStarred = settings.autoArchiveIncludesStarred.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                freeGiftAcknowledgement = settings.freeGiftAcknowledged.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                gridOrder = settings.podcastsSortType.getSyncSetting(lastSyncTime) { podcastSortType, modifiedAt ->
+                autoArchiveIncludesStarred = settings.autoArchiveIncludesStarred.getSyncSetting(::NamedChangedSettingBool),
+                freeGiftAcknowledgement = settings.freeGiftAcknowledged.getSyncSetting(::NamedChangedSettingBool),
+                gridOrder = settings.podcastsSortType.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
-                        value = podcastSortType.serverId,
+                        value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                gridLayout = settings.podcastGridLayout.getSyncSetting(lastSyncTime) { type, modifiedAt ->
+                gridLayout = settings.podcastGridLayout.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
-                        value = type.serverId,
+                        value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                marketingOptIn = settings.marketingOptIn.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                skipBack = settings.skipBackInSecs.getSyncSetting(lastSyncTime, ::NamedChangedSettingInt),
-                skipForward = settings.skipForwardInSecs.getSyncSetting(lastSyncTime, ::NamedChangedSettingInt),
-                playbackSpeed = settings.globalPlaybackEffects.getSyncSetting(lastSyncTime) { effects, modifiedAt ->
-                    NamedChangedSettingDouble(effects.playbackSpeed, modifiedAt)
+                marketingOptIn = settings.marketingOptIn.getSyncSetting(::NamedChangedSettingBool),
+                skipBack = settings.skipBackInSecs.getSyncSetting(::NamedChangedSettingInt),
+                skipForward = settings.skipForwardInSecs.getSyncSetting(::NamedChangedSettingInt),
+                playbackSpeed = settings.globalPlaybackEffects.getSyncSetting { setting, modifiedAt ->
+                    NamedChangedSettingDouble(setting.playbackSpeed, modifiedAt)
                 },
-                trimSilence = settings.globalPlaybackEffects.getSyncSetting(lastSyncTime) { effects, modifiedAt ->
-                    NamedChangedSettingInt(effects.trimMode.serverId, modifiedAt)
+                trimSilence = settings.globalPlaybackEffects.getSyncSetting { setting, modifiedAt ->
+                    NamedChangedSettingInt(setting.trimMode.serverId, modifiedAt)
                 },
-                volumeBoost = settings.globalPlaybackEffects.getSyncSetting(lastSyncTime) { effects, modifiedAt ->
-                    NamedChangedSettingBool(effects.isVolumeBoosted, modifiedAt)
+                volumeBoost = settings.globalPlaybackEffects.getSyncSetting { setting, modifiedAt ->
+                    NamedChangedSettingBool(setting.isVolumeBoosted, modifiedAt)
                 },
-                rowAction = settings.streamingMode.getSyncSetting(lastSyncTime) { mode, modifiedAt ->
+                rowAction = settings.streamingMode.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
-                        value = if (mode) 0 else 1,
+                        value = if (setting) 0 else 1,
                         modifiedAt = modifiedAt,
                     )
                 },
-                upNextSwipe = settings.upNextSwipe.getSyncSetting(lastSyncTime) { action, modifiedAt ->
+                upNextSwipe = settings.upNextSwipe.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
-                        value = action.serverId,
+                        value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                episodeGrouping = settings.podcastGroupingDefault.getSyncSetting(lastSyncTime) { type, modifiedAt ->
+                episodeGrouping = settings.podcastGroupingDefault.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
-                        value = type.serverId,
+                        value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                showCustomMediaActions = settings.customMediaActionsVisibility.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                mediaActionsOrder = settings.mediaControlItems.getSyncSetting(lastSyncTime) { items, modifiedAt ->
+                showCustomMediaActions = settings.customMediaActionsVisibility.getSyncSetting(::NamedChangedSettingBool),
+                mediaActionsOrder = settings.mediaControlItems.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingString(
-                        value = items.joinToString(separator = ",", transform = Settings.MediaNotificationControls::serverId),
+                        value = setting.joinToString(separator = ",", transform = Settings.MediaNotificationControls::serverId),
                         modifiedAt = modifiedAt,
                     )
                 },
-                keepScreenAwake = settings.keepScreenAwake.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                openPlayerAutomatically = settings.openPlayerAutomatically.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                showArchived = settings.showArchivedDefault.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                intelligentResumption = settings.intelligentPlaybackResumption.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                autoPlayEnabled = settings.autoPlayNextEpisodeOnEmpty.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                hideNotificationOnPause = settings.hideNotificationOnPause.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                playUpNextOnTap = settings.tapOnUpNextShouldPlay.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                playOverNotifications = settings.playOverNotification.getSyncSetting(lastSyncTime) { mode, modifiedAt ->
+                keepScreenAwake = settings.keepScreenAwake.getSyncSetting(::NamedChangedSettingBool),
+                openPlayerAutomatically = settings.openPlayerAutomatically.getSyncSetting(::NamedChangedSettingBool),
+                showArchived = settings.showArchivedDefault.getSyncSetting(::NamedChangedSettingBool),
+                intelligentResumption = settings.intelligentPlaybackResumption.getSyncSetting(::NamedChangedSettingBool),
+                autoPlayEnabled = settings.autoPlayNextEpisodeOnEmpty.getSyncSetting(::NamedChangedSettingBool),
+                hideNotificationOnPause = settings.hideNotificationOnPause.getSyncSetting(::NamedChangedSettingBool),
+                playUpNextOnTap = settings.tapOnUpNextShouldPlay.getSyncSetting(::NamedChangedSettingBool),
+                playOverNotifications = settings.playOverNotification.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
-                        value = mode.serverId,
+                        value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                autoUpNextLimit = settings.autoAddUpNextLimit.getSyncSetting(lastSyncTime, ::NamedChangedSettingInt),
-                autoUpNextLimitReached = settings.autoAddUpNextLimitBehaviour.getSyncSetting(lastSyncTime) { behaviour, modifiedAt ->
+                autoUpNextLimit = settings.autoAddUpNextLimit.getSyncSetting(::NamedChangedSettingInt),
+                autoUpNextLimitReached = settings.autoAddUpNextLimitBehaviour.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
-                        value = behaviour.serverId,
+                        value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                warnDataUsage = settings.warnOnMeteredNetwork.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                showPodcastNotifications = settings.notifyRefreshPodcast.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                collectAnalytics = settings.collectAnalytics.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                sendCrashReports = settings.sendCrashReports.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                linkCrashReportsToUser = settings.linkCrashReportsToUser.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                addFileToUpNextAutomatically = settings.cloudAddToUpNext.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                theme = settings.theme.getSyncSetting(lastSyncTime) { value, modifiedAt ->
+                warnDataUsage = settings.warnOnMeteredNetwork.getSyncSetting(::NamedChangedSettingBool),
+                showPodcastNotifications = settings.notifyRefreshPodcast.getSyncSetting(::NamedChangedSettingBool),
+                collectAnalytics = settings.collectAnalytics.getSyncSetting(::NamedChangedSettingBool),
+                sendCrashReports = settings.sendCrashReports.getSyncSetting(::NamedChangedSettingBool),
+                linkCrashReportsToUser = settings.linkCrashReportsToUser.getSyncSetting(::NamedChangedSettingBool),
+                addFileToUpNextAutomatically = settings.cloudAddToUpNext.getSyncSetting(::NamedChangedSettingBool),
+                theme = settings.theme.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
-                        value = value.serverId,
+                        value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                podcastBadges = settings.podcastBadgeType.getSyncSetting(lastSyncTime) { type, modifiedAt ->
+                podcastBadges = settings.podcastBadgeType.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
-                        value = type.serverId,
+                        value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                autoShowPlayed = settings.autoShowPlayed.takeIf { Util.isAutomotive(context) }?.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                autoSubscribeToPlayed = settings.autoSubscribeToPlayed.takeIf { Util.isAutomotive(context) }?.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                autoPlayLastSource = settings.lastAutoPlaySource.getSyncSetting(lastSyncTime) { source, modifiedAt ->
+                autoShowPlayed = settings.autoShowPlayed.takeIf { Util.isAutomotive(context) }?.getSyncSetting(::NamedChangedSettingBool),
+                autoSubscribeToPlayed = settings.autoSubscribeToPlayed.takeIf { Util.isAutomotive(context) }?.getSyncSetting(::NamedChangedSettingBool),
+                autoPlayLastSource = settings.lastAutoPlaySource.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingString(
-                        value = source.serverId,
+                        value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                useEmbeddedArtwork = settings.useEmbeddedArtwork.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                notificationSettingActions = settings.newEpisodeNotificationActions.getSyncSetting(lastSyncTime) { actions, modifiedAt ->
+                useEmbeddedArtwork = settings.useEmbeddedArtwork.getSyncSetting(::NamedChangedSettingBool),
+                notificationSettingActions = settings.newEpisodeNotificationActions.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingString(
-                        value = actions.joinToString(separator = ",", transform = NewEpisodeNotificationAction::serverId),
+                        value = setting.joinToString(separator = ",", transform = NewEpisodeNotificationAction::serverId),
                         modifiedAt = modifiedAt,
                     )
                 },
-                playerShelfItems = settings.shelfItems.getSyncSetting(lastSyncTime) { items, modifiedAt ->
+                playerShelfItems = settings.shelfItems.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingString(
-                        value = items.joinToString(separator = ",", transform = ShelfItem::serverId),
+                        value = setting.joinToString(separator = ",", transform = ShelfItem::serverId),
                         modifiedAt = modifiedAt,
                     )
                 },
-                showArtworkOnLockScreen = settings.showArtworkOnLockScreen.getSyncSetting(lastSyncTime) { setting, modifiedAt ->
-                    NamedChangedSettingBool(
-                        value = setting,
-                        modifiedAt = modifiedAt,
-                    )
-                },
-                headphoneControlsNextAction = settings.headphoneControlsNextAction.getSyncSetting(lastSyncTime) { setting, modifiedAt ->
+                showArtworkOnLockScreen = settings.showArtworkOnLockScreen.getSyncSetting(::NamedChangedSettingBool),
+                headphoneControlsNextAction = settings.headphoneControlsNextAction.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
                         value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                headphoneControlsPreviousAction = settings.headphoneControlsPreviousAction.getSyncSetting(lastSyncTime) { setting, modifiedAt ->
+                headphoneControlsPreviousAction = settings.headphoneControlsPreviousAction.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
                         value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                headphoneControlsPlayBookmarkConfirmationSound = settings.headphoneControlsPlayBookmarkConfirmationSound.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                episodeBookmarksSortType = settings.episodeBookmarksSortType.getSyncSetting(lastSyncTime) { setting, modifiedAt ->
+                headphoneControlsPlayBookmarkConfirmationSound = settings.headphoneControlsPlayBookmarkConfirmationSound.getSyncSetting(::NamedChangedSettingBool),
+                episodeBookmarksSortType = settings.episodeBookmarksSortType.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
                         value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                playerBookmarksSortType = settings.playerBookmarksSortType.getSyncSetting(lastSyncTime) { setting, modifiedAt ->
+                playerBookmarksSortType = settings.playerBookmarksSortType.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
                         value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                podcastBookmarksSortType = settings.podcastBookmarksSortType.getSyncSetting(lastSyncTime) { setting, modifiedAt ->
+                podcastBookmarksSortType = settings.podcastBookmarksSortType.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
                         value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                useDarkUpNextTheme = settings.useDarkUpNextTheme.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                useDynamicColorsForWidget = settings.useDynamicColorsForWidget.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
-                filesSortOrder = settings.cloudSortOrder.getSyncSetting(lastSyncTime) { setting, modifiedAt ->
+                useDarkUpNextTheme = settings.useDarkUpNextTheme.getSyncSetting(::NamedChangedSettingBool),
+                useDynamicColorsForWidget = settings.useDynamicColorsForWidget.getSyncSetting(::NamedChangedSettingBool),
+                filesSortOrder = settings.cloudSortOrder.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
                         value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                darkThemePreference = settings.darkThemePreference.getSyncSetting(lastSyncTime) { value, modifiedAt ->
+                darkThemePreference = settings.darkThemePreference.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
-                        value = value.serverId,
+                        value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                lightThemePreference = settings.lightThemePreference.getSyncSetting(lastSyncTime) { value, modifiedAt ->
+                lightThemePreference = settings.lightThemePreference.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingInt(
-                        value = value.serverId,
+                        value = setting.serverId,
                         modifiedAt = modifiedAt,
                     )
                 },
-                useSystemTheme = settings.useSystemTheme.getSyncSetting(lastSyncTime, ::NamedChangedSettingBool),
+                useSystemTheme = settings.useSystemTheme.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -592,7 +584,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 return null
             }
 
-            val serverModifiedAtInstant = try {
+            val serverModifiedAt = try {
                 Instant.parse(changedSettingResponse.modifiedAt)
             } catch (e: DateTimeParseException) {
                 LogBuffer.e(
@@ -602,10 +594,8 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 return null
             }
 
-            val localModifiedAt = setting.getModifiedAt()
-            // Don't exit early if we don't have a local modifiedAt time since
-            // we don't know the local value is newer than the server value.
-            if (localModifiedAt != null && localModifiedAt.isAfter(serverModifiedAtInstant)) {
+            val localModifiedAt = setting.modifiedAt
+            if (localModifiedAt > serverModifiedAt) {
                 Timber.i("Not syncing ${setting.sharedPrefKey} value of $newSettingValue from the server because setting was modified more recently locally")
                 return null
             }
@@ -664,8 +654,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
     lateinit var namedSettingsCaller: NamedSettingsCaller
 
     override suspend fun doWork(): Result {
-        val lastSyncTime = runCatching { Instant.parse(settings.getLastModified()) }.getOrDefault(Instant.EPOCH)
-        return run(context, lastSyncTime, settings, namedSettingsCaller)
+        return run(context, settings, namedSettingsCaller)
     }
 }
 


### PR DESCRIPTION
## Description

After much deliberation we decided to use epoch as a default timestamp. It doesn't have issues that `lastSyncTime` introduces and we won't have to deal with enabling or disabling syncing per device.

I added a simple `Instant` JSON adapter to avoid mapping. It doesn't do anything special and just delegates to `Date` adapter provided by Moshi. I didn't add any tests for it since it is a simple delegation.

## Testing Instructions

### Basic syncing

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Podcasts`/`Some podcast`/`Settings (cog icon)`/`Playback effects`.
4. D1: Modify`Playback effects` settings.
5. D1: Go to `Profile`/`Settings (cog icon)`/`General`.
6. D1: Modify `Skip forward time` setting.
7. D1: Sync the device in the Profile.
8. D2: sync the device in the Profile.
9. D2: Verify that the changes from D1 did apply.

### Latest change syncing

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Podcasts`/`Some podcast`/`Settings (cog icon)`/`Playback effects`.
4. D1: Modify`Playback effects` settings.
5. D1: Go to `Profile`/`Settings (cog icon)`/`General`.
6. D1: Modify `Skip forward time` setting.
7. **DO NOT** sync D1.
8. D2: Modify the same settings as for D1 but with different values.
9. D1: Sync the device in the Profile.
10. D2: Sync the device in the Profile.
11. D2: Verify that the changes from D1 did not apply.
12. D1: Sync the device in the Profile.
13. D1: Verify that the changes from D1 did apply.

### Feature launch

1. Have two devices D1 and D2.
2. D1: Install app from c86132a18ae6eebe67b65ccde33f46e9173c7dd1.
3. D2: Do not install any app.
4. D1: Create a new account.
5. D1: Add a podcast.
6. D1: Go to `Podcasts`/`podcast`/`Settings (cog icon)`/`Playback effects`.
7. D1: Modify`Playback effects` settings.
8. D1: Go to `Profile`/`Settings (cog icon)`/`General`.
9. D1: Modify `Skip forward time` setting.
10. D1: Install app from `task/sync-epoch` branch.
11. D1: Sync the device in the Profile.
12. D2: Install app from `task/sync-epoch` branch.
13. D2: Sign in with the same account.
14. D2: sync the device in the Profile.
15. D2: Verify that the changes from D1 did apply.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
