### PR TITLE
Discover redesign - Tracks

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -809,7 +809,7 @@ internal class DiscoverAdapter(
                 categoriesViewHolder.binding.lblTitle.text = tittle
                 categoriesViewHolder.binding.lblTitle.contentDescription = tittle
             }
-            categoriesViewHolder.adapter.fromListId = row.listId
+            row.listId?.let { categoriesViewHolder.adapter.setFromListId(it) }
             categoriesViewHolder.adapter.replaceList(row.podcasts)
         } else if (row is RemainingPodcastsByCategoryRow) {
             val remainingPodcastHolder = holder as RemainingPodcastsByCategoryViewHolder

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -540,7 +540,7 @@ internal class DiscoverAdapter(
                     holder.loadFlowable(
                         loadPodcastList(row.source),
                         onNext = {
-                            holder.adapter.fromListId = row.listUuid
+                            row.listUuid?.let { listUuid -> holder.adapter.setFromListId(listUuid) }
                             holder.adapter.submitList(it.podcasts) { onRestoreInstanceState(holder) }
                         },
                     )

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -593,7 +593,7 @@ internal class DiscoverAdapter(
                         onNext = {
                             val podcasts = it.podcasts.subList(0, Math.min(MAX_ROWS_SMALL_LIST, it.podcasts.count()))
                             holder.binding.pageIndicatorView.count = Math.ceil(podcasts.count().toDouble() / SmallListRowAdapter.SmallListViewHolder.NUMBER_OF_ROWS_PER_PAGE.toDouble()).toInt()
-                            holder.adapter.fromListId = row.listUuid
+                            row.listUuid?.let { listUuid -> holder.adapter.setFromListId(listUuid) }
                             holder.adapter.submitPodcastList(podcasts) { onRestoreInstanceState(holder) }
                         },
                     )

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -80,10 +80,7 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
             analyticsTracker.track(AnalyticsEvent.DISCOVER_SHOW_ALL_TAPPED, mapOf(LIST_ID_KEY to transformedList.inferredId()))
         }
         if (list is DiscoverCategory) {
-            viewModel.currentRegionCode?.let {
-                FirebaseAnalyticsTracker.openedCategory(list.id, it)
-                analyticsTracker.track(AnalyticsEvent.DISCOVER_CATEGORY_SHOWN, mapOf(NAME_KEY to list.name, REGION_KEY to it, ID_KEY to list.id))
-            }
+            trackCategoryImpression(list)
         }
 
         if (list.expandedStyle is ExpandedStyle.GridList) {
@@ -126,6 +123,8 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
     }
 
     override fun onCategoryClick(selectedCategory: CategoryPill, onCategorySelectionSuccess: () -> Unit) {
+        trackCategoryImpression(selectedCategory.discoverCategory)
+
         val categoryWithRegionUpdated =
             viewModel.transformNetworkLoadableList(selectedCategory.discoverCategory, resources)
 
@@ -279,7 +278,19 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
             adapter?.submitList(updatedList)
         }
     }
