### PR TITLE
Add playedUpTo tag for illegal playback state error

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -86,6 +86,7 @@ import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 import kotlin.math.abs
 import kotlin.math.min
+import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -1153,7 +1154,10 @@ open class PlaybackManager @Inject constructor(
                     event.message
                 }
                 Sentry.withScope { scope ->
-                    episode?.uuid?.let { scope.setTag("episodeUuid", it) }
+                    episode?.let {
+                        scope.setTag("episodeUuid", it.uuid)
+                        scope.setTag("playedUpTo", it.playedUpTo.roundToInt().toString())
+                    }
                     SentryHelper.recordException(
                         message = "Illegal playback state encountered",
                         throwable = event.error ?: IllegalStateException(event.message),


### PR DESCRIPTION
## Description

This adds a new tag `playedUpTo` while tracking `Illegal playback state encountered`.  In some situations (like playback stuck bufferring) it could be helpful to know the approximate playback position in an episode when the playback error occurs.

## Testing Instructions
1. Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/14588445/playback_error.patch) to through a playback error
2. Install release build
3. Play the episode >= 10sec for few times
4. ✅ Notice that the new tag is shown in Sentry `playedUpTo` in Tag summary on the right side

<img width="169" alt="Screenshot 2024-03-13 at 7 13 58 PM" src="https://github.com/Automattic/pocket-casts-android/assets/1405144/94862659-8fa2-45a3-a9be-2259b7878311">



## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
