### PR TITLE
Use a correct intent action when tapping download on notification

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -686,5 +686,5 @@ private val NewEpisodeNotificationAction.notificationAction: String get() = when
     NewEpisodeNotificationAction.PlayNext -> NotificationBroadcastReceiver.INTENT_ACTION_PLAY_NEXT
     NewEpisodeNotificationAction.PlayLast -> NotificationBroadcastReceiver.INTENT_ACTION_PLAY_LAST
     NewEpisodeNotificationAction.Archive -> NotificationBroadcastReceiver.INTENT_ACTION_ARCHIVE
-    NewEpisodeNotificationAction.Download -> NotificationBroadcastReceiver.INTENT_ACTION_PLAY_DOWNLOADED
+    NewEpisodeNotificationAction.Download -> NotificationBroadcastReceiver.INTENT_ACTION_DOWNLOAD_EPISODE
 }


### PR DESCRIPTION
## Description

In #1785 I introduced a bug where an incorrect intent action was assigned to the `Download` notification action.

I'm not adding a changelog entry because the bug was introduced in `7.58` which isn't in production yet.

Closes #1877

## Testing Instructions

1. Have notifications enabled for a podcast.
2. Have a `Download` action available as one of the notification actions.
3. Go to `Profile`/`Settings (cog icon)`/`Developer`.
4. Tap on `Trigger new episode notification` and wait for notification.
5. Open the notification center and tap on `Download` action.
6. The episode should download.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
