### PR TITLE
[Fix] Categories tapping

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoriesListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoriesListRowAdapter.kt
@@ -24,20 +24,30 @@ val CATEGORY_DIFF = object : DiffUtil.ItemCallback<DiscoverCategory>() {
 }
 
 class CategoriesListRowAdapter(val onPodcastListClick: (NetworkLoadableList) -> Unit) : ListAdapter<DiscoverCategory, CategoriesListRowAdapter.CategoryViewHolder>(CATEGORY_DIFF) {
-
-    class CategoryViewHolder(val binding: ItemCategoryBinding) : RecyclerView.ViewHolder(binding.root)
-
+    class CategoryViewHolder(
+        val binding: ItemCategoryBinding,
+        onItemClicked: (Int) -> Unit,
+    ) : RecyclerView.ViewHolder(binding.root) {
+        init {
+            binding.itemCategoryLinear.setOnClickListener {
+                onItemClicked(bindingAdapterPosition)
+            }
+        }
+        fun bind(category: DiscoverCategory) {
+            binding.lblTitle.text = category.name
+            binding.imageView.load(category.icon)
+        }
+    }
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CategoryViewHolder {
         val inflater = LayoutInflater.from(parent.context)
         val binding = ItemCategoryBinding.inflate(inflater, parent, false)
-        return CategoryViewHolder(binding)
-    }
 
+        return CategoryViewHolder(binding) { position ->
+            onPodcastListClick(getItem(position))
+        }
+    }
     override fun onBindViewHolder(holder: CategoryViewHolder, position: Int) {
-        val category = getItem(position)
-        holder.binding.lblTitle.text = category.name
-        holder.binding.imageView.load(category.icon)
-        holder.itemView.setOnClickListener { onPodcastListClick(category) }
+        holder.bind(getItem(position))
     }
 }
 class CategoriesListRowRedesignAdapter(


### PR DESCRIPTION
## Description
- After https://github.com/Automattic/pocket-casts-android/pull/1930 tapping on categories stopped working when `CATEGORIES_REDESIGN` feature flag is `OFF`. This PR fixes this issue


## Testing Instructions
- With the feature flag OFF try to tap on some category
- The category view should be opened


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
