### PR TITLE
Do not remember formatted bookmark timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
     *   Fixed an issue where bookmarks did not play when episodes where filtered out due to search queries.
         ([#1857](https://github.com/Automattic/pocket-casts-android/pull/1857))    
     *   Fixed an issue where bookmarks on description could become unresponsive.
-        ([#1873](https://github.com/Automattic/pocket-casts-android/pull/1873))    
+        ([#1873](https://github.com/Automattic/pocket-casts-android/pull/1873))        
+    *   Fixed an issue where bookmarks could display incorrect timestamps.
+        ([#1876](https://github.com/Automattic/pocket-casts-android/pull/1876))    
 
 7.58
 -----

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/TimePlayButton.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/TimePlayButton.kt
@@ -11,8 +11,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -80,9 +78,7 @@ fun TimePlayButton(
     colors: TimePlayButtonColors = TimePlayButtonColors.Default,
     buttonStyle: TimePlayButtonStyle = TimePlayButtonStyle.Outlined,
 ) {
-    val timeText by remember {
-        mutableStateOf(TimeHelper.formattedSeconds(timeSecs.toDouble()))
-    }
+    val timeText = TimeHelper.formattedSeconds(timeSecs.toDouble())
     val description = stringResource(contentDescriptionId, timeText)
     val border = when (buttonStyle) {
         is TimePlayButtonStyle.Outlined -> BorderStroke(2.dp, colors.borderColor())


### PR DESCRIPTION
## Description

Remembering displayed bookmark timestamp in a composable causes issues with `ViewHolder` and `RecyclerView`. A composable can use previously remembered timestamp in some cases. I'm not sure why it was remembered in the first place but I suspect we wanted to avoid clock cycles for this computation which isn't heavy anyway.

Closes #1824

## Testing Instructions

> [!note]
> Because it is impossible to prove a negative you need to test it and assume correctness with some confidence after enough tries.

See a video in #1824 for more context.

1. Create multiple bookmarks within an episode. It will be helpful to name the bookmark after a creation timestamp.
2. Go to Bookmarks tab of the podcast.
3. Notice timestamps should be correct.
4. Change sorting multiple times.
5. Bookmark timestamp should always correspond to their respective bookmakrs.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
