### PR TITLE
Update AGP to 8.2.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@
 aboutlibraries = "10.5.0"
 accompanist = "0.30.1"
 # Android Gradle Plugin - https://developer.android.com/studio/releases/gradle-plugin
-android-application = "8.1.1"
+android-application = "8.2.2"
 billing = "6.0.1"
 coil = "2.2.1"
 compose = "2023.04.01" # uses compose version 1.4.2, see https://developer.android.com/jetpack/compose/bom/bom-mapping


### PR DESCRIPTION
## Description

JDK 17 with sealed classes has issues with R8 on Android Gradle Plugin below `8.2.0`.

Internal ref: paaHJt-68S-p2

## Testing Instructions

Build the release version of the app with `./gradlew :app:assembleRelease`. The build should be successful.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack