### PR TITLE
Do not use deprecated on back pressed API

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -103,7 +103,7 @@ class WhatsNewFragment : BaseFragment() {
             is NavigationState.SlumberStudiosRedeemPromoCode -> redeemSlumberStudiosPromoCode()
             is NavigationState.SlumberStudiosClose -> Unit // It will not be sent to confirm action in real world scenario
             is NavigationState.DeselectChapterClose -> {
-                activity?.onBackPressed()
+                activity?.onBackPressedDispatcher?.onBackPressed()
             }
         }
     }


### PR DESCRIPTION
## Description

Builds started failing because of the deprecated API. I don't really understand how it could have happened. More info here: p1709560886817259-slack-CC7L49W13

## Testing Instructions

CI checks should be enough.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack