### PR TITLE
Deselect Chapters - Tracks

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -4,6 +4,9 @@ import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.models.to.Chapters
@@ -46,6 +49,7 @@ class ChaptersViewModel
     private val playbackManager: PlaybackManager,
     private val theme: Theme,
     private val settings: Settings,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ViewModel(), CoroutineScope {
 
     override val coroutineContext: CoroutineContext
@@ -100,6 +104,8 @@ class ChaptersViewModel
 
     private val _snackbarMessage: MutableSharedFlow<Int> = MutableSharedFlow()
     val snackbarMessage = _snackbarMessage.asSharedFlow()
+
+    private var numberOfDeselectedChapters = 0
 
     init {
         viewModelScope.launch {
@@ -202,6 +208,7 @@ class ChaptersViewModel
             }
         } else {
             playbackManager.toggleChapter(selected, chapter)
+            trackChapterSelectionToggled(selected)
         }
     }
 
@@ -215,6 +222,7 @@ class ChaptersViewModel
                     userTier = _uiState.value.userTier,
                 ),
             )
+            trackSkipChaptersToggled(checked)
         } else {
             viewModelScope.launch {
                 _navigationState.emit(NavigationState.StartUpsell)
@@ -239,6 +247,48 @@ class ChaptersViewModel
 
     private fun canSkipChapters(userTier: UserTier) = FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS) &&
         Feature.isUserEntitled(Feature.DESELECT_CHAPTERS, userTier)
+
+    private fun trackChapterSelectionToggled(selected: Boolean) {
+        val currentEpisode = playbackManager.getCurrentEpisode()
+        analyticsTracker.track(
+            if (selected) {
+                AnalyticsEvent.DESELECT_CHAPTERS_CHAPTER_SELECTED
+            } else {
+                AnalyticsEvent.DESELECT_CHAPTERS_CHAPTER_DESELECTED
+            },
+            Analytics.chapterSelectionToggled(currentEpisode),
+        )
+    }
+
+    private fun trackSkipChaptersToggled(checked: Boolean) {
+        val selectedChaptersCount = _uiState.value.allChapters.filter { it.chapter.selected }.size
+        if (checked) {
+            numberOfDeselectedChapters = selectedChaptersCount
+            analyticsTracker.track(AnalyticsEvent.DESELECT_CHAPTERS_TOGGLED_ON)
+        } else {
+            numberOfDeselectedChapters -= selectedChaptersCount
+            analyticsTracker.track(
+                AnalyticsEvent.DESELECT_CHAPTERS_TOGGLED_OFF,
+                Analytics.skipChaptersToggled(numberOfDeselectedChapters),
+            )
+        }
+    }
+
+    private object Analytics {
+        private const val EPISODE_UUID = "episode_uuid"
+        private const val PODCAST_UUID = "podcast_uuid"
+        private const val NUMBER_OF_DESELECTED_CHAPTERS = "number_of_deselected_chapters"
+        private const val UNKNOWN = "unknown"
+
+        fun chapterSelectionToggled(episode: BaseEpisode?) =
+            mapOf(
+                EPISODE_UUID to (episode?.uuid ?: UNKNOWN),
+                PODCAST_UUID to (episode?.podcastOrSubstituteUuid ?: UNKNOWN),
+            )
+
+        fun skipChaptersToggled(count: Int) =
+            mapOf(NUMBER_OF_DESELECTED_CHAPTERS to count)
+    }
 
     sealed class NavigationState {
         data object StartUpsell : NavigationState()

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -192,6 +192,7 @@ class ChaptersViewModelTest {
                 chaptersViewModel.onSelectionChange(false, chapters.getList().first { it.selected })
                 assertTrue(awaitItem() == LR.string.select_one_chapter_message)
             }
+            cancelAndConsumeRemainingEvents()
         }
     }
 
