### PR TITLE
Deselect Chapters -  Add skip chapter header

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
@@ -71,7 +71,7 @@ fun ChapterRow(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .clickable { onClick() }
-                .padding(horizontal = 12.dp),
+                .padding(end = 12.dp),
         ) {
             AnimatedVisibility(visible = isTogglingChapters) {
                 Checkbox(
@@ -85,6 +85,8 @@ fun ChapterRow(
             TextH50(
                 text = chapter.index.toString(),
                 color = textColor,
+                modifier = Modifier
+                    .padding(horizontal = 12.dp),
             )
             Spacer(Modifier.width(8.dp))
             TextH50(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.player.view.chapters
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -40,8 +41,6 @@ import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -49,18 +48,14 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 fun ChapterRow(
     state: ChaptersViewModel.ChapterState,
+    isTogglingChapters: Boolean,
     onSelectionChange: (Boolean, Chapter) -> Unit,
     onClick: () -> Unit,
     onUrlClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val chapter = state.chapter
-    val textColor =
-        if (state is ChaptersViewModel.ChapterState.Played) {
-            MaterialTheme.theme.colors.playerContrast04
-        } else {
-            MaterialTheme.theme.colors.playerContrast01
-        }
+    val textColor = getTextColor(state, isTogglingChapters)
     Box(
         modifier = modifier
             // use intrinsic height so the progress bar fills the height of the row
@@ -78,14 +73,12 @@ fun ChapterRow(
                 .clickable { onClick() }
                 .padding(horizontal = 12.dp),
         ) {
-            if (FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS)) {
+            AnimatedVisibility(visible = isTogglingChapters) {
                 Checkbox(
                     checked = state.chapter.selected,
                     onCheckedChange = { selected ->
                         onSelectionChange(selected, chapter)
                     },
-                    modifier = Modifier
-                        .padding(start = 16.dp),
                 )
                 Spacer(Modifier.width(8.dp))
             }
@@ -157,6 +150,24 @@ private fun LinkButton(textColor: Color, onClick: () -> Unit, modifier: Modifier
     }
 }
 
+@Composable
+private fun getTextColor(
+    state: ChaptersViewModel.ChapterState,
+    isTogglingChapters: Boolean,
+) = if (isTogglingChapters) {
+    if (state.chapter.selected) {
+        MaterialTheme.theme.colors.playerContrast01
+    } else {
+        MaterialTheme.theme.colors.playerContrast02
+    }
+} else {
+    if (state is ChaptersViewModel.ChapterState.Played) {
+        MaterialTheme.theme.colors.playerContrast04
+    } else {
+        MaterialTheme.theme.colors.playerContrast01
+    }
+}
+
 @ShowkaseComposable(name = "ChapterRow", group = "Chapter", styleName = "Default - DARK")
 @Preview(name = "Dark")
 @Composable
@@ -174,18 +185,21 @@ fun ChapterRowPreview() {
         Column {
             ChapterRow(
                 state = ChaptersViewModel.ChapterState.Played(chapter = chapter),
+                isTogglingChapters = false,
                 onSelectionChange = { _, _ -> },
                 onClick = {},
                 onUrlClick = {},
             )
             ChapterRow(
                 state = ChaptersViewModel.ChapterState.Playing(chapter = chapter, progress = 0.5f),
+                isTogglingChapters = false,
                 onSelectionChange = { _, _ -> },
                 onClick = {},
                 onUrlClick = {},
             )
             ChapterRow(
                 state = ChaptersViewModel.ChapterState.NotPlayed(chapter = chapter),
+                isTogglingChapters = false,
                 onSelectionChange = { _, _ -> },
                 onClick = {},
                 onUrlClick = {},

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -68,7 +68,7 @@ class ChaptersFragment : BaseFragment() {
                 Surface(modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection())) {
                     ChaptersPage(
                         lazyListState = lazyListState,
-                        chapters = uiState.chapters,
+                        chapters = uiState.displayChapters,
                         totalChaptersCount = uiState.totalChaptersCount,
                         onSelectionChange = { selected, chapter -> chaptersViewModel.onSelectionChange(selected, chapter) },
                         onChapterClick = ::onChapterClick,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -69,9 +69,12 @@ class ChaptersFragment : BaseFragment() {
                     ChaptersPage(
                         lazyListState = lazyListState,
                         chapters = uiState.chapters,
+                        totalChaptersCount = uiState.totalChaptersCount,
                         onSelectionChange = { selected, chapter -> chaptersViewModel.onSelectionChange(selected, chapter) },
                         onChapterClick = ::onChapterClick,
                         onUrlClick = ::onUrlClick,
+                        onSkipChaptersClick = { chaptersViewModel.onSkipChaptersClick(it) },
+                        isTogglingChapters = uiState.isTogglingChapters,
                         backgroundColor = uiState.backgroundColor,
                     )
                 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersHeader.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersHeader.kt
@@ -1,0 +1,167 @@
+package au.com.shiftyjelly.pocketcasts.player.view.chapters
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun ChaptersHeader(
+    totalChaptersCount: Int,
+    hiddenChaptersCount: Int,
+    onSkipChaptersClick: (Boolean) -> Unit,
+    isTogglingChapters: Boolean,
+) {
+    HeaderRow(
+        text = getHeaderTitle(totalChaptersCount, hiddenChaptersCount),
+        toggle = TextToggle(
+            checked = isTogglingChapters,
+            text = if (isTogglingChapters) {
+                stringResource(LR.string.done)
+            } else {
+                stringResource(LR.string.skip_chapters)
+            },
+        ),
+        onClick = { onSkipChaptersClick(!isTogglingChapters) },
+    )
+    Divider(
+        color = MaterialTheme.theme.colors.playerContrast06,
+        thickness = 1.dp,
+    )
+}
+
+@Composable
+private fun HeaderRow(
+    text: String,
+    modifier: Modifier = Modifier,
+    toggle: TextToggle,
+    onClick: () -> Unit,
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .padding(
+                start = 20.dp,
+                end = 4.dp,
+            ),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.weight(1f),
+        ) {
+            TextH50(
+                text = text,
+                modifier = Modifier
+                    .padding(vertical = 16.dp),
+                color = MaterialTheme.theme.colors.playerContrast02,
+            )
+        }
+
+        Spacer(Modifier.width(12.dp))
+
+        TextButton(
+            text = toggle.text,
+            onClick = onClick,
+        )
+    }
+}
+
+@Composable
+private fun TextButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+    Row(
+        modifier = modifier
+            .clickable { onClick() }
+            .widthIn(max = screenWidth / 2)
+            .padding(horizontal = 12.dp, vertical = 16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        TextH50(
+            text = text,
+            textAlign = TextAlign.End,
+            color = MaterialTheme.theme.colors.primaryText01,
+        )
+    }
+}
+
+@Composable
+private fun getHeaderTitle(
+    chaptersTotalCount: Int,
+    unselectedChaptersCount: Int,
+) = if (unselectedChaptersCount > 0) {
+    if (chaptersTotalCount > 1) {
+        stringResource(LR.string.number_of_chapters_summary_plural, chaptersTotalCount, unselectedChaptersCount)
+    } else {
+        stringResource(LR.string.number_of_chapters_summary_singular, unselectedChaptersCount)
+    }
+} else {
+    if (chaptersTotalCount > 1) {
+        stringResource(LR.string.number_of_chapters, chaptersTotalCount)
+    } else {
+        stringResource(LR.string.single_chapter)
+    }
+}
+
+data class TextToggle(
+    val checked: Boolean,
+    val text: String,
+)
+
+@ShowkaseComposable(name = "ChaptersHeader", group = "Chapter", styleName = "Default - DARK")
+@Preview(name = "Dark")
+@Composable
+fun ChaptersHeaderPreview() {
+    AppThemeWithBackground(Theme.ThemeType.DARK) {
+        Column {
+            ChaptersHeader(
+                totalChaptersCount = 5,
+                hiddenChaptersCount = 2,
+                onSkipChaptersClick = {},
+                isTogglingChapters = false,
+            )
+            ChaptersHeader(
+                totalChaptersCount = 5,
+                hiddenChaptersCount = 0,
+                onSkipChaptersClick = {},
+                isTogglingChapters = false,
+            )
+            ChaptersHeader(
+                totalChaptersCount = 5,
+                hiddenChaptersCount = 2,
+                onSkipChaptersClick = {},
+                isTogglingChapters = true,
+            )
+            ChaptersHeader(
+                totalChaptersCount = 1,
+                hiddenChaptersCount = 0,
+                onSkipChaptersClick = {},
+                isTogglingChapters = true,
+            )
+        }
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
@@ -37,7 +37,7 @@ fun ChaptersPage(
         modifier = modifier
             .background(backgroundColor)
             .fillMaxSize()
-            .padding(top = 16.dp),
+            .padding(top = if (FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS)) 0.dp else 16.dp),
     ) {
         if (FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS)) {
             item {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.player.view.chapters
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -14,14 +15,20 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ChaptersPage(
     lazyListState: LazyListState,
     chapters: List<ChaptersViewModel.ChapterState>,
+    totalChaptersCount: Int,
     onSelectionChange: (Boolean, Chapter) -> Unit,
     onChapterClick: (Chapter, Boolean) -> Unit,
     onUrlClick: (String) -> Unit,
+    onSkipChaptersClick: (Boolean) -> Unit,
+    isTogglingChapters: Boolean,
     backgroundColor: Color,
     modifier: Modifier = Modifier,
 ) {
@@ -32,12 +39,24 @@ fun ChaptersPage(
             .fillMaxSize()
             .padding(top = 16.dp),
     ) {
+        if (FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS)) {
+            item {
+                ChaptersHeader(
+                    totalChaptersCount = totalChaptersCount,
+                    hiddenChaptersCount = totalChaptersCount - chapters.filter { it.chapter.selected }.size,
+                    onSkipChaptersClick = onSkipChaptersClick,
+                    isTogglingChapters = isTogglingChapters,
+                )
+            }
+        }
         itemsIndexed(chapters, key = { _, state -> state.chapter.index }) { index, state ->
             ChapterRow(
                 state = state,
+                isTogglingChapters = isTogglingChapters,
                 onSelectionChange = onSelectionChange,
                 onClick = { onChapterClick(state.chapter, state is ChaptersViewModel.ChapterState.Playing) },
                 onUrlClick = { onUrlClick(state.chapter.url.toString()) },
+                modifier = Modifier.animateItemPlacement(),
             )
             if (index < chapters.lastIndex) {
                 Divider(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -14,7 +14,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.Observable
 import io.reactivex.schedulers.Schedulers
@@ -39,7 +39,6 @@ class ChaptersViewModel
     podcastManager: PodcastManager,
     private val playbackManager: PlaybackManager,
     private val theme: Theme,
-    private val featureFlagWrapper: FeatureFlagWrapper,
 ) : ViewModel(), CoroutineScope {
 
     override val coroutineContext: CoroutineContext
@@ -137,7 +136,7 @@ class ChaptersViewModel
                 // a chapter that hasn't been played
                 ChapterState.NotPlayed(chapter)
             } else if (chapter.containsTime(playbackPositionMs)) {
-                if (chapter.selected || !featureFlagWrapper.isEnabled(Feature.DESELECT_CHAPTERS)) {
+                if (chapter.selected || !FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS)) {
                     // the chapter currently playing
                     currentChapter = chapter
                     val progress = chapter.calculateProgress(playbackPositionMs)
@@ -179,7 +178,7 @@ class ChaptersViewModel
         chapters: List<ChapterState>,
         isTogglingChapters: Boolean,
     ): List<ChapterState> {
-        val shouldFilterChapters = featureFlagWrapper.isEnabled(Feature.DESELECT_CHAPTERS) &&
+        val shouldFilterChapters = FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS) &&
             !isTogglingChapters
 
         return if (shouldFilterChapters) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -13,6 +13,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.Observable
 import io.reactivex.schedulers.Schedulers
@@ -37,6 +39,7 @@ class ChaptersViewModel
     podcastManager: PodcastManager,
     private val playbackManager: PlaybackManager,
     private val theme: Theme,
+    private val featureFlagWrapper: FeatureFlagWrapper,
 ) : ViewModel(), CoroutineScope {
 
     override val coroutineContext: CoroutineContext
@@ -108,11 +111,13 @@ class ChaptersViewModel
             playbackPositionMs = playbackState.positionMs,
             lastChangeFrom = playbackState.lastChangeFrom,
         )
+        val shouldFilterChapters = featureFlagWrapper.isEnabled(Feature.DESELECT_CHAPTERS) &&
+            !_uiState.value.isTogglingChapters
         return UiState(
-            chapters = if (_uiState.value.isTogglingChapters) {
-                chapters
-            } else {
+            chapters = if (shouldFilterChapters) {
                 chapters.filter { it.chapter.selected }
+            } else {
+                chapters
             },
             totalChaptersCount = chapters.size,
             backgroundColor = Color(backgroundColor),

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -44,7 +44,9 @@ class ChaptersViewModel
 
     data class UiState(
         val chapters: List<ChapterState> = emptyList(),
+        val totalChaptersCount: Int = 0,
         val backgroundColor: Color,
+        val isTogglingChapters: Boolean = false,
     )
 
     sealed class ChapterState {
@@ -107,8 +109,14 @@ class ChaptersViewModel
             lastChangeFrom = playbackState.lastChangeFrom,
         )
         return UiState(
-            chapters = chapters,
+            chapters = if (_uiState.value.isTogglingChapters) {
+                chapters
+            } else {
+                chapters.filter { it.chapter.selected }
+            },
+            totalChaptersCount = chapters.size,
             backgroundColor = Color(backgroundColor),
+            isTogglingChapters = _uiState.value.isTogglingChapters,
         )
     }
 
@@ -151,5 +159,9 @@ class ChaptersViewModel
 
     fun onSelectionChange(selected: Boolean, chapter: Chapter) {
         playbackManager.toggleChapter(selected, chapter)
+    }
+
+    fun onSkipChaptersClick(show: Boolean) {
+        _uiState.value = _uiState.value.copy(isTogglingChapters = show)
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -138,7 +138,7 @@ class ChaptersViewModel
                 // a chapter that hasn't been played
                 ChapterState.NotPlayed(chapter)
             } else if (chapter.containsTime(playbackPositionMs)) {
-                if (chapter.selected) {
+                if (chapter.selected || !featureFlagWrapper.isEnabled(Feature.DESELECT_CHAPTERS)) {
                     // the chapter currently playing
                     currentChapter = chapter
                     val progress = chapter.calculateProgress(playbackPositionMs)

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
 import com.jakewharton.rxrelay2.BehaviorRelay
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -97,7 +98,7 @@ class ChaptersViewModelTest {
     @Test
     fun `given feature flag off, then chapter is not skipped`() = runTest {
         val chapters = initChapters()
-        initViewModel()
+        initViewModel(featureEnabled = false)
 
         chaptersViewModel.buildChaptersWithState(chapters, 150)
 
@@ -113,7 +114,8 @@ class ChaptersViewModelTest {
             ),
         )
 
-    private fun initViewModel() {
+    private fun initViewModel(featureEnabled: Boolean = true) {
+        whenever(featureFlagWrapper.isEnabled(Feature.DESELECT_CHAPTERS)).thenReturn(featureEnabled)
         whenever(playbackManager.playbackStateRelay)
             .thenReturn(BehaviorRelay.create<PlaybackState>().toSerialized())
         whenever(upNextQueue.getChangesObservableWithLiveCurrentEpisode(episodeManager, podcastManager))

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
 import com.jakewharton.rxrelay2.BehaviorRelay
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -47,6 +48,9 @@ class ChaptersViewModelTest {
 
     @Mock
     private lateinit var upNextQueue: UpNextQueue
+
+    @Mock
+    private lateinit var featureFlagWrapper: FeatureFlagWrapper
 
     private lateinit var chaptersViewModel: ChaptersViewModel
 
@@ -90,6 +94,16 @@ class ChaptersViewModelTest {
         verify(playbackManager, never()).skipToNextSelectedOrLastChapter()
     }
 
+    @Test
+    fun `given feature flag off, then chapter is not skipped`() = runTest {
+        val chapters = initChapters()
+        initViewModel()
+
+        chaptersViewModel.buildChaptersWithState(chapters, 150)
+
+        verify(playbackManager, never()).skipToNextSelectedOrLastChapter()
+    }
+
     private fun initChapters() =
         Chapters(
             listOf(
@@ -112,6 +126,7 @@ class ChaptersViewModelTest {
             podcastManager = podcastManager,
             playbackManager = playbackManager,
             theme = theme,
+            featureFlagWrapper = featureFlagWrapper,
         )
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -343,6 +343,18 @@
     <string name="player_open_full_size_player">Activate to open full size player</string>
     <string name="player_play_failed_check_internet">Could not load podcast. Please check your internet connection and try again.</string>
 
+    <!-- Chapters -->
+
+    <!-- Label that toggles the option for the user to choose which chapters of the podcast they want to skip (to not be played) -->
+    <string name="skip_chapters">Skip chapters</string>
+    <!-- Indicates the number of chapters in a podcast episode. %d is the number of chapters. -->
+    <string name="number_of_chapters">%d chapters</string>
+    <!-- Singular indication of number of chapters -->
+    <string name="single_chapter">1 chapter</string>
+    <!-- %1$d is the number of total chapters. %2$d is the number of hidden chapters. -->
+    <string name="number_of_chapters_summary_plural">%1$d chapters &#x2022; %2$d hidden</string>
+    <string name="number_of_chapters_summary_singular">1 chapter &#x2022; %d hidden</string>
+
     <!-- Podcasts -->
 
     <string name="podcasts">Podcasts</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapters.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapters.kt
@@ -1,11 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.models.to
 
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 
 data class Chapters(
     private val items: List<Chapter> = emptyList(),
-    private val featureFlagWrapper: FeatureFlagWrapper = FeatureFlagWrapper(),
 ) {
 
     val isEmpty: Boolean
@@ -22,7 +21,7 @@ data class Chapters(
 
     fun getNextSelectedChapter(timeMs: Int): Chapter? {
         val currentTimeFinal = if (timeMs < 0) 0 else timeMs
-        val items = if (featureFlagWrapper.isEnabled(Feature.DESELECT_CHAPTERS)) selectedItems else items
+        val items = if (FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS)) selectedItems else items
         for (chapter in items) {
             if (chapter.startTime > currentTimeFinal) {
                 return chapter
@@ -37,7 +36,7 @@ data class Chapters(
         }
         var foundChapter: Chapter? = null
         var lastChapter: Chapter? = null
-        val items = if (featureFlagWrapper.isEnabled(Feature.DESELECT_CHAPTERS)) selectedItems else items
+        val items = if (FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS)) selectedItems else items
         for (chapter in items) {
             if (chapter.containsTime(timeMs)) {
                 if (foundChapter != null) {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapters.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapters.kt
@@ -1,6 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.models.to
 
-data class Chapters(private val items: List<Chapter> = emptyList()) {
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
+
+data class Chapters(
+    private val items: List<Chapter> = emptyList(),
+    private val featureFlagWrapper: FeatureFlagWrapper = FeatureFlagWrapper(),
+) {
 
     val isEmpty: Boolean
         get() = items.isEmpty()
@@ -16,7 +22,8 @@ data class Chapters(private val items: List<Chapter> = emptyList()) {
 
     fun getNextSelectedChapter(timeMs: Int): Chapter? {
         val currentTimeFinal = if (timeMs < 0) 0 else timeMs
-        for (chapter in selectedItems) {
+        val items = if (featureFlagWrapper.isEnabled(Feature.DESELECT_CHAPTERS)) selectedItems else items
+        for (chapter in items) {
             if (chapter.startTime > currentTimeFinal) {
                 return chapter
             }
@@ -30,7 +37,8 @@ data class Chapters(private val items: List<Chapter> = emptyList()) {
         }
         var foundChapter: Chapter? = null
         var lastChapter: Chapter? = null
-        for (chapter in selectedItems) {
+        val items = if (featureFlagWrapper.isEnabled(Feature.DESELECT_CHAPTERS)) selectedItems else items
+        for (chapter in items) {
             if (chapter.containsTime(timeMs)) {
                 if (foundChapter != null) {
                     lastChapter = foundChapter

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/ChaptersTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/ChaptersTest.kt
@@ -1,16 +1,44 @@
 package au.com.shiftyjelly.pocketcasts.models.to
 
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class ChaptersTest {
 
+    @Mock
+    private lateinit var featureFlagWrapper: FeatureFlagWrapper
+
     @Test
-    fun `next chapter returned from selected chapters`() {
+    fun `given feature flag true, then next chapter returned from selected chapters`() {
+        whenever(featureFlagWrapper.isEnabled(any())).thenReturn(true)
+        val chapters = initChapters()
+
+        val chapter = chapters.getNextSelectedChapter(150)
+
+        assert(chapter?.title == "5")
+    }
+
+    @Test
+    fun `given feature flag true, then prev chapter returned from selected chapters`() {
+        whenever(featureFlagWrapper.isEnabled(any())).thenReturn(true)
+        val chapters = initChapters()
+
+        val chapter = chapters.getPreviousSelectedChapter(350)
+
+        assert(chapter?.title == "1")
+    }
+
+    @Test
+    fun `given feature flag false, then next chapter returned from all chapters`() {
+        whenever(featureFlagWrapper.isEnabled(any())).thenReturn(false)
         val chapters = initChapters()
 
         val chapter = chapters.getNextSelectedChapter(150)
@@ -19,20 +47,25 @@ class ChaptersTest {
     }
 
     @Test
-    fun `prev chapter returned from selected chapters`() {
+    fun `given feature flag false, then prev chapter returned from all chapters`() {
+        whenever(featureFlagWrapper.isEnabled(any())).thenReturn(false)
         val chapters = initChapters()
 
-        val chapter = chapters.getPreviousSelectedChapter(150)
+        val chapter = chapters.getPreviousSelectedChapter(350)
 
-        assert(chapter?.title == "1")
+        assert(chapter?.title == "3")
     }
 
-    private fun initChapters() =
-        Chapters(
-            listOf(
+    private fun initChapters(): Chapters {
+        return Chapters(
+            items = listOf(
                 Chapter("1", 0, 100, selected = true),
                 Chapter("2", 101, 200, selected = false),
-                Chapter("3", 201, 300, selected = true),
+                Chapter("3", 201, 300, selected = false),
+                Chapter("4", 301, 400, selected = false),
+                Chapter("5", 401, 500, selected = true),
             ),
+            featureFlagWrapper = featureFlagWrapper,
         )
+    }
 }

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/ChaptersTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/ChaptersTest.kt
@@ -1,24 +1,27 @@
 package au.com.shiftyjelly.pocketcasts.models.to
 
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlagWrapper
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.providers.InMemoryFeatureProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.mockito.kotlin.any
-import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class ChaptersTest {
-
-    @Mock
-    private lateinit var featureFlagWrapper: FeatureFlagWrapper
+    @Before
+    fun setUp() {
+        FeatureFlag.initialize(
+            listOf(object : InMemoryFeatureProvider() {}),
+        )
+    }
 
     @Test
     fun `given feature flag true, then next chapter returned from selected chapters`() {
-        whenever(featureFlagWrapper.isEnabled(any())).thenReturn(true)
+        FeatureFlag.setEnabled(Feature.DESELECT_CHAPTERS, true)
         val chapters = initChapters()
 
         val chapter = chapters.getNextSelectedChapter(150)
@@ -28,7 +31,7 @@ class ChaptersTest {
 
     @Test
     fun `given feature flag true, then prev chapter returned from selected chapters`() {
-        whenever(featureFlagWrapper.isEnabled(any())).thenReturn(true)
+        FeatureFlag.setEnabled(Feature.DESELECT_CHAPTERS, true)
         val chapters = initChapters()
 
         val chapter = chapters.getPreviousSelectedChapter(350)
@@ -38,7 +41,7 @@ class ChaptersTest {
 
     @Test
     fun `given feature flag false, then next chapter returned from all chapters`() {
-        whenever(featureFlagWrapper.isEnabled(any())).thenReturn(false)
+        FeatureFlag.setEnabled(Feature.DESELECT_CHAPTERS, false)
         val chapters = initChapters()
 
         val chapter = chapters.getNextSelectedChapter(150)
@@ -48,7 +51,7 @@ class ChaptersTest {
 
     @Test
     fun `given feature flag false, then prev chapter returned from all chapters`() {
-        whenever(featureFlagWrapper.isEnabled(any())).thenReturn(false)
+        FeatureFlag.setEnabled(Feature.DESELECT_CHAPTERS, false)
         val chapters = initChapters()
 
         val chapter = chapters.getPreviousSelectedChapter(350)
@@ -65,7 +68,6 @@ class ChaptersTest {
                 Chapter("4", 301, 400, selected = false),
                 Chapter("5", 401, 500, selected = true),
             ),
-            featureFlagWrapper = featureFlagWrapper,
         )
     }
 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/FeatureFlagWrapper.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/FeatureFlagWrapper.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.utils.featureflag
+
+import javax.inject.Inject
+
+open class FeatureFlagWrapper @Inject constructor() {
+    open fun isEnabled(feature: Feature) = FeatureFlag.isEnabled(feature)
+}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/FeatureFlagWrapper.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/FeatureFlagWrapper.kt
@@ -1,7 +1,0 @@
-package au.com.shiftyjelly.pocketcasts.utils.featureflag
-
-import javax.inject.Inject
-
-open class FeatureFlagWrapper @Inject constructor() {
-    open fun isEnabled(feature: Feature) = FeatureFlag.isEnabled(feature)
-}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/InMemoryFeatureProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/InMemoryFeatureProvider.kt
@@ -1,0 +1,18 @@
+package au.com.shiftyjelly.pocketcasts.utils.featureflag.providers
+
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.ModifiableFeatureProvider
+
+open class InMemoryFeatureProvider : ModifiableFeatureProvider {
+    private val features = mutableMapOf<Feature, Boolean>()
+
+    override val priority = 0
+
+    override fun setEnabled(feature: Feature, enabled: Boolean) {
+        features[feature] = enabled
+    }
+
+    override fun hasFeature(feature: Feature) = true
+
+    override fun isEnabled(feature: Feature) = features[feature] ?: feature.defaultValue
+}


### PR DESCRIPTION
Part of #1807 

## Description
Toggle the chapter selection/deselection.

(This is not the final design)

These are podcasts with chapters you can use to test:

* Upgrade: https://pca.st/upgrade
* Clublife: https://pca.st/rLzZCv

## Testing Instructions

#### Feature Flag ON

2. Run the app
4. Play any episode with chapters
5. Go to the `Chapters` tab
6. ✅ You should see a header indicating the number of chapters and a button to "Skip chapters"
7. Tap "Skip chapters"
8. ✅ You can now select/deselect chapters
9. Tap "Done"
10. ✅ The number of chapters and hidden chapters should be correctly updated and hidden chapters don't appear on the listing
11. Leave some chapters deselected

#### Feature Flag OFF
13. Go to `Profile` > `Settings` > Beta Features > `Deselect Chapters` and turn it off
14. Kill the app and restart
15. Open `Chapters` tab again
16. ✅ All chapters should be there and there shouldn't be a header

** I also made changes to not skip chapters if feature flag is off in https://github.com/Automattic/pocket-casts-android/pull/1874/commits/4d10992fd8b6d061c65989ede096b8ef9407ec8. I've tried to cover them in tests, it would be good to test it as well.

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/f7714748-4089-4cdc-aa86-410ce0c6863c

Large font

<img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/6febf24f-4e39-4b3b-aa0e-4a9144ad7ebf"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack