### PR TITLE
Reduce recomposition count

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
@@ -36,6 +36,7 @@ import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlinx.coroutines.flow.distinctUntilChanged
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -92,6 +93,11 @@ class BookmarksFragment : BaseFragment() {
                 // https://stackoverflow.com/a/70195667/193545
                 Surface(modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection())) {
                     val listData = playerViewModel.listDataLive.asFlow()
+                        // ignore the episode progress
+                        .distinctUntilChanged { t1, t2 ->
+                            t1.podcastHeader.episodeUuid == t2.podcastHeader.episodeUuid &&
+                                t1.podcastHeader.isPlaying == t2.podcastHeader.isPlaying
+                        }
                         .collectAsState(initial = null)
 
                     val episodeUuid = episodeUuid(listData)


### PR DESCRIPTION
## Description

This reduces the recomposition count for the bookmarks page.

## Testing Instructions

- Login as a paid user 
- Play an episode having bookmarks
- Open full-screen player
- Switch to the `Bookmarks` tab
- ✅ Notice in Android Studio Layout Manager that the recomposition count doesn't increment on episode progress changes
- Go to playing episode's Podcast details -> Bookmarks tab
- Update bookmark title for the playing episode bookmark
- ✅ Notice that the title is changed on Player -> Bookmarks tab

## Screenshots or Screencast 
N/A

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
