### PR TITLE
Process show notes asynchronously

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesManager.kt
@@ -1,46 +1,33 @@
 package au.com.shiftyjelly.pocketcasts.repositories.shownotes
 
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.ImageUrlUpdate
 import au.com.shiftyjelly.pocketcasts.servers.ServerShowNotesManager
-import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesResponse
 import au.com.shiftyjelly.pocketcasts.servers.shownotes.ShowNotesState
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
-import org.jetbrains.annotations.VisibleForTesting
 
 class ShowNotesManager @Inject constructor(
     private val serverShowNotesManager: ServerShowNotesManager,
-    private val episodeManager: EpisodeManager,
+    private val showNotesProcessor: ShowNotesProcessor,
 ) {
 
     fun loadShowNotesFlow(podcastUuid: String, episodeUuid: String): Flow<ShowNotesState> =
         serverShowNotesManager.loadShowNotesFlow(
             podcastUuid = podcastUuid,
             episodeUuid = episodeUuid,
-            persistImageUrls = ::updateEpisodesWithImageUrls,
+            processShowNotes = showNotesProcessor::process,
         )
 
     suspend fun loadShowNotes(podcastUuid: String, episodeUuid: String): ShowNotesState =
         serverShowNotesManager.loadShowNotes(
             podcastUuid = podcastUuid,
             episodeUuid = episodeUuid,
-            persistImageUrls = ::updateEpisodesWithImageUrls,
+            processShowNotes = showNotesProcessor::process,
         )
 
     suspend fun downloadToCacheShowNotes(podcastUuid: String) {
         serverShowNotesManager.downloadToCacheShowNotes(
             podcastUuid = podcastUuid,
-            persistImageUrls = ::updateEpisodesWithImageUrls,
+            processShowNotes = showNotesProcessor::process,
         )
-    }
-
-    @VisibleForTesting
-    internal suspend fun updateEpisodesWithImageUrls(showNotesResponse: ShowNotesResponse) {
-        showNotesResponse.podcast?.episodes?.mapNotNull { showNotesEpisode ->
-            showNotesEpisode.image?.let { image ->
-                ImageUrlUpdate(showNotesEpisode.uuid, image)
-            }
-        }?.let { episodeManager.updateImageUrls(it) }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessor.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessor.kt
@@ -1,0 +1,27 @@
+package au.com.shiftyjelly.pocketcasts.repositories.shownotes
+
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.ImageUrlUpdate
+import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesResponse
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+class ShowNotesProcessor @Inject constructor(
+    @ApplicationScope private val scope: CoroutineScope,
+    private val episodeManager: EpisodeManager,
+) {
+    fun process(showNotes: ShowNotesResponse) {
+        scope.launch {
+            updateImageUrls(showNotes)
+        }
+    }
+
+    private suspend fun updateImageUrls(showNotes: ShowNotesResponse) {
+        val imageUrlUpdates = showNotes.podcast?.episodes?.mapNotNull { episodeShowNotes ->
+            episodeShowNotes.image?.let { image -> ImageUrlUpdate(episodeShowNotes.uuid, image) }
+        }
+        imageUrlUpdates?.let { episodeManager.updateImageUrls(it) }
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessTest.kt
@@ -2,43 +2,27 @@ package au.com.shiftyjelly.pocketcasts.repositories.shownotes
 
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ImageUrlUpdate
-import au.com.shiftyjelly.pocketcasts.servers.ServerShowNotesManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesEpisode
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesPodcast
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesResponse
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(MockitoJUnitRunner::class)
-class ShowNotesManagerTest {
+class ShowNotesProcessTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
 
-    @Mock lateinit var serverShowNotesManager: ServerShowNotesManager
-
-    @Mock lateinit var episodeManager: EpisodeManager
-
-    private lateinit var showNotesManager: ShowNotesManager
-
-    @Before
-    fun setup() {
-        showNotesManager = ShowNotesManager(
-            serverShowNotesManager = serverShowNotesManager,
-            episodeManager = episodeManager,
-        )
-    }
+    private val episodeManager = mock<EpisodeManager>()
 
     @Test
-    fun updatesEpisodesWithImageUrls() = runTest {
+    fun `update episodes with image URLs`() = runTest(coroutineRule.testDispatcher) {
+        val processor = ShowNotesProcessor(this, episodeManager)
         val episodeWithImage1 = ShowNotesEpisode(
             uuid = "episode_uuid1",
             showNotes = "show_notes1",
@@ -65,7 +49,8 @@ class ShowNotesManagerTest {
                 ),
             ),
         )
-        showNotesManager.updateEpisodesWithImageUrls(showNotesResponse)
+
+        processor.process(showNotesResponse)
 
         val imageUrlUpdateForEpisode = { episode: ShowNotesEpisode ->
             ImageUrlUpdate(


### PR DESCRIPTION
## Description

Chapters are available in one of two forms. Either they are directly embedded in show notes, or show notes contain an URL for chapters. Fetching chapters from an URL can take substantial time and we shouldn't wait for them to be fetched before we display show notes.

This PR prepares our show notes processing for chapters by making the processing flow asynchronous.

## Testing Instructions

1. Clear the storage in the app.
2. Enable `Use embedded RSS artwork` setting.
3. Play an episode like [this one](https://pca.st/7oix2d93) with an episode artwork.
4. Episode artwork should be displayed in the app.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
