### PR TITLE
Sync auto download when added to up next setting

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -34,7 +34,7 @@ class AutoDownloadSettingsViewModel @Inject constructor(
     }
 
     fun onUpNextChange(newValue: Boolean) {
-        settings.autoDownloadUpNext.set(newValue, needsSync = false)
+        settings.autoDownloadUpNext.set(newValue, needsSync = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_UP_NEXT_TOGGLED,
             mapOf("enabled" to newValue),

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -73,6 +73,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "lightThemePreference") val lightThemePreference: NamedChangedSettingInt? = null,
     @field:Json(name = "useSystemTheme") val useSystemTheme: NamedChangedSettingBool? = null,
     @field:Json(name = "filesAfterPlayingDeleteCloud") val deleteCloudFilesAfterPlayback: NamedChangedSettingBool? = null,
+    @field:Json(name = "autoDownloadUpNext") val autoDownloadUpNext: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -252,6 +252,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 },
                 useSystemTheme = settings.useSystemTheme.getSyncSetting(::NamedChangedSettingBool),
                 deleteCloudFilesAfterPlayback = settings.deleteCloudFileAfterPlaying.getSyncSetting(::NamedChangedSettingBool),
+                autoDownloadUpNext = settings.autoDownloadUpNext.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -564,6 +565,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "filesAfterPlayingDeleteCloud" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.deleteCloudFileAfterPlaying,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "autoDownloadUpNext" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.autoDownloadUpNext,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")


### PR DESCRIPTION
## Description

Add syncing of the global setting to auto-download up next items when added to the queue

## Testing Instructions

> [!note]
> This should be tested with staging. Use `debug` variant instead of `debugProd`.

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Settings (cog icon)`/`Auto download`.
4. D1: Toggle `Episodes added to Up Next` setting `ON`.
5. D1: Sync the device in the Profile.
6. D2: Sync the device in the Profile.
7. D2: Add some episodes to the Up Next.
8. D2: Go to `Profile`/`Downloads`.
9. D2: Notice that just added episodes are there.
10. D2: Go to `Profile`/`Settings (cog icon)`/`Auto download`.
11. D2: Toggle `Episodes added to Up Next` setting `OFF`.
12. D2: Sync the device in the Profile.
13. D1: Sync the device in the Profile.
14. D1: Add some episodes to the Up Next.
15. D1: Go to `Profile`/`Downloads`.
16. D1: Notice that just added episodes are not there.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
