### PR TITLE
Profile Bookmarks - Add menu and show empty screen

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksContainerFragment.kt
@@ -30,7 +30,7 @@ class BookmarksContainerFragment :
         private const val ARG_EPISODE_UUID = "episodeUUID"
         private const val ARG_SOURCE_VIEW = "sourceView"
         fun newInstance(
-            episodeUuid: String,
+            episodeUuid: String? = null,
             sourceView: SourceView,
         ) = BookmarksContainerFragment().apply {
             arguments = bundleOf(
@@ -110,7 +110,15 @@ class BookmarksContainerFragment :
             .addToBackStack(null)
             .commit()
 
-        binding.btnClose.setOnClickListener { dismiss() }
+        dialog?.let {
+            binding.btnClose.setOnClickListener { dismiss() }
+        } ?: run {
+            binding.btnClose.setImageResource(R.drawable.ic_arrow_back)
+            binding.btnClose.setOnClickListener {
+                @Suppress("DEPRECATION")
+                activity?.onBackPressed()
+            }
+        }
     }
 
     private fun FragmentBookmarksContainerBinding.setupMultiSelectHelper() {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -154,7 +154,11 @@ class ProfileFragment : BaseFragment() {
                         (activity as? FragmentHostListener)?.addFragment(fragment)
                     }
                     BookmarksContainerFragment::class.java -> {
-                        // TODO: Navigate to profile bookmarks
+                        analyticsTracker.track(AnalyticsEvent.PROFILE_BOOKMARKS_SHOWN)
+                        val fragment = BookmarksContainerFragment.newInstance(
+                            sourceView = SourceView.PROFILE,
+                        )
+                        (activity as? FragmentHostListener)?.addFragment(fragment)
                     }
                     HelpFragment::class.java -> {
                         (activity as? FragmentHostListener)?.addFragment(fragmentClass.getDeclaredConstructor().newInstance())

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -23,11 +23,13 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesFragment.StoriesSource
 import au.com.shiftyjelly.pocketcasts.endofyear.views.EndOfYearPromptCard
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralSecondsMinutesHoursDaysOrYears
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
+import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarksContainerFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.ProfileEpisodeListFragment
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.profile.cloud.CloudFilesFragment
@@ -45,6 +47,8 @@ import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeTintedDrawable
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Date
@@ -69,14 +73,18 @@ class ProfileFragment : BaseFragment() {
     private val viewModel: ProfileViewModel by viewModels()
 
     private var binding: FragmentProfileBinding? = null
-    private val sections = listOf(
+    private val sections = arrayListOf(
         SettingsAdapter.Item(LR.string.profile_navigation_stats, R.drawable.ic_stats, StatsFragment::class.java),
         SettingsAdapter.Item(LR.string.profile_navigation_downloads, R.drawable.ic_profile_download, ProfileEpisodeListFragment::class.java),
         SettingsAdapter.Item(LR.string.profile_navigation_files, R.drawable.ic_file, CloudFilesFragment::class.java),
         SettingsAdapter.Item(LR.string.profile_navigation_starred, R.drawable.ic_starred, ProfileEpisodeListFragment::class.java),
         SettingsAdapter.Item(LR.string.profile_navigation_listening_history, R.drawable.ic_listen_history, ProfileEpisodeListFragment::class.java),
         SettingsAdapter.Item(LR.string.settings_title_help, IR.drawable.ic_help, HelpFragment::class.java),
-    )
+    ).apply {
+        if (FeatureFlag.isEnabled(Feature.ACCOUNT_BOOKMARKS)) {
+            add(4, SettingsAdapter.Item(LR.string.bookmarks, IR.drawable.ic_bookmark, BookmarksContainerFragment::class.java))
+        }
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentProfileBinding.inflate(inflater, container, false)
@@ -144,6 +152,9 @@ class ProfileFragment : BaseFragment() {
                             else -> throw IllegalStateException("Unknown row")
                         }
                         (activity as? FragmentHostListener)?.addFragment(fragment)
+                    }
+                    BookmarksContainerFragment::class.java -> {
+                        // TODO: Navigate to profile bookmarks
                     }
                     HelpFragment::class.java -> {
                         (activity as? FragmentHostListener)?.addFragment(fragmentClass.getDeclaredConstructor().newInstance())

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -16,6 +16,7 @@ enum class AnalyticsEvent(val key: String) {
     BOOKMARK_PLAY_TAPPED("bookmark_play_tapped"),
     BOOKMARKS_SORT_BY_CHANGED("bookmarks_sort_by_changed"),
     BOOKMARK_DELETED("bookmark_deleted"),
+    PROFILE_BOOKMARKS_SHOWN("profile_bookmarks_shown"),
 
     /* User lifecycle events */
     USER_SIGNED_IN("user_signed_in"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
@@ -27,6 +27,7 @@ enum class SourceView(val analyticsValue: String) {
     AUTO_PAUSE("auto_pause"),
     PLAYER_PLAYBACK_EFFECTS("player_playback_effects"),
     PODCAST_SETTINGS("podcast_settings"),
+    PROFILE("profile"),
     ONBOARDING_RECOMMENDATIONS("onboarding_recommendations"),
     ONBOARDING_RECOMMENDATIONS_SEARCH("onboarding_recommendations_search"),
     UNKNOWN("unknown"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -535,6 +535,7 @@ open class PlaybackManager @Inject constructor(
             SourceView.PLAYER,
             SourceView.PLAYER_BROADCAST_ACTION,
             SourceView.PLAYER_PLAYBACK_EFFECTS,
+            SourceView.PROFILE,
             SourceView.EPISODE_SWIPE_ACTION,
             SourceView.TASKER,
             SourceView.UNKNOWN,

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -83,6 +83,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
+    ACCOUNT_BOOKMARKS(
+        key = "account_bookmarks",
+        title = "Account Bookmarks",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Plus(null),
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true,
+    ),
     ;
 
     companion object {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseDialogFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseDialogFragment.kt
@@ -62,16 +62,16 @@ open class BaseDialogFragment : BottomSheetDialogFragment(), CoroutineScope {
     }
 
     private fun addDismissCallback() {
-        val dialog = dialog as BottomSheetDialog
-        (dialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) as FrameLayout?)?.let { bottomSheet ->
+        val dialog = dialog as? BottomSheetDialog
+        (dialog?.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) as? FrameLayout?)?.let { bottomSheet ->
             val behavior = BottomSheetBehavior.from(bottomSheet)
             behavior.addBottomSheetCallback(dismissCallback)
         }
     }
 
     private fun removeDismissCallback() {
-        val dialog = dialog as BottomSheetDialog
-        (dialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) as FrameLayout?)?.let { bottomSheet ->
+        val dialog = dialog as? BottomSheetDialog
+        (dialog?.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) as? FrameLayout?)?.let { bottomSheet ->
             val behavior = BottomSheetBehavior.from(bottomSheet)
             behavior.removeBottomSheetCallback(dismissCallback)
         }
@@ -88,8 +88,8 @@ open class BaseDialogFragment : BottomSheetDialogFragment(), CoroutineScope {
         // as it causes the bottomsheet flicker to the expanded state
         if (isBeingDragged) return
 
-        val dialog = dialog as BottomSheetDialog
-        (dialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) as FrameLayout?)?.let { bottomSheet ->
+        val dialog = dialog as? BottomSheetDialog
+        (dialog?.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) as? FrameLayout?)?.let { bottomSheet ->
             val behavior = BottomSheetBehavior.from(bottomSheet)
             behavior.state = BottomSheetBehavior.STATE_EXPANDED
             behavior.peekHeight = BottomSheetBehavior.PEEK_HEIGHT_AUTO


### PR DESCRIPTION
## Description
This adds a bookmarks menu in the Profile screen and displays an empty bookmarks view on tap.
It is added behind a local feature flag.

## Testing Instructions
1. Install the app
2. Go to the Profile tab
3. ✅ Notice that there's a bookmarks menu
4. Tap on it
5. ✅ Notice that an empty bookmarks screen is opened
6. ✅ Notice that `profile_bookmarks_shown` is shown in logs
7. Go back either by tapping the back arrow or swiping gesture
8. ✅ Notice that the screen closes
9. Go to Profile -> Settings -> Beta features
10. Disable Account bookmarks feature
11. Restart the app
12. Go to the Profile tab
13. ✅ Notice that there's no bookmarks menu

## Screenshots or Screencast 
<img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/426b383f-0729-4ee5-ad75-8b6bf111cc06"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
