### PR TITLE
Add alphabetical sort order for podcast episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 *   Updates:
     *   Display episode's RSS artwork in more places in the app.
         ([#1943](https://github.com/Automattic/pocket-casts-android/pull/1943))
+    *   Add alphabetical sort order for podcast episodes.
+        ([#1968](https://github.com/Automattic/pocket-casts-android/pull/1968))
 
 7.60
 -----

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -273,6 +273,16 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         viewModel.searchQueryUpdated(searchQuery)
     }
 
+    private val sortEpisodesTitleAZ = {
+        adapter?.signalLargeDiff()
+        viewModel.updateEpisodesSortType(EpisodesSortType.EPISODES_SORT_BY_TITLE_ASC)
+    }
+
+    private val sortEpisodesTitleZA = {
+        adapter?.signalLargeDiff()
+        viewModel.updateEpisodesSortType(EpisodesSortType.EPISODES_SORT_BY_TITLE_DESC)
+    }
+
     private val sortEpisodesNewestToOldest = {
         adapter?.signalLargeDiff()
         viewModel.updateEpisodesSortType(EpisodesSortType.EPISODES_SORT_BY_DATE_DESC)
@@ -295,6 +305,16 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
     private val showEpisodeSortOptions = {
         val dialog = OptionsDialog()
+            .addCheckedOption(
+                titleId = LR.string.episode_sort_title_a_z,
+                checked = viewModel.podcast.value?.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_TITLE_ASC,
+                click = sortEpisodesTitleAZ,
+            )
+            .addCheckedOption(
+                titleId = LR.string.episode_sort_title_z_a,
+                checked = viewModel.podcast.value?.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_TITLE_DESC,
+                click = sortEpisodesTitleZA,
+            )
             .addCheckedOption(
                 titleId = LR.string.episode_sort_newest_to_oldest,
                 checked = viewModel.podcast.value?.episodesSortType == EpisodesSortType.EPISODES_SORT_BY_DATE_DESC,
@@ -402,11 +422,13 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
     private fun selectedSortOrderStringId(): Int {
         return when (viewModel.podcast.value?.episodesSortType) {
+            EpisodesSortType.EPISODES_SORT_BY_TITLE_ASC -> LR.string.episode_sort_title_a_z
+            EpisodesSortType.EPISODES_SORT_BY_TITLE_DESC -> LR.string.episode_sort_title_z_a
             EpisodesSortType.EPISODES_SORT_BY_DATE_ASC -> LR.string.episode_sort_oldest_to_newest
             EpisodesSortType.EPISODES_SORT_BY_DATE_DESC -> LR.string.episode_sort_newest_to_oldest
             EpisodesSortType.EPISODES_SORT_BY_LENGTH_ASC -> LR.string.episode_sort_short_to_long
             EpisodesSortType.EPISODES_SORT_BY_LENGTH_DESC -> LR.string.episode_sort_long_to_short
-            else -> LR.string.empty
+            null -> LR.string.empty
         }
     }
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -579,6 +579,8 @@
     <string name="episode_row_waiting_for_power">Waiting for power</string>
     <string name="episode_row_waiting_for_wifi">Waiting for WiFi</string>
     <string name="episode_sort_long_to_short">Longest to shortest</string>
+    <string name="episode_sort_title_a_z">Title (A–Z)</string>
+    <string name="episode_sort_title_z_a">Title (Z–A)</string>
     <string name="episode_sort_newest_to_oldest" translatable="false">@string/sort_newest_to_oldest</string>
     <string name="episode_sort_oldest_to_newest" translatable="false">@string/sort_oldest_to_newest</string>
     <string name="episode_sort_short_to_long">Shortest to longest</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -62,16 +62,76 @@ abstract class EpisodeDao {
     @Query("SELECT * FROM podcast_episodes WHERE playing_status = :episodePlayingStatus AND archived = :archived AND podcast_id = :podcastUuid")
     abstract fun findByEpisodePlayingAndArchiveStatus(podcastUuid: String, episodePlayingStatus: EpisodePlayingStatus, archived: Boolean): List<PodcastEpisode>
 
-    @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY UPPER(title) ASC")
+    @Query(
+        """
+        SELECT
+          *
+        FROM
+          podcast_episodes
+        WHERE
+          podcast_id = :podcastUuid
+        ORDER BY (CASE
+          WHEN UPPER(title) LIKE 'THE %' THEN SUBSTR(UPPER(title), 5)
+          WHEN UPPER(title) LIKE 'A %' THEN SUBSTR(UPPER(title), 3)
+          WHEN UPPER(title) LIKE 'AN %' THEN SUBSTR(UPPER(title), 4)
+          ELSE UPPER(title)
+        END) ASC
+    """,
+    )
     abstract fun findByPodcastOrderTitleAsc(podcastUuid: String): List<PodcastEpisode>
 
-    @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY UPPER(title) ASC")
+    @Query(
+        """
+        SELECT
+          *
+        FROM
+          podcast_episodes
+        WHERE
+          podcast_id = :podcastUuid
+        ORDER BY (CASE
+          WHEN UPPER(title) LIKE 'THE %' THEN SUBSTR(UPPER(title), 5)
+          WHEN UPPER(title) LIKE 'A %' THEN SUBSTR(UPPER(title), 3)
+          WHEN UPPER(title) LIKE 'AN %' THEN SUBSTR(UPPER(title), 4)
+          ELSE UPPER(title)
+        END) ASC
+    """,
+    )
     abstract suspend fun findByPodcastOrderTitleAscSuspend(podcastUuid: String): List<PodcastEpisode>
 
-    @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY UPPER(title) DESC")
+    @Query(
+        """
+        SELECT
+          *
+        FROM
+          podcast_episodes
+        WHERE
+          podcast_id = :podcastUuid
+        ORDER BY (CASE
+          WHEN UPPER(title) LIKE 'THE %' THEN SUBSTR(UPPER(title), 5)
+          WHEN UPPER(title) LIKE 'A %' THEN SUBSTR(UPPER(title), 3)
+          WHEN UPPER(title) LIKE 'AN %' THEN SUBSTR(UPPER(title), 4)
+          ELSE UPPER(title)
+        END) DESC
+    """,
+    )
     abstract fun findByPodcastOrderTitleDesc(podcastUuid: String): List<PodcastEpisode>
 
-    @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY UPPER(title) DESC")
+    @Query(
+        """
+        SELECT
+          *
+        FROM
+          podcast_episodes
+        WHERE
+          podcast_id = :podcastUuid
+        ORDER BY (CASE
+          WHEN UPPER(title) LIKE 'THE %' THEN SUBSTR(UPPER(title), 5)
+          WHEN UPPER(title) LIKE 'A %' THEN SUBSTR(UPPER(title), 3)
+          WHEN UPPER(title) LIKE 'AN %' THEN SUBSTR(UPPER(title), 4)
+          ELSE UPPER(title)
+        END) DESC
+    """,
+    )
     abstract suspend fun findByPodcastOrderTitleDescSuspend(podcastUuid: String): List<PodcastEpisode>
 
     @Transaction
@@ -122,11 +182,41 @@ abstract class EpisodeDao {
     abstract fun findNotificationEpisodes(date: Date, playingStatus: Int = EpisodePlayingStatus.NOT_PLAYED.ordinal): List<PodcastEpisode>
 
     @Transaction
-    @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY UPPER(title) ASC")
+    @Query(
+        """
+        SELECT
+          *
+        FROM
+          podcast_episodes
+        WHERE
+          podcast_id = :podcastUuid
+        ORDER BY (CASE
+          WHEN UPPER(title) LIKE 'THE %' THEN SUBSTR(UPPER(title), 5)
+          WHEN UPPER(title) LIKE 'A %' THEN SUBSTR(UPPER(title), 3)
+          WHEN UPPER(title) LIKE 'AN %' THEN SUBSTR(UPPER(title), 4)
+          ELSE UPPER(title)
+        END) ASC
+    """,
+    )
     abstract fun observeByPodcastOrderTitleAsc(podcastUuid: String): Flowable<List<PodcastEpisode>>
 
     @Transaction
-    @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY UPPER(title) DESC")
+    @Query(
+        """
+        SELECT
+          *
+        FROM
+          podcast_episodes
+        WHERE
+          podcast_id = :podcastUuid
+        ORDER BY (CASE
+          WHEN UPPER(title) LIKE 'THE %' THEN SUBSTR(UPPER(title), 5)
+          WHEN UPPER(title) LIKE 'A %' THEN SUBSTR(UPPER(title), 3)
+          WHEN UPPER(title) LIKE 'AN %' THEN SUBSTR(UPPER(title), 4)
+          ELSE UPPER(title)
+        END) DESC
+    """,
+    )
     abstract fun observeByPodcastOrderTitleDesc(podcastUuid: String): Flowable<List<PodcastEpisode>>
 
     @Transaction


### PR DESCRIPTION
## Description

Web has alphabetical sort ordering for episodes. We also have it in the code but never used it. This PR adds it to the UI.

Also this PR improves the alphabetical sorting order for English titles and matches it with Web. Instead of doing dummy sorting we exclude `a`, `an`, and `the` articles from sorting. So for example `The Big Bad Wolf` isn't treated as staring with `The` but with `Big`.

## Testing Instructions

1. Subscribe to a podcast.
2. Sort episodes by `A-Z`.
3. Check that the episodes are sorted alphabetically. English articles at the beginning of titles shouldn't be included in sorting.
4. Change sorting order to `Z-A`.
5. Check that the episodes are sorted alphabetically in a reversed order. English articles at the beginning of titles shouldn't be included in sorting.

## Screenshots or Screencast 

| Settings | A-Z sorting |
| - | - |
| ![Screenshot_20240322-141144](https://github.com/Automattic/pocket-casts-android/assets/30936061/db508a75-75e5-43f5-9ed1-36f4d5f54b31) | ![Screenshot_20240322-141152](https://github.com/Automattic/pocket-casts-android/assets/30936061/bca749be-a489-4951-bd8e-1aacc8e1f1d8) |

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
