### PR TITLE
Migrate search fragment from data binding. Disable data binding in search module.

### DIFF
--- a/modules/features/search/build.gradle.kts
+++ b/modules/features/search/build.gradle.kts
@@ -14,7 +14,6 @@ android {
     buildFeatures {
         buildConfig = true
         viewBinding = true
-        dataBinding = true
         compose = true
     }
 }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -11,6 +11,7 @@ import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import androidx.appcompat.widget.SearchView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.view.updatePadding
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
@@ -39,7 +40,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
-import androidx.core.view.updatePadding
 
 private const val ARG_FLOATING = "arg_floating"
 private const val ARG_ONLY_SEARCH_REMOTE = "arg_only_search_remote"
@@ -105,15 +105,17 @@ class SearchFragment : BaseFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         val binding = FragmentSearchBinding.inflate(inflater, container, false)
-        binding.lifecycleOwner = viewLifecycleOwner
         viewModel.setOnlySearchRemote(onlySearchRemote)
         searchHistoryViewModel.setOnlySearchRemote(onlySearchRemote)
         searchHistoryViewModel.setSource(source)
-        binding.floating = floating
         binding.floatingLayout.updatePadding(
-            top = if (floating) binding.floatingLayout.context.resources.getDimensionPixelSize(
-                R.dimen.search_box_floating_top
-            ) else 0
+            top = if (floating) {
+                binding.floatingLayout.context.resources.getDimensionPixelSize(
+                    R.dimen.search_box_floating_top,
+                )
+            } else {
+                0
+            },
         )
 
         this.binding = binding

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -39,6 +39,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
+import androidx.core.view.updatePadding
 
 private const val ARG_FLOATING = "arg_floating"
 private const val ARG_ONLY_SEARCH_REMOTE = "arg_only_search_remote"
@@ -109,6 +110,11 @@ class SearchFragment : BaseFragment() {
         searchHistoryViewModel.setOnlySearchRemote(onlySearchRemote)
         searchHistoryViewModel.setSource(source)
         binding.floating = floating
+        binding.floatingLayout.updatePadding(
+            top = if (floating) binding.floatingLayout.context.resources.getDimensionPixelSize(
+                R.dimen.search_box_floating_top
+            ) else 0
+        )
 
         this.binding = binding
 

--- a/modules/features/search/src/main/res/layout/fragment_search.xml
+++ b/modules/features/search/src/main/res/layout/fragment_search.xml
@@ -1,73 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
-
-    <data>
-        <variable
-            name="floating"
-            type="boolean" />
-    </data>
-
-    <FrameLayout
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical"
-            android:background="?attr/primary_ui_01"
-            tools:context=".SearchFragment">
-
-            <FrameLayout
-                android:id="@+id/floatingLayout"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingStart="16dp"
-                android:background="?attr/secondary_ui_01">
-
-                <androidx.appcompat.widget.SearchView
-                    android:id="@+id/searchView"
-                    android:layout_width="match_parent"
-                    android:layout_height="?android:attr/actionBarSize"
-                    android:hint="@string/search_podcasts_or_add_url"
-                    android:textColorHint="?attr/secondary_text_02"
-                    android:paddingStart="40dp"
-                    android:paddingEnd="8dp"
-                    app:searchIcon="@null"
-                    android:theme="@style/Widget.AppCompat.SearchView.PCAccent"
-                    android:textColor="?attr/secondary_text_01" />
-
-                <ImageButton
-                    android:id="@+id/backButton"
-                    android:layout_width="44dp"
-                    android:layout_height="44dp"
-                    android:layout_marginTop="6dp"
-                    android:layout_marginStart="6dp"
-                    android:src="@drawable/ic_arrow_back_24dp"
-                    android:background="?android:attr/actionBarItemBackground"
-                    android:contentDescription="@string/back"
-                    app:tint="?attr/secondary_icon_01" />
-
-            </FrameLayout>
-
-            <androidx.compose.ui.platform.ComposeView
-                android:id="@+id/searchHistoryPanel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-
-            <androidx.compose.ui.platform.ComposeView
-                android:id="@+id/searchInlineResults"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
-
-        </LinearLayout>
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:background="?attr/primary_ui_01"
+        tools:context=".SearchFragment">
 
         <FrameLayout
-            android:id="@+id/searchResults"
+            android:id="@+id/floatingLayout"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="wrap_content"
+            android:paddingStart="16dp"
+            android:background="?attr/secondary_ui_01">
 
-    </FrameLayout>
+            <androidx.appcompat.widget.SearchView
+                android:id="@+id/searchView"
+                android:layout_width="match_parent"
+                android:layout_height="?android:attr/actionBarSize"
+                android:hint="@string/search_podcasts_or_add_url"
+                android:textColorHint="?attr/secondary_text_02"
+                android:paddingStart="40dp"
+                android:paddingEnd="8dp"
+                app:searchIcon="@null"
+                android:theme="@style/Widget.AppCompat.SearchView.PCAccent"
+                android:textColor="?attr/secondary_text_01" />
 
-</layout>
+            <ImageButton
+                android:id="@+id/backButton"
+                android:layout_width="44dp"
+                android:layout_height="44dp"
+                android:layout_marginTop="6dp"
+                android:layout_marginStart="6dp"
+                android:src="@drawable/ic_arrow_back_24dp"
+                android:background="?android:attr/actionBarItemBackground"
+                android:contentDescription="@string/back"
+                app:tint="?attr/secondary_icon_01" />
+
+        </FrameLayout>
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/searchHistoryPanel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/searchInlineResults"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
+    </LinearLayout>
+
+    <FrameLayout
+        android:id="@+id/searchResults"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</FrameLayout>

--- a/modules/features/search/src/main/res/layout/fragment_search.xml
+++ b/modules/features/search/src/main/res/layout/fragment_search.xml
@@ -24,7 +24,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:paddingStart="16dp"
-                android:paddingTop="@{floating ? @dimen/search_box_floating_top : 0}"
                 android:background="?attr/secondary_ui_01">
 
                 <androidx.appcompat.widget.SearchView


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Related to: #1908 

This PR migrates search view from data binding to view binding and disables data binding in whole `search` module.

## Review hints

1. I've prepared this PR in a way that it's easy to review the change commit by commit, and I advise doing so.
2. I find it helpful to check "Hide white spaces" option. It makes much more easy to review some XML changes, as indentation in the file was changed. 

![image](https://github.com/Automattic/pocket-casts-android/assets/5845095/f778447f-2a75-4c80-81c6-e2bd1695b88c)

## Testing Instructions

Please smoke test search. Assert that in search in `Discover` there's higher top padding than in search in `Podcasts` tabs.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