-
+    private fun trackCategoryImpression(category: DiscoverCategory) {
+        viewModel.currentRegionCode?.let {
+            FirebaseAnalyticsTracker.openedCategory(category.id, it)
+            analyticsTracker.track(
+                AnalyticsEvent.DISCOVER_CATEGORY_SHOWN,
+                mapOf(
+                    NAME_KEY to category.name,
+                    REGION_KEY to it,
+                    ID_KEY to category.id,
+                ),
+            )
+        }
+    }
     companion object {
         private const val ID_KEY = "id"
         private const val NAME_KEY = "name"

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/LargeListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/LargeListRowAdapter.kt
@@ -27,19 +27,19 @@ import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 internal class LargeListRowAdapter(
-    private val context: Context,
+    context: Context,
     val onPodcastClicked: ((DiscoverPodcast, String?) -> Unit),
     val onPodcastSubscribe: ((DiscoverPodcast, String?) -> Unit),
     private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ListAdapter<Any, LargeListRowAdapter.LargeListItemViewHolder>(DISCOVER_PODCAST_DIFF_CALLBACK) {
-    var fromListId: String? = null
+    private var fromListId: String? = null
 
     class LargeListItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val placeholderDrawable = itemView.context.getThemeDrawable(UR.attr.defaultArtworkSmall)
-        val imageView = itemView.findViewById<ImageView>(R.id.imageView)
-        val lblTitle = itemView.findViewById<TextView>(R.id.lblTitle)
-        val lblSubtitle = itemView.findViewById<TextView>(R.id.lblSubtitle)
-        val btnSubscribe = itemView.findViewById<ImageButton>(R.id.btnSubscribe)
+        val imageView: ImageView = itemView.findViewById(R.id.imageView)
+        val lblTitle: TextView = itemView.findViewById(R.id.lblTitle)
+        val lblSubtitle: TextView = itemView.findViewById(R.id.lblSubtitle)
+        val btnSubscribe: ImageButton = itemView.findViewById(R.id.btnSubscribe)
     }
 
     companion object {
@@ -89,9 +89,11 @@ internal class LargeListRowAdapter(
             holder.btnSubscribe.isVisible = false
         }
     }
-
     fun showLoadingList() {
         val loadingList = listOf(MutableList(NUMBER_OF_LOADING_ITEMS) { LoadingItem() })
         submitList(loadingList)
+    }
+    fun setFromListId(value: String) {
+        this.fromListId = value
     }
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/MostPopularPodcastsAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/MostPopularPodcastsAdapter.kt
@@ -24,7 +24,7 @@ internal class MostPopularPodcastsAdapter(
     private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ListAdapter<Any, MostPopularPodcastsViewHolder>(DISCOVER_PODCAST_DIFF_CALLBACK) {
 
-    var fromListId: String? = null
+    private var fromListId: String? = null
 
     class MostPopularPodcastsViewHolder(
         val binding: ItemMostPopularPodcastsBinding,
@@ -60,17 +60,10 @@ internal class MostPopularPodcastsAdapter(
         val binding = ItemMostPopularPodcastsBinding.inflate(inflater, parent, false)
         return MostPopularPodcastsViewHolder(binding) { position ->
             val podcast = getItem(position) as DiscoverPodcast
-            fromListId?.let {
-                FirebaseAnalyticsTracker.podcastTappedFromList(it, podcast.uuid)
-                analyticsTracker.track(
-                    AnalyticsEvent.DISCOVER_LIST_PODCAST_TAPPED,
-                    mapOf(LIST_ID_KEY to it, PODCAST_UUID_KEY to podcast.uuid),
-                )
-            }
+            trackImpression(podcast)
             onPodcastClicked(podcast, fromListId)
         }
     }
-
     override fun onBindViewHolder(holder: MostPopularPodcastsViewHolder, position: Int) {
         val podcast = getItem(position)
 
@@ -81,5 +74,17 @@ internal class MostPopularPodcastsAdapter(
     fun replaceList(list: List<DiscoverPodcast>) {
         submitList(null) // We need this to avoid displaying the previous category list when switching from a different category
         submitList(list)
+    }
+    fun setFromListId(value: String) {
+        this.fromListId = value
+    }
+    private fun trackImpression(podcast: DiscoverPodcast) {
+        fromListId?.let {
+            FirebaseAnalyticsTracker.podcastTappedFromList(it, podcast.uuid)
+            analyticsTracker.track(
+                AnalyticsEvent.DISCOVER_LIST_PODCAST_TAPPED,
+                mapOf(LIST_ID_KEY to it, PODCAST_UUID_KEY to podcast.uuid),
+            )
+        }
     }
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/SmallListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/SmallListRowAdapter.kt
@@ -46,7 +46,7 @@ internal class SmallListRowAdapter(
         val rows = listOf(binding.row0, binding.row1, binding.row2, binding.row3)
     }
 
-    var fromListId: String? = null
+    private var fromListId: String? = null
 
     fun submitPodcastList(list: List<DiscoverPodcast>, commitCallback: Runnable?) {
         submitList(list.chunked(SmallListViewHolder.NUMBER_OF_ROWS_PER_PAGE), commitCallback)
@@ -93,5 +93,8 @@ internal class SmallListRowAdapter(
                 podcastRow.isClickable = false
             }
         }
+    }
+    fun setFromListId(value: String) {
+        this.fromListId = value
     }
 }


### PR DESCRIPTION
## Description
- Make sure we send the existing tracks to the new design
- I also did a small refactor. Changed the visibility of `fromListId` to private

## Testing Instructions
Have the new discover redesign enabled in Beta features

1. Go to Discover
2. Select a Category from the category pill
3. You see `Tracked: discover_category_shown, Properties: {"name":"[category name here]","region":"[region]","id":"[category id]" ...` ✅
4. Clear category filter
5. Tap on `All categories` button to open the category bottom sheet dialog
6. Select a Category
7. You see `Tracked: discover_category_shown, Properties: {"name":"[category name here]","region":"[region]","id":"[category id]" ...` ✅
8. At the top you can see the most popular podcasts filtered by the category that you selected
9. Click on any podcast of this section
10. You see `Tracked: podcast_screen_shown...` ✅
11. You see `Tracked: discover_list_podcast_tapped, Properties: {"list_id":"category-[category name]-[region]","podcast_uuid":"[uuid here]" ...` ✅
12. Go back to Discover View
13. Subscribe to a Podcast from the remaining podcasts list (the posdcast list below of the most popular podcasts section)
14. You see `Tracked: podcast_subscribed ...` ✅
15. Click on any podcasts from this list
16. You see `Tracked: podcast_screen_shown...` ✅


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
