### PR TITLE
Player update release time out

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -685,7 +685,10 @@ class AddFileActivity :
     @UnstableApi
     private fun preparePlayer(uri: Uri) {
         val loadControl = DefaultLoadControl.Builder().setBufferDurationsMs(0, 0, 0, 0).build()
-        val player = ExoPlayer.Builder(this).setLoadControl(loadControl).build()
+        val player = ExoPlayer.Builder(this)
+            .setLoadControl(loadControl)
+            .setReleaseTimeoutMs(settings.getPlayerReleaseTimeOutMs())
+            .build()
         player.addListener(object : Player.Listener {
             override fun onTracksChanged(tracks: Tracks) {
                 val episodeMetadata = EpisodeFileMetadata()

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -380,6 +380,7 @@ interface Settings {
 
     // Firebase remote config
     fun getPeriodicSaveTimeMs(): Long
+    fun getPlayerReleaseTimeOutMs(): Long
     fun getPodcastSearchDebounceMs(): Long
     fun getEpisodeSearchDebounceMs(): Long
     fun getReportViolationUrl(): String

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -874,6 +874,10 @@ class SettingsImpl @Inject constructor(
         return getRemoteConfigLong(FirebaseConfig.PERIODIC_SAVE_TIME_MS)
     }
 
+    override fun getPlayerReleaseTimeOutMs(): Long {
+        return getRemoteConfigLong(FirebaseConfig.PLAYER_RELEASE_TIME_OUT_MS)
+    }
+
     override fun getPodcastSearchDebounceMs(): Long {
         return getRemoteConfigLong(FirebaseConfig.PODCAST_SEARCH_DEBOUNCE_MS)
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -209,6 +209,7 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
         val player = ExoPlayer.Builder(context, renderer)
             .setTrackSelector(trackSelector)
             .setLoadControl(loadControl)
+            .setReleaseTimeoutMs(settings.getPlayerReleaseTimeOutMs())
             .setSeekForwardIncrementMs(settings.skipForwardInSecs.value * 1000L)
             .setSeekBackIncrementMs(settings.skipBackInSecs.value * 1000L)
             .build()

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
@@ -4,6 +4,7 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 
 object FirebaseConfig {
     const val PERIODIC_SAVE_TIME_MS = "periodic_playback_save_ms"
+    const val PLAYER_RELEASE_TIME_OUT_MS = "player_release_time_out_ms"
     const val PODCAST_SEARCH_DEBOUNCE_MS = "podcast_search_debounce_ms"
     const val EPISODE_SEARCH_DEBOUNCE_MS = "episode_search_debounce_ms"
     const val CLOUD_STORAGE_LIMIT = "custom_storage_limit_gb"
@@ -11,6 +12,7 @@ object FirebaseConfig {
     const val SLUMBER_STUDIOS_YEARLY_PROMO_CODE = "slumber_studios_yearly_promo_code"
     val defaults = mapOf(
         PERIODIC_SAVE_TIME_MS to 60000L,
+        PLAYER_RELEASE_TIME_OUT_MS to 500L,
         PODCAST_SEARCH_DEBOUNCE_MS to 2000L,
         EPISODE_SEARCH_DEBOUNCE_MS to 2000L,
         CLOUD_STORAGE_LIMIT to 10L,


### PR DESCRIPTION
## Description

This increases player release timeout from default `500ms` to `750ms` using remote config field `player_release_time_out_ms`.

Reports in Sentry include a variety of devices with 53% low-end devices in the last 90 days for this error:
[Search for `error.value:"Player release timed out."` in Discover]

It would be interesting to increase player release time-out slightly as suggested [here](https://rb.gy/7hav6r) and monitor to see if it makes any difference. 

## Testing Instructions

1. `setMinimumFetchIntervalInSeconds` to 5L (5 secs) in `FirebaseModule`
2. Add a log statement at the end of `PocketCastsApplication.onCreate()` that prints `settings.getPlayerReleaseTimeOutMs()`
3. Install release build
4. Launch the app
5. ✅ Notice in logs that the release time out is 750.
6. Play a few episodes.  ✅ Notice that they play fine.
7. Uninstall the apk


## Checklist N/A
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
