### PR TITLE
Migrate podcast header top from data binding

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -266,6 +266,7 @@ class PodcastAdapter(
         }
         holder.binding.expanded = headerExpanded
         holder.binding.top.chevron.isEnabled = headerExpanded
+        holder.binding.top.settings.isVisible = podcast.isSubscribed
         holder.binding.tintColor = ThemeColor.podcastText02(theme.activeTheme, tintColor)
         holder.binding.top.header.setBackgroundColor(ThemeColor.podcastUi03(theme.activeTheme, podcast.backgroundColor))
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -247,7 +247,7 @@ class PodcastAdapter(
         holder.binding.podcast = podcast
         holder.binding.expanded = headerExpanded
         holder.binding.tintColor = ThemeColor.podcastText02(theme.activeTheme, tintColor)
-        holder.binding.headerColor = ThemeColor.podcastUi03(theme.activeTheme, podcast.backgroundColor)
+        holder.binding.top.header.setBackgroundColor(ThemeColor.podcastUi03(theme.activeTheme, podcast.backgroundColor))
         holder.binding.isPlusOrPatronUser = signInState.isSignedInAsPlusOrPatron
 
         holder.binding.bottom.ratings.setContent {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -68,6 +68,7 @@ import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelpe
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import timber.log.Timber
+import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
@@ -244,12 +245,17 @@ class PodcastAdapter(
     }
 
     private fun bindPodcastViewHolder(holder: PodcastViewHolder) {
+        val isPlusOrPatronUser = signInState.isSignedInAsPlusOrPatron
         holder.binding.podcast = podcast
+        holder.binding.top.folders.setImageResource(
+            if (podcast.folderUuid != null) R.drawable.ic_folder_check else IR.drawable.ic_folder,
+        )
+        holder.binding.top.folders.isVisible = podcast.isSubscribed && isPlusOrPatronUser
         holder.binding.expanded = headerExpanded
         holder.binding.top.chevron.isEnabled = headerExpanded
         holder.binding.tintColor = ThemeColor.podcastText02(theme.activeTheme, tintColor)
         holder.binding.top.header.setBackgroundColor(ThemeColor.podcastUi03(theme.activeTheme, podcast.backgroundColor))
-        holder.binding.isPlusOrPatronUser = signInState.isSignedInAsPlusOrPatron
+        holder.binding.isPlusOrPatronUser = isPlusOrPatronUser
 
         holder.binding.bottom.ratings.setContent {
             AppTheme(theme.activeTheme) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -595,7 +595,7 @@ class PodcastAdapter(
             interpolator = FastOutSlowInInterpolator()
         }
 
-        val constraintLayout = binding.top.root as ConstraintLayout
+        val constraintLayout = binding.top.root
         val constraintSet = ConstraintSet()
         constraintSet.clone(constraintLayout)
         constraintSet.constrainPercentWidth(R.id.artworkContainer, if (!binding.bottom.root.isVisible) 0.40f else 0.38f)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -246,6 +246,7 @@ class PodcastAdapter(
     private fun bindPodcastViewHolder(holder: PodcastViewHolder) {
         holder.binding.podcast = podcast
         holder.binding.expanded = headerExpanded
+        holder.binding.top.chevron.isEnabled = headerExpanded
         holder.binding.tintColor = ThemeColor.podcastText02(theme.activeTheme, tintColor)
         holder.binding.top.header.setBackgroundColor(ThemeColor.podcastUi03(theme.activeTheme, podcast.backgroundColor))
         holder.binding.isPlusOrPatronUser = signInState.isSignedInAsPlusOrPatron

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -72,6 +72,7 @@ import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
+import au.com.shiftyjelly.pocketcasts.views.helper.ViewDataBindings.toCircle
 
 private val differ: DiffUtil.ItemCallback<Any> = object : DiffUtil.ItemCallback<Any>() {
     override fun areItemsTheSame(oldItem: Any, newItem: Any): Boolean {
@@ -268,6 +269,8 @@ class PodcastAdapter(
         holder.binding.top.chevron.isEnabled = headerExpanded
         holder.binding.top.settings.isVisible = podcast.isSubscribed
         holder.binding.top.subscribeButton.isVisible = !podcast.isSubscribed
+        holder.binding.top.subscribedButton.isVisible = podcast.isSubscribed
+        holder.binding.top.subscribedButton.toCircle(true)
         holder.binding.tintColor = ThemeColor.podcastText02(theme.activeTheme, tintColor)
         holder.binding.top.header.setBackgroundColor(ThemeColor.podcastUi03(theme.activeTheme, podcast.backgroundColor))
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -247,32 +247,10 @@ class PodcastAdapter(
     }
 
     private fun bindPodcastViewHolder(holder: PodcastViewHolder) {
-        val isPlusOrPatronUser = signInState.isSignedInAsPlusOrPatron
         holder.binding.podcast = podcast
-        holder.binding.top.folders.setImageResource(
-            if (podcast.folderUuid != null) R.drawable.ic_folder_check else IR.drawable.ic_folder,
-        )
-        holder.binding.top.folders.isVisible = podcast.isSubscribed && isPlusOrPatronUser
-        with(holder.binding.top.notifications) {
-            val notificationsIconText =
-                context.getString(if (podcast.isShowNotifications) LR.string.podcast_notifications_on else LR.string.podcast_notifications_off)
-            contentDescription = notificationsIconText
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                tooltipText = notificationsIconText
-            }
-            setImageResource(
-                if (podcast.isShowNotifications) R.drawable.ic_notifications_on else R.drawable.ic_notifications_off,
-            )
-            isVisible = podcast.isSubscribed
-        }
         holder.binding.expanded = headerExpanded
-        holder.binding.top.chevron.isEnabled = headerExpanded
-        holder.binding.top.settings.isVisible = podcast.isSubscribed
-        holder.binding.top.subscribeButton.isVisible = !podcast.isSubscribed
-        holder.binding.top.subscribedButton.isVisible = podcast.isSubscribed
-        holder.binding.top.subscribedButton.toCircle(true)
         holder.binding.tintColor = ThemeColor.podcastText02(theme.activeTheme, tintColor)
-        holder.binding.top.header.setBackgroundColor(ThemeColor.podcastUi03(theme.activeTheme, podcast.backgroundColor))
+        bindHeaderTop(holder)
 
         holder.binding.bottom.ratings.setContent {
             AppTheme(theme.activeTheme) {
@@ -299,6 +277,32 @@ class PodcastAdapter(
         holder.binding.podcastHeader.contentDescription = podcast.title
 
         holder.binding.executePendingBindings()
+    }
+
+    private fun bindHeaderTop(holder: PodcastViewHolder) {
+        val isPlusOrPatronUser = signInState.isSignedInAsPlusOrPatron
+        holder.binding.top.chevron.isEnabled = headerExpanded
+        holder.binding.top.settings.isVisible = podcast.isSubscribed
+        holder.binding.top.subscribeButton.isVisible = !podcast.isSubscribed
+        holder.binding.top.subscribedButton.isVisible = podcast.isSubscribed
+        holder.binding.top.subscribedButton.toCircle(true)
+        holder.binding.top.header.setBackgroundColor(ThemeColor.podcastUi03(theme.activeTheme, podcast.backgroundColor))
+        holder.binding.top.folders.setImageResource(
+            if (podcast.folderUuid != null) R.drawable.ic_folder_check else IR.drawable.ic_folder,
+        )
+        holder.binding.top.folders.isVisible = podcast.isSubscribed && isPlusOrPatronUser
+        with(holder.binding.top.notifications) {
+            val notificationsIconText =
+                context.getString(if (podcast.isShowNotifications) LR.string.podcast_notifications_on else LR.string.podcast_notifications_off)
+            contentDescription = notificationsIconText
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                tooltipText = notificationsIconText
+            }
+            setImageResource(
+                if (podcast.isShowNotifications) R.drawable.ic_notifications_on else R.drawable.ic_notifications_off,
+            )
+            isVisible = podcast.isSubscribed
+        }
     }
 
     private fun bindingEpisodeHeaderViewHolder(holder: EpisodeHeaderViewHolder, position: Int) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -268,7 +268,6 @@ class PodcastAdapter(
         holder.binding.top.chevron.isEnabled = headerExpanded
         holder.binding.tintColor = ThemeColor.podcastText02(theme.activeTheme, tintColor)
         holder.binding.top.header.setBackgroundColor(ThemeColor.podcastUi03(theme.activeTheme, podcast.backgroundColor))
-        holder.binding.isPlusOrPatronUser = isPlusOrPatronUser
 
         holder.binding.bottom.ratings.setContent {
             AppTheme(theme.activeTheme) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -19,7 +19,6 @@ import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.TextView
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.content.ContextCompat
 import androidx.core.content.ContextCompat.startActivity
@@ -64,6 +63,7 @@ import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.extensions.toggleVisibility
 import au.com.shiftyjelly.pocketcasts.views.helper.AnimatorUtil
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
+import au.com.shiftyjelly.pocketcasts.views.helper.ViewDataBindings.toCircle
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import io.reactivex.Observable
@@ -72,7 +72,6 @@ import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
-import au.com.shiftyjelly.pocketcasts.views.helper.ViewDataBindings.toCircle
 
 private val differ: DiffUtil.ItemCallback<Any> = object : DiffUtil.ItemCallback<Any>() {
     override fun areItemsTheSame(oldItem: Any, newItem: Any): Boolean {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -8,6 +8,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.ForegroundColorSpan
@@ -251,6 +252,18 @@ class PodcastAdapter(
             if (podcast.folderUuid != null) R.drawable.ic_folder_check else IR.drawable.ic_folder,
         )
         holder.binding.top.folders.isVisible = podcast.isSubscribed && isPlusOrPatronUser
+        with(holder.binding.top.notifications) {
+            val notificationsIconText =
+                context.getString(if (podcast.isShowNotifications) LR.string.podcast_notifications_on else LR.string.podcast_notifications_off)
+            contentDescription = notificationsIconText
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                tooltipText = notificationsIconText
+            }
+            setImageResource(
+                if (podcast.isShowNotifications) R.drawable.ic_notifications_on else R.drawable.ic_notifications_off,
+            )
+            isVisible = podcast.isSubscribed
+        }
         holder.binding.expanded = headerExpanded
         holder.binding.top.chevron.isEnabled = headerExpanded
         holder.binding.tintColor = ThemeColor.podcastText02(theme.activeTheme, tintColor)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -267,6 +267,7 @@ class PodcastAdapter(
         holder.binding.expanded = headerExpanded
         holder.binding.top.chevron.isEnabled = headerExpanded
         holder.binding.top.settings.isVisible = podcast.isSubscribed
+        holder.binding.top.subscribeButton.isVisible = !podcast.isSubscribed
         holder.binding.tintColor = ThemeColor.podcastText02(theme.activeTheme, tintColor)
         holder.binding.top.header.setBackgroundColor(ThemeColor.podcastUi03(theme.activeTheme, podcast.backgroundColor))
 

--- a/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
@@ -1,174 +1,167 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
-    <data>
-        <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast"/>
-    </data>
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/primary_ui_01"
+    android:clipToPadding="false"
+    android:paddingBottom="8dp">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <View
+        android:id="@+id/header"
         android:layout_width="match_parent"
+        android:layout_height="@dimen/podcast_header_height"
+        android:contentDescription="@string/podcasts_show_podcast_details"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/chevron"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:background="?attr/primary_ui_01"
-        android:clipToPadding="false"
-        android:paddingBottom="8dp">
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:rotation="180"
+        android:scaleType="center"
+        android:stateListAnimator="@animator/rotate_chevron"
+        app:srcCompat="@drawable/ic_chevron"
+        app:tint="@color/white"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="@+id/header" />
 
-        <View
-            android:id="@+id/header"
+    <androidx.cardview.widget.CardView
+        android:id="@+id/artworkContainer"
+        android:layout_height="80dp"
+        android:layout_width="80dp"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="12dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:scaleType="centerCrop"
+        android:elevation="8dp"
+        app:cardCornerRadius="8dp"
+        android:layout_marginBottom="16dp"
+        android:clipToPadding="false">
+
+        <ImageView
+            android:id="@+id/artwork"
             android:layout_width="match_parent"
-            android:layout_height="@dimen/podcast_header_height"
-            android:contentDescription="@string/podcasts_show_podcast_details"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <ImageView
-            android:id="@+id/chevron"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
-            android:layout_marginBottom="16dp"
-            android:rotation="180"
-            android:scaleType="center"
-            android:stateListAnimator="@animator/rotate_chevron"
-            app:srcCompat="@drawable/ic_chevron"
-            app:tint="@color/white"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="@+id/header" />
-
-        <androidx.cardview.widget.CardView
-            android:id="@+id/artworkContainer"
-            android:layout_height="80dp"
-            android:layout_width="80dp"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="12dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
+            android:layout_height="match_parent"
             android:scaleType="centerCrop"
-            android:elevation="8dp"
-            app:cardCornerRadius="8dp"
-            android:layout_marginBottom="16dp"
-            android:clipToPadding="false">
+            android:adjustViewBounds="true"
+            tools:src="@tools:sample/avatars" />
 
-            <ImageView
-                android:id="@+id/artwork"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:scaleType="centerCrop"
-                android:adjustViewBounds="true"
-                tools:src="@tools:sample/avatars" />
+    </androidx.cardview.widget.CardView>
 
-        </androidx.cardview.widget.CardView>
+    <ImageView
+        android:id="@+id/folders"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_marginEnd="16dp"
+        android:background="?android:attr/actionBarItemBackground"
+        android:clickable="true"
+        android:contentDescription="@string/podcast_change_folder"
+        android:tooltipText="@string/folders"
+        android:focusable="true"
+        android:scaleType="center"
+        app:tint="?attr/primary_icon_02"
+        app:layout_constraintEnd_toStartOf="@+id/notifications"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
-        <ImageView
-            android:id="@+id/folders"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_marginEnd="16dp"
-            android:background="?android:attr/actionBarItemBackground"
-            android:clickable="true"
-            android:contentDescription="@string/podcast_change_folder"
-            android:tooltipText="@string/folders"
-            android:focusable="true"
-            android:scaleType="center"
-            app:tint="?attr/primary_icon_02"
-            app:layout_constraintEnd_toStartOf="@+id/notifications"
-            app:layout_constraintBottom_toBottomOf="parent" />
+    <ImageView
+        android:id="@+id/notifications"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_marginEnd="16dp"
+        android:background="?android:attr/actionBarItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        app:tint="?attr/primary_icon_02"
+        android:scaleType="center"
+        app:layout_constraintEnd_toStartOf="@+id/settings"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
-        <ImageView
-            android:id="@+id/notifications"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_marginEnd="16dp"
-            android:background="?android:attr/actionBarItemBackground"
-            android:clickable="true"
-            android:focusable="true"
-            app:tint="?attr/primary_icon_02"
-            android:scaleType="center"
-            app:layout_constraintEnd_toStartOf="@+id/settings"
-            app:layout_constraintBottom_toBottomOf="parent" />
+    <ImageView
+        android:id="@+id/settings"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_marginEnd="68dp"
+        android:background="?android:attr/actionBarItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        app:tint="?attr/primary_icon_02"
+        app:srcCompat="@drawable/ic_settings_small"
+        android:scaleType="center"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:visibility="visible" />
 
-        <ImageView
-            android:id="@+id/settings"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_marginEnd="68dp"
-            android:background="?android:attr/actionBarItemBackground"
-            android:clickable="true"
-            android:focusable="true"
-            app:tint="?attr/primary_icon_02"
-            app:srcCompat="@drawable/ic_settings_small"
-            android:scaleType="center"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            tools:visibility="visible" />
+    <TextView
+        android:id="@+id/subscribeButton"
+        android:layout_width="wrap_content"
+        android:layout_height="32dp"
+        app:cornerRadius="16dp"
+        android:background="@drawable/button_rounded"
+        android:text="@string/subscribe"
+        android:textColor="?attr/primary_icon_02"
+        android:textSize="15sp"
+        android:fontFamily="sans-serif-medium"
+        android:layout_marginEnd="16dp"
+        android:foreground="@drawable/button_rounded_ripple"
+        android:paddingEnd="48dp"
+        android:paddingStart="48dp"
+        android:gravity="center_vertical"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
-        <TextView
-            android:id="@+id/subscribeButton"
-            android:layout_width="wrap_content"
-            android:layout_height="32dp"
-            app:cornerRadius="16dp"
-            android:background="@drawable/button_rounded"
-            android:text="@string/subscribe"
-            android:textColor="?attr/primary_icon_02"
-            android:textSize="15sp"
-            android:fontFamily="sans-serif-medium"
-            android:layout_marginEnd="16dp"
-            android:foreground="@drawable/button_rounded_ripple"
-            android:paddingEnd="48dp"
-            android:paddingStart="48dp"
-            android:gravity="center_vertical"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent" />
+    <TextView
+        android:id="@+id/animationSubscribedButton"
+        android:layout_width="wrap_content"
+        android:layout_height="32dp"
+        app:cornerRadius="16dp"
+        android:background="@drawable/button_rounded_green"
+        android:text="@string/subscribe"
+        android:textColor="?attr/support_02"
+        android:textSize="15sp"
+        android:fontFamily="sans-serif-medium"
+        android:visibility="gone"
+        android:layout_marginEnd="16dp"
+        android:paddingEnd="48dp"
+        android:paddingStart="48dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
-        <TextView
-            android:id="@+id/animationSubscribedButton"
-            android:layout_width="wrap_content"
-            android:layout_height="32dp"
-            app:cornerRadius="16dp"
-            android:background="@drawable/button_rounded_green"
-            android:text="@string/subscribe"
-            android:textColor="?attr/support_02"
-            android:textSize="15sp"
-            android:fontFamily="sans-serif-medium"
-            android:visibility="gone"
-            android:layout_marginEnd="16dp"
-            android:paddingEnd="48dp"
-            android:paddingStart="48dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent" />
+    <TextView
+        android:id="@+id/animationSubscribeText"
+        android:layout_width="wrap_content"
+        android:layout_height="32dp"
+        android:text="@string/podcast_subscribed"
+        android:textColor="?attr/primary_interactive_02"
+        android:textSize="15sp"
+        android:fontFamily="sans-serif-medium"
+        android:gravity="center"
+        android:visibility="gone"
+        android:layout_marginEnd="16dp"
+        android:paddingEnd="48dp"
+        android:paddingStart="48dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
-        <TextView
-            android:id="@+id/animationSubscribeText"
-            android:layout_width="wrap_content"
-            android:layout_height="32dp"
-            android:text="@string/podcast_subscribed"
-            android:textColor="?attr/primary_interactive_02"
-            android:textSize="15sp"
-            android:fontFamily="sans-serif-medium"
-            android:gravity="center"
-            android:visibility="gone"
-            android:layout_marginEnd="16dp"
-            android:paddingEnd="48dp"
-            android:paddingStart="48dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent" />
+    <ImageView
+        android:id="@+id/subscribedButton"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:background="?attr/support_02"
+        app:cornerRadius="8dp"
+        app:srcCompat="@drawable/ic_tick_small"
+        android:scaleType="center"
+        app:tint="?attr/primary_interactive_02"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="0dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
-        <ImageView
-            android:id="@+id/subscribedButton"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:background="?attr/support_02"
-            app:cornerRadius="8dp"
-            app:srcCompat="@drawable/ic_tick_small"
-            android:scaleType="center"
-            app:tint="?attr/primary_interactive_02"
-            android:layout_marginEnd="16dp"
-            android:layout_marginBottom="0dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-</layout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
@@ -73,11 +73,9 @@
             android:tooltipText="@string/folders"
             android:focusable="true"
             android:scaleType="center"
-            android:src="@drawable/ic_folder"
             app:tint="?attr/primary_icon_02"
             app:layout_constraintEnd_toStartOf="@+id/notifications"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:show="@{podcast.isSubscribed &amp;&amp; isPlusOrPatronUser}" />
+            app:layout_constraintBottom_toBottomOf="parent" />
 
         <ImageView
             android:id="@+id/notifications"

--- a/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
@@ -166,8 +166,6 @@
             app:tint="?attr/primary_interactive_02"
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="0dp"
-            app:circle="@{true}"
-            app:show="@{podcast.isSubscribed}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent" />
 

--- a/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
@@ -119,7 +119,6 @@
             android:paddingEnd="48dp"
             android:paddingStart="48dp"
             android:gravity="center_vertical"
-            app:show="@{!podcast.isSubscribed}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent" />
 

--- a/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
@@ -98,7 +98,6 @@
             android:clickable="true"
             android:focusable="true"
             app:tint="?attr/primary_icon_02"
-            app:show="@{podcast.isSubscribed}"
             app:srcCompat="@drawable/ic_settings_small"
             android:scaleType="center"
             app:layout_constraintEnd_toEndOf="parent"

--- a/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools">
     <data>
         <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast"/>
-        <variable name="isPlusOrPatronUser" type="boolean" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools">
     <data>
         <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast"/>
-        <variable name="expanded" type="boolean" />
         <variable name="isPlusOrPatronUser" type="boolean" />
     </data>
 
@@ -30,7 +29,6 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="16dp"
-            android:enabled="@{expanded}"
             android:rotation="180"
             android:scaleType="center"
             android:stateListAnimator="@animator/rotate_chevron"

--- a/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools">
     <data>
         <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast"/>
-        <variable name="tintColor" type="int"/>
         <variable name="headerColor" type="int"/>
         <variable name="expanded" type="boolean" />
         <variable name="isPlusOrPatronUser" type="boolean" />

--- a/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools">
     <data>
         <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast"/>
-        <variable name="headerColor" type="int"/>
         <variable name="expanded" type="boolean" />
         <variable name="isPlusOrPatronUser" type="boolean" />
     </data>
@@ -20,7 +19,6 @@
             android:id="@+id/header"
             android:layout_width="match_parent"
             android:layout_height="@dimen/podcast_header_height"
-            android:background="@{headerColor}"
             android:contentDescription="@string/podcasts_show_podcast_details"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
@@ -86,8 +86,6 @@
             android:clickable="true"
             android:focusable="true"
             app:tint="?attr/primary_icon_02"
-            app:show="@{podcast.isSubscribed}"
-            android:src="@{podcast.isShowNotifications() ? @drawable/ic_notifications_on : @drawable/ic_notifications_off}"
             android:scaleType="center"
             app:layout_constraintEnd_toStartOf="@+id/settings"
             app:layout_constraintBottom_toBottomOf="parent" />

--- a/modules/features/podcasts/src/main/res/layout/adapter_podcast_header.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_podcast_header.xml
@@ -14,8 +14,7 @@
 
         <include
             android:id="@+id/top"
-            layout="@layout/view_podcast_header_top"
-            app:podcast="@{podcast}" />
+            layout="@layout/view_podcast_header_top" />
 
         <include
             android:id="@+id/bottom"

--- a/modules/features/podcasts/src/main/res/layout/adapter_podcast_header.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_podcast_header.xml
@@ -5,7 +5,6 @@
         <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast"/>
         <variable name="expanded" type="boolean" />
         <variable name="tintColor" type="int"/>
-        <variable name="headerColor" type="int"/>
         <variable name="isPlusOrPatronUser" type="boolean"/>
     </data>
 
@@ -18,7 +17,6 @@
             android:id="@+id/top"
             layout="@layout/view_podcast_header_top"
             app:podcast="@{podcast}"
-            app:headerColor="@{headerColor}"
             app:expanded="@{expanded}"
             app:isPlusOrPatronUser="@{isPlusOrPatronUser}"/>
 

--- a/modules/features/podcasts/src/main/res/layout/adapter_podcast_header.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_podcast_header.xml
@@ -17,7 +17,6 @@
             android:id="@+id/top"
             layout="@layout/view_podcast_header_top"
             app:podcast="@{podcast}"
-            app:expanded="@{expanded}"
             app:isPlusOrPatronUser="@{isPlusOrPatronUser}"/>
 
         <include

--- a/modules/features/podcasts/src/main/res/layout/adapter_podcast_header.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_podcast_header.xml
@@ -5,7 +5,6 @@
         <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast"/>
         <variable name="expanded" type="boolean" />
         <variable name="tintColor" type="int"/>
-        <variable name="isPlusOrPatronUser" type="boolean"/>
     </data>
 
     <LinearLayout android:id="@+id/podcast_header"
@@ -16,8 +15,7 @@
         <include
             android:id="@+id/top"
             layout="@layout/view_podcast_header_top"
-            app:podcast="@{podcast}"
-            app:isPlusOrPatronUser="@{isPlusOrPatronUser}"/>
+            app:podcast="@{podcast}" />
 
         <include
             android:id="@+id/bottom"

--- a/modules/features/podcasts/src/main/res/layout/adapter_podcast_header.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_podcast_header.xml
@@ -18,7 +18,6 @@
             android:id="@+id/top"
             layout="@layout/view_podcast_header_top"
             app:podcast="@{podcast}"
-            app:tintColor="@{tintColor}"
             app:headerColor="@{headerColor}"
             app:expanded="@{expanded}"
             app:isPlusOrPatronUser="@{isPlusOrPatronUser}"/>

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
@@ -110,7 +110,6 @@
             app:tint="?attr/primary_icon_02"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/header"
-            app:show="@{podcast.isSubscribed}"
             app:srcCompat="@drawable/ic_settings_small"
             tools:visibility="visible" />
 

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
@@ -78,11 +78,9 @@
             android:tooltipText="@string/folders"
             android:focusable="true"
             android:scaleType="center"
-            android:src="@{podcast.folderUuid == null ? @drawable/ic_folder : @drawable/ic_folder_check}"
             app:tint="?attr/primary_icon_02"
             app:layout_constraintEnd_toStartOf="@+id/notifications"
-            app:layout_constraintTop_toBottomOf="@+id/header"
-            app:show="@{podcast.isSubscribed &amp;&amp; isPlusOrPatronUser}" />
+            app:layout_constraintTop_toBottomOf="@+id/header" />
 
         <ImageView
             android:id="@+id/notifications"

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
@@ -180,11 +180,9 @@
             android:tooltipText="@string/unsubscribe"
             android:scaleType="center"
             app:tint="?attr/primary_interactive_02"
-            app:circle="@{true}"
             app:cornerRadius="8dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/header"
-            app:show="@{podcast.isSubscribed}"
             app:srcCompat="@drawable/ic_tick_small" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools">
     <data>
         <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast"/>
-        <variable name="expanded" type="boolean" />
         <variable name="isPlusOrPatronUser" type="boolean" />
     </data>
 
@@ -30,7 +29,6 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="16dp"
             android:contentDescription="@string/expand_details"
-            android:enabled="@{expanded}"
             android:rotation="180"
             android:scaleType="center"
             android:stateListAnimator="@animator/rotate_chevron"

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
@@ -1,190 +1,183 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
-    <data>
-        <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast"/>
-    </data>
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/primary_ui_02"
+    android:clipToPadding="false"
+    android:paddingBottom="8dp">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <View
+        android:id="@+id/header"
         android:layout_width="match_parent"
+        android:layout_height="@dimen/podcast_header_height"
+        android:contentDescription="@string/podcasts_show_podcast_details"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/chevron"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:background="?attr/primary_ui_02"
+        android:layout_marginEnd="16dp"
+        android:contentDescription="@string/expand_details"
+        android:rotation="180"
+        android:scaleType="center"
+        android:stateListAnimator="@animator/rotate_chevron"
+        app:tint="?attr/contrast_02"
+        android:layout_marginBottom="22dp"
+        app:layout_constraintBottom_toBottomOf="@+id/header"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:srcCompat="@drawable/ic_chevron" />
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/artworkContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="16dp"
         android:clipToPadding="false"
-        android:paddingBottom="8dp">
+        android:elevation="8dp"
+        android:importantForAccessibility="noHideDescendants"
+        android:scaleType="centerCrop"
+        app:cardCornerRadius="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintWidth_default="percent"
+        app:layout_constraintWidth_percent="0.38">
 
-        <View
-            android:id="@+id/header"
+        <ImageView
+            android:id="@+id/artwork"
             android:layout_width="match_parent"
-            android:layout_height="@dimen/podcast_header_height"
-            android:contentDescription="@string/podcasts_show_podcast_details"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <ImageView
-            android:id="@+id/chevron"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
-            android:contentDescription="@string/expand_details"
-            android:rotation="180"
-            android:scaleType="center"
-            android:stateListAnimator="@animator/rotate_chevron"
-            app:tint="?attr/contrast_02"
-            android:layout_marginBottom="22dp"
-            app:layout_constraintBottom_toBottomOf="@+id/header"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:srcCompat="@drawable/ic_chevron" />
-
-        <androidx.cardview.widget.CardView
-            android:id="@+id/artworkContainer"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_marginStart="16dp"
-            android:clipToPadding="false"
-            android:elevation="8dp"
-            android:importantForAccessibility="noHideDescendants"
+            android:layout_height="match_parent"
+            android:adjustViewBounds="true"
+            android:foreground="?attr/selectableItemBackgroundBorderless"
+            android:importantForAccessibility="no"
             android:scaleType="centerCrop"
-            app:cardCornerRadius="8dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintDimensionRatio="1:1"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintWidth_default="percent"
-            app:layout_constraintWidth_percent="0.38">
+            tools:src="@tools:sample/avatars" />
 
-            <ImageView
-                android:id="@+id/artwork"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:adjustViewBounds="true"
-                android:foreground="?attr/selectableItemBackgroundBorderless"
-                android:importantForAccessibility="no"
-                android:scaleType="centerCrop"
-                tools:src="@tools:sample/avatars" />
+    </androidx.cardview.widget.CardView>
 
-        </androidx.cardview.widget.CardView>
+    <ImageView
+        android:id="@+id/folders"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:background="?android:attr/actionBarItemBackground"
+        android:clickable="true"
+        android:contentDescription="@string/podcast_change_folder"
+        android:tooltipText="@string/folders"
+        android:focusable="true"
+        android:scaleType="center"
+        app:tint="?attr/primary_icon_02"
+        app:layout_constraintEnd_toStartOf="@+id/notifications"
+        app:layout_constraintTop_toBottomOf="@+id/header" />
 
-        <ImageView
-            android:id="@+id/folders"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="8dp"
-            android:background="?android:attr/actionBarItemBackground"
-            android:clickable="true"
-            android:contentDescription="@string/podcast_change_folder"
-            android:tooltipText="@string/folders"
-            android:focusable="true"
-            android:scaleType="center"
-            app:tint="?attr/primary_icon_02"
-            app:layout_constraintEnd_toStartOf="@+id/notifications"
-            app:layout_constraintTop_toBottomOf="@+id/header" />
+    <ImageView
+        android:id="@+id/notifications"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:background="?android:attr/actionBarItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:scaleType="center"
+        app:tint="?attr/primary_icon_02"
+        app:layout_constraintEnd_toStartOf="@+id/settings"
+        app:layout_constraintTop_toBottomOf="@+id/header" />
 
-        <ImageView
-            android:id="@+id/notifications"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="8dp"
-            android:background="?android:attr/actionBarItemBackground"
-            android:clickable="true"
-            android:focusable="true"
-            android:scaleType="center"
-            app:tint="?attr/primary_icon_02"
-            app:layout_constraintEnd_toStartOf="@+id/settings"
-            app:layout_constraintTop_toBottomOf="@+id/header" />
+    <ImageView
+        android:id="@+id/settings"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="68dp"
+        android:background="?android:attr/actionBarItemBackground"
+        android:clickable="true"
+        android:contentDescription="@string/settings"
+        android:tooltipText="@string/settings"
+        android:focusable="true"
+        android:scaleType="center"
+        app:tint="?attr/primary_icon_02"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/header"
+        app:srcCompat="@drawable/ic_settings_small"
+        tools:visibility="visible" />
 
-        <ImageView
-            android:id="@+id/settings"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="68dp"
-            android:background="?android:attr/actionBarItemBackground"
-            android:clickable="true"
-            android:contentDescription="@string/settings"
-            android:tooltipText="@string/settings"
-            android:focusable="true"
-            android:scaleType="center"
-            app:tint="?attr/primary_icon_02"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/header"
-            app:srcCompat="@drawable/ic_settings_small"
-            tools:visibility="visible" />
+    <TextView
+        android:id="@+id/subscribeButton"
+        android:layout_width="wrap_content"
+        android:layout_height="32dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:background="@drawable/button_rounded"
+        android:contentDescription="@string/subscribe"
+        android:fontFamily="sans-serif-medium"
+        android:foreground="@drawable/button_rounded_ripple"
+        android:gravity="center_vertical"
+        android:paddingStart="48dp"
+        android:paddingEnd="48dp"
+        android:text="@string/subscribe"
+        android:textColor="?attr/primary_icon_02"
+        android:textSize="15sp"
+        app:cornerRadius="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/header" />
 
-        <TextView
-            android:id="@+id/subscribeButton"
-            android:layout_width="wrap_content"
-            android:layout_height="32dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="16dp"
-            android:background="@drawable/button_rounded"
-            android:contentDescription="@string/subscribe"
-            android:fontFamily="sans-serif-medium"
-            android:foreground="@drawable/button_rounded_ripple"
-            android:gravity="center_vertical"
-            android:paddingStart="48dp"
-            android:paddingEnd="48dp"
-            android:text="@string/subscribe"
-            android:textColor="?attr/primary_icon_02"
-            android:textSize="15sp"
-            app:cornerRadius="16dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/header" />
+    <TextView
+        android:id="@+id/animationSubscribedButton"
+        android:layout_width="wrap_content"
+        android:layout_height="32dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:background="@drawable/button_rounded_green"
+        android:fontFamily="sans-serif-medium"
+        android:paddingStart="48dp"
+        android:paddingEnd="48dp"
+        android:text="@string/subscribe"
+        android:textColor="?attr/support_02"
+        android:textSize="15sp"
+        android:visibility="gone"
+        app:cornerRadius="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/header" />
 
-        <TextView
-            android:id="@+id/animationSubscribedButton"
-            android:layout_width="wrap_content"
-            android:layout_height="32dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="16dp"
-            android:background="@drawable/button_rounded_green"
-            android:fontFamily="sans-serif-medium"
-            android:paddingStart="48dp"
-            android:paddingEnd="48dp"
-            android:text="@string/subscribe"
-            android:textColor="?attr/support_02"
-            android:textSize="15sp"
-            android:visibility="gone"
-            app:cornerRadius="16dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/header" />
+    <TextView
+        android:id="@+id/animationSubscribeText"
+        android:layout_width="wrap_content"
+        android:layout_height="32dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:fontFamily="sans-serif-medium"
+        android:gravity="center"
+        android:paddingStart="48dp"
+        android:paddingEnd="48dp"
+        android:text="@string/podcast_subscribed"
+        android:textColor="?attr/primary_interactive_02"
+        android:textSize="15sp"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/header" />
 
-        <TextView
-            android:id="@+id/animationSubscribeText"
-            android:layout_width="wrap_content"
-            android:layout_height="32dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="16dp"
-            android:fontFamily="sans-serif-medium"
-            android:gravity="center"
-            android:paddingStart="48dp"
-            android:paddingEnd="48dp"
-            android:text="@string/podcast_subscribed"
-            android:textColor="?attr/primary_interactive_02"
-            android:textSize="15sp"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/header" />
+    <ImageView
+        android:id="@+id/subscribedButton"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="0dp"
+        android:background="?attr/support_02"
+        android:contentDescription="@string/unsubscribe"
+        android:tooltipText="@string/unsubscribe"
+        android:scaleType="center"
+        app:tint="?attr/primary_interactive_02"
+        app:cornerRadius="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/header"
+        app:srcCompat="@drawable/ic_tick_small" />
 
-        <ImageView
-            android:id="@+id/subscribedButton"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginBottom="0dp"
-            android:background="?attr/support_02"
-            android:contentDescription="@string/unsubscribe"
-            android:tooltipText="@string/unsubscribe"
-            android:scaleType="center"
-            app:tint="?attr/primary_interactive_02"
-            app:cornerRadius="8dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/header"
-            app:srcCompat="@drawable/ic_tick_small" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-</layout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools">
     <data>
         <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast"/>
-        <variable name="isPlusOrPatronUser" type="boolean" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
@@ -131,8 +131,7 @@
             android:textSize="15sp"
             app:cornerRadius="16dp"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/header"
-            app:show="@{!podcast.isSubscribed}" />
+            app:layout_constraintTop_toBottomOf="@id/header" />
 
         <TextView
             android:id="@+id/animationSubscribedButton"

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools">
     <data>
         <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast"/>
-        <variable name="tintColor" type="int"/>
         <variable name="headerColor" type="int"/>
         <variable name="expanded" type="boolean" />
         <variable name="isPlusOrPatronUser" type="boolean" />

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
@@ -90,15 +90,11 @@
             android:layout_marginEnd="8dp"
             android:background="?android:attr/actionBarItemBackground"
             android:clickable="true"
-            android:contentDescription="@{podcast.isShowNotifications() ? @string/podcast_notifications_on : @string/podcast_notifications_off}"
-            android:tooltipText="@{podcast.isShowNotifications() ? @string/podcast_notifications_on : @string/podcast_notifications_off}"
             android:focusable="true"
             android:scaleType="center"
-            android:src="@{podcast.isShowNotifications() ? @drawable/ic_notifications_on : @drawable/ic_notifications_off}"
             app:tint="?attr/primary_icon_02"
             app:layout_constraintEnd_toStartOf="@+id/settings"
-            app:layout_constraintTop_toBottomOf="@+id/header"
-            app:show="@{podcast.isSubscribed}" />
+            app:layout_constraintTop_toBottomOf="@+id/header" />
 
         <ImageView
             android:id="@+id/settings"

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools">
     <data>
         <variable name="podcast" type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast"/>
-        <variable name="headerColor" type="int"/>
         <variable name="expanded" type="boolean" />
         <variable name="isPlusOrPatronUser" type="boolean" />
     </data>
@@ -20,7 +19,6 @@
             android:id="@+id/header"
             android:layout_width="match_parent"
             android:layout_height="@dimen/podcast_header_height"
-            android:background="@{headerColor}"
             android:contentDescription="@string/podcasts_show_podcast_details"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Related to: #1908 

This PR migrates top header view on podcast details from data binding to view binding.

## Review hints

1. I've prepared this PR in a way that it's easy to review the change commit by commit, and I advise doing so.
2. I find it helpful to check "Hide white spaces" option. It makes much more easy to review some XML changes, as indentation in the file was changed. 

![image](https://github.com/Automattic/pocket-casts-android/assets/5845095/f778447f-2a75-4c80-81c6-e2bd1695b88c)

## Testing Instructions

Please smoke test the top header on episode details. Check portrait and landscape layouts, verify subscribed vs. not subscribed states, check if icons change if the podcast is/is not in a folder or if it has an alarm.


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
