### PR TITLE
Consolidate embedded episode artwork settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 *   Updates:
     *   Display episode's RSS artwork in more places in the app.
         ([#1943](https://github.com/Automattic/pocket-casts-android/pull/1943))
+    *   Consolidate episode's embedded file artwork and RSS artwork into a single setting.
+        ([#1987](https://github.com/Automattic/pocket-casts-android/pull/1987))
     *   Add alphabetical sort order for podcast episodes.
         ([#1968](https://github.com/Automattic/pocket-casts-android/pull/1968))
 * Bug Fixes:

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -262,7 +262,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
         settings.useDynamicColorsForWidget.flow
             .onEach { widgetManager.updateWidgetFromSettings(playbackManager) }
             .launchIn(applicationScope)
-        settings.useRssArtwork.flow
+        settings.useEpisodeArtwork.flow
             .onEach { widgetManager.updateWidgetRssArtwork(playbackManager) }
             .launchIn(applicationScope)
 

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -754,18 +754,18 @@ class MainActivity :
         }
 
         val upNextQueueChanges = playbackManager.upNextQueue.getChangesFlowWithLiveCurrentEpisode(episodeManager, podcastManager)
-        val useRssArtworkChanges = settings.useRssArtwork.flow
+        val useEpisodeArtworkChanges = settings.useEpisodeArtwork.flow
 
-        val combinedFlow = combine(upNextQueueChanges, useRssArtworkChanges) { upNextQueue, useRssArtwork ->
-            upNextQueue to useRssArtwork
+        val combinedFlow = combine(upNextQueueChanges, useEpisodeArtworkChanges) { upNextQueue, useEpisodeArtwork ->
+            upNextQueue to useEpisodeArtwork
         }
-            .onEach { (upNextQueue, useRssArtwork) ->
+            .onEach { (upNextQueue, useEpisodeArtwork) ->
                 updatePlaybackStateDeselectedChapterIndices(upNextQueue)
                 binding.playerBottomSheet.setUpNext(
                     upNext = upNextQueue,
                     theme = theme,
                     shouldAnimateOnAttach = !showMiniPlayerImmediately,
-                    useRssArtwork = useRssArtwork,
+                    useEpisodeArtwork = useEpisodeArtwork,
                 )
             }
             .catch { Timber.e(it) }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterChipFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterChipFragment.kt
@@ -245,7 +245,7 @@ private class SimpleEpisodeListAdapter(
         holder.binding.lblSubtitle.text = timeLeft.text
         holder.binding.lblSubtitle.contentDescription = timeLeft.description
 
-        imageRequestFactory.create(item, settings.useRssArtwork.value).loadInto(holder.binding.imageView)
+        imageRequestFactory.create(item, settings.useEpisodeArtwork.value).loadInto(holder.binding.imageView)
     }
 }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerBottomSheet.kt
@@ -131,8 +131,8 @@ class PlayerBottomSheet @JvmOverloads constructor(context: Context, attrs: Attri
         binding.miniPlayer.setPlaybackState(playbackState)
     }
 
-    fun setUpNext(upNext: UpNextQueue.State, theme: Theme, shouldAnimateOnAttach: Boolean, useRssArtwork: Boolean) {
-        binding.miniPlayer.setUpNext(upNext, theme, useRssArtwork)
+    fun setUpNext(upNext: UpNextQueue.State, theme: Theme, shouldAnimateOnAttach: Boolean, useEpisodeArtwork: Boolean) {
+        binding.miniPlayer.setUpNext(upNext, theme, useEpisodeArtwork)
 
         // only show the mini player when an episode is loaded
         if (upNext is UpNextQueue.State.Loaded) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -189,7 +189,7 @@ class UpNextAdapter(
             binding.reorder.imageTintList = ColorStateList.valueOf(ThemeColor.primaryInteractive01(theme))
 
             if (loadedUuid != playingState.episode.uuid) {
-                imageRequestFactory.create(playingState.episode, settings.useRssArtwork.value).loadInto(binding.image)
+                imageRequestFactory.create(playingState.episode, settings.useEpisodeArtwork.value).loadInto(binding.image)
                 loadedUuid = playingState.episode.uuid
             }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
@@ -118,7 +118,7 @@ class UpNextEpisodeViewHolder(
             false
         }
 
-        imageRequestFactory.create(episode, settings.useRssArtwork.value).loadInto(binding.image)
+        imageRequestFactory.create(episode, settings.useEpisodeArtwork.value).loadInto(binding.image)
 
         val context = binding.itemContainer.context
         val transition = AutoTransition()

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
@@ -192,7 +192,7 @@ private fun BookmarksView(
                     else -> TimePlayButtonColors.Default
                 },
                 showIcon = false,
-                useRssArtwork = state.useRssArtwork,
+                useEpisodeArtwork = state.useEpisodeArtwork,
             )
         }
     }
@@ -222,7 +222,7 @@ private fun BookmarksPreview(
                     publishedDate = Date(),
                 ),
                 isMultiSelecting = false,
-                useRssArtwork = false,
+                useEpisodeArtwork = false,
                 isSelected = { false },
                 onRowClick = {},
                 sourceView = SourceView.PLAYER,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -158,8 +158,8 @@ class BookmarksViewModel
                     isMultiSelectingFlow,
                     selectedListFlow,
                     settings.cachedSubscriptionStatus.flow,
-                    settings.useRssArtwork.flow,
-                ) { bookmarks, isMultiSelecting, selectedList, cachedSubscriptionStatus, useRssArtwork ->
+                    settings.useEpisodeArtwork.flow,
+                ) { bookmarks, isMultiSelecting, selectedList, cachedSubscriptionStatus, useEpisodeArtwork ->
                     val userTier = (cachedSubscriptionStatus as? SubscriptionStatus.Paid)?.tier?.toUserTier() ?: UserTier.Free
                     _uiState.value = if (!bookmarkFeature.isAvailable(userTier)) {
                         UiState.Upsell(sourceView)
@@ -170,7 +170,7 @@ class BookmarksViewModel
                             bookmarks = bookmarks,
                             episode = episode,
                             isMultiSelecting = isMultiSelecting,
-                            useRssArtwork = useRssArtwork,
+                            useEpisodeArtwork = useEpisodeArtwork,
                             isSelected = { selectedBookmark ->
                                 selectedList.map { bookmark -> bookmark.uuid }
                                     .contains(selectedBookmark.uuid)
@@ -293,7 +293,7 @@ class BookmarksViewModel
             val bookmarks: List<Bookmark> = emptyList(),
             val episode: BaseEpisode,
             val isMultiSelecting: Boolean,
-            val useRssArtwork: Boolean,
+            val useEpisodeArtwork: Boolean,
             val isSelected: (Bookmark) -> Boolean,
             val onRowClick: (Bookmark) -> Unit,
             val sourceView: SourceView,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -29,7 +29,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
-import au.com.shiftyjelly.pocketcasts.repositories.extensions.getUrlForArtwork
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.SleepTimer
@@ -38,7 +37,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
-import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
@@ -64,8 +62,6 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlowable
@@ -79,7 +75,6 @@ class PlayerViewModel @Inject constructor(
     private val playbackManager: PlaybackManager,
     private val episodeManager: EpisodeManager,
     private val userEpisodeManager: UserEpisodeManager,
-    private val userManager: UserManager,
     private val downloadManager: DownloadManager,
     private val podcastManager: PodcastManager,
     private val bookmarkManager: BookmarkManager,
@@ -95,24 +90,14 @@ class PlayerViewModel @Inject constructor(
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
 
-    sealed class Artwork {
-        data class Url(val url: String) : Artwork()
-        data class Path(val path: String) : Artwork()
-        object None : Artwork()
-    }
-
     data class PodcastEffectsPair(val podcast: Podcast, val effects: PlaybackEffects)
     data class PlayerHeader(
         val positionMs: Int = 0,
         val durationMs: Int = -1,
         val isPlaying: Boolean = false,
         val isPrepared: Boolean = false,
-        val podcastUuid: String? = "",
-        val episodeUuid: String = "",
-        val episodeTitle: String = "",
+        val episode: BaseEpisode? = null,
         val podcastTitle: String? = null,
-        val isVideo: Boolean = false,
-        val isStarred: Boolean = false,
         val isPlaybackRemote: Boolean = false,
         val chapters: Chapters = Chapters(),
         val backgroundColor: Int = 0xFF000000.toInt(),
@@ -122,12 +107,17 @@ class PlayerViewModel @Inject constructor(
         val isSleepRunning: Boolean = false,
         val isEffectsOn: Boolean = false,
         val isBuffering: Boolean = false,
-        val downloadStatus: EpisodeStatusEnum = EpisodeStatusEnum.NOT_DOWNLOADED,
         val bufferedUpToMs: Int = 0,
-        val embeddedArtwork: Artwork = Artwork.None,
-        val isUserEpisode: Boolean = false,
         val theme: Theme.ThemeType = Theme.ThemeType.DARK,
+        val useEpisodeArtwork: Boolean = false,
     ) {
+        val podcastUuid = (episode as? PodcastEpisode)?.podcastUuid
+        val episodeUuid = episode?.uuid.orEmpty()
+        val episodeTitle = episode?.title.orEmpty()
+        val isVideo = episode?.isVideo == true
+        val isStarred = (episode as? PodcastEpisode)?.isStarred == true
+        val isUserEpisode = episode is UserEpisode
+
         val isChaptersPresent: Boolean = !chapters.isEmpty
         val chapter: Chapter? = chapters.getChapter(positionMs.milliseconds)
         val chapterProgress: Float = chapter?.calculateProgress(positionMs.milliseconds) ?: 0f
@@ -151,7 +141,6 @@ class PlayerViewModel @Inject constructor(
         }
     }
 
-    data class ChaptersHeader(val expanded: Boolean)
     data class UpNextSummary(val episodeCount: Int, val totalTimeSecs: Double)
 
     data class ListData(
@@ -164,8 +153,6 @@ class PlayerViewModel @Inject constructor(
         var upNextSummary: UpNextSummary,
     )
     private val source = SourceView.PLAYER
-    private val _showPlayerFlow = MutableSharedFlow<Unit>()
-    val showPlayerFlow: SharedFlow<Unit> = _showPlayerFlow
 
     var upNextExpanded = settings.getBooleanForKey(Settings.PREFERENCE_UPNEXT_EXPANDED, true)
     var chaptersExpanded = settings.getBooleanForKey(Settings.PREFERENCE_CHAPTERS_EXPANDED, true)
@@ -188,7 +175,7 @@ class PlayerViewModel @Inject constructor(
         upNextExpandedObservable,
         chaptersExpandedObservable,
         settings.globalPlaybackEffects.flow.asObservable(coroutineContext),
-        settings.useRssArtwork.flow.asObservable(coroutineContext),
+        settings.useEpisodeArtwork.flow.asObservable(coroutineContext),
         this::mergeListData,
     )
         .distinctUntilChanged()
@@ -315,7 +302,7 @@ class PlayerViewModel @Inject constructor(
             }
     }
 
-    private fun mergeListData(upNextState: UpNextQueue.State, playbackState: PlaybackState, skipBackwardInSecs: Int, skipForwardInSecs: Int, upNextExpanded: Boolean, chaptersExpanded: Boolean, globalPlaybackEffects: PlaybackEffects, useRssArtwork: Boolean): ListData {
+    private fun mergeListData(upNextState: UpNextQueue.State, playbackState: PlaybackState, skipBackwardInSecs: Int, skipForwardInSecs: Int, upNextExpanded: Boolean, chaptersExpanded: Boolean, globalPlaybackEffects: PlaybackEffects, useEpisodeArtwork: Boolean): ListData {
         val podcast: Podcast? = (upNextState as? UpNextQueue.State.Loaded)?.podcast
         val episode = (upNextState as? UpNextQueue.State.Loaded)?.episode
 
@@ -323,20 +310,6 @@ class PlayerViewModel @Inject constructor(
         this.podcast = podcast
 
         val effects = if (podcast?.overrideGlobalEffects == true) podcast.playbackEffects else globalPlaybackEffects
-
-        val showNotesImageUrl = (episode as? PodcastEpisode)?.imageUrl
-        val embeddedPath = playbackState.embeddedArtworkPath
-
-        val embeddedArtwork: Artwork = if (showNotesImageUrl != null && useRssArtwork) {
-            Artwork.Url(showNotesImageUrl)
-        } else if (embeddedPath != null) {
-            Artwork.Path(embeddedPath)
-        } else if (episode is UserEpisode) {
-            val artworkUrl = episode.getUrlForArtwork(themeIsDark = true)
-            if (artworkUrl.startsWith("/")) Artwork.Path(artworkUrl) else Artwork.Url(artworkUrl)
-        } else {
-            Artwork.None
-        }
 
         val podcastHeader: PlayerHeader
         if (episode == null) {
@@ -351,26 +324,20 @@ class PlayerViewModel @Inject constructor(
                 durationMs = playbackState.durationMs,
                 isPlaying = playbackState.isPlaying,
                 isPrepared = playbackState.isPrepared,
-                isVideo = episode.isVideo,
-                isStarred = (episode is PodcastEpisode && episode.isStarred),
+                episode = episode,
                 isPlaybackRemote = playbackManager.isPlaybackRemote(),
                 chapters = playbackState.chapters,
                 backgroundColor = playerBackground,
                 iconTintColor = iconTintColor,
-                podcastUuid = podcast?.uuid,
-                episodeUuid = episode.uuid,
-                episodeTitle = episode.title,
                 podcastTitle = if (playbackState.chapters.isEmpty) podcast?.title else null,
                 skipBackwardInSecs = skipBackwardInSecs,
                 skipForwardInSecs = skipForwardInSecs,
                 isSleepRunning = playbackState.isSleepTimerRunning,
                 isEffectsOn = !effects.usingDefaultValues,
                 isBuffering = playbackState.isBuffering,
-                downloadStatus = episode.episodeStatus,
                 bufferedUpToMs = playbackState.bufferedMs,
-                embeddedArtwork = embeddedArtwork,
-                isUserEpisode = episode is UserEpisode,
                 theme = theme.activeTheme,
+                useEpisodeArtwork = useEpisodeArtwork,
             )
         }
         val chapters = playbackState.chapters

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
@@ -98,10 +98,10 @@ class BookmarksViewModelTest {
             .thenReturn(MutableLiveData<Boolean>().apply { value = false })
         whenever(multiSelectHelper.selectedListLive)
             .thenReturn(MutableLiveData<List<Bookmark>>().apply { value = emptyList() })
-        val useRssArtwork = mock<UserSetting<Boolean>> {
+        val useEpisodeArtwork = mock<UserSetting<Boolean>> {
             on { flow } doReturn MutableStateFlow(false)
         }
-        whenever(settings.useRssArtwork).thenReturn(useRssArtwork)
+        whenever(settings.useEpisodeArtwork).thenReturn(useEpisodeArtwork)
 
         bookmarksViewModel = BookmarksViewModel(
             analyticsTracker = analyticsTracker,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -342,7 +342,7 @@ class EpisodeFragment : BaseFragment() {
                                 .show()
                             true
                         }
-                        imageRequestFactory.create(state.episode, settings.useRssArtwork.value).loadInto(binding.podcastArtwork)
+                        imageRequestFactory.create(state.episode, settings.useEpisodeArtwork.value).loadInto(binding.podcastArtwork)
 
                         binding.btnPlay.setOnPlayClicked {
                             val context = binding.root.context

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
@@ -290,7 +290,7 @@ class EpisodeViewHolder(
         val artworkVisible = viewMode is ViewMode.Artwork
         imgArtwork.isVisible = artworkVisible
         if (!sameEpisode && artworkVisible) {
-            imageRequestFactory.create(episode, settings.useRssArtwork.value).loadInto(imgArtwork)
+            imageRequestFactory.create(episode, settings.useEpisodeArtwork.value).loadInto(imgArtwork)
         }
 
         val transition = AutoTransition()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -166,7 +166,7 @@ class PodcastAdapter(
     data class BookmarkItemData(
         val bookmark: Bookmark,
         val episode: BaseEpisode,
-        val useRssArtwork: Boolean,
+        val useEpisodeArtwork: Boolean,
         val onBookmarkPlayClicked: (Bookmark) -> Unit,
         val onBookmarkRowLongPress: (Bookmark) -> Unit,
         val onBookmarkRowClick: (Bookmark, Int) -> Unit,
@@ -573,7 +573,7 @@ class PodcastAdapter(
                                         bookmark,
                                     )
                                 },
-                                useRssArtwork = settings.useRssArtwork.value,
+                                useEpisodeArtwork = settings.useEpisodeArtwork.value,
                             )
                         },
                     )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/UserEpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/UserEpisodeViewHolder.kt
@@ -218,7 +218,7 @@ class UserEpisodeViewHolder(
 
         titleTextView.text = episode.title
 
-        imageRequestFactory.create(episode, settings.useRssArtwork.value).loadInto(artworkImageView)
+        imageRequestFactory.create(episode, settings.useEpisodeArtwork.value).loadInto(artworkImageView)
 
         val checkbox = binding.checkbox
         if (checkbox.isVisible != multiSelectEnabled) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkViewHolder.kt
@@ -38,7 +38,7 @@ class BookmarkViewHolder(
                     timePlayButtonStyle = TimePlayButtonStyle.Outlined,
                     timePlayButtonColors = TimePlayButtonColors.Default,
                     showIcon = true,
-                    useRssArtwork = data.useRssArtwork,
+                    useEpisodeArtwork = data.useEpisodeArtwork,
                 )
             }
         }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -692,7 +692,7 @@ class AddFileActivity :
         player.addListener(object : Player.Listener {
             override fun onTracksChanged(tracks: Tracks) {
                 val episodeMetadata = EpisodeFileMetadata()
-                episodeMetadata.read(tracks, true, this@AddFileActivity)
+                episodeMetadata.read(tracks, useEpisodeArtwork = false, this@AddFileActivity)
                 episodeMetadata.embeddedArtworkPath?.let {
                     val artworkUri = Uri.parse(it)
                     loadImageFromUri(artworkUri, isFile = true)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheetFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheetFragment.kt
@@ -308,7 +308,7 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
                         dialog?.dismiss()
                     }
                 }
-                pocketCastsImageRequestFactory?.create(episode, useRssArtwork = false)?.loadInto(binding.imgFile)
+                pocketCastsImageRequestFactory?.create(episode, useEpisodeArtwork = false)?.loadInto(binding.imgFile)
             },
         )
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
@@ -199,20 +199,12 @@ class AppearanceSettingsFragment : BaseFragment() {
             binding.swtShowArtwork.isChecked = !binding.swtShowArtwork.isChecked
         }
 
-        binding.swtUseEmbeddedArtwork.isChecked = viewModel.useEmbeddedArtwork.value
-        binding.swtUseEmbeddedArtwork.setOnCheckedChangeListener { _, isChecked ->
-            viewModel.updateUseEmbeddedArtwork(isChecked)
+        binding.swtUseEpisodeArtwork.isChecked = viewModel.useEpisodeArtwork.value
+        binding.swtUseEpisodeArtwork.setOnCheckedChangeListener { _, isChecked ->
+            viewModel.updateUseEpisodeArtwork(isChecked)
         }
-        binding.btnUseEmbeddedArtwork.setOnClickListener {
-            binding.swtUseEmbeddedArtwork.isChecked = !binding.swtUseEmbeddedArtwork.isChecked
-        }
-
-        binding.swtUseRssArtwork.isChecked = viewModel.useRssArtwork.value
-        binding.swtUseRssArtwork.setOnCheckedChangeListener { _, isChecked ->
-            viewModel.updateUseRssArtwork(isChecked)
-        }
-        binding.btnUseRssArtwork.setOnClickListener {
-            binding.swtUseRssArtwork.isChecked = !binding.swtUseRssArtwork.isChecked
+        binding.btnUseEpisodeArtwork.setOnClickListener {
+            binding.swtUseEpisodeArtwork.isChecked = !binding.swtUseEpisodeArtwork.isChecked
         }
 
         binding.lblRefreshAllPodcastArtwork.setOnClickListener {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
@@ -29,8 +29,7 @@ class SettingsAppearanceViewModel @Inject constructor(
     val signInState: LiveData<SignInState> = userManager.getSignInState().toLiveData()
     val createAccountState = MutableLiveData<SettingsAppearanceState>().apply { value = SettingsAppearanceState.Empty }
     val showArtworkOnLockScreen = settings.showArtworkOnLockScreen.flow
-    val useEmbeddedArtwork = settings.useEmbeddedArtwork.flow
-    val useRssArtwork = settings.useRssArtwork.flow
+    val useEpisodeArtwork = settings.useEpisodeArtwork.flow
 
     var changeThemeType: Pair<Theme.ThemeType?, Theme.ThemeType?> = Pair(null, null)
     var changeAppIconType: Pair<AppIcon.AppIconType?, AppIcon.AppIconType?> = Pair(null, null)
@@ -132,16 +131,8 @@ class SettingsAppearanceViewModel @Inject constructor(
         )
     }
 
-    fun updateUseEmbeddedArtwork(value: Boolean) {
-        settings.useEmbeddedArtwork.set(value, needsSync = true)
-        analyticsTracker.track(
-            AnalyticsEvent.SETTINGS_APPEARANCE_USE_EMBEDDED_ARTWORK_TOGGLED,
-            mapOf("enabled" to value),
-        )
-    }
-
-    fun updateUseRssArtwork(value: Boolean) {
-        settings.useRssArtwork.set(value, needsSync = true)
+    fun updateUseEpisodeArtwork(value: Boolean) {
+        settings.useEpisodeArtwork.set(value, needsSync = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_APPEARANCE_USE_EPISODE_ARTWORK_TOGGLED,
             mapOf("enabled" to value),

--- a/modules/features/settings/src/main/res/layout/fragment_settings_appearance.xml
+++ b/modules/features/settings/src/main/res/layout/fragment_settings_appearance.xml
@@ -202,104 +202,54 @@
                 app:layout_constraintTop_toBottomOf="@+id/lblShowArtwork" />
 
             <View
-                android:id="@+id/btnUseRssArtwork"
+                android:id="@+id/btnUseEpisodeArtwork"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 android:background="?android:attr/selectableItemBackground"
                 android:importantForAccessibility="no"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/lblUseRssArtwork"
-                app:layout_constraintBottom_toBottomOf="@+id/lblUseRssArtworkDetails"/>
+                app:layout_constraintTop_toTopOf="@+id/lblUseEpisodeArtwork"
+                app:layout_constraintBottom_toBottomOf="@+id/lblUseEpisodeArtworkDetails"/>
 
             <TextView
-                android:id="@+id/lblUseRssArtwork"
+                android:id="@+id/lblUseEpisodeArtwork"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:paddingTop="8dp"
                 android:layout_marginEnd="16dp"
-                android:text="@string/settings_use_episode_podcast_artwork"
+                android:text="@string/settings_use_episode_artwork"
                 android:textAppearance="@style/H40"
                 android:textColor="?attr/primary_text_01"
                 android:importantForAccessibility="no"
-                app:layout_constraintEnd_toStartOf="@+id/swtUseRssArtwork"
+                app:layout_constraintEnd_toStartOf="@+id/swtUseEpisodeArtwork"
                 app:layout_constraintStart_toStartOf="@+id/lblPodcastArtwork"
                 app:layout_constraintTop_toBottomOf="@+id/lblShowArtworkDetails" />
 
             <Switch
-                android:id="@+id/swtUseRssArtwork"
+                android:id="@+id/swtUseEpisodeArtwork"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
                 android:layout_marginEnd="24dp"
-                android:contentDescription="@string/settings_use_episode_podcast_artwork"
+                android:contentDescription="@string/settings_use_episode_artwork"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/lblUseRssArtwork" />
+                app:layout_constraintTop_toTopOf="@+id/lblUseEpisodeArtwork" />
 
             <TextView
-                android:id="@+id/lblUseRssArtworkDetails"
+                android:id="@+id/lblUseEpisodeArtworkDetails"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
                 android:layout_marginEnd="16dp"
                 android:paddingBottom="8dp"
-                android:text="@string/settings_episode_artwork_details"
+                android:text="@string/settings_use_episode_artwork_details"
                 android:textAppearance="@style/H40"
                 android:textColor="?attr/primary_text_02"
-                app:layout_constraintEnd_toStartOf="@+id/swtUseRssArtwork"
+                app:layout_constraintEnd_toStartOf="@+id/swtUseEpisodeArtwork"
                 app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="@+id/lblUseRssArtwork"
-                app:layout_constraintTop_toBottomOf="@+id/lblUseRssArtwork" />
-
-            <View
-                android:id="@+id/btnUseEmbeddedArtwork"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:background="?android:attr/selectableItemBackground"
-                android:importantForAccessibility="no"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/lblUseEmbeddedArtwork"
-                app:layout_constraintBottom_toBottomOf="@+id/lblUseEmbeddedArtworkDetails"/>
-
-            <TextView
-                android:id="@+id/lblUseEmbeddedArtwork"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:paddingTop="8dp"
-                android:layout_marginEnd="16dp"
-                android:text="@string/settings_use_embedded_podcast_artwork"
-                android:textAppearance="@style/H40"
-                android:textColor="?attr/primary_text_01"
-                android:importantForAccessibility="no"
-                app:layout_constraintEnd_toStartOf="@+id/swtUseEmbeddedArtwork"
-                app:layout_constraintStart_toStartOf="@+id/lblPodcastArtwork"
-                app:layout_constraintTop_toBottomOf="@+id/lblUseRssArtworkDetails" />
-
-            <Switch
-                android:id="@+id/swtUseEmbeddedArtwork"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:layout_marginEnd="24dp"
-                android:contentDescription="@string/settings_use_embedded_podcast_artwork"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/lblUseEmbeddedArtwork" />
-
-            <TextView
-                android:id="@+id/lblUseEmbeddedArtworkDetails"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="16dp"
-                android:paddingBottom="8dp"
-                android:text="@string/settings_embedded_artwork_details"
-                android:textAppearance="@style/H40"
-                android:textColor="?attr/primary_text_02"
-                app:layout_constraintEnd_toStartOf="@+id/swtUseEmbeddedArtwork"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="@+id/lblUseEmbeddedArtwork"
-                app:layout_constraintTop_toBottomOf="@+id/lblUseEmbeddedArtwork" />
+                app:layout_constraintStart_toStartOf="@+id/lblUseEpisodeArtwork"
+                app:layout_constraintTop_toBottomOf="@+id/lblUseEpisodeArtwork" />
 
             <TextView
                 android:id="@+id/lblRefreshAllPodcastArtwork"
@@ -315,7 +265,7 @@
                 android:background="?android:attr/selectableItemBackground"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/lblUseEmbeddedArtworkDetails" />
+                app:layout_constraintTop_toBottomOf="@+id/lblUseEpisodeArtworkDetails" />
 
             <View
                 android:id="@+id/dividerViewUpNext"

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -438,7 +438,6 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_APPEARANCE_THEME_CHANGED("settings_appearance_theme_changed"),
     SETTINGS_APPEARANCE_APP_ICON_CHANGED("settings_appearance_app_icon_changed"),
     SETTINGS_APPEARANCE_REFRESH_ALL_ARTWORK_TAPPED("settings_appearance_refresh_all_artwork_tapped"),
-    SETTINGS_APPEARANCE_USE_EMBEDDED_ARTWORK_TOGGLED("settings_appearance_use_embedded_artwork_toggled"),
     SETTINGS_APPEARANCE_USE_EPISODE_ARTWORK_TOGGLED("settings_appearance_use_episode_artwork_toggled"),
     SETTINGS_APPEARANCE_SHOW_ARTWORK_ON_LOCK_SCREEN_TOGGLED("settings_appearance_show_artwork_on_lock_screen_toggled"),
     SETTINGS_APPEARANCE_USE_DARK_UP_NEXT_TOGGLED("settings_appearance_use_dark_up_next_toggled"),

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkRow.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkRow.kt
@@ -112,7 +112,7 @@ fun BookmarkRow(
     timePlayButtonStyle: TimePlayButtonStyle,
     timePlayButtonColors: TimePlayButtonColors,
     showIcon: Boolean,
-    useRssArtwork: Boolean,
+    useEpisodeArtwork: Boolean,
 ) {
     Column(
         modifier = modifier,
@@ -149,7 +149,7 @@ fun BookmarkRow(
                 Box(modifier = Modifier.padding(start = 16.dp)) {
                     EpisodeImage(
                         episode = episode,
-                        useRssArtwork = useRssArtwork,
+                        useEpisodeArtwork = useEpisodeArtwork,
                         modifier = modifier.size(56.dp),
                     )
                 }
@@ -253,7 +253,7 @@ private fun BookmarkRowNormalPreview(themeType: Theme.ThemeType) {
             timePlayButtonStyle = TimePlayButtonStyle.Outlined,
             timePlayButtonColors = TimePlayButtonColors.Default,
             showIcon = false,
-            useRssArtwork = false,
+            useEpisodeArtwork = false,
         )
     }
 }
@@ -284,7 +284,7 @@ fun BookmarkRowPlayerPreview() {
             timePlayButtonStyle = TimePlayButtonStyle.Solid,
             timePlayButtonColors = TimePlayButtonColors.Player(textColor = Color.Black),
             showIcon = false,
-            useRssArtwork = false,
+            useEpisodeArtwork = false,
         )
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/EpisodeImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/EpisodeImage.kt
@@ -12,13 +12,13 @@ import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 @Composable
 fun EpisodeImage(
     episode: BaseEpisode,
-    useRssArtwork: Boolean,
+    useEpisodeArtwork: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
 
-    val imageRequest = remember(episode.uuid, useRssArtwork) {
-        PocketCastsImageRequestFactory(context).themed().create(episode, useRssArtwork)
+    val imageRequest = remember(episode.uuid, useEpisodeArtwork) {
+        PocketCastsImageRequestFactory(context).themed().create(episode, useEpisodeArtwork)
     }
 
     CoilImage(

--- a/modules/services/localization/src/main/res/values-ar/strings.xml
+++ b/modules/services/localization/src/main/res/values-ar/strings.xml
@@ -803,7 +803,6 @@ Language: ar
     <string name="settings_export_send_email">إرسال بريد إلكتروني</string>
     <string name="settings_export_save_file_summary">قم بتصدير ملف OPML إلى مساحة تخزينك.</string>
     <string name="settings_export_save_file">حفظ الملف</string>
-    <string name="settings_embedded_artwork_details">يعرض العمل الفني من الملف الذي تم تنزيله (إذا كان موجودًا) في المُشغِّل بدلاً من استخدام العمل الفني للعرض.</string>
     <string name="settings_developer">مطوّر</string>
     <string name="settings_close_upgrade_offer">إغلاق عرض الترقية</string>
     <string name="settings_choose_podcasts">اختيار البث الصوتي</string>

--- a/modules/services/localization/src/main/res/values-de/strings.xml
+++ b/modules/services/localization/src/main/res/values-de/strings.xml
@@ -15,8 +15,6 @@ Language: de
     <string name="whats_new_deselect_chapters_patron_message">Als Teil deines Patron-Abonnements kannst du nun in jeder Folge Kapitel auswählen und überspringen kannst (falls unterstützt).</string>
     <string name="skip_chapters_patron_prompt">Überspringe Kapitel und mehr mit Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Überspringe Kapitel und mehr mit Pocket Casts Plus</string>
-    <string name="settings_use_embedded_podcast_artwork">Eingebettetes Datei-Cover verwenden</string>
-    <string name="settings_episode_artwork_details">Dadurch wird anstelle des Show-Covers das Cover der Shownotizen der Episode (falls vorhanden) angezeigt. Wenn sowohl Datei- als auch RSS-Cover vorhanden sind, wir das RSS-Cover verwendet.</string>
     <string name="select_one_chapter_message">Bitte wähle mindestens ein Kapitel aus</string>
     <string name="number_of_chapters_summary_singular">1 Kapitel • %d versteckt</string>
     <string name="number_of_chapters_summary_plural">%1$d Kapitel • %2$d versteckt</string>
@@ -801,7 +799,6 @@ Language: de
     <string name="settings_website_link">Website-Link</string>
     <string name="settings_view">Ansehen</string>
     <string name="settings_version">Version %1$s (%2$s)</string>
-    <string name="settings_use_episode_podcast_artwork">Eingebettetes RSS-Cover verwenden</string>
     <string name="settings_use_android_light_dark_mode">Android Light Mode/Dark Mode verwenden</string>
     <string name="settings_up_next_tap_summary">Wenn diese Funktion aktiviert ist, wird eine Folge in deiner Warteschlange abgespielt, wenn du sie antippst. Durch Gedrückthalten werden Optionen für die Folge angezeigt.</string>
     <string name="settings_up_next_tap">Folgen in der Warteschlange beim Antippen abspielen</string>
@@ -913,7 +910,6 @@ Language: de
     <string name="settings_export_send_email">E-Mail senden</string>
     <string name="settings_export_save_file_summary">Exportiere die OPML-Datei in deinen Speicher.</string>
     <string name="settings_export_save_file">Datei speichern</string>
-    <string name="settings_embedded_artwork_details">Dadurch wird im Player anstelle des Podcast-Covers das Cover aus der heruntergeladenen Datei (falls vorhanden) angezeigt.</string>
     <string name="settings_developer">Entwickler</string>
     <string name="settings_close_upgrade_offer">Upgrade-Angebot beenden</string>
     <string name="settings_choose_podcasts">Podcasts auswählen</string>

--- a/modules/services/localization/src/main/res/values-en-rGB/strings.xml
+++ b/modules/services/localization/src/main/res/values-en-rGB/strings.xml
@@ -818,7 +818,6 @@ Language: en_GB
     <string name="settings_export_send_email">Send email</string>
     <string name="settings_export_save_file_summary">Export the OPML file to your storage.</string>
     <string name="settings_export_save_file">Save file</string>
-    <string name="settings_embedded_artwork_details">Shows artwork from the downloaded file (if it exists) in the player instead of using the show\'s artwork.</string>
     <string name="settings_developer">Developer</string>
     <string name="settings_close_upgrade_offer">close upgrade offer</string>
     <string name="settings_choose_podcasts">Choose podcasts</string>

--- a/modules/services/localization/src/main/res/values-es-rMX/strings.xml
+++ b/modules/services/localization/src/main/res/values-es-rMX/strings.xml
@@ -15,8 +15,6 @@ Language: es
     <string name="whats_new_deselect_chapters_patron_message">Como parte de tu suscripción a Patron, ahora podrás elegir y omitir capítulos en los episodios compatibles.</string>
     <string name="skip_chapters_patron_prompt">Omite capítulos y haz otros cambios con Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Omite capítulos y haz otros cambios con Pocket Casts Plus</string>
-    <string name="settings_use_embedded_podcast_artwork">Utilizar carátula de archivo insertada</string>
-    <string name="settings_episode_artwork_details">Muestra la carátula de las notas del programa del episodio (si tiene) en lugar de usar la carátula del programa. Si se incluyen tanto la carátula de RSS como la del archivo, se usará la carátula de RSS. </string>
     <string name="select_one_chapter_message">Selecciona al menos un capítulo</string>
     <string name="number_of_chapters_summary_singular">1 capítulo • %d oculto</string>
     <string name="number_of_chapters_summary_plural">%1$d capítulos • %2$d ocultos</string>
@@ -801,7 +799,6 @@ Language: es
     <string name="settings_website_link">enlace del sitio web</string>
     <string name="settings_view">Ver</string>
     <string name="settings_version">Versión %1$s (%2$s)</string>
-    <string name="settings_use_episode_podcast_artwork">Utilizar carátula de RSS insertada</string>
     <string name="settings_use_android_light_dark_mode">Usar el modo oscuro o claro de Android</string>
     <string name="settings_up_next_tap_summary">Si se activa esta opción, se reproducirá el elemento cuando lo toques en la cola de A continuación. Si lo mantienes pulsado, se mostrarán las opciones del episodio.</string>
     <string name="settings_up_next_tap">Reproducir episodio de A continuación al tocar</string>
@@ -913,7 +910,6 @@ Language: es
     <string name="settings_export_send_email">Enviar correo electrónico</string>
     <string name="settings_export_save_file_summary">Exportar el archivo OPML a tu almacenamiento.</string>
     <string name="settings_export_save_file">Guardar archivo</string>
-    <string name="settings_embedded_artwork_details">En el reproductor, muestra las carátulas desde el archivo descargado (si existe), en lugar de utilizar las del programa.</string>
     <string name="settings_developer">Desarrollador</string>
     <string name="settings_close_upgrade_offer">cerrar oferta de mejora</string>
     <string name="settings_choose_podcasts">Elegir podcasts</string>

--- a/modules/services/localization/src/main/res/values-es/strings.xml
+++ b/modules/services/localization/src/main/res/values-es/strings.xml
@@ -15,8 +15,6 @@ Language: es
     <string name="whats_new_deselect_chapters_patron_message">Como parte de tu suscripción a Patron, ahora podrás elegir y omitir capítulos en los episodios compatibles.</string>
     <string name="skip_chapters_patron_prompt">Omite capítulos y haz otros cambios con Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Omite capítulos y haz otros cambios con Pocket Casts Plus</string>
-    <string name="settings_use_embedded_podcast_artwork">Utilizar carátula de archivo insertada</string>
-    <string name="settings_episode_artwork_details">Muestra la carátula de las notas del programa del episodio (si tiene) en lugar de usar la carátula del programa. Si se incluyen tanto la carátula de RSS como la del archivo, se usará la carátula de RSS. </string>
     <string name="select_one_chapter_message">Selecciona al menos un capítulo</string>
     <string name="number_of_chapters_summary_singular">1 capítulo • %d oculto</string>
     <string name="number_of_chapters_summary_plural">%1$d capítulos • %2$d ocultos</string>
@@ -801,7 +799,6 @@ Language: es
     <string name="settings_website_link">enlace del sitio web</string>
     <string name="settings_view">Ver</string>
     <string name="settings_version">Versión %1$s (%2$s)</string>
-    <string name="settings_use_episode_podcast_artwork">Utilizar carátula de RSS insertada</string>
     <string name="settings_use_android_light_dark_mode">Usar el modo oscuro o claro de Android</string>
     <string name="settings_up_next_tap_summary">Si se activa esta opción, se reproducirá el elemento cuando lo toques en la cola de A continuación. Si lo mantienes pulsado, se mostrarán las opciones del episodio.</string>
     <string name="settings_up_next_tap">Reproducir episodio de A continuación al tocar</string>
@@ -913,7 +910,6 @@ Language: es
     <string name="settings_export_send_email">Enviar correo electrónico</string>
     <string name="settings_export_save_file_summary">Exportar el archivo OPML a tu almacenamiento.</string>
     <string name="settings_export_save_file">Guardar archivo</string>
-    <string name="settings_embedded_artwork_details">En el reproductor, muestra las carátulas desde el archivo descargado (si existe), en lugar de utilizar las del programa.</string>
     <string name="settings_developer">Desarrollador</string>
     <string name="settings_close_upgrade_offer">cerrar oferta de mejora</string>
     <string name="settings_choose_podcasts">Elegir podcasts</string>

--- a/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
@@ -15,8 +15,6 @@ Language: fr
     <string name="whats_new_deselect_chapters_patron_message">Dans le cadre de votre abonnement Patron, vous pouvez maintenant sélectionner et passer des chapitres dans n’importe quel épisode qui en comporte.</string>
     <string name="skip_chapters_patron_prompt">Passer des chapitres et plus encore avec Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Passer des chapitres et plus encore avec Pocket Casts Plus</string>
-    <string name="settings_use_embedded_podcast_artwork">Utiliser les illustrations de fichiers intégrées</string>
-    <string name="settings_episode_artwork_details">Affiche l’illustration issue des notes de l’émission à laquelle appartient l’épisode (le cas échéant) au lieu d’utiliser l’illustration de l’émission. Si un fichier et une illustration RSS sont disponibles, l\'illustration RSS sera utilisée.</string>
     <string name="select_one_chapter_message">Veuillez sélectionner au moins un chapitre</string>
     <string name="number_of_chapters_summary_singular">1 chapitre • %d masqué</string>
     <string name="number_of_chapters_summary_plural">%1$d chapitres • %2$d masqués</string>
@@ -801,7 +799,6 @@ Language: fr
     <string name="settings_website_link">lien de site Web</string>
     <string name="settings_view">Voir</string>
     <string name="settings_version">Version %1$s (%2$s)</string>
-    <string name="settings_use_episode_podcast_artwork">Utiliser les illustrations RSS intégrées</string>
     <string name="settings_use_android_light_dark_mode">Utiliser le mode clair/sombre d’Android</string>
     <string name="settings_up_next_tap_summary">S’il est activé, un appui sur un élément dans votre file d’attente déclenche sa lecture. Une pression prolongée affiche les options de l’épisode.</string>
     <string name="settings_up_next_tap">Lire le prochain épisode par une pression</string>
@@ -913,7 +910,6 @@ Language: fr
     <string name="settings_export_send_email">Envoyer un e-mail</string>
     <string name="settings_export_save_file_summary">Exportez le fichier OPML vers votre stockage.</string>
     <string name="settings_export_save_file">Enregistrer le fichier</string>
-    <string name="settings_embedded_artwork_details">Affiche l’illustration du fichier téléchargé (si elle existe) dans le lecteur au lieu d’utiliser l’illustration de l’émission.</string>
     <string name="settings_developer">Développeur</string>
     <string name="settings_close_upgrade_offer">fermer l’offre de mise à niveau</string>
     <string name="settings_choose_podcasts">Sélectionner des podcasts</string>

--- a/modules/services/localization/src/main/res/values-fr/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr/strings.xml
@@ -15,8 +15,6 @@ Language: fr
     <string name="whats_new_deselect_chapters_patron_message">Dans le cadre de votre abonnement Patron, vous pouvez maintenant sélectionner et passer des chapitres dans n’importe quel épisode qui en comporte.</string>
     <string name="skip_chapters_patron_prompt">Passer des chapitres et plus encore avec Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Passer des chapitres et plus encore avec Pocket Casts Plus</string>
-    <string name="settings_use_embedded_podcast_artwork">Utiliser les illustrations de fichiers intégrées</string>
-    <string name="settings_episode_artwork_details">Affiche l’illustration issue des notes de l’émission à laquelle appartient l’épisode (le cas échéant) au lieu d’utiliser l’illustration de l’émission. Si un fichier et une illustration RSS sont disponibles, l\'illustration RSS sera utilisée.</string>
     <string name="select_one_chapter_message">Veuillez sélectionner au moins un chapitre</string>
     <string name="number_of_chapters_summary_singular">1 chapitre • %d masqué</string>
     <string name="number_of_chapters_summary_plural">%1$d chapitres • %2$d masqués</string>
@@ -801,7 +799,6 @@ Language: fr
     <string name="settings_website_link">lien de site Web</string>
     <string name="settings_view">Voir</string>
     <string name="settings_version">Version %1$s (%2$s)</string>
-    <string name="settings_use_episode_podcast_artwork">Utiliser les illustrations RSS intégrées</string>
     <string name="settings_use_android_light_dark_mode">Utiliser le mode clair/sombre d’Android</string>
     <string name="settings_up_next_tap_summary">S’il est activé, un appui sur un élément dans votre file d’attente déclenche sa lecture. Une pression prolongée affiche les options de l’épisode.</string>
     <string name="settings_up_next_tap">Lire le prochain épisode par une pression</string>
@@ -913,7 +910,6 @@ Language: fr
     <string name="settings_export_send_email">Envoyer un e-mail</string>
     <string name="settings_export_save_file_summary">Exportez le fichier OPML vers votre stockage.</string>
     <string name="settings_export_save_file">Enregistrer le fichier</string>
-    <string name="settings_embedded_artwork_details">Affiche l’illustration du fichier téléchargé (si elle existe) dans le lecteur au lieu d’utiliser l’illustration de l’émission.</string>
     <string name="settings_developer">Développeur</string>
     <string name="settings_close_upgrade_offer">fermer l’offre de mise à niveau</string>
     <string name="settings_choose_podcasts">Sélectionner des podcasts</string>

--- a/modules/services/localization/src/main/res/values-it/strings.xml
+++ b/modules/services/localization/src/main/res/values-it/strings.xml
@@ -15,8 +15,6 @@ Language: it
     <string name="whats_new_deselect_chapters_patron_message">Grazie al tuo abbonamento a Patron, ora puoi selezionare e saltare i capitoli in qualsiasi episodio che li supporta.</string>
     <string name="skip_chapters_patron_prompt">Salta capitoli e altro ancora con Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Salta capitoli e altro ancora con Pocket Casts Plus</string>
-    <string name="settings_use_embedded_podcast_artwork">Usa grafica del file incorporata</string>
-    <string name="settings_episode_artwork_details">Mostra la grafica delle note dell\'episodio (se esiste) invece di usare la grafica dello show. Se sono presenti sia la grafica del file che quella dell\'RSS, verrà utilizzata la grafica dell\'RSS.</string>
     <string name="select_one_chapter_message">Seleziona almeno un capitolo</string>
     <string name="number_of_chapters_summary_singular">1 capitolo • %d nascosto</string>
     <string name="number_of_chapters_summary_plural">%1$d capitoli • %2$d nascosto</string>
@@ -801,7 +799,6 @@ Language: it
     <string name="settings_website_link">link al sito web</string>
     <string name="settings_view">Visualizza</string>
     <string name="settings_version">Versione %1$s (%2$s)</string>
-    <string name="settings_use_episode_podcast_artwork">Usa grafica dell\'RSS incorporata</string>
     <string name="settings_use_android_light_dark_mode">Usa la modalità chiaro/scuro di Android</string>
     <string name="settings_up_next_tap_summary">Se attivo, potrai riprodurre il prossimo elemento in coda con un semplice tocco. Se tieni premuto, potrai visualizzare le opzioni dell\'episodio.</string>
     <string name="settings_up_next_tap">Tocca per riprodurre il prossimo episodio</string>
@@ -913,7 +910,6 @@ Language: it
     <string name="settings_export_send_email">Invia e-mail</string>
     <string name="settings_export_save_file_summary">Esporta il file OPML nel tuo spazio di archiviazione.</string>
     <string name="settings_export_save_file">Salva il file</string>
-    <string name="settings_embedded_artwork_details">Mostra l\'illustrazione legata al file scaricato (se esiste) nel lettore invece dell\'illustrazione del podcast.</string>
     <string name="settings_developer">Sviluppatore</string>
     <string name="settings_close_upgrade_offer">chiudi l\'offerta di aggiornamento</string>
     <string name="settings_choose_podcasts">Scegli i podcast</string>

--- a/modules/services/localization/src/main/res/values-ja/strings.xml
+++ b/modules/services/localization/src/main/res/values-ja/strings.xml
@@ -15,8 +15,6 @@ Language: ja_JP
     <string name="whats_new_deselect_chapters_patron_message">Patron サブスクリプションの一環として、チャプターに対応するどのエピソードでも、選択したチャプターをスキップできるようになりました。</string>
     <string name="skip_chapters_patron_prompt">Pocket Casts Patron でチャプターのスキップやその他の機能を利用</string>
     <string name="skip_chapters_plus_prompt">Pocket Casts Plus でチャプターのスキップやその他の機能を利用</string>
-    <string name="settings_use_embedded_podcast_artwork">埋め込みファイルアートワークを使用</string>
-    <string name="settings_episode_artwork_details">番組のアートワークを使用する代わりに、エピソードのショーノートからのアートワークを表示します (存在する場合)。 ファイルと RSS アートワークの両方が存在する場合、RSS アートワークが使用されます。</string>
     <string name="select_one_chapter_message">チャプターを少なくとも1つ選択してください</string>
     <string name="number_of_chapters_summary_singular">1個のチャプター • %d個が非表示</string>
     <string name="number_of_chapters_summary_plural">%1$d個のチャプター • %2$d個が非表示</string>
@@ -801,7 +799,6 @@ Language: ja_JP
     <string name="settings_website_link">サイトのリンク</string>
     <string name="settings_view">表示</string>
     <string name="settings_version">バージョン%1$s (%2$s)</string>
-    <string name="settings_use_episode_podcast_artwork">埋め込み RSS アートワークを使用</string>
     <string name="settings_use_android_light_dark_mode">Android のライト / ダークモードを使用</string>
     <string name="settings_up_next_tap_summary">オンにすると、次のエピソード待機リストでアイテムをタップすることでアイテムが再生されます。 長押しするとエピソードオプションが表示されます。</string>
     <string name="settings_up_next_tap">タップして次のエピソードを再生</string>
@@ -913,7 +910,6 @@ Language: ja_JP
     <string name="settings_export_send_email">メールを送信</string>
     <string name="settings_export_save_file_summary">OPML ファイルをストレージにエクスポートします。</string>
     <string name="settings_export_save_file">ファイルを保存</string>
-    <string name="settings_embedded_artwork_details">番組のアートワークを使用する代わりに、プレーヤーのダウンロードファイルからのアートワークを表示します (存在する場合)。</string>
     <string name="settings_developer">開発者</string>
     <string name="settings_close_upgrade_offer">アップグレードのオファーを閉じる</string>
     <string name="settings_choose_podcasts">ポッドキャストを選択</string>

--- a/modules/services/localization/src/main/res/values-ko/strings.xml
+++ b/modules/services/localization/src/main/res/values-ko/strings.xml
@@ -15,8 +15,6 @@ Language: ko_KR
     <string name="whats_new_deselect_chapters_patron_message">Patron 구독의 일부로 이제 해당 챕터를 지원하는 모든 에피소드에서 챕터를 선택하고 건너뛸 수 있습니다.</string>
     <string name="skip_chapters_patron_prompt">Pocket Casts Patron으로 챕터 건너뛰기 등</string>
     <string name="skip_chapters_plus_prompt">Pocket Casts Plus로 챕터 건너뛰기 등</string>
-    <string name="settings_use_embedded_podcast_artwork">임베드한 파일 아트워크 사용</string>
-    <string name="settings_episode_artwork_details">프로그램의 아트워크를 사용하지 않고 에피소드의 프로그램 메모(있는 경우)의 아트워크를 보여줍니다. 파일과 RSS 아트워크가 둘 다 있으면 RSS 아트워크가 사용됩니다.</string>
     <string name="select_one_chapter_message">챕터를 하나 이상 선택하세요.</string>
     <string name="number_of_chapters_summary_singular">1개 챕터 • %d개 숨김</string>
     <string name="number_of_chapters_summary_plural">%1$d개 챕터 • %2$d개 숨김</string>
@@ -801,7 +799,6 @@ Language: ko_KR
     <string name="settings_website_link">웹사이트 링크</string>
     <string name="settings_view">보기</string>
     <string name="settings_version">버전 %1$s(%2$s)</string>
-    <string name="settings_use_episode_podcast_artwork">임베드한 아트워크 RSS 사용</string>
     <string name="settings_use_android_light_dark_mode">Android 밝게/어둡게 모드 사용</string>
     <string name="settings_up_next_tap_summary">켜진 경우, 다음 차례 대기열의 아이템을 누르면 해당 아이템이 재생됩니다. 길게 누르면 에피소드 옵션이 표시됩니다.</string>
     <string name="settings_up_next_tap">탭에서 다음 차례 에피소드 재생</string>
@@ -913,7 +910,6 @@ Language: ko_KR
     <string name="settings_export_send_email">이메일 보내기</string>
     <string name="settings_export_save_file_summary">저장 공간으로 OPML 파일을 내보냅니다.</string>
     <string name="settings_export_save_file">파일 저장</string>
-    <string name="settings_embedded_artwork_details">프로그램의 아트워크를 사용하지 않고 다운로드한 파일(있는 경우)의 아트워크를 플레이어에서 보여줍니다.</string>
     <string name="settings_developer">개발자</string>
     <string name="settings_close_upgrade_offer">업그레이드 제안 닫기</string>
     <string name="settings_choose_podcasts">팟캐스트 선택</string>

--- a/modules/services/localization/src/main/res/values-nb/strings.xml
+++ b/modules/services/localization/src/main/res/values-nb/strings.xml
@@ -802,7 +802,6 @@ Language: nb_NO
     <string name="settings_export_send_email">Send e-post</string>
     <string name="settings_export_save_file_summary">Eksport OPML-filen til lagringen din.</string>
     <string name="settings_export_save_file">Lagre fil</string>
-    <string name="settings_embedded_artwork_details">Viser grafikk fra den nedlastede filen (hvis den finnes) i avspilleren i stedet for å bruke grafikk fra programmet.</string>
     <string name="settings_developer">Utvikler</string>
     <string name="settings_close_upgrade_offer">lukk oppgraderingstilbud</string>
     <string name="settings_choose_podcasts">Velg podcaster</string>

--- a/modules/services/localization/src/main/res/values-nl/strings.xml
+++ b/modules/services/localization/src/main/res/values-nl/strings.xml
@@ -15,8 +15,6 @@ Language: nl
     <string name="whats_new_deselect_chapters_patron_message">Met het Patron-abonnement kan je waar mogelijk hoofdstukken van afleveringen selecteren en overslaan.</string>
     <string name="skip_chapters_patron_prompt">Sla hoofdstukken over en geniet van extra functies met Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Sla hoofdstukken over en geniet van extra functies met Pocket Casts Plus</string>
-    <string name="settings_use_embedded_podcast_artwork">Artwork-embed gebruiken</string>
-    <string name="settings_episode_artwork_details">Geeft de artwork van het gedownloade bestand weer (als het bestaat) in de speler, in plaats van de artwork van de serie te gebruiken. If both file and RSS artwork are present, RSS artwork will be used.</string>
     <string name="select_one_chapter_message">Please select at least one chapter</string>
     <string name="number_of_chapters_summary_singular">1 hoofdstuk • %d verborgen</string>
     <string name="number_of_chapters_summary_plural">%1$d hoofdstukken • %2$d verborgen</string>
@@ -801,7 +799,6 @@ Language: nl
     <string name="settings_website_link">websitelink</string>
     <string name="settings_view">Bekijk</string>
     <string name="settings_version">Versie %1$s (%2$s)</string>
-    <string name="settings_use_episode_podcast_artwork">Artwork-embed gebruiken</string>
     <string name="settings_use_android_light_dark_mode">Lichte/donkere Android-modus gebruiken</string>
     <string name="settings_up_next_tap_summary">Als dit is ingeschakeld, dan wordt een aflevering afgespeeld als je erop tikt in Hierna. Bij lang ingedrukt houden, worden opties voor de aflevering weergegeven.</string>
     <string name="settings_up_next_tap">Aflevering afspelen na tikken in Hierna</string>
@@ -913,7 +910,6 @@ Language: nl
     <string name="settings_export_send_email">Verstuur e-mail</string>
     <string name="settings_export_save_file_summary">Exporteer het OPML-bestanden naar je opslag.</string>
     <string name="settings_export_save_file">Bestand opslaan</string>
-    <string name="settings_embedded_artwork_details">Geeft de artwork van het gedownloade bestand weer (als het bestaat) in de speler, in plaats van de artwork van de serie te gebruiken.</string>
     <string name="settings_developer">Ontwikkelaar</string>
     <string name="settings_close_upgrade_offer">upgrade-aanbod sluiten</string>
     <string name="settings_choose_podcasts">Podcasts kiezen</string>

--- a/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
+++ b/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
@@ -15,8 +15,6 @@ Language: pt_BR
     <string name="whats_new_deselect_chapters_patron_message">Como parte da assinatura do Patron, você pode selecionar e pular capítulos em qualquer episódio que seja compatível com esses recursos.</string>
     <string name="skip_chapters_patron_prompt">Pule capítulos e muito mais com o Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Pule capítulos e muito mais com o Pocket Casts Plus</string>
-    <string name="settings_use_embedded_podcast_artwork">Usar arte do arquivo incorporada</string>
-    <string name="settings_episode_artwork_details">Mostra a arte das observações do programa no episódio (se houver) em vez da arte do programa. Se a arte do arquivo e RSS estiverem presentes, a arte RSS será usada.</string>
     <string name="select_one_chapter_message">Selecione ao menos um capítulo</string>
     <string name="number_of_chapters_summary_singular">1 capítulo • %d oculto</string>
     <string name="number_of_chapters_summary_plural">%1$d capítulos • %2$d oculto</string>
@@ -801,7 +799,6 @@ Language: pt_BR
     <string name="settings_website_link">link do site</string>
     <string name="settings_view">Visualizar</string>
     <string name="settings_version">Versão %1$s (%2$s)</string>
-    <string name="settings_use_episode_podcast_artwork">Usar arte RSS incorporada</string>
     <string name="settings_use_android_light_dark_mode">Usar modo claro/escuro do Android</string>
     <string name="settings_up_next_tap_summary">Se esta opção estiver ativa, um item na sua lista de Próximos será reproduzido ao tocar nele. Manter pressionado exibirá as opções do episódio.</string>
     <string name="settings_up_next_tap">Reproduzir lista de Próximos com toque</string>
@@ -913,7 +910,6 @@ Language: pt_BR
     <string name="settings_export_send_email">Enviar e-mail</string>
     <string name="settings_export_save_file_summary">Exporte o arquivo OPML para o seu armazenamento.</string>
     <string name="settings_export_save_file">Salvar arquivo</string>
-    <string name="settings_embedded_artwork_details">Mostra a arte dos arquivos baixados (se houver) no reprodutor, em vez da arte do programa.</string>
     <string name="settings_developer">Desenvolvedor</string>
     <string name="settings_close_upgrade_offer">fechar oferta de upgrade</string>
     <string name="settings_choose_podcasts">Escolher podcasts</string>

--- a/modules/services/localization/src/main/res/values-ru/strings.xml
+++ b/modules/services/localization/src/main/res/values-ru/strings.xml
@@ -15,8 +15,6 @@ Language: ru
     <string name="whats_new_deselect_chapters_patron_message">В рамках подписки на Patron вы теперь можете выбирать и пропускать главы во всех выпусках, поддерживающих эту функцию.</string>
     <string name="skip_chapters_patron_prompt">Возможность пропускать главы и множество других функций с Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Возможность пропускать главы и множество других функций с Pocket Casts Plus</string>
-    <string name="settings_use_embedded_podcast_artwork">Использовать встроенные обложки файлов</string>
-    <string name="settings_episode_artwork_details">Показывает тему из заметок для показа эпизода (при наличии) вместо темы шоу. Если имеется одновременно и обложка файла, и тема RSS, будет применяться тема RSS.</string>
     <string name="select_one_chapter_message">Выберите хотя бы одну главу</string>
     <string name="number_of_chapters_summary_singular">1 глава • Скрыто: %d</string>
     <string name="number_of_chapters_summary_plural">Глав: %1$d • Скрыто: %2$d</string>
@@ -801,7 +799,6 @@ Language: ru
     <string name="settings_website_link">ссылка на веб-сайт</string>
     <string name="settings_view">Просмотреть</string>
     <string name="settings_version">Версия%1$s (%2$s)</string>
-    <string name="settings_use_episode_podcast_artwork">Использовать встроенную тему RSS</string>
     <string name="settings_use_android_light_dark_mode">Использовать светлый/тёмный режим Android</string>
     <string name="settings_up_next_tap_summary">Если функция включена, элемент очереди «Следующие» будет воспроизводиться при нажатии. При долгом нажатии появятся настройки выпуска.</string>
     <string name="settings_up_next_tap">Воспроизводить выпуск из очереди «Следующие» по нажатию</string>
@@ -913,7 +910,6 @@ Language: ru
     <string name="settings_export_send_email">Послать сообщение по эл.почте</string>
     <string name="settings_export_save_file_summary">Экспортировать файл OPML в ваше хранилище.</string>
     <string name="settings_export_save_file">Сохранить файл</string>
-    <string name="settings_embedded_artwork_details">Показывает в плеере тему из загруженного файла (при наличии) вместо темы шоу.</string>
     <string name="settings_developer">Разработчик</string>
     <string name="settings_close_upgrade_offer">закрыть предложение платной услуги</string>
     <string name="settings_choose_podcasts">Выбрать подкасты</string>

--- a/modules/services/localization/src/main/res/values-sv/strings.xml
+++ b/modules/services/localization/src/main/res/values-sv/strings.xml
@@ -15,8 +15,6 @@ Language: sv_SE
     <string name="whats_new_deselect_chapters_patron_message">Som en del av din Patron-prenumeration kan du nu välja och hoppa över kapitel i avsnitt som stöder detta.</string>
     <string name="skip_chapters_patron_prompt">Hoppa över kapitel och mycket annat med Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Hoppa över kapitel och mycket annat med Pocket Casts Plus</string>
-    <string name="settings_use_embedded_podcast_artwork">Använd inbäddat filomslag</string>
-    <string name="settings_episode_artwork_details">Visar omslag från avsnittets showanteckningar (om sådana finns) istället för att använda showens omslag. Om både fil- och RSS-omslag finns kommer RSS-omslaget att användas.</string>
     <string name="select_one_chapter_message">Välj minst ett kapitel</string>
     <string name="number_of_chapters_summary_singular">1 kapitel • %d dolda</string>
     <string name="number_of_chapters_summary_plural">%1$d kapitel • %2$d dolda</string>
@@ -801,7 +799,6 @@ Language: sv_SE
     <string name="settings_website_link">webbplatslänk</string>
     <string name="settings_view">Visa</string>
     <string name="settings_version">Version %1$s (%2$s)</string>
-    <string name="settings_use_episode_podcast_artwork">Använd inbäddat RSS-omslag</string>
     <string name="settings_use_android_light_dark_mode">Använd ljust/mörkt läge för Android</string>
     <string name="settings_up_next_tap_summary">Om detta är aktiverat spelas objekt i din Nästa-kö upp om du trycker på dem. En lång tryckning visar avsnittsalternativen.</string>
     <string name="settings_up_next_tap">Spela upp nästa avsnitt vid tryckning</string>
@@ -913,7 +910,6 @@ Language: sv_SE
     <string name="settings_export_send_email">Skicka e-post</string>
     <string name="settings_export_save_file_summary">Exportera OPML-filen till ditt lagringsutrymme.</string>
     <string name="settings_export_save_file">Spara fil</string>
-    <string name="settings_embedded_artwork_details">Visar omslag från den nedladdade filen (om ett sådant finns) i spelaren istället för att använda showens omslag.</string>
     <string name="settings_developer">Utvecklare</string>
     <string name="settings_close_upgrade_offer">stäng uppgraderingserbjudande</string>
     <string name="settings_choose_podcasts">Välj podcasts</string>

--- a/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
@@ -15,8 +15,6 @@ Language: zh_TW
     <string name="whats_new_deselect_chapters_patron_message">你已訂閱 Patron，現在可以在支援章節功能的節目中選取並跳過章節。</string>
     <string name="skip_chapters_patron_prompt">訂閱 Pocket Casts Patron，就能跳過章節並享有更多功能</string>
     <string name="skip_chapters_plus_prompt">訂閱 Pocket Casts Plus，就能跳過章節並享有更多功能</string>
-    <string name="settings_use_embedded_podcast_artwork">使用嵌入檔案圖片</string>
-    <string name="settings_episode_artwork_details">使用單集節目說明的圖片 (若有)，而非該節目的圖片。 若該檔案和 RSS 圖片皆存在，則將使用 RSS 圖片。</string>
     <string name="select_one_chapter_message">請選取至少一章</string>
     <string name="number_of_chapters_summary_singular">1 個章節 • %d 個章節已隱藏</string>
     <string name="number_of_chapters_summary_plural">%1$d 個章節 • %2$d 個章節已隱藏</string>
@@ -801,7 +799,6 @@ Language: zh_TW
     <string name="settings_website_link">網站連結</string>
     <string name="settings_view">檢視</string>
     <string name="settings_version">版本 %1$s (%2$s)</string>
-    <string name="settings_use_episode_podcast_artwork">使用嵌入的 RSS 圖片</string>
     <string name="settings_use_android_light_dark_mode">使用 Android 淺色/深色模式</string>
     <string name="settings_up_next_tap_summary">若啟用，點選「接下來播放」佇列中的項目將開始播放。 長按將顯示單集選項。</string>
     <string name="settings_up_next_tap">點選「接下來播放」即可播放單集</string>
@@ -913,7 +910,6 @@ Language: zh_TW
     <string name="settings_export_send_email">傳送電子郵件</string>
     <string name="settings_export_save_file_summary">將 OPML 檔案匯出到你的儲存空間。</string>
     <string name="settings_export_save_file">儲存檔案</string>
-    <string name="settings_embedded_artwork_details">在播放器中顯示下載檔案的封面 (如有)，而不使用節目的封面。</string>
     <string name="settings_developer">開發人員</string>
     <string name="settings_close_upgrade_offer">關閉升級方案</string>
     <string name="settings_choose_podcasts">選擇 Podcast</string>

--- a/modules/services/localization/src/main/res/values-zh/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh/strings.xml
@@ -15,8 +15,6 @@ Language: zh_CN
     <string name="whats_new_deselect_chapters_patron_message">订阅 Patron 后，您就能在任何支持相应功能的剧集中选择和跳过章节。</string>
     <string name="skip_chapters_patron_prompt">使用 Pocket Casts Patron，享受跳过章节等更多功能</string>
     <string name="skip_chapters_plus_prompt">使用 Pocket Casts Plus，享受跳过章节等更多功能</string>
-    <string name="settings_use_embedded_podcast_artwork">使用嵌入式文件插图</string>
-    <string name="settings_episode_artwork_details">显示剧集节目注释（如果存在）中的插图，而非使用节目的插图。 如果文件插图和 RSS 插图都存在，则使用 RSS 插图。</string>
     <string name="select_one_chapter_message">请至少选择一个章节</string>
     <string name="number_of_chapters_summary_singular">1 个章节 • %d 已隐藏</string>
     <string name="number_of_chapters_summary_plural">%1$d 个章节 • %2$d 已隐藏</string>
@@ -801,7 +799,6 @@ Language: zh_CN
     <string name="settings_website_link">网站链接</string>
     <string name="settings_view">查看</string>
     <string name="settings_version">版本 %1$s (%2$s)</string>
-    <string name="settings_use_episode_podcast_artwork">使用嵌入式 RSS 插图</string>
     <string name="settings_use_android_light_dark_mode">使用 Android 浅色/深色模式</string>
     <string name="settings_up_next_tap_summary">如果打开，点按“接下来播放”队列中的某个项目将播放该项目。 长按将显示剧集选项。</string>
     <string name="settings_up_next_tap">点按时播放“接下来播放”剧集</string>
@@ -913,7 +910,6 @@ Language: zh_CN
     <string name="settings_export_send_email">发送电子邮件</string>
     <string name="settings_export_save_file_summary">将 OPML 文件导出到您的存储设备。</string>
     <string name="settings_export_save_file">保存文件</string>
-    <string name="settings_embedded_artwork_details">在播放器中显示下载文件（如果存在）中的插图，而不是使用节目的插图。</string>
     <string name="settings_developer">开发人员</string>
     <string name="settings_close_upgrade_offer">关闭升级优惠</string>
     <string name="settings_choose_podcasts">选择播客</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1104,7 +1104,6 @@
     <string name="settings_developer">Developer</string>
     <string name="settings_downloads_clean_up">Clean up</string>
     <string name="settings_downloads_clean_up_summary">Are you sure you want to delete these downloaded files?</string>
-    <string name="settings_embedded_artwork_details">Shows artwork from the downloaded file (if it exists) in the player instead of using the show\'s artwork.</string>
     <string name="settings_export_save_file">Save file</string>
     <string name="settings_export_save_file_summary">Export the OPML file to your storage.</string>
     <string name="settings_export_send_email">Send email</string>
@@ -1285,9 +1284,8 @@
     <string name="settings_use_dark_up_next_details">When enabled the Up Next will always use the dark theme, or will match the current theme when disabled</string>
     <string name="settings_use_dynamic_colors_widget">Use dynamic colors for widget</string>
     <string name="settings_use_dynamic_colors_widget_details">When enabled, widget colors will change based on the device theme colors.</string>
-    <string name="settings_use_embedded_podcast_artwork">Use embedded file artwork</string>
-    <string name="settings_use_episode_podcast_artwork">Use embedded RSS artwork</string>
-    <string name="settings_episode_artwork_details">Shows artwork from the episode\'s show notes (if it exists) instead of using the show\'s artwork. If both file and RSS artwork are present, RSS artwork will be used.</string>
+    <string name="settings_use_episode_artwork">Use episode artwork</string>
+    <string name="settings_use_episode_artwork_details">Some shows have custom artwork for certain episodes. Enable this option and Pocket Casts will display them instead of the show’s artwork.</string>
     <string name="settings_version">Version %1$s (%2$s)</string>
     <string name="settings_view">View</string>
     <string name="settings_website_link">website link</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -328,8 +328,7 @@ interface Settings {
     val autoDownloadOnlyWhenCharging: UserSetting<Boolean>
     val autoDownloadUpNext: UserSetting<Boolean>
 
-    val useEmbeddedArtwork: UserSetting<Boolean>
-    val useRssArtwork: UserSetting<Boolean>
+    val useEpisodeArtwork: UserSetting<Boolean>
 
     val globalPlaybackEffects: UserSetting<PlaybackEffects>
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -538,15 +538,9 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override val useEmbeddedArtwork = UserSetting.BoolPref(
-        sharedPrefKey = "useEmbeddedArtwork",
+    override val useEpisodeArtwork = UserSetting.BoolPref(
+        sharedPrefKey = "useEpisodeArtwork",
         defaultValue = false,
-        sharedPrefs = sharedPreferences,
-    )
-
-    override val useRssArtwork = UserSetting.BoolPref(
-        sharedPrefKey = "useRssArtwork",
-        defaultValue = true,
         sharedPrefs = sharedPreferences,
     )
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PocketCastsImageRequestFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PocketCastsImageRequestFactory.kt
@@ -6,6 +6,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.Px
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.playback.EpisodeFileMetadata
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.images.RoundedCornersTransformation
@@ -52,11 +53,11 @@ data class PocketCastsImageRequestFactory(
 
     fun create(
         episode: BaseEpisode,
-        useRssArtwork: Boolean,
+        useEpisodeArtwork: Boolean,
         onSuccess: () -> Unit = {},
     ) = when (episode) {
-        is PodcastEpisodeEntity -> create(RequestType.PodcastEpisode(episode, useRssArtwork), onSuccess)
-        is UserEpisodeEntity -> create(RequestType.UserEpisode(episode), onSuccess)
+        is PodcastEpisodeEntity -> create(RequestType.PodcastEpisode(episode, useEpisodeArtwork), onSuccess)
+        is UserEpisodeEntity -> create(RequestType.UserEpisode(episode, useEpisodeArtwork), onSuccess)
     }
 
     private fun create(
@@ -92,15 +93,23 @@ data class PocketCastsImageRequestFactory(
 
     private fun RequestType.Podcast.data(context: Context) = podcastUuid?.let { podcastArtworkUrl(context, it) } ?: placeholderId
 
-    private fun RequestType.PodcastEpisode.data(context: Context) = if (useRssArtwork) {
-        episode.imageUrl ?: episode.podcastArtworkUrl(context)
+    private fun RequestType.PodcastEpisode.data(context: Context) = if (useEpisodeArtwork) {
+        episode.imageUrl ?: EpisodeFileMetadata.artworkCacheFile(context, episode.uuid).takeIf(File::exists) ?: episode.podcastArtworkUrl(context)
     } else {
         episode.podcastArtworkUrl(context)
     }
 
-    private fun RequestType.UserEpisode.data(): String {
-        val tintColorIndex = episode.tintColorIndex
-        val artworkUrl = episode.artworkUrl
+    private fun RequestType.UserEpisode.data() = if (useEpisodeArtwork) {
+        EpisodeFileMetadata.artworkCacheFile(context, episode.uuid).takeIf(File::exists) ?: episode.artworkUrl()
+    } else {
+        episode.artworkUrl()
+    }
+
+    private fun PodcastEpisodeEntity.podcastArtworkUrl(context: Context) = podcastArtworkUrl(context, podcastUuid)
+
+    private fun UserEpisodeEntity.artworkUrl(): String {
+        val tintColorIndex = tintColorIndex
+        val artworkUrl = artworkUrl
         return if (tintColorIndex == 0 && artworkUrl != null) {
             artworkUrl
         } else {
@@ -113,8 +122,6 @@ data class PocketCastsImageRequestFactory(
             "${Settings.SERVER_STATIC_URL}/discover/images/artwork/$themeType/$urlSize/$tintColorIndex.png"
         }
     }
-
-    private fun PodcastEpisodeEntity.podcastArtworkUrl(context: Context) = podcastArtworkUrl(context, podcastUuid)
 
     private fun podcastArtworkUrl(context: Context, podcastUuid: String): String {
         val maxSize = if (Util.isWearOs(context)) 480 else 960
@@ -147,8 +154,8 @@ fun ImageRequest.loadInto(target: Target) = context.imageLoader.enqueue(newBuild
 
 private sealed interface RequestType {
     data class Podcast(val podcastUuid: String?) : RequestType
-    data class PodcastEpisode(val episode: PodcastEpisodeEntity, val useRssArtwork: Boolean) : RequestType
-    data class UserEpisode(val episode: UserEpisodeEntity) : RequestType
+    data class PodcastEpisode(val episode: PodcastEpisodeEntity, val useEpisodeArtwork: Boolean) : RequestType
+    data class UserEpisode(val episode: UserEpisodeEntity, val useEpisodeArtwork: Boolean) : RequestType
     data class FileOrUrl(val filePathOrUrl: String) : RequestType
 }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
@@ -19,6 +19,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
+import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -158,6 +159,10 @@ class VersionMigrationsJob : JobService() {
         if (previousVersionCode < 6362) {
             upgradeTrimSilenceMode()
         }
+
+        if (previousVersionCode < 9204) {
+            consolidateEmbeddedArtworkSettings(applicationContext)
+        }
     }
 
     private fun removeOldTempPodcastDirectory() {
@@ -233,6 +238,14 @@ class VersionMigrationsJob : JobService() {
             }
         } catch (e: Exception) {
             LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, e, "Could not migrate trimsilence mode on podcasts")
+        }
+    }
+
+    private fun consolidateEmbeddedArtworkSettings(context: Context) {
+        if (!Util.isWearOs(context) && !Util.isAutomotive(context)) {
+            val useEpisodeArtwork = settings.getBooleanForKey("useEpisodeArtwork", false)
+            val useFileArtwork = settings.getBooleanForKey("useEmbeddedArtwork", false)
+            settings.useEpisodeArtwork.set(useEpisodeArtwork || useFileArtwork, needsSync = true)
         }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
@@ -160,7 +160,7 @@ class VersionMigrationsJob : JobService() {
             upgradeTrimSilenceMode()
         }
 
-        if (previousVersionCode < 9204) {
+        if (previousVersionCode < 9207) {
             consolidateEmbeddedArtworkSettings(applicationContext)
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
@@ -92,7 +92,7 @@ class NotificationDrawerImpl @Inject constructor(
     }
 
     private fun loadUserEpisodeArtwork(episode: UserEpisode): Bitmap? {
-        val request = imageRequestFactory.create(episode, settings.useRssArtwork.value)
+        val request = imageRequestFactory.create(episode, settings.useEpisodeArtwork.value)
         return context.imageLoader.executeBlocking(request).drawable?.toBitmap() ?: loadPlaceholderBitmap()
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1539,7 +1539,6 @@ open class PlaybackManager @Inject constructor(
             playbackStateRelay.accept(
                 playbackState.copy(
                     chapters = chapters,
-                    embeddedArtworkPath = episodeMetadata.embeddedArtworkPath,
                     lastChangeFrom = LastChangeFrom.OnMetadataAvailable.value,
                 ),
             )
@@ -1773,7 +1772,6 @@ open class PlaybackManager @Inject constructor(
                     episodeUuid = episode.uuid,
                     podcast = podcast,
                     chapters = if (sameEpisode) (previousPlaybackState?.chapters ?: Chapters()) else Chapters(),
-                    embeddedArtworkPath = if (sameEpisode) previousPlaybackState?.embeddedArtworkPath else null,
                     lastChangeFrom = LastChangeFrom.OnLoadCurrentEpisodeDataWarning.value,
                 )
                 withContext(Dispatchers.Main) {
@@ -1887,7 +1885,6 @@ open class PlaybackManager @Inject constructor(
             episodeUuid = episode.uuid,
             podcast = podcast,
             chapters = if (sameEpisode) (previousPlaybackState?.chapters ?: Chapters()) else Chapters(),
-            embeddedArtworkPath = if (sameEpisode) previousPlaybackState?.embeddedArtworkPath else null,
             playbackSpeed = playbackEffects.playbackSpeed,
             trimMode = playbackEffects.trimMode,
             isVolumeBoosted = playbackEffects.isVolumeBoosted,
@@ -2344,7 +2341,6 @@ open class PlaybackManager @Inject constructor(
                 positionMs = episode.playedUpToMs,
                 episodeUuid = episode.uuid,
                 podcast = podcast,
-                embeddedArtworkPath = if (sameEpisode) previousPlaybackState?.embeddedArtworkPath else null,
                 chapters = if (sameEpisode) (previousPlaybackState?.chapters ?: Chapters()) else Chapters(),
                 lastChangeFrom = LastChangeFrom.OnUpdatePausedPlaybackState.value,
             )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -460,7 +460,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
             // find the podcast
             val podcast = if (episode is PodcastEpisode) podcastManager.findPodcastByUuidSuspend(episode.podcastUuid) else Podcast.userPodcast
             // convert to a media item
-            if (podcast == null) null else AutoConverter.convertEpisodeToMediaItem(context = this, episode = episode, parentPodcast = podcast, useRssArtwork = settings.useRssArtwork.value)
+            if (podcast == null) null else AutoConverter.convertEpisodeToMediaItem(context = this, episode = episode, parentPodcast = podcast, useEpisodeArtwork = settings.useEpisodeArtwork.value)
         }
     }
 
@@ -510,12 +510,12 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
             folderManager.getHomeFolder().mapNotNull { item ->
                 when (item) {
                     is FolderItem.Folder -> convertFolderToMediaItem(this, item.folder)
-                    is FolderItem.Podcast -> convertPodcastToMediaItem(podcast = item.podcast, context = this, useRssArtwork = settings.useRssArtwork.value)
+                    is FolderItem.Podcast -> convertPodcastToMediaItem(podcast = item.podcast, context = this, useEpisodeArtwork = settings.useEpisodeArtwork.value)
                 }
             }
         } else {
             podcastManager.findSubscribedSorted().mapNotNull { podcast ->
-                convertPodcastToMediaItem(podcast = podcast, context = this, useRssArtwork = settings.useRssArtwork.value)
+                convertPodcastToMediaItem(podcast = podcast, context = this, useEpisodeArtwork = settings.useEpisodeArtwork.value)
             }
         }
     }
@@ -523,7 +523,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
     suspend fun loadFolderPodcastsChildren(folderUuid: String): List<MediaBrowserCompat.MediaItem> {
         return if (subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid) {
             folderManager.findFolderPodcastsSorted(folderUuid).mapNotNull { podcast ->
-                convertPodcastToMediaItem(podcast = podcast, context = this, useRssArtwork = settings.useRssArtwork.value)
+                convertPodcastToMediaItem(podcast = podcast, context = this, useEpisodeArtwork = settings.useEpisodeArtwork.value)
             }
         } else {
             emptyList()
@@ -541,7 +541,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
             if (topEpisodes.isNotEmpty()) {
                 for (episode in topEpisodes) {
                     podcastManager.findPodcastByUuidSuspend(episode.podcastUuid)?.let { parentPodcast ->
-                        episodeItems.add(AutoConverter.convertEpisodeToMediaItem(this, episode, parentPodcast, sourceId = playlist.uuid, useRssArtwork = settings.useRssArtwork.value))
+                        episodeItems.add(AutoConverter.convertEpisodeToMediaItem(this, episode, parentPodcast, sourceId = playlist.uuid, useEpisodeArtwork = settings.useEpisodeArtwork.value))
                     }
                 }
             }
@@ -559,7 +559,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
                     episodes.sortBy { it.episodeType !is PodcastEpisode.EpisodeType.Trailer } // Bring trailers to the top
                 }
                 episodes.forEach { episode ->
-                    episodeItems.add(AutoConverter.convertEpisodeToMediaItem(this, episode, podcast, groupTrailers = !podcast.isSubscribed, useRssArtwork = settings.useRssArtwork.value))
+                    episodeItems.add(AutoConverter.convertEpisodeToMediaItem(this, episode, podcast, groupTrailers = !podcast.isSubscribed, useEpisodeArtwork = settings.useEpisodeArtwork.value))
                 }
             }
         }
@@ -569,14 +569,14 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
 
     protected suspend fun loadFilesChildren(): List<MediaBrowserCompat.MediaItem> {
         return userEpisodeManager.findUserEpisodes().map {
-            AutoConverter.convertEpisodeToMediaItem(this, it, Podcast.userPodcast, useRssArtwork = settings.useRssArtwork.value)
+            AutoConverter.convertEpisodeToMediaItem(this, it, Podcast.userPodcast, useEpisodeArtwork = settings.useEpisodeArtwork.value)
         }
     }
 
     protected suspend fun loadStarredChildren(): List<MediaBrowserCompat.MediaItem> {
         return episodeManager.findStarredEpisodes().take(EPISODE_LIMIT).mapNotNull { episode ->
             podcastManager.findPodcastByUuid(episode.podcastUuid)?.let { podcast ->
-                AutoConverter.convertEpisodeToMediaItem(context = this, episode = episode, parentPodcast = podcast, useRssArtwork = settings.useRssArtwork.value)
+                AutoConverter.convertEpisodeToMediaItem(context = this, episode = episode, parentPodcast = podcast, useEpisodeArtwork = settings.useEpisodeArtwork.value)
             }
         }
     }
@@ -584,7 +584,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
     protected suspend fun loadListeningHistoryChildren(): List<MediaBrowserCompat.MediaItem> {
         return episodeManager.findPlaybackHistoryEpisodes().take(EPISODE_LIMIT).mapNotNull { episode ->
             podcastManager.findPodcastByUuid(episode.podcastUuid)?.let { podcast ->
-                AutoConverter.convertEpisodeToMediaItem(context = this, episode = episode, parentPodcast = podcast, useRssArtwork = settings.useRssArtwork.value)
+                AutoConverter.convertEpisodeToMediaItem(context = this, episode = episode, parentPodcast = podcast, useEpisodeArtwork = settings.useEpisodeArtwork.value)
             }
         }
     }
@@ -626,6 +626,6 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
         // merge the local and remote podcasts
         val podcasts = (localPodcasts + serverPodcasts).distinctBy { it.uuid }
         // convert podcasts to the media browser format
-        return podcasts.mapNotNull { podcast -> convertPodcastToMediaItem(context = this, podcast = podcast, useRssArtwork = settings.useRssArtwork.value) }
+        return podcasts.mapNotNull { podcast -> convertPodcastToMediaItem(context = this, podcast = podcast, useEpisodeArtwork = settings.useEpisodeArtwork.value) }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackState.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackState.kt
@@ -16,7 +16,6 @@ data class PlaybackState(
     val episodeUuid: String = "",
     val podcast: Podcast? = null,
     val fileMetadata: EpisodeFileMetadata? = null,
-    val embeddedArtworkPath: String? = null,
     val showNotesImageUrl: String? = null,
     val chapters: Chapters = Chapters(),
     val lastChangeFrom: String? = null,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -225,7 +225,7 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
             override fun onTracksChanged(tracks: Tracks) {
                 episodeUuid?.let { onEpisodeChanged(it) }
                 val episodeMetadata = EpisodeFileMetadata(filenamePrefix = episodeUuid)
-                episodeMetadata.read(tracks, settings, context)
+                episodeMetadata.read(tracks, settings.useEpisodeArtwork.value, context)
                 onMetadataAvailable(episodeMetadata)
             }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/AutoConverter.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/AutoConverter.kt
@@ -62,8 +62,8 @@ data class AutoMediaId(
 }
 
 object AutoConverter {
-    fun convertEpisodeToMediaItem(context: Context, episode: BaseEpisode, parentPodcast: Podcast, useRssArtwork: Boolean, groupTrailers: Boolean = false, sourceId: String = parentPodcast.uuid): MediaBrowserCompat.MediaItem {
-        val localUri = getBitmapUriForPodcast(parentPodcast, episode, context, useRssArtwork)
+    fun convertEpisodeToMediaItem(context: Context, episode: BaseEpisode, parentPodcast: Podcast, useEpisodeArtwork: Boolean, groupTrailers: Boolean = false, sourceId: String = parentPodcast.uuid): MediaBrowserCompat.MediaItem {
+        val localUri = getBitmapUriForPodcast(parentPodcast, episode, context, useEpisodeArtwork)
 
         val extrasForEpisode = extrasForEpisode(episode)
         if (groupTrailers) {
@@ -83,9 +83,9 @@ object AutoConverter {
         return MediaBrowserCompat.MediaItem(episodeDesc, MediaBrowserCompat.MediaItem.FLAG_PLAYABLE)
     }
 
-    fun convertPodcastToMediaItem(podcast: Podcast, context: Context, useRssArtwork: Boolean): MediaBrowserCompat.MediaItem? {
+    fun convertPodcastToMediaItem(podcast: Podcast, context: Context, useEpisodeArtwork: Boolean): MediaBrowserCompat.MediaItem? {
         return try {
-            val localUri = getBitmapUriForPodcast(podcast = podcast, episode = null, context = context, showRssArtwork = useRssArtwork)
+            val localUri = getBitmapUriForPodcast(podcast = podcast, episode = null, context = context, showRssArtwork = useEpisodeArtwork)
 
             val podcastDesc = MediaDescriptionCompat.Builder()
                 .setTitle(podcast.title)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -671,7 +671,7 @@ class RefreshPodcastsThread(
             val resources = context.resources
             val width = resources.getDimension(android.R.dimen.notification_large_icon_width).toInt()
 
-            val imageRequest = PocketCastsImageRequestFactory(context, isDarkTheme = true, size = width).create(episode, settings.useRssArtwork.value)
+            val imageRequest = PocketCastsImageRequestFactory(context, isDarkTheme = true, size = width).create(episode, settings.useEpisodeArtwork.value)
             return context.imageLoader.executeBlocking(imageRequest).drawable?.toBitmap()
         }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
@@ -100,7 +100,7 @@ class WidgetManagerImpl @Inject constructor(
             RemoteViews(context.packageName, remoteViewsLayoutId),
             R.id.widget_artwork,
         )
-        imageRequestFactory.create(currentEpisode, settings.useRssArtwork.value).loadInto(target)
+        imageRequestFactory.create(currentEpisode, settings.useEpisodeArtwork.value).loadInto(target)
     }
 
     override fun updateWidgetFromPlaybackState(playbackManager: PlaybackManager?) {
@@ -200,7 +200,7 @@ class WidgetManagerImpl @Inject constructor(
             views,
             R.id.widget_artwork,
         )
-        imageRequestFactory.create(playingEpisode, settings.useRssArtwork.value).loadInto(target)
+        imageRequestFactory.create(playingEpisode, settings.useEpisodeArtwork.value).loadInto(target)
     }
 
     private fun showPlayButton(playing: Boolean, views: RemoteViews) {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/NamedSettings.kt
@@ -56,7 +56,7 @@ data class ChangedNamedSettings(
     @field:Json(name = "autoSubscribeToPlayed") val autoSubscribeToPlayed: NamedChangedSettingBool? = null,
     @field:Json(name = "autoShowPlayed") val autoShowPlayed: NamedChangedSettingBool? = null,
     @field:Json(name = "autoPlayLastListUuid") val autoPlayLastSource: NamedChangedSettingString? = null,
-    @field:Json(name = "useEmbeddedArtworkGlobal") val useEmbeddedArtwork: NamedChangedSettingBool? = null,
+    @field:Json(name = "useEmbeddedArtworkGlobal") val useEpisodeArtwork: NamedChangedSettingBool? = null,
     @field:Json(name = "notificationActions") val notificationSettingActions: NamedChangedSettingString? = null,
     @field:Json(name = "playerShelfGlobal") val playerShelfItems: NamedChangedSettingString? = null,
     @field:Json(name = "showArtworkOnLockScreen") val showArtworkOnLockScreen: NamedChangedSettingBool? = null,
@@ -75,7 +75,6 @@ data class ChangedNamedSettings(
     @field:Json(name = "filesAfterPlayingDeleteCloudGlobal") val deleteCloudFilesAfterPlayback: NamedChangedSettingBool? = null,
     @field:Json(name = "filesAfterPlayingDeleteLocalGlobal") val deleteLocalFilesAfterPlayback: NamedChangedSettingBool? = null,
     @field:Json(name = "backgroundRefresh") val isPodcastBackgroundRefreshEnabled: NamedChangedSettingBool? = null,
-    @field:Json(name = "useRssArtwork") val useRssArtwork: NamedChangedSettingBool? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -185,7 +185,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         modifiedAt = modifiedAt,
                     )
                 },
-                useEmbeddedArtwork = settings.useEmbeddedArtwork.getSyncSetting(::NamedChangedSettingBool),
+                useEpisodeArtwork = settings.useEpisodeArtwork.getSyncSetting(::NamedChangedSettingBool),
                 notificationSettingActions = settings.newEpisodeNotificationActions.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingString(
                         value = setting.joinToString(separator = ",", transform = NewEpisodeNotificationAction::serverId),
@@ -254,7 +254,6 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                 deleteCloudFilesAfterPlayback = settings.deleteCloudFileAfterPlaying.getSyncSetting(::NamedChangedSettingBool),
                 deleteLocalFilesAfterPlayback = settings.deleteLocalFileAfterPlaying.getSyncSetting(::NamedChangedSettingBool),
                 isPodcastBackgroundRefreshEnabled = settings.backgroundRefreshPodcasts.getSyncSetting(::NamedChangedSettingBool),
-                useRssArtwork = settings.useRssArtwork.getSyncSetting(::NamedChangedSettingBool),
             ),
         )
 
@@ -437,7 +436,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     )
                     "useEmbeddedArtworkGlobal" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
-                        setting = settings.useEmbeddedArtwork,
+                        setting = settings.useEpisodeArtwork,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     "privacyCrashReports" -> updateSettingIfPossible(
@@ -577,11 +576,6 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     "backgroundRefresh" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
                         setting = settings.backgroundRefreshPodcasts,
-                        newSettingValue = (changedSettingResponse.value as? Boolean),
-                    )
-                    "useRssArtwork" -> updateSettingIfPossible(
-                        changedSettingResponse = changedSettingResponse,
-                        setting = settings.useRssArtwork,
                         newSettingValue = (changedSettingResponse.value as? Boolean),
                     )
                     else -> LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Cannot handle named setting response with unknown key: $key")

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesScreen.kt
@@ -32,7 +32,7 @@ fun FilesScreen(
     val viewModel = hiltViewModel<FilesViewModel>()
     val userEpisodesState = viewModel.userEpisodes.collectAsState(null)
     val userEpisodes = userEpisodesState.value
-    val useRssArtwork by viewModel.useRssArtwork.collectAsState()
+    val useEpisodeArtwork by viewModel.useEpisodeArtwork.collectAsState()
 
     when {
         // Show nothing while screen is loading
@@ -49,7 +49,7 @@ fun FilesScreen(
                 items(userEpisodes) { episode ->
                     EpisodeChip(
                         episode = episode,
-                        useRssArtwork = useRssArtwork,
+                        useEpisodeArtwork = useEpisodeArtwork,
                         onClick = { navigateToEpisode(episode.uuid) },
                     )
                 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesViewModel.kt
@@ -17,5 +17,5 @@ class FilesViewModel @Inject constructor(
         .observeUserEpisodesSorted(settings.cloudSortOrder.value)
         .asFlow()
 
-    val useRssArtwork = settings.useRssArtwork.flow
+    val useEpisodeArtwork = settings.useEpisodeArtwork.flow
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/NowPlayingChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/NowPlayingChip.kt
@@ -47,7 +47,7 @@ fun NowPlayingChip(
 
     val state by viewModel.state.collectAsState()
     val playbackState = state.playbackState
-    val useRssArtwork by viewModel.useRssArtwork.collectAsState()
+    val useEpisodeArtwork by viewModel.useEpisodeArtwork.collectAsState()
 
     val upNextQueue = state.upNextQueue
     val podcast = (upNextQueue as? UpNextQueue.State.Loaded)?.podcast
@@ -57,7 +57,7 @@ fun NowPlayingChip(
         podcast = podcast,
         episode = episode,
         isPlaying = playbackState?.isPlaying == true,
-        useRssArtwork = useRssArtwork,
+        useEpisodeArtwork = useEpisodeArtwork,
         onClick = onClick,
     )
 }
@@ -67,7 +67,7 @@ private fun Content(
     podcast: Podcast?,
     episode: BaseEpisode?,
     isPlaying: Boolean,
-    useRssArtwork: Boolean,
+    useEpisodeArtwork: Boolean,
     onClick: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -88,8 +88,8 @@ private fun Content(
         secondaryLabel = episode?.title,
         colors = ChipDefaults.imageBackgroundChipColors(
             backgroundImagePainter = if (episode != null) {
-                val imageRequest = remember(episode.uuid, useRssArtwork) {
-                    PocketCastsImageRequestFactory(context).themed().create(episode, useRssArtwork)
+                val imageRequest = remember(episode.uuid, useEpisodeArtwork) {
+                    PocketCastsImageRequestFactory(context).themed().create(episode, useEpisodeArtwork)
                 }
                 rememberAsyncImagePainter(
                     model = imageRequest,
@@ -161,7 +161,7 @@ private fun Preview() {
                 uuid = "57853d71-30ac-4477-af73-e8fe2b1d4dda",
                 publishedDate = Date(),
             ),
-            useRssArtwork = false,
+            useEpisodeArtwork = false,
             isPlaying = false,
             onClick = {},
         )

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/NowPlayingChipViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/NowPlayingChipViewModel.kt
@@ -34,7 +34,7 @@ class NowPlayingChipViewModel @Inject constructor(
     private val _state = MutableStateFlow(State())
     val state = _state.asStateFlow()
 
-    val useRssArtwork = settings.useRssArtwork.flow
+    val useEpisodeArtwork = settings.useEpisodeArtwork.flow
 
     init {
         viewModelScope.launch {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
@@ -41,7 +41,7 @@ fun UpNextScreen(
     columnState: ScalingLazyColumnState,
 ) {
     val queueState by viewModel.upNextQueue.subscribeAsState(initial = null)
-    val useRssArtwork by viewModel.useRssArtwork.collectAsState()
+    val useEpisodeArtwork by viewModel.useEpisodeArtwork.collectAsState()
 
     when (queueState) {
         null -> { /* Show nothing while loading */ }
@@ -65,7 +65,7 @@ fun UpNextScreen(
                         items(list) { episode ->
                             EpisodeChip(
                                 episode = episode,
-                                useRssArtwork = useRssArtwork,
+                                useEpisodeArtwork = useEpisodeArtwork,
                                 useUpNextIcon = false,
                                 onClick = {
                                     navigateToEpisode(episode.uuid)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextViewModel.kt
@@ -20,5 +20,5 @@ class UpNextViewModel @Inject constructor(
 
     val upNextQueue: Observable<UpNextQueue.State> = playbackManager.upNextQueue.getChangesObservableWithLiveCurrentEpisode(episodeManager, podcastManager)
 
-    val useRssArtwork = settings.useRssArtwork.flow
+    val useEpisodeArtwork = settings.useEpisodeArtwork.flow
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChip.kt
@@ -46,7 +46,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 fun EpisodeChip(
     episode: BaseEpisode,
-    useRssArtwork: Boolean,
+    useEpisodeArtwork: Boolean,
     useUpNextIcon: Boolean = true,
     onClick: () -> Unit,
     showImage: Boolean = true,
@@ -86,7 +86,7 @@ fun EpisodeChip(
                 if (showImage) {
                     EpisodeImage(
                         episode = episode,
-                        useRssArtwork = useRssArtwork,
+                        useEpisodeArtwork = useEpisodeArtwork,
                         modifier = Modifier
                             .size(30.dp)
                             .clip(RoundedCornerShape(4.dp)),

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreen.kt
@@ -27,16 +27,16 @@ fun DownloadsScreen(
 ) {
     val viewModel = hiltViewModel<DownloadsScreenViewModel>()
     val state by viewModel.stateFlow.collectAsState()
-    val useRssArtwork by viewModel.useRssArtwork.collectAsState()
+    val useEpisodeArtwork by viewModel.useEpisodeArtwork.collectAsState()
 
-    Content(columnState, state, useRssArtwork, onItemClick)
+    Content(columnState, state, useEpisodeArtwork, onItemClick)
 }
 
 @Composable
 private fun Content(
     columnState: ScalingLazyColumnState,
     episodes: List<PodcastEpisode>?,
-    useRssArtwork: Boolean,
+    useEpisodeArtwork: Boolean,
     onItemClick: (PodcastEpisode) -> Unit,
 ) {
     ScalingLazyColumn(
@@ -56,7 +56,7 @@ private fun Content(
             items(episodes) { episode ->
                 EpisodeChip(
                     episode = episode,
-                    useRssArtwork = useRssArtwork,
+                    useEpisodeArtwork = useEpisodeArtwork,
                     onClick = { onItemClick(episode) },
                 )
             }
@@ -74,7 +74,7 @@ private fun DownloadsScreenPreview() {
     WearAppTheme {
         Content(
             columnState = ScalingLazyColumnState(),
-            useRssArtwork = false,
+            useEpisodeArtwork = false,
             onItemClick = {},
             episodes = listOf(
                 PodcastEpisode(

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreenViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreenViewModel.kt
@@ -20,5 +20,5 @@ class DownloadsScreenViewModel @Inject constructor(
         .asFlow()
         .stateIn(viewModelScope, SharingStarted.Lazily, null)
 
-    val useRssArtwork = settings.useRssArtwork.flow
+    val useEpisodeArtwork = settings.useEpisodeArtwork.flow
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterScreen.kt
@@ -41,12 +41,12 @@ fun FilterScreen(
     columnState: ScalingLazyColumnState,
 ) {
     val uiState by viewModel.uiState.collectAsState(UiState.Loading)
-    val useRssArtwork by viewModel.useRssArtwork.collectAsState()
+    val useEpisodeArtwork by viewModel.useEpisodeArtwork.collectAsState()
 
     when (val state = uiState) {
         is UiState.Loaded -> Content(
             state = state,
-            useRssArtwork = useRssArtwork,
+            useEpisodeArtwork = useEpisodeArtwork,
             onEpisodeTap = onEpisodeTap,
             modifier = modifier,
             listState = columnState,
@@ -85,7 +85,7 @@ fun FilterScreen(
 @Composable
 private fun Content(
     state: UiState.Loaded,
-    useRssArtwork: Boolean,
+    useEpisodeArtwork: Boolean,
     onEpisodeTap: (PodcastEpisode) -> Unit,
     modifier: Modifier = Modifier,
     listState: ScalingLazyColumnState,
@@ -103,7 +103,7 @@ private fun Content(
                 onClick = {
                     onEpisodeTap(episode)
                 },
-                useRssArtwork = useRssArtwork,
+                useEpisodeArtwork = useEpisodeArtwork,
                 showImage = true,
             )
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterViewModel.kt
@@ -57,5 +57,5 @@ class FilterViewModel @Inject constructor(
         .asFlow()
         .stateIn(viewModelScope, SharingStarted.Lazily, FiltersViewModel.UiState.Loading)
 
-    val useRssArtwork = settings.useRssArtwork.flow
+    val useEpisodeArtwork = settings.useEpisodeArtwork.flow
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
@@ -48,12 +48,12 @@ fun PodcastScreen(
     viewModel: PodcastViewModel = hiltViewModel(),
     columnState: ScalingLazyColumnState,
 ) {
-    val useRssArtwork by viewModel.useRssArtwork.collectAsState()
+    val useEpisodeArtwork by viewModel.useEpisodeArtwork.collectAsState()
 
     when (val state = viewModel.uiState) {
         is UiState.Loaded -> Content(
             state = state,
-            useRssArtwork = useRssArtwork,
+            useEpisodeArtwork = useEpisodeArtwork,
             onEpisodeTap = onEpisodeTap,
             modifier = modifier,
             columnState = columnState,
@@ -66,7 +66,7 @@ fun PodcastScreen(
 @Composable
 private fun Content(
     state: UiState.Loaded,
-    useRssArtwork: Boolean,
+    useEpisodeArtwork: Boolean,
     onEpisodeTap: (PodcastEpisode) -> Unit,
     modifier: Modifier = Modifier,
     columnState: ScalingLazyColumnState,
@@ -123,7 +123,7 @@ private fun Content(
             items(state.episodes) { episode ->
                 EpisodeChip(
                     episode = episode,
-                    useRssArtwork = useRssArtwork,
+                    useEpisodeArtwork = useEpisodeArtwork,
                     onClick = {
                         onEpisodeTap(episode)
                     },

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastViewModel.kt
@@ -40,7 +40,7 @@ class PodcastViewModel @Inject constructor(
         ) : UiState()
     }
 
-    val useRssArtwork = settings.useRssArtwork.flow
+    val useEpisodeArtwork = settings.useEpisodeArtwork.flow
 
     var uiState: UiState by mutableStateOf(UiState.Empty)
         private set


### PR DESCRIPTION
## Description

This PR consolidates file artwork and RSS artwork into a single setting. It also improves handling file artwork by using it if possible in all of the same places that we use RSS artwork. There are some limitation though. For example it isn't supported in the media notifications.

Closes #1983

## Testing Instructions

### Migration

1. Clean install the app from b78b3acb38b23650acfddfb619747ed6e23a06cd.
2. Set the `Use embedded RSS artwork` setting or the `Use embedded file artwork` setting on.
3. Update the app from the `task/consolidate-embedded` branch.
4. Go to `Profile`/`Settings`/`Appearance`.
5. Check the `Use episode artwork` setting. If any of the settings from the 2nd step was enabled it should be enabled too.
6. Repeat this test for different combinations of settings.

### Syncing

Check that the `Use episode artwork` setting syncs.

### RSS Artwork 

Smoke test displaying RSS artwork from #1943.

### File Artwork

1. Enable the `Use episode artwork` setting.
2. Subscribe to [Upgrade](https://pca.st/upgrade) podcast and play [this episode](https://pca.st/7hesqiu3).
3. Check that the app displays embedded artwork in most places. There are some limitations that I mentioned in the description.
4. There might be small delay (~10 seconds) before the artwork takes effect.
5. Disable the `Use episode artwork` setting. App should display podcast artwork.

| File artwork | Podcast artwork |
| - | - |
| ![Screenshot_20240327_232628](https://github.com/Automattic/pocket-casts-android/assets/30936061/d00f2f12-450a-4164-8ae5-135d05aead99) | ![Screenshot_20240327_232643](https://github.com/Automattic/pocket-casts-android/assets/30936061/59b48057-7bed-4852-a70d-b4418bf6515d) |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
