### PR TITLE
Fix podcast setting screen becoming unresponsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Bug Fixes:
     *   Fixed: The total remaining time was incorrectly displayed for some languages when large font sizes were set on the device in Up Next
         ([#1815](https://github.com/Automattic/pocket-casts-android/pull/1815))
+    * Fixed a bug where podcast setting screen could become unresponsive.
+        ([#1845](https://github.com/Automattic/pocket-casts-android/pull/1845))
 
 7.57
 -----

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
@@ -115,18 +115,6 @@ class PodcastSettingsFragment : BasePreferenceFragment(), FilterSelectFragment.L
     }
 
     override fun onDestroyView() {
-        preferenceFeedIssueDetected = null
-        preferenceNotifications = null
-        preferenceAutoDownload = null
-        preferenceAddToUpNext = null
-        preferenceAddToUpNextOrder = null
-        preferenceAddToUpNextGlobal = null
-        preferencePlaybackEffects = null
-        preferenceSkipFirst = null
-        preferenceAutoArchive = null
-        preferenceFilters = null
-        preferenceUnsubscribe = null
-        preferenceSkipLast = null
         toolbar = null
         super.onDestroyView()
     }


### PR DESCRIPTION
## Description

The podcast settings  screen could become unresponsive when navigating from and back to it. It was because we were nulling out the preferences. This is a mistake. Preferences do not hold references to views. Instead they fetch them by IDs every time.

Closes #1770

## Testing Instructions

1. Open a podcast.
2. Go to the podcast settings by tapping on a cog icon.
3. Enable `Add to Up Next`.
4. Change the `Position` setting.
5. Open a different screen. For example tap on `Auto archive` or `Global settings`.
6. Go back.
7. Change the `Position` setting.
8. The state on screen should reflect the position correctly.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
