### PR TITLE
Advanced feature - Audio offload

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AdvancedSettingsPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AdvancedSettingsPage.kt
@@ -28,7 +28,6 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.AdvancedSettingsViewModel
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import java.util.*
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 /**
@@ -84,6 +83,13 @@ fun AdvancedSettingsView(
             ) {
                 SyncOnMeteredRow(state.backgroundSyncOnMeteredState)
             }
+
+            SettingSection(
+                heading = stringResource(LR.string.settings_advanced_battery_consumption),
+                indent = false,
+            ) {
+                AudioOffloadRow(state.audioOffloadEnabledState)
+            }
         }
     }
 }
@@ -106,6 +112,24 @@ private fun SyncOnMeteredRow(
     )
 }
 
+@Composable
+private fun AudioOffloadRow(
+    state: AdvancedSettingsViewModel.State.AudioOffloadEnabledState,
+    modifier: Modifier = Modifier,
+) {
+    SettingRow(
+        primaryText = stringResource(LR.string.settings_advanced_audio_offload),
+        secondaryText = stringResource(LR.string.settings_advanced_audio_offload_summary),
+        toggle = SettingRowToggle.Switch(state.isChecked, state.isEnabled),
+        indent = false,
+        modifier = modifier.toggleable(
+            value = state.isChecked,
+            role = Role.Switch,
+            onValueChange = { state.onCheckedChange(it) },
+        ),
+    )
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun AdvancedSettingsPreview(
@@ -115,6 +139,11 @@ private fun AdvancedSettingsPreview(
         AdvancedSettingsView(
             state = AdvancedSettingsViewModel.State(
                 backgroundSyncOnMeteredState = AdvancedSettingsViewModel.State.BackgroundSyncOnMeteredState(
+                    isChecked = true,
+                    isEnabled = true,
+                    onCheckedChange = {},
+                ),
+                audioOffloadEnabledState = AdvancedSettingsViewModel.State.AudioOffloadEnabledState(
                     isChecked = true,
                     isEnabled = true,
                     onCheckedChange = {},

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModel.kt
@@ -42,6 +42,10 @@ class AdvancedSettingsViewModel
             isChecked = settings.audioOffloadEnabled(),
             onCheckedChange = {
                 onAudioOffloadCheckedChange(it)
+                analyticsTracker.track(
+                    AnalyticsEvent.SETTINGS_ADVANCED_AUDIO_OFFLOAD_ENABLED,
+                    mapOf("enabled" to it),
+                )
             },
         ),
     )

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModel.kt
@@ -38,6 +38,12 @@ class AdvancedSettingsViewModel
                 }
             },
         ),
+        audioOffloadEnabledState = State.AudioOffloadEnabledState(
+            isChecked = settings.audioOffloadEnabled(),
+            onCheckedChange = {
+                onAudioOffloadCheckedChange(it)
+            },
+        ),
     )
 
     private fun onSyncOnMeteredCheckedChange(isChecked: Boolean) {
@@ -56,17 +62,37 @@ class AdvancedSettingsViewModel
         )
     }
 
+    private fun onAudioOffloadCheckedChange(isChecked: Boolean) {
+        settings.setAudioOffloadEnabled(isChecked)
+        updateAudioOffloadEnabledState()
+    }
+
+    private fun updateAudioOffloadEnabledState() {
+        mutableState.value = mutableState.value.copy(
+            audioOffloadEnabledState = mutableState.value.audioOffloadEnabledState.copy(
+                isChecked = settings.audioOffloadEnabled(),
+            ),
+        )
+    }
+
     fun onShown() {
         analyticsTracker.track(AnalyticsEvent.SETTINGS_ADVANCED_SHOWN)
     }
 
     data class State(
         val backgroundSyncOnMeteredState: BackgroundSyncOnMeteredState,
+        val audioOffloadEnabledState: AudioOffloadEnabledState,
     ) {
 
         data class BackgroundSyncOnMeteredState(
             val isChecked: Boolean,
             val isEnabled: Boolean,
+            val onCheckedChange: (Boolean) -> Unit,
+        )
+
+        data class AudioOffloadEnabledState(
+            val isChecked: Boolean,
+            val isEnabled: Boolean = true,
             val onCheckedChange: (Boolean) -> Unit,
         )
     }

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModelTest.kt
@@ -38,6 +38,7 @@ class AdvancedSettingsViewModelTest {
     fun setUp() {
         whenever(settings.syncOnMeteredNetwork()).thenReturn(false)
         whenever(settings.backgroundRefreshPodcasts).thenReturn(UserSetting.Mock(true, mock()))
+        whenever(settings.audioOffloadEnabled()).thenReturn(false)
         viewModel = AdvancedSettingsViewModel(
             settings,
             analyticsTracker,
@@ -47,6 +48,9 @@ class AdvancedSettingsViewModelTest {
 
     @Test
     fun `verify settings methods initialize the viewModel state correctly`() {
-        TestCase.assertEquals(viewModel.state.value.backgroundSyncOnMeteredState.isChecked, false)
+        with(viewModel.state.value) {
+            TestCase.assertEquals(backgroundSyncOnMeteredState.isChecked, false)
+            TestCase.assertEquals(audioOffloadEnabledState.isChecked, false)
+        }
     }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -540,6 +540,7 @@ enum class AnalyticsEvent(val key: String) {
     /* Settings - Advanced */
     SETTINGS_ADVANCED_SHOWN("settings_advanced_shown"),
     SETTINGS_ADVANCED_SYNC_ON_METERED("settings_advanced_sync_on_metered"),
