### PR TITLE
Fix changelog formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
         ([#1845](https://github.com/Automattic/pocket-casts-android/pull/1845))
     *   Fixed: Widget uses custom Headphone controls instead of skipping.
         ([#1853](https://github.com/Automattic/pocket-casts-android/pull/1853))
+
 7.57
 -----
 


### PR DESCRIPTION
## Description

Changelog had a broken formatting.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![Screenshot 2024-02-26 at 15 03 46](https://github.com/Automattic/pocket-casts-android/assets/30936061/d3d61180-1575-4fb6-a7ee-e8804b4bdbd9) | ![Screenshot 2024-02-26 at 15 03 31](https://github.com/Automattic/pocket-casts-android/assets/30936061/b8d192a9-4bd9-43bc-94a2-0ddba6c121ef) |

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
