### PR TITLE
Fix cancellation info link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
         ([#1943](https://github.com/Automattic/pocket-casts-android/pull/1943))
     *   Add alphabetical sort order for podcast episodes.
         ([#1968](https://github.com/Automattic/pocket-casts-android/pull/1968))
+* Bug Fixes:
+    *   Subscription cancellation redirects now to a correct page.
+        ([#1973](https://github.com/Automattic/pocket-casts-android/pull/1973))
 
 7.60
 -----

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -54,7 +54,7 @@ interface Settings {
         const val INFO_LEARN_MORE_URL = "https://www.pocketcasts.com/plus/"
         const val INFO_TOS_URL = "https://support.pocketcasts.com/article/terms-of-use-overview/"
         const val INFO_PRIVACY_URL = "https://support.pocketcasts.com/article/privacy-policy/"
-        const val INFO_CANCEL_URL = "https://support.pocketcasts.com/article/subscription-info/"
+        const val INFO_CANCEL_URL = "https://support.pocketcasts.com/knowledge-base/how-to-cancel-a-subscription/"
         const val INFO_FAQ_URL = "https://support.pocketcasts.com/android/?device=android"
 
         const val USER_AGENT_POCKETCASTS_SERVER = "Pocket Casts/Android/" + BuildConfig.VERSION_NAME


### PR DESCRIPTION
## Description

Cancellation web link was incorrect.

## Testing Instructions

1. Sign in with an account that has a purchased (not gifted) Plus or Patron.
2. Go `Profile`/`Account`.
3. Tap on `Cancel subscription`.
4. You should be redirected to support page.

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/30936061/14bed6d3-5a13-40bb-a418-3775b883cb61

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
