### PR TITLE
Disable data binding in podcasts module

### DIFF
--- a/modules/features/podcasts/build.gradle.kts
+++ b/modules/features/podcasts/build.gradle.kts
@@ -14,7 +14,6 @@ android {
     buildFeatures {
         buildConfig = true
         viewBinding = true
-        dataBinding = true
         compose = true
     }
 }


### PR DESCRIPTION
Related to #1908 

This tiny PR disables data binding in `podcasts` module.

### Testing
It's just about build - passed checks from CI makes this PR safe to merge.