### PR TITLE
Remove hardcoded categories setup

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -369,7 +369,7 @@ internal class DiscoverAdapter(
         private lateinit var source: String
         private lateinit var region: String
         private lateinit var allCategories: CategoryPill
-        private lateinit var mostPopularCategoriesId: List<Int>
+        private var mostPopularCategoriesId: List<Int> = emptyList()
 
         private val adapter = CategoryPillListAdapter(
             onCategoryClick = { selectedCategory, onCategorySelectionSuccess ->
@@ -426,7 +426,7 @@ internal class DiscoverAdapter(
             this.mostPopularCategoriesId = ids
         }
         private fun getMostPopularCategories(categories: List<CategoryPill>): List<CategoryPill> {
-            if (::mostPopularCategoriesId.isInitialized.not()) return categories
+            if (mostPopularCategoriesId.isEmpty()) return categories
 
             return categories
                 .filter { it.discoverCategory.id in mostPopularCategoriesId }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -490,28 +490,25 @@ internal class DiscoverAdapter(
 
         when (row) {
             is DiscoverRow -> {
-                when (row.type) {
-                    is ListType.PodcastList -> {
-                        return when (row.displayStyle) {
-                            is DisplayStyle.Carousel -> R.layout.row_carousel_list
-                            is DisplayStyle.LargeList -> R.layout.row_podcast_large_list
-                            is DisplayStyle.SmallList -> R.layout.row_podcast_small_list
-                            is DisplayStyle.SinglePodcast -> R.layout.row_single_podcast
-                            is DisplayStyle.CollectionList -> R.layout.row_collection_list
-                            else -> R.layout.row_error
-                        }
+                if (row.type is ListType.PodcastList) {
+                    return when (row.displayStyle) {
+                        is DisplayStyle.Carousel -> R.layout.row_carousel_list
+                        is DisplayStyle.LargeList -> R.layout.row_podcast_large_list
+                        is DisplayStyle.SmallList -> R.layout.row_podcast_small_list
+                        is DisplayStyle.SinglePodcast -> R.layout.row_single_podcast
+                        is DisplayStyle.CollectionList -> R.layout.row_collection_list
+                        else -> R.layout.row_error
                     }
-                    is ListType.EpisodeList -> {
-                        return when (row.displayStyle) {
-                            is DisplayStyle.SingleEpisode -> R.layout.row_single_episode
-                            is DisplayStyle.CollectionList -> R.layout.row_collection_list
-                            else -> R.layout.row_error
-                        }
+                } else if (row.type is ListType.EpisodeList) {
+                    return when (row.displayStyle) {
+                        is DisplayStyle.SingleEpisode -> R.layout.row_single_episode
+                        is DisplayStyle.CollectionList -> R.layout.row_collection_list
+                        else -> R.layout.row_error
                     }
-                    is ListType.Categories -> {
-                        return if (FeatureFlag.isEnabled(Feature.CATEGORIES_REDESIGN)) R.layout.row_category_pills else R.layout.row_categories
-                    }
-                    else -> {}
+                } else if (row.type is ListType.Categories && row.displayStyle is DisplayStyle.Pills) {
+                    return R.layout.row_category_pills
+                } else if (row.type is ListType.Categories && row.displayStyle is DisplayStyle.Category) {
+                    return R.layout.row_categories
                 }
             }
             is ChangeRegionRow -> {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -369,6 +369,7 @@ internal class DiscoverAdapter(
         private lateinit var source: String
         private lateinit var region: String
         private lateinit var allCategories: CategoryPill
+        private lateinit var mostPopularCategoriesId: List<Int>
 
         private val adapter = CategoryPillListAdapter(
             onCategoryClick = { selectedCategory, onCategorySelectionSuccess ->
@@ -421,9 +422,11 @@ internal class DiscoverAdapter(
                 adapter.loadCategories(categoriesFilter)
             }
         }
+        fun setMostPopularCategoriesId(ids: List<Int>) {
+            this.mostPopularCategoriesId = ids
+        }
         private fun getMostPopularCategories(categories: List<CategoryPill>): List<CategoryPill> {
-            // True Crime, Comedy, Culture, History, Fiction, Technology
-            val mostPopularCategoriesId = setOf(19, 3, 13, 18, 17, 15)
+            if (::mostPopularCategoriesId.isInitialized.not()) return categories
 
             return categories
                 .filter { it.discoverCategory.id in mostPopularCategoriesId }
@@ -616,6 +619,7 @@ internal class DiscoverAdapter(
                         loadCategories(row.source),
                         onNext = { categories ->
                             val context = holder.itemView.context
+                            row.mostPopularCategoriesId?.let { holder.setMostPopularCategoriesId(it) }
                             holder.submitCategories(categories, row.source, context, region = row.regionCode)
                         },
                     )

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -32,8 +32,6 @@ import au.com.shiftyjelly.pocketcasts.servers.model.ListType
 import au.com.shiftyjelly.pocketcasts.servers.model.NetworkLoadableList
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -213,9 +211,9 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
                         }
                         adapter?.onChangeRegion = onChangeRegion
 
-                        val sortedContent = sortContent(content, state.selectedRegion.code)
+                        val updatedContent = addRegionToCategoryRow(content, state.selectedRegion.code)
 
-                        adapter?.submitList(sortedContent)
+                        adapter?.submitList(updatedContent)
                     }
                     is DiscoverState.Error -> {
                         binding.errorLayout.isVisible = true
@@ -258,16 +256,14 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
             FirebaseAnalyticsTracker.navigatedToDiscover()
         }
     }
-    private fun sortContent(content: List<Any>, region: String): MutableList<Any> {
+    private fun addRegionToCategoryRow(content: List<Any>, region: String): MutableList<Any> {
         val mutableContentList = content.toMutableList()
 
-        if (FeatureFlag.isEnabled(Feature.CATEGORIES_REDESIGN)) {
-            val categoriesIndex = mutableContentList.indexOfFirst { it is DiscoverRow && it.type is ListType.Categories }
+        val categoriesIndex = mutableContentList.indexOfFirst { it is DiscoverRow && it.type is ListType.Categories }
 
-            if (categoriesIndex != -1) {
-                val categoriesItem = mutableContentList.removeAt(categoriesIndex)
-                mutableContentList.add(0, (categoriesItem as DiscoverRow).copy(regionCode = region))
-            }
+        if (categoriesIndex != -1) {
+            val categoriesItem = mutableContentList[categoriesIndex] as DiscoverRow
+            mutableContentList[categoriesIndex] = categoriesItem.copy(regionCode = region)
         }
 
         return mutableContentList

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastListFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastListFragment.kt
@@ -161,6 +161,7 @@ class PodcastListFragment : PodcastGridListFragment() {
             is ExpandedStyle.RankedList -> RankedListAdapter(onPodcastClicked, onPodcastSubscribe, tagline, theme)
             is ExpandedStyle.DescriptiveList -> DescriptiveListAdapter(onPodcastClicked, onPodcastSubscribe) as ListAdapter<Any, RecyclerView.ViewHolder>
             is ExpandedStyle.GridList -> GridListAdapter(GridListAdapter.defaultImageSize, onPodcastClicked, onPodcastSubscribe) as ListAdapter<Any, RecyclerView.ViewHolder>
+            else -> PlainListAdapter(onPodcastClicked, onPodcastSubscribe, onPromotionClick, onEpisodeClick, onEpisodePlayClick, onEpisodeStopClick)
         }
         recyclerView.adapter = adapter
         (recyclerView.itemAnimator as? SimpleItemAnimator)?.supportsChangeAnimations = false

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -25,6 +25,8 @@ import au.com.shiftyjelly.pocketcasts.servers.model.SponsoredPodcast
 import au.com.shiftyjelly.pocketcasts.servers.model.transformWithRegion
 import au.com.shiftyjelly.pocketcasts.servers.server.ListRepository
 import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
@@ -66,7 +68,12 @@ class DiscoverViewModel @Inject constructor(
     }
 
     fun loadData(resources: Resources) {
-        val feed = repository.getDiscoverFeed()
+        val feed =
+            if (FeatureFlag.isEnabled(Feature.CATEGORIES_REDESIGN)) {
+                repository.getDiscoverFeedWithCategoriesAtTheTop()
+            } else {
+                repository.getDiscoverFeed()
+            }
 
         feed.toFlowable()
             .subscribeBy(

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModel.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModel.kt
@@ -64,6 +64,7 @@ data class DiscoverRow(
     @field:Json(name = "sponsored") val sponsored: Boolean = false,
     @field:Json(name = "curated") override val curated: Boolean = false,
     @field:Json(name = "sponsored_podcasts") val sponsoredPodcasts: List<SponsoredPodcast> = emptyList(),
+    @field:Json(name = "popular") val mostPopularCategoriesId: List<Int>?,
     val regionCode: String? = null,
 ) : NetworkLoadableList {
 
@@ -98,6 +99,7 @@ data class DiscoverRow(
             sponsored = sponsored,
             curated = curated,
             sponsoredPodcasts = sponsoredPodcasts,
+            mostPopularCategoriesId = mostPopularCategoriesId,
         )
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DisplayStyle.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DisplayStyle.kt
@@ -10,6 +10,7 @@ sealed class DisplayStyle(val stringValue: String) {
         private const val LARGE_LIST = "large_list"
         private const val NETWORK = "network"
         private const val CATEGORY = "category"
+        private const val PILLS = "pills"
         private const val SINGLE_PODCAST = "single_podcast"
         private const val SINGLE_EPISODE = "single_episode"
         private const val COLLECTION_LIST = "collection"
@@ -21,6 +22,7 @@ sealed class DisplayStyle(val stringValue: String) {
                 LARGE_LIST -> LargeList()
                 NETWORK -> Network()
                 CATEGORY -> Category()
+                PILLS -> Pills()
                 SINGLE_PODCAST -> SinglePodcast()
                 SINGLE_EPISODE -> SingleEpisode()
                 COLLECTION_LIST -> CollectionList()
@@ -34,6 +36,7 @@ sealed class DisplayStyle(val stringValue: String) {
     class LargeList : DisplayStyle(LARGE_LIST)
     class Network : DisplayStyle(NETWORK)
     class Category : DisplayStyle(CATEGORY)
+    class Pills : DisplayStyle(PILLS)
     class SinglePodcast : DisplayStyle(SINGLE_PODCAST)
     class SingleEpisode : DisplayStyle(SINGLE_EPISODE)
     class CollectionList : DisplayStyle(COLLECTION_LIST)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/ExpandedStyle.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/ExpandedStyle.kt
@@ -9,6 +9,7 @@ sealed class ExpandedStyle(val stringValue: String) {
         private const val PLAIN_LIST = "plain_list"
         private const val DESCRIPTIVE_LIST = "descriptive_list"
         private const val GRID_LIST = "grid"
+        private const val POPOVER = "popover"
 
         fun fromString(value: String?): ExpandedStyle? {
             return when (value) {
@@ -16,6 +17,7 @@ sealed class ExpandedStyle(val stringValue: String) {
                 PLAIN_LIST -> PlainList()
                 DESCRIPTIVE_LIST -> DescriptiveList()
                 GRID_LIST -> GridList()
+                POPOVER -> Popover()
                 else -> PlainList()
             }
         }
@@ -25,6 +27,7 @@ sealed class ExpandedStyle(val stringValue: String) {
     class PlainList : ExpandedStyle(PLAIN_LIST)
     class DescriptiveList : ExpandedStyle(DESCRIPTIVE_LIST)
     class GridList : ExpandedStyle(GRID_LIST)
+    class Popover : ExpandedStyle(POPOVER)
 }
 
 class ExpandedStyleMoshiAdapter {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/server/ListRepository.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/server/ListRepository.kt
@@ -15,6 +15,11 @@ class ListRepository(private val listWebService: ListWebService, private val pla
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
     }
+    fun getDiscoverFeedWithCategoriesAtTheTop(): Single<Discover> {
+        return listWebService.getDiscoverFeedWithCategoriesAtTheTop(platform)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+    }
 
     suspend fun getDiscoverFeedSuspend(): Discover {
         return listWebService.getDiscoverFeedSuspend(platform)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/server/ListWebService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/server/ListWebService.kt
@@ -12,6 +12,9 @@ interface ListWebService {
     @GET("/discover/{platform}/content.json")
     fun getDiscoverFeed(@Path("platform") platform: String): Single<Discover>
 
+    @GET("/discover/{platform}/content_v2.json")
+    fun getDiscoverFeedWithCategoriesAtTheTop(@Path("platform") platform: String): Single<Discover>
+
     @GET("/discover/{platform}/content.json")
     suspend fun getDiscoverFeedSuspend(@Path("platform") platform: String): Discover
 


### PR DESCRIPTION
## Description
- [Backend is now returning](https://github.com/Automattic/pocket-casts-node-server/pull/626) categories at the top and the most popular categories id, so we don't need to move categories at the top and sort the categories using hardcoded id. 
- This PR removes the hardcoded category sort -> 3e26ebca5b4d85277b8fb6042f3d12badb48d8dc
- Also removes the hardcoded category position update -> 62a12e28107cea233d71b5d0f34b72c5958b9f47


## Testing Instructions
- Go to `Beta Features` -> Make sure `Podcasts by category shown in discover view` is enabled. In case it's not enabled you should toggle this feature `on` and restart the app
- Go to `Discover`
- Make sure that categories are displayed at the top ✅
- Make sure you have `All categories` and then you see `True crime`, `Comedy`, `Society & Culture`, `History`, `Fiction` and `Technology` ✅ (They are not returned from backend)

## Screencast 
[Screen_recording_20240326_092149.webm](https://github.com/Automattic/pocket-casts-android/assets/42220351/ab22b263-63b6-428a-834e-4cdd90b2085a)

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
