### PR TITLE
Filter offers when have more than one available

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
@@ -109,8 +109,9 @@ class CreateAccountViewModel
                                     isOfferEligible = subscriptionManager.isOfferEligible(SubscriptionMapper.mapProductIdToTier(it.productId)),
                                 )
                             }
-                        subscriptionManager.getDefaultSubscription(subscriptions)?.let { updateSubscription(it) }
-                        createAccountState.postValue(CreateAccountState.ProductsLoaded(subscriptions))
+                        val filteredOffer = Subscription.filterOffers(subscriptions)
+                        subscriptionManager.getDefaultSubscription(filteredOffer)?.let { updateSubscription(it) }
+                        createAccountState.postValue(CreateAccountState.ProductsLoaded(filteredOffer))
                     } else {
                         errorUpdate(CreateAccountError.CANNOT_LOAD_SUBS, true)
                     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
@@ -70,7 +70,10 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
                             )
                         }
                     } ?: emptyList()
-                    _state.update { stateFromList(subscriptions) }
+                    _state.update {
+                        val filteredOffer = Subscription.filterOffers(subscriptions)
+                        stateFromList(filteredOffer)
+                    }
                 }
         }
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -65,7 +65,8 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
                             )
                         }
                     }
-                    updateState(subscriptions)
+                    val filteredOffer = Subscription.filterOffers(subscriptions)
+                    updateState(filteredOffer)
                 }
         }
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/ProfileUpgradeBannerViewModel.kt
@@ -64,12 +64,14 @@ class ProfileUpgradeBannerViewModel @Inject constructor(
                     // Get user's subscription status from cache
                     val cachedSubscriptionStatus = subscriptionManager.getCachedStatus()
 
+                    val filteredOffer = Subscription.filterOffers(subscriptions)
+
                     // If the user is a patron, only show the patron subscription
                     val cachedTier = (cachedSubscriptionStatus as? SubscriptionStatus.Paid)?.tier
                     val filteredSubscriptions = if (cachedTier == SubscriptionTier.PATRON) {
-                        subscriptions.filter { it.tier == Subscription.SubscriptionTier.PATRON }
+                        filteredOffer.filter { it.tier == Subscription.SubscriptionTier.PATRON }
                     } else {
-                        subscriptions
+                        filteredOffer
                     }
                     val defaultSubscription = getDefaultSubscription(
                         filteredSubscriptions = filteredSubscriptions,

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
@@ -57,7 +57,8 @@ class AccountDetailsViewModel
                         ),
                     )
                 }
