### PR TITLE
Deselect Chapters - Add purchase flow

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -208,6 +208,7 @@ private fun Content(
                 OnboardingUpgradeSource.OVERFLOW_MENU,
                 OnboardingUpgradeSource.PLUS_DETAILS,
                 OnboardingUpgradeSource.PROFILE,
+                OnboardingUpgradeSource.SKIP_CHAPTERS,
                 OnboardingUpgradeSource.SETTINGS,
                 OnboardingUpgradeSource.SLUMBER_STUDIOS,
                 OnboardingUpgradeSource.UNKNOWN,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -92,6 +92,7 @@ class ChaptersFragment : BaseFragment() {
                         onUrlClick = ::onUrlClick,
                         onSkipChaptersClick = { chaptersViewModel.onSkipChaptersClick(it) },
                         isTogglingChapters = uiState.isTogglingChapters,
+                        showSubscriptionIcon = uiState.showSubscriptionIcon,
                         backgroundColor = uiState.backgroundColor,
                     )
                 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersHeader.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersHeader.kt
@@ -20,8 +20,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
+import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionIconForTier
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -31,6 +34,7 @@ fun ChaptersHeader(
     hiddenChaptersCount: Int,
     onSkipChaptersClick: (Boolean) -> Unit,
     isTogglingChapters: Boolean,
+    showSubscriptionIcon: Boolean,
 ) {
     HeaderRow(
         text = getHeaderTitle(totalChaptersCount, hiddenChaptersCount),
@@ -42,6 +46,7 @@ fun ChaptersHeader(
                 stringResource(LR.string.skip_chapters)
             },
         ),
+        showSubscriptionIcon = showSubscriptionIcon,
         onClick = { onSkipChaptersClick(!isTogglingChapters) },
     )
     Divider(
@@ -55,6 +60,7 @@ private fun HeaderRow(
     text: String,
     modifier: Modifier = Modifier,
     toggle: TextToggle,
+    showSubscriptionIcon: Boolean,
     onClick: () -> Unit,
 ) {
     Row(
@@ -82,6 +88,7 @@ private fun HeaderRow(
 
         TextButton(
             text = toggle.text,
+            showSubscriptionIcon = showSubscriptionIcon,
             onClick = onClick,
         )
     }
@@ -90,6 +97,7 @@ private fun HeaderRow(
 @Composable
 private fun TextButton(
     text: String,
+    showSubscriptionIcon: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -100,12 +108,18 @@ private fun TextButton(
             .widthIn(max = screenWidth / 2)
             .padding(horizontal = 12.dp, vertical = 16.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         TextH50(
             text = text,
             textAlign = TextAlign.End,
             color = MaterialTheme.theme.colors.primaryText01,
         )
+
+        if (showSubscriptionIcon) {
+            Spacer(modifier = Modifier.width(8.dp))
+            SubscriptionIconForTier(SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS))
+        }
     }
 }
 
@@ -143,24 +157,28 @@ fun ChaptersHeaderPreview() {
                 hiddenChaptersCount = 2,
                 onSkipChaptersClick = {},
                 isTogglingChapters = false,
+                showSubscriptionIcon = true,
             )
             ChaptersHeader(
                 totalChaptersCount = 5,
                 hiddenChaptersCount = 0,
                 onSkipChaptersClick = {},
                 isTogglingChapters = false,
+                showSubscriptionIcon = true,
             )
             ChaptersHeader(
                 totalChaptersCount = 5,
                 hiddenChaptersCount = 2,
                 onSkipChaptersClick = {},
                 isTogglingChapters = true,
+                showSubscriptionIcon = false,
             )
             ChaptersHeader(
                 totalChaptersCount = 1,
                 hiddenChaptersCount = 0,
                 onSkipChaptersClick = {},
                 isTogglingChapters = true,
+                showSubscriptionIcon = false,
             )
         }
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
@@ -29,6 +29,7 @@ fun ChaptersPage(
     onUrlClick: (String) -> Unit,
     onSkipChaptersClick: (Boolean) -> Unit,
     isTogglingChapters: Boolean,
+    showSubscriptionIcon: Boolean,
     backgroundColor: Color,
     modifier: Modifier = Modifier,
 ) {
@@ -46,6 +47,7 @@ fun ChaptersPage(
                     hiddenChaptersCount = totalChaptersCount - chapters.filter { it.chapter.selected }.size,
                     onSkipChaptersClick = onSkipChaptersClick,
                     isTogglingChapters = isTogglingChapters,
+                    showSubscriptionIcon = showSubscriptionIcon,
                 )
             }
         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -58,7 +58,10 @@ class ChaptersViewModel
         val isTogglingChapters: Boolean = false,
         val userTier: UserTier = UserTier.Free,
         val canSkipChapters: Boolean = false,
-    )
+    ) {
+        val showSubscriptionIcon
+            get() = !isTogglingChapters && !canSkipChapters
+    }
 
     sealed class ChapterState {
         abstract val chapter: Chapter

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -84,7 +84,11 @@ class ChaptersViewModel
         .observeOn(Schedulers.io())
 
     private val _uiState = MutableStateFlow(
-        UiState(backgroundColor = Color(theme.playerBackgroundColor(null))),
+        UiState(
+            backgroundColor = Color(theme.playerBackgroundColor(null)),
+            userTier = settings.userTier,
+            canSkipChapters = canSkipChapters(settings.userTier),
+        ),
     )
     val uiState: StateFlow<UiState>
         get() = _uiState
@@ -127,19 +131,23 @@ class ChaptersViewModel
             playbackPositionMs = playbackState.positionMs,
             lastChangeFrom = playbackState.lastChangeFrom,
         )
-        val userTier = (cachedSubscriptionStatus as? SubscriptionStatus.Paid)?.tier?.toUserTier() ?: UserTier.Free
+        val currentUserTier = (cachedSubscriptionStatus as? SubscriptionStatus.Paid)?.tier?.toUserTier() ?: UserTier.Free
+        val lastUserTier = _uiState.value.userTier
+        val canSkipChapters = canSkipChapters(currentUserTier)
+        val isTogglingChapters = ((lastUserTier != currentUserTier) && canSkipChapters) || _uiState.value.isTogglingChapters
+
         return UiState(
             allChapters = chapters,
             displayChapters = getFilteredChaptersIfNeeded(
                 chapters = chapters,
-                isTogglingChapters = _uiState.value.isTogglingChapters,
-                userTier = userTier,
+                isTogglingChapters = isTogglingChapters,
+                userTier = currentUserTier,
             ),
             totalChaptersCount = chapters.size,
             backgroundColor = Color(backgroundColor),
-            isTogglingChapters = _uiState.value.isTogglingChapters,
-            userTier = userTier,
-            canSkipChapters = canSkipChapters(userTier),
+            isTogglingChapters = isTogglingChapters,
+            userTier = currentUserTier,
+            canSkipChapters = canSkipChapters,
         )
     }
 

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -12,16 +12,15 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.providers.InMemoryFeatureProvider
 import com.jakewharton.rxrelay2.BehaviorRelay
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -41,6 +40,9 @@ class ChaptersViewModelTest {
 
     @get:Rule
     val coroutineRule = MainCoroutineRule()
+
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
 
     @Mock
     private lateinit var episodeManager: EpisodeManager
@@ -63,13 +65,6 @@ class ChaptersViewModelTest {
     private val cachedSubscriptionStatus = SubscriptionStatus.Free()
 
     private lateinit var chaptersViewModel: ChaptersViewModel
-
-    @Before
-    fun setUp() {
-        FeatureFlag.initialize(
-            listOf(object : InMemoryFeatureProvider() {}),
-        )
-    }
 
     @Test
     fun `given unselected chapter contains playback pos, then skip to next selected chapter`() = runTest {

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -1,9 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.player.viewmodel
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.models.to.Chapters
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
 import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
@@ -17,10 +21,15 @@ import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import com.jakewharton.rxrelay2.BehaviorRelay
+import io.reactivex.Observable
+import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -62,7 +71,17 @@ class ChaptersViewModelTest {
     @Mock
     private lateinit var upNextQueue: UpNextQueue
 
-    private val cachedSubscriptionStatus = SubscriptionStatus.Free()
+    private val freeSubscriptionStatus = SubscriptionStatus.Free()
+
+    private val paidSubscriptionStatus = SubscriptionStatus.Paid(
+        expiry = Date(),
+        autoRenew = false,
+        index = 0,
+        platform = SubscriptionPlatform.GIFT,
+        tier = SubscriptionTier.PATRON,
+        type = SubscriptionType.PLUS,
+    )
+    private val cachedSubscriptionStatusFlow: MutableStateFlow<SubscriptionStatus> = MutableStateFlow(freeSubscriptionStatus)
 
     private lateinit var chaptersViewModel: ChaptersViewModel
 
@@ -117,6 +136,34 @@ class ChaptersViewModelTest {
         verify(playbackManager, never()).skipToNextSelectedOrLastChapter()
     }
 
+    @Test
+    fun `given user not entitled to feature, when user taps skip chapters, then upsell starts`() = runTest {
+        initViewModel()
+
+        chaptersViewModel.uiState.test {
+            assertFalse(awaitItem().canSkipChapters)
+            chaptersViewModel.navigationState.test {
+                chaptersViewModel.onSkipChaptersClick(true)
+                assertTrue(awaitItem() is ChaptersViewModel.NavigationState.StartUpsell)
+            }
+        }
+    }
+
+    @Test
+    fun `given user entitled to feature, when user taps skip chapters, then upsell does not start`() = runTest {
+        initViewModel()
+
+        chaptersViewModel.uiState.test {
+            assertFalse(awaitItem().canSkipChapters)
+            cachedSubscriptionStatusFlow.value = paidSubscriptionStatus
+            assertTrue(awaitItem().canSkipChapters)
+            chaptersViewModel.navigationState.test {
+                chaptersViewModel.onSkipChaptersClick(true)
+                expectNoEvents()
+            }
+        }
+    }
+
     private fun initChapters() =
         Chapters(
             listOf(
@@ -128,13 +175,16 @@ class ChaptersViewModelTest {
 
     private fun initViewModel() {
         whenever(playbackManager.playbackStateRelay)
-            .thenReturn(BehaviorRelay.create<PlaybackState>().toSerialized())
+            .thenReturn(BehaviorRelay.create<PlaybackState>().toSerialized().apply { accept(PlaybackState()) })
         whenever(upNextQueue.getChangesObservableWithLiveCurrentEpisode(episodeManager, podcastManager))
-            .thenReturn(BehaviorRelay.create<UpNextQueue.State>().toSerialized())
+            .thenReturn(Observable.just(UpNextQueue.State.Empty))
         whenever(playbackManager.upNextQueue)
             .thenReturn(upNextQueue)
+        whenever(settings.userTier)
+            .thenReturn(UserTier.Free)
+
         val userSetting = mock<UserSetting<SubscriptionStatus?>>()
-        whenever(userSetting.flow).thenReturn(MutableStateFlow(cachedSubscriptionStatus))
+        whenever(userSetting.flow).thenReturn(cachedSubscriptionStatusFlow)
         whenever(settings.cachedSubscriptionStatus).thenReturn(userSetting)
 
         chaptersViewModel = ChaptersViewModel(

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -3,7 +3,10 @@ package au.com.shiftyjelly.pocketcasts.player.viewmodel
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.models.to.Chapters
+import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
@@ -16,6 +19,7 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.providers.InMemoryFeatureProvider
 import com.jakewharton.rxrelay2.BehaviorRelay
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -23,6 +27,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -50,7 +55,12 @@ class ChaptersViewModelTest {
     private lateinit var theme: Theme
 
     @Mock
+    private lateinit var settings: Settings
+
+    @Mock
     private lateinit var upNextQueue: UpNextQueue
+
+    private val cachedSubscriptionStatus = SubscriptionStatus.Free()
 
     private lateinit var chaptersViewModel: ChaptersViewModel
 
@@ -128,12 +138,16 @@ class ChaptersViewModelTest {
             .thenReturn(BehaviorRelay.create<UpNextQueue.State>().toSerialized())
         whenever(playbackManager.upNextQueue)
             .thenReturn(upNextQueue)
+        val userSetting = mock<UserSetting<SubscriptionStatus?>>()
+        whenever(userSetting.flow).thenReturn(MutableStateFlow(cachedSubscriptionStatus))
+        whenever(settings.cachedSubscriptionStatus).thenReturn(userSetting)
 
         chaptersViewModel = ChaptersViewModel(
             episodeManager = episodeManager,
             podcastManager = podcastManager,
             playbackManager = playbackManager,
             theme = theme,
+            settings = settings,
         )
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
@@ -15,6 +15,7 @@ enum class OnboardingUpgradeSource(val analyticsValue: String) {
     PLUS_DETAILS("plus_details"),
     PROFILE("profile"),
     RECOMMENDATIONS("recommendations"),
+    SKIP_CHAPTERS("skip_chapters"),
     SETTINGS("settings"),
     SLUMBER_STUDIOS("slumber_studios"),
     UNKNOWN("unknown"),

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,6 +25,7 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
+import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -121,6 +123,36 @@ fun SubscriptionBadgeForTier(
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
         )
+        SubscriptionTier.UNKNOWN -> Unit
+    }
+}
+
+@Composable
+fun SubscriptionIconForTier(
+    tier: SubscriptionTier,
+    iconSize: Dp = 16.dp,
+) {
+    when (tier) {
+        SubscriptionTier.PLUS -> Icon(
+            painter = painterResource(IR.drawable.ic_plus),
+            contentDescription = stringResource(LR.string.pocket_casts_plus_short),
+            tint = SubscriptionTierColor.plusGold,
+            modifier = Modifier
+                .size(iconSize),
+        )
+
+        SubscriptionTier.PATRON -> Icon(
+            painter = painterResource(IR.drawable.ic_patron),
+            contentDescription = stringResource(LR.string.pocket_casts_patron_short),
+            tint = if (MaterialTheme.theme.isLight) {
+                SubscriptionTierColor.patronPurple
+            } else {
+                SubscriptionTierColor.patronPurpleLight
+            },
+            modifier = Modifier
+                .size(iconSize),
+        )
+
         SubscriptionTier.UNKNOWN -> Unit
     }
 }

--- a/modules/services/model/build.gradle.kts
+++ b/modules/services/model/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
 
     api(libs.room.ktx)
     implementation(libs.bundles.room)
+    testImplementation(project(":modules:services:sharedtest"))
 
     ksp(libs.room.compiler)
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -4,6 +4,7 @@ import android.content.res.Resources
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import com.android.billingclient.api.ProductDetails
 
@@ -104,6 +105,12 @@ sealed interface Subscription {
                 UserTier.Free -> UNKNOWN
                 UserTier.Plus -> PLUS
                 UserTier.Patron -> PATRON
+            }
+
+            fun fromFeatureTier(feature: Feature) = when (feature.tier) {
+                FeatureTier.Free -> UNKNOWN
+                is FeatureTier.Plus -> if (feature.isCurrentlyExclusiveToPatron()) PATRON else PLUS
+                FeatureTier.Patron -> PATRON
             }
         }
     }

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/ChaptersTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/ChaptersTest.kt
@@ -1,10 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.models.to
 
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.providers.InMemoryFeatureProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
@@ -12,12 +12,8 @@ import org.mockito.junit.MockitoJUnitRunner
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class ChaptersTest {
-    @Before
-    fun setUp() {
-        FeatureFlag.initialize(
-            listOf(object : InMemoryFeatureProvider() {}),
-        )
-    }
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
 
     @Test
     fun `given feature flag true, then next chapter returned from selected chapters`() {

--- a/modules/services/sharedtest/build.gradle.kts
+++ b/modules/services/sharedtest/build.gradle.kts
@@ -24,4 +24,5 @@ dependencies {
     implementation(libs.junit) {
         exclude(group = "org.hamcrest")
     }
+    implementation(project(":modules:services:utils"))
 }

--- a/modules/services/sharedtest/src/main/java/au/com/shiftyjelly/pocketcasts/sharedtest/InMemoryFeatureFlagRule.kt
+++ b/modules/services/sharedtest/src/main/java/au/com/shiftyjelly/pocketcasts/sharedtest/InMemoryFeatureFlagRule.kt
@@ -1,0 +1,21 @@
+package au.com.shiftyjelly.pocketcasts.sharedtest
+
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.providers.InMemoryFeatureProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@ExperimentalCoroutinesApi
+class InMemoryFeatureFlagRule : TestWatcher() {
+
+    override fun starting(description: Description) {
+        FeatureFlag.initialize(
+            listOf(object : InMemoryFeatureProvider() {}),
+        )
+    }
+
+    override fun finished(description: Description) {
+        FeatureFlag.clearProviders()
+    }
+}


### PR DESCRIPTION
Part of: #1807 

## Description
This adds purchase flow for the deselect chapters feature.

## Testing Instructions

Prerequisites

- Release build
- Licence testing account

### Test.1 Plus account

1. Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/14403634/plus.patch)
2. Install release build
3. Login with a free license testing account
4. Play an episode with chapters (e.g. https://pca.st/upgrade)
5. Open the player screen and go to `Chapters`
6. ✅ Notice that you see a plus icon next to `Skip chapters` in the header
7. Tap `Skip chapters`
8. ✅ Notice that the upsell flow starts
9. Purchase Plus monthly plan and complete upsell flow
10. ✅ Notice that chapters with checkboxes are shown with a `Done` button at the top

### Test.2 Patron account (patron exclusive release)

1. Continue from above (logged in as Plus)
2. Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/14403649/patron_only.patch) assigning a patron-exclusive release to the `Feature`
3. Install release build
4. Play an episode with chapters (e.g. https://pca.st/upgrade)
5. Open the player screen and go to `Chapters`
6. ✅ Notice that you see a patron icon next to `Skip chapters` in the header
7. Tap `Skip chapters`
8. ✅ Notice that the upsell flow starts displaying only Patron plan
9. Purchase `Patron` monthly plan and complete upsell flow
10. ✅ Notice that chapters with checkboxes are shown with a `Done` button at the top

## Screenshots or Screencast 
 
Enabled to Plus

https://github.com/Automattic/pocket-casts-android/assets/1405144/c19b2b83-f787-4649-b3f0-efea9e1b96d5


Patron exclusive release

https://github.com/Automattic/pocket-casts-android/assets/1405144/d34f5dc4-18a3-49c9-8d73-5da230f44d7d




## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
