### PR TITLE
Fix playback state chapter indices update

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -891,6 +891,7 @@ class MainActivity :
     private fun updatePlaybackStateDeselectedChapterIndices(upNextQueue: UpNextQueue.State) {
         (upNextQueue as? UpNextQueue.State.Loaded)?.let {
             val lastPlaybackState = viewModel.lastPlaybackState
+            if (lastPlaybackState?.chapters?.getList()?.isEmpty() == true) return
             val currentEpisodeDeselectedChapterIndicesChanged = playbackManager.getCurrentEpisode()?.let { currentEpisode ->
                 currentEpisode.uuid == it.episode.uuid &&
                     lastPlaybackState != null &&

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -894,8 +894,8 @@ class MainActivity :
             val currentEpisodeDeselectedChapterIndicesChanged = playbackManager.getCurrentEpisode()?.let { currentEpisode ->
                 currentEpisode.uuid == it.episode.uuid &&
                     lastPlaybackState != null &&
-                    it.episode.deselectedChapters !=
-                    lastPlaybackState.chapters.getList().filterNot { it.selected }.map { it.index }
+                    it.episode.deselectedChapters.sorted() !=
+                    lastPlaybackState.chapters.getList().filterNot { it.selected }.map { it.index }.sorted()
             } ?: false
             if (currentEpisodeDeselectedChapterIndicesChanged) {
                 playbackManager.updatePlaybackStateDeselectedChapterIndices()

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/ChapterIndicesTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/ChapterIndicesTest.kt
@@ -1,0 +1,42 @@
+package au.com.shiftyjelly.pocketcasts.models.entity
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChapterIndicesTest {
+    @Test
+    fun testEqualitySameOrder() {
+        val chapterIndices1 = ChapterIndices(listOf(1, 2))
+        val chapterIndices2 = ChapterIndices(listOf(1, 2))
+        assertTrue(chapterIndices1 == chapterIndices2)
+    }
+
+    @Test
+    fun testEqualitySameOrderWithList() {
+        val chapterIndices = ChapterIndices(listOf(1, 2))
+        val listOfIndices = listOf(1, 2)
+        assertFalse(chapterIndices == listOfIndices)
+    }
+
+    @Test
+    fun testEqualityDiffOrder() {
+        val chapterIndices1 = ChapterIndices(listOf(1, 2))
+        val chapterIndices2 = ChapterIndices(listOf(2, 1))
+        assertFalse(chapterIndices1 == chapterIndices2)
+    }
+
+    @Test
+    fun testEqualityDiffOrderSorted() {
+        val chapterIndices1 = ChapterIndices(listOf(1, 2))
+        val chapterIndices2 = ChapterIndices(listOf(2, 1))
+        assertTrue(chapterIndices1.sorted() == chapterIndices2.sorted())
+    }
+
+    @Test
+    fun testEqualityDiffOrderWithListSorted() {
+        val chapterIndices = ChapterIndices(listOf(1, 2))
+        val listOfIndices = listOf(2, 1)
+        assertTrue(chapterIndices.sorted() == listOfIndices.sorted())
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
@@ -137,7 +137,7 @@ interface UpNextQueue {
     fun updateCurrentEpisodeStateIfNeeded(episodeFromDb: BaseEpisode, state: State) {
         currentEpisode?.let { currentEpisode ->
             if (episodeFromDb.uuid == currentEpisode.uuid &&
-                episodeFromDb.deselectedChapters != currentEpisode.deselectedChapters
+                episodeFromDb.deselectedChapters.sorted() != currentEpisode.deselectedChapters.sorted()
             ) {
                 updateCurrentEpisodeState(state)
             }


### PR DESCRIPTION
## Description

This prevents unnecessary playback state updates for chapter indices under two conditions:
1. When chapters in playback state for the current episode are not yet loaded
2. When before and after deselected chapter indices are the same but in a different order

## Testing Instructions

#### Test.1 Playback state is not updated if the current episode has deselected chapter indices in db but its chapters are not yet populated in playback state

1. Login with Patron account
3. Play an episode with chapters
4. Deselect a chapter 
5. Sync deselected chapter indices by tapping Refresh now in settings
6. Restart the app (so that the episode with chapters remains selected but chapters are not loaded for it)
7. Put a breakpoint at line 894 and 902 in MainActivity
8. Go to Profile and tap Refresh now
9. Notice that the breakpoint at 894 is hit but not at line 902

#### Test.2 Test that deselected chapter indices comparison ignores item order

I added equality tests in  `ChapterIndicesTest` and noticed that chapter indices with the same but unordered items were unequal so I compared sorted deselected indices in f9795a9c.

It should be sufficient to go through tests to verify this scenario.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
