### PR TITLE
Toggle chapter selection on title click

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
@@ -24,7 +24,10 @@ import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -56,6 +59,7 @@ fun ChapterRow(
     modifier: Modifier = Modifier,
 ) {
     val chapter = state.chapter
+    var selectedState by remember(chapter.index) { mutableStateOf(state.chapter.selected) }
     val textColor = getTextColor(state, isTogglingChapters)
     Box(
         modifier = modifier
@@ -71,13 +75,22 @@ fun ChapterRow(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
-                .clickable { onClick() }
+                .clickable {
+                    if (isTogglingChapters) {
+                        val selected = !selectedState
+                        selectedState = selected
+                        onSelectionChange(selected, chapter)
+                    } else {
+                        onClick()
+                    }
+                }
                 .padding(end = 12.dp),
         ) {
             AnimatedVisibility(visible = isTogglingChapters) {
                 Checkbox(
-                    checked = state.chapter.selected,
+                    checked = selectedState,
                     onCheckedChange = { selected ->
+                        selectedState = selected
                         onSelectionChange(selected, chapter)
                     },
                     colors = CheckboxDefaults.colors(


### PR DESCRIPTION
## Description

When chapters were in a selection mode tapping on titles played them instead of toggling selection. This PR changes it.

## Testing Instructions

> [!note]
> Test this with Patron account.

1. Play an episode with chapters like [this one](https://pca.st/cb8an86i).
2. Tap on chapter titles and make sure that the playback switches to them.
3. Go to chapters edit mode.
4. Tap on titles and make sure that selection toggles.
5. Tap on check-boxes and make sure that selection toggles.

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/30936061/6345b5e6-4194-48e9-bc4d-ea9a74ec620b

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
