### PR TITLE
Migrate notes from data binding

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
@@ -30,6 +30,7 @@ import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.extensions.showIf
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.IntentUtil
+import au.com.shiftyjelly.pocketcasts.views.helper.ViewDataBindings.applyTimeLong
 import au.com.shiftyjelly.pocketcasts.views.helper.ViewDataBindings.setLongStyleDate
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -72,6 +73,7 @@ class NotesFragment : BaseFragment() {
             binding?.root?.setBackgroundColor(backgroundColor)
             binding?.showNotes?.setBackgroundColor(backgroundColor)
             binding?.date?.setLongStyleDate(episode.publishedDate)
+            binding?.time?.applyTimeLong(episode.durationMs)
         }
 
         binding = FragmentNotesBinding.inflate(inflater, container, false)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
@@ -30,6 +30,7 @@ import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.extensions.showIf
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.IntentUtil
+import au.com.shiftyjelly.pocketcasts.views.helper.ViewDataBindings.setLongStyleDate
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import timber.log.Timber
@@ -69,6 +70,7 @@ class NotesFragment : BaseFragment() {
 
             binding?.root?.setBackgroundColor(it.second)
             binding?.showNotes?.setBackgroundColor(it.second)
+            binding?.date?.setLongStyleDate(it.first.publishedDate)
         }
 
         binding = FragmentNotesBinding.inflate(inflater, container, false)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
@@ -66,11 +66,12 @@ class NotesFragment : BaseFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         playerViewModel.playingEpisodeLive.observe(viewLifecycleOwner) {
-            viewModel.loadEpisode(it.first, it.second)
+            val (episode, backgroundColor) = it
+            viewModel.loadEpisode(episode, backgroundColor)
 
-            binding?.root?.setBackgroundColor(it.second)
-            binding?.showNotes?.setBackgroundColor(it.second)
-            binding?.date?.setLongStyleDate(it.first.publishedDate)
+            binding?.root?.setBackgroundColor(backgroundColor)
+            binding?.showNotes?.setBackgroundColor(backgroundColor)
+            binding?.date?.setLongStyleDate(episode.publishedDate)
         }
 
         binding = FragmentNotesBinding.inflate(inflater, container, false)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
@@ -78,7 +78,6 @@ class NotesFragment : BaseFragment() {
         }
 
         binding = FragmentNotesBinding.inflate(inflater, container, false)
