### PR TITLE
Use read_version_name to get app version

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -479,7 +479,7 @@ platform :android do
 
   def release_is_hotfix?
     # Read the current release version from the .xcconfig file and parse it into an AppVersion object
-    current_version = VERSION_FORMATTER.parse(VERSION_FILE.read_release_version)
+    current_version = VERSION_FORMATTER.parse(version_name_current)
     # Calculate and return whether the release version is a hotfix
     VERSION_CALCULATOR.release_is_hotfix?(version: current_version)
   end
@@ -500,7 +500,7 @@ platform :android do
   #
   def release_version_current
     # Read the current release version from `version.properties` and parse it into an AppVersion object
-    current_version = VERSION_FORMATTER.parse(VERSION_FILE.read_version_name)
+    current_version = VERSION_FORMATTER.parse(version_name_current)
     # Return the formatted release version
     VERSION_FORMATTER.release_version(current_version)
   end
@@ -509,7 +509,7 @@ platform :android do
   #
   def release_version_next
     # Read the current release version from `version.properties` and parse it into an AppVersion object
-    current_version = VERSION_FORMATTER.parse(VERSION_FILE.read_version_name)
+    current_version = VERSION_FORMATTER.parse(version_name_current)
     # Calculate the next release version
     release_version_next = VERSION_CALCULATOR.next_release_version(version: current_version)
     # Return the formatted release version
@@ -520,7 +520,7 @@ platform :android do
   #
   def beta_version_current
     # Read the current release version from `version.properties` and parse it into an AppVersion object
-    current_version = VERSION_FORMATTER.parse(VERSION_FILE.read_version_name)
+    current_version = VERSION_FORMATTER.parse(version_name_current)
     # Return the formatted release version
     VERSION_FORMATTER.beta_version(current_version)
   end
@@ -530,7 +530,7 @@ platform :android do
   # It then bumps the build number so the -rc-1 can be appended to the code freeze version
   def beta_version_code_freeze
     # Read the current release version from the version.properties file and parse it into an AppVersion object
-    current_version = VERSION_FORMATTER.parse(VERSION_FILE.read_version_name)
+    current_version = VERSION_FORMATTER.parse(version_name_current)
     # Calculate the next major version number
     next_version = VERSION_CALCULATOR.next_release_version(version: current_version)
     # Calculate the next build number
@@ -543,7 +543,7 @@ platform :android do
   #
   def beta_version_next
     # Read the current release version from `version.properties` and parse it into an AppVersion object
-    current_version = VERSION_FORMATTER.parse(VERSION_FILE.read_version_name)
+    current_version = VERSION_FORMATTER.parse(version_name_current)
     # Calculate the next beta version
     beta_version_next = VERSION_CALCULATOR.next_build_number(version: current_version)
     # Return the formatted release version


### PR DESCRIPTION
## Description

[`AndroidVersionFile`](https://github.com/wordpress-mobile/release-toolkit/blob/6c808e522c63a87458417d1d00803c8d50e23b59/lib/fastlane/plugin/wpmreleasetoolkit/versioning/files/android_version_file.rb#L26-L33) defined in the release-toolkit repo does not have `read_release_version` method defined. When trying to finalize the release I'm getting this error.

```
[04:51:00]: Error in your Fastfile at line 482
[04:51:00]:     480:      def release_is_hotfix?
[04:51:00]:     481:        # Read the current release version from the .xcconfig file and parse it into an AppVersion object
[04:51:00]:  => 482:        current_version = VERSION_FORMATTER.parse(VERSION_FILE.read_release_version)
[04:51:00]:     483:        # Calculate and return whether the release version is a hotfix
[04:51:00]:     484:        VERSION_CALCULATOR.release_is_hotfix?(version: current_version)
```

There is, however `read_version_name`, which we use for other functions.

https://github.com/wordpress-mobile/release-toolkit/blob/6c808e522c63a87458417d1d00803c8d50e23b59/lib/fastlane/plugin/wpmreleasetoolkit/versioning/files/android_version_file.rb#L26-L33

Internal ref: p1708055632911849-slack-CC7L49W13

## Testing Instructions

I'm not sure. Code review should be fine.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
