### PR TITLE
[Categories Redesign] - Display categories at the top

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
@@ -12,6 +12,8 @@ import au.com.shiftyjelly.pocketcasts.discover.R
 import au.com.shiftyjelly.pocketcasts.discover.extensions.updateSubscribeButtonIcon
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private val differ: DiffUtil.ItemCallback<Any> = object : DiffUtil.ItemCallback<Any>() {
@@ -36,7 +38,9 @@ private val differ: DiffUtil.ItemCallback<Any> = object : DiffUtil.ItemCallback<
 
 internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, val onPodcastClicked: ((DiscoverPodcast, String?) -> Unit), val onPodcastSubscribe: ((DiscoverPodcast, String?) -> Unit), private val analyticsTracker: AnalyticsTrackerWrapper) : ListAdapter<Any, CarouselItemViewHolder>(differ) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CarouselItemViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_carousel, parent, false)
+        val layout =
+            if (FeatureFlag.isEnabled(Feature.CATEGORIES_REDESIGN)) R.layout.item_top_ranked else R.layout.item_carousel
+        val view = LayoutInflater.from(parent.context).inflate(layout, parent, false)
         return CarouselItemViewHolder(theme, view)
     }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -57,6 +57,8 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatPattern
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.extensions.showIf
 import coil.imageLoader
@@ -459,7 +461,10 @@ internal class DiscoverAdapter(
                         },
                     )
 
-                    holder.binding.layoutSearch.setOnClickListener { listener.onSearchClicked() }
+                    if (!FeatureFlag.isEnabled(Feature.CATEGORIES_REDESIGN)) {
+                        holder.binding.layoutSearch.visibility = View.VISIBLE
+                        holder.binding.layoutSearch.setOnClickListener { listener.onSearchClicked() }
+                    }
                 }
                 is SmallListViewHolder -> {
                     holder.binding.lblTitle.text = row.title.tryToLocalise(resources)

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -26,10 +26,14 @@ import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverEpisode
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverRegion
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverRow
 import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyle
+import au.com.shiftyjelly.pocketcasts.servers.model.ListType
 import au.com.shiftyjelly.pocketcasts.servers.model.NetworkLoadableList
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -179,7 +183,10 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
                             fragment.listener = this
                         }
                         adapter?.onChangeRegion = onChangeRegion
-                        adapter?.submitList(content)
+
+                        val sortedContent = sortContent(content)
+
+                        adapter?.submitList(sortedContent)
                     }
                     is DiscoverState.Error -> {
                         binding.errorLayout.isVisible = true
@@ -197,7 +204,6 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
             },
         )
     }
-
     override fun onRegionSelected(region: DiscoverRegion) {
         viewModel.changeRegion(region, resources)
 
@@ -213,6 +219,20 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
         if (visible) {
             FirebaseAnalyticsTracker.navigatedToDiscover()
         }
+    }
+    private fun sortContent(content: List<Any>): MutableList<Any> {
+        val mutableContentList = content.toMutableList()
+
+        if (FeatureFlag.isEnabled(Feature.CATEGORIES_REDESIGN)) {
+            val categoriesIndex = mutableContentList.indexOfFirst { it is DiscoverRow && it.type is ListType.Categories }
+
+            if (categoriesIndex != -1) {
+                val categoriesItem = mutableContentList.removeAt(categoriesIndex)
+                mutableContentList.add(0, categoriesItem)
+            }
+        }
+
+        return mutableContentList
     }
 
     companion object {

--- a/modules/features/discover/src/main/res/layout/row_carousel_list.xml
+++ b/modules/features/discover/src/main/res/layout/row_carousel_list.xml
@@ -20,6 +20,7 @@
         android:background="@drawable/search_background"
         android:foreground="?attr/selectableItemBackground"
         android:layout_margin="16dp"
+        android:visibility="gone"
         android:clickable="true"
         android:focusable="true"
         android:contentDescription="@string/search_podcasts_or_add_url"

--- a/modules/features/discover/src/main/res/layout/row_categories_redesign.xml
+++ b/modules/features/discover/src/main/res/layout/row_categories_redesign.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingBottom="16dp">
+
+    <LinearLayout
+        android:id="@+id/layoutSearch"
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:orientation="horizontal"
+        android:background="?attr/primary_ui_03"
+        android:foreground="?attr/selectableItemBackground"
+        android:layout_margin="16dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:contentDescription="@string/search_podcasts_or_add_url"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingBottom="8dp">
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:src="@drawable/ic_search"
+            app:tint="?attr/primary_icon_02"
+            android:layout_marginEnd="16dp"/>
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            style="?attr/textBody1"
+            android:importantForAccessibility="no"
+            android:textColor="?attr/primary_icon_02"
+            android:maxLines="1"
+            android:ellipsize="end"
+            app:autoSizeTextType="uniform"
+            android:text="@string/search_podcasts_or_add_url"/>
+    </LinearLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rowRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</LinearLayout>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -75,6 +75,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = false,
     ),
+    CATEGORIES_REDESIGN(
+        key = "CATEGORIES_REDESIGN",
+        title = "Categories Redesign and Ads in Categories",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = false,
+    ),
     ;
 
     companion object {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -78,7 +78,7 @@ enum class Feature(
     CATEGORIES_REDESIGN(
         key = "CATEGORIES_REDESIGN",
         title = "Categories Redesign and Ads in Categories",
-        defaultValue = BuildConfig.DEBUG,
+        defaultValue = false,
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = false,
         hasDevToggle = false,


### PR DESCRIPTION
## Description
- This PR moves the categories from bottom to the top of Discover.
- Hides the search bar from carousel and displays above of categories.

This is part of the categories redesign. You can find references and figma here in our internal reference: `pdeCcb-4tv-p2`.

> [!note]
> This is not the final design. The new design will be implemented in different pull requests to make it easier to review


> [!note]
> This feature is behind the local feature flag `CATEGORIES_REDESIGN`

## Testing Instructions

#### 1. With Feature flag OFF
1. You should see the Discover tab with the current implementation in prod without any change

#### 2. With Feature flag ON
1. The categories should be displayed at the top below of the search bar


## Screenshots or Screencast 
[Screen_recording_20240308_143124.webm](https://github.com/Automattic/pocket-casts-android/assets/42220351/3f03f52a-7fc8-435a-ad87-ae868d514ee3)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
