### PR TITLE
Add stale downloads analytics event

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
@@ -1,0 +1,155 @@
+package au.com.shiftyjelly.pocketcasts.models.db
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
+import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeDownloadFailureStatistics
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
+import java.time.Instant
+import java.util.Date
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class EpisodeDaoTest {
+    lateinit var episodeDao: EpisodeDao
+    lateinit var testDb: AppDatabase
+
+    @Before
+    fun setupDb() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        episodeDao = testDb.episodeDao()
+    }
+
+    @After
+    fun closeDb() {
+        testDb.close()
+    }
+
+    @Test
+    fun insertAndFindEpisode() = runBlocking {
+        val episode = PodcastEpisode(uuid = "id", publishedDate = Date())
+
+        episodeDao.insert(episode)
+
+        assertEquals(episode, episodeDao.findByUuid(episode.uuid))
+    }
+
+    @Test
+    fun insertAllAndFindEpisodes() = runBlocking {
+        val episodes = listOf(
+            PodcastEpisode(uuid = "1", publishedDate = Date()),
+            PodcastEpisode(uuid = "2", publishedDate = Date()),
+        )
+
+        episodeDao.insertAll(episodes)
+
+        assertEquals(episodes[0], episodeDao.findByUuid(episodes[0].uuid))
+        assertEquals(episodes[1], episodeDao.findByUuid(episodes[1].uuid))
+    }
+
+    @Test
+    fun getFailedDownloadStatisticsWithNoEpisodes() = runBlocking {
+        val statistics = episodeDao.getFailedDownloadsStatistics()
+
+        val expected = EpisodeDownloadFailureStatistics(
+            count = 0,
+            newestTimestamp = null,
+            oldestTimestamp = null,
+        )
+        assertEquals(expected, statistics)
+    }
+
+    @Test
+    fun getFailedDownloadStatisticsWithSingleEpisode() = runBlocking {
+        val episode = PodcastEpisode(
+            uuid = "1",
+            publishedDate = Date(),
+            episodeStatus = EpisodeStatusEnum.DOWNLOAD_FAILED,
+            lastDownloadAttemptDate = Date.from(Instant.EPOCH),
+        )
+        episodeDao.insert(episode)
+
+        val statistics = episodeDao.getFailedDownloadsStatistics()
+
+        val expected = EpisodeDownloadFailureStatistics(
+            count = 1,
+            newestTimestamp = Instant.EPOCH,
+            oldestTimestamp = Instant.EPOCH,
+        )
+        assertEquals(expected, statistics)
+    }
+
+    @Test
+    fun getFailedDownloadStatisticsWithMultipleEpisodes() = runBlocking {
+        val episodes = List(10) { index ->
+            PodcastEpisode(
+                uuid = index.toString(),
+                publishedDate = Date(),
+                episodeStatus = EpisodeStatusEnum.DOWNLOAD_FAILED,
+                lastDownloadAttemptDate = Date.from(Instant.EPOCH.plusMillis(index.toLong())),
+            )
+        }
+        episodeDao.insertAll(episodes)
+
+        val statistics = episodeDao.getFailedDownloadsStatistics()
+
+        val expected = EpisodeDownloadFailureStatistics(
+            count = episodes.size.toLong(),
+            newestTimestamp = Instant.EPOCH.plusMillis(episodes.size.toLong() - 1),
+            oldestTimestamp = Instant.EPOCH,
+        )
+        assertEquals(expected, statistics)
+    }
+
+    @Test
+    fun getFailedDownloadStatisticsWithMissingDownloadAttemptDate() = runBlocking {
+        val episodes = List(10) { index ->
+            PodcastEpisode(
+                uuid = index.toString(),
+                publishedDate = Date(),
+                episodeStatus = EpisodeStatusEnum.DOWNLOAD_FAILED,
+                lastDownloadAttemptDate = null,
+            )
+        }
+        episodeDao.insertAll(episodes)
+
+        val statistics = episodeDao.getFailedDownloadsStatistics()
+
+        val expected = EpisodeDownloadFailureStatistics(
+            count = episodes.size.toLong(),
+            newestTimestamp = null,
+            oldestTimestamp = null,
+        )
+        assertEquals(expected, statistics)
+    }
+
+    @Test
+    fun getFailedDownloadStatisticsOnlyForFailedDownloads() = runBlocking {
+        val episodes = EpisodeStatusEnum.entries.map { entry ->
+            PodcastEpisode(
+                uuid = entry.ordinal.toString(),
+                publishedDate = Date(),
+                episodeStatus = entry,
+                lastDownloadAttemptDate = Date.from(Instant.EPOCH.plusMillis(entry.ordinal.toLong())),
+            )
+        }
+        episodeDao.insertAll(episodes)
+
+        val statistics = episodeDao.getFailedDownloadsStatistics()
+
+        val expected = EpisodeDownloadFailureStatistics(
+            count = 1,
+            newestTimestamp = Instant.EPOCH.plusMillis(EpisodeStatusEnum.DOWNLOAD_FAILED.ordinal.toLong()),
+            oldestTimestamp = Instant.EPOCH.plusMillis(EpisodeStatusEnum.DOWNLOAD_FAILED.ordinal.toLong()),
+        )
+        assertEquals(expected, statistics)
+    }
+}

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -28,6 +28,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.repositories.widget.WidgetManager
 import au.com.shiftyjelly.pocketcasts.shared.AppLifecycleObserver
