### PR TITLE
Sync cloud auto download and upload on wifi setting

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
@@ -73,7 +73,7 @@ class CloudSettingsViewModel @Inject constructor(
     }
 
     fun setCloudOnlyWifi(enabled: Boolean) {
-        settings.cloudDownloadOnlyOnWifi.set(enabled, needsSync = false)
+        settings.cloudDownloadOnlyOnWifi.set(enabled, needsSync = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_FILES_ONLY_ON_WIFI_TOGGLED,
             mapOf("enabled" to enabled),

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -80,6 +80,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "autoDownloadOnlyWhenCharging") val autoDownloadOnlyWhenCharging: NamedChangedSettingBool? = null,
     @field:Json(name = "autoDownloadUpNext") val autoDownloadUpNext: NamedChangedSettingBool? = null,
     @field:Json(name = "backgroundRefresh") val isPodcastBackgroundRefreshEnabled: NamedChangedSettingBool? = null,
+    @field:Json(name = "cloudDownloadUnmeteredOnly") val cloudDownloadUnmeteredOnly: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -259,6 +259,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 autoDownloadOnlyWhenCharging = settings.autoDownloadOnlyWhenCharging.getSyncSetting(::NamedChangedSettingBool),
                 autoDownloadUpNext = settings.autoDownloadUpNext.getSyncSetting(::NamedChangedSettingBool),
                 isPodcastBackgroundRefreshEnabled = settings.backgroundRefreshPodcasts.getSyncSetting(::NamedChangedSettingBool),
+                cloudDownloadUnmeteredOnly = settings.cloudDownloadOnlyOnWifi.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -606,6 +607,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "backgroundRefresh" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.backgroundRefreshPodcasts,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "cloudDownloadUnmeteredOnly" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.cloudDownloadOnlyOnWifi,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")


### PR DESCRIPTION
## Description

Add syncing of the global setting to auto-upload and auto-download cloud files only on unmetered networks.

## Testing Instructions

> [!note]
> This should be tested with staging. Use `debug` variant instead of `debugProd`.

> [!note]
> This should be tested with a Plus account.

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Go to `Profile`/`Files`/`Overflow menu (three dots)`/`File settings`.
4. D1: Toggle `Only On WiFi` setting `OFF`.
5. D1: Sync the device in the Profile.
6. D2: Sync the device in the Profile.
7. D2: Go to `Profile`/`Files`/`Overflow menu (three dots)`/`File settings`.
8. D2: `Only On WiFi` setting should be `OFF`.
9. D2: Toggle `Only On WiFi` setting `ON`.
10. D2: Sync the device in the Profile.
11. D1: Sync the device in the Profile.
12. D1: Go to `Profile`/`Files`/`Overflow menu (three dots)`/`File settings`.
13. D1: `Only on WiFi` setting should be `ON`.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
