### PR TITLE
Sync auto download condition settings

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -73,7 +73,7 @@ class AutoDownloadSettingsViewModel @Inject constructor(
     fun getAutoDownloadUnmeteredOnly() = settings.autoDownloadUnmeteredOnly.value
 
     fun onDownloadOnlyWhenChargingChange(enabled: Boolean) {
-        settings.autoDownloadOnlyWhenCharging.set(enabled, needsSync = false)
+        settings.autoDownloadOnlyWhenCharging.set(enabled, needsSync = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_ONLY_WHEN_CHARGING_TOGGLED,
             mapOf("enabled" to enabled),

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -63,7 +63,7 @@ class AutoDownloadSettingsViewModel @Inject constructor(
     }
 
     fun onDownloadOnlyOnUnmeteredChange(enabled: Boolean) {
-        settings.autoDownloadUnmeteredOnly.set(enabled, needsSync = false)
+        settings.autoDownloadUnmeteredOnly.set(enabled, needsSync = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_ONLY_ON_WIFI_TOGGLED,
             mapOf("enabled" to enabled),

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -73,6 +73,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "lightThemePreference") val lightThemePreference: NamedChangedSettingInt? = null,
     @field:Json(name = "useSystemTheme") val useSystemTheme: NamedChangedSettingBool? = null,
     @field:Json(name = "filesAfterPlayingDeleteCloud") val deleteCloudFilesAfterPlayback: NamedChangedSettingBool? = null,
+    @field:Json(name = "autoDownloadUnmeteredOnly") val autoDownloadUnmeteredOnly: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -74,6 +74,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "useSystemTheme") val useSystemTheme: NamedChangedSettingBool? = null,
     @field:Json(name = "filesAfterPlayingDeleteCloud") val deleteCloudFilesAfterPlayback: NamedChangedSettingBool? = null,
     @field:Json(name = "autoDownloadUnmeteredOnly") val autoDownloadUnmeteredOnly: NamedChangedSettingBool? = null,
+    @field:Json(name = "autoDownloadOnlyWhenCharging") val autoDownloadOnlyWhenCharging: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -252,6 +252,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 },
                 useSystemTheme = settings.useSystemTheme.getSyncSetting(::NamedChangedSettingBool),
                 deleteCloudFilesAfterPlayback = settings.deleteCloudFileAfterPlaying.getSyncSetting(::NamedChangedSettingBool),
+                autoDownloadUnmeteredOnly = settings.autoDownloadUnmeteredOnly.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -564,6 +565,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "filesAfterPlayingDeleteCloud" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.deleteCloudFileAfterPlaying,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "autoDownloadUnmeteredOnly" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.autoDownloadUnmeteredOnly,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -253,6 +253,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 useSystemTheme = settings.useSystemTheme.getSyncSetting(::NamedChangedSettingBool),
                 deleteCloudFilesAfterPlayback = settings.deleteCloudFileAfterPlaying.getSyncSetting(::NamedChangedSettingBool),
                 autoDownloadUnmeteredOnly = settings.autoDownloadUnmeteredOnly.getSyncSetting(::NamedChangedSettingBool),
+                autoDownloadOnlyWhenCharging = settings.autoDownloadOnlyWhenCharging.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -570,6 +571,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "autoDownloadUnmeteredOnly" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.autoDownloadUnmeteredOnly,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "autoDownloadOnlyWhenCharging" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.autoDownloadOnlyWhenCharging,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")


### PR DESCRIPTION
## Description

Add syncing of the global setting to auto-download on metered networks and auto-download when charging.

## Testing Instructions

> [!note]
> This should be tested with staging. Use `debug` variant instead of `debugProd`.

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`Auto download`.
4. D1: Toggle `Only on unmetered WiFi` setting `OFF`.
5. D1: Toggle `Only when charging` setting `ON`.
6. D1: Sync the device in the Profile.
7. D2: Sync the device in the Profile.
8. D2: Go to `Profile`/`Settings (cog icon)`/`Auto download`.
9. D2: `Only on unmetered WiFi` setting should be `OFF`.
10. D2: `Only when charging` setting should be `ON`.
11. D2: Toggle `Only when charging` setting `OFF`.
12. D2: Sync the device in the Profile.
13. D1: Sync the device in the Profile.
14. D1: Go to `Profile`/`Settings (cog icon)`/`Auto download`.
15. D1: `Only when charging` setting should be `OFF`.
16. D1: Toggle `Only on unmetered WiFi` setting `ON`.
17. D1: Sync the device in the Profile.
18. D2: Sync the device in the Profile.
19. D2: Go to `Profile`/`Settings (cog icon)`/`Auto download`.
20. D2: `Only on unmetered WiFi` setting should be `ON`.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