@@ -234,6 +235,7 @@ class ChaptersViewModelTest {
             playbackManager = playbackManager,
             theme = theme,
             settings = settings,
+            analyticsTracker = mock(),
         )
     }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -585,4 +585,10 @@ enum class AnalyticsEvent(val key: String) {
 
     /* App Store Review */
     APP_STORE_REVIEW_REQUESTED("app_store_review_requested"),
+
+    /* Deselect Chapters */
+    DESELECT_CHAPTERS_TOGGLED_ON("deselect_chapters_toggled_on"),
+    DESELECT_CHAPTERS_TOGGLED_OFF("deselect_chapters_toggled_off"),
+    DESELECT_CHAPTERS_CHAPTER_SELECTED("deselect_chapters_chapter_selected"),
+    DESELECT_CHAPTERS_CHAPTER_DESELECTED("deselect_chapters_chapter_deselected"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -591,4 +591,5 @@ enum class AnalyticsEvent(val key: String) {
     DESELECT_CHAPTERS_TOGGLED_OFF("deselect_chapters_toggled_off"),
     DESELECT_CHAPTERS_CHAPTER_SELECTED("deselect_chapters_chapter_selected"),
     DESELECT_CHAPTERS_CHAPTER_DESELECTED("deselect_chapters_chapter_deselected"),
+    PLAYBACK_CHAPTER_SKIPPED("playback_chapter_skipped")
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -591,5 +591,5 @@ enum class AnalyticsEvent(val key: String) {
     DESELECT_CHAPTERS_TOGGLED_OFF("deselect_chapters_toggled_off"),
     DESELECT_CHAPTERS_CHAPTER_SELECTED("deselect_chapters_chapter_selected"),
     DESELECT_CHAPTERS_CHAPTER_DESELECTED("deselect_chapters_chapter_deselected"),
-    PLAYBACK_CHAPTER_SKIPPED("playback_chapter_skipped")
+    PLAYBACK_CHAPTER_SKIPPED("playback_chapter_skipped"),
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -901,6 +901,7 @@ open class PlaybackManager @Inject constructor(
             val currentTimeMs = getCurrentTimeMs(episode = episode)
             playbackStateRelay.blockingFirst().chapters.getNextSelectedChapter(currentTimeMs)?.let { chapter ->
                 seekToTimeMsInternal(chapter.startTime)
+                trackPlayback(AnalyticsEvent.PLAYBACK_CHAPTER_SKIPPED, SourceView.PLAYER)
             } ?: skipToEndOfLastChapter()
         }
     }
@@ -911,6 +912,7 @@ open class PlaybackManager @Inject constructor(
             val currentTimeMs = getCurrentTimeMs(episode)
             playbackStateRelay.blockingFirst().chapters.getPreviousSelectedChapter(currentTimeMs)?.let { chapter ->
                 seekToTimeMsInternal(chapter.startTime)
+                trackPlayback(AnalyticsEvent.PLAYBACK_CHAPTER_SKIPPED, SourceView.PLAYER)
             }
         }
     }
@@ -919,6 +921,7 @@ open class PlaybackManager @Inject constructor(
         launch {
             playbackStateRelay.blockingFirst().chapters.lastChapter?.let { chapter ->
                 seekToTimeMsInternal(chapter.endTime)
+                trackPlayback(AnalyticsEvent.PLAYBACK_CHAPTER_SKIPPED, SourceView.PLAYER)
             }
         }
     }


### PR DESCRIPTION
Part of: #1807
## Description

- Adds tracks
- Fixes skipping issue noticed here: https://github.com/Automattic/pocket-casts-android/pull/1886#pullrequestreview-1903028979


## Testing Instructions

### Tracks

1. Login with a paid account
2. Play any episode with chapters (e.g. https://pca.st/upgrade)
4. Open the player and go to Chapters
5. Toggle the chapter selection on
6. ✅ `Tracked: deselect_chapters_toggled_on` should be tracked
7. Deselect 3 chapters
8. ✅ `deselect_chapters_chapter_deselected` should be tracked with `podcast_uuid` and `episode_uuid`
9. Tap Done
8. ✅ `Tracked: deselect_chapters_toggled_off ["number_of_deselected_chapters": 3]` should be tracked
10. Toggle chapter selection again
11. Select a chapter that was deselected
12. ✅ `deselect_chapters_chapter_selected` should be tracked with `podcast_uuid` and `episode_uuid`
13. Tap Done
14. ✅ `Tracked: deselect_chapters_toggled_off ["number_of_deselected_chapters": -1]` should be tracked
15. Play the episode
16. ✅  Whenever a chapter is skipped `Tracked: playback_chapter_skipped ["content_type": "audio", "source": "player"]` should be tracked

### Skipping bug fix
- Deselect chapters from episode that is currently playing
- ✅  Notice that the playback jumps only to the next chapter

## Screenshots or Screencast 

Skipping bug fix 

https://github.com/Automattic/pocket-casts-android/assets/1405144/7ef61dff-817a-4216-b5e6-2cc8e01e0a6e



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
