### PR TITLE
[Playback skipping] Smooth transition from streaming to downloaded episode

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1890,7 +1890,7 @@ open class PlaybackManager @Inject constructor(
         widgetManager.updateWidget(podcast, play, episode)
 
         if (play) {
-            if (sameEpisode && currentPositionMs != null) {
+            if (sameEpisode && currentPositionMs != null && !isCached) {
                 player?.seekToTimeMs(currentPositionMs)
             }
             play(sourceView, posUpdatedOnPlayerReset)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1823,9 +1823,9 @@ open class PlaybackManager @Inject constructor(
                     episodeManager.updatePlayedUpTo(episode, playerPositionSeconds, forceUpdate = true)
                     posUpdatedOnPlayerReset = true
                 }
-                // This is to avoid unnecessary player resets for cached episodes
-                // when switching from streaming to downloaded episode.
-                if (!isCached || (isPlayerSwitchRequired() && FeatureFlag.isEnabled(Feature.CACHE_PLAYING_EPISODE))) {
+                val switchEpisode: Boolean = !upNextQueue.isCurrentEpisode(episode)
+                // This is to avoid unnecessary player resets for cached episodes when switching from streaming to downloaded episode.
+                if (!isCached || ((isPlayerSwitchRequired() || switchEpisode) && FeatureFlag.isEnabled(Feature.CACHE_PLAYING_EPISODE))) {
                     Timber.d("Resetting player")
                     resetPlayer()
                 }


### PR DESCRIPTION
## Description
- As was reported [here](https://github.com/Automattic/pocket-casts-android/pull/1878#pullrequestreview-1900099251), the system to switch from streaming to downloaded episode was resulting in jumping a second or two back.
- This is caused by an random playback restart that we tracked here: https://github.com/Automattic/pocket-casts-android/issues/1509
- This PR removes the unnecessary playback restart for the caching episode case to implement a better transition between streaming and downloaded the episode.

> [!note]
> While you are testing, you might encounter the existing issue https://github.com/Automattic/pocket-casts-android/issues/86 related to the downloading percentage. I won't address it here as it's not within the scope of this task

> [!note]
> To test this PR I will to have the local `CACHE_PLAYING_EPISODE` feature flag enabled.

## Testing Instructions
- Repeat the tests described in https://github.com/Automattic/pocket-casts-android/pull/1878
- You can skip the `Charging Phone`, `Only on Unmetered WiFi` and `Automotive and Watch` tests if you wanted
- You should see a better transition after download finishes

## Screenshots or Screencast 
- See the video reported here when we were reseting the player for cached episodes: https://github.com/Automattic/pocket-casts-android/pull/1878#pullrequestreview-1900099251

After this improvement the transition will look like this:

[Screen_recording_20240227_135712.webm](https://github.com/Automattic/pocket-casts-android/assets/42220351/4fa23525-b4e3-4052-8e74-c365d5cb18b6)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
