### PR TITLE
Fix What's New closing the app

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -103,7 +103,8 @@ class WhatsNewFragment : BaseFragment() {
             is NavigationState.SlumberStudiosRedeemPromoCode -> redeemSlumberStudiosPromoCode()
             is NavigationState.SlumberStudiosClose -> Unit // It will not be sent to confirm action in real world scenario
             is NavigationState.DeselectChapterClose -> {
-                activity?.onBackPressedDispatcher?.onBackPressed()
+                @Suppress("DEPRECATION")
+                activity?.onBackPressed()
             }
         }
     }


### PR DESCRIPTION
## Description

Tapping `Got It` on "What's New" popup closed the app instead of closing the dialog. This fixes it.

## Testing Instructions

1. Sign in with a Patron account.
2. Install the app with [this patch](https://github.com/Automattic/pocket-casts-android/files/14648532/what-new.patch).
3. Open the app.
4. Tap on `Got It` in the popup.
5. The app should not close.

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/30936061/7d165499-5506-4ab5-bbe6-68a499ebcb52

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