+    SETTINGS_ADVANCED_AUDIO_OFFLOAD_ENABLED("settings_advanced_audio_offload_enabled"),
 
     /* Search */
     SEARCH_SHOWN("search_shown"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1432,6 +1432,9 @@
 
     <string name="settings_advanced_sync_on_metered">Sync on Metered Networks</string>
     <string name="settings_advanced_sync_on_metered_summary">Permits automatic background sync on metered networks. This is enabled by default and has no effect if background refresh is turned off.</string>
+    <string name="settings_advanced_battery_consumption">Battery Consumption</string>
+    <string name="settings_advanced_audio_offload">Audio Offload</string>
+    <string name="settings_advanced_audio_offload_summary">Audio offload allows audio processing to be offloaded from the CPU to a dedicated signal processor and helps in battery saving.</string>
     <string name="whats_new_slumber_studios_title">Dream big</string>
     <!-- %1$s is Slumber Studios promo code -->
     <string name="whats_new_slumber_studios_body">As part of your Yearly Plus subscription, enjoy a 1-year subscription to Slumber Studios content using code %1$s. <![CDATA[<a href="https://slumberstudios.com/">Learn more</a>.]]></string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -80,6 +80,7 @@ interface Settings {
         const val PREFERENCE_SELECT_PODCAST_LIBRARY_SORT = "selectPodcastLibrarySort"
         const val PREFERENCE_WARN_WHEN_NOT_ON_WIFI = "warnWhenNotOnWifi"
         const val PREFERENCE_SYNC_ON_METERED = "SyncWhenOnMetered"
+        const val PREFERENCE_AUDIO_OFFLOAD_ENABLED = "AudioOffloadEnabled"
         const val PREFERENCE_LAST_MODIFIED = "lastModified"
         const val PREFERENCE_FIRST_SYNC_RUN = "firstSyncRun"
         const val PREFERENCE_GLOBAL_STREAMING_MODE = "globalStreamingMode"
@@ -270,6 +271,8 @@ interface Settings {
 
     fun syncOnMeteredNetwork(): Boolean
     fun setSyncOnMeteredNetwork(shouldSyncOnMetered: Boolean)
+    fun audioOffloadEnabled(): Boolean
+    fun setAudioOffloadEnabled(enable: Boolean)
     fun getWorkManagerNetworkTypeConstraint(): NetworkType
     fun refreshPodcastsOnResume(isUnmetered: Boolean): Boolean
     val backgroundRefreshPodcasts: UserSetting<Boolean>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -175,6 +175,14 @@ class SettingsImpl @Inject constructor(
         setBoolean(Settings.PREFERENCE_SYNC_ON_METERED, shouldSyncOnMetered)
     }
 
+    override fun audioOffloadEnabled(): Boolean {
+        return getBoolean(Settings.PREFERENCE_AUDIO_OFFLOAD_ENABLED, false)
+    }
+
+    override fun setAudioOffloadEnabled(enable: Boolean) {
+        setBoolean(Settings.PREFERENCE_AUDIO_OFFLOAD_ENABLED, enable)
+    }
+
     override fun getWorkManagerNetworkTypeConstraint(): NetworkType =
         if (syncOnMeteredNetwork()) {
             NetworkType.CONNECTED

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -13,6 +13,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
+import androidx.media3.common.TrackSelectionParameters.AudioOffloadPreferences
 import androidx.media3.common.Tracks
 import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
@@ -213,6 +214,22 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
             .setSeekForwardIncrementMs(settings.skipForwardInSecs.value * 1000L)
             .setSeekBackIncrementMs(settings.skipBackInSecs.value * 1000L)
             .build()
+
+        if (settings.audioOffloadEnabled()) {
+            val audioOffloadPreferences = AudioOffloadPreferences.Builder()
+                .setAudioOffloadMode(AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_ENABLED)
+                .setIsGaplessSupportRequired(true)
+                .setIsSpeedChangeSupportRequired(true)
+                .build()
+
+            player.apply {
+                trackSelectionParameters = trackSelectionParameters
+                    .buildUpon()
+                    .setAudioOffloadPreferences(audioOffloadPreferences)
+                    .build()
+            }
+        }
+
         player.addListener(WearUnsuitableOutputPlaybackSuppressionResolverListener(context))
 
         renderer.onAudioSessionId(player.audioSessionId)


### PR DESCRIPTION
## Description

🚧 WIP

This adds an advanced settings option to enable experimental [Audio offload](https://developer.android.com/media/media3/exoplayer/battery-consumption#audio-playback) feature for battery saving. 

## Testing Instructions
- Go to `Profile` -> `Settings` -> `Advanced` 
- Enable `Audio Offload`
- Play a queue of episodes for several hours
- Check battery usage in device settings
- Compare results with `Audio Offload` disabled

## Screenshots or Screencast 

<img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/74d01ffe-8caf-4896-94d4-35e4e5859cf0"/>

** Feel free to update the option summary text. 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
