### PR TITLE
Do not sync any auto download related settings

### DIFF
--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -74,13 +74,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "useSystemTheme") val useSystemTheme: NamedChangedSettingBool? = null,
     @field:Json(name = "filesAfterPlayingDeleteCloudGlobal") val deleteCloudFilesAfterPlayback: NamedChangedSettingBool? = null,
     @field:Json(name = "filesAfterPlayingDeleteLocalGlobal") val deleteLocalFilesAfterPlayback: NamedChangedSettingBool? = null,
-    @field:Json(name = "cloudAutoUpload") val cloudAutoUpload: NamedChangedSettingBool? = null,
-    @field:Json(name = "cloudAutoDownload") val cloudAutoDownload: NamedChangedSettingBool? = null,
-    @field:Json(name = "autoDownloadUnmeteredOnly") val autoDownloadUnmeteredOnly: NamedChangedSettingBool? = null,
-    @field:Json(name = "autoDownloadOnlyWhenCharging") val autoDownloadOnlyWhenCharging: NamedChangedSettingBool? = null,
-    @field:Json(name = "autoDownloadUpNext") val autoDownloadUpNext: NamedChangedSettingBool? = null,
     @field:Json(name = "backgroundRefresh") val isPodcastBackgroundRefreshEnabled: NamedChangedSettingBool? = null,
-    @field:Json(name = "cloudDownloadUnmeteredOnly") val cloudDownloadUnmeteredOnly: NamedChangedSettingBool? = null,
     @field:Json(name = "useRssArtwork") val useRssArtwork: NamedChangedSettingBool? = null,
 )
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -253,13 +253,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 useSystemTheme = settings.useSystemTheme.getSyncSetting(::NamedChangedSettingBool),
                 deleteCloudFilesAfterPlayback = settings.deleteCloudFileAfterPlaying.getSyncSetting(::NamedChangedSettingBool),
                 deleteLocalFilesAfterPlayback = settings.deleteLocalFileAfterPlaying.getSyncSetting(::NamedChangedSettingBool),
-                cloudAutoUpload = settings.cloudAutoUpload.getSyncSetting(::NamedChangedSettingBool),
-                cloudAutoDownload = settings.cloudAutoDownload.getSyncSetting(::NamedChangedSettingBool),
-                autoDownloadUnmeteredOnly = settings.autoDownloadUnmeteredOnly.getSyncSetting(::NamedChangedSettingBool),
-                autoDownloadOnlyWhenCharging = settings.autoDownloadOnlyWhenCharging.getSyncSetting(::NamedChangedSettingBool),
-                autoDownloadUpNext = settings.autoDownloadUpNext.getSyncSetting(::NamedChangedSettingBool),
                 isPodcastBackgroundRefreshEnabled = settings.backgroundRefreshPodcasts.getSyncSetting(::NamedChangedSettingBool),
-                cloudDownloadUnmeteredOnly = settings.cloudDownloadOnlyOnWifi.getSyncSetting(::NamedChangedSettingBool),
                 useRssArtwork = settings.useRssArtwork.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
@@ -580,39 +574,9 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         setting = settings.deleteLocalFileAfterPlaying,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
-                    "cloudAutoUpload" -> updateSettingIfPossible(
-                        changedSettingResponse = changedSettingResponse,
-                        setting = settings.cloudAutoUpload,
-                        newSettingValue = (changedSettingResponse.value as? Boolean),
-                    )
-                    "cloudAutoDownload" -> updateSettingIfPossible(
-                        changedSettingResponse = changedSettingResponse,
-                        setting = settings.cloudAutoDownload,
-                        newSettingValue = (changedSettingResponse.value as? Boolean),
-                    )
-                    "autoDownloadUnmeteredOnly" -> updateSettingIfPossible(
-                        changedSettingResponse = changedSettingResponse,
-                        setting = settings.autoDownloadUnmeteredOnly,
-                        newSettingValue = (changedSettingResponse.value as? Boolean),
-                    )
-                    "autoDownloadOnlyWhenCharging" -> updateSettingIfPossible(
-                        changedSettingResponse = changedSettingResponse,
-                        setting = settings.autoDownloadOnlyWhenCharging,
-                        newSettingValue = (changedSettingResponse.value as? Boolean),
-                    )
-                    "autoDownloadUpNext" -> updateSettingIfPossible(
-                        changedSettingResponse = changedSettingResponse,
-                        setting = settings.autoDownloadUpNext,
-                        newSettingValue = (changedSettingResponse.value as? Boolean),
-                    )
                     "backgroundRefresh" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.backgroundRefreshPodcasts,
-                        newSettingValue = (changedSettingResponse.value as? Boolean),
-                    )
-                    "cloudDownloadUnmeteredOnly" -> updateSettingIfPossible(
-                        changedSettingResponse = changedSettingResponse,
-                        setting = settings.cloudDownloadOnlyOnWifi,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     "useRssArtwork" -> updateSettingIfPossible(


### PR DESCRIPTION
## Description

Removes any auto download related settings from the sync process.

## Testing Instructions

I don't think there's a need to test it. Code review should be fine. However, you can test if any settings from the `Auto download` and `Files Settings/Plus features` sections do not sync.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