-            Optional.of(subscriptionManager.getDefaultSubscription(subscriptions))
+            val filteredOffer = Subscription.filterOffers(subscriptions)
+            Optional.of(subscriptionManager.getDefaultSubscription(filteredOffer))
         } else {
             Optional.empty()
         }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -124,9 +124,19 @@ sealed interface Subscription {
         const val TRIAL_OFFER_ID = "plus-yearly-trial-30days"
         const val INTRO_OFFER_ID = "plus-yearly-intro-50percent"
 
-        fun fromProductDetails(productDetails: ProductDetails, isOfferEligible: Boolean): Subscription? {
-            val subscription = SubscriptionMapper.map(productDetails, isOfferEligible)
-            return if (FeatureFlag.isEnabled(Feature.INTRO_PLUS_OFFER_ENABLED) && subscription is Trial) null else subscription
+        fun fromProductDetails(productDetails: ProductDetails, isOfferEligible: Boolean): Subscription? =
+            SubscriptionMapper.map(productDetails, isOfferEligible)
+        fun filterOffers(subscriptions: List<Subscription>): List<Subscription> {
+            val offers = subscriptions.count { it is WithOffer }
+            val hasIntro = subscriptions.any { it is Intro }
+
+            if (offers <= 1) return subscriptions // Has at least only one offer
+
+            return if (FeatureFlag.isEnabled(Feature.INTRO_PLUS_OFFER_ENABLED) && hasIntro) {
+                subscriptions.filterNot { it is Trial }
+            } else {
+                subscriptions.filterNot { it is Intro }
+            }
         }
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
@@ -5,6 +5,8 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_MONTHLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_YEARLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.android.billingclient.api.ProductDetails
 import java.time.Period
@@ -42,16 +44,16 @@ object SubscriptionMapper {
                         offerToken = relevantSubscriptionOfferDetails.offerToken,
                     )
                 } else {
-                    if (isTrial(productDetails)) {
-                        Subscription.Trial(
+                    if (FeatureFlag.isEnabled(Feature.INTRO_PLUS_OFFER_ENABLED) && hasIntro(productDetails)) {
+                        Subscription.Intro(
                             tier = mapProductIdToTier(productDetails.productId),
                             recurringPricingPhase = recurringPricingPhase,
                             offerPricingPhase = offerPricingPhase,
                             productDetails = productDetails,
                             offerToken = relevantSubscriptionOfferDetails.offerToken,
                         )
-                    } else if (isIntro(productDetails)) {
-                        Subscription.Intro(
+                    } else if (hasTrial(productDetails)) {
+                        Subscription.Trial(
                             tier = mapProductIdToTier(productDetails.productId),
                             recurringPricingPhase = recurringPricingPhase,
                             offerPricingPhase = offerPricingPhase,
@@ -64,12 +66,12 @@ object SubscriptionMapper {
                 }
             }
     }
-    private fun isTrial(productDetails: ProductDetails): Boolean {
+    private fun hasTrial(productDetails: ProductDetails): Boolean {
         return productDetails.subscriptionOfferDetails?.any {
             it.offerId == Subscription.TRIAL_OFFER_ID
         } ?: false
     }
-    private fun isIntro(productDetails: ProductDetails): Boolean {
+    private fun hasIntro(productDetails: ProductDetails): Boolean {
         return productDetails.subscriptionOfferDetails?.any {
             it.offerId == Subscription.INTRO_OFFER_ID
         } ?: false

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -431,7 +431,8 @@ class SubscriptionManagerImpl @Inject constructor(
                 }
             } ?: emptyList()
 
-            val updatedSubscriptions = subscriptions.filter { it.tier == subscriptionTier }
+            val filteredOffer = Subscription.filterOffers(subscriptions)
+            val updatedSubscriptions = filteredOffer.filter { it.tier == subscriptionTier }
             val defaultSubscription = getDefaultSubscription(
                 subscriptions = updatedSubscriptions,
                 tier = subscriptionTier,


### PR DESCRIPTION
## Description
- This pull request changes the way we handle cases where both an introductory offer and a trial are available. The app was treating the Plus Yearly subscription as a monthly subscription, which resulted in the offer not being displayed.
- Currently we have `intro offer` activated and `trial` activated.
- If the `INTRO_PLUS_OFFER_ENABLED` feature flag is enabled we should display the intro offer
- The intro offer is not available for India, South Africa and Brazil

> [!note]
> I always have **a lot of cache** issues when I am testing subscriptions, so even If I clear the play store cache, reinstall pocket casts app I still can't see the offer after I updated it in Play Store.

## Testing Instructions

- Apply [subscription_test.patch](https://github.com/Automattic/pocket-casts-android/files/14779592/subscription_test.patch)
-  Run the app in `debugProd` and log in with an account that never had a subscription before
-  Have both offers active in Play Store and the `INTRO_PLUS_OFFER_ENABLED` FF enabled
<img width="720" alt="image" src="https://github.com/Automattic/pocket-casts-android/assets/42220351/f75e380b-35aa-4c7d-90b5-33fc6153b3e6">

-  Open the app and click on some subscription banner (You can go to Podcasts tab and tap on 🔒). You should see the Intro offer
-  Have the `INTRO_PLUS_OFFER_ENABLED` FF disabled
-  Open the app and click on some subscription banner. You should see the trial offer
-  Have trial offer active,  intro offer inactivated for your country and  `INTRO_PLUS_OFFER_ENABLED` FF enabled
-  Open the app and click on some subscription banner. You should see trial offer

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
