### PR TITLE
Show slumber studios yearly only

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -81,7 +81,7 @@ class MainActivityViewModel
         val migratedVersion = settings.getMigratedVersionCode()
         if (migratedVersion != 0) { // We don't want to show this to new users, there is a race condition between this and the version migration
             val whatsNewShouldBeShown = WhatsNewFragment.isWhatsNewNewerThan(lastSeenVersionCode) &&
-                    FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_YEARLY_PROMO)
+                FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_YEARLY_PROMO)
             _state.update { state -> state.copy(shouldShowWhatsNew = whatsNewShouldBeShown) }
         }
     }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -81,7 +81,7 @@ class MainActivityViewModel
         val migratedVersion = settings.getMigratedVersionCode()
         if (migratedVersion != 0) { // We don't want to show this to new users, there is a race condition between this and the version migration
             val whatsNewShouldBeShown = WhatsNewFragment.isWhatsNewNewerThan(lastSeenVersionCode) &&
-                FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_PROMO)
+                    FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_YEARLY_PROMO)
             _state.update { state -> state.copy(shouldShowWhatsNew = whatsNewShouldBeShown) }
         }
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -267,6 +267,7 @@ fun FeatureCards(
     onFeatureCardChanged: (Int) -> Unit,
 ) {
     val featureCardsState = state.featureCardsState
+    val currentSubscriptionFrequency = state.currentSubscriptionFrequency
     HorizontalPagerWrapper(
         pageCount = featureCardsState.featureCards.size,
         initialPage = featureCardsState.featureCards.indexOf(state.currentFeatureCard),
@@ -278,6 +279,7 @@ fun FeatureCards(
         FeatureCard(
             subscription = state.currentSubscription,
             card = featureCardsState.featureCards[index],
+            subscriptionFrequency = currentSubscriptionFrequency,
             upgradeButton = upgradeButton,
             modifier = if (pagerHeight > 0) {
                 Modifier.height(pagerHeight.pxToDp(LocalContext.current).dp)
@@ -293,6 +295,7 @@ private fun FeatureCard(
     card: UpgradeFeatureCard,
     upgradeButton: UpgradeButton,
     subscription: Subscription,
+    subscriptionFrequency: SubscriptionFrequency,
     modifier: Modifier = Modifier,
 ) {
     Card(
@@ -372,7 +375,7 @@ private fun FeatureCard(
 
                 Spacer(modifier = Modifier.padding(vertical = 4.dp))
 
-                card.featureItems.forEach {
+                card.featureItems(subscriptionFrequency).forEach {
                     UpgradeFeatureItem(it)
                 }
                 Spacer(modifier = Modifier.weight(1f))

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -28,6 +28,7 @@ import au.com.shiftyjelly.pocketcasts.compose.images.OfferBadge
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -77,6 +78,7 @@ fun ProfileUpgradeBannerView(
             card = featureCardsState.featureCards[index],
             button = requireNotNull(state.upgradeButtons.find { it.subscription.tier == currentTier }),
             onClick = onClick,
+            subscriptionFrequency = state.featureCardsState.currentFrequency,
             modifier = if (pagerHeight > 0) {
                 Modifier.height(pagerHeight.pxToDp(LocalContext.current).dp)
             } else {
@@ -91,6 +93,7 @@ private fun FeatureCard(
     card: UpgradeFeatureCard,
     button: UpgradeButton,
     onClick: () -> Unit,
+    subscriptionFrequency: SubscriptionFrequency,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -122,7 +125,7 @@ private fun FeatureCard(
                 subscription = button.subscription,
             )
 
-            card.featureItems.forEach {
+            card.featureItems(subscriptionFrequency).forEach {
                 UpgradeFeatureItem(
                     item = it,
                     color = MaterialTheme.theme.colors.primaryText01,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
@@ -5,6 +5,7 @@ import androidx.annotation.StringRes
 import au.com.shiftyjelly.pocketcasts.account.R
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -13,7 +14,7 @@ enum class UpgradeFeatureCard(
     @StringRes val shortNameRes: Int,
     @DrawableRes val backgroundGlowsRes: Int,
     @DrawableRes val iconRes: Int,
-    val featureItems: List<UpgradeFeatureItem>,
+    val featureItems: (SubscriptionFrequency) -> List<UpgradeFeatureItem>,
     val subscriptionTier: SubscriptionTier,
 ) {
     PLUS(
@@ -21,7 +22,12 @@ enum class UpgradeFeatureCard(
         shortNameRes = LR.string.pocket_casts_plus_short,
         backgroundGlowsRes = R.drawable.upgrade_background_plus_glows,
         iconRes = IR.drawable.ic_plus,
-        featureItems = PlusUpgradeFeatureItem.entries.filter { it.isVisible },
+        featureItems = { subscriptionFreq ->
+            when (subscriptionFreq) {
+                SubscriptionFrequency.YEARLY -> PlusUpgradeFeatureItem.entries.filter { it.isYearlyFeature }
+                SubscriptionFrequency.MONTHLY, SubscriptionFrequency.NONE -> PlusUpgradeFeatureItem.entries.filter { it.isMonthlyFeature }
+            }
+        },
         subscriptionTier = SubscriptionTier.PLUS,
     ),
     PATRON(
@@ -29,7 +35,12 @@ enum class UpgradeFeatureCard(
         shortNameRes = LR.string.pocket_casts_patron_short,
         backgroundGlowsRes = R.drawable.upgrade_background_patron_glows,
         iconRes = IR.drawable.ic_patron,
-        featureItems = PatronUpgradeFeatureItem.entries.filter { it.isVisible },
+        featureItems = { subscriptionFreq ->
+            when (subscriptionFreq) {
+                SubscriptionFrequency.YEARLY -> PatronUpgradeFeatureItem.entries.filter { it.isYearlyFeature }
+                SubscriptionFrequency.MONTHLY, SubscriptionFrequency.NONE -> PatronUpgradeFeatureItem.entries.filter { it.isMonthlyFeature }
+            }
+        },
         subscriptionTier = SubscriptionTier.PATRON,
     ),
 }
@@ -37,8 +48,9 @@ enum class UpgradeFeatureCard(
 data class FeatureCardsState(
     val subscriptions: List<Subscription>,
     val currentFeatureCard: UpgradeFeatureCard,
+    val currentFrequency: SubscriptionFrequency,
 ) {
-    val featureCards = SubscriptionTier.values().toList()
+    val featureCards = SubscriptionTier.entries
         .filter { tier -> tier != SubscriptionTier.UNKNOWN && tier in subscriptions.map { it.tier } }
         .map { it.toUpgradeFeatureCard() }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
@@ -48,13 +48,13 @@ enum class PlusUpgradeFeatureItem(
     UndyingGratitude(
         image = IR.drawable.ic_heart,
         title = LR.string.onboarding_plus_feature_gratitude_title,
-        isYearlyFeature = !FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_PROMO),
+        isYearlyFeature = !FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_YEARLY_PROMO),
     ),
     SlumberStudiosPromo(
         image = IR.drawable.ic_slumber_studios,
         title = LR.string.onboarding_plus_feature_slumber_studios_title,
         isMonthlyFeature = false,
-        isYearlyFeature = FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_PROMO),
+        isYearlyFeature = FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_YEARLY_PROMO),
     ),
 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
@@ -14,14 +14,16 @@ interface UpgradeFeatureItem {
 
     @get:StringRes val text: Int?
 
-    val isVisible: Boolean
+    val isYearlyFeature: Boolean
+    val isMonthlyFeature: Boolean
 }
 
 enum class PlusUpgradeFeatureItem(
     override val image: Int,
     override val title: Int,
     override val text: Int? = null,
-    override val isVisible: Boolean = true,
+    override val isYearlyFeature: Boolean = true,
+    override val isMonthlyFeature: Boolean = true,
 ) : UpgradeFeatureItem {
     DesktopApps(
         image = IR.drawable.ic_desktop_apps,
@@ -46,12 +48,13 @@ enum class PlusUpgradeFeatureItem(
     UndyingGratitude(
         image = IR.drawable.ic_heart,
         title = LR.string.onboarding_plus_feature_gratitude_title,
-        isVisible = !FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_PROMO),
+        isYearlyFeature = !FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_PROMO),
     ),
     SlumberStudiosPromo(
         image = IR.drawable.ic_slumber_studios,
         title = LR.string.onboarding_plus_feature_slumber_studios_title,
-        isVisible = FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_PROMO),
+        isMonthlyFeature = false,
+        isYearlyFeature = FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_PROMO),
     ),
 }
 
@@ -59,7 +62,8 @@ enum class PatronUpgradeFeatureItem(
     override val image: Int,
     override val title: Int,
     override val text: Int? = null,
-    override val isVisible: Boolean = true,
+    override val isYearlyFeature: Boolean = true,
+    override val isMonthlyFeature: Boolean = true,
 ) : UpgradeFeatureItem {
     EverythingInPlus(
         image = IR.drawable.ic_check,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -12,11 +12,9 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.toUpgradeButton
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.toUpgradeFeatureCard
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
-import au.com.shiftyjelly.pocketcasts.models.type.RecurringSubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
-import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.PurchaseEvent
@@ -103,6 +101,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
                     featureCardsState = FeatureCardsState(
                         subscriptions = updatedSubscriptions,
                         currentFeatureCard = currentFeatureCard,
+                        currentFrequency = currentSubscriptionFrequency,
                     ),
                     currentSubscription = selectedSubscription,
                     currentFeatureCard = currentFeatureCard,
@@ -257,9 +256,4 @@ sealed class OnboardingUpgradeFeaturesState {
         val currentUpgradeButton: UpgradeButton
             get() = currentSubscription.toUpgradeButton()
     }
-}
-
-private fun RecurringSubscriptionPricingPhase.toSubscriptionFrequency() = when (this) {
-    is SubscriptionPricingPhase.Months -> SubscriptionFrequency.MONTHLY
-    is SubscriptionPricingPhase.Years -> SubscriptionFrequency.YEARLY
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
@@ -100,6 +100,7 @@ class ProfileUpgradeBannerViewModel @Inject constructor(
                             featureCardsState = FeatureCardsState(
                                 subscriptions = filteredSubscriptions,
                                 currentFeatureCard = currentTier.toUpgradeFeatureCard(),
+                                currentFrequency = defaultSubscription.recurringPricingPhase.toSubscriptionFrequency(),
                             ),
                             upgradeButtons = upgradeButtons,
                         )

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -98,6 +98,7 @@ class WhatsNewFragment : BaseFragment() {
             is NavigationState.FullScreenPlayerScreen -> openPlayer()
             is NavigationState.StartUpsellFlow -> startUpsellFlow(navigationState.source)
             is NavigationState.SlumberStudiosRedeemPromoCode -> redeemSlumberStudiosPromoCode()
+            is NavigationState.SlumberStudiosClose -> Unit // It will not be sent to confirm action in real world scenario
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
@@ -84,7 +84,11 @@ fun WhatsNewPage(
     LaunchedEffect(Unit) {
         viewModel.navigationState
             .collect { navigationState ->
-                onConfirm(navigationState)
+                if (navigationState is WhatsNewViewModel.NavigationState.SlumberStudiosClose) {
+                    onClose()
+                } else {
+                    onConfirm(navigationState)
+                }
             }
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
@@ -41,7 +41,7 @@ class WhatsNewViewModel @Inject constructor(
             settings.cachedSubscriptionStatus.flow
                 .stateIn(viewModelScope)
                 .collect {
-                    if (FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_PROMO)) {
+                    if (FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_YEARLY_PROMO)) {
                         updateStateForSlumberStudiosPromo()
                     } else {
                         updateStateForBookmarks()

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1421,8 +1421,8 @@
     <string name="whats_new_bookmarks_try_now_button">Try it now</string>
     <string name="whats_new_slumber_studios_title">Dream big</string>
     <!-- %1$s is Slumber Studios promo code -->
-    <string name="whats_new_slumber_studios_body">As part of your Plus subscription, enjoy a 1-year subscription to Slumber Studios content using code %1$s. <![CDATA[<a href="https://slumberstudios.com/">Learn more</a>.]]></string>
-    <string name="whats_new_slumber_studios_body_free_user">Subscribe to Plus and enjoy a 1-year subscription to Slumber Studios content, podcasts designed for the sweetest dreams. <![CDATA[<a href="https://slumberstudios.com/">Learn more</a>.]]></string>
+    <string name="whats_new_slumber_studios_body">As part of your Yearly Plus subscription, enjoy a 1-year subscription to Slumber Studios content using code %1$s. <![CDATA[<a href="https://slumberstudios.com/">Learn more</a>.]]></string>
+    <string name="whats_new_slumber_studios_body_free_user">Subscribe to Plus Yearly and enjoy a 1-year subscription to Slumber Studios content, podcasts designed for the sweetest dreams. <![CDATA[<a href="https://slumberstudios.com/">Learn more</a>.]]></string>
     <string name="whats_new_slumber_studios_redeem_now_button">Redeem your code</string>
 
     <!-- Errors -->

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionPricingPhase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionPricingPhase.kt
@@ -50,6 +50,11 @@ sealed interface RecurringSubscriptionPricingPhase : SubscriptionPricingPhase {
     fun pricePerPeriod(res: Resources): String
     override fun priceSlashPeriod(res: Resources): String
     fun thenPriceSlashPeriod(res: Resources): String
+
+    fun toSubscriptionFrequency() = when (this) {
+        is SubscriptionPricingPhase.Months -> SubscriptionFrequency.MONTHLY
+        is SubscriptionPricingPhase.Years -> SubscriptionFrequency.YEARLY
+    }
 }
 
 sealed interface SubscriptionPricingPhase {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -60,7 +60,7 @@ interface Settings {
 
         const val CHROME_CAST_APP_ID = "2FA4D21B"
 
-        const val WHATS_NEW_VERSION_CODE = 9117
+        const val WHATS_NEW_VERSION_CODE = 9118
 
         const val DEFAULT_MAX_AUTO_ADD_LIMIT = 100
         const val MAX_DOWNLOAD = 100

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -878,7 +878,7 @@ class SettingsImpl @Inject constructor(
     }
 
     override fun getSlumberStudiosPromoCode(): String {
-        return firebaseRemoteConfig.getString(FirebaseConfig.SLUMBER_STUDIOS_PROMO_CODE)
+        return firebaseRemoteConfig.getString(FirebaseConfig.SLUMBER_STUDIOS_YEARLY_PROMO_CODE)
     }
 
     private fun getRemoteConfigLong(key: String): Long {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
@@ -8,7 +8,7 @@ object FirebaseConfig {
     const val EPISODE_SEARCH_DEBOUNCE_MS = "episode_search_debounce_ms"
     const val CLOUD_STORAGE_LIMIT = "custom_storage_limit_gb"
     const val REPORT_VIOLATION_URL = "report_violation_url"
-    const val SLUMBER_STUDIOS_PROMO_CODE = "slumber_studios_promo_code"
+    const val SLUMBER_STUDIOS_YEARLY_PROMO_CODE = "slumber_studios_yearly_promo_code"
     val defaults = mapOf(
         PERIODIC_SAVE_TIME_MS to 60000L,
         PODCAST_SEARCH_DEBOUNCE_MS to 2000L,

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -64,7 +64,7 @@ enum class Feature(
         title = "Deselect Chapters",
         defaultValue = BuildConfig.DEBUG,
         tier = FeatureTier.Plus(null),
-        hasFirebaseRemoteFlag = true,
+        hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),
     ;

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -51,9 +51,9 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = false,
     ),
-    SLUMBER_STUDIOS_PROMO(
-        key = "slumber_studios_promo",
-        title = "Slumber Studios Promo",
+    SLUMBER_STUDIOS_YEARLY_PROMO(
+        key = "slumber_studios_yearly_promo_code",
+        title = "Slumber Studios Yearly Promo",
         defaultValue = BuildConfig.DEBUG,
         tier = FeatureTier.Plus(null),
         hasFirebaseRemoteFlag = true,

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
@@ -18,9 +18,10 @@ class FirebaseRemoteFeatureProvider @Inject constructor(
             firebaseRemoteConfig
                 .getString(FirebaseConfig.REPORT_VIOLATION_URL)
                 .isNotEmpty()
-        Feature.SLUMBER_STUDIOS_PROMO ->
+
+        Feature.SLUMBER_STUDIOS_YEARLY_PROMO ->
             firebaseRemoteConfig
-                .getString(FirebaseConfig.SLUMBER_STUDIOS_PROMO_CODE)
+                .getString(FirebaseConfig.SLUMBER_STUDIOS_YEARLY_PROMO_CODE)
                 .isNotEmpty()
         else -> firebaseRemoteConfig.getBoolean(feature.key)
     }


### PR DESCRIPTION
## Description

The Slumber benefit is available only for:

1. Lifetime subscriptions
2. Yearly subscriptions

This PR changes this behavior in:

1. The Upgrade modal
2. The What's new



## To test

### Prerequisites
- Release build
- License test account (initially with lifetime access)


#### Lifetime Plus
1. Update `Settings.WHATS_NEW_VERSION_CODE` to 9117
2. Install release build and launch the app
4. Notice you do not see what's new dialog
5. Login with a Lifetime paid account
6. Update `Settings.WHATS_NEW_VERSION_CODE` to 9118
7. Set `setMinimumFetchIntervalInSeconds` to 5 secs in `FirebaseModule`
8. Reinstall release and launch the app
9. You should see the What's New with promo code
10. Remove Lifetime access from the account

#### Monthly Plan
1. Update `Settings.WHATS_NEW_VERSION_CODE` to 9119
2. Reinstall release and launch the app
3. Tap the upgrade button
4. Toggle between Yearly/Monthly plus
5. ✅ Slumber is only shown for Yearly
6. Subscribe to monthly
7. ✅ What's new should close (see comment [here](https://github.com/Automattic/pocket-casts-android/commit/120f91d6f63c759445af96d1040d2f76ff031dcb#diff-80dc49f33abc9ee7494a96d4bb7091702a728cdd68ee50fffa946c428a160ed4R46-R47) for the rationale)
8. Cancel monthly plan and wait for it to cancel

#### Yearly Plan
1. Update `Settings.WHATS_NEW_VERSION_CODE` to 9120
2. Install release build and launch the app
3. Tap the upgrade button
4. Subscribe to yearly
5. ✅ What's new should not close and you should see the promo code

Important:  
- Uninstall the build
- Reset Slumber Studios Yearly Promo Code remote config value to blank in Firebase and publish changes

## Screenshots or Screencast


Monthly Plan Purchase

https://github.com/Automattic/pocket-casts-android/assets/1405144/bb9c6293-120a-4753-aebf-e6e335b14520

Yearly Plan Purchase

https://github.com/Automattic/pocket-casts-android/assets/1405144/ffe147d1-ade1-4105-8c26-b53b58e41bd1



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
