### PR TITLE
build: bump Dagger/Hilt to 2.50

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ espresso = "3.4.0"
 firebase = "30.5.0"
 glide = "4.13.2"
 google-services = "4.3.14"
-hilt = "2.49"
+hilt = "2.50"
 hilt-compiler = "1.1.0"
 horologist = "0.4.17"
 kotlin = "1.9.0"
@@ -106,8 +106,8 @@ coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", ve
 dagger-hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hilt-compiler" }
-hilt-navigation-compose = "androidx.hilt:hilt-navigation-compose:1.0.0"
-hilt-work = "androidx.hilt:hilt-work:1.0.0"
+hilt-navigation-compose = "androidx.hilt:hilt-navigation-compose:1.1.0"
+hilt-work = "androidx.hilt:hilt-work:1.1.0"
 
 # Espresso
 espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }


### PR DESCRIPTION
And hilt helpers to 1.1.0

## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR bumps Dagger/Hilt dependencies to complete the `ksp` migration.

## Testing Instructions
CI test should be enough. You can also run and smoke test basic features of the app.


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews

