### PR TITLE
Enable remote flag for settings sync

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@
 aboutlibraries = "10.5.0"
 accompanist = "0.30.1"
 # Android Gradle Plugin - https://developer.android.com/studio/releases/gradle-plugin
-android-application = "8.1.1"
+android-application = "8.2.2"
 billing = "6.0.1"
 coil = "2.2.1"
 compose = "2023.04.01" # uses compose version 1.4.2, see https://developer.android.com/jetpack/compose/bom/bom-mapping

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -32,7 +32,7 @@ enum class Feature(
         title = "Settings Sync",
         defaultValue = BuildConfig.DEBUG,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = false,
+        hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
     REPORT_VIOLATION(


### PR DESCRIPTION
## Description

This adds a remote control to our sync settings feature flag.

## Testing Instructions

1. Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/14310308/sync_flag.patch).
2. Install release version of the app.
3. Open the app and go to the settings.
4. Open `Beta features`.
5. `Settings Sync` flag should be disabled.
6. Close the app.
7. Go to the [Firebase remote config](https://console.firebase.google.com/project/singular-vector-91401/config).
8. Change the `settings_sync` flag on Android to `true` and publish the changes.
9. Open the app and go to the settings.
10. Open `Beta features`.
11. `Settings Sync` flag should be enabled.
12. Close the app.
13. Go to the [Firebase remote config](https://console.firebase.google.com/project/singular-vector-91401/config).
14. Change the `settings_sync` flag on Android to `false` and publish the changes.
15. Open the app and go to the settings.
16. Open `Beta features`.
17. `Settings Sync` flag should be disabled.

> [!warning]
> It is important to leave the Firebase config with `settings_sync` flag set to `false` after the test.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
