### PR TITLE
Add navigation to podcast from the player screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 7.59
 -----
+*   Updates:
+    *   Navigate to a podcast when a podcast title in the player tapped.
+        ([#1875](https://github.com/Automattic/pocket-casts-android/pull/1875))
 * Bug Fixes:
     *   Fixed an issue where bookmarks did not play when episodes where filtered out due to search queries.
         ([#1857](https://github.com/Automattic/pocket-casts-android/pull/1857))    

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -22,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.player.databinding.AdapterPlayerHeaderBinding
 import au.com.shiftyjelly.pocketcasts.player.view.ShelfFragment.Companion.AnalyticsProp
@@ -232,6 +233,23 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
                         if (result is ErrorResult && headerViewModel.podcastUuid != null) {
                             loadArtwork(headerViewModel.podcastUuid, binding.artwork)
                         }
+                    }
+                }
+            }
+
+            binding.podcastTitle?.let { podcastTitle ->
+                podcastTitle.setOnClickListener {
+                    val podcastUuid = headerViewModel.podcastUuid ?: return@setOnClickListener
+                    analyticsTracker.track(
+                        AnalyticsEvent.EPISODE_DETAIL_PODCAST_NAME_TAPPED,
+                        mapOf(
+                            AnalyticsProp.Key.EPISODE_UUID to headerViewModel.episodeUuid,
+                            AnalyticsProp.Key.SOURCE to EpisodeViewSource.NOW_PLAYING.value,
+                        ),
+                    )
+                    (activity as? FragmentHostListener)?.let { listener ->
+                        listener.closePlayer()
+                        listener.openPodcastPage(podcastUuid)
                     }
                 }
             }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
@@ -203,6 +203,8 @@ class ShelfFragment : BaseFragment(), ShelfTouchCallback.ItemTouchHelperAdapter 
                 const val MOVED_FROM = "moved_from"
                 const val MOVED_TO = "moved_to"
                 const val POSITION = "position"
+                const val SOURCE = "source"
+                const val EPISODE_UUID = "episode_uuid"
             }
             object Value {
                 const val SHELF = "shelf"

--- a/modules/features/player/src/main/res/layout/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout/adapter_player_header.xml
@@ -133,11 +133,18 @@
                 android:text="@{viewModel.title}"
                 android:textColor="#FFFFFFFF"
                 android:textSize="18sp"
-                app:layout_constraintBottom_toTopOf="@+id/podcastTitle"
-                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toTopOf="@+id/subtitleBarrier"
                 app:layout_constraintEnd_toStartOf="@+id/nextChapter"
                 app:layout_constraintStart_toEndOf="@+id/previousChapter"
                 tools:text="@tools:sample/lorem" />
+
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/subtitleBarrier"
+                android:layout_width="1dp"
+                android:layout_height="match_parent"
+                app:barrierAllowsGoneWidgets="true"
+                app:barrierDirection="top"
+                app:constraint_referenced_ids="podcastTitle,chapterSummary" />
 
             <TextView
                 android:id="@+id/podcastTitle"
@@ -146,17 +153,17 @@
                 android:layout_gravity="center_vertical"
                 android:layout_marginStart="16dp"
                 android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
                 android:ellipsize="end"
                 android:fontFamily="sans-serif-medium"
                 android:gravity="center"
                 android:includeFontPadding="false"
                 android:maxLines="1"
                 android:text="@{viewModel.podcastTitle}"
-                android:visibility="@{viewModel.podcastTitle != null}"
                 android:textColor="?attr/player_contrast_02"
                 android:textSize="14sp"
+                android:visibility="@{viewModel.podcastTitle != null}"
                 app:layout_constraintBottom_toTopOf="@+id/chapterSummary"
-                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintEnd_toStartOf="@+id/nextChapter"
                 app:layout_constraintStart_toEndOf="@+id/previousChapter"
                 tools:text="Invisibilia" />
@@ -168,13 +175,14 @@
                 android:layout_gravity="center_vertical"
                 android:layout_marginStart="16dp"
                 android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
                 android:gravity="center"
                 android:text="@{viewModel.chapterSummary}"
                 android:textAppearance="?attr/textCaption"
                 android:visibility="@{viewModel.isChaptersPresent}"
                 app:layout_constraintBottom_toTopOf="@+id/seekBar"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/nextChapter"
+                app:layout_constraintStart_toEndOf="@+id/previousChapter"
                 tools:text="@tools:sample/lorem" />
 
             <ImageButton

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/EpisodeViewSource.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/EpisodeViewSource.kt
@@ -13,6 +13,7 @@ enum class EpisodeViewSource(val value: String) {
     NOTIFICATION_BOOKMARK("notification_bookmark"),
     SEARCH("search"),
     SEARCH_HISTORY("search_history"),
+    NOW_PLAYING("now_playing"),
     UNKNOWN("unknown"),
     ;
 


### PR DESCRIPTION
## Description

This PR adds navigation from the `Now Playing` tab to a podcast directly.

Closes #1644 

## Testing Instructions

1. Play an episode without any chapters.
2. Open the player.
3. Tap on the podcast title.
5. The app should navigate to the podcast.

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/30936061/7519db18-77b8-44b3-8322-e540f6c3d140

## Checklist

- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
