### PR TITLE
Task/sync cloud auto download

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
@@ -57,7 +57,7 @@ class CloudSettingsViewModel @Inject constructor(
     }
 
     fun setCloudAutoUpload(enabled: Boolean) {
-        settings.cloudAutoUpload.set(enabled, needsSync = false)
+        settings.cloudAutoUpload.set(enabled, needsSync = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_FILES_AUTO_UPLOAD_TO_CLOUD_TOGGLED,
             mapOf("enabled" to enabled),

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
@@ -65,7 +65,7 @@ class CloudSettingsViewModel @Inject constructor(
     }
 
     fun setCloudAutoDownload(enabled: Boolean) {
-        settings.cloudAutoDownload.set(enabled, needsSync = false)
+        settings.cloudAutoDownload.set(enabled, needsSync = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_FILES_AUTO_DOWNLOAD_FROM_CLOUD_TOGGLED,
             mapOf("enabled" to enabled),

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -74,6 +74,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "useSystemTheme") val useSystemTheme: NamedChangedSettingBool? = null,
     @field:Json(name = "filesAfterPlayingDeleteCloud") val deleteCloudFilesAfterPlayback: NamedChangedSettingBool? = null,
     @field:Json(name = "cloudAutoUpload") val cloudAutoUpload: NamedChangedSettingBool? = null,
+    @field:Json(name = "cloudAutoDownload") val cloudAutoDownload: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -73,6 +73,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "lightThemePreference") val lightThemePreference: NamedChangedSettingInt? = null,
     @field:Json(name = "useSystemTheme") val useSystemTheme: NamedChangedSettingBool? = null,
     @field:Json(name = "filesAfterPlayingDeleteCloud") val deleteCloudFilesAfterPlayback: NamedChangedSettingBool? = null,
+    @field:Json(name = "cloudAutoUpload") val cloudAutoUpload: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -252,6 +252,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 },
                 useSystemTheme = settings.useSystemTheme.getSyncSetting(::NamedChangedSettingBool),
                 deleteCloudFilesAfterPlayback = settings.deleteCloudFileAfterPlaying.getSyncSetting(::NamedChangedSettingBool),
+                cloudAutoUpload = settings.cloudAutoUpload.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -564,6 +565,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "filesAfterPlayingDeleteCloud" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.deleteCloudFileAfterPlaying,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "cloudAutoUpload" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.cloudAutoUpload,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -253,6 +253,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 useSystemTheme = settings.useSystemTheme.getSyncSetting(::NamedChangedSettingBool),
                 deleteCloudFilesAfterPlayback = settings.deleteCloudFileAfterPlaying.getSyncSetting(::NamedChangedSettingBool),
                 cloudAutoUpload = settings.cloudAutoUpload.getSyncSetting(::NamedChangedSettingBool),
+                cloudAutoDownload = settings.cloudAutoDownload.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -570,6 +571,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "cloudAutoUpload" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.cloudAutoUpload,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "cloudAutoDownload" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.cloudAutoDownload,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")


### PR DESCRIPTION
## Description

Add syncing of the global setting to auto-upload and auto-download cloud files.

## Testing Instructions

> [!note]
> This should be tested with staging. Use `debug` variant instead of `debugProd`.

> [!note]
> This should be tested with a Plus account.

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Files`/`Overflow menu (three dots)`/`File settings`.
4. D1: Toggle `Auto upload to cloud` setting `ON`.
5. D1: Sync the device in the Profile.
6. D2: Sync the device in the Profile.
7. D2: Go to `Profile`/`Files` and add a file.
8. D2: Notice that the file is automatically uploaded to the cloud.
9. D2: Go to `Overflow menu (three dots)`/`File settings`.
10. D2: Toggle `Auto upload to cloud` setting `OFF`.
11. D2: Toggle `Auto download from cloud` setting `ON`.
12. D2: Sync the device in the Profile.
13. D1: Sync the device in the Profile.
14. D1: Go to `Profile`/`Files`.
15. D1: The file added from D2 should be downloaded automatically.
16. D1: Add a file. It should not be uploaded automatically.
17. D1: Upload the file manually.
18. D1: Go to `Overflow menu (three dots)`/`File settings`.
19. D1: Toggle `Auto download from cloud` setting `OFF`.
20. D1: Sync the device in the Profile.
21. D2: Sync the device in the Profile.
22. D2: Go to `Profile`/`Files`.
23. D2: The file added from D1 should not be downloaded automatically.
24. D1: Play a local file and let it finish.
25. D1: Check that the played file is no longer in local files.
26. D1: Add a local file.
27. D2: Go to `Profile`/`Files`/`Overflow menu (three dots)`/`File settings`.
28. D2: Toggle `Delete local file` setting `OFF`.
29. D2: Sync the device in the Profile.
30. D1: Sync the device in the Profile.
31. D1: Play a local file and let it finish.
32. D1:  Check that the played file is still available in local files.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
