### PR TITLE
Add a bottom sheet behavior compatible with ViewPager2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Bug Fixes:
     *   Fixed an issue where bookmarks did not play when episodes where filtered out due to search queries.
         ([#1857](https://github.com/Automattic/pocket-casts-android/pull/1857))    
+    *   Fixed an issue where bookmarks on description could become unresponsive.
+        ([#1873](https://github.com/Automattic/pocket-casts-android/pull/1873))    
 
 7.58
 -----

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/view/LockableBottomSheetBehavior.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/view/LockableBottomSheetBehavior.kt
@@ -5,13 +5,12 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.ViewPager2AwareBottomSheetBehavior
 
 // StackOverflow: https://stackoverflow.com/questions/35794264/disabling-user-dragging-on-bottomsheet
 
 @Suppress("unused")
-class LockableBottomSheetBehavior<V : View> : BottomSheetBehavior<V> {
-    constructor() : super()
+class LockableBottomSheetBehavior<V : View> : ViewPager2AwareBottomSheetBehavior<V> {
     constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
 
     var swipeEnabled = true

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -32,7 +32,7 @@
             android:elevation="8dp"
             android:visibility="gone"
             app:behavior_peekHeight="@dimen/miniPlayerPeekHeight"
-            app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior" />
+            app:layout_behavior="com.google.android.material.bottomsheet.ViewPager2AwareBottomSheetBehavior" />
 
         <com.google.android.material.bottomnavigation.BottomNavigationView
             android:id="@+id/bottomNavigation"

--- a/modules/features/player/src/main/res/layout/fragment_player_container.xml
+++ b/modules/features/player/src/main/res/layout/fragment_player_container.xml
@@ -104,7 +104,7 @@
         android:elevation="8dp"
         android:translationZ="200dp"
         app:behavior_peekHeight="0dp"
-        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior" />
+        app:layout_behavior="com.google.android.material.bottomsheet.ViewPager2AwareBottomSheetBehavior" />
 
     <au.com.shiftyjelly.pocketcasts.views.tour.TourView
         android:id="@+id/tourView"

--- a/modules/services/views/src/main/java/com/google/android/material/bottomsheet/ViewPager2AwareBottomSheetBehavior.kt
+++ b/modules/services/views/src/main/java/com/google/android/material/bottomsheet/ViewPager2AwareBottomSheetBehavior.kt
@@ -1,0 +1,48 @@
+package com.google.android.material.bottomsheet
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.core.view.forEach
+import androidx.core.view.get
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.ViewPager2
+
+/**
+ * [BottomSheetBehavior] that has a support for detecting nested scrolling in [ViewPager2].
+ *
+ * See [GitHub issue](https://github.com/Automattic/pocket-casts-android/issues/1752) for more context.
+ */
+open class ViewPager2AwareBottomSheetBehavior<V : View> @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : BottomSheetBehavior<V>(context, attrs) {
+    override fun findScrollingChild(view: View): View? {
+        if (!view.isVisible) {
+            return null
+        }
+        if (ViewCompat.isNestedScrollingEnabled(view)) {
+            return view
+        }
+        if (view is ViewPager2) {
+            val selectedPageIndex = view.currentItem
+            val pagerRecycler = requireNotNull(view[0] as? RecyclerView) {
+                "First child of ViewPager2 is expected to be a RecyclerView"
+            }
+            val viewHolder = pagerRecycler.findViewHolderForAdapterPosition(selectedPageIndex) ?: return null
+            return findScrollingChild(viewHolder.itemView)
+        }
+        if (view is ViewGroup) {
+            view.forEach { childView ->
+                val scrollingChild = findScrollingChild(childView)
+                if (scrollingChild != null) {
+                    return scrollingChild
+                }
+            }
+        }
+        return null
+    }
+}

--- a/modules/services/views/src/main/res/values/strings.xml
+++ b/modules/services/views/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="bottom_sheet_behavior" translatable="false">com.google.android.material.bottomsheet.ViewPager2AwareBottomSheetBehavior</string>
+</resources>


### PR DESCRIPTION
## Description

`BottomSheetBehavior` from the Material library doesn't work with `ViewPager2`. Whenever it attempts to find a nested scrolling child it always grabs the first view that it finds. This means that if there are multiple scrolling pages the other ones can become unresponsive to scroll events.

Closes #1752 

## Testing Instructions

> [!note]
> You need to test this with a Patron account.

> [!note]
> Test this with an episode with a longer description like this one: https://pca.st/episode/c0f9ad0a-cf24-4cd6-a7c4-67591e59ae06

### Player

1. Add multiple bookmarks to an episode. You should have enough of them to fill more than 1 screen.
2. Play that episode and open up a player.
3. Switch the active tab to `Bookmarks`.
4. Bookmarks content should be scrollable.
5. You should be able to close the player with a drag motion from the bookmarks tab.
6. Open up the player.
7. Switch the active tab to `Details`.
8. Details content should be scrollable.
9. You should be able to close the player with a drag motion from the details tab.
10. Open up the player.
11. Switch between different tabs multiple times. Every time you switch the content should be scrollable and the sheet should be draggable.

### Episode details

1. Add multiple bookmarks to an episode. You should have enough of them to fill more than 1 screen.
2. Open episode details by tapping on the episode.
3. Switch the active tab to `Bookmarks`.
4. Bookmarks content should be scrollable.
5. You should be able to close the episode details with a drag motion from the bookmarks tab.
6. Open up the episode details.
7. Switch the active tab to `Details`.
8. Details content should be scrollable.
9. You should be able to close the episode details with a drag motion from the details tab.
10. Open up the episode details.
11. Switch between different tabs multiple times. Every time you switch the content should be scrollable and the sheet should be draggable.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
