### PR TITLE
Deselect Chapters: Skip to selected chapter

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -103,6 +103,7 @@ class ChaptersViewModel
         val chapters = buildChaptersWithState(
             chapters = playbackState.chapters,
             playbackPositionMs = playbackState.positionMs,
+            lastChangeFrom = playbackState.lastChangeFrom
         )
         return UiState(
             chapters = chapters,
@@ -113,6 +114,7 @@ class ChaptersViewModel
     private fun buildChaptersWithState(
         chapters: Chapters,
         playbackPositionMs: Int,
+        lastChangeFrom: String? = null,
     ): List<ChapterState> {
         val chapterStates = mutableListOf<ChapterState>()
         var currentChapter: Chapter? = null
@@ -127,7 +129,9 @@ class ChaptersViewModel
                     val progress = chapter.calculateProgress(playbackPositionMs)
                     ChapterState.Playing(chapter = chapter, progress = progress)
                 } else {
-                    playbackManager.skipToNextSelectedOrLastChapter()
+                    if (!listOf("onUserSeeking", "onSeekComplete").contains(lastChangeFrom)) {
+                        playbackManager.skipToNextSelectedOrLastChapter()
+                    }
                     ChapterState.NotPlayed(chapter)
                 }
             } else {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.player.view.chapters
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -103,7 +104,7 @@ class ChaptersViewModel
         val chapters = buildChaptersWithState(
             chapters = playbackState.chapters,
             playbackPositionMs = playbackState.positionMs,
-            lastChangeFrom = playbackState.lastChangeFrom
+            lastChangeFrom = playbackState.lastChangeFrom,
         )
         return UiState(
             chapters = chapters,
@@ -111,7 +112,8 @@ class ChaptersViewModel
         )
     }
 
