### PR TITLE
build: apply Gradle Enterprise plugin. Enable remote build cache on CI

### DIFF
--- a/gradle_build_cache.gradle.kts
+++ b/gradle_build_cache.gradle.kts
@@ -1,0 +1,11 @@
+// Only run build cache on CI builds.
+if (System.getenv("CI") != null) {
+    buildCache {
+        remote(HttpBuildCache::class) {
+            url = uri("http://10.0.2.215:5071/cache/")
+            isAllowUntrustedServer = true
+            isAllowInsecureProtocol = true
+            isPush = true
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,11 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("com.gradle.enterprise").version("3.16.2")
+}
+apply(from = File("gradle_build_cache.gradle.kts"))
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR enables Gradle Remote Build Cache on CI, to reduce build times.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->
Not needed - as PR is built on CI, this change is safe to merge.

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
