### PR TITLE
Deselect Chapters - Add to list of features

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -119,6 +119,7 @@ internal fun OnboardingUpgradeFeaturesPage(
             val loadedState = state as OnboardingUpgradeFeaturesState.Loaded
             UpgradeLayout(
                 state = loadedState,
+                source = source,
                 scrollState = scrollState,
                 onBackPressed = onBackPressed,
                 onNotNowPressed = onNotNowPressed,
@@ -141,6 +142,7 @@ internal fun OnboardingUpgradeFeaturesPage(
 @Composable
 private fun UpgradeLayout(
     state: OnboardingUpgradeFeaturesState.Loaded,
+    source: OnboardingUpgradeSource,
     scrollState: ScrollState,
     onBackPressed: () -> Unit,
     onNotNowPressed: () -> Unit,
@@ -205,7 +207,7 @@ private fun UpgradeLayout(
                             contentAlignment = Alignment.Center,
                         ) {
                             AutoResizeText(
-                                text = stringResource(state.currentFeatureCard.titleRes),
+                                text = stringResource(state.currentFeatureCard.titleRes(source)),
                                 color = Color.White,
                                 maxFontSize = 22.sp,
                                 lineHeight = 30.sp,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -32,6 +33,14 @@ enum class PlusUpgradeFeatureItem(
     Folders(
         image = IR.drawable.ic_folders,
         title = LR.string.onboarding_plus_feature_folders_and_bookmarks_title,
+    ),
+    SkipChapters(
+        image = IR.drawable.ic_tick_circle_filled,
+        title = LR.string.skip_chapters,
+        isYearlyFeature = FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS) &&
+            SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS) == SubscriptionTier.PLUS,
+        isMonthlyFeature = FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS) &&
+            SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS) == SubscriptionTier.PLUS,
     ),
     CloudStorage(
         image = IR.drawable.ic_cloud_storage,
@@ -72,6 +81,14 @@ enum class PatronUpgradeFeatureItem(
     EarlyAccess(
         image = IR.drawable.ic_new_features,
         title = LR.string.onboarding_patron_feature_early_access_title,
+    ),
+    SkipChapters(
+        image = IR.drawable.ic_tick_circle_filled,
+        title = LR.string.skip_chapters,
+        isYearlyFeature = FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS) &&
+            SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS) == SubscriptionTier.PATRON,
+        isMonthlyFeature = FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS) &&
+            SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS) == SubscriptionTier.PATRON,
     ),
     CloudStorage(
         image = IR.drawable.ic_cloud_storage,

--- a/modules/services/images/src/main/res/drawable/ic_tick_circle_filled.xml
+++ b/modules/services/images/src/main/res/drawable/ic_tick_circle_filled.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="19dp"
+    android:height="19dp"
+    android:viewportWidth="19"
+    android:viewportHeight="19">
+  <path
+      android:pathData="M9.619,18.19C14.59,18.19 18.619,14.16 18.619,9.189C18.619,4.219 14.59,0.189 9.619,0.189C4.649,0.189 0.619,4.219 0.619,9.189C0.619,14.16 4.649,18.19 9.619,18.19ZM13.104,6.367C12.787,6.099 12.314,6.139 12.047,6.455L8.448,10.708L6.774,9.034C6.482,8.741 6.007,8.741 5.714,9.034C5.421,9.327 5.421,9.802 5.714,10.095L8.54,12.921L13.192,7.424C13.459,7.108 13.42,6.634 13.104,6.367Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+</vector>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -355,6 +355,8 @@
     <string name="number_of_chapters_summary_plural">%1$d chapters &#x2022; %2$d hidden</string>
     <string name="number_of_chapters_summary_singular">1 chapter &#x2022; %d hidden</string>
     <string name="select_one_chapter_message">Please select at least one chapter</string>
+    <string name="skip_chapters_plus_prompt">Skip chapters and more with Pocket Casts Plus</string>
+    <string name="skip_chapters_patron_prompt">Skip chapters and more with Pocket Casts Patron</string>
 
     <!-- Podcasts -->
 


### PR DESCRIPTION
 Part of: #1807 | Design:  hHFpI1RtnW4TRb448Q4Don-fi-4383%3A26935 

## Description

To keep it consistent with the iOS app (https://github.com/Automattic/pocket-casts-ios/pull/1467), "Skip chapters" feature is shown in the features list even when the upgrade source is skip chapters. This will be addressed separately along with changes for bookmarks and folders. 

## To test

#### For Plus feature

1. Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/14444007/plus_feature.patch) and install `debugProg` build
2. Login to an account without `Plus`/`Patron`
3. Play any episode with chapters (E.g. from podcast: https://pca.st/upgrade)
4. Open the player and go to `Chapters` 
5. Tap `Skip chapters`
6. ✅ You should see the upgrade landing view with a custom title and `Skip chapters` among the features in the `Plus` feature card
7.  Swipe left
17. ✅ You should see the `Patron` card and no custom title
8. Dismiss it
9. Go to `Profile` > `Account`
10. ✅ You should see `Skip chapters` in the `Plus` feature card

#### For Patron-exclusive feature

12. Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/14444013/patron_exclusive_feature.patch)
13. Re-run the app
14. Open the player and go to `Chapters`
15. Tap `Skip chapters`
16. ✅ You should see the `Patron` card and a custom title
7. Dismiss it
8. Go to `Profile` > `Account`
9. Swipe to `Patron` card
10. ✅ You should see `Skip chapters` in the `Patron` feature card

## Screenshot or Screencast

#### Profile screen 

Plus feature | Patron-exclusive feature
-----|-----
<img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/672004f2-d478-4498-bfc5-30c6b9ac1543"/> | <img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/201785d9-e99f-4b3c-b2cb-672783072e79"/>

#### Upgrade screen

Plus feature 

https://github.com/Automattic/pocket-casts-android/assets/1405144/ae6a653a-e6f5-4dfe-8d36-462b5f803029

Patron-exclusive feature

https://github.com/Automattic/pocket-casts-android/assets/1405144/71dc2e40-2f72-418b-bb47-939a60d41780

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