-    private fun buildChaptersWithState(
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun buildChaptersWithState(
         chapters: Chapters,
         playbackPositionMs: Int,
         lastChangeFrom: String? = null,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -131,7 +131,11 @@ class ChaptersViewModel
                     val progress = chapter.calculateProgress(playbackPositionMs)
                     ChapterState.Playing(chapter = chapter, progress = progress)
                 } else {
-                    if (!listOf("onUserSeeking", "onSeekComplete").contains(lastChangeFrom)) {
+                    if (!listOf(
+                            PlaybackManager.LastChangeFrom.OnUserSeeking.value,
+                            PlaybackManager.LastChangeFrom.OnSeekComplete.value,
+                        ).contains(lastChangeFrom)
+                    ) {
                         playbackManager.skipToNextSelectedOrLastChapter()
                     }
                     ChapterState.NotPlayed(chapter)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -617,10 +617,10 @@ class PlayerViewModel @Inject constructor(
     }
 
     fun nextChapter() {
-        playbackManager.skipToNextSelectedChapter()
+        playbackManager.skipToNextSelectedOrLastChapter()
     }
 
     fun previousChapter() {
-        playbackManager.skipToPreviousSelectedChapter()
+        playbackManager.skipToPreviousSelectedOrLastChapter()
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -65,7 +65,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlowable
@@ -618,10 +617,10 @@ class PlayerViewModel @Inject constructor(
     }
 
     fun nextChapter() {
-        playbackManager.skipToNextChapter()
+        playbackManager.skipToNextSelectedChapter()
     }
 
     fun previousChapter() {
-        playbackManager.skipToPreviousChapter()
+        playbackManager.skipToPreviousSelectedChapter()
     }
 }

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -51,7 +51,7 @@ class ChaptersViewModelTest {
     private lateinit var chaptersViewModel: ChaptersViewModel
 
     @Test
-    fun `given unselected chapter contains playback pos, then skip to next chapter`() = runTest {
+    fun `given unselected chapter contains playback pos, then skip to next selected chapter`() = runTest {
         val chapters = initChapters()
         initViewModel()
 
@@ -61,11 +61,31 @@ class ChaptersViewModelTest {
     }
 
     @Test
-    fun `given selected chapter contains playback pos, then do not skip to next chapter`() = runTest {
+    fun `given selected chapter contains playback pos, then do not skip to next selected chapter`() = runTest {
         val chapters = initChapters()
         initViewModel()
 
         chaptersViewModel.buildChaptersWithState(chapters, 50)
+
+        verify(playbackManager, never()).skipToNextSelectedOrLastChapter()
+    }
+
+    @Test
+    fun `given user seeking playback pos, then do not skip to next selected chapter`() = runTest {
+        val chapters = initChapters()
+        initViewModel()
+
+        chaptersViewModel.buildChaptersWithState(chapters, 150, lastChangeFrom = PlaybackManager.LastChangeFrom.OnUserSeeking.value)
+
+        verify(playbackManager, never()).skipToNextSelectedOrLastChapter()
+    }
+
+    @Test
+    fun `given seek complete, then do not skip to next selected chapter`() = runTest {
+        val chapters = initChapters()
+        initViewModel()
+
+        chaptersViewModel.buildChaptersWithState(chapters, 150, lastChangeFrom = PlaybackManager.LastChangeFrom.OnSeekComplete.value)
 
         verify(playbackManager, never()).skipToNextSelectedOrLastChapter()
     }

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -1,0 +1,97 @@
+package au.com.shiftyjelly.pocketcasts.player.viewmodel
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import au.com.shiftyjelly.pocketcasts.models.to.Chapter
+import au.com.shiftyjelly.pocketcasts.models.to.Chapters
+import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import com.jakewharton.rxrelay2.BehaviorRelay
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class ChaptersViewModelTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    @Mock
+    private lateinit var episodeManager: EpisodeManager
+
+    @Mock
+    private lateinit var podcastManager: PodcastManager
+
+    @Mock
+    private lateinit var playbackManager: PlaybackManager
+
+    @Mock
+    private lateinit var theme: Theme
+
+    @Mock
+    private lateinit var upNextQueue: UpNextQueue
+
+    private lateinit var chaptersViewModel: ChaptersViewModel
+
+    @Test
+    fun `given unselected chapter contains playback pos, then skip to next chapter`() = runTest {
+        val chapters = initChapters()
+        initViewModel()
+
+        chaptersViewModel.buildChaptersWithState(chapters, 150)
+
+        verify(playbackManager).skipToNextSelectedOrLastChapter()
+    }
+
+    @Test
+    fun `given selected chapter contains playback pos, then do not skip to next chapter`() = runTest {
+        val chapters = initChapters()
+        initViewModel()
+
+        chaptersViewModel.buildChaptersWithState(chapters, 50)
+
+        verify(playbackManager, never()).skipToNextSelectedOrLastChapter()
+    }
+
+    private fun initChapters() =
+        Chapters(
+            listOf(
+                Chapter("1", 0, 100, selected = true),
+                Chapter("2", 101, 200, selected = false),
+                Chapter("3", 201, 300, selected = true),
+            ),
+        )
+
+    private fun initViewModel() {
+        whenever(playbackManager.playbackStateRelay)
+            .thenReturn(BehaviorRelay.create<PlaybackState>().toSerialized())
+        whenever(upNextQueue.getChangesObservableWithLiveCurrentEpisode(episodeManager, podcastManager))
+            .thenReturn(BehaviorRelay.create<UpNextQueue.State>().toSerialized())
+        whenever(playbackManager.upNextQueue)
+            .thenReturn(upNextQueue)
+
+        chaptersViewModel = ChaptersViewModel(
+            episodeManager = episodeManager,
+            podcastManager = podcastManager,
+            playbackManager = playbackManager,
+            theme = theme,
+        )
+    }
+}

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
@@ -33,13 +33,13 @@ class ActionRunnerControlPlayback : TaskerPluginRunnerActionNoOutput<InputContro
         val commandEnum = input.regular.commandEnum ?: return TaskerPluginResultError(ERROR_INVALIUD_COMMAND_PROVIDED, context.getString(R.string.command_x_not_valid, command))
 
         when (commandEnum) {
-            InputControlPlayback.PlaybackCommand.SkipToNextChapter -> playbackManager.skipToNextChapter()
+            InputControlPlayback.PlaybackCommand.SkipToNextChapter -> playbackManager.skipToNextSelectedChapter()
             InputControlPlayback.PlaybackCommand.SkipToChapter -> {
                 val chapterToSkipTo = input.regular.chapterToSkipTo?.toIntOrNull() ?: return TaskerPluginResultError(ERROR_INVALID_CHAPTER_TO_SKIP_TO_PROVIDED, context.getString(R.string.chapter_to_skip_to_not_valid, input.regular.chapterToSkipTo))
 
                 playbackManager.skipToChapter(chapterToSkipTo)
             }
-            InputControlPlayback.PlaybackCommand.SkipToPreviousChapter -> playbackManager.skipToPreviousChapter()
+            InputControlPlayback.PlaybackCommand.SkipToPreviousChapter -> playbackManager.skipToPreviousSelectedChapter()
             InputControlPlayback.PlaybackCommand.SkipToTime -> playbackManager.seekToTimeMs(input.regular.skipToSeconds?.toIntOrNull()?.let { it * 1000 } ?: return TaskerPluginResultError(ERROR_INVALID_TIME_TO_SKIP_TO_PROVIDED, context.getString(R.string.time_to_skip_to_not_valid, input.regular.skipToSeconds)))
             InputControlPlayback.PlaybackCommand.SkipForward, InputControlPlayback.PlaybackCommand.SkipBack -> {
                 val jumpAmountSeconds = input.regular.skipSeconds?.toIntOrNull() ?: return TaskerPluginResultError(ERROR_INVALID_TIME_TO_SKIP_PROVIDED, context.getString(R.string.time_to_skip_not_valid, input.regular.skipSeconds))

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
@@ -33,13 +33,13 @@ class ActionRunnerControlPlayback : TaskerPluginRunnerActionNoOutput<InputContro
         val commandEnum = input.regular.commandEnum ?: return TaskerPluginResultError(ERROR_INVALIUD_COMMAND_PROVIDED, context.getString(R.string.command_x_not_valid, command))
 
         when (commandEnum) {
-            InputControlPlayback.PlaybackCommand.SkipToNextChapter -> playbackManager.skipToNextSelectedChapter()
+            InputControlPlayback.PlaybackCommand.SkipToNextChapter -> playbackManager.skipToNextSelectedOrLastChapter()
             InputControlPlayback.PlaybackCommand.SkipToChapter -> {
                 val chapterToSkipTo = input.regular.chapterToSkipTo?.toIntOrNull() ?: return TaskerPluginResultError(ERROR_INVALID_CHAPTER_TO_SKIP_TO_PROVIDED, context.getString(R.string.chapter_to_skip_to_not_valid, input.regular.chapterToSkipTo))
 
                 playbackManager.skipToChapter(chapterToSkipTo)
             }
-            InputControlPlayback.PlaybackCommand.SkipToPreviousChapter -> playbackManager.skipToPreviousSelectedChapter()
+            InputControlPlayback.PlaybackCommand.SkipToPreviousChapter -> playbackManager.skipToPreviousSelectedOrLastChapter()
             InputControlPlayback.PlaybackCommand.SkipToTime -> playbackManager.seekToTimeMs(input.regular.skipToSeconds?.toIntOrNull()?.let { it * 1000 } ?: return TaskerPluginResultError(ERROR_INVALID_TIME_TO_SKIP_TO_PROVIDED, context.getString(R.string.time_to_skip_to_not_valid, input.regular.skipToSeconds)))
             InputControlPlayback.PlaybackCommand.SkipForward, InputControlPlayback.PlaybackCommand.SkipBack -> {
                 val jumpAmountSeconds = input.regular.skipSeconds?.toIntOrNull() ?: return TaskerPluginResultError(ERROR_INVALID_TIME_TO_SKIP_PROVIDED, context.getString(R.string.time_to_skip_not_valid, input.regular.skipSeconds))

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapter.kt
@@ -10,7 +10,7 @@ data class Chapter(
     val imagePath: String? = null,
     val mimeType: String? = null,
     var index: Int = 0,
-    val selected: Boolean = false,
+    val selected: Boolean = true,
 ) {
 
     val isImagePresent: Boolean

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapters.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapters.kt
@@ -11,8 +11,8 @@ data class Chapters(private val items: List<Chapter> = emptyList()) {
     private val selectedItems: List<Chapter>
         get() = items.filter { it.selected }
 
-    val lastChapter: Chapter
-        get() = items[items.size - 1]
+    val lastChapter: Chapter?
+        get() = items.getOrNull(items.size - 1)
 
     fun getNextSelectedChapter(timeMs: Int): Chapter? {
         val currentTimeFinal = if (timeMs < 0) 0 else timeMs

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapters.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapters.kt
@@ -8,9 +8,12 @@ data class Chapters(private val items: List<Chapter> = emptyList()) {
     val size: Int
         get() = items.size
 
-    fun getNextChapter(timeMs: Int): Chapter? {
+    private val selectedItems: List<Chapter>
+        get() = items.filter { it.selected }
+
+    fun getNextSelectedChapter(timeMs: Int): Chapter? {
         val currentTimeFinal = if (timeMs < 0) 0 else timeMs
-        for (chapter in items) {
+        for (chapter in selectedItems) {
             if (chapter.startTime > currentTimeFinal) {
                 return chapter
             }
@@ -18,13 +21,13 @@ data class Chapters(private val items: List<Chapter> = emptyList()) {
         return null
     }
 
-    fun getPreviousChapter(timeMs: Int): Chapter? {
+    fun getPreviousSelectedChapter(timeMs: Int): Chapter? {
         if (items.isEmpty()) {
             return null
         }
         var foundChapter: Chapter? = null
         var lastChapter: Chapter? = null
-        for (chapter in items) {
+        for (chapter in selectedItems) {
             if (chapter.containsTime(timeMs)) {
                 if (foundChapter != null) {
                     lastChapter = foundChapter

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapters.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapters.kt
@@ -11,6 +11,9 @@ data class Chapters(private val items: List<Chapter> = emptyList()) {
     private val selectedItems: List<Chapter>
         get() = items.filter { it.selected }
 
+    val lastChapter: Chapter
+        get() = items[items.size - 1]
+
     fun getNextSelectedChapter(timeMs: Int): Chapter? {
         val currentTimeFinal = if (timeMs < 0) 0 else timeMs
         for (chapter in selectedItems) {

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/ChaptersTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/ChaptersTest.kt
@@ -1,0 +1,38 @@
+package au.com.shiftyjelly.pocketcasts.models.to
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class ChaptersTest {
+
+    @Test
+    fun `next chapter returned from selected chapters`() {
+        val chapters = initChapters()
+
+        val chapter = chapters.getNextSelectedChapter(150)
+
+        assert(chapter?.title == "3")
+    }
+
+    @Test
+    fun `prev chapter returned from selected chapters`() {
+        val chapters = initChapters()
+
+        val chapter = chapters.getPreviousSelectedChapter(150)
+
+        assert(chapter?.title == "1")
+    }
+
+    private fun initChapters() =
+        Chapters(
+            listOf(
+                Chapter("1", 0, 100, selected = true),
+                Chapter("2", 101, 200, selected = false),
+                Chapter("3", 201, 300, selected = true),
+            ),
+        )
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -326,11 +326,11 @@ class MediaSessionManager(
     private fun observePlaybackState() {
         val ignoreStates = listOf(
             // ignore buffer position because it isn't displayed in the media session
-            "updateBufferPosition",
+            PlaybackManager.LastChangeFrom.OnUpdateBufferPosition.value,
             // ignore the playback progress updates as the media session can calculate this without being sent it every second
-            "updateCurrentPosition",
+            PlaybackManager.LastChangeFrom.OnUpdateCurrentPosition.value,
             // ignore the user seeking as the event onBufferingStateChanged will update the buffering state
-            "onUserSeeking",
+            PlaybackManager.LastChangeFrom.OnUserSeeking.value,
         )
 
         var previousEpisode: BaseEpisode? = null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -888,21 +888,21 @@ open class PlaybackManager @Inject constructor(
         trackPlayback(AnalyticsEvent.PLAYBACK_SKIP_BACK, sourceView)
     }
 
-    fun skipToNextChapter() {
+    fun skipToNextSelectedChapter() {
         launch {
             val episode = getCurrentEpisode() ?: return@launch
             val currentTimeMs = getCurrentTimeMs(episode = episode)
-            playbackStateRelay.blockingFirst().chapters.getNextChapter(currentTimeMs)?.let { chapter ->
+            playbackStateRelay.blockingFirst().chapters.getNextSelectedChapter(currentTimeMs)?.let { chapter ->
                 seekToTimeMsInternal(chapter.startTime)
             }
         }
     }
 
-    fun skipToPreviousChapter() {
+    fun skipToPreviousSelectedChapter() {
         launch {
             val episode = getCurrentEpisode() ?: return@launch
             val currentTimeMs = getCurrentTimeMs(episode)
-            playbackStateRelay.blockingFirst().chapters.getPreviousChapter(currentTimeMs)?.let { chapter ->
+            playbackStateRelay.blockingFirst().chapters.getPreviousSelectedChapter(currentTimeMs)?.let { chapter ->
                 seekToTimeMsInternal(chapter.startTime)
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -12,7 +12,6 @@ import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
-import androidx.lifecycle.asFlow
 import androidx.lifecycle.toLiveData
 import androidx.media3.datasource.HttpDataSource
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
@@ -888,22 +887,30 @@ open class PlaybackManager @Inject constructor(
         trackPlayback(AnalyticsEvent.PLAYBACK_SKIP_BACK, sourceView)
     }
 
-    fun skipToNextSelectedChapter() {
+    fun skipToNextSelectedOrLastChapter() {
         launch {
             val episode = getCurrentEpisode() ?: return@launch
             val currentTimeMs = getCurrentTimeMs(episode = episode)
             playbackStateRelay.blockingFirst().chapters.getNextSelectedChapter(currentTimeMs)?.let { chapter ->
                 seekToTimeMsInternal(chapter.startTime)
-            }
+            } ?: skipToEndOfLastChapter()
         }
     }
 
-    fun skipToPreviousSelectedChapter() {
+    fun skipToPreviousSelectedOrLastChapter() {
         launch {
             val episode = getCurrentEpisode() ?: return@launch
             val currentTimeMs = getCurrentTimeMs(episode)
             playbackStateRelay.blockingFirst().chapters.getPreviousSelectedChapter(currentTimeMs)?.let { chapter ->
                 seekToTimeMsInternal(chapter.startTime)
+            }
+        }
+    }
+
+    private fun skipToEndOfLastChapter() {
+        launch {
+            playbackStateRelay.blockingFirst().chapters.lastChapter.let { chapter ->
+                seekToTimeMsInternal(chapter.endTime)
             }
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -917,14 +917,22 @@ open class PlaybackManager @Inject constructor(
 
     fun skipToChapter(chapter: Chapter) {
         launch {
-            seekToTimeMsInternal(chapter.startTime)
+            if (chapter.selected) {
+                seekToTimeMsInternal(chapter.startTime)
+            } else {
+                skipToNextSelectedOrLastChapter()
+            }
         }
     }
 
     fun skipToChapter(index: Int) {
         launch {
             val chapter = playbackStateRelay.blockingFirst().chapters.getList().firstOrNull { it.index == index } ?: return@launch
-            seekToTimeMsInternal(chapter.startTime)
+            if (chapter.selected) {
+                seekToTimeMsInternal(chapter.startTime)
+            } else {
+                skipToNextSelectedOrLastChapter()
+            }
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -909,7 +909,7 @@ open class PlaybackManager @Inject constructor(
 
     private fun skipToEndOfLastChapter() {
         launch {
-            playbackStateRelay.blockingFirst().chapters.lastChapter.let { chapter ->
+            playbackStateRelay.blockingFirst().chapters.lastChapter?.let { chapter ->
                 seekToTimeMsInternal(chapter.endTime)
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -921,6 +921,27 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
+    fun toggleChapter(select: Boolean, chapter: Chapter) {
+        launch {
+            playbackStateRelay.blockingFirst().let { playbackState ->
+                val updatedItems = playbackState.chapters.getList().map {
+                    if (it.index == chapter.index) {
+                        it.copy(selected = select)
+                    } else {
+                        it
+                    }
+                }
+
+                playbackStateRelay.accept(
+                    playbackState.copy(
+                        chapters = playbackState.chapters.copy(items = updatedItems),
+                        lastChangeFrom = "onChapterSelectionToggled",
+                    ),
+                )
+            }
+        }
+    }
+
     fun clearUpNextAsync() {
         launch {
             upNextQueue.clearUpNext()


### PR DESCRIPTION
Part of #1807 

## Description
Handles skipping chapters when they are deselected. 
(It doesn't add select at least one chapter condition yet.)

## Testing Instructions

#### Test.1 Skipping from chapter controls 

1. Play an episode having chapters from https://pca.st/upgrade
2. On the full player, go to "Chapters" tab and deselect some chapters
3. Go back to the "Now Playing Tab"
4. Use the chapter controls to move forward/backwards 
5. ✅ Notice that the chapters you unselected are not played

#### Test.2 Skipping from scrubbing playback position on the seekbar

1. Play an episode having chapters from https://pca.st/upgrade
2. On the full player, go to "Chapters" tab and deselect some chapters
3. Go back to the "Now Playing Tab"
4. Tap on the seek bar at different positions
6. ✅ Notice that the chapters you unselected are not played

#### Test.3 Skipping on chapter end

1. Play an episode having chapters from https://pca.st/upgrade
2. On the full player, go to "Chapters" tab and deselect some chapters
3. Go back to the "Now Playing Tab"
4. Let the current chapter complete
6. ✅ Notice that the next selected chapter is played or playback is seeked to end of the last chapter if there were no selected chapters left

**Important**

In iOS, there is a test case (https://github.com/Automattic/pocket-casts-ios/pull/1426) to check skipping for a podcast (`Clublife`) where the last chapter doesn't end the episode in iOS. 

In Android, we set the end time of the last chapter to episode duration [here](https://github.com/Automattic/pocket-casts-android/blob/main/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt#L1452).  So the behavior is different from iOS where in Android, skipping to the next chapter when there are no unselected chapters after current chapter, seeks to the end of last chapter which is the episode duration.

I'll discuss it with the iOS team about which behavior to keep for consistency and address it in a future PR if needed.




## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/17c17801-53b4-4708-a9eb-0767b1189e56


## Checklist
- If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- with different themes
- with a landscape orientation
- with the device set to have a large display and font size
- for accessibility with TalkBack
