### PR TITLE
Configure app to cache episodes when playing using Exoplayer Cache

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -294,18 +294,17 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
             }
         }
 
-        val cacheDataSourceFactory: CacheDataSource.Factory? =
-            simpleCache?.let {
-                CacheDataSource.Factory()
-                    .setCache(it)
-                    .setUpstreamDataSourceFactory(httpDataSourceFactory)
-            }
+        val sourceFactory = simpleCache?.let {
+            CacheDataSource.Factory()
+                .setCache(it)
+                .setUpstreamDataSourceFactory(httpDataSourceFactory)
+        } ?: dataSourceFactory
 
         val mediaItem = MediaItem.fromUri(uri)
         val source = if (isHLS) {
-            HlsMediaSource.Factory(cacheDataSourceFactory ?: dataSourceFactory)
+            HlsMediaSource.Factory(sourceFactory)
         } else {
-            ProgressiveMediaSource.Factory(cacheDataSourceFactory ?: dataSourceFactory, extractorsFactory)
+            ProgressiveMediaSource.Factory(sourceFactory, extractorsFactory)
         }.createMediaSource(mediaItem)
 
         player.setMediaSource(source)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -16,8 +16,12 @@ import androidx.media3.common.Player
 import androidx.media3.common.Tracks
 import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.database.StandaloneDatabaseProvider
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.datasource.cache.CacheDataSource
+import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
+import androidx.media3.datasource.cache.SimpleCache
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.hls.HlsMediaSource
@@ -31,6 +35,8 @@ import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.utils.Util
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -39,6 +45,9 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val context: Context, override val onPlayerEvent: (au.com.shiftyjelly.pocketcasts.repositories.playback.Player, PlayerEvent) -> Unit) : LocalPlayer(onPlayerEvent) {
+    companion object {
+        private const val MAX_DEVICE_CACHE_SIZE_BYTES = 50 * 1024 * 1024
+    }
     private val reducedBufferManufacturers = listOf("mercedes-benz")
     private val useReducedBuffer = reducedBufferManufacturers.contains(Build.MANUFACTURER.lowercase()) || Util.isWearOs(context)
     private val bufferTimeMinMillis = TimeUnit.MINUTES.toMillis(2).toInt()
@@ -58,6 +67,9 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
     override var isPip: Boolean = false
 
     private var videoChangedListener: VideoChangedListener? = null
+
+    private var databaseProvider: StandaloneDatabaseProvider? = null
+    private var simpleCache: SimpleCache? = null
 
     @Volatile
     private var prepared = false
@@ -103,19 +115,24 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
         prepare()
     }
 
+    @OptIn(UnstableApi::class)
     override fun handleStop() {
         try {
             player?.stop()
         } catch (e: Exception) {
+            LogBuffer.e(LogBuffer.TAG_PLAYBACK, e, "Play failed to stop.")
         }
 
         try {
             player?.release()
         } catch (e: Exception) {
+            LogBuffer.e(LogBuffer.TAG_PLAYBACK, e, "Play failed to release.")
         }
 
         player = null
         prepared = false
+        databaseProvider?.close()
+        simpleCache?.release()
 
         videoChangedListener?.videoNeedsReset()
     }
@@ -265,13 +282,32 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
             }
         } ?: return
 
+        if (FeatureFlag.isEnabled(Feature.CACHE_PLAYING_EPISODE) && location is EpisodeLocation.Stream) {
+            databaseProvider ?: run { databaseProvider = StandaloneDatabaseProvider(context) }
+
+            simpleCache ?: run {
+                simpleCache = SimpleCache(
+                    File(context.cacheDir, "podcasts-cache"),
+                    LeastRecentlyUsedCacheEvictor(MAX_DEVICE_CACHE_SIZE_BYTES.toLong()),
+                    databaseProvider!!,
+                )
+            }
+        }
+
+        val cacheDataSourceFactory: CacheDataSource.Factory? =
+            simpleCache?.let {
+                CacheDataSource.Factory()
+                    .setCache(it)
+                    .setUpstreamDataSourceFactory(httpDataSourceFactory)
+            }
+
         val mediaItem = MediaItem.fromUri(uri)
         val source = if (isHLS) {
-            HlsMediaSource.Factory(dataSourceFactory).createMediaSource(mediaItem)
+            HlsMediaSource.Factory(cacheDataSourceFactory ?: dataSourceFactory)
         } else {
-            ProgressiveMediaSource.Factory(dataSourceFactory, extractorsFactory)
-                .createMediaSource(mediaItem)
-        }
+            ProgressiveMediaSource.Factory(cacheDataSourceFactory ?: dataSourceFactory, extractorsFactory)
+        }.createMediaSource(mediaItem)
+
         player.setMediaSource(source)
         player.prepare()
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -72,7 +72,7 @@ enum class Feature(
         title = "Cache playing episode",
         defaultValue = BuildConfig.DEBUG,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = false,
+        hasFirebaseRemoteFlag = true,
         hasDevToggle = false,
     ),
     ;

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -67,7 +67,16 @@ enum class Feature(
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),
+    CACHE_PLAYING_EPISODE(
+        key = "cache_playing_episode",
+        title = "Cache playing episode",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = false,
+    ),
     ;
+
     companion object {
 
         fun isUserEntitled(


### PR DESCRIPTION
## Description
- This is to implement episodes caching using exoplayer instead of creating our own cache system https://github.com/Automattic/pocket-casts-android/pull/1878
- For reference: https://developer.android.com/media/media3/exoplayer/network-stacks#caching

This is part of #1865

> [!note]
> To test this PR I will to have the local `CACHE_PLAYING_EPISODE` feature flag enabled.

## Testing Instructions

- Do playback regression tests such as play episodes, downloaded episodes and uploaded episodes
- Try to apply playback effects
- During my tests, I observed an improvement when I switched from one episode to another that I had played before, thanks to the cache. 👌
- You can use the device explore see the cache downloaded by Exoplayer. `Android studio -> Device explore -> /data/data/au.com.shiftyjelly.pocketcasts.debug/cache/podcasts-cache`


<img width="454" alt="image" src="https://github.com/Automattic/pocket-casts-android/assets/42220351/447b635e-83e3-4083-ab97-0d46c0dda564">



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
