### PR TITLE
Migrate episode from data binding

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -225,6 +225,7 @@ class EpisodeFragment : BaseFragment() {
                         )
 
                         binding.episode = state.episode
+                        binding.lblTitle.text = state.episode.title
                         binding.podcast = state.podcast
                         binding.tintColor = iconColor
                         binding.podcastColor = ThemeColor.podcastIcon02(activeTheme, state.podcastColor)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -57,6 +57,7 @@ import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.IntentUtil
 import au.com.shiftyjelly.pocketcasts.views.helper.ShowNotesFormatter
+import au.com.shiftyjelly.pocketcasts.views.helper.ViewDataBindings.setLongStyleDate
 import au.com.shiftyjelly.pocketcasts.views.helper.WarningsHelper
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -227,6 +228,7 @@ class EpisodeFragment : BaseFragment() {
                         binding.episode = state.episode
                         binding.lblTitle.text = state.episode.title
                         binding.progressBar.progress = state.episode.playedPercentage
+                        binding.lblDate.setLongStyleDate(state.episode.publishedDate)
                         binding.podcast = state.podcast
                         binding.tintColor = iconColor
                         binding.podcastColor = ThemeColor.podcastIcon02(activeTheme, state.podcastColor)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -230,8 +230,6 @@ class EpisodeFragment : BaseFragment() {
                         binding.lblDate.setLongStyleDate(state.episode.publishedDate)
                         binding.lblAuthor.text = state.podcast.title
                         binding.lblAuthor.setTextColor(state.podcastColor)
-                        binding.tintColor = iconColor
-                        binding.podcastColor = ThemeColor.podcastIcon02(activeTheme, state.podcastColor)
 
                         binding.btnDownload.tintColor = iconColor
                         binding.btnAddToUpNext.tintColor = iconColor

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -229,6 +229,8 @@ class EpisodeFragment : BaseFragment() {
                         binding.progressBar.progress = state.episode.playedPercentage
                         binding.lblDate.setLongStyleDate(state.episode.publishedDate)
                         binding.podcast = state.podcast
+                        binding.lblAuthor.text = state.podcast.title
+                        binding.lblAuthor.setTextColor(state.podcastColor)
                         binding.tintColor = iconColor
                         binding.podcastColor = ThemeColor.podcastIcon02(activeTheme, state.podcastColor)
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -225,7 +225,6 @@ class EpisodeFragment : BaseFragment() {
                             ),
                         )
 
-                        binding.episode = state.episode
                         binding.lblTitle.text = state.episode.title
                         binding.progressBar.progress = state.episode.playedPercentage
                         binding.lblDate.setLongStyleDate(state.episode.publishedDate)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -226,6 +226,7 @@ class EpisodeFragment : BaseFragment() {
 
                         binding.episode = state.episode
                         binding.lblTitle.text = state.episode.title
+                        binding.progressBar.progress = state.episode.playedPercentage
                         binding.podcast = state.podcast
                         binding.tintColor = iconColor
                         binding.podcastColor = ThemeColor.podcastIcon02(activeTheme, state.podcastColor)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -228,7 +228,6 @@ class EpisodeFragment : BaseFragment() {
                         binding.lblTitle.text = state.episode.title
                         binding.progressBar.progress = state.episode.playedPercentage
                         binding.lblDate.setLongStyleDate(state.episode.publishedDate)
-                        binding.podcast = state.podcast
                         binding.lblAuthor.text = state.podcast.title
                         binding.lblAuthor.setTextColor(state.podcastColor)
                         binding.tintColor = iconColor

--- a/modules/features/podcasts/src/main/res/layout-land/fragment_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/fragment_episode.xml
@@ -6,10 +6,6 @@
     <data>
 
         <variable
-            name="podcast"
-            type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast" />
-
-        <variable
             name="tintColor"
             type="int" />
 

--- a/modules/features/podcasts/src/main/res/layout-land/fragment_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/fragment_episode.xml
@@ -6,10 +6,6 @@
     <data>
 
         <variable
-            name="episode"
-            type="au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode" />
-
-        <variable
             name="podcast"
             type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast" />
 

--- a/modules/features/podcasts/src/main/res/layout-land/fragment_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/fragment_episode.xml
@@ -71,7 +71,6 @@
                 android:layout_marginStart="@dimen/episode_card_edge_padding"
                 android:layout_marginEnd="@dimen/episode_card_edge_padding"
                 android:gravity="start"
-                android:text="@{episode.title}"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintLeft_toRightOf="@id/episodeArt"
                 app:layout_constraintRight_toRightOf="parent"

--- a/modules/features/podcasts/src/main/res/layout-land/fragment_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/fragment_episode.xml
@@ -82,8 +82,6 @@
                 android:drawableRight="@drawable/ic_chevron_right"
                 android:drawablePadding="8dp"
                 android:gravity="start"
-                android:text="@{podcast.title}"
-                android:textColor="@{podcastColor}"
                 app:layout_constraintLeft_toLeftOf="@id/lblTitle"
                 app:layout_constraintTop_toBottomOf="@+id/lblTitle"
                 tools:text="Invisibilia" />

--- a/modules/features/podcasts/src/main/res/layout-land/fragment_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/fragment_episode.xml
@@ -231,7 +231,6 @@
                 android:layout_height="3dp"
                 android:indeterminate="false"
                 android:max="100"
-                android:progress="@{episode.playedPercentage}"
                 android:progressDrawable="@drawable/progress_bar"
                 app:layout_constraintBottom_toBottomOf="@id/bottomDivider"
                 app:layout_constraintLeft_toLeftOf="parent"

--- a/modules/features/podcasts/src/main/res/layout-land/fragment_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/fragment_episode.xml
@@ -245,7 +245,6 @@
                 android:layout_marginStart="@dimen/episode_card_edge_padding"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/bottomDivider"
-                app:mediumDate="@{episode.publishedDate}"
                 tools:text="3 December 2018" />
 
             <TextView

--- a/modules/features/podcasts/src/main/res/layout-land/fragment_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/fragment_episode.xml
@@ -1,283 +1,269 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/primary_ui_01">
 
-    <data>
-
-        <variable
-            name="tintColor"
-            type="int" />
-
-        <variable
-            name="podcastColor"
-            type="int" />
-    </data>
-
-    <androidx.core.widget.NestedScrollView
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="?attr/primary_ui_01">
+        android:layout_height="wrap_content"
+        android:clickable="true"
+        android:focusable="true"
+        android:paddingBottom="32dp">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/loadingGroup"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="lblDate,lblTimeLeft,btnDownload, btnShare, btnFav, btnAddToUpNext, btnArchive, btnPlay, btnPlayed"
+            android:visibility="gone"
+            tools:visibility="visible"
+            />
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/episodeArt"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginStart="@dimen/episode_card_edge_padding"
+            android:layout_marginEnd="@dimen/episode_card_edge_padding"
+            app:cardCornerRadius="10dp"
+            app:cardElevation="16dp"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/podcastArtwork"
+                android:layout_width="@dimen/episode_card_image_size"
+                android:layout_height="@dimen/episode_card_image_size" />
+
+        </androidx.cardview.widget.CardView>
+
+        <TextView
+            android:id="@+id/lblTitle"
+            style="?attr/textH2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginStart="@dimen/episode_card_edge_padding"
+            android:layout_marginEnd="@dimen/episode_card_edge_padding"
+            android:gravity="start"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintLeft_toRightOf="@id/episodeArt"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/episodeArt"
+            tools:text="Vergecast 193: Encryption in the hype matrix" />
+
+        <TextView
+            android:id="@+id/lblAuthor"
+            style="?attr/textH4"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:drawableRight="@drawable/ic_chevron_right"
+            android:drawablePadding="8dp"
+            android:gravity="start"
+            app:layout_constraintLeft_toLeftOf="@id/lblTitle"
+            app:layout_constraintTop_toBottomOf="@+id/lblTitle"
+            tools:text="Invisibilia" />
+
+        <View
+            android:id="@+id/topDivider"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/divider_height"
+            android:background="?attr/primary_ui_05"
+            app:layout_constraintBottom_toBottomOf="@+id/btnPlay"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/btnPlay" />
+
+        <au.com.shiftyjelly.pocketcasts.views.buttons.AnimatedPlayButton
+            android:id="@+id/btnPlay"
+            android:layout_width="@dimen/episode_card_dimen"
+            android:layout_height="@dimen/episode_card_dimen"
+            android:layout_marginTop="16dp"
+            app:icon_height="38dp"
+            app:icon_tint="?attr/primary_ui_01"
+            app:icon_width="38dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/episodeArt" />
+
+        <au.com.shiftyjelly.pocketcasts.podcasts.view.episode.DownloadButton
+            android:id="@+id/btnDownload"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:layout_marginBottom="20dp"
+            app:layout_constraintBottom_toTopOf="@+id/errorLayout"
+            app:layout_constraintEnd_toStartOf="@+id/btnAddToUpNext"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/topDivider"
+            tools:background="@tools:sample/avatars"
+            tools:text="Download" />
+
+        <au.com.shiftyjelly.pocketcasts.podcasts.view.episode.ToggleActionButton
+            android:id="@+id/btnAddToUpNext"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            tools:background="@tools:sample/avatars"
+            app:layout_constraintStart_toEndOf="@+id/btnDownload"
+            app:layout_constraintEnd_toStartOf="@+id/btnPadding"
+            app:layout_constraintTop_toTopOf="@+id/btnDownload"
+            app:layout_constraintHorizontal_chainStyle="packed" />
+
+        <View
+            android:id="@+id/btnPadding"
+            android:layout_width="@dimen/episode_card_action_middle_padding"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="@+id/btnPlay"
+            app:layout_constraintStart_toStartOf="@+id/btnPlay"
+            app:layout_constraintTop_toTopOf="@+id/btnDownload"
+            app:layout_constraintHorizontal_chainStyle="packed" />
+
+        <au.com.shiftyjelly.pocketcasts.podcasts.view.episode.ToggleActionButton
+            android:id="@+id/btnPlayed"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            tools:background="@tools:sample/avatars"
+            app:layout_constraintEnd_toStartOf="@+id/btnArchive"
+            app:layout_constraintStart_toEndOf="@+id/btnPadding"
+            app:layout_constraintTop_toTopOf="@+id/btnDownload"
+            app:layout_constraintHorizontal_chainStyle="packed" />
+
+        <au.com.shiftyjelly.pocketcasts.podcasts.view.episode.ToggleActionButton
+            android:id="@+id/btnArchive"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toEndOf="@+id/btnPlayed"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/btnDownload"
+            tools:background="@tools:sample/avatars" />
+
+        <LinearLayout
+            android:id="@+id/errorLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:clickable="true"
-            android:focusable="true"
-            android:paddingBottom="32dp">
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="20dp"
+            android:background="@drawable/background_episode_card_error_layout"
+            android:orientation="horizontal"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="13dp"
+            android:paddingBottom="13dp"
+            android:visibility="visible"
+            app:layout_constraintBottom_toTopOf="@+id/bottomDivider"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
 
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/loadingGroup"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:constraint_referenced_ids="lblDate,lblTimeLeft,btnDownload, btnShare, btnFav, btnAddToUpNext, btnArchive, btnPlay, btnPlayed"
-                android:visibility="gone"
-                tools:visibility="visible"
-                />
-
-            <androidx.cardview.widget.CardView
-                android:id="@+id/episodeArt"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:layout_marginStart="@dimen/episode_card_edge_padding"
-                android:layout_marginEnd="@dimen/episode_card_edge_padding"
-                app:cardCornerRadius="10dp"
-                app:cardElevation="16dp"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
-
-                <ImageView
-                    android:id="@+id/podcastArtwork"
-                    android:layout_width="@dimen/episode_card_image_size"
-                    android:layout_height="@dimen/episode_card_image_size" />
-
-            </androidx.cardview.widget.CardView>
-
-            <TextView
-                android:id="@+id/lblTitle"
-                style="?attr/textH2"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:layout_marginStart="@dimen/episode_card_edge_padding"
-                android:layout_marginEnd="@dimen/episode_card_edge_padding"
-                android:gravity="start"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintLeft_toRightOf="@id/episodeArt"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/episodeArt"
-                tools:text="Vergecast 193: Encryption in the hype matrix" />
-
-            <TextView
-                android:id="@+id/lblAuthor"
-                style="?attr/textH4"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:drawableRight="@drawable/ic_chevron_right"
-                android:drawablePadding="8dp"
-                android:gravity="start"
-                app:layout_constraintLeft_toLeftOf="@id/lblTitle"
-                app:layout_constraintTop_toBottomOf="@+id/lblTitle"
-                tools:text="Invisibilia" />
-
-            <View
-                android:id="@+id/topDivider"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/divider_height"
-                android:background="?attr/primary_ui_05"
-                app:layout_constraintBottom_toBottomOf="@+id/btnPlay"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/btnPlay" />
-
-            <au.com.shiftyjelly.pocketcasts.views.buttons.AnimatedPlayButton
-                android:id="@+id/btnPlay"
-                android:layout_width="@dimen/episode_card_dimen"
-                android:layout_height="@dimen/episode_card_dimen"
-                android:layout_marginTop="16dp"
-                app:icon_height="38dp"
-                app:icon_tint="?attr/primary_ui_01"
-                app:icon_width="38dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/episodeArt" />
-
-            <au.com.shiftyjelly.pocketcasts.podcasts.view.episode.DownloadButton
-                android:id="@+id/btnDownload"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
-                android:layout_marginBottom="20dp"
-                app:layout_constraintBottom_toTopOf="@+id/errorLayout"
-                app:layout_constraintEnd_toStartOf="@+id/btnAddToUpNext"
-                app:layout_constraintHorizontal_chainStyle="packed"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/topDivider"
-                tools:background="@tools:sample/avatars"
-                tools:text="Download" />
-
-            <au.com.shiftyjelly.pocketcasts.podcasts.view.episode.ToggleActionButton
-                android:id="@+id/btnAddToUpNext"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                tools:background="@tools:sample/avatars"
-                app:layout_constraintStart_toEndOf="@+id/btnDownload"
-                app:layout_constraintEnd_toStartOf="@+id/btnPadding"
-                app:layout_constraintTop_toTopOf="@+id/btnDownload"
-                app:layout_constraintHorizontal_chainStyle="packed" />
-
-            <View
-                android:id="@+id/btnPadding"
-                android:layout_width="@dimen/episode_card_action_middle_padding"
-                android:layout_height="wrap_content"
-                app:layout_constraintEnd_toEndOf="@+id/btnPlay"
-                app:layout_constraintStart_toStartOf="@+id/btnPlay"
-                app:layout_constraintTop_toTopOf="@+id/btnDownload"
-                app:layout_constraintHorizontal_chainStyle="packed" />
-
-            <au.com.shiftyjelly.pocketcasts.podcasts.view.episode.ToggleActionButton
-                android:id="@+id/btnPlayed"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                tools:background="@tools:sample/avatars"
-                app:layout_constraintEnd_toStartOf="@+id/btnArchive"
-                app:layout_constraintStart_toEndOf="@+id/btnPadding"
-                app:layout_constraintTop_toTopOf="@+id/btnDownload"
-                app:layout_constraintHorizontal_chainStyle="packed" />
-
-            <au.com.shiftyjelly.pocketcasts.podcasts.view.episode.ToggleActionButton
-                android:id="@+id/btnArchive"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                app:layout_constraintHorizontal_chainStyle="packed"
-                app:layout_constraintStart_toEndOf="@+id/btnPlayed"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/btnDownload"
-                tools:background="@tools:sample/avatars" />
+            <ImageView
+                android:id="@+id/imgError"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_gravity="center_vertical"
+                android:layout_marginEnd="16dp"
+                app:tint="?attr/colorIconMessage" />
 
             <LinearLayout
-                android:id="@+id/errorLayout"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
-                android:layout_marginEnd="16dp"
-                android:layout_marginBottom="20dp"
-                android:background="@drawable/background_episode_card_error_layout"
-                android:orientation="horizontal"
-                android:paddingStart="16dp"
-                android:paddingEnd="16dp"
-                android:paddingTop="13dp"
-                android:paddingBottom="13dp"
-                android:visibility="visible"
-                app:layout_constraintBottom_toTopOf="@+id/bottomDivider"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent">
-
-                <ImageView
-                    android:id="@+id/imgError"
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
-                    android:layout_gravity="center_vertical"
-                    android:layout_marginEnd="16dp"
-                    app:tint="?attr/colorIconMessage" />
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:gravity="center_vertical">
-                    <TextView
-                        android:id="@+id/lblError"
-                        style="?attr/textBody1"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        tools:text="Error downloading" />
-                    <TextView
-                        android:id="@+id/lblErrorDetail"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:paddingTop="8dp"
-                        style="?attr/textBody2" />
-                </LinearLayout>
-
-            </LinearLayout>
-
-            <View
-                android:id="@+id/bottomDivider"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/divider_height"
-                android:layout_marginTop="20dp"
-                android:background="?attr/primary_ui_05"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/errorLayout" />
-
-            <ProgressBar
-                android:id="@+id/progressBar"
-                style="?android:attr/progressBarStyleHorizontal"
-                android:layout_width="match_parent"
-                android:layout_height="3dp"
-                android:indeterminate="false"
-                android:max="100"
-                android:progressDrawable="@drawable/progress_bar"
-                app:layout_constraintBottom_toBottomOf="@id/bottomDivider"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent" />
-
-            <TextView
-                android:id="@+id/lblDate"
-                style="?attr/textCaption"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:layout_marginStart="@dimen/episode_card_edge_padding"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/bottomDivider"
-                tools:text="3 December 2018" />
-
-            <TextView
-                android:id="@+id/lblTimeLeft"
-                style="?attr/textCaption"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="@dimen/episode_card_edge_padding"
-                app:layout_constraintBottom_toBottomOf="@+id/lblDate"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/lblDate"
-                tools:text="1h 50m left" />
-
-            <FrameLayout
-                android:id="@+id/webViewShowNotes"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:paddingStart="@dimen/episode_card_edge_padding"
-                android:paddingEnd="@dimen/episode_card_edge_padding"
-                android:visibility="gone"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/lblDate" />
-
-            <ProgressBar
-                android:id="@+id/webViewLoader"
-                style="?android:attr/progressBarStyleSmall"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/lblDate" />
-
-            <androidx.constraintlayout.widget.Guideline
-                android:id="@+id/center_vertical_guideline"
-                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                app:layout_constraintGuide_percent="0.5" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.core.widget.NestedScrollView>
-</layout>
+                android:gravity="center_vertical">
+                <TextView
+                    android:id="@+id/lblError"
+                    style="?attr/textBody1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    tools:text="Error downloading" />
+                <TextView
+                    android:id="@+id/lblErrorDetail"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="8dp"
+                    style="?attr/textBody2" />
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <View
+            android:id="@+id/bottomDivider"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/divider_height"
+            android:layout_marginTop="20dp"
+            android:background="?attr/primary_ui_05"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/errorLayout" />
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="3dp"
+            android:indeterminate="false"
+            android:max="100"
+            android:progressDrawable="@drawable/progress_bar"
+            app:layout_constraintBottom_toBottomOf="@id/bottomDivider"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent" />
+
+        <TextView
+            android:id="@+id/lblDate"
+            style="?attr/textCaption"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:layout_marginStart="@dimen/episode_card_edge_padding"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/bottomDivider"
+            tools:text="3 December 2018" />
+
+        <TextView
+            android:id="@+id/lblTimeLeft"
+            style="?attr/textCaption"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/episode_card_edge_padding"
+            app:layout_constraintBottom_toBottomOf="@+id/lblDate"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/lblDate"
+            tools:text="1h 50m left" />
+
+        <FrameLayout
+            android:id="@+id/webViewShowNotes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:paddingStart="@dimen/episode_card_edge_padding"
+            android:paddingEnd="@dimen/episode_card_edge_padding"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/lblDate" />
+
+        <ProgressBar
+            android:id="@+id/webViewLoader"
+            style="?android:attr/progressBarStyleSmall"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/lblDate" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/center_vertical_guideline"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="0.5" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.core.widget.NestedScrollView>

--- a/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
@@ -6,10 +6,6 @@
     <data>
 
         <variable
-            name="podcast"
-            type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast" />
-
-        <variable
             name="tintColor"
             type="int" />
 

--- a/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
@@ -6,10 +6,6 @@
     <data>
 
         <variable
-            name="episode"
-            type="au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode" />
-
-        <variable
             name="podcast"
             type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast" />
 

--- a/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
@@ -1,348 +1,334 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="64dp"
+    android:clipToPadding="false"
+    android:background="?attr/primary_ui_01">
 
-    <data>
-
-        <variable
-            name="tintColor"
-            type="int" />
-
-        <variable
-            name="podcastColor"
-            type="int" />
-    </data>
-
-    <androidx.core.widget.NestedScrollView
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:paddingBottom="64dp"
-        android:clipToPadding="false"
-        android:background="?attr/primary_ui_01">
+        android:layout_height="wrap_content"
+        android:clickable="true"
+        android:focusable="true">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/loadingGroup"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:clickable="true"
-            android:focusable="true">
+            app:constraint_referenced_ids="lblDate,lblTimeLeft,lblAuthor,buttonGroupLayout"
+            android:visibility="invisible"
+            tools:visibility="visible" />
 
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/loadingGroup"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:constraint_referenced_ids="lblDate,lblTimeLeft,lblAuthor,buttonGroupLayout"
-                android:visibility="invisible"
-                tools:visibility="visible" />
-
-            <androidx.cardview.widget.CardView
-                android:id="@+id/episodeArt"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:layout_marginStart="@dimen/episode_card_edge_padding"
-                android:layout_marginEnd="@dimen/episode_card_edge_padding"
-                app:cardCornerRadius="10dp"
-                app:cardElevation="16dp"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                android:importantForAccessibility="noHideDescendants">
-
-                <ImageView
-                    android:id="@+id/podcastArtwork"
-                    android:layout_width="192dp"
-                    android:layout_height="192dp" />
-            </androidx.cardview.widget.CardView>
-
-            <TextView
-                android:id="@+id/lblTitle"
-                style="?attr/textH2"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:layout_marginStart="@dimen/episode_card_edge_padding"
-                android:layout_marginEnd="@dimen/episode_card_edge_padding"
-                android:gravity="center"
-                android:textColor="?attr/primary_text_01"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/episodeArt"
-                tools:text="Vergecast 193: Encryption in the hype matrix" />
-
-            <TextView
-                android:id="@+id/lblAuthor"
-                style="?attr/textH4"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:drawableRight="@drawable/ic_chevron_right"
-                android:drawablePadding="8dp"
-                android:gravity="center"
-                android:paddingStart="@dimen/episode_card_edge_padding"
-                android:paddingEnd="@dimen/episode_card_edge_padding"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/lblTitle"
-                tools:text="Invisibilia" />
-
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/buttonGroupLayout"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/lblAuthor">
-
-                <View
-                    android:id="@+id/topDivider"
-                    android:layout_width="0dp"
-                    android:layout_height="@dimen/divider_height"
-                    android:background="?attr/primary_ui_05"
-                    app:layout_constraintBottom_toBottomOf="@+id/btnPlay"
-                    app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintRight_toRightOf="parent"
-                    app:layout_constraintTop_toTopOf="@+id/btnPlay" />
-
-                <au.com.shiftyjelly.pocketcasts.views.buttons.AnimatedPlayButton
-                    android:id="@+id/btnPlay"
-                    android:layout_width="@dimen/episode_card_dimen"
-                    android:layout_height="@dimen/episode_card_dimen"
-                    android:layout_marginTop="16dp"
-                    app:icon_height="38dp"
-                    app:icon_tint="?attr/primary_ui_01"
-                    app:icon_width="38dp"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <au.com.shiftyjelly.pocketcasts.podcasts.view.episode.DownloadButton
-                    android:id="@+id/btnDownload"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="24dp"
-                    android:paddingBottom="5dp"
-                    app:layout_constraintEnd_toStartOf="@+id/btnAddToUpNext"
-                    app:layout_constraintHorizontal_chainStyle="packed"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/topDivider"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintVertical_bias="0.01"
-                    android:contentDescription="@string/download"
-                    tools:background="@tools:sample/avatars"
-                    tools:text="Download" />
-
-                <au.com.shiftyjelly.pocketcasts.podcasts.view.episode.ToggleActionButton
-                    android:id="@+id/btnAddToUpNext"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:paddingBottom="5dp"
-                    android:gravity="top"
-                    tools:background="@tools:sample/avatars"
-                    android:contentDescription="@string/add_to_up_next"
-                    app:layout_constraintStart_toEndOf="@+id/btnDownload"
-                    app:layout_constraintEnd_toStartOf="@+id/btnPadding"
-                    app:layout_constraintTop_toTopOf="@+id/btnDownload"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintVertical_bias="0.01"
-                    app:layout_constraintHorizontal_chainStyle="packed" />
-
-                <View
-                    android:id="@+id/btnPadding"
-                    android:layout_width="@dimen/episode_card_action_middle_padding"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintEnd_toEndOf="@+id/btnPlay"
-                    app:layout_constraintStart_toStartOf="@+id/btnPlay"
-                    app:layout_constraintTop_toTopOf="@+id/btnDownload"
-                    app:layout_constraintHorizontal_chainStyle="packed" />
-
-                <au.com.shiftyjelly.pocketcasts.podcasts.view.episode.ToggleActionButton
-                    android:id="@+id/btnPlayed"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:paddingBottom="5dp"
-                    tools:background="@tools:sample/avatars"
-                    app:layout_constraintEnd_toStartOf="@+id/btnArchive"
-                    app:layout_constraintStart_toEndOf="@+id/btnPadding"
-                    app:layout_constraintTop_toTopOf="@+id/btnDownload"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintVertical_bias="0.01"
-                    app:layout_constraintHorizontal_chainStyle="packed" />
-
-                <au.com.shiftyjelly.pocketcasts.podcasts.view.episode.ToggleActionButton
-                    android:id="@+id/btnArchive"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:paddingBottom="5dp"
-                    app:layout_constraintHorizontal_chainStyle="packed"
-                    app:layout_constraintStart_toEndOf="@+id/btnPlayed"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="@+id/btnDownload"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintVertical_bias="0.01"
-                    tools:background="@tools:sample/avatars" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/errorLayout"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:visibility="invisible"
-                app:constraint_referenced_ids="errorBorder,imgError,lblError,lblErrorDetail,viewErrorPadding" />
-
-            <View
-                android:id="@+id/errorBorder"
-                android:layout_width="match_parent"
-                android:layout_height="0dp"
-                android:layout_marginStart="16dp"
-                android:layout_marginEnd="16dp"
-                android:background="@drawable/background_episode_card_error_layout"
-                app:layout_constraintTop_toTopOf="@+id/lblError"
-                app:layout_constraintBottom_toBottomOf="@+id/viewErrorPadding"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
+        <androidx.cardview.widget.CardView
+            android:id="@+id/episodeArt"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginStart="@dimen/episode_card_edge_padding"
+            android:layout_marginEnd="@dimen/episode_card_edge_padding"
+            app:cardCornerRadius="10dp"
+            app:cardElevation="16dp"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:importantForAccessibility="noHideDescendants">
 
             <ImageView
-                android:id="@+id/imgError"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_marginStart="31dp"
-                android:layout_marginTop="10dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/lblError"
-                tools:src="@drawable/ic_failedwarning"
-                app:tint="?attr/primary_icon_03" />
+                android:id="@+id/podcastArtwork"
+                android:layout_width="192dp"
+                android:layout_height="192dp" />
+        </androidx.cardview.widget.CardView>
 
-            <TextView
-                android:id="@+id/lblError"
-                style="?attr/textBody1"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:layout_marginStart="64dp"
-                android:layout_marginEnd="64dp"
-                android:paddingTop="10dp"
-                android:textColor="?attr/primary_text_01"
-                app:layout_constraintTop_toBottomOf="@+id/buttonGroupLayout"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                tools:text="Error downloading" />
+        <TextView
+            android:id="@+id/lblTitle"
+            style="?attr/textH2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginStart="@dimen/episode_card_edge_padding"
+            android:layout_marginEnd="@dimen/episode_card_edge_padding"
+            android:gravity="center"
+            android:textColor="?attr/primary_text_01"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/episodeArt"
+            tools:text="Vergecast 193: Encryption in the hype matrix" />
 
-            <TextView
-                android:id="@+id/lblErrorDetail"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:layout_marginStart="64dp"
-                android:layout_marginEnd="64dp"
-                android:paddingBottom="5dp"
-                android:textColor="?attr/primary_text_02"
-                app:layout_constraintTop_toBottomOf="@+id/lblError"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                tools:text="Really long error description"
-                style="?attr/textBody2" />
+        <TextView
+            android:id="@+id/lblAuthor"
+            style="?attr/textH4"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:drawableRight="@drawable/ic_chevron_right"
+            android:drawablePadding="8dp"
+            android:gravity="center"
+            android:paddingStart="@dimen/episode_card_edge_padding"
+            android:paddingEnd="@dimen/episode_card_edge_padding"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/lblTitle"
+            tools:text="Invisibilia" />
 
-            <View
-                android:id="@+id/viewErrorPadding"
-                android:layout_width="match_parent"
-                android:layout_height="13dp"
-                app:layout_constraintTop_toBottomOf="@+id/lblErrorDetail"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/buttonGroupLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/lblAuthor">
 
             <View
-                android:id="@+id/bottomDivider"
-                android:layout_width="match_parent"
+                android:id="@+id/topDivider"
+                android:layout_width="0dp"
                 android:layout_height="@dimen/divider_height"
-                android:layout_marginTop="20dp"
                 android:background="?attr/primary_ui_05"
+                app:layout_constraintBottom_toBottomOf="@+id/btnPlay"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/viewErrorPadding" />
+                app:layout_constraintTop_toTopOf="@+id/btnPlay" />
 
-            <ProgressBar
-                android:id="@+id/progressBar"
-                style="?android:attr/progressBarStyleHorizontal"
-                android:layout_width="match_parent"
-                android:layout_height="3dp"
-                android:indeterminate="false"
-                android:max="100"
-                android:progressDrawable="@drawable/progress_bar"
-                app:layout_constraintBottom_toBottomOf="@id/bottomDivider"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent" />
-
-            <TextView
-                android:id="@+id/lblDate"
-                style="?attr/textCaption"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:layout_marginStart="@dimen/episode_card_edge_padding"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/bottomDivider"
-                android:textColor="?attr/primary_text_02"
-                tools:text="3 December 2018" />
-
-            <TextView
-                android:id="@+id/lblTimeLeft"
-                style="?attr/textCaption"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="@dimen/episode_card_edge_padding"
-                app:layout_constraintBottom_toBottomOf="@+id/lblDate"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/lblDate"
-                android:textColor="?attr/primary_text_02"
-                tools:text="1h 50m left" />
-
-            <FrameLayout
-                android:id="@+id/webViewShowNotes"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+            <au.com.shiftyjelly.pocketcasts.views.buttons.AnimatedPlayButton
+                android:id="@+id/btnPlay"
+                android:layout_width="@dimen/episode_card_dimen"
+                android:layout_height="@dimen/episode_card_dimen"
                 android:layout_marginTop="16dp"
-                android:paddingStart="@dimen/episode_card_edge_padding"
-                android:paddingEnd="@dimen/episode_card_edge_padding"
-                android:visibility="gone"
+                app:icon_height="38dp"
+                app:icon_tint="?attr/primary_ui_01"
+                app:icon_width="38dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <au.com.shiftyjelly.pocketcasts.podcasts.view.episode.DownloadButton
+                android:id="@+id/btnDownload"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:paddingBottom="5dp"
+                app:layout_constraintEnd_toStartOf="@+id/btnAddToUpNext"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/topDivider"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/lblDate" />
+                app:layout_constraintVertical_bias="0.01"
+                android:contentDescription="@string/download"
+                tools:background="@tools:sample/avatars"
+                tools:text="Download" />
 
-            <TextView
-                android:id="@+id/webViewErrorText"
-                style="?attr/textBody2"
-                android:layout_width="match_parent"
+            <au.com.shiftyjelly.pocketcasts.podcasts.view.episode.ToggleActionButton
+                android:id="@+id/btnAddToUpNext"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:paddingStart="@dimen/episode_card_edge_padding"
-                android:paddingEnd="@dimen/episode_card_edge_padding"
-                android:visibility="gone"
-                android:textColor="?attr/primary_text_01"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/lblDate" />
-
-            <ProgressBar
-                android:id="@+id/webViewLoader"
-                style="?android:attr/progressBarStyleSmall"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
+                android:paddingBottom="5dp"
+                android:gravity="top"
+                tools:background="@tools:sample/avatars"
+                android:contentDescription="@string/add_to_up_next"
+                app:layout_constraintStart_toEndOf="@+id/btnDownload"
+                app:layout_constraintEnd_toStartOf="@+id/btnPadding"
+                app:layout_constraintTop_toTopOf="@+id/btnDownload"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/lblDate" />
+                app:layout_constraintVertical_bias="0.01"
+                app:layout_constraintHorizontal_chainStyle="packed" />
 
-            <androidx.constraintlayout.widget.Guideline
-                android:id="@+id/center_vertical_guideline"
-                android:layout_width="wrap_content"
+            <View
+                android:id="@+id/btnPadding"
+                android:layout_width="@dimen/episode_card_action_middle_padding"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                app:layout_constraintGuide_percent="0.5" />
+                app:layout_constraintEnd_toEndOf="@+id/btnPlay"
+                app:layout_constraintStart_toStartOf="@+id/btnPlay"
+                app:layout_constraintTop_toTopOf="@+id/btnDownload"
+                app:layout_constraintHorizontal_chainStyle="packed" />
+
+            <au.com.shiftyjelly.pocketcasts.podcasts.view.episode.ToggleActionButton
+                android:id="@+id/btnPlayed"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:paddingBottom="5dp"
+                tools:background="@tools:sample/avatars"
+                app:layout_constraintEnd_toStartOf="@+id/btnArchive"
+                app:layout_constraintStart_toEndOf="@+id/btnPadding"
+                app:layout_constraintTop_toTopOf="@+id/btnDownload"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintVertical_bias="0.01"
+                app:layout_constraintHorizontal_chainStyle="packed" />
+
+            <au.com.shiftyjelly.pocketcasts.podcasts.view.episode.ToggleActionButton
+                android:id="@+id/btnArchive"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:paddingBottom="5dp"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintStart_toEndOf="@+id/btnPlayed"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/btnDownload"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintVertical_bias="0.01"
+                tools:background="@tools:sample/avatars" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.core.widget.NestedScrollView>
-</layout>
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/errorLayout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="invisible"
+            app:constraint_referenced_ids="errorBorder,imgError,lblError,lblErrorDetail,viewErrorPadding" />
+
+        <View
+            android:id="@+id/errorBorder"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:background="@drawable/background_episode_card_error_layout"
+            app:layout_constraintTop_toTopOf="@+id/lblError"
+            app:layout_constraintBottom_toBottomOf="@+id/viewErrorPadding"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <ImageView
+            android:id="@+id/imgError"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="31dp"
+            android:layout_marginTop="10dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/lblError"
+            tools:src="@drawable/ic_failedwarning"
+            app:tint="?attr/primary_icon_03" />
+
+        <TextView
+            android:id="@+id/lblError"
+            style="?attr/textBody1"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:layout_marginStart="64dp"
+            android:layout_marginEnd="64dp"
+            android:paddingTop="10dp"
+            android:textColor="?attr/primary_text_01"
+            app:layout_constraintTop_toBottomOf="@+id/buttonGroupLayout"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="Error downloading" />
+
+        <TextView
+            android:id="@+id/lblErrorDetail"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginStart="64dp"
+            android:layout_marginEnd="64dp"
+            android:paddingBottom="5dp"
+            android:textColor="?attr/primary_text_02"
+            app:layout_constraintTop_toBottomOf="@+id/lblError"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="Really long error description"
+            style="?attr/textBody2" />
+
+        <View
+            android:id="@+id/viewErrorPadding"
+            android:layout_width="match_parent"
+            android:layout_height="13dp"
+            app:layout_constraintTop_toBottomOf="@+id/lblErrorDetail"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <View
+            android:id="@+id/bottomDivider"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/divider_height"
+            android:layout_marginTop="20dp"
+            android:background="?attr/primary_ui_05"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/viewErrorPadding" />
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="3dp"
+            android:indeterminate="false"
+            android:max="100"
+            android:progressDrawable="@drawable/progress_bar"
+            app:layout_constraintBottom_toBottomOf="@id/bottomDivider"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent" />
+
+        <TextView
+            android:id="@+id/lblDate"
+            style="?attr/textCaption"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:layout_marginStart="@dimen/episode_card_edge_padding"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/bottomDivider"
+            android:textColor="?attr/primary_text_02"
+            tools:text="3 December 2018" />
+
+        <TextView
+            android:id="@+id/lblTimeLeft"
+            style="?attr/textCaption"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/episode_card_edge_padding"
+            app:layout_constraintBottom_toBottomOf="@+id/lblDate"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/lblDate"
+            android:textColor="?attr/primary_text_02"
+            tools:text="1h 50m left" />
+
+        <FrameLayout
+            android:id="@+id/webViewShowNotes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:paddingStart="@dimen/episode_card_edge_padding"
+            android:paddingEnd="@dimen/episode_card_edge_padding"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/lblDate" />
+
+        <TextView
+            android:id="@+id/webViewErrorText"
+            style="?attr/textBody2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:paddingStart="@dimen/episode_card_edge_padding"
+            android:paddingEnd="@dimen/episode_card_edge_padding"
+            android:visibility="gone"
+            android:textColor="?attr/primary_text_01"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/lblDate" />
+
+        <ProgressBar
+            android:id="@+id/webViewLoader"
+            style="?android:attr/progressBarStyleSmall"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/lblDate" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/center_vertical_guideline"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="0.5" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.core.widget.NestedScrollView>

--- a/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
@@ -72,7 +72,6 @@
                 android:layout_marginStart="@dimen/episode_card_edge_padding"
                 android:layout_marginEnd="@dimen/episode_card_edge_padding"
                 android:gravity="center"
-                android:text="@{episode.title}"
                 android:textColor="?attr/primary_text_01"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintLeft_toLeftOf="parent"

--- a/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
@@ -84,8 +84,6 @@
                 android:drawableRight="@drawable/ic_chevron_right"
                 android:drawablePadding="8dp"
                 android:gravity="center"
-                android:text="@{podcast.title}"
-                android:textColor="@{podcastColor}"
                 android:paddingStart="@dimen/episode_card_edge_padding"
                 android:paddingEnd="@dimen/episode_card_edge_padding"
                 app:layout_constraintLeft_toLeftOf="parent"

--- a/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
@@ -294,7 +294,6 @@
                 android:layout_marginStart="@dimen/episode_card_edge_padding"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/bottomDivider"
-                app:mediumDate="@{episode.publishedDate}"
                 android:textColor="?attr/primary_text_02"
                 tools:text="3 December 2018" />
 

--- a/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
@@ -280,7 +280,6 @@
                 android:layout_height="3dp"
                 android:indeterminate="false"
                 android:max="100"
-                android:progress="@{episode.playedPercentage}"
                 android:progressDrawable="@drawable/progress_bar"
                 app:layout_constraintBottom_toBottomOf="@id/bottomDivider"
                 app:layout_constraintLeft_toLeftOf="parent"

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ViewDataBindings.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ViewDataBindings.kt
@@ -74,6 +74,10 @@ object ViewDataBindings {
         }
     }
 
+    fun TextView.setLongStyleDate(date: Date?) {
+        text = date?.toLocalizedFormatLongStyle().orEmpty()
+    }
+
     @BindingAdapter("timeLeft")
     @JvmStatic
     fun setTimeLeft(textView: TextView, episode: BaseEpisode) {


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Related to: #1908 

This PR migrates episode details view from data binding to view binding.

## Review hints

1. I've prepared this PR in a way that it's easy to review the change commit by commit, and I advise doing so.
2. I find it helpful to check "Hide white spaces" option. It makes much more easy to review some XML changes, as indentation in the file was changed. 

![image](https://github.com/Automattic/pocket-casts-android/assets/5845095/f778447f-2a75-4c80-81c6-e2bd1695b88c)

## Testing Instructions

Please smoke test the episode details view. Verify that the same content is displayed as on `main`. Verify both layouts - portrait and landscape.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
