### PR TITLE
Fix chapters syncing

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -654,7 +654,7 @@ class PodcastSyncProcess(
 
             episode.deselectedChaptersModified?.let { deselectedChaptersModified ->
                 fields.put("deselected_chapters", ChapterIndices.toString(episode.deselectedChapters))
-                fields.put("deselected_chapters_modified", deselectedChaptersModified)
+                fields.put("deselected_chapters_modified", deselectedChaptersModified.time)
             }
 
             val record = JSONObject().apply {
@@ -1041,7 +1041,7 @@ class PodcastSyncProcess(
 
             sync.deselectedChapters?.let {
                 episode.deselectedChapters = it
-                episode.deselectedChaptersModified = null
+                episode.deselectedChaptersModified = sync.deselectedChaptersModified?.let(::Date)
             }
 
             episodeManager.update(episode)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponse.kt
@@ -25,6 +25,7 @@ import com.pocketcasts.service.api.autoSkipLastOrNull
 import com.pocketcasts.service.api.autoStartFromOrNull
 import com.pocketcasts.service.api.bookmarkOrNull
 import com.pocketcasts.service.api.dateAddedOrNull
+import com.pocketcasts.service.api.deselectedChaptersModifiedOrNull
 import com.pocketcasts.service.api.durationOrNull
 import com.pocketcasts.service.api.episodeGroupingOrNull
 import com.pocketcasts.service.api.episodeOrNull
@@ -203,7 +204,7 @@ data class SyncUpdateResponse(
                         EpisodePlayingStatus.fromInt(it)
                     } ?: EpisodePlayingStatus.NOT_PLAYED,
                     deselectedChapters = ChapterIndices.fromString(syncUserEpisode.deselectedChapters),
-                    deselectedChaptersModified = syncUserEpisode.deselectedChaptersModified.value,
+                    deselectedChaptersModified = syncUserEpisode.deselectedChaptersModifiedOrNull?.value,
                 )
         }
     }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
@@ -12,6 +12,7 @@ import au.com.shiftyjelly.pocketcasts.servers.extensions.nextBooleanOrNull
 import au.com.shiftyjelly.pocketcasts.servers.extensions.nextDoubleOrNull
 import au.com.shiftyjelly.pocketcasts.servers.extensions.nextIntOrDefault
 import au.com.shiftyjelly.pocketcasts.servers.extensions.nextIntOrNull
+import au.com.shiftyjelly.pocketcasts.servers.extensions.nextLongOrNull
 import au.com.shiftyjelly.pocketcasts.servers.extensions.nextStringOrNull
 import au.com.shiftyjelly.pocketcasts.utils.extensions.parseIsoDate
 import com.squareup.moshi.FromJson
@@ -106,6 +107,7 @@ class SyncUpdateResponseParser : JsonAdapter<SyncUpdateResponse>() {
                 "playing_status" -> episode.playingStatus = readPlayingStatus(reader)
                 "is_deleted" -> episode.isArchived = reader.nextBooleanOrNull()
                 "deselected_chapters" -> episode.deselectedChapters = readDeselectedChapters(reader)
+                "deselected_chapters_modified" -> episode.deselectedChaptersModified = readDeselectedChaptersModified(reader)
                 else -> reader.skipValue()
             }
         }
@@ -130,6 +132,10 @@ class SyncUpdateResponseParser : JsonAdapter<SyncUpdateResponse>() {
             return reader.nextNull()
         }
         return ChapterIndices.fromString(reader.nextString())
+    }
+
+    private fun readDeselectedChaptersModified(reader: JsonReader): Long? {
+        return reader.nextLongOrNull()
     }
 
     private fun readPodcast(reader: JsonReader, response: SyncUpdateResponse) {


### PR DESCRIPTION
## Description

Chapters syncing was broken for the old sync. Modification timestamp was sent as a `Date.toString()` instead of milliseconds.

## Testing Instructions

> [!note]
> Test this with Patron account.

1. Go to `Profile`/`Settings`/`Beta features`.
2. Disable `Settings Sync`.
3. Play an episodes like [this one](https://pca.st/cb8an86i) with chapters.
4. Deselect some chapters.
5. Go back to `Profile` and sync the account.
6. There should be no errors.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
