### PR TITLE
Hide report shelf item for user episodes

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
@@ -23,7 +23,6 @@ import androidx.recyclerview.widget.SimpleItemAnimator
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.player.databinding.AdapterShelfItemBinding
 import au.com.shiftyjelly.pocketcasts.player.databinding.AdapterShelfTitleBinding
@@ -303,8 +302,8 @@ class ShelfAdapter(val editable: Boolean, val listener: ((ShelfItem) -> Unit)? =
                 holder.itemView.setOnClickListener { listener.invoke(item) }
             }
 
-            val subtitle = item.subtitleId
-            binding.lblSubtitle.isVisible = editable && subtitle != null && episode is UserEpisode
+            val subtitle = item.subtitleId(episode)
+            binding.lblSubtitle.isVisible = editable && subtitle != null
             if (subtitle != null) {
                 binding.lblSubtitle.setText(subtitle)
             }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ShelfItem.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ShelfItem.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.preferences.model
 
-import androidx.annotation.StringRes
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -10,7 +9,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 enum class ShelfItem(
     val id: String,
     val titleId: (BaseEpisode?) -> Int,
-    @StringRes val subtitleId: Int? = null,
+    val subtitleId: (BaseEpisode?) -> Int? = { null },
     val iconId: (BaseEpisode?) -> Int,
     val showIf: (BaseEpisode?) -> Boolean = { true },
     val analyticsValue: String,
@@ -30,7 +29,7 @@ enum class ShelfItem(
     Star(
         id = "star",
         titleId = { if (it is PodcastEpisode && it.isStarred) LR.string.unstar_episode else LR.string.star_episode },
-        subtitleId = LR.string.player_actions_hidden_for_custom,
+        subtitleId = { episode -> LR.string.player_actions_hidden_for_custom.takeIf { episode is UserEpisode } },
         iconId = { if (it is PodcastEpisode && it.isStarred) IR.drawable.ic_star_filled else IR.drawable.ic_star },
         showIf = { it is PodcastEpisode },
         analyticsValue = "star_episode",
@@ -38,7 +37,7 @@ enum class ShelfItem(
     Share(
         id = "share",
         titleId = { LR.string.podcast_share_episode },
-        subtitleId = LR.string.player_actions_hidden_for_custom,
+        subtitleId = { episode -> LR.string.player_actions_hidden_for_custom.takeIf { episode is UserEpisode } },
         iconId = { IR.drawable.ic_share },
         showIf = { it is PodcastEpisode },
         analyticsValue = "share_episode",
@@ -70,15 +69,16 @@ enum class ShelfItem(
     Archive(
         id = "archive",
         titleId = { if (it is UserEpisode) LR.string.delete else LR.string.archive },
-        subtitleId = LR.string.player_actions_show_as_delete_for_custom,
+        subtitleId = { episode -> LR.string.player_actions_show_as_delete_for_custom.takeIf { episode is UserEpisode } },
         iconId = { if (it is UserEpisode) IR.drawable.ic_delete else IR.drawable.ic_archive },
         analyticsValue = "archive",
     ),
     Report(
         id = "report",
         titleId = { LR.string.report },
-        subtitleId = LR.string.report_subtitle,
+        subtitleId = { if (it is PodcastEpisode) LR.string.report_subtitle else LR.string.player_actions_hidden_for_custom },
         iconId = { IR.drawable.ic_flag },
+        showIf = { it is PodcastEpisode },
         analyticsValue = "report",
     ),
     ;


### PR DESCRIPTION
## Description

Reporting custom user episodes doesn't make much sense. This PR hides the report flag for user episodes and uses different subtitle depending on the episode that is being currently played.

Closes #1788

## Testing Instructions

1. Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/14416815/report.patch).
2. Play a podcast episode.
3. Open the player.
4. Tap on the shelf items overflow menu.
5. Report item should be present.
6. Edit the shelf.
7. You should see `Report` item with `Report inappropriate content` subtitle.
8. No other item should have any subtitles.
9. Move `Report` item to `Shortcut on player` section.
10. Go back to the player.
11. `Report` item should be in the shortcuts.
12. Play a custom file.
13. Open the player.
14. `Report` item should not be present.
15. Tap on the shelf item overflow menu.
16. Report item shouldn't be present.
17. Edit the shelf.
18. You should see `Report` item with `Hidden for custom episodes` subtitles.
19. Some of the other items should display their subtitles as well.

## Screenshots or Screencast 

| Podcast | Custom file |
| - | - |
| ![Screenshot_20240227-094046](https://github.com/Automattic/pocket-casts-android/assets/30936061/6b593905-a5ec-4592-a34c-9367650d4de6) | ![Screenshot_20240227-094133](https://github.com/Automattic/pocket-casts-android/assets/30936061/5c28b48c-cbb6-4d01-92a2-e1f2d9361d60) |

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
