### PR TITLE
Sanitize share list URL path segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 *   New Features
     *   Ability to deselect chapters entering Patron early access with full release for Plus users in next release
         ([#1940](https://github.com/Automattic/pocket-casts-android/pull/1940))
+* Bug Fixes:
+    *   Fix an issue where shared lists from the newsletter might not open.
+        ([#1988](https://github.com/Automattic/pocket-casts-android/pull/1988))
 
 7.59
 -----

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/ShareServerManagerImplTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/ShareServerManagerImplTest.kt
@@ -152,5 +152,9 @@ class ShareServerManagerImplTest {
         websiteUrl = "/${BuildConfig.SERVER_LIST_HOST}/fddf52be-6058-48c4-a821-09edc8ad023d"
         id = ListServerManagerImpl.extractShareListIdFromWebUrl(websiteUrl)
         assertEquals("fddf52be-6058-48c4-a821-09edc8ad023d", id)
+
+        websiteUrl = "/share-and-explore"
+        id = ListServerManagerImpl.extractShareListIdFromWebUrl(websiteUrl)
+        assertEquals("share-and-explore", id)
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListIncomingViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListIncomingViewModel.kt
@@ -40,7 +40,7 @@ class ShareListIncomingViewModel
 
     fun loadShareUrl(url: String) {
         share.postValue(ShareState.Loading)
-        val id = listServerManager.extractShareListIdFromWebUrl(url) ?: return
+        val id = listServerManager.extractShareListIdFromWebUrl(url)
         viewModelScope.launch {
             try {
                 val list = listServerManager.openPodcastList(id)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/list/ListServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/list/ListServerManager.kt
@@ -7,5 +7,5 @@ import java.util.Date
 interface ListServerManager {
     suspend fun createPodcastList(title: String, description: String, podcasts: List<Podcast>, date: Date = Date(), serverSecret: String = Settings.SHARING_SERVER_SECRET): String?
     suspend fun openPodcastList(listId: String): PodcastList
-    fun extractShareListIdFromWebUrl(webUrl: String?): String?
+    fun extractShareListIdFromWebUrl(webUrl: String): String
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/list/ListServerManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/list/ListServerManagerImpl.kt
@@ -20,7 +20,6 @@ class ListServerManagerImpl @Inject constructor(
     private val downloadServer: ListDownloadServer = downloadRetrofit.create(ListDownloadServer::class.java)
 
     companion object {
-
         private val DATE_FORMAT = SimpleDateFormat("yyyyMMddHHmmss", Locale.US)
 
         fun buildSecurityHash(date: String, serverSecret: String): String? {
@@ -28,9 +27,14 @@ class ListServerManagerImpl @Inject constructor(
             return stringToHash.sha1()
         }
 
-        fun extractShareListIdFromWebUrl(id: String?): String? {
+        fun extractShareListIdFromWebUrl(webUrl: String): String {
             val host = Settings.SERVER_LIST_HOST
-            return id?.replace("https://$host/", "")?.replace("http://$host/", "")?.replace("/$host/", "")?.replace(".html", "")
+            return webUrl
+                .trimStart { it == '/' }
+                .replace("https://$host/", "")
+                .replace("http://$host/", "")
+                .replace("$host/", "")
+                .replace(".html", "")
         }
     }
 
@@ -52,7 +56,7 @@ class ListServerManagerImpl @Inject constructor(
         return downloadServer.getPodcastList(listId)
     }
 
-    override fun extractShareListIdFromWebUrl(webUrl: String?): String? {
+    override fun extractShareListIdFromWebUrl(webUrl: String): String {
         return Companion.extractShareListIdFromWebUrl(webUrl)
     }
 }


### PR DESCRIPTION
## Description

Some playlist shared in newsletter could not be opened because of the leading slash character in the path segment.

Internal ref: p1711552213427409-slack-C028JAG44VD

Even though the `7.60` release is coming soon I think it is safe to add this change because it is non-intrusive and it is rather important.

## Testing Instructions

1. Install the app.
2. Enable opening all links in the app (see screenshots).
3. On your device go to [this newsletter](https://mailchi.mp/pocketcasts.com/january-2024).
4. Scroll to the bottom.
5. In the Explorers and Wanderers section tap `Open this playlist`.
6. The app should intercept the link and open the playlist.

## Screenshots or Screencast 

| Open links | Playlist |
| - | - |
| ![Screenshot_20240328_082835](https://github.com/Automattic/pocket-casts-android/assets/30936061/30bdfca6-1b86-4f3a-ae1c-9b85eea890fa) | ![Screenshot_20240328_082758](https://github.com/Automattic/pocket-casts-android/assets/30936061/e56ffbfb-299b-4c48-b18a-fb581bb914d5) |

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack