### PR TITLE
Migrate episode container from data binding

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -312,9 +312,7 @@ class EpisodeContainerFragment :
     override fun onEpisodeLoaded(state: EpisodeFragment.EpisodeToolbarState) {
         binding?.apply {
             val iconColor = ThemeColor.podcastIcon02(activeTheme, state.tintColor)
-            episode = state.episode
             btnFav.setImageResource(if (state.episode.isStarred) R.drawable.ic_star_filled else R.drawable.ic_star)
-            toolbarTintColor = iconColor
             btnFav.imageTintList = ColorStateList.valueOf(iconColor)
             btnClose.imageTintList = ColorStateList.valueOf(iconColor)
             btnShare.imageTintList = ColorStateList.valueOf(iconColor)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -312,11 +312,12 @@ class EpisodeContainerFragment :
     override fun onEpisodeLoaded(state: EpisodeFragment.EpisodeToolbarState) {
         binding?.apply {
             val iconColor = ThemeColor.podcastIcon02(activeTheme, state.tintColor)
+            val iconTint = ColorStateList.valueOf(iconColor)
             btnFav.setImageResource(if (state.episode.isStarred) R.drawable.ic_star_filled else R.drawable.ic_star)
-            btnFav.imageTintList = ColorStateList.valueOf(iconColor)
-            btnClose.imageTintList = ColorStateList.valueOf(iconColor)
-            btnShare.imageTintList = ColorStateList.valueOf(iconColor)
-            tabLayout.tabTextColors = ColorStateList.valueOf(iconColor)
+            btnFav.imageTintList = iconTint
+            btnClose.imageTintList = iconTint
+            btnShare.imageTintList = iconTint
+            tabLayout.tabTextColors = iconTint
             tabLayout.setSelectedTabIndicatorColor(iconColor)
             btnShare.setOnClickListener { state.onShareClicked() }
             btnFav.contentDescription = getString(if (state.episode.isStarred) LR.string.podcast_episode_starred else LR.string.podcast_episode_unstarred)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -317,6 +317,7 @@ class EpisodeContainerFragment :
             toolbarTintColor = iconColor
             btnFav.imageTintList = ColorStateList.valueOf(iconColor)
             btnClose.imageTintList = ColorStateList.valueOf(iconColor)
+            btnShare.imageTintList = ColorStateList.valueOf(iconColor)
             tabLayout.tabTextColors = ColorStateList.valueOf(iconColor)
             tabLayout.setSelectedTabIndicatorColor(iconColor)
             btnShare.setOnClickListener { state.onShareClicked() }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -313,7 +313,9 @@ class EpisodeContainerFragment :
         binding?.apply {
             val iconColor = ThemeColor.podcastIcon02(activeTheme, state.tintColor)
             episode = state.episode
+            btnFav.setImageResource(if (state.episode.isStarred) R.drawable.ic_star_filled else R.drawable.ic_star)
             toolbarTintColor = iconColor
+            btnFav.imageTintList = ColorStateList.valueOf(iconColor)
             tabLayout.tabTextColors = ColorStateList.valueOf(iconColor)
             tabLayout.setSelectedTabIndicatorColor(iconColor)
             btnShare.setOnClickListener { state.onShareClicked() }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -316,6 +316,7 @@ class EpisodeContainerFragment :
             btnFav.setImageResource(if (state.episode.isStarred) R.drawable.ic_star_filled else R.drawable.ic_star)
             toolbarTintColor = iconColor
             btnFav.imageTintList = ColorStateList.valueOf(iconColor)
+            btnClose.imageTintList = ColorStateList.valueOf(iconColor)
             tabLayout.tabTextColors = ColorStateList.valueOf(iconColor)
             tabLayout.setSelectedTabIndicatorColor(iconColor)
             btnShare.setOnClickListener { state.onShareClicked() }

--- a/modules/features/podcasts/src/main/res/layout/fragment_episode_container.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_episode_container.xml
@@ -59,7 +59,6 @@
                 android:layout_marginEnd="@dimen/episode_card_edge_padding"
                 android:background="?attr/selectableItemBackgroundBorderless"
                 android:src="@drawable/ic_share"
-                android:tint="@{toolbarTintColor}"
                 android:contentDescription="@string/podcast_share_episode"
                 app:layout_constraintBottom_toBottomOf="@+id/btnClose"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/modules/features/podcasts/src/main/res/layout/fragment_episode_container.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_episode_container.xml
@@ -30,7 +30,6 @@
                 android:layout_marginStart="@dimen/episode_card_edge_padding"
                 android:background="?attr/selectableItemBackgroundBorderless"
                 android:src="@drawable/ic_chevron"
-                android:tint="@{toolbarTintColor}"
                 android:contentDescription="@string/close"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />

--- a/modules/features/podcasts/src/main/res/layout/fragment_episode_container.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_episode_container.xml
@@ -1,95 +1,83 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-    <data>
-        <variable
-            name="episode"
-            type="au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode" />
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-        <variable
-            name="toolbarTintColor"
-            type="int" />
-    </data>
-
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:layout_height="wrap_content"
+        android:clickable="true"
+        android:focusable="true"
+        android:background="?attr/primary_ui_01">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
+        <ImageButton
+            android:id="@+id/btnClose"
+            android:layout_width="28dp"
+            android:layout_height="48dp"
+            android:layout_marginStart="@dimen/episode_card_edge_padding"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_chevron"
+            android:contentDescription="@string/close"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tabLayout"
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:background="@color/transparent"
+            style="@style/Widget.MaterialComponents.TabLayout"
+            app:tabIndicatorFullWidth="false"
+            app:tabTextAppearance="@style/PlayerTabTextAppearance"
+            app:tabGravity="fill"
+            app:tabMode="scrollable"
+            app:tabBackground="@color/transparent"
+            app:tabPaddingStart="8dp"
+            app:tabPaddingEnd="8dp"
+            app:tabMinWidth="0dp"
+            app:layout_constraintStart_toEndOf="@+id/btnClose"
+            app:layout_constraintTop_toTopOf="@+id/btnClose"
+            app:layout_constraintEnd_toEndOf="@+id/btnShare"/>
+
+        <ImageButton
+            android:id="@+id/btnShare"
+            android:layout_width="28dp"
+            android:layout_height="28dp"
+            android:layout_marginEnd="@dimen/episode_card_edge_padding"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_share"
+            android:contentDescription="@string/podcast_share_episode"
+            app:layout_constraintBottom_toBottomOf="@+id/btnClose"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/btnClose" />
+
+        <ImageButton
+            android:id="@+id/btnFav"
+            android:layout_width="28dp"
+            android:layout_height="28dp"
+            android:layout_marginEnd="10dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            app:layout_constraintBottom_toBottomOf="@+id/btnClose"
+            app:layout_constraintEnd_toStartOf="@+id/btnShare"
+            app:layout_constraintTop_toTopOf="@+id/btnClose" />
+
+        <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
+            android:id="@+id/multiSelectToolbar"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:clickable="true"
-            android:focusable="true"
-            android:background="?attr/primary_ui_01">
+            android:minHeight="?android:attr/actionBarSize"
+            android:visibility="gone"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"/>
 
-            <ImageButton
-                android:id="@+id/btnClose"
-                android:layout_width="28dp"
-                android:layout_height="48dp"
-                android:layout_marginStart="@dimen/episode_card_edge_padding"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:src="@drawable/ic_chevron"
-                android:contentDescription="@string/close"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <com.google.android.material.tabs.TabLayout
-                android:id="@+id/tabLayout"
-                android:layout_width="0dp"
-                android:layout_height="48dp"
-                android:background="@color/transparent"
-                style="@style/Widget.MaterialComponents.TabLayout"
-                app:tabIndicatorFullWidth="false"
-                app:tabTextAppearance="@style/PlayerTabTextAppearance"
-                app:tabGravity="fill"
-                app:tabMode="scrollable"
-                app:tabBackground="@color/transparent"
-                app:tabPaddingStart="8dp"
-                app:tabPaddingEnd="8dp"
-                app:tabMinWidth="0dp"
-                app:layout_constraintStart_toEndOf="@+id/btnClose"
-                app:layout_constraintTop_toTopOf="@+id/btnClose"
-                app:layout_constraintEnd_toEndOf="@+id/btnShare"/>
-
-            <ImageButton
-                android:id="@+id/btnShare"
-                android:layout_width="28dp"
-                android:layout_height="28dp"
-                android:layout_marginEnd="@dimen/episode_card_edge_padding"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:src="@drawable/ic_share"
-                android:contentDescription="@string/podcast_share_episode"
-                app:layout_constraintBottom_toBottomOf="@+id/btnClose"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/btnClose" />
-
-            <ImageButton
-                android:id="@+id/btnFav"
-                android:layout_width="28dp"
-                android:layout_height="28dp"
-                android:layout_marginEnd="10dp"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                app:layout_constraintBottom_toBottomOf="@+id/btnClose"
-                app:layout_constraintEnd_toStartOf="@+id/btnShare"
-                app:layout_constraintTop_toTopOf="@+id/btnClose" />
-
-            <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
-                android:id="@+id/multiSelectToolbar"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:minHeight="?android:attr/actionBarSize"
-                android:visibility="gone"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"/>
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.viewpager2.widget.ViewPager2
-            android:id="@+id/viewPager"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1" />
-    </LinearLayout>
-</layout>
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/viewPager"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+</LinearLayout>

--- a/modules/features/podcasts/src/main/res/layout/fragment_episode_container.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_episode_container.xml
@@ -72,8 +72,6 @@
                 android:layout_height="28dp"
                 android:layout_marginEnd="10dp"
                 android:background="?attr/selectableItemBackgroundBorderless"
-                android:src="@{episode.starred ? @drawable/ic_star_filled : @drawable/ic_star}"
-                android:tint="@{toolbarTintColor}"
                 app:layout_constraintBottom_toBottomOf="@+id/btnClose"
                 app:layout_constraintEnd_toStartOf="@+id/btnShare"
                 app:layout_constraintTop_toTopOf="@+id/btnClose" />


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Related to: #1908 

This PR migrates episode container from data binding to view binding.

## Review hints

1. I've prepared this PR in a way that it's easy to review the change commit by commit, and I advise doing so.
2. I find it helpful to check "Hide white spaces" option. It makes much more easy to review some XML changes, as indentation in the file was changed. 

![image](https://github.com/Automattic/pocket-casts-android/assets/5845095/f778447f-2a75-4c80-81c6-e2bd1695b88c)

## Testing Instructions
Open episode, verify if icons are in the expected color and star icon changes when you tap on it.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