-        binding?.lifecycleOwner = viewLifecycleOwner
 
         binding?.progressBar?.apply {
             setIndicatorColor(ThemeColor.playerContrast03(theme.activeTheme))
@@ -97,8 +96,6 @@ class NotesFragment : BaseFragment() {
             val notes = if (state is ShowNotesState.Loaded) state.showNotes else ""
             loadShowNotes(notes)
         }
-
-        binding?.viewModel = viewModel
 
         return binding?.root
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
@@ -72,6 +72,7 @@ class NotesFragment : BaseFragment() {
 
             binding?.root?.setBackgroundColor(backgroundColor)
             binding?.showNotes?.setBackgroundColor(backgroundColor)
+            binding?.title?.text = episode.title
             binding?.date?.setLongStyleDate(episode.publishedDate)
             binding?.time?.applyTimeLong(episode.durationMs)
         }

--- a/modules/features/player/src/main/res/layout/fragment_notes.xml
+++ b/modules/features/player/src/main/res/layout/fragment_notes.xml
@@ -30,7 +30,6 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:layout_marginTop="8dp"
-                android:text="@{viewModel.episode.title}"
                 android:paddingStart="16dp"
                 android:paddingEnd="16dp"
                 android:textColor="?attr/player_contrast_01"

--- a/modules/features/player/src/main/res/layout/fragment_notes.xml
+++ b/modules/features/player/src/main/res/layout/fragment_notes.xml
@@ -60,7 +60,6 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical"
-                    app:mediumDate="@{viewModel.episode.publishedDate}"
                     tools:text="16th November"
                     style="@style/DarkSubtitle2"
                     android:textColor="?attr/player_contrast_02" />

--- a/modules/features/player/src/main/res/layout/fragment_notes.xml
+++ b/modules/features/player/src/main/res/layout/fragment_notes.xml
@@ -84,7 +84,6 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical"
-                    app:timeLong="@{viewModel.episode.durationMs}"
                     tools:text="23 minutes"
                     style="@style/DarkSubtitle2"
                     android:textColor="?attr/player_contrast_02" />

--- a/modules/features/player/src/main/res/layout/fragment_notes.xml
+++ b/modules/features/player/src/main/res/layout/fragment_notes.xml
@@ -1,134 +1,123 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:theme="@style/PlayerTheme"
+    android:background="#000000"
+    android:scrollbars="vertical"
+    android:fillViewport="true" >
 
-    <data>
-
-        <variable
-            name="viewModel"
-            type="au.com.shiftyjelly.pocketcasts.player.viewmodel.NotesViewModel" />
-    </data>
-
-    <androidx.core.widget.NestedScrollView
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:theme="@style/PlayerTheme"
-        android:background="#000000"
-        android:scrollbars="vertical"
-        android:fillViewport="true" >
+        android:orientation="vertical"
+        android:paddingTop="0dp">
+
+        <TextView
+            android:id="@+id/title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginTop="8dp"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:textColor="?attr/player_contrast_01"
+            style="@style/H20" />
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical"
-            android:paddingTop="0dp">
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginTop="16dp"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp">
+
+            <ImageView
+                android:layout_width="17dp"
+                android:layout_height="18dp"
+                android:layout_gravity="center_vertical"
+                app:srcCompat="@drawable/ic_calendar"
+                app:tint="?attr/player_contrast_02" />
+
+            <Space
+                android:layout_width="8dp"
+                android:layout_height="match_parent" />
 
             <TextView
-                android:id="@+id/title"
-                android:layout_width="match_parent"
+                android:id="@+id/date"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
-                android:layout_marginTop="8dp"
-                android:paddingStart="16dp"
-                android:paddingEnd="16dp"
-                android:textColor="?attr/player_contrast_01"
-                style="@style/H20" />
+                tools:text="16th November"
+                style="@style/DarkSubtitle2"
+                android:textColor="?attr/player_contrast_02" />
 
-            <LinearLayout
-                android:layout_width="match_parent"
+            <Space
+                android:layout_width="8dp"
+                android:layout_height="match_parent" />
+
+            <ImageView
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:layout_marginTop="16dp"
-                android:paddingStart="16dp"
-                android:paddingEnd="16dp">
+                android:layout_gravity="center_vertical"
+                app:tint="?attr/player_contrast_02"
+                app:srcCompat="@drawable/ic_duration" />
 
-                <ImageView
-                    android:layout_width="17dp"
-                    android:layout_height="18dp"
-                    android:layout_gravity="center_vertical"
-                    app:srcCompat="@drawable/ic_calendar"
-                    app:tint="?attr/player_contrast_02" />
-
-                <Space
-                    android:layout_width="8dp"
-                    android:layout_height="match_parent" />
-
-                <TextView
-                    android:id="@+id/date"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    tools:text="16th November"
-                    style="@style/DarkSubtitle2"
-                    android:textColor="?attr/player_contrast_02" />
-
-                <Space
-                    android:layout_width="8dp"
-                    android:layout_height="match_parent" />
-
-                <ImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    app:tint="?attr/player_contrast_02"
-                    app:srcCompat="@drawable/ic_duration" />
-
-                <Space
-                    android:layout_width="8dp"
-                    android:layout_height="match_parent" />
-
-                <TextView
-                    android:id="@+id/time"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    tools:text="23 minutes"
-                    style="@style/DarkSubtitle2"
-                    android:textColor="?attr/player_contrast_02" />
-            </LinearLayout>
-
-            <FrameLayout
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginStart="16dp"
-                android:layout_marginEnd="16dp"
-                android:layout_marginTop="16dp"
-                android:layout_marginBottom="16dp"
-                android:orientation="vertical">
-
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:background="?attr/player_contrast_05" />
-
-                <com.google.android.material.progressindicator.LinearProgressIndicator
-                    android:id="@+id/progressBar"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:indeterminate="true"
-                    android:visibility="gone" />
-
-            </FrameLayout>
-
-            <FrameLayout
-                android:id="@+id/showNotes"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingStart="16dp"
-                android:paddingEnd="16dp" />
+            <Space
+                android:layout_width="8dp"
+                android:layout_height="match_parent" />
 
             <TextView
-                android:id="@+id/showNotesErrorText"
-                style="@style/DarkBody2"
-                android:layout_width="match_parent"
+                android:id="@+id/time"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:paddingStart="16dp"
-                android:paddingEnd="16dp"
-                android:visibility="gone" />
-
+                android:layout_gravity="center_vertical"
+                tools:text="23 minutes"
+                style="@style/DarkSubtitle2"
+                android:textColor="?attr/player_contrast_02" />
         </LinearLayout>
 
-    </androidx.core.widget.NestedScrollView>
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"
+            android:orientation="vertical">
 
-</layout>
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="?attr/player_contrast_05" />
+
+            <com.google.android.material.progressindicator.LinearProgressIndicator
+                android:id="@+id/progressBar"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:indeterminate="true"
+                android:visibility="gone" />
+
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/showNotes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp" />
+
+        <TextView
+            android:id="@+id/showNotesErrorText"
+            style="@style/DarkBody2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:visibility="gone" />
+
+    </LinearLayout>
+
+</androidx.core.widget.NestedScrollView>

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ViewDataBindings.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ViewDataBindings.kt
@@ -74,6 +74,10 @@ object ViewDataBindings {
         }
     }
 
+    fun TextView.setLongStyleDate(date: Date?) {
+        text = date?.toLocalizedFormatLongStyle().orEmpty()
+    }
+
     @BindingAdapter("timeLeft")
     @JvmStatic
     fun setTimeLeft(textView: TextView, episode: BaseEpisode) {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ViewDataBindings.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ViewDataBindings.kt
@@ -107,4 +107,15 @@ object ViewDataBindings {
         textView.text = timeLeft.text
         textView.contentDescription = timeLeft.description
     }
+
+    fun TextView.applyTimeLong(time: Int) {
+        val timeLeft = TimeHelper.getTimeLeft(
+            currentTimeMs = 0,
+            durationMs = time.toLong(),
+            inProgress = false,
+            context = context,
+        )
+        text = timeLeft.text
+        contentDescription = timeLeft.description
+    }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Related to: #1908 

This PR migrates the notes/details screen from data binding to view binding.

## Review hints

1. I've prepared this PR in a way that it's easy to review the change commit by commit, and I advise doing so.
2. I find it helpful to check "Hide white spaces" option. It makes much more easy to review some XML changes, as indentation in the file was changed. 

![image](https://github.com/Automattic/pocket-casts-android/assets/5845095/f778447f-2a75-4c80-81c6-e2bd1695b88c)

## Testing Instructions

Please smoke test the notes/details screen on player. Assert the values are displayed as before this PR.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
