### PR TITLE
Migrate mini player from data binding

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -121,6 +121,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
         binding.skipForward.imageTintList = tintColorStateList
         binding.miniPlayButton.backgroundTintList = tintColorStateList
         binding.skipBack.imageTintList = tintColorStateList
+        binding.upNextButton.imageTintList = tintColorStateList
 
         val colorStateList = ThemeColor.podcastUi02(theme.activeTheme, tintColor)
         binding.miniPlayerTint.setBackgroundColor(colorStateList)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -141,7 +141,6 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
         if (upNextState is UpNextQueue.State.Loaded) {
             loadArtwork(upNextState.podcast, upNextState.episode, useRssArtwork)
 
-            binding.episode = upNextState.episode
             binding.podcast = upNextState.podcast
 
             val podcast = upNextState.podcast

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -9,7 +9,7 @@ import android.view.LayoutInflater
 import android.widget.FrameLayout
 import android.widget.ImageView
 import androidx.core.content.ContextCompat
-import androidx.databinding.DataBindingUtil
+import androidx.core.view.isVisible
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -45,7 +45,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
-import androidx.core.view.isVisible
 
 class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
     FrameLayout(context, attrs), CoroutineScope {
@@ -55,9 +54,8 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
 
     private val inflater =
         context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
-    private val binding = DataBindingUtil.inflate<ViewMiniPlayerBinding>(
+    private val binding = ViewMiniPlayerBinding.inflate(
         inflater,
-        R.layout.view_mini_player,
         this,
         true,
     )

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -224,6 +224,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
     private fun loadArtwork(podcast: Podcast?, episode: BaseEpisode, useRssArtwork: Boolean) {
         val imageLoader = PodcastImageLoaderThemed(context)
         val imageView = binding.artwork
+        imageView.clipToOutline = true
         imageLoader.radiusPx = 2.dpToPx(context.resources.displayMetrics)
 
         val artwork = getEpisodeArtwork(episode, useRssArtwork)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import androidx.core.view.isVisible
 
 class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
     FrameLayout(context, attrs), CoroutineScope {
@@ -155,7 +156,8 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
         }
 
         val upNextCount: Int = upNextState.queueSize()
-        binding.upNextCount = upNextCount
+        binding.countText.text = upNextCount.toString()
+        binding.countText.isVisible = upNextCount > 0
 
         val drawableId = when {
             upNextCount == 0 -> R.drawable.mini_player_upnext

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -114,7 +114,6 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
     }
 
     private fun updateTintColor(tintColor: Int, theme: Theme) {
-        binding.tintColor = ThemeColor.podcastIcon03(theme.activeTheme, tintColor)
         val tintColorStateList: ColorStateList =
             ColorStateList.valueOf(ThemeColor.podcastIcon03(theme.activeTheme, tintColor))
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -140,8 +140,6 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
         if (upNextState is UpNextQueue.State.Loaded) {
             loadArtwork(upNextState.podcast, upNextState.episode, useRssArtwork)
 
-            binding.podcast = upNextState.podcast
-
             val podcast = upNextState.podcast
             if (podcast != null) {
                 updateTintColor(podcast.getPlayerTintColor(theme.isDarkTheme), theme)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -119,6 +119,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
             ColorStateList.valueOf(ThemeColor.podcastIcon03(theme.activeTheme, tintColor))
 
         binding.skipForward.imageTintList = tintColorStateList
+        binding.miniPlayButton.backgroundTintList = tintColorStateList
 
         val colorStateList = ThemeColor.podcastUi02(theme.activeTheme, tintColor)
         binding.miniPlayerTint.setBackgroundColor(colorStateList)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -115,6 +115,10 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
 
     private fun updateTintColor(tintColor: Int, theme: Theme) {
         binding.tintColor = ThemeColor.podcastIcon03(theme.activeTheme, tintColor)
+        val tintColorStateList: ColorStateList =
+            ColorStateList.valueOf(ThemeColor.podcastIcon03(theme.activeTheme, tintColor))
+
+        binding.skipForward.imageTintList = tintColorStateList
 
         val colorStateList = ThemeColor.podcastUi02(theme.activeTheme, tintColor)
         binding.miniPlayerTint.setBackgroundColor(colorStateList)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -104,7 +104,6 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
     }
 
     fun setPlaybackState(playbackState: PlaybackState) {
-        binding.playbackState = playbackState
         // set the progress bar values as we need the max to be set before progress or the initial state doesn't work
         with(binding.progressBar) {
             max = playbackState.durationMs

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -120,6 +120,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
 
         binding.skipForward.imageTintList = tintColorStateList
         binding.miniPlayButton.backgroundTintList = tintColorStateList
+        binding.skipBack.imageTintList = tintColorStateList
 
         val colorStateList = ThemeColor.podcastUi02(theme.activeTheme, tintColor)
         binding.miniPlayerTint.setBackgroundColor(colorStateList)

--- a/modules/features/player/src/main/res/layout/view_mini_player.xml
+++ b/modules/features/player/src/main/res/layout/view_mini_player.xml
@@ -81,7 +81,6 @@
             android:scaleType="centerInside"
             android:clickable="false"
             android:contentDescription="@string/player_up_next"
-            app:tint="@{tintColor}"
             app:layout_constraintBottom_toTopOf="@+id/progressBar"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/modules/features/player/src/main/res/layout/view_mini_player.xml
+++ b/modules/features/player/src/main/res/layout/view_mini_player.xml
@@ -41,7 +41,6 @@
             android:scaleType="centerInside"
             android:clickable="false"
             android:contentDescription="@string/skip_forward"
-            app:tint="@{tintColor}"
             app:layout_constraintBottom_toTopOf="@+id/progressBar"
             app:layout_constraintStart_toEndOf="@+id/miniPlayButton"
             app:layout_constraintTop_toTopOf="parent"

--- a/modules/features/player/src/main/res/layout/view_mini_player.xml
+++ b/modules/features/player/src/main/res/layout/view_mini_player.xml
@@ -19,7 +19,6 @@
         android:layout_height="48dp"
         android:layout_marginStart="8dp"
         android:background="@drawable/round_corners_2dp"
-        app:clipToOutline="@{true}"
         app:layout_constraintBottom_toTopOf="@+id/progressBar"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/modules/features/player/src/main/res/layout/view_mini_player.xml
+++ b/modules/features/player/src/main/res/layout/view_mini_player.xml
@@ -53,7 +53,6 @@
             android:background="@drawable/mini_player_play_background"
             android:scaleType="centerInside"
             android:clickable="false"
-            app:backgroundTint="@{tintColor}"
             app:lottie_rawRes="@raw/mini_player_play_button"
             app:layout_constraintBottom_toTopOf="@+id/progressBar"
             app:layout_constraintEnd_toEndOf="parent"

--- a/modules/features/player/src/main/res/layout/view_mini_player.xml
+++ b/modules/features/player/src/main/res/layout/view_mini_player.xml
@@ -4,7 +4,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
-        <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast" />
         <variable name="tintColor" type="int"/>
         <variable name="upNextCount" type="int"/>
     </data>

--- a/modules/features/player/src/main/res/layout/view_mini_player.xml
+++ b/modules/features/player/src/main/res/layout/view_mini_player.xml
@@ -4,7 +4,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
-        <variable name="upNextCount" type="int"/>
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -97,9 +96,7 @@
             android:letterSpacing="-0.05"
             android:fontFamily="sans-serif-medium"
             android:gravity="center"
-            android:text="@{`` + upNextCount}"
             android:textColor="?attr/primary_ui_01"
-            android:visibility="@{upNextCount > 0}"
             app:layout_constraintBottom_toTopOf="@+id/progressBar"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/modules/features/player/src/main/res/layout/view_mini_player.xml
+++ b/modules/features/player/src/main/res/layout/view_mini_player.xml
@@ -4,7 +4,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
-        <variable name="tintColor" type="int"/>
         <variable name="upNextCount" type="int"/>
     </data>
 

--- a/modules/features/player/src/main/res/layout/view_mini_player.xml
+++ b/modules/features/player/src/main/res/layout/view_mini_player.xml
@@ -4,7 +4,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
-        <variable name="playbackState" type="au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState" />
         <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast" />
         <variable name="tintColor" type="int"/>
         <variable name="upNextCount" type="int"/>

--- a/modules/features/player/src/main/res/layout/view_mini_player.xml
+++ b/modules/features/player/src/main/res/layout/view_mini_player.xml
@@ -68,7 +68,6 @@
             android:scaleType="centerInside"
             android:clickable="false"
             android:contentDescription="@string/skip_back"
-            app:tint="@{tintColor}"
             app:layout_constraintBottom_toTopOf="@+id/progressBar"
             app:layout_constraintEnd_toStartOf="@+id/miniPlayButton"
             app:layout_constraintTop_toTopOf="parent"

--- a/modules/features/player/src/main/res/layout/view_mini_player.xml
+++ b/modules/features/player/src/main/res/layout/view_mini_player.xml
@@ -1,117 +1,109 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:tools="http://schemas.android.com/tools"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="68dp"
+    android:focusable="true"
+    android:clickable="true"
+    android:contentDescription="@string/player_open_full_size_player">
 
-    <data>
-    </data>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <View
+        android:id="@+id/miniPlayerTint"
         android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?attr/primary_ui_01" />
+
+    <ImageView
+        android:id="@+id/artwork"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_marginStart="8dp"
+        android:background="@drawable/round_corners_2dp"
+        app:clipToOutline="@{true}"
+        app:layout_constraintBottom_toTopOf="@+id/progressBar"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageButton
+        android:id="@+id/skipForward"
+        android:layout_width="68dp"
         android:layout_height="68dp"
-        android:focusable="true"
-        android:clickable="true"
-        android:contentDescription="@string/player_open_full_size_player">
+        android:layout_marginStart="8dp"
+        android:background="?android:attr/actionBarItemBackground"
+        android:scaleType="centerInside"
+        android:clickable="false"
+        android:contentDescription="@string/skip_forward"
+        app:layout_constraintBottom_toTopOf="@+id/progressBar"
+        app:layout_constraintStart_toEndOf="@+id/miniPlayButton"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/mini_player_skip_forward" />
 
-        <View
-            android:id="@+id/miniPlayerTint"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="?attr/primary_ui_01" />
+    <com.airbnb.lottie.LottieAnimationView
+        android:id="@+id/miniPlayButton"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:background="@drawable/mini_player_play_background"
+        android:scaleType="centerInside"
+        android:clickable="false"
+        app:lottie_rawRes="@raw/mini_player_play_button"
+        app:layout_constraintBottom_toTopOf="@+id/progressBar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <ImageView
-            android:id="@+id/artwork"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:layout_marginStart="8dp"
-            android:background="@drawable/round_corners_2dp"
-            app:clipToOutline="@{true}"
-            app:layout_constraintBottom_toTopOf="@+id/progressBar"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+    <ImageButton
+        android:id="@+id/skipBack"
+        android:layout_width="68dp"
+        android:layout_height="68dp"
+        android:layout_marginEnd="8dp"
+        android:background="?android:attr/actionBarItemBackground"
+        android:scaleType="centerInside"
+        android:clickable="false"
+        android:contentDescription="@string/skip_back"
+        app:layout_constraintBottom_toTopOf="@+id/progressBar"
+        app:layout_constraintEnd_toStartOf="@+id/miniPlayButton"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/mini_player_skip_back" />
 
-        <ImageButton
-            android:id="@+id/skipForward"
-            android:layout_width="68dp"
-            android:layout_height="68dp"
-            android:layout_marginStart="8dp"
-            android:background="?android:attr/actionBarItemBackground"
-            android:scaleType="centerInside"
-            android:clickable="false"
-            android:contentDescription="@string/skip_forward"
-            app:layout_constraintBottom_toTopOf="@+id/progressBar"
-            app:layout_constraintStart_toEndOf="@+id/miniPlayButton"
-            app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/mini_player_skip_forward" />
+    <ImageButton
+        android:id="@+id/upNextButton"
+        android:layout_width="68dp"
+        android:layout_height="68dp"
+        android:background="?android:attr/actionBarItemBackground"
+        android:scaleType="centerInside"
+        android:clickable="false"
+        android:contentDescription="@string/player_up_next"
+        app:layout_constraintBottom_toTopOf="@+id/progressBar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <com.airbnb.lottie.LottieAnimationView
-            android:id="@+id/miniPlayButton"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:background="@drawable/mini_player_play_background"
-            android:scaleType="centerInside"
-            android:clickable="false"
-            app:lottie_rawRes="@raw/mini_player_play_button"
-            app:layout_constraintBottom_toTopOf="@+id/progressBar"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+    <TextView
+        android:id="@+id/countText"
+        android:layout_width="19dp"
+        android:layout_height="19dp"
+        android:layout_marginEnd="30.5dp"
+        android:textStyle="bold"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="8sp"
+        app:autoSizeMaxTextSize="16sp"
+        app:autoSizeStepGranularity="1sp"
+        android:letterSpacing="-0.05"
+        android:fontFamily="sans-serif-medium"
+        android:gravity="center"
+        android:textColor="?attr/primary_ui_01"
+        app:layout_constraintBottom_toTopOf="@+id/progressBar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <ImageButton
-            android:id="@+id/skipBack"
-            android:layout_width="68dp"
-            android:layout_height="68dp"
-            android:layout_marginEnd="8dp"
-            android:background="?android:attr/actionBarItemBackground"
-            android:scaleType="centerInside"
-            android:clickable="false"
-            android:contentDescription="@string/skip_back"
-            app:layout_constraintBottom_toTopOf="@+id/progressBar"
-            app:layout_constraintEnd_toStartOf="@+id/miniPlayButton"
-            app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/mini_player_skip_back" />
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="0dp"
+        android:layout_height="3dp"
+        android:layout_gravity="center"
+        android:progressDrawable="@drawable/mini_player_progress_bar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        style="@style/Widget.AppCompat.ProgressBar.Horizontal" />
 
-        <ImageButton
-            android:id="@+id/upNextButton"
-            android:layout_width="68dp"
-            android:layout_height="68dp"
-            android:background="?android:attr/actionBarItemBackground"
-            android:scaleType="centerInside"
-            android:clickable="false"
-            android:contentDescription="@string/player_up_next"
-            app:layout_constraintBottom_toTopOf="@+id/progressBar"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:id="@+id/countText"
-            android:layout_width="19dp"
-            android:layout_height="19dp"
-            android:layout_marginEnd="30.5dp"
-            android:textStyle="bold"
-            app:autoSizeTextType="uniform"
-            app:autoSizeMinTextSize="8sp"
-            app:autoSizeMaxTextSize="16sp"
-            app:autoSizeStepGranularity="1sp"
-            android:letterSpacing="-0.05"
-            android:fontFamily="sans-serif-medium"
-            android:gravity="center"
-            android:textColor="?attr/primary_ui_01"
-            app:layout_constraintBottom_toTopOf="@+id/progressBar"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <ProgressBar
-            android:id="@+id/progressBar"
-            android:layout_width="0dp"
-            android:layout_height="3dp"
-            android:layout_gravity="center"
-            android:progressDrawable="@drawable/mini_player_progress_bar"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            style="@style/Widget.AppCompat.ProgressBar.Horizontal" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-</layout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/modules/features/player/src/main/res/layout/view_mini_player.xml
+++ b/modules/features/player/src/main/res/layout/view_mini_player.xml
@@ -5,7 +5,6 @@
 
     <data>
         <variable name="playbackState" type="au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState" />
-        <variable name="episode" type="au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode" />
         <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast" />
         <variable name="tintColor" type="int"/>
         <variable name="upNextCount" type="int"/>


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Related to: #1908 

This PR migrates the mini player from data binding to view binding.

## Review hints

1. I've prepared this PR in a way that it's easy to review the change commit by commit, and I advise doing so.
2. I find it helpful to check "Hide white spaces" option. It makes much more easy to review some XML changes, as indentation in the file was changed. 

![image](https://github.com/Automattic/pocket-casts-android/assets/5845095/f778447f-2a75-4c80-81c6-e2bd1695b88c)

## Testing Instructions

Please carefully smoke test the mini player. Tap all the buttons, navigate to full player or “up next” queue. Play episodes from different podcasts and observe if the colors of control buttons and seek bars are as expected.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
