### PR TITLE
Use correct title when listening to chapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 * Bug Fixes:
     *   Subscription cancellation redirects now to a correct page.
         ([#1973](https://github.com/Automattic/pocket-casts-android/pull/1973))
+    *   Fix not displaying chapter titles in the player.
+        ([#2008](https://github.com/Automattic/pocket-casts-android/pull/2008))
 
 7.60
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -296,7 +296,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
             binding.chapterUrl.showIfPresent(headerViewModel.chapter?.url)
             binding.chapterUrlFront?.showIfPresent(headerViewModel.chapter?.url)
             binding.videoView.isVisible = headerViewModel.isVideoVisible()
-            binding.episodeTitle.text = headerViewModel.episodeTitle
+            binding.episodeTitle.text = headerViewModel.title
             binding.podcastTitle?.text = headerViewModel.podcastTitle
             binding.podcastTitle?.isVisible = headerViewModel.podcastTitle?.isNotBlank() == true
             binding.chapterSummary.text = headerViewModel.chapterSummary


### PR DESCRIPTION
## Description

In #1911 we incorrectly migrated DataBinding title property for the player header.

I feel this is important to add to `7.61` since we've just added chapter selection and in `7.61` we add chapter tags support.

Closes #2000

## Testing Instructions

1. Play an episode with chapters like [this one]().
2. Chapter titles should display on the player screen.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![Screenshot (Apr 4, 2024 11_28_41 PM)](https://github.com/Automattic/pocket-casts-android/assets/30936061/e2972560-7e3d-466b-ad51-e434c4609d54) | ![Screenshot_20240404-232734](https://github.com/Automattic/pocket-casts-android/assets/30936061/5b115c88-12d4-44d0-8314-6abbc05f387f) |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
