### PR TITLE
Fix: Widget uses custom Headphone controls instead of skipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
         ([#1846](https://github.com/Automattic/pocket-casts-android/pull/1846))
     *   Fixed a bug where podcast setting screen could become unresponsive.
         ([#1845](https://github.com/Automattic/pocket-casts-android/pull/1845))
-
+    *   Fixed: Widget uses custom Headphone controls instead of skipping.
+        ([#1853](https://github.com/Automattic/pocket-casts-android/pull/1853))
 7.57
 -----
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/core/ui/widget/PodcastWidget.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/core/ui/widget/PodcastWidget.kt
@@ -21,6 +21,13 @@ import timber.log.Timber
 @AndroidEntryPoint
 class PodcastWidget : AppWidgetProvider(), CoroutineScope {
 
+    companion object {
+        const val SKIP_FORWARD_REQUEST_CODE = 0
+        const val SKIP_FORWARD_ACTION = "SKIP_FORWARD_ACTION"
+        const val SKIP_BACKWARD_REQUEST_CODE = 1
+        const val SKIP_BACKWARD_ACTION = "SKIP_BACKWARD_ACTION"
+    }
+
     @Inject lateinit var widgetManager: WidgetManager
 
     @Inject lateinit var playbackManager: PlaybackManager
@@ -44,6 +51,13 @@ class PodcastWidget : AppWidgetProvider(), CoroutineScope {
     override fun onReceive(context: Context, intent: Intent) {
         super.onReceive(context, intent)
         Timber.i("Widget onReceive called.")
+
+        if (intent.action != null) {
+            when (intent.action) {
+                SKIP_FORWARD_ACTION -> { playbackManager.skipForward() }
+                SKIP_BACKWARD_ACTION -> { playbackManager.skipBackward() }
+            }
+        }
     }
 
     override fun onEnabled(context: Context) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
@@ -4,6 +4,7 @@ import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
+import android.content.Intent
 import android.support.v4.media.session.PlaybackStateCompat
 import android.view.View
 import android.widget.RemoteViews
@@ -221,13 +222,23 @@ class WidgetManagerImpl @Inject constructor(
         return MediaButtonReceiver.buildMediaButtonPendingIntent(context, PlaybackStateCompat.ACTION_PAUSE)
     }
 
-    private fun getSkipBackIntent(): PendingIntent? {
-        return MediaButtonReceiver.buildMediaButtonPendingIntent(context, PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS)
-    }
+    private fun getSkipBackIntent(): PendingIntent? = PendingIntent.getBroadcast(
+        context,
+        PodcastWidget.SKIP_BACKWARD_REQUEST_CODE,
+        Intent(context, PodcastWidget::class.java).apply {
+            action = PodcastWidget.SKIP_BACKWARD_ACTION
+        },
+        PendingIntent.FLAG_UPDATE_CURRENT.or(PendingIntent.FLAG_IMMUTABLE),
+    )
 
-    private fun getSkipForwardIntent(): PendingIntent? {
-        return MediaButtonReceiver.buildMediaButtonPendingIntent(context, PlaybackStateCompat.ACTION_SKIP_TO_NEXT)
-    }
+    private fun getSkipForwardIntent(): PendingIntent? = PendingIntent.getBroadcast(
+        context,
+        PodcastWidget.SKIP_FORWARD_REQUEST_CODE,
+        Intent(context, PodcastWidget::class.java).apply {
+            action = PodcastWidget.SKIP_FORWARD_ACTION
+        },
+        PendingIntent.FLAG_UPDATE_CURRENT.or(PendingIntent.FLAG_IMMUTABLE),
+    )
 
     private fun getRemoteViewsLayoutId() = if (settings.useDynamicColorsForWidget.value) {
         R.layout.widget_dynamic_colors_theme


### PR DESCRIPTION
## Description
- The **skip forward** and **skip backward** buttons in the widget were not functioning as expected when the `previous action` and `next action` on the headphone control was set to `Add bookmark`.
- This issue occurred because when we clicked on these widget buttons, we were handling them in the `MediaSession` in the same place where we react to headphone taps. Therefore, this PR now handles the widget skip forward and skip backward clicks in `PodcastWidget` instead.

Closes #1832

## Testing Instructions

#### 1. Widget test without `Add bookmark` set as the headphone control action

1. Log in with Plus/Patron user
2. Go to Settings -> Headphone controls -> Make sure `Previous action` is set to `Skip back`
3. Go to Settings -> Headphone controls -> Make sure `Next action` is set to `Skip forward`
4. Play a podcast
5. Put the app in background
6. Hold the app to add the widget
7. Tap on Skip forward button and Skip backward button
8. They should work as expected

#### 2. Widget test with `Add bookmark` set as the headphone control action

1. Log in with Plus/Patron user
2. Go to Settings -> Headphone controls -> Set `Skip back` for `Previous action`
3. Go to Settings -> Headphone controls -> Set `Skip forward` for `Next action`
4. Play a podcast
5. Put the app in background
6. Hold the app to add the widget
7. Tap on Skip forward button and Skip backward button
8. They should work as expected

#### 3. Headphone regression test ⚠️
@ashiagr @MiSikora I need help to do the headphone test since I don't have it. Does any of you have headphones to test? I would like to test the headphone taps just to make sure I did not break anything.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
