### PR TITLE
Migrate podcast fragment from data binding

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -297,22 +297,22 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         val dialog = OptionsDialog()
             .addCheckedOption(
                 titleId = LR.string.episode_sort_newest_to_oldest,
-                checked = binding?.podcast?.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_DATE_DESC,
+                checked = viewModel.podcast.value?.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_DATE_DESC,
                 click = sortEpisodesNewestToOldest,
             )
             .addCheckedOption(
                 titleId = LR.string.episode_sort_oldest_to_newest,
-                checked = binding?.podcast?.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_DATE_ASC,
+                checked = viewModel.podcast.value?.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_DATE_ASC,
                 click = sortEpisodesOldestToNewest,
             )
             .addCheckedOption(
                 titleId = LR.string.episode_sort_short_to_long,
-                checked = binding?.podcast?.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_LENGTH_ASC,
+                checked = viewModel.podcast.value?.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_LENGTH_ASC,
                 click = sortEpisodesLengthShortToLong,
             )
             .addCheckedOption(
                 titleId = LR.string.episode_sort_long_to_short,
-                checked = binding?.podcast?.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_LENGTH_DESC,
+                checked = viewModel.podcast.value?.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_LENGTH_DESC,
                 click = sortEpisodesLengthLongToShort,
             )
         activity?.supportFragmentManager?.let {
@@ -653,8 +653,6 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
         binding.btnRetry.setOnClickListener {
             loadData()
-            binding.error = null
-            binding.executePendingBindings()
         }
 
         binding.episodesRecyclerView.requestFocus()
@@ -770,14 +768,9 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         viewModel.podcast.observe(
             viewLifecycleOwner,
             Observer<Podcast> { podcast ->
-                val binding = binding ?: return@Observer
-
-                binding.podcast = podcast
-
                 val backgroundColor = ThemeColor.podcastUi03(theme.activeTheme, podcast.backgroundColor)
-                binding.headerColor = backgroundColor
-                binding.toolbar.setBackgroundColor(backgroundColor)
-                binding.headerBackgroundPlaceholder.setBackgroundColor(backgroundColor)
+                binding?.toolbar?.setBackgroundColor(backgroundColor)
+                binding?.headerBackgroundPlaceholder?.setBackgroundColor(backgroundColor)
 
                 adapter?.setPodcast(podcast)
 
@@ -786,12 +779,10 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                 statusBarColor = StatusBarColor.Custom(backgroundColor, true)
                 updateStatusBar()
 
-                binding.executePendingBindings()
             },
         )
 
         viewModel.tintColor.observe(viewLifecycleOwner) { tintColor ->
-            binding?.tintColor = tintColor
             adapter?.setTint(tintColor)
         }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -560,6 +560,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         val context = binding.root.context
         val headerColor = context.getThemeColor(UR.attr.support_09)
         binding.headerColor = headerColor
+        binding.toolbar.setBackgroundColor(headerColor)
         statusBarColor = StatusBarColor.Custom(headerColor, true)
         updateStatusBar()
 
@@ -775,6 +776,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
                 val backgroundColor = ThemeColor.podcastUi03(theme.activeTheme, podcast.backgroundColor)
                 binding.headerColor = backgroundColor
+                binding.toolbar.setBackgroundColor(backgroundColor)
 
                 adapter?.setPodcast(podcast)
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -798,9 +798,11 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             when (state) {
                 is PodcastViewModel.UiState.Loading -> {
                     binding?.loading?.visibility = View.VISIBLE
+                    binding?.errorContainer?.visibility = View.GONE
                 }
                 is PodcastViewModel.UiState.Loaded -> {
                     binding?.loading?.visibility = View.GONE
+                    binding?.errorContainer?.visibility = View.GONE
                     addPaddingForEpisodeSearch(state.episodes)
                     when (state.showTab) {
                         PodcastTab.EPISODES -> {
@@ -834,6 +836,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                 is PodcastViewModel.UiState.Error -> {
                     adapter?.setError()
                     binding?.loading?.visibility = View.GONE
+                    binding?.errorContainer?.visibility = View.VISIBLE
                     binding?.error = getString(LR.string.podcast_load_error)
 
                     if (BuildConfig.DEBUG) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -778,7 +778,6 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
                 statusBarColor = StatusBarColor.Custom(backgroundColor, true)
                 updateStatusBar()
-
             },
         )
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -796,8 +796,11 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
         viewModel.uiState.observe(viewLifecycleOwner) { state ->
             when (state) {
-                is PodcastViewModel.UiState.Loading -> Unit
+                is PodcastViewModel.UiState.Loading -> {
+                    binding?.loading?.visibility = View.VISIBLE
+                }
                 is PodcastViewModel.UiState.Loaded -> {
+                    binding?.loading?.visibility = View.GONE
                     addPaddingForEpisodeSearch(state.episodes)
                     when (state.showTab) {
                         PodcastTab.EPISODES -> {
@@ -830,6 +833,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                 }
                 is PodcastViewModel.UiState.Error -> {
                     adapter?.setError()
+                    binding?.loading?.visibility = View.GONE
                     binding?.error = getString(LR.string.podcast_load_error)
 
                     if (BuildConfig.DEBUG) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -559,7 +559,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
         val context = binding.root.context
         val headerColor = context.getThemeColor(UR.attr.support_09)
-        binding.headerColor = headerColor
+        binding.headerBackgroundPlaceholder.setBackgroundColor(headerColor)
         binding.toolbar.setBackgroundColor(headerColor)
         statusBarColor = StatusBarColor.Custom(headerColor, true)
         updateStatusBar()
@@ -777,6 +777,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                 val backgroundColor = ThemeColor.podcastUi03(theme.activeTheme, podcast.backgroundColor)
                 binding.headerColor = backgroundColor
                 binding.toolbar.setBackgroundColor(backgroundColor)
+                binding.headerBackgroundPlaceholder.setBackgroundColor(backgroundColor)
 
                 adapter?.setPodcast(podcast)
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -837,7 +837,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                     adapter?.setError()
                     binding?.loading?.visibility = View.GONE
                     binding?.errorContainer?.visibility = View.VISIBLE
-                    binding?.error = getString(LR.string.podcast_load_error)
+                    binding?.errorMessage?.text = getString(LR.string.podcast_load_error)
 
                     if (BuildConfig.DEBUG) {
                         UiUtil.displayAlertError(requireContext(), state.errorMessage, null)

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
@@ -62,8 +62,7 @@
                 <View
                     android:id="@+id/headerBackgroundPlaceholder"
                     android:layout_width="match_parent"
-                    android:layout_height="@dimen/podcast_header_height"
-                    android:background="@{headerColor}" />
+                    android:layout_height="@dimen/podcast_header_height" />
 
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/episodesRecyclerView"

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
@@ -90,10 +90,10 @@
                     android:clipToPadding="false"
                     android:padding="16dp">
                     <TextView
+                        android:id="@+id/errorMessage"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:gravity="center"
-                        android:text="@{error}"
                         style="?attr/textBody1"
                         android:layout_marginBottom="8dp"/>
                     <com.google.android.material.button.MaterialButton

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
@@ -27,7 +27,6 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?android:attr/actionBarSize"
-            android:background="@{headerColor}"
             android:elevation="0dp"
             android:minHeight="?android:attr/actionBarSize"
             android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
@@ -78,8 +78,7 @@
                     android:id="@+id/loading"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:visibility="@{podcast == null &amp;&amp; error == null}"/>
+                    android:layout_gravity="center" />
 
                 <LinearLayout
                     android:layout_width="wrap_content"

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
@@ -81,11 +81,11 @@
                     android:layout_gravity="center" />
 
                 <LinearLayout
+                    android:id="@+id/errorContainer"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
                     android:layout_gravity="center"
-                    android:visibility="@{error != null}"
                     android:clipChildren="false"
                     android:clipToPadding="false"
                     android:padding="16dp">

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
@@ -1,121 +1,102 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <data>
-        <variable
-            name="podcast"
-            type="au.com.shiftyjelly.pocketcasts.models.entity.Podcast" />
-        <variable
-            name="tintColor"
-            type="int" />
-        <variable
-            name="headerColor"
-            type="int" />
-        <variable
-            name="error"
-            type="String" />
-    </data>
-
-    <LinearLayout
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:layout_height="?android:attr/actionBarSize"
+        android:elevation="0dp"
+        android:minHeight="?android:attr/actionBarSize"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        app:navigationIcon="@drawable/ic_arrow_back_24dp"
+        app:popupTheme="@style/LightPopupTheme" />
 
-        <androidx.appcompat.widget.Toolbar
-            android:id="@+id/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="?android:attr/actionBarSize"
-            android:elevation="0dp"
-            android:minHeight="?android:attr/actionBarSize"
-            android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-            app:navigationIcon="@drawable/ic_arrow_back_24dp"
-            app:popupTheme="@style/LightPopupTheme" />
+    <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
+        android:id="@+id/multiSelectEpisodesToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?android:attr/actionBarSize"
+        app:navigationIcon="?attr/homeAsUpIndicator"
+        android:visibility="gone"/>
 
-        <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
-            android:id="@+id/multiSelectEpisodesToolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:minHeight="?android:attr/actionBarSize"
-            app:navigationIcon="?attr/homeAsUpIndicator"
-            android:visibility="gone"/>
+    <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
+        android:id="@+id/multiSelectBookmarksToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?android:attr/actionBarSize"
+        app:navigationIcon="?attr/homeAsUpIndicator"
+        android:visibility="gone"/>
 
-        <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
-            android:id="@+id/multiSelectBookmarksToolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:minHeight="?android:attr/actionBarSize"
-            app:navigationIcon="?attr/homeAsUpIndicator"
-            android:visibility="gone"/>
+    <FrameLayout
+        android:id="@+id/podcastContentWrapper"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
         <FrameLayout
-            android:id="@+id/podcastContentWrapper"
+            android:id="@+id/podcastContent"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <FrameLayout
-                android:id="@+id/podcastContent"
+            <View
+                android:id="@+id/headerBackgroundPlaceholder"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
+                android:layout_height="@dimen/podcast_header_height" />
 
-                <View
-                    android:id="@+id/headerBackgroundPlaceholder"
-                    android:layout_width="match_parent"
-                    android:layout_height="@dimen/podcast_header_height" />
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/episodesRecyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:scrollbars="vertical"
+                android:scrollbarStyle="outsideOverlay"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
 
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/episodesRecyclerView"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:clipToPadding="false"
-                    android:scrollbars="vertical"
-                    android:scrollbarStyle="outsideOverlay"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
+            <ProgressBar
+                android:id="@+id/loading"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center" />
 
-                <ProgressBar
-                    android:id="@+id/loading"
+            <LinearLayout
+                android:id="@+id/errorContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_gravity="center"
+                android:clipChildren="false"
+                android:clipToPadding="false"
+                android:padding="16dp">
+                <TextView
+                    android:id="@+id/errorMessage"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center" />
-
-                <LinearLayout
-                    android:id="@+id/errorContainer"
+                    android:gravity="center"
+                    style="?attr/textBody1"
+                    android:layout_marginBottom="8dp"/>
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnRetry"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
                     android:layout_gravity="center"
-                    android:clipChildren="false"
-                    android:clipToPadding="false"
-                    android:padding="16dp">
-                    <TextView
-                        android:id="@+id/errorMessage"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:gravity="center"
-                        style="?attr/textBody1"
-                        android:layout_marginBottom="8dp"/>
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/btnRetry"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:text="@string/podcasts_download_retry"/>
-                </LinearLayout>
-            </FrameLayout>
-
-            <ImageView
-                android:id="@+id/transitionArtwork"
-                android:layout_width="80dp"
-                android:layout_height="80dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                android:adjustViewBounds="false"
-                android:scaleType="centerCrop"
-                tools:src="@tools:sample/avatars" />
-
+                    android:text="@string/podcasts_download_retry"/>
+            </LinearLayout>
         </FrameLayout>
 
-    </LinearLayout>
+        <ImageView
+            android:id="@+id/transitionArtwork"
+            android:layout_width="80dp"
+            android:layout_height="80dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:adjustViewBounds="false"
+            android:scaleType="centerCrop"
+            tools:src="@tools:sample/avatars" />
 
-</layout>
+    </FrameLayout>
+
+</LinearLayout>


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Related to: #1908 

This PR migrates podcast view from data binding to view binding.

## Review hints

1. I've prepared this PR in a way that it's easy to review the change commit by commit, and I advise doing so.
2. I find it helpful to check "Hide white spaces" option. It makes much more easy to review some XML changes, as indentation in the file was changed. 

![image](https://github.com/Automattic/pocket-casts-android/assets/5845095/f778447f-2a75-4c80-81c6-e2bd1695b88c)

## Testing Instructions

Please smoke test podcast fragment. Focus on 3 states: loading, loaded and error. I've used this snippet to help reproducing those 3 states:

<details><summary>PATCH to alternate between loaded and error states on each open of podcast details</summary>

```PATCH
Subject: [PATCH] feat: remove data binding from `fragment_podcast`
---
Index: modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt	(revision deb0a0e072c3036f90dc52b862b314a065d2a10b)
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt	(date 1710433906639)
@@ -64,6 +64,8 @@
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
+var counter = 0
+
 @HiltViewModel
 class PodcastViewModel
 @Inject constructor(
@@ -689,7 +691,12 @@
                 episodeLimit = podcast.autoArchiveEpisodeLimit,
                 episodeLimitIndex = episodeLimitIndex,
             )
-            state
+            counter++
+            if (counter % 2 == 0) {
+                PodcastViewModel.UiState.Error("There was an error loading the episodes or bookmarks")
+            } else {
+                state
+            }
         }
             .doOnError { Timber.e("Error loading episodes or bookmarks: ${it.message}") }
             .onErrorReturnItem(PodcastViewModel.UiState.Error("There was an error loading the episodes or bookmarks"))

```
</details>

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/5845095/38f2260f-974b-4d74-9a3d-26d83b61c3b9



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
