### PR TITLE
Update categories UI

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoriesBottomSheet.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoriesBottomSheet.kt
@@ -8,10 +8,14 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.discover.R.layout
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import au.com.shiftyjelly.pocketcasts.servers.model.NetworkLoadableList
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 
-class CategoriesBottomSheet(private val categories: List<DiscoverCategory>) : BaseDialogFragment() {
+class CategoriesBottomSheet(
+    private val categories: List<DiscoverCategory>,
+    private val onCategoryClick: (NetworkLoadableList) -> Unit,
+) : BaseDialogFragment() {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -26,7 +30,10 @@ class CategoriesBottomSheet(private val categories: List<DiscoverCategory>) : Ba
         recyclerView.layoutManager =
             LinearLayoutManager(view.context, LinearLayoutManager.VERTICAL, false)
 
-        val adapter = CategoriesBottomSheetAdapter()
+        val adapter = CategoriesBottomSheetAdapter {
+            onCategoryClick(it)
+            dismiss()
+        }
         recyclerView.adapter = adapter
         adapter.submitList(categories)
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoriesBottomSheet.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoriesBottomSheet.kt
@@ -1,0 +1,39 @@
+package au.com.shiftyjelly.pocketcasts.discover.view
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import au.com.shiftyjelly.pocketcasts.discover.R.layout
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+
+class CategoriesBottomSheet(private val categories: List<DiscoverCategory>) : BaseDialogFragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View? {
+        return inflater.inflate(layout.fragment_categories_bottom_sheet, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val recyclerView: RecyclerView =
+            view.findViewById(au.com.shiftyjelly.pocketcasts.discover.R.id.categoriesRecyclerView)
+        recyclerView.layoutManager =
+            LinearLayoutManager(view.context, LinearLayoutManager.VERTICAL, false)
+
+        val adapter = CategoriesBottomSheetAdapter()
+        recyclerView.adapter = adapter
+        adapter.submitList(categories)
+
+        val behavior = BottomSheetBehavior.from(view.parent as View)
+        val windowHeight = resources.displayMetrics.heightPixels
+        val halfHeight = windowHeight / 2
+        behavior.peekHeight = halfHeight
+        behavior.state = BottomSheetBehavior.STATE_COLLAPSED
+    }
+}

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoriesBottomSheetAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoriesBottomSheetAdapter.kt
@@ -4,12 +4,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.discover.R
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import au.com.shiftyjelly.pocketcasts.servers.model.NetworkLoadableList
 import coil.load
 
 private val CATEGORY_DIFF = object : DiffUtil.ItemCallback<DiscoverCategory>() {
@@ -22,10 +24,11 @@ private val CATEGORY_DIFF = object : DiffUtil.ItemCallback<DiscoverCategory>() {
     }
 }
 
-class CategoriesBottomSheetAdapter : ListAdapter<DiscoverCategory, CategoriesBottomSheetAdapter.CategoryViewHolder>(CATEGORY_DIFF) {
+class CategoriesBottomSheetAdapter(val onCategoryClick: (NetworkLoadableList) -> Unit) : ListAdapter<DiscoverCategory, CategoriesBottomSheetAdapter.CategoryViewHolder>(CATEGORY_DIFF) {
     class CategoryViewHolder(val itemView: View) : RecyclerView.ViewHolder(itemView) {
         val categoryIcon: ImageView = itemView.findViewById(R.id.imageView)
         val categoryName: TextView = itemView.findViewById(R.id.lblTitle)
+        val itemCategoryLayout: LinearLayout = itemView.findViewById(R.id.itemCategoryLinear)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CategoryViewHolder {
@@ -38,5 +41,6 @@ class CategoriesBottomSheetAdapter : ListAdapter<DiscoverCategory, CategoriesBot
         val category = getItem(position)
         holder.categoryName.text = category.name
         holder.categoryIcon.load(category.icon)
+        holder.itemCategoryLayout.setOnClickListener { onCategoryClick(category) }
     }
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoriesBottomSheetAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoriesBottomSheetAdapter.kt
@@ -1,0 +1,42 @@
+package au.com.shiftyjelly.pocketcasts.discover.view
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import au.com.shiftyjelly.pocketcasts.discover.R
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import coil.load
+
+private val CATEGORY_DIFF = object : DiffUtil.ItemCallback<DiscoverCategory>() {
+    override fun areItemsTheSame(oldItem: DiscoverCategory, newItem: DiscoverCategory): Boolean {
+        return oldItem == newItem
+    }
+
+    override fun areContentsTheSame(oldItem: DiscoverCategory, newItem: DiscoverCategory): Boolean {
+        return oldItem.hashCode() == newItem.hashCode()
+    }
+}
+
+class CategoriesBottomSheetAdapter : ListAdapter<DiscoverCategory, CategoriesBottomSheetAdapter.CategoryViewHolder>(CATEGORY_DIFF) {
+    class CategoryViewHolder(val itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val categoryIcon: ImageView = itemView.findViewById(R.id.imageView)
+        val categoryName: TextView = itemView.findViewById(R.id.lblTitle)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CategoryViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val itemView = inflater.inflate(R.layout.item_category, parent, false)
+        return CategoryViewHolder(itemView)
+    }
+
+    override fun onBindViewHolder(holder: CategoryViewHolder, position: Int) {
+        val category = getItem(position)
+        holder.categoryName.text = category.name
+        holder.categoryIcon.load(category.icon)
+    }
+}

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoriesListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoriesListRowAdapter.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.discover.view
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -8,6 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.discover.databinding.ItemCategoryBinding
 import au.com.shiftyjelly.pocketcasts.discover.databinding.ItemCategoryRedesignBinding
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory.Companion.ALL_CATEGORIES_ID
 import au.com.shiftyjelly.pocketcasts.servers.model.NetworkLoadableList
 import coil.load
 
@@ -38,7 +40,7 @@ class CategoriesListRowAdapter(val onPodcastListClick: (NetworkLoadableList) -> 
         holder.itemView.setOnClickListener { onPodcastListClick(category) }
     }
 }
-class CategoriesListRowRedesignAdapter(val onPodcastListClick: (NetworkLoadableList) -> Unit) : ListAdapter<DiscoverCategory, CategoriesListRowRedesignAdapter.CategoriesRedesignViewHolder>(CATEGORY_DIFF) {
+class CategoriesListRowRedesignAdapter(val onPodcastListClick: (NetworkLoadableList) -> Unit, val onAllCategoriesClick: (View) -> Unit) : ListAdapter<DiscoverCategory, CategoriesListRowRedesignAdapter.CategoriesRedesignViewHolder>(CATEGORY_DIFF) {
 
     class CategoriesRedesignViewHolder(val binding: ItemCategoryRedesignBinding) : RecyclerView.ViewHolder(binding.root)
 
@@ -51,6 +53,13 @@ class CategoriesListRowRedesignAdapter(val onPodcastListClick: (NetworkLoadableL
         val category = getItem(position)
         holder.binding.categoryChip.text = category.name
         holder.binding.categoryChip.contentDescription = category.name
-        holder.itemView.setOnClickListener { onPodcastListClick(category) }
+
+        holder.itemView.setOnClickListener {
+            if (category.id == ALL_CATEGORIES_ID) {
+                onAllCategoriesClick(it)
+            } else {
+                onPodcastListClick(category)
+            }
+        }
     }
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoriesListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoriesListRowAdapter.kt
@@ -6,6 +6,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.discover.databinding.ItemCategoryBinding
+import au.com.shiftyjelly.pocketcasts.discover.databinding.ItemCategoryRedesignBinding
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.servers.model.NetworkLoadableList
 import coil.load
@@ -34,6 +35,22 @@ class CategoriesListRowAdapter(val onPodcastListClick: (NetworkLoadableList) -> 
         val category = getItem(position)
         holder.binding.lblTitle.text = category.name
         holder.binding.imageView.load(category.icon)
+        holder.itemView.setOnClickListener { onPodcastListClick(category) }
+    }
+}
+class CategoriesListRowRedesignAdapter(val onPodcastListClick: (NetworkLoadableList) -> Unit) : ListAdapter<DiscoverCategory, CategoriesListRowRedesignAdapter.CategoriesRedesignViewHolder>(CATEGORY_DIFF) {
+
+    class CategoriesRedesignViewHolder(val binding: ItemCategoryRedesignBinding) : RecyclerView.ViewHolder(binding.root)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CategoriesRedesignViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = ItemCategoryRedesignBinding.inflate(inflater, parent, false)
+        return CategoriesRedesignViewHolder(binding)
+    }
+    override fun onBindViewHolder(holder: CategoriesRedesignViewHolder, position: Int) {
+        val category = getItem(position)
+        holder.binding.categoryChip.text = category.name
+        holder.binding.categoryChip.contentDescription = category.name
         holder.itemView.setOnClickListener { onPodcastListClick(category) }
     }
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -43,6 +43,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.images.into
 import au.com.shiftyjelly.pocketcasts.servers.cdn.ArtworkColors
 import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServerManagerImpl
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory.Companion.ALL_CATEGORIES_ID
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverEpisode
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverRegion
@@ -108,6 +109,7 @@ internal class DiscoverAdapter(
         fun onEpisodePlayClicked(episode: DiscoverEpisode)
         fun onEpisodeStopClicked()
         fun onSearchClicked()
+        fun onAllCategoriesClicked(categories: List<DiscoverCategory>)
     }
 
     val loadPodcastList = { s: String ->
@@ -503,16 +505,20 @@ internal class DiscoverAdapter(
                     )
                 }
                 is CategoriesRedesignViewHolder -> {
-                    val adapter = CategoriesListRowRedesignAdapter(listener::onPodcastListClicked)
+                    var discoverCategories = emptyList<DiscoverCategory>()
+                    val adapter = CategoriesListRowRedesignAdapter(
+                        onPodcastListClick = listener::onPodcastListClicked,
+                        onAllCategoriesClick = { listener.onAllCategoriesClicked(discoverCategories) },
+                    )
                     holder.recyclerView?.adapter = adapter
                     holder.loadSingle(
                         service.getCategoriesList(row.source),
                         onSuccess = { categories ->
                             val context = holder.itemView.context
-                            val allCategories = DiscoverCategory(-1, context.getString(LR.string.discover_all_categories), "", "")
-                            val sortedCategories = categories.map { it.copy(name = it.name.tryToLocalise(resources)) }.take(7)
+                            val allCategories = DiscoverCategory(ALL_CATEGORIES_ID, context.getString(LR.string.discover_all_categories), "", "")
+                            discoverCategories = categories.map { it.copy(name = it.name.tryToLocalise(resources)) }.sortedBy { it.name }
 
-                            adapter.submitList(listOf(allCategories) + sortedCategories) {
+                            adapter.submitList(listOf(allCategories) + discoverCategories.take(7)) {
                                 onRestoreInstanceState(holder)
                             }
                         },

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -42,6 +42,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.images.into
 import au.com.shiftyjelly.pocketcasts.servers.cdn.ArtworkColors
 import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServerManagerImpl
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverEpisode
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverRegion
@@ -348,7 +349,7 @@ internal class DiscoverAdapter(
     }
     class CategoriesRedesignViewHolder(val binding: RowCategoriesRedesignBinding) : NetworkLoadableViewHolder(binding.root) {
         init {
-            recyclerView?.layoutManager = LinearLayoutManager(itemView.context, RecyclerView.VERTICAL, false)
+            recyclerView?.layoutManager = LinearLayoutManager(itemView.context, RecyclerView.HORIZONTAL, false)
         }
     }
 
@@ -502,18 +503,21 @@ internal class DiscoverAdapter(
                     )
                 }
                 is CategoriesRedesignViewHolder -> {
-                    val adapter = CategoriesListRowAdapter(listener::onPodcastListClicked)
+                    val adapter = CategoriesListRowRedesignAdapter(listener::onPodcastListClicked)
                     holder.recyclerView?.adapter = adapter
                     holder.loadSingle(
                         service.getCategoriesList(row.source),
                         onSuccess = { categories ->
-                            val sortedCategories = categories.map { it.copy(name = it.name.tryToLocalise(resources)) }.sortedBy { it.name }
+                            val context = holder.itemView.context
+                            val allCategories = DiscoverCategory(-1, context.getString(LR.string.discover_all_categories), "", "")
+                            val sortedCategories = categories.map { it.copy(name = it.name.tryToLocalise(resources)) }.take(7)
 
-                            adapter.submitList(sortedCategories) {
+                            adapter.submitList(listOf(allCategories) + sortedCategories) {
                                 onRestoreInstanceState(holder)
                             }
                         },
                     )
+                    holder.binding.layoutSearch.setOnClickListener { listener.onSearchClicked() }
                 }
                 is SinglePodcastViewHolder -> {
                     holder.loadFlowable(

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -130,7 +130,12 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
     }
 
     override fun onAllCategoriesClicked(categories: List<DiscoverCategory>) {
-        CategoriesBottomSheet(categories).show(childFragmentManager, "categories_bottom_sheet")
+        CategoriesBottomSheet(
+            categories,
+            onCategoryClick = {
+                onPodcastListClicked(it)
+            },
+        ).show(childFragmentManager, "categories_bottom_sheet")
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -129,6 +129,10 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
         binding?.recyclerView?.smoothScrollToPosition(0)
     }
 
+    override fun onAllCategoriesClicked(categories: List<DiscoverCategory>) {
+        CategoriesBottomSheet(categories).show(childFragmentManager, "categories_bottom_sheet")
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentDiscoverBinding.inflate(inflater, container, false)
 

--- a/modules/features/discover/src/main/res/layout/fragment_categories_bottom_sheet.xml
+++ b/modules/features/discover/src/main/res/layout/fragment_categories_bottom_sheet.xml
@@ -1,0 +1,24 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingTop="14dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="start"
+        android:gravity="start"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:text="@string/discover_select_categories"
+        android:textAllCaps="true"
+        android:textAppearance="@style/C50"
+        android:textColor="@color/select_categories_tittle_color" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/categoriesRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</LinearLayout>

--- a/modules/features/discover/src/main/res/layout/item_category.xml
+++ b/modules/features/discover/src/main/res/layout/item_category.xml
@@ -3,13 +3,18 @@
     android:layout_width="match_parent"
     android:layout_height="56dp"
     xmlns:app="http://schemas.android.com/apk/res-auto">
+
     <LinearLayout
-        android:orientation="horizontal" android:layout_width="match_parent"
+        android:id="@+id/itemCategoryLinear"
+        android:layout_width="match_parent"
         android:layout_height="56dp"
         android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:clipToPadding="false"
+        android:focusable="true"
+        android:orientation="horizontal"
         android:paddingLeft="16dp"
-        android:paddingRight="16dp"
-        android:clipToPadding="false">
+        android:paddingRight="16dp">
         <ImageView
             android:id="@+id/imageView"
             android:layout_width="24dp"

--- a/modules/features/discover/src/main/res/layout/item_category_redesign.xml
+++ b/modules/features/discover/src/main/res/layout/item_category_redesign.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<com.google.android.material.chip.Chip xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/categoryChip"
+    style="@style/H40"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="8dp"
+    android:backgroundTint="?attr/primary_ui_01"
+    app:chipStrokeColor="@color/coolgrey_50"
+    app:chipStrokeWidth="1dp" />

--- a/modules/features/discover/src/main/res/layout/row_categories_redesign.xml
+++ b/modules/features/discover/src/main/res/layout/row_categories_redesign.xml
@@ -18,8 +18,7 @@
         android:focusable="true"
         android:contentDescription="@string/search_podcasts_or_add_url"
         android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        android:paddingBottom="8dp">
+        android:paddingEnd="16dp">
         <ImageView
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
@@ -35,12 +34,14 @@
             android:textColor="?attr/primary_icon_02"
             android:maxLines="1"
             android:ellipsize="end"
-            app:autoSizeTextType="uniform"
-            android:text="@string/search_podcasts_or_add_url"/>
+            android:text="@string/search_podcasts_or_add_url"
+            app:autoSizeTextType="uniform" />
     </LinearLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rowRecyclerView"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:paddingStart="16dp" />
+
 </LinearLayout>

--- a/modules/features/discover/src/main/res/values/colors.xml
+++ b/modules/features/discover/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="row_title_color">#1E1F1E</color>
     <color name="row_subtitle_color">#8F97A4</color>
     <color name="row_divider">?attr/primary_ui_05</color>
+    <color name="select_categories_tittle_color">#03A9F4</color>
 </resources>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1569,6 +1569,7 @@
     <string name="discover_button_play_episode">Play Episode</string>
     <string name="discover_button_play_trailer">Play Trailer</string>
     <string name="discover_sponsored">Sponsored</string>
+    <string name="discover_all_categories">All categories</string>
 
     <!-- Server errors -->
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1570,6 +1570,7 @@
     <string name="discover_button_play_trailer">Play Trailer</string>
     <string name="discover_sponsored">Sponsored</string>
     <string name="discover_all_categories">All categories</string>
+    <string name="discover_select_categories">Select a category</string>
 
     <!-- Server errors -->
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModel.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModel.kt
@@ -243,6 +243,9 @@ data class DiscoverCategory(
     @field:Json(name = "source") override val source: String,
     override val curated: Boolean = false,
 ) : NetworkLoadableList {
+    companion object {
+        const val ALL_CATEGORIES_ID = -99
+    }
     override val title: String
         get() = name
     override val type: ListType


### PR DESCRIPTION
## Description
- This PR updates the categories to be displayed as a horizontal list and introduces the `All categories` button
- Also opens the categories bottom sheet dialog when `All categories` is pressed

This is part of the categories redesign. You can find references and figma here in our internal reference: `pdeCcb-4tv-p2`.

> [!note]
> This is not the final design. The new design will be implemented in different pull requests to make it easier to review


> [!note]
> This feature is behind the local feature flag `CATEGORIES_REDESIGN`

## Testing Instructions

#### With Feature flag ON
1. Go to Discover view
2. Click on some category
3. It should open the existing category view
4. Click on All categories button
5. It should open categories bottom sheet dialog with all categories listed
6. Click on some category
7. It should open the existing category view

## Screenshots or Screencast 
 
[Screen_recording_20240312_152750.webm](https://github.com/Automattic/pocket-casts-android/assets/42220351/1d026086-2c4b-43ac-aa13-fbbc65f53990)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