+import au.com.shiftyjelly.pocketcasts.shared.DownloadStatisticsReporter
 import au.com.shiftyjelly.pocketcasts.ui.helper.AppIcon
 import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import au.com.shiftyjelly.pocketcasts.utils.SentryHelper.AppPlatform
@@ -97,6 +98,8 @@ class PocketCastsApplication : Application(), Configuration.Provider {
 
     @Inject lateinit var widgetManager: WidgetManager
 
+    @Inject lateinit var downloadStatisticsReporter: DownloadStatisticsReporter
+
     @Inject @ApplicationScope
     lateinit var applicationScope: CoroutineScope
 
@@ -131,6 +134,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
         AnalyticsTracker.register(tracksTracker, bumpStatsTracker)
         AnalyticsTracker.init(settings)
         AnalyticsTracker.refreshMetadata()
+        downloadStatisticsReporter.setup()
     }
 
     private fun setupSentry() {

--- a/base.gradle
+++ b/base.gradle
@@ -255,6 +255,7 @@ dependencies {
     testImplementation libs.mockito.kotlin
     testImplementation libs.okHttp.mockwebserver
     testImplementation libs.turbine
+    testImplementation libs.lifecycle.runtime.testing
 
     coreLibraryDesugaring libs.desugar.jdk
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -150,6 +150,7 @@ lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.r
 lifecycle-reactivestreams = { module = "androidx.lifecycle:lifecycle-reactivestreams-ktx", version.ref = "lifecycle" }
 lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
+lifecycle-runtime-testing = { module = "androidx.lifecycle:lifecycle-runtime-testing", version.ref = "lifecycle" }
 lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 

--- a/modules/features/shared/build.gradle.kts
+++ b/modules/features/shared/build.gradle.kts
@@ -25,5 +25,6 @@ dependencies {
     implementation(project(":modules:services:preferences"))
     implementation(project(":modules:services:repositories"))
     implementation(project(":modules:services:utils"))
+    implementation(project(":modules:services:model"))
     testImplementation(project(":modules:services:sharedtest"))
 }

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/DownloadStatisticsReporter.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/DownloadStatisticsReporter.kt
@@ -1,0 +1,42 @@
+package au.com.shiftyjelly.pocketcasts.shared
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
+import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.ProcessLifecycle
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@Singleton
+class DownloadStatisticsReporter @Inject constructor(
+    private val episodeDao: EpisodeDao,
+    private val episodeAnalytics: EpisodeAnalytics,
+    @ProcessLifecycle private val lifecycleOwner: LifecycleOwner,
+    @ApplicationScope private val coroutineScope: CoroutineScope,
+) {
+    private val isSetupUpForReporting = AtomicBoolean()
+
+    fun setup() {
+        if (isSetupUpForReporting.getAndSet(true)) {
+            return
+        }
+        lifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onResume(owner: LifecycleOwner) {
+                lifecycleOwner.lifecycle.removeObserver(this)
+                reportStatistics()
+            }
+        })
+    }
+
+    private fun reportStatistics() {
+        coroutineScope.launch {
+            val statistics = episodeDao.getFailedDownloadsStatistics()
+            episodeAnalytics.trackStaleEpisodeDownloads(statistics)
+        }
+    }
+}

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/DownloadStatisticsReporterTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/DownloadStatisticsReporterTest.kt
@@ -1,0 +1,133 @@
+package au.com.shiftyjelly.pocketcasts.shared
+
+import androidx.lifecycle.Lifecycle.Event.ON_CREATE
+import androidx.lifecycle.Lifecycle.Event.ON_PAUSE
+import androidx.lifecycle.Lifecycle.Event.ON_RESUME
+import androidx.lifecycle.Lifecycle.Event.ON_START
+import androidx.lifecycle.Lifecycle.Event.ON_STOP
+import androidx.lifecycle.Lifecycle.State.INITIALIZED
+import androidx.lifecycle.testing.TestLifecycleOwner
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
+import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
+import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeDownloadFailureStatistics
+import java.time.Instant
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DownloadStatisticsReporterTest {
+    private val statistics = EpisodeDownloadFailureStatistics(
+        count = 10,
+        newestTimestamp = Instant.EPOCH.plusSeconds(15),
+        oldestTimestamp = Instant.EPOCH,
+    )
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val tracker = TestTracker()
+    private val lifecycleOwner = TestLifecycleOwner(
+        initialState = INITIALIZED,
+        coroutineDispatcher = testDispatcher,
+    )
+    private lateinit var episodeDao: EpisodeDao
+    private lateinit var reporter: DownloadStatisticsReporter
+
+    @Before
+    fun setUp() {
+        episodeDao = mock<EpisodeDao> {
+            onBlocking { getFailedDownloadsStatistics() } doReturn statistics
+        }
+        reporter = DownloadStatisticsReporter(
+            episodeDao,
+            EpisodeAnalytics(tracker),
+            lifecycleOwner,
+            CoroutineScope(testDispatcher),
+        )
+    }
+
+    @Test
+    fun `report stale downloads event`() = runTest(testDispatcher) {
+        reporter.setup()
+
+        lifecycleOwner.handleLifecycleEvent(ON_RESUME)
+        val (event, properties) = tracker.trackedEvents.single()
+
+        assertEquals(AnalyticsEvent.EPISODE_DOWNLOAD_STALE, event)
+        assertEquals(
+            mapOf(
+                "failed_download_count" to 10L,
+                "newest_failed_download" to "1970-01-01T00:00:15Z",
+                "oldest_failed_download" to "1970-01-01T00:00:00Z",
+            ),
+            properties,
+        )
+    }
+
+    @Test
+    fun `report stale downloads event only on resume`() = runTest(testDispatcher) {
+        reporter.setup()
+
+        lifecycleOwner.handleLifecycleEvent(ON_CREATE)
+        lifecycleOwner.handleLifecycleEvent(ON_START)
+        lifecycleOwner.handleLifecycleEvent(ON_STOP)
+
+        assertEquals(0, tracker.trackedEvents.size)
+
+        lifecycleOwner.handleLifecycleEvent(ON_RESUME)
+
+        assertEquals(1, tracker.trackedEvents.size)
+    }
+
+    @Test
+    fun `report stale downloads event only once`() = runTest(testDispatcher) {
+        reporter.setup()
+
+        lifecycleOwner.handleLifecycleEvent(ON_RESUME)
+        lifecycleOwner.handleLifecycleEvent(ON_PAUSE)
+        lifecycleOwner.handleLifecycleEvent(ON_RESUME)
+
+        assertEquals(1, tracker.trackedEvents.size)
+    }
+
+    @Test
+    fun `unregister observer after reporting`() = runTest(testDispatcher) {
+        reporter.setup()
+
+        lifecycleOwner.handleLifecycleEvent(ON_RESUME)
+
+        assertEquals(0, lifecycleOwner.observerCount)
+    }
+
+    @Test
+    fun `setup only once`() = runTest(testDispatcher) {
+        reporter.setup()
+        reporter.setup()
+
+        assertEquals(1, lifecycleOwner.observerCount)
+
+        lifecycleOwner.handleLifecycleEvent(ON_RESUME)
+        lifecycleOwner.handleLifecycleEvent(ON_PAUSE)
+        reporter.setup()
+        lifecycleOwner.handleLifecycleEvent(ON_RESUME)
+
+        assertEquals(0, lifecycleOwner.observerCount)
+        assertEquals(1, tracker.trackedEvents.size)
+    }
+
+    private class TestTracker : AnalyticsTrackerWrapper() {
+        private val _trackedEvents = mutableListOf<Pair<AnalyticsEvent, Map<String, Any>>>()
+        val trackedEvents get() = _trackedEvents.toList()
+
+        override fun track(event: AnalyticsEvent, properties: Map<String, Any>) {
+            _trackedEvents.add(event to properties)
+        }
+    }
+}

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -350,6 +350,7 @@ enum class AnalyticsEvent(val key: String) {
     EPISODE_DOWNLOAD_FINISHED("episode_download_finished"),
     EPISODE_DOWNLOAD_FAILED("episode_download_failed"),
     EPISODE_DOWNLOAD_CANCELLED("episode_download_cancelled"),
+    EPISODE_DOWNLOAD_STALE("episode_downloads_stale"),
     EPISODE_UPLOAD_QUEUED("episode_upload_queued"),
     EPISODE_UPLOAD_CANCELLED("episode_upload_cancelled"),
     EPISODE_UPLOAD_FINISHED("episode_upload_finished"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTrackerWrapper.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTrackerWrapper.kt
@@ -4,7 +4,7 @@ import javax.inject.Inject
 
 open class AnalyticsTrackerWrapper @Inject constructor() {
 
-    fun track(event: AnalyticsEvent, properties: Map<String, Any> = emptyMap()) {
+    open fun track(event: AnalyticsEvent, properties: Map<String, Any> = emptyMap()) {
         AnalyticsTracker.track(event, properties)
     }
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.analytics
 
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeDownloadFailureStatistics
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -78,6 +79,15 @@ class EpisodeAnalytics @Inject constructor(
             return
         }
         analyticsTracker.track(AnalyticsEvent.EPISODE_DOWNLOAD_FAILED, error.toProperties())
+    }
+
+    fun trackStaleEpisodeDownloads(data: EpisodeDownloadFailureStatistics) {
+        val properties = buildMap {
+            put("failed_download_count", data.count)
+            data.newestTimestamp?.let { put("newest_failed_download", it.toString()) }
+            data.oldestTimestamp?.let { put("oldest_failed_download", it.toString()) }
+        }
+        analyticsTracker.track(AnalyticsEvent.EPISODE_DOWNLOAD_STALE, properties)
     }
 
     private object AnalyticsProp {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/InstantConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/InstantConverter.kt
@@ -1,0 +1,12 @@
+package au.com.shiftyjelly.pocketcasts.models.converter
+
+import androidx.room.TypeConverter
+import java.time.Instant
+
+class InstantConverter {
+    @TypeConverter
+    fun fromDbValue(value: Long?): Instant? = value?.let(Instant::ofEpochMilli)
+
+    @TypeConverter
+    fun toDbValue(value: Instant?): Long? = value?.toEpochMilli()
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -21,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.models.converter.DateTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.EpisodePlayingStatusConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.EpisodeStatusEnumConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.EpisodesSortTypeConverter
+import au.com.shiftyjelly.pocketcasts.models.converter.InstantConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.PodcastAutoUpNextConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.PodcastGroupingTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.PodcastLicensingEnumConverter
@@ -94,6 +95,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
     AutoArchiveInactiveTypeConverter::class,
     PodcastGroupingTypeConverter::class,
     ChapterIndicesConverter::class,
+    InstantConverter::class,
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun podcastDao(): PodcastDao

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -15,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.db.helper.LongestEpisode
 import au.com.shiftyjelly.pocketcasts.models.db.helper.QueryHelper
 import au.com.shiftyjelly.pocketcasts.models.db.helper.UuidCount
+import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeDownloadFailureStatistics
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
@@ -431,4 +432,18 @@ abstract class EpisodeDao {
         """,
     )
     abstract suspend fun countEpisodesCompleted(fromEpochMs: Long, toEpochMs: Long): Int
+
+    @Query(
+        """
+        SELECT 
+          COUNT(*) AS count, 
+          MAX(last_download_attempt_date) AS newest_timestamp,
+          MIN(last_download_attempt_date) AS oldest_timestamp 
+        FROM 
+          podcast_episodes
+        WHERE
+          episode_status IS 3;
+        """,
+    )
+    abstract suspend fun getFailedDownloadsStatistics(): EpisodeDownloadFailureStatistics
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/di/ModelModule.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/di/ModelModule.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.models.di
 
 import android.app.Application
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
+import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -15,4 +16,7 @@ object ModelModule {
     fun providesAppDatabase(application: Application): AppDatabase {
         return AppDatabase.getInstance(application)
     }
+
+    @Provides
+    fun provideEpisodeDao(database: AppDatabase): EpisodeDao = database.episodeDao()
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/EpisodeDownloadFailureStatistics.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/EpisodeDownloadFailureStatistics.kt
@@ -1,0 +1,10 @@
+package au.com.shiftyjelly.pocketcasts.models.entity
+
+import androidx.room.ColumnInfo
+import java.time.Instant
+
+data class EpisodeDownloadFailureStatistics(
+    @ColumnInfo(name = "count") val count: Long,
+    @ColumnInfo(name = "newest_timestamp") val newestTimestamp: Instant?,
+    @ColumnInfo(name = "oldest_timestamp") val oldestTimestamp: Instant?,
+)

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/converter/InstantConverterTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/converter/InstantConverterTest.kt
@@ -1,0 +1,29 @@
+package au.com.shiftyjelly.pocketcasts.models.converter
+
+import java.time.Instant
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+
+class InstantConverterTest {
+    private val converter = InstantConverter()
+
+    @Test
+    fun `convert from db value`() {
+        val dbValue = 125542352L
+
+        val instant = converter.fromDbValue(dbValue)
+
+        val expected = Instant.ofEpochMilli(dbValue)
+        assertEquals(expected, instant)
+    }
+
+    @Test
+    fun `convert to db value`() {
+        val millis = 984572L
+        val instant = Instant.ofEpochMilli(millis)
+
+        val dbValue = converter.toDbValue(instant)
+
+        assertEquals(millis, dbValue)
+    }
+}

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/converter/SafeDateTypeConverterTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/converter/SafeDateTypeConverterTest.kt
@@ -1,6 +1,5 @@
-package au.com.shiftyjelly.pocketcasts.models
+package au.com.shiftyjelly.pocketcasts.models.converter
 
-import au.com.shiftyjelly.pocketcasts.models.converter.SafeDateTypeConverter
 import java.time.Instant
 import java.util.Date
 import junit.framework.TestCase.assertEquals

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/Annotations.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/Annotations.kt
@@ -34,3 +34,10 @@ annotation class DownloadRequestBuilder
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class ApplicationScope
+
+/**
+ * Annotation for providing lifecycle owner that is associated with the app's process.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ProcessLifecycle

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
@@ -1,5 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.di
 
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncAccountManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
 import dagger.Module
@@ -42,4 +44,9 @@ class RepositoryProviderModule {
     @ApplicationScope
     fun coroutineScope(): CoroutineScope =
         CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    @Provides
+    @Singleton
+    @ProcessLifecycle
+    fun processLifecycle(): LifecycleOwner = ProcessLifecycleOwner.get()
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -20,6 +20,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.shared.AppLifecycleObserver
+import au.com.shiftyjelly.pocketcasts.shared.DownloadStatisticsReporter
 import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import au.com.shiftyjelly.pocketcasts.utils.SentryHelper.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
@@ -67,6 +68,8 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
     @Inject lateinit var tracksTracker: TracksAnalyticsTracker
 
     @Inject lateinit var bumpStatsTracker: AnonymousBumpStatsTracker
+
+    @Inject lateinit var downloadStatisticsReporter: DownloadStatisticsReporter
 
     override fun onCreate() {
         super.onCreate()
@@ -145,6 +148,7 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
         AnalyticsTracker.register(tracksTracker, bumpStatsTracker)
         AnalyticsTracker.init(settings)
         AnalyticsTracker.refreshMetadata()
+        downloadStatisticsReporter.setup()
     }
 
     override fun getWorkManagerConfiguration(): Configuration {


### PR DESCRIPTION
## Description

This adds an event for tracking how many stale downloads users have during app startup.

## Testing Instructions

Currently, `Inside the FBI` podcast blocks our user agent so we can use it to test `403` error.

1. Open [`Inside the FBI`](https://pca.st/ljzvpptr) podcast.
2. Try to download some of the episodes.
3. Download episodes from some other podcast.
4. Close the app.
5. Open the app again.
6. You should see something like below in the logs. `failed_download_count` should match the number of episodes that failed to be downloaded. `oldest_failed_download` and `newest_failed_download` should match timestamps of when you tried to download the episodes.

```
🔵 Tracked: episode_downloads_stale, Properties: {"failed_download_count":3,"newest_failed_download":"2024-03-08T09:19:28.451Z","oldest_failed_download":"2024-03-08T09:19:00.193Z","has_dynamic_font_size":true,"user_is_logged_in":true,"plus_has_subscription":true,"plus_has_lifetime":false,"plus_subscription_type":"plus","plus_subscription_tier":"plus","plus_subscription_platform":"gift","plus_subsc
ription_frequency":"none","platform":"phone"}
```

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
