### PR TITLE
Deselect chapter - Update design

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Checkbox
+import androidx.compose.material.CheckboxDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -79,6 +80,10 @@ fun ChapterRow(
                     onCheckedChange = { selected ->
                         onSelectionChange(selected, chapter)
                     },
+                    colors = CheckboxDefaults.colors(
+                        checkedColor = MaterialTheme.theme.colors.playerContrast01,
+                        uncheckedColor = MaterialTheme.theme.colors.playerContrast02,
+                    ),
                 )
                 Spacer(Modifier.width(8.dp))
             }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
@@ -98,7 +98,7 @@ fun ChapterRow(
                     .padding(vertical = 16.dp),
             )
             Spacer(Modifier.width(4.dp))
-            if (chapter.url != null) {
+            if (chapter.url != null && !isTogglingChapters) {
                 LinkButton(
                     textColor = textColor,
                     onClick = onUrlClick,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -6,7 +6,6 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Surface
@@ -17,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.fragment.app.activityViewModels
@@ -31,10 +31,12 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
+import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.delay
@@ -62,6 +64,7 @@ class ChaptersFragment : BaseFragment() {
                 val lazyListState = rememberLazyListState()
                 this@ChaptersFragment.lazyListState = lazyListState
                 val context = LocalContext.current
+                val currentView = LocalView.current
 
                 val scrollToChapter by chaptersViewModel.scrollToChapterState.collectAsState()
                 LaunchedEffect(scrollToChapter) {
@@ -89,11 +92,10 @@ class ChaptersFragment : BaseFragment() {
                     chaptersViewModel
                         .snackbarMessage
                         .collectLatest { message ->
-                            Toast.makeText(
-                                context,
-                                context.getString(message),
-                                Toast.LENGTH_SHORT,
-                            ).show()
+                            Snackbar.make(currentView, context.getString(message), Snackbar.LENGTH_SHORT)
+                                .setBackgroundTint(ThemeColor.playerContrast01(Theme.ThemeType.DARK))
+                                .setTextColor(ThemeColor.playerBackground01(Theme.ThemeType.DARK, theme.playerBackgroundColor(uiState.podcast)))
+                                .show()
                         }
                 }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Surface
@@ -15,6 +16,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.fragment.app.activityViewModels
@@ -59,6 +61,7 @@ class ChaptersFragment : BaseFragment() {
                 val uiState by chaptersViewModel.uiState.collectAsStateWithLifecycle()
                 val lazyListState = rememberLazyListState()
                 this@ChaptersFragment.lazyListState = lazyListState
+                val context = LocalContext.current
 
                 val scrollToChapter by chaptersViewModel.scrollToChapterState.collectAsState()
                 LaunchedEffect(scrollToChapter) {
@@ -79,6 +82,18 @@ class ChaptersFragment : BaseFragment() {
                             when (event) {
                                 is NavigationState.StartUpsell -> startUpsell()
                             }
+                        }
+                }
+
+                LaunchedEffect(Unit) {
+                    chaptersViewModel
+                        .snackbarMessage
+                        .collectLatest { message ->
+                            Toast.makeText(
+                                context,
+                                context.getString(message),
+                                Toast.LENGTH_SHORT,
+                            ).show()
                         }
                 }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersHeader.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersHeader.kt
@@ -113,7 +113,7 @@ private fun TextButton(
         TextH50(
             text = text,
             textAlign = TextAlign.End,
-            color = MaterialTheme.theme.colors.primaryText01,
+            color = MaterialTheme.theme.colors.playerContrast01,
         )
 
         if (showSubscriptionIcon) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlow
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
 class ChaptersViewModel
@@ -95,6 +96,9 @@ class ChaptersViewModel
 
     private val _navigationState: MutableSharedFlow<NavigationState> = MutableSharedFlow()
     val navigationState = _navigationState.asSharedFlow()
+
+    private val _snackbarMessage: MutableSharedFlow<Int> = MutableSharedFlow()
+    val snackbarMessage = _snackbarMessage.asSharedFlow()
 
     init {
         viewModelScope.launch {
@@ -189,7 +193,14 @@ class ChaptersViewModel
     }
 
     fun onSelectionChange(selected: Boolean, chapter: Chapter) {
-        playbackManager.toggleChapter(selected, chapter)
+        val selectedChapters = _uiState.value.allChapters.filter { it.chapter.selected }
+        if (!selected && selectedChapters.size == 1) {
+            viewModelScope.launch {
+                _snackbarMessage.emit(LR.string.select_one_chapter_message)
+            }
+        } else {
+            playbackManager.toggleChapter(selected, chapter)
+        }
     }
 
     fun onSkipChaptersClick(checked: Boolean) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -59,6 +59,7 @@ class ChaptersViewModel
         val isTogglingChapters: Boolean = false,
         val userTier: UserTier = UserTier.Free,
         val canSkipChapters: Boolean = false,
+        val podcast: Podcast? = null,
     ) {
         val showSubscriptionIcon
             get() = !isTogglingChapters && !canSkipChapters
@@ -152,6 +153,7 @@ class ChaptersViewModel
             isTogglingChapters = isTogglingChapters,
             userTier = currentUserTier,
             canSkipChapters = canSkipChapters,
+            podcast = playbackState.podcast,
         )
     }
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -354,6 +354,7 @@
     <!-- %1$d is the number of total chapters. %2$d is the number of hidden chapters. -->
     <string name="number_of_chapters_summary_plural">%1$d chapters &#x2022; %2$d hidden</string>
     <string name="number_of_chapters_summary_singular">1 chapter &#x2022; %d hidden</string>
+    <string name="select_one_chapter_message">Please select at least one chapter</string>
 
     <!-- Podcasts -->
 


### PR DESCRIPTION
Part of: #1807 

## Description
Updates design for deselecting chapters and adds a few tweaks.

## Testing Instructions
1. Login with a paid account
2. Play any episode with chapters
3. Open the player and go to Chapters
4. Toggle the chapter selection
5. ✅ Compare what you see with the designs in Figma (hHFpI1RtnW4TRb448Q4Don-fi-4383_27080) (notice that checkboxes are still square instead of round which is more of a style for iOS) 
6. Deselect all chapters
7. ✅ On the latest selected chapter you should see a message when you try to deselect

## Screenshots or Screencast 

![image](https://github.com/Automattic/pocket-casts-android/assets/1405144/9b0f7506-3a01-4edf-84d5-724c0390b525)


@david-gonzalez-a8c, I've kept checkboxes as squares instead of round to remain consistent with checkboxes at other places. Let us know if you think otherwise.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack