### PR TITLE
Align download failure event with the latest design

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeDownloadError.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeDownloadError.kt
@@ -2,31 +2,32 @@ package au.com.shiftyjelly.pocketcasts.analytics
 
 data class EpisodeDownloadError(
     var reason: Reason = Reason.Unknown,
-    var episodeUuid: String = "",
-    var podcastUuid: String = "",
-    var taskDuration: Long = -1,
-    var httpStatusCode: Int = -1,
-    var contentType: String = "",
-    var expectedContentLength: Long = -1,
-    var responseBodyBytesReceived: Long = -1,
-    var tlsCipherSuite: String = "",
-    var isCellular: Boolean = false,
-    var isProxy: Boolean = false,
+    var episodeUuid: String? = null,
+    var podcastUuid: String? = null,
+    var taskDuration: Long? = null,
+    var httpStatusCode: Int? = null,
+    var contentType: String? = null,
+    var expectedContentLength: Long? = null,
+    var responseBodyBytesReceived: Long? = null,
+    var fileSize: Long? = null,
+    var tlsCipherSuite: String? = null,
+    var isCellular: Boolean? = null,
+    var isProxy: Boolean? = null,
 ) {
-
-    fun toProperties() = mapOf(
-        REASON_KEY to reason.analyticsValue,
-        EPISODE_UUID_KEY to episodeUuid,
-        PODCAST_UUID_KEY to podcastUuid,
-        TASK_DURATION_KEY to taskDuration,
-        HTTP_STATUS_CODE_KEY to httpStatusCode,
-        CONTENT_TYPE_KEY to contentType,
-        EXPECTED_CONTENT_LENGTH_KEY to expectedContentLength,
-        RESPONSE_BODY_BYTES_RECEIVED_KEY to responseBodyBytesReceived,
-        TLS_CIPHER_SUITE_KEY to tlsCipherSuite,
-        IS_CELLULAR_KEY to isCellular,
-        IS_PROXY_KEY to isProxy,
-    )
+    fun toProperties() = buildMap<String, Any> {
+        put(REASON_KEY, reason.analyticsValue)
+        episodeUuid?.let { put(EPISODE_UUID_KEY, it) }
+        podcastUuid?.let { put(PODCAST_UUID_KEY, it) }
+        taskDuration?.let { put(TASK_DURATION_KEY, it) }
+        httpStatusCode?.let { put(HTTP_STATUS_CODE_KEY, it) }
+        contentType?.let { put(CONTENT_TYPE_KEY, it) }
+        expectedContentLength?.let { put(EXPECTED_CONTENT_LENGTH_KEY, it) }
+        responseBodyBytesReceived?.let { put(RESPONSE_BODY_BYTES_RECEIVED_KEY, it) }
+        fileSize?.let { put(FILE_SIZE_KEY, it) }
+        tlsCipherSuite?.let { put(TLS_CIPHER_SUITE_KEY, it) }
+        isCellular?.let { put(IS_CELLULAR_KEY, it) }
+        isProxy?.let { put(IS_PROXY_KEY, it) }
+    }
 
     enum class Reason(
         val analyticsValue: String,
@@ -54,29 +55,29 @@ data class EpisodeDownloadError(
         const val PODCAST_UUID_KEY = "podcast_uuid"
         const val TASK_DURATION_KEY = "duration"
         const val HTTP_STATUS_CODE_KEY = "http_status_code"
-        const val CONTENT_TYPE_KEY = "content_type"
+        const val CONTENT_TYPE_KEY = "http_content_type"
         const val EXPECTED_CONTENT_LENGTH_KEY = "expected_content_length"
         const val RESPONSE_BODY_BYTES_RECEIVED_KEY = "response_body_bytes_received"
+        const val FILE_SIZE_KEY = "file_size_key"
         const val TLS_CIPHER_SUITE_KEY = "tls_cipher_suite"
         const val IS_CELLULAR_KEY = "is_cellular"
         const val IS_PROXY_KEY = "is_proxy"
 
-        fun fromProperties(properties: Map<String, Any>) = EpisodeDownloadError(
-            reason = properties.require<String>(REASON_KEY).let { reason -> Reason.entries.single { it.analyticsValue == reason } },
-            episodeUuid = properties.require<String>(EPISODE_UUID_KEY),
-            podcastUuid = properties.require<String>(PODCAST_UUID_KEY),
-            taskDuration = properties.require<Long>(TASK_DURATION_KEY),
-            httpStatusCode = properties.require<Int>(HTTP_STATUS_CODE_KEY),
-            contentType = properties.require<String>(CONTENT_TYPE_KEY),
-            expectedContentLength = properties.require<Long>(EXPECTED_CONTENT_LENGTH_KEY),
-            responseBodyBytesReceived = properties.require<Long>(RESPONSE_BODY_BYTES_RECEIVED_KEY),
-            tlsCipherSuite = properties.require<String>(TLS_CIPHER_SUITE_KEY),
-            isCellular = properties.require<Boolean>(IS_CELLULAR_KEY),
-            isProxy = properties.require<Boolean>(IS_PROXY_KEY),
+        fun fromProperties(properties: Map<String, Any?>) = EpisodeDownloadError(
+            reason = properties.find<String>(REASON_KEY)?.let { reason -> Reason.entries.find { it.analyticsValue == reason } } ?: Reason.Unknown,
+            episodeUuid = properties.find<String>(EPISODE_UUID_KEY),
+            podcastUuid = properties.find<String>(PODCAST_UUID_KEY),
+            taskDuration = properties.find<Long>(TASK_DURATION_KEY),
+            httpStatusCode = properties.find<Int>(HTTP_STATUS_CODE_KEY),
+            contentType = properties.find<String>(CONTENT_TYPE_KEY),
+            expectedContentLength = properties.find<Long>(EXPECTED_CONTENT_LENGTH_KEY),
+            responseBodyBytesReceived = properties.find<Long>(RESPONSE_BODY_BYTES_RECEIVED_KEY),
+            fileSize = properties.find<Long>(FILE_SIZE_KEY),
+            tlsCipherSuite = properties.find<String>(TLS_CIPHER_SUITE_KEY),
+            isCellular = properties.find<Boolean>(IS_CELLULAR_KEY),
+            isProxy = properties.find<Boolean>(IS_PROXY_KEY),
         )
 
-        private inline fun <reified T> Map<String, Any>.require(key: String) = requireNotNull(get(key) as T) {
-            "Missing property '$key' of type '${T::class.java}'"
-        }
+        private inline fun <reified T> Map<String, Any?>.find(key: String) = get(key) as? T
     }
 }

--- a/modules/services/analytics/src/test/kotlin/au/com/shiftyjelly/pocketcasts/analytics/EpisodeDownloadErrorTest.kt
+++ b/modules/services/analytics/src/test/kotlin/au/com/shiftyjelly/pocketcasts/analytics/EpisodeDownloadErrorTest.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.analytics
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.CONTENT_TYPE_KEY
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.EPISODE_UUID_KEY
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.EXPECTED_CONTENT_LENGTH_KEY
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.FILE_SIZE_KEY
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.HTTP_STATUS_CODE_KEY
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.IS_CELLULAR_KEY
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError.Companion.IS_PROXY_KEY
@@ -26,6 +27,7 @@ class EpisodeDownloadErrorTest {
             contentType = "content type",
             expectedContentLength = 30,
             responseBodyBytesReceived = 40,
+            fileSize = 50,
             tlsCipherSuite = "tls cipher suite",
             isCellular = true,
             isProxy = false,
@@ -40,10 +42,20 @@ class EpisodeDownloadErrorTest {
             CONTENT_TYPE_KEY to "content type",
             EXPECTED_CONTENT_LENGTH_KEY to 30L,
             RESPONSE_BODY_BYTES_RECEIVED_KEY to 40L,
+            FILE_SIZE_KEY to 50L,
             TLS_CIPHER_SUITE_KEY to "tls cipher suite",
             IS_CELLULAR_KEY to true,
             IS_PROXY_KEY to false,
         )
+
+        assertEquals(expected, error.toProperties())
+    }
+
+    @Test
+    fun `skip null properties during conversion`() {
+        val error = EpisodeDownloadError(reason = EpisodeDownloadError.Reason.Unknown)
+
+        val expected = mapOf(REASON_KEY to EpisodeDownloadError.Reason.Unknown.analyticsValue)
 
         assertEquals(expected, error.toProperties())
     }
@@ -59,6 +71,7 @@ class EpisodeDownloadErrorTest {
             CONTENT_TYPE_KEY to "content type",
             EXPECTED_CONTENT_LENGTH_KEY to 30L,
             RESPONSE_BODY_BYTES_RECEIVED_KEY to 40L,
+            FILE_SIZE_KEY to 50L,
             TLS_CIPHER_SUITE_KEY to "tls cipher suite",
             IS_CELLULAR_KEY to true,
             IS_PROXY_KEY to false,
@@ -73,10 +86,20 @@ class EpisodeDownloadErrorTest {
             contentType = "content type",
             expectedContentLength = 30,
             responseBodyBytesReceived = 40,
+            fileSize = 50,
             tlsCipherSuite = "tls cipher suite",
             isCellular = true,
             isProxy = false,
         )
+
+        assertEquals(expected, EpisodeDownloadError.fromProperties(properties))
+    }
+
+    @Test
+    fun `handle null properties during creation`() {
+        val properties = mapOf(REASON_KEY to EpisodeDownloadError.Reason.Unknown.analyticsValue)
+
+        val expected = EpisodeDownloadError(reason = EpisodeDownloadError.Reason.Unknown)
 
         assertEquals(expected, EpisodeDownloadError.fromProperties(properties))
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadResult.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadResult.kt
@@ -15,7 +15,7 @@ class DownloadResult private constructor(
         }
 
         fun failedResult(episodeDownloadError: EpisodeDownloadError, errorMessage: String?): DownloadResult {
-            return DownloadResult(success = false, episodeUuid = episodeDownloadError.episodeUuid, error = episodeDownloadError, errorMessage = errorMessage)
+            return DownloadResult(success = false, episodeUuid = episodeDownloadError.episodeUuid.orEmpty(), error = episodeDownloadError, errorMessage = errorMessage)
         }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
@@ -449,6 +449,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
                     tempDownloadMetaDataFile.delete() // at this point we have the file, don't need the metadata about it anymore
                     val fullDownloadFile = File(pathToSaveTo)
                     try {
+                        episodeDownloadError.fileSize = tempDownloadFile.length()
                         FileUtil.copy(tempDownloadFile, fullDownloadFile)
                     } catch (exception: IOException) {
                         episodeDownloadError.reason = EpisodeDownloadError.Reason.StorageIssue
@@ -602,7 +603,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
         val statusCode = response.code
         episodeDownloadError.httpStatusCode = statusCode
         episodeDownloadError.contentType = response.header("Content-Type") ?: "Missing"
-        episodeDownloadError.tlsCipherSuite = response.handshake?.cipherSuite?.javaName.orEmpty()
+        episodeDownloadError.tlsCipherSuite = response.handshake?.cipherSuite?.javaName?.uppercase().orEmpty()
         if (statusCode in 400..599) {
             val responseReason = response.message
             val message = if (statusCode == 404) {


### PR DESCRIPTION
## Description

Follow-up to #1912. This aligns episode failure event with the latest design:

* Properties are optional.
* Added `file_size` property.

## Testing Instructions

You can repeat the test from #1912 but code review should be enough.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
