### PR TITLE
[Accessibility] - Add missing content description to back button in Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Bug Fixes:
     *   Fixed: The total remaining time was incorrectly displayed for some languages when large font sizes were set on the device in Up Next
         ([#1815](https://github.com/Automattic/pocket-casts-android/pull/1815))
+    *   Fixed: The back button in the search was lacking a description, causing an accessibility issue.
+           ([#1846](https://github.com/Automattic/pocket-casts-android/pull/1846))
 
 7.57
 -----

--- a/modules/features/search/src/main/res/layout/fragment_search.xml
+++ b/modules/features/search/src/main/res/layout/fragment_search.xml
@@ -46,8 +46,9 @@
                     android:layout_marginTop="6dp"
                     android:layout_marginStart="6dp"
                     android:src="@drawable/ic_arrow_back_24dp"
-                    android:tint="?attr/secondary_icon_01"
-                    android:background="?android:attr/actionBarItemBackground" />
+                    android:background="?android:attr/actionBarItemBackground"
+                    android:contentDescription="@string/back"
+                    app:tint="?attr/secondary_icon_01" />
 
             </FrameLayout>
 


### PR DESCRIPTION
## Description
- Add missing content description to back button in Search for accessibility

Closes #1711

## Testing Instructions
- Follow the steps described in https://github.com/Automattic/pocket-casts-android/issues/1711

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
