### PR TITLE
Sync RSS artwork setting

### DIFF
--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -81,6 +81,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "autoDownloadUpNext") val autoDownloadUpNext: NamedChangedSettingBool? = null,
     @field:Json(name = "backgroundRefresh") val isPodcastBackgroundRefreshEnabled: NamedChangedSettingBool? = null,
     @field:Json(name = "cloudDownloadUnmeteredOnly") val cloudDownloadUnmeteredOnly: NamedChangedSettingBool? = null,
+    @field:Json(name = "useRssArtwork") val useRssArtwork: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -260,6 +260,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 autoDownloadUpNext = settings.autoDownloadUpNext.getSyncSetting(::NamedChangedSettingBool),
                 isPodcastBackgroundRefreshEnabled = settings.backgroundRefreshPodcasts.getSyncSetting(::NamedChangedSettingBool),
                 cloudDownloadUnmeteredOnly = settings.cloudDownloadOnlyOnWifi.getSyncSetting(::NamedChangedSettingBool),
+                useRssArtwork = settings.useRssArtwork.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -612,6 +613,11 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "cloudDownloadUnmeteredOnly" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.cloudDownloadOnlyOnWifi,
+                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                    )
+                    "useRssArtwork" -> updateSettingIfPossible(
+                        changedSettingResponse = changedSettingResponse,
+                        setting = settings.useRssArtwork,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")


### PR DESCRIPTION
## Description

I'm targeting `7.59` but it might as well go into `7.60`. It doesn't really matter and depends only on if we manage to merge before we trigger the next release.

## Testing Instructions

> [!note]
> This should be tested with staging. Use `debug` variant instead of `debugProd`.

1. Have two devices D1 and D2.
2. Make sure that both devices are synced before starting the test by refreshing apps in the profile.
3. D1: Play an episode with RSS artwork like [this one](https://pca.st/8674dclc).
4. D2: Go to `Profile/`Settings (cog icon)`/`Appearance`.
5. D2: Toggle `Use embedded RSS artwork` setting `OFF`.
6. D2: Sync the device in the Profile.
7. D1: Sync the device in the Profile.
8. D1: Artwork in the mini player should change to the podcast artwork.
9. D2: Toggle `Use embedded RSS artwork` setting `ON`.
10. D2: Sync the device in the `Profile`.
11. D1: Sync the device in the `Profile`.
12. D1: Artwork in the mini player should change to the episode RSS artwork.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
