### PR TITLE
Assemble release apk on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -52,6 +52,10 @@ steps:
 
   - label: "Assemble release APK"
     command: |
+      echo "--- :rubygems: Setting up Gems"
+      install_gems
+      echo "--- :closed_lock_with_key: Installing Secrets"
+      bundle exec fastlane run configure_apply
       echo "--- ⚙️ Building release variant"
       ./gradlew assembleRelease -PskipSentryProguardMappingUpload=true
     plugins: *common_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -49,3 +49,11 @@ steps:
     plugins: *common_plugins
     artifact_paths:
       - "**/build/instrumented-tests/**/*"
+
+  - label: "Assemble release APK"
+    command: |
+      echo "--- ⚙️ Building release variant"
+      ./gradlew assembleRelease -PskipSentryProguardMappingUpload=true
+    plugins: *common_plugins
+    artifact_paths:
+      - "**/build/outputs/apk/**/*"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,7 +75,8 @@ android {
 }
 
 sentry {
-    includeProguardMapping = file("$rootDir/sentry.properties").exists()
+    includeProguardMapping = System.getenv()["CI"].toBoolean()
+            && !(project.properties["skipSentryProguardMappingUpload"]?.toString()?.toBoolean() ?: false)
     tracingInstrumentation {
         features.set(EnumSet.allOf(InstrumentationFeature::class.java) - InstrumentationFeature.FILE_IO)
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,7 +76,7 @@ android {
 
 sentry {
     includeProguardMapping = System.getenv()["CI"].toBoolean()
-            && !(project.properties["skipSentryProguardMappingUpload"]?.toString()?.toBoolean() ?: false)
+            && !project.properties["skipSentryProguardMappingUpload"]?.toString().toBoolean()
     tracingInstrumentation {
         features.set(EnumSet.allOf(InstrumentationFeature::class.java) - InstrumentationFeature.FILE_IO)
     }

--- a/automotive/build.gradle.kts
+++ b/automotive/build.gradle.kts
@@ -92,4 +92,9 @@ dependencies {
     implementation(project(":modules:features:shared"))
 }
 
+sentry {
+    includeProguardMapping = System.getenv()["CI"].toBoolean()
+            && !(project.properties["skipSentryProguardMappingUpload"]?.toString()?.toBoolean() ?: false)
+}
+
 apply(plugin = "com.google.gms.google-services")

--- a/automotive/build.gradle.kts
+++ b/automotive/build.gradle.kts
@@ -94,7 +94,7 @@ dependencies {
 
 sentry {
     includeProguardMapping = System.getenv()["CI"].toBoolean()
-            && !(project.properties["skipSentryProguardMappingUpload"]?.toString()?.toBoolean() ?: false)
+            && !project.properties["skipSentryProguardMappingUpload"]?.toString().toBoolean()
 }
 
 apply(plugin = "com.google.gms.google-services")

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -72,7 +72,8 @@ android {
 }
 
 sentry {
-    includeProguardMapping = file("$rootDir/sentry.properties").exists()
+    includeProguardMapping = System.getenv()["CI"].toBoolean()
+            && !(project.properties["skipSentryProguardMappingUpload"]?.toString()?.toBoolean() ?: false)
     tracingInstrumentation {
         features.set(EnumSet.allOf(InstrumentationFeature::class.java) - InstrumentationFeature.FILE_IO)
     }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -73,7 +73,7 @@ android {
 
 sentry {
     includeProguardMapping = System.getenv()["CI"].toBoolean()
-            && !(project.properties["skipSentryProguardMappingUpload"]?.toString()?.toBoolean() ?: false)
+            && !project.properties["skipSentryProguardMappingUpload"]?.toString().toBoolean()
     tracingInstrumentation {
         features.set(EnumSet.allOf(InstrumentationFeature::class.java) - InstrumentationFeature.FILE_IO)
     }


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Internal communication link: pdnsEh-1wk-p2

This PR adds another job in the CI pipeline, to run release build variant to verify the R8 obfuscation process.

My assumptions:
- Locally, we don't ever want to send code mappings to Sentry. We want to do this only from CI
- I don't want to change the default behavior of "always sending code mappings when release variant is built", to not modify release flow we use now

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

### 1. Local build
Assert `./gradlew assembleRelease --dry-run | grep uploadSentry` doesn't return any tasks.

### 2. CI release build
Let's simulate release build:
assert `CI=true ./gradlew assembleRelease --dry-run | grep uploadSentry` returns 3 tasks for each releasable module in the app:

```
:app:uploadSentryProguardMappingsRelease SKIPPED
:automotive:uploadSentryProguardMappingsRelease SKIPPED
:wear:uploadSentryProguardMappingsRelease SKIPPED
```

### 3. CI verification build
Let's simulate release verification build (the one added in this PR):
assert: `CI=true ./gradlew assembleRelease -PskipSentryProguardMappingUpload=true --dry-run | grep uploadSentry` doesn't return any tasks.



## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack