### PR TITLE
Improve episode download failure analytics

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
@@ -71,6 +71,15 @@ class EpisodeAnalytics @Inject constructor(
         analyticsTracker.track(event, AnalyticsProp.bulkToTopMap(source, count, toTop))
     }
 
+    fun trackEpisodeDownloadFailure(error: EpisodeDownloadError) {
+        if (downloadEpisodeUuidQueue.contains(error.episodeUuid)) {
+            downloadEpisodeUuidQueue.remove(error.episodeUuid)
+        } else {
+            return
+        }
+        analyticsTracker.track(AnalyticsEvent.EPISODE_DOWNLOAD_FAILED, error.toProperties())
+    }
+
     private object AnalyticsProp {
         private const val source = "source"
         private const val episode_uuid = "episode_uuid"

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeDownloadError.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeDownloadError.kt
@@ -1,0 +1,82 @@
+package au.com.shiftyjelly.pocketcasts.analytics
+
+data class EpisodeDownloadError(
+    var reason: Reason = Reason.Unknown,
+    var episodeUuid: String = "",
+    var podcastUuid: String = "",
+    var taskDuration: Long = -1,
+    var httpStatusCode: Int = -1,
+    var contentType: String = "",
+    var expectedContentLength: Long = -1,
+    var responseBodyBytesReceived: Long = -1,
+    var tlsCipherSuite: String = "",
+    var isCellular: Boolean = false,
+    var isProxy: Boolean = false,
+) {
+
+    fun toProperties() = mapOf(
+        REASON_KEY to reason.analyticsValue,
+        EPISODE_UUID_KEY to episodeUuid,
+        PODCAST_UUID_KEY to podcastUuid,
+        TASK_DURATION_KEY to taskDuration,
+        HTTP_STATUS_CODE_KEY to httpStatusCode,
+        CONTENT_TYPE_KEY to contentType,
+        EXPECTED_CONTENT_LENGTH_KEY to expectedContentLength,
+        RESPONSE_BODY_BYTES_RECEIVED_KEY to responseBodyBytesReceived,
+        TLS_CIPHER_SUITE_KEY to tlsCipherSuite,
+        IS_CELLULAR_KEY to isCellular,
+        IS_PROXY_KEY to isProxy,
+    )
+
+    enum class Reason(
+        val analyticsValue: String,
+    ) {
+        Unknown("unknown"),
+        TaskIdMismatch("task_id_mismatch"),
+        MalformedHost("malformed_host"),
+        UnknownHost("unknown_host"),
+        ConnectionTimeout("connection_timeout"),
+        SocketIssue("socket_issue"),
+        NoSSl("no_ssl"),
+        ChartableBlocked("chartable_blocked"),
+        StatusCode("status_code"),
+        ContentType("content_type"),
+        SuspiciousContent("suspicious_content"),
+        PartialDownload("partial_download"),
+        NotEnoughStorage("not_enough_storage"),
+        NoSavePath("no_save_path"),
+        StorageIssue("storage_issue"),
+    }
+
+    companion object {
+        const val REASON_KEY = "reason"
+        const val EPISODE_UUID_KEY = "episode_uuid"
+        const val PODCAST_UUID_KEY = "podcast_uuid"
+        const val TASK_DURATION_KEY = "duration"
+        const val HTTP_STATUS_CODE_KEY = "http_status_code"
+        const val CONTENT_TYPE_KEY = "content_type"
+        const val EXPECTED_CONTENT_LENGTH_KEY = "expected_content_length"
+        const val RESPONSE_BODY_BYTES_RECEIVED_KEY = "response_body_bytes_received"
+        const val TLS_CIPHER_SUITE_KEY = "tls_cipher_suite"
+        const val IS_CELLULAR_KEY = "is_cellular"
+        const val IS_PROXY_KEY = "is_proxy"
+
+        fun fromProperties(properties: Map<String, Any>) = EpisodeDownloadError(
+            reason = properties.require<String>(REASON_KEY).let { reason -> Reason.entries.single { it.analyticsValue == reason } },
+            episodeUuid = properties.require<String>(EPISODE_UUID_KEY),
+            podcastUuid = properties.require<String>(PODCAST_UUID_KEY),
+            taskDuration = properties.require<Long>(TASK_DURATION_KEY),
+            httpStatusCode = properties.require<Int>(HTTP_STATUS_CODE_KEY),
+            contentType = properties.require<String>(CONTENT_TYPE_KEY),
+            expectedContentLength = properties.require<Long>(EXPECTED_CONTENT_LENGTH_KEY),
+            responseBodyBytesReceived = properties.require<Long>(RESPONSE_BODY_BYTES_RECEIVED_KEY),
+            tlsCipherSuite = properties.require<String>(TLS_CIPHER_SUITE_KEY),
+            isCellular = properties.require<Boolean>(IS_CELLULAR_KEY),
+            isProxy = properties.require<Boolean>(IS_PROXY_KEY),
+        )
+
+        private inline fun <reified T> Map<String, Any>.require(key: String) = requireNotNull(get(key) as T) {
+            "Missing property '$key' of type '${T::class.java}'"
+        }
+    }
+}

--- a/modules/services/analytics/src/test/kotlin/au/com/shiftyjelly/pocketcasts/analytics/EpisodeDownloadErrorTest.kt
+++ b/modules/services/analytics/src/test/kotlin/au/com/shiftyjelly/pocketcasts/analytics/EpisodeDownloadErrorTest.kt
@@ -1,0 +1,92 @@
+package au.com.shiftyjelly.pocketcasts.analytics
+
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.CONTENT_TYPE_KEY
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.EPISODE_UUID_KEY
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.EXPECTED_CONTENT_LENGTH_KEY
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.HTTP_STATUS_CODE_KEY
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.IS_CELLULAR_KEY
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.IS_PROXY_KEY
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.PODCAST_UUID_KEY
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.REASON_KEY
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.RESPONSE_BODY_BYTES_RECEIVED_KEY
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.TASK_DURATION_KEY
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.TLS_CIPHER_SUITE_KEY
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EpisodeDownloadErrorTest {
+    @Test
+    fun `convert to properties`() {
+        val error = EpisodeDownloadError(
+            reason = EpisodeDownloadError.Reason.Unknown,
+            episodeUuid = "episode uuid",
+            podcastUuid = "podcast uuid",
+            taskDuration = 10,
+            httpStatusCode = 20,
+            contentType = "content type",
+            expectedContentLength = 30,
+            responseBodyBytesReceived = 40,
+            tlsCipherSuite = "tls cipher suite",
+            isCellular = true,
+            isProxy = false,
+        )
+
+        val expected = mapOf(
+            REASON_KEY to EpisodeDownloadError.Reason.Unknown.analyticsValue,
+            EPISODE_UUID_KEY to "episode uuid",
+            PODCAST_UUID_KEY to "podcast uuid",
+            TASK_DURATION_KEY to 10L,
+            HTTP_STATUS_CODE_KEY to 20,
+            CONTENT_TYPE_KEY to "content type",
+            EXPECTED_CONTENT_LENGTH_KEY to 30L,
+            RESPONSE_BODY_BYTES_RECEIVED_KEY to 40L,
+            TLS_CIPHER_SUITE_KEY to "tls cipher suite",
+            IS_CELLULAR_KEY to true,
+            IS_PROXY_KEY to false,
+        )
+
+        assertEquals(expected, error.toProperties())
+    }
+
+    @Test
+    fun `create from properties`() {
+        val properties = mapOf(
+            REASON_KEY to EpisodeDownloadError.Reason.Unknown.analyticsValue,
+            EPISODE_UUID_KEY to "episode uuid",
+            PODCAST_UUID_KEY to "podcast uuid",
+            TASK_DURATION_KEY to 10L,
+            HTTP_STATUS_CODE_KEY to 20,
+            CONTENT_TYPE_KEY to "content type",
+            EXPECTED_CONTENT_LENGTH_KEY to 30L,
+            RESPONSE_BODY_BYTES_RECEIVED_KEY to 40L,
+            TLS_CIPHER_SUITE_KEY to "tls cipher suite",
+            IS_CELLULAR_KEY to true,
+            IS_PROXY_KEY to false,
+        )
+
+        val expected = EpisodeDownloadError(
+            reason = EpisodeDownloadError.Reason.Unknown,
+            episodeUuid = "episode uuid",
+            podcastUuid = "podcast uuid",
+            taskDuration = 10,
+            httpStatusCode = 20,
+            contentType = "content type",
+            expectedContentLength = 30,
+            responseBodyBytesReceived = 40,
+            tlsCipherSuite = "tls cipher suite",
+            isCellular = true,
+            isProxy = false,
+        )
+
+        assertEquals(expected, EpisodeDownloadError.fromProperties(properties))
+    }
+
+    @Test
+    fun `handle all reasons in properties`() {
+        val errors = EpisodeDownloadError.Reason.entries.map { EpisodeDownloadError(reason = it).toProperties() }
+
+        val reasons = errors.map { EpisodeDownloadError.fromProperties(it).reason }
+
+        assertEquals(EpisodeDownloadError.Reason.entries, reasons)
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadResult.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadResult.kt
@@ -1,21 +1,21 @@
 package au.com.shiftyjelly.pocketcasts.repositories.download
 
-import java.util.UUID
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError
 
 class DownloadResult private constructor(
-    val jobId: UUID?,
     val success: Boolean,
     val episodeUuid: String,
+    val error: EpisodeDownloadError? = null,
     val errorMessage: String? = null,
 ) {
 
     companion object {
-        fun successResult(jobId: UUID, episodeUuid: String): DownloadResult {
-            return DownloadResult(jobId = jobId, success = true, episodeUuid = episodeUuid)
+        fun successResult(episodeUuid: String): DownloadResult {
+            return DownloadResult(success = true, episodeUuid = episodeUuid)
         }
 
-        fun failedResult(jobId: UUID?, errorMessage: String?, episodeUuid: String): DownloadResult {
-            return DownloadResult(jobId = jobId, success = false, episodeUuid = episodeUuid, errorMessage = errorMessage)
+        fun failedResult(episodeDownloadError: EpisodeDownloadError, errorMessage: String?): DownloadResult {
+            return DownloadResult(success = false, episodeUuid = episodeDownloadError.episodeUuid, error = episodeDownloadError, errorMessage = errorMessage)
         }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/ResponseValidationResult.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/ResponseValidationResult.kt
@@ -3,5 +3,4 @@ package au.com.shiftyjelly.pocketcasts.repositories.download
 data class ResponseValidationResult(
     var errorMessage: String? = null,
     var isValid: Boolean = false,
-    var isAlternateUrlFound: Boolean = false,
 )

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/Network.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/Network.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.utils
 
 import android.content.Context
 import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.os.Build
 
 object Network {
@@ -51,6 +52,38 @@ object Network {
         }
         return false
     }
+
+    @Suppress("DEPRECATION")
+    fun isCellularConnection(context: Context): Boolean {
+        val connectivityManager = getConnectivityManager(context)
+        val networks = connectivityManager.allNetworks
+
+        for (index in networks.indices) {
+            val network = networks[index]
+            val networkInfo = connectivityManager.getNetworkInfo(network) ?: continue
+            if (networkInfo.type == ConnectivityManager.TYPE_MOBILE && networkInfo.isConnected) {
+                return true
+            }
+        }
+        return false
+    }
+
+    @Suppress("DEPRECATION")
+    fun isVpnConnection(context: Context): Boolean {
+        val connectivityManager = getConnectivityManager(context)
+        val networks = connectivityManager.allNetworks
+
+        for (index in networks.indices) {
+            val network = networks[index]
+            val networkInfo = connectivityManager.getNetworkInfo(network) ?: continue
+            val networkCapabilities = connectivityManager.getNetworkCapabilities(network) ?: continue
+            if (networkInfo.isConnected && networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
+                return true
+            }
+        }
+        return false
+    }
+
     fun getConnectivityManager(context: Context): ConnectivityManager {
         return context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
     }


### PR DESCRIPTION
## Description

This PR adds more properties to `episode_download_failed` event. I'm targeting `7.59` because the PR has very low risk and it will be better to collect these properties as soon as possible so we can decide how to approach improvements.

## Testing Instructions

Currently, `Inside the FBI` podcast blocks our user agent so we can use it to test `403` error.

1. Open [`Inside the FBI`](https://pca.st/ljzvpptr) podcast.
2. Open any episode details.
3. Try to download the episode.
4. You should see something like below in the logs.

```
🔵 Tracked: episode_download_failed, Properties: {"reason":"status_code","episode_uuid":"bf8e6b69-f5c5-42db-b2e7-ac9bfb820b52","podcast_uuid":"2fbc99a0-8828-0138-ee3a-0acc26574db2","duration":227,"http_status_code":403,"content_type":"text\/html; charset=UTF-8","expected_content_length":-1,"response_body_bytes_received":-1,"tls_cipher_suite":"TLS_AES_128_GCM_SHA256","is_cellular":false,"is_proxy":
false,"has_dynamic_font_size":true,"user_is_logged_in":true,"plus_has_subscription":false,"plus_has_lifetime":false,"plus_subscription_type":"none","plus_subscription_tier":"none","plus_subscription_platform":"none","plus_subscription_frequency":"none","platform":"phone"}
```

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
