### PR TITLE
Add widget installation analytics

### DIFF
--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/core/ui/widget/PodcastWidget.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/core/ui/widget/PodcastWidget.kt
@@ -1,10 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.core.ui.widget
 
-import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import au.com.shiftyjelly.pocketcasts.widget.MediumPlayerWidget
+import au.com.shiftyjelly.pocketcasts.widget.PlayerWidgetReceiver
 
 //  This receiver has to be kept in this package due to legacy reasons. Old widget was defined here.
-internal class PodcastWidget : GlanceAppWidgetReceiver() {
-    override val glanceAppWidget: GlanceAppWidget = MediumPlayerWidget()
+internal class PodcastWidget : PlayerWidgetReceiver() {
+    override val glanceAppWidget = MediumPlayerWidget()
+    override val widgetTypeAnalyticsValue = "player_medium"
 }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/LargePlayerWidgetReceiver.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/LargePlayerWidgetReceiver.kt
@@ -1,8 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.widget
 
-import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
-
-internal class LargePlayerWidgetReceiver : GlanceAppWidgetReceiver() {
-    override val glanceAppWidget: GlanceAppWidget = LargePlayerWidget()
+internal class LargePlayerWidgetReceiver : PlayerWidgetReceiver() {
+    override val glanceAppWidget = LargePlayerWidget()
+    override val widgetTypeAnalyticsValue = "player_large"
 }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/PlayerWidgetReceiver.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/PlayerWidgetReceiver.kt
@@ -1,0 +1,20 @@
+package au.com.shiftyjelly.pocketcasts.widget
+
+import android.content.Context
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.widget.di.widgetEntryPoint
+
+internal abstract class PlayerWidgetReceiver : GlanceAppWidgetReceiver() {
+    abstract val widgetTypeAnalyticsValue: String
+
+    override fun onEnabled(context: Context) {
+        val tracker = context.widgetEntryPoint().analyticsTracker()
+        tracker.track(AnalyticsEvent.WIDGET_INSTALLED, mapOf("widget_type" to widgetTypeAnalyticsValue))
+    }
+
+    override fun onDisabled(context: Context) {
+        val tracker = context.widgetEntryPoint().analyticsTracker()
+        tracker.track(AnalyticsEvent.WIDGET_UNINSTALLED, mapOf("widget_type" to widgetTypeAnalyticsValue))
+    }
+}

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/SmallPlayerWidgetReceiver.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/SmallPlayerWidgetReceiver.kt
@@ -1,8 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.widget
 
-import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
-
-internal class SmallPlayerWidgetReceiver : GlanceAppWidgetReceiver() {
-    override val glanceAppWidget: GlanceAppWidget = SmallPlayerWidget()
+internal class SmallPlayerWidgetReceiver : PlayerWidgetReceiver() {
+    override val glanceAppWidget = SmallPlayerWidget()
+    override val widgetTypeAnalyticsValue = "player_small"
 }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/di/WidgetEntryPoint.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/di/WidgetEntryPoint.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.widget.di
 
 import android.content.Context
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextDao
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -17,6 +18,7 @@ interface WidgetEntryPoint {
     fun upNextDao(): UpNextDao
     fun playbackManager(): PlaybackManager
     fun settings(): Settings
+    fun analyticsTracker(): AnalyticsTrackerWrapper
 }
 
 internal fun Context.widgetEntryPoint() = EntryPointAccessors.fromApplication<WidgetEntryPoint>(this)

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -593,4 +593,8 @@ enum class AnalyticsEvent(val key: String) {
     DESELECT_CHAPTERS_CHAPTER_SELECTED("deselect_chapters_chapter_selected"),
     DESELECT_CHAPTERS_CHAPTER_DESELECTED("deselect_chapters_chapter_deselected"),
     PLAYBACK_CHAPTER_SKIPPED("playback_chapter_skipped"),
+
+    /* Widgets */
+    WIDGET_INSTALLED("widget_installed"),
+    WIDGET_UNINSTALLED("widget_uninstalled"),
 }


### PR DESCRIPTION
## Description

This PR adds installation widget events. All other events like play/pause are already tracked in the app by using `SourceView.WIDGET_PLAYER_X` sources.

## Testing Instructions

1. Add widget of any type to the home screen.
2. You should see in the logs an analytics event. `🔵 Tracked: widget_installed, Properties: {"widget_type":"player_small"`
3. Remove that widget from the home screen.
4. You should see in the logs an analytics event. `🔵 Tracked: widget_uninstalled, Properties: {"widget_type":"player_small"`.
5. Check that only the first widget of a particular type added to the home screen triggers `widget_installed` event, and only the last widget of a particular type removed from the home screen triggers `widget_uninstalled` event.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
