### PR TITLE
Remove unused binding adapters. Disable data binding in views module. 

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/binding/ViewExtensions.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/binding/ViewExtensions.kt
@@ -7,37 +7,34 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.airbnb.lottie.LottieAnimationView
 import okhttp3.HttpUrl
 
-object ViewExtensions {
+fun View.showIfPresent(url: HttpUrl?) {
+    visibility = if (url?.toString().isNullOrEmpty()) View.GONE else View.VISIBLE
+}
 
-    fun View.showIfPresent(url: HttpUrl?) {
-        visibility = if (url?.toString().isNullOrEmpty()) View.GONE else View.VISIBLE
+fun PlayerSeekBar.setPlaybackState(playbackState: PlaybackState?) {
+    if (playbackState == null) {
+        return
     }
+    setDurationMs(playbackState.durationMs)
+    setCurrentTimeMs(playbackState.positionMs)
+    setTintColor(playbackState.podcast?.tintColorForDarkBg, Theme.ThemeType.DARK)
+}
 
-    fun PlayerSeekBar.setPlaybackState(playbackState: PlaybackState?) {
-        if (playbackState == null) {
-            return
+fun PlayerSeekBar.setSeekBarState(durationMs: Int, positionMs: Int, tintColor: Int, bufferedUpTo: Int, isBuffering: Boolean, theme: Theme.ThemeType) {
+    setDurationMs(durationMs)
+    setCurrentTimeMs(positionMs)
+    setTintColor(tintColor, theme)
+    this.isBuffering = isBuffering
+    bufferedUpToInSecs = bufferedUpTo / 1000
+}
+
+fun LottieAnimationView.playIfTrue(play: Boolean?) {
+    if (play != null && play) {
+        if (!isAnimating) {
+            playAnimation()
         }
-        setDurationMs(playbackState.durationMs)
-        setCurrentTimeMs(playbackState.positionMs)
-        setTintColor(playbackState.podcast?.tintColorForDarkBg, Theme.ThemeType.DARK)
-    }
-
-    fun PlayerSeekBar.setSeekBarState(durationMs: Int, positionMs: Int, tintColor: Int, bufferedUpTo: Int, isBuffering: Boolean, theme: Theme.ThemeType) {
-        setDurationMs(durationMs)
-        setCurrentTimeMs(positionMs)
-        setTintColor(tintColor, theme)
-        this.isBuffering = isBuffering
-        bufferedUpToInSecs = bufferedUpTo / 1000
-    }
-
-    fun LottieAnimationView.playIfTrue(play: Boolean?) {
-        if (play != null && play) {
-            if (!isAnimating) {
-                playAnimation()
-            }
-        } else {
-            pauseAnimation()
-            progress = 0.5f
-        }
+    } else {
+        pauseAnimation()
+        progress = 0.5f
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
@@ -30,8 +30,8 @@ import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.extensions.showIf
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.IntentUtil
-import au.com.shiftyjelly.pocketcasts.views.helper.ViewExtensions.applyTimeLong
-import au.com.shiftyjelly.pocketcasts.views.helper.ViewExtensions.setLongStyleDate
+import au.com.shiftyjelly.pocketcasts.views.helper.applyTimeLong
+import au.com.shiftyjelly.pocketcasts.views.helper.setLongStyleDate
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import timber.log.Timber

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
@@ -30,8 +30,8 @@ import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.extensions.showIf
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.IntentUtil
-import au.com.shiftyjelly.pocketcasts.views.helper.ViewDataBindings.applyTimeLong
-import au.com.shiftyjelly.pocketcasts.views.helper.ViewDataBindings.setLongStyleDate
+import au.com.shiftyjelly.pocketcasts.views.helper.ViewExtensions.applyTimeLong
+import au.com.shiftyjelly.pocketcasts.views.helper.ViewExtensions.setLongStyleDate
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import timber.log.Timber

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -24,9 +24,9 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
 import au.com.shiftyjelly.pocketcasts.player.R
-import au.com.shiftyjelly.pocketcasts.player.binding.ViewExtensions.playIfTrue
-import au.com.shiftyjelly.pocketcasts.player.binding.ViewExtensions.setSeekBarState
-import au.com.shiftyjelly.pocketcasts.player.binding.ViewExtensions.showIfPresent
+import au.com.shiftyjelly.pocketcasts.player.binding.playIfTrue
+import au.com.shiftyjelly.pocketcasts.player.binding.setSeekBarState
+import au.com.shiftyjelly.pocketcasts.player.binding.showIfPresent
 import au.com.shiftyjelly.pocketcasts.player.databinding.AdapterPlayerHeaderBinding
 import au.com.shiftyjelly.pocketcasts.player.view.ShelfFragment.Companion.AnalyticsProp
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarkActivityContract
@@ -53,8 +53,8 @@ import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.extensions.updateColor
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
-import au.com.shiftyjelly.pocketcasts.views.helper.ViewExtensions.toCircle
 import au.com.shiftyjelly.pocketcasts.views.helper.WarningsHelper
+import au.com.shiftyjelly.pocketcasts.views.helper.toCircle
 import coil.load
 import coil.request.Disposable
 import coil.request.ErrorResult

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -53,7 +53,7 @@ import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.extensions.updateColor
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
-import au.com.shiftyjelly.pocketcasts.views.helper.ViewDataBindings.toCircle
+import au.com.shiftyjelly.pocketcasts.views.helper.ViewExtensions.toCircle
 import au.com.shiftyjelly.pocketcasts.views.helper.WarningsHelper
 import coil.load
 import coil.request.Disposable

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -33,7 +33,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
-import au.com.shiftyjelly.pocketcasts.views.helper.ViewExtensions.setEpisodeTimeLeft
+import au.com.shiftyjelly.pocketcasts.views.helper.setEpisodeTimeLeft
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import com.airbnb.lottie.LottieAnimationView
 import com.airbnb.lottie.LottieProperty

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -33,7 +33,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
-import au.com.shiftyjelly.pocketcasts.views.helper.ViewDataBindings.setEpisodeTimeLeft
+import au.com.shiftyjelly.pocketcasts.views.helper.ViewExtensions.setEpisodeTimeLeft
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import com.airbnb.lottie.LottieAnimationView
 import com.airbnb.lottie.LottieProperty

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
@@ -33,7 +33,7 @@ import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.RowSwipeable
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayout
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
-import au.com.shiftyjelly.pocketcasts.views.helper.ViewDataBindings.setEpisodeTimeLeft
+import au.com.shiftyjelly.pocketcasts.views.helper.ViewExtensions.setEpisodeTimeLeft
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.rxkotlin.subscribeBy

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
@@ -33,7 +33,7 @@ import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.RowSwipeable
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayout
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
-import au.com.shiftyjelly.pocketcasts.views.helper.ViewExtensions.setEpisodeTimeLeft
+import au.com.shiftyjelly.pocketcasts.views.helper.setEpisodeTimeLeft
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.rxkotlin.subscribeBy

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
@@ -21,7 +21,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.SimplePlayer
 import au.com.shiftyjelly.pocketcasts.views.extensions.hide
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
-import au.com.shiftyjelly.pocketcasts.views.helper.ViewDataBindings.toCircle
+import au.com.shiftyjelly.pocketcasts.views.helper.ViewExtensions.toCircle
 import com.airbnb.lottie.LottieAnimationView
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
@@ -12,7 +12,7 @@ import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.player.binding.ViewExtensions.setPlaybackState
+import au.com.shiftyjelly.pocketcasts.player.binding.setPlaybackState
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentVideoBinding
 import au.com.shiftyjelly.pocketcasts.player.view.PlayerSeekBar
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.VideoViewModel
@@ -21,7 +21,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.SimplePlayer
 import au.com.shiftyjelly.pocketcasts.views.extensions.hide
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
-import au.com.shiftyjelly.pocketcasts.views.helper.ViewExtensions.toCircle
+import au.com.shiftyjelly.pocketcasts.views.helper.toCircle
 import com.airbnb.lottie.LottieAnimationView
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -57,8 +57,8 @@ import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.IntentUtil
 import au.com.shiftyjelly.pocketcasts.views.helper.ShowNotesFormatter
-import au.com.shiftyjelly.pocketcasts.views.helper.ViewExtensions.setLongStyleDate
 import au.com.shiftyjelly.pocketcasts.views.helper.WarningsHelper
+import au.com.shiftyjelly.pocketcasts.views.helper.setLongStyleDate
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import timber.log.Timber

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -57,7 +57,7 @@ import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.IntentUtil
 import au.com.shiftyjelly.pocketcasts.views.helper.ShowNotesFormatter
-import au.com.shiftyjelly.pocketcasts.views.helper.ViewDataBindings.setLongStyleDate
+import au.com.shiftyjelly.pocketcasts.views.helper.ViewExtensions.setLongStyleDate
 import au.com.shiftyjelly.pocketcasts.views.helper.WarningsHelper
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -64,7 +64,7 @@ import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.extensions.toggleVisibility
 import au.com.shiftyjelly.pocketcasts.views.helper.AnimatorUtil
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
-import au.com.shiftyjelly.pocketcasts.views.helper.ViewDataBindings.toCircle
+import au.com.shiftyjelly.pocketcasts.views.helper.ViewExtensions.toCircle
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import io.reactivex.Observable

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -64,7 +64,7 @@ import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.extensions.toggleVisibility
 import au.com.shiftyjelly.pocketcasts.views.helper.AnimatorUtil
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
-import au.com.shiftyjelly.pocketcasts.views.helper.ViewExtensions.toCircle
+import au.com.shiftyjelly.pocketcasts.views.helper.toCircle
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
 import io.reactivex.Observable

--- a/modules/services/views/build.gradle.kts
+++ b/modules/services/views/build.gradle.kts
@@ -14,7 +14,6 @@ android {
     buildFeatures {
         buildConfig = true
         viewBinding = true
-        dataBinding = true
         compose = true
     }
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ViewDataBindings.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ViewDataBindings.kt
@@ -16,26 +16,6 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 object ViewDataBindings {
 
-    @BindingConversion
-    @JvmStatic
-    fun convertBooleanToVisibility(visible: Boolean): Int {
-        return if (visible) View.VISIBLE else View.GONE
-    }
-
-    @BindingAdapter("circle")
-    @JvmStatic
-    fun clipToCircle(view: View, circle: Boolean) {
-        if (!circle) {
-            return
-        }
-        view.clipToOutline = true
-        view.outlineProvider = object : ViewOutlineProvider() {
-            override fun getOutline(view: View, outline: Outline) {
-                outline.setOval(0, 0, view.width, view.height)
-            }
-        }
-    }
-
     fun View.toCircle(circle: Boolean) {
         if (!circle) {
             return
@@ -48,51 +28,8 @@ object ViewDataBindings {
         }
     }
 
-    @BindingAdapter("clipToOutline")
-    @JvmStatic
-    fun setClipToOutline(view: View, clip: Boolean) {
-        view.clipToOutline = clip
-    }
-
-    @BindingAdapter("android:textColor")
-    @JvmStatic
-    fun setTextColor(textView: TextView, color: Int) {
-        textView.setTextColor(color)
-    }
-
-    /**
-     * Date format: d MMMM yyyy
-     * For example: 4 January 2017
-     */
-    @BindingAdapter("mediumDate")
-    @JvmStatic
-    fun setMediumDate(textView: TextView, date: Date?) {
-        if (date == null) {
-            textView.text = ""
-        } else {
-            textView.text = date.toLocalizedFormatLongStyle()
-        }
-    }
-
     fun TextView.setLongStyleDate(date: Date?) {
         text = date?.toLocalizedFormatLongStyle().orEmpty()
-    }
-
-    @BindingAdapter("timeLeft")
-    @JvmStatic
-    fun setTimeLeft(textView: TextView, episode: BaseEpisode) {
-        if (episode is UserEpisode && episode.serverStatus == UserEpisodeServerStatus.MISSING) {
-            textView.text = textView.resources.getString(LR.string.podcast_episode_file_not_uploaded)
-        } else {
-            val timeLeft = TimeHelper.getTimeLeft(
-                currentTimeMs = episode.playedUpToMs,
-                durationMs = episode.durationMs.toLong(),
-                inProgress = episode.isInProgress,
-                context = textView.context,
-            )
-            textView.text = timeLeft.text
-            textView.contentDescription = timeLeft.description
-        }
     }
 
     fun TextView.setEpisodeTimeLeft(episode: BaseEpisode) {
@@ -108,19 +45,6 @@ object ViewDataBindings {
             text = timeLeft.text
             contentDescription = timeLeft.description
         }
-    }
-
-    @BindingAdapter("timeLong")
-    @JvmStatic
-    fun setTimeLong(textView: TextView, time: Int) {
-        val timeLeft = TimeHelper.getTimeLeft(
-            currentTimeMs = 0,
-            durationMs = time.toLong(),
-            inProgress = false,
-            context = textView.context,
-        )
-        textView.text = timeLeft.text
-        textView.contentDescription = timeLeft.description
     }
 
     fun TextView.applyTimeLong(time: Int) {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ViewExtensions.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ViewExtensions.kt
@@ -12,47 +12,44 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatLongStyl
 import java.util.Date
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-object ViewExtensions {
-
-    fun View.toCircle(circle: Boolean) {
-        if (!circle) {
-            return
-        }
-        clipToOutline = true
-        outlineProvider = object : ViewOutlineProvider() {
-            override fun getOutline(view: View, outline: Outline) {
-                outline.setOval(0, 0, view.width, view.height)
-            }
+fun View.toCircle(circle: Boolean) {
+    if (!circle) {
+        return
+    }
+    clipToOutline = true
+    outlineProvider = object : ViewOutlineProvider() {
+        override fun getOutline(view: View, outline: Outline) {
+            outline.setOval(0, 0, view.width, view.height)
         }
     }
+}
 
-    fun TextView.setLongStyleDate(date: Date?) {
-        text = date?.toLocalizedFormatLongStyle().orEmpty()
-    }
+fun TextView.setLongStyleDate(date: Date?) {
+    text = date?.toLocalizedFormatLongStyle().orEmpty()
+}
 
-    fun TextView.setEpisodeTimeLeft(episode: BaseEpisode) {
-        if (episode is UserEpisode && episode.serverStatus == UserEpisodeServerStatus.MISSING) {
-            text = resources.getString(LR.string.podcast_episode_file_not_uploaded)
-        } else {
-            val timeLeft = TimeHelper.getTimeLeft(
-                currentTimeMs = episode.playedUpToMs,
-                durationMs = episode.durationMs.toLong(),
-                inProgress = episode.isInProgress,
-                context = context,
-            )
-            text = timeLeft.text
-            contentDescription = timeLeft.description
-        }
-    }
-
-    fun TextView.applyTimeLong(time: Int) {
+fun TextView.setEpisodeTimeLeft(episode: BaseEpisode) {
+    if (episode is UserEpisode && episode.serverStatus == UserEpisodeServerStatus.MISSING) {
+        text = resources.getString(LR.string.podcast_episode_file_not_uploaded)
+    } else {
         val timeLeft = TimeHelper.getTimeLeft(
-            currentTimeMs = 0,
-            durationMs = time.toLong(),
-            inProgress = false,
+            currentTimeMs = episode.playedUpToMs,
+            durationMs = episode.durationMs.toLong(),
+            inProgress = episode.isInProgress,
             context = context,
         )
         text = timeLeft.text
         contentDescription = timeLeft.description
     }
+}
+
+fun TextView.applyTimeLong(time: Int) {
+    val timeLeft = TimeHelper.getTimeLeft(
+        currentTimeMs = 0,
+        durationMs = time.toLong(),
+        inProgress = false,
+        context = context,
+    )
+    text = timeLeft.text
+    contentDescription = timeLeft.description
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ViewExtensions.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/ViewExtensions.kt
@@ -4,8 +4,6 @@ import android.graphics.Outline
 import android.view.View
 import android.view.ViewOutlineProvider
 import android.widget.TextView
-import androidx.databinding.BindingAdapter
-import androidx.databinding.BindingConversion
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -14,7 +12,7 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatLongStyl
 import java.util.Date
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-object ViewDataBindings {
+object ViewExtensions {
 
     fun View.toCircle(circle: Boolean) {
         if (!circle) {


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Related to: #1908 

This PR migrates removes unused binding adapters and disables data binding in views module

## Testing Instructions
Not needed. This PR affects only build - if CI checks are green, this PR should be good to merge.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
