### PR TITLE
Bookmark share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.62
 -----
-
+*   New Features
+    *   Allow sharing of bookmarks from bookmarks list
+        ([#2022](https://github.com/Automattic/pocket-casts-android/pull/2022))
 
 7.61
 -----

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1386,7 +1386,7 @@ class MainActivity :
         source: EpisodeViewSource,
         podcastUuid: String?,
         forceDark: Boolean,
-        timestampInSecs: Duration?,
+        timestamp: Duration?,
     ) {
         episodeUuid ?: return
 
@@ -1401,7 +1401,7 @@ class MainActivity :
                     source = source,
                     podcastUuid = podcastUuidFound,
                     forceDark = forceDark,
-                    timestampInSecs = timestampInSecs,
+                    timestamp = timestamp,
                 )
             } else if (episode is PodcastEpisode) {
                 EpisodeContainerFragment.newInstance(
@@ -1409,7 +1409,7 @@ class MainActivity :
                     source = source,
                     podcastUuid = podcastUuid,
                     forceDark = forceDark,
-                    timestampInSecs = timestampInSecs,
+                    timestamp = timestamp,
                 )
             } else {
                 CloudFileBottomSheetFragment.newInstance(episode.uuid, forceDark = true)
@@ -1462,7 +1462,7 @@ class MainActivity :
         if (intent.data?.pathSegments?.size == 1) {
             sharePath = "$SOCIAL_SHARE_PATH$sharePath"
         }
-        val timestampInSecs = intent.data?.getQueryParameter("t")?.toIntOrNull()
+        val timestamp = intent.data?.getQueryParameter("t")?.toIntOrNull()
         val dialog = android.app.ProgressDialog.show(this, getString(LR.string.loading), getString(LR.string.please_wait), true)
         serverManager.getSharedItemDetails(
             sharePath,
@@ -1489,7 +1489,7 @@ class MainActivity :
                             source = EpisodeViewSource.SHARE,
                             podcastUuid = podcastUuid,
                             forceDark = false,
-                            timestampInSecs = timestampInSecs?.seconds,
+                            timestamp = timestamp?.seconds,
                         )
                     } else {
                         openPodcastPage(podcastUuid)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1460,11 +1460,7 @@ class MainActivity :
         if (intent.data?.pathSegments?.size == 1) {
             sharePath = "$SOCIAL_SHARE_PATH$sharePath"
         }
-        val includesTimeStamp = intent.data?.queryParameterNames?.contains("t") ?: false
-        var timestampInSecs: Int? = null
-        if (includesTimeStamp) {
-            timestampInSecs = intent.data?.getQueryParameter("t")?.toIntOrNull()
-        }
+        val timestampInSecs = intent.data?.getQueryParameter("t")?.toIntOrNull()
         val dialog = android.app.ProgressDialog.show(this, getString(LR.string.loading), getString(LR.string.please_wait), true)
         serverManager.getSharedItemDetails(
             sharePath,

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1486,15 +1486,13 @@ class MainActivity :
 
                     val episode = result.episode
                     if (episode != null) {
-                        launch(Dispatchers.Default) {
-                            openEpisodeDialog(
-                                episodeUuid = episode.uuid,
-                                source = EpisodeViewSource.SHARE,
-                                podcastUuid = podcastUuid,
-                                forceDark = false,
-                                timestampInSecs = timestampInSecs,
-                            )
-                        }
+                        openEpisodeDialog(
+                            episodeUuid = episode.uuid,
+                            source = EpisodeViewSource.SHARE,
+                            podcastUuid = podcastUuid,
+                            forceDark = false,
+                            timestampInSecs = timestampInSecs,
+                        )
                     } else {
                         openPodcastPage(podcastUuid)
                     }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1384,6 +1384,7 @@ class MainActivity :
         source: EpisodeViewSource,
         podcastUuid: String?,
         forceDark: Boolean,
+        timestampInSecs: Int?,
     ) {
         episodeUuid ?: return
 
@@ -1398,6 +1399,7 @@ class MainActivity :
                     source = source,
                     podcastUuid = podcastUuidFound,
                     forceDark = forceDark,
+                    timestampInSecs = timestampInSecs,
                 )
             } else if (episode is PodcastEpisode) {
                 EpisodeContainerFragment.newInstance(
@@ -1405,6 +1407,7 @@ class MainActivity :
                     source = source,
                     podcastUuid = podcastUuid,
                     forceDark = forceDark,
+                    timestampInSecs = timestampInSecs,
                 )
             } else {
                 CloudFileBottomSheetFragment.newInstance(episode.uuid, forceDark = true)
@@ -1457,6 +1460,11 @@ class MainActivity :
         if (intent.data?.pathSegments?.size == 1) {
             sharePath = "$SOCIAL_SHARE_PATH$sharePath"
         }
+        val includesTimeStamp = intent.data?.queryParameterNames?.contains("t") ?: false
+        var timestampInSecs: Int? = null
+        if (includesTimeStamp) {
+            timestampInSecs = intent.data?.getQueryParameter("t")?.toIntOrNull()
+        }
         val dialog = android.app.ProgressDialog.show(this, getString(LR.string.loading), getString(LR.string.please_wait), true)
         serverManager.getSharedItemDetails(
             sharePath,
@@ -1478,12 +1486,15 @@ class MainActivity :
 
                     val episode = result.episode
                     if (episode != null) {
-                        openEpisodeDialog(
-                            episodeUuid = episode.uuid,
-                            source = EpisodeViewSource.SHARE,
-                            podcastUuid = podcastUuid,
-                            forceDark = false,
-                        )
+                        launch(Dispatchers.Default) {
+                            openEpisodeDialog(
+                                episodeUuid = episode.uuid,
+                                source = EpisodeViewSource.SHARE,
+                                podcastUuid = podcastUuid,
+                                forceDark = false,
+                                timestampInSecs = timestampInSecs,
+                            )
+                        }
                     } else {
                         openPodcastPage(podcastUuid)
                     }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -138,6 +138,8 @@ import java.util.Locale
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -1384,7 +1386,7 @@ class MainActivity :
         source: EpisodeViewSource,
         podcastUuid: String?,
         forceDark: Boolean,
-        timestampInSecs: Int?,
+        timestampInSecs: Duration?,
     ) {
         episodeUuid ?: return
 
@@ -1487,7 +1489,7 @@ class MainActivity :
                             source = EpisodeViewSource.SHARE,
                             podcastUuid = podcastUuid,
                             forceDark = false,
-                            timestampInSecs = timestampInSecs,
+                            timestampInSecs = timestampInSecs?.seconds,
                         )
                     } else {
                         openPodcastPage(podcastUuid)

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
@@ -128,7 +128,7 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
         source: EpisodeViewSource,
         podcastUuid: String?,
         forceDark: Boolean,
-        timestampInSecs: Duration?,
+        timestamp: Duration?,
     ) {
     }
 

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
@@ -127,6 +127,7 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
         source: EpisodeViewSource,
         podcastUuid: String?,
         forceDark: Boolean,
+        timestampInSecs: Int?,
     ) {
     }
 

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import dagger.hilt.android.AndroidEntryPoint
+import kotlin.time.Duration
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.profile.R as PR
 
@@ -127,7 +128,7 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
         source: EpisodeViewSource,
         podcastUuid: String?,
         forceDark: Boolean,
-        timestampInSecs: Int?,
+        timestampInSecs: Duration?,
     ) {
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
@@ -116,6 +116,7 @@ class BookmarksFragment : BaseFragment() {
                                     forceDarkTheme = sourceView == SourceView.PLAYER,
                                 )
                             },
+                            onShareBookmarkClick = ::onShareBookmarkClick,
                             onEditBookmarkClick = ::onEditBookmarkClick,
                             onUpgradeClicked = ::onUpgradeClicked,
                             showOptionsDialog = { showOptionsDialog(it) },
@@ -185,6 +186,10 @@ class BookmarksFragment : BaseFragment() {
                     },
                 ).show(it, "bookmarks_options_dialog")
         }
+    }
+
+    private fun onShareBookmarkClick() {
+        bookmarksViewModel.onShareClicked(requireContext())
     }
 
     private fun onEditBookmarkClick() {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
@@ -38,6 +38,7 @@ import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
+import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper.NavigationState
 import java.util.Date
 import java.util.UUID
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -51,6 +52,7 @@ fun BookmarksPage(
     bookmarksViewModel: BookmarksViewModel,
     multiSelectHelper: MultiSelectBookmarksHelper,
     onRowLongPressed: (Bookmark) -> Unit,
+    onShareBookmarkClick: () -> Unit,
     onEditBookmarkClick: () -> Unit,
     onUpgradeClicked: () -> Unit,
     showOptionsDialog: (Int) -> Unit,
@@ -89,9 +91,12 @@ fun BookmarksPage(
     }
 
     LaunchedEffect(context) {
-        multiSelectHelper.showEditBookmarkPage
-            .collect { show ->
-                if (show) onEditBookmarkClick()
+        multiSelectHelper.navigationState
+            .collect { navigationState ->
+                when (navigationState) {
+                    NavigationState.ShareBookmark -> onShareBookmarkClick()
+                    NavigationState.EditBookmark -> onEditBookmarkClick()
+                }
             }
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -224,7 +224,7 @@ class BookmarksViewModel
             val bookmark =
                 it.bookmarks.firstOrNull { bookmark -> multiSelectHelper.isSelected(bookmark) }
             bookmark?.let {
-                viewModelScope.launch(ioDispatcher) {
+                viewModelScope.launch {
                     val podcast = podcastManager.findPodcastByUuidSuspend(bookmark.podcastUuid)
                     val episode = episodeManager.findEpisodeByUuid(bookmark.episodeUuid)
                     if (podcast != null && episode is PodcastEpisode) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -36,6 +36,8 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
@@ -75,11 +77,11 @@ class EpisodeContainerFragment :
             podcastUuid: String? = null,
             fromListUuid: String? = null,
             forceDark: Boolean = false,
-            timestampInSecs: Int? = null,
+            timestampInSecs: Duration? = null,
         ) = EpisodeContainerFragment().apply {
             arguments = bundleOf(
                 ARG_EPISODE_UUID to episodeUuid,
-                ARG_TIMESTAMP_IN_SECS to timestampInSecs,
+                ARG_TIMESTAMP_IN_SECS to timestampInSecs?.inWholeSeconds,
                 ARG_EPISODE_VIEW_SOURCE to source.value,
                 ARG_OVERRIDE_PODCAST_LINK to overridePodcastLink,
                 ARG_PODCAST_UUID to podcastUuid,
@@ -101,8 +103,8 @@ class EpisodeContainerFragment :
     private val episodeUUID: String?
         get() = arguments?.getString(ARG_EPISODE_UUID)
 
-    private val timestampInSecs: Int?
-        get() = arguments?.getInt(ARG_TIMESTAMP_IN_SECS)
+    private val timestampInSecs: Duration?
+        get() = arguments?.getLong(ARG_TIMESTAMP_IN_SECS)?.seconds
 
     private val episodeViewSource: EpisodeViewSource
         get() = EpisodeViewSource.fromString(arguments?.getString(ARG_EPISODE_VIEW_SOURCE))
@@ -258,7 +260,7 @@ class EpisodeContainerFragment :
         fragmentManager: FragmentManager,
         lifecycle: Lifecycle,
         private val episodeUUID: String?,
-        private val timestampInSecs: Int?,
+        private val timestampInSecs: Duration?,
         private val episodeViewSource: EpisodeViewSource,
         private val overridePodcastLink: Boolean,
         private val podcastUuid: String?,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -77,11 +77,11 @@ class EpisodeContainerFragment :
             podcastUuid: String? = null,
             fromListUuid: String? = null,
             forceDark: Boolean = false,
-            timestampInSecs: Duration? = null,
+            timestamp: Duration? = null,
         ) = EpisodeContainerFragment().apply {
             arguments = bundleOf(
                 ARG_EPISODE_UUID to episodeUuid,
-                ARG_TIMESTAMP_IN_SECS to timestampInSecs?.inWholeSeconds,
+                ARG_TIMESTAMP_IN_SECS to timestamp?.inWholeSeconds,
                 ARG_EPISODE_VIEW_SOURCE to source.value,
                 ARG_OVERRIDE_PODCAST_LINK to overridePodcastLink,
                 ARG_PODCAST_UUID to podcastUuid,
@@ -103,7 +103,7 @@ class EpisodeContainerFragment :
     private val episodeUUID: String?
         get() = arguments?.getString(ARG_EPISODE_UUID)
 
-    private val timestampInSecs: Duration?
+    private val timestamp: Duration?
         get() = arguments?.getLong(ARG_TIMESTAMP_IN_SECS)?.seconds
 
     private val episodeViewSource: EpisodeViewSource
@@ -193,7 +193,7 @@ class EpisodeContainerFragment :
             fragmentManager = childFragmentManager,
             lifecycle = viewLifecycleOwner.lifecycle,
             episodeUUID = episodeUUID,
-            timestampInSecs = timestampInSecs,
+            timestamp = timestamp,
             episodeViewSource = episodeViewSource,
             overridePodcastLink = overridePodcastLink,
             podcastUuid = podcastUuid,
@@ -260,7 +260,7 @@ class EpisodeContainerFragment :
         fragmentManager: FragmentManager,
         lifecycle: Lifecycle,
         private val episodeUUID: String?,
-        private val timestampInSecs: Duration?,
+        private val timestamp: Duration?,
         private val episodeViewSource: EpisodeViewSource,
         private val overridePodcastLink: Boolean,
         private val podcastUuid: String?,
@@ -296,7 +296,7 @@ class EpisodeContainerFragment :
             return when (sections[position]) {
                 Section.Details -> EpisodeFragment.newInstance(
                     episodeUuid = requireNotNull(episodeUUID),
-                    timestampInSecs = timestampInSecs,
+                    timestamp = timestamp,
                     source = episodeViewSource,
                     overridePodcastLink = overridePodcastLink,
                     podcastUuid = podcastUuid,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -46,6 +46,7 @@ class EpisodeContainerFragment :
     EpisodeFragment.EpisodeLoadedListener {
     companion object {
         const val ARG_EPISODE_UUID = "episodeUUID"
+        const val ARG_TIMESTAMP_IN_SECS = "timestamp_in_secs"
         const val ARG_EPISODE_VIEW_SOURCE = "episode_view_source"
         const val ARG_OVERRIDE_PODCAST_LINK = "override_podcast_link"
         const val ARG_PODCAST_UUID = "podcastUUID"
@@ -74,9 +75,11 @@ class EpisodeContainerFragment :
             podcastUuid: String? = null,
             fromListUuid: String? = null,
             forceDark: Boolean = false,
+            timestampInSecs: Int? = null,
         ) = EpisodeContainerFragment().apply {
             arguments = bundleOf(
                 ARG_EPISODE_UUID to episodeUuid,
+                ARG_TIMESTAMP_IN_SECS to timestampInSecs,
                 ARG_EPISODE_VIEW_SOURCE to source.value,
                 ARG_OVERRIDE_PODCAST_LINK to overridePodcastLink,
                 ARG_PODCAST_UUID to podcastUuid,
@@ -97,6 +100,9 @@ class EpisodeContainerFragment :
 
     private val episodeUUID: String?
         get() = arguments?.getString(ARG_EPISODE_UUID)
+
+    private val timestampInSecs: Int?
+        get() = arguments?.getInt(ARG_TIMESTAMP_IN_SECS)
 
     private val episodeViewSource: EpisodeViewSource
         get() = EpisodeViewSource.fromString(arguments?.getString(ARG_EPISODE_VIEW_SOURCE))
@@ -185,6 +191,7 @@ class EpisodeContainerFragment :
             fragmentManager = childFragmentManager,
             lifecycle = viewLifecycleOwner.lifecycle,
             episodeUUID = episodeUUID,
+            timestampInSecs = timestampInSecs,
             episodeViewSource = episodeViewSource,
             overridePodcastLink = overridePodcastLink,
             podcastUuid = podcastUuid,
@@ -251,6 +258,7 @@ class EpisodeContainerFragment :
         fragmentManager: FragmentManager,
         lifecycle: Lifecycle,
         private val episodeUUID: String?,
+        private val timestampInSecs: Int?,
         private val episodeViewSource: EpisodeViewSource,
         private val overridePodcastLink: Boolean,
         private val podcastUuid: String?,
@@ -286,6 +294,7 @@ class EpisodeContainerFragment :
             return when (sections[position]) {
                 Section.Details -> EpisodeFragment.newInstance(
                     episodeUuid = requireNotNull(episodeUUID),
+                    timestampInSecs = timestampInSecs,
                     source = episodeViewSource,
                     overridePodcastLink = overridePodcastLink,
                     podcastUuid = podcastUuid,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -85,10 +85,12 @@ class EpisodeFragment : BaseFragment() {
             podcastUuid: String? = null,
             fromListUuid: String? = null,
             forceDark: Boolean = false,
+            timestampInSecs: Int? = null,
         ): EpisodeFragment {
             return EpisodeFragment().apply {
                 arguments = bundleOf(
                     EpisodeContainerFragment.ARG_EPISODE_UUID to episodeUuid,
+                    EpisodeContainerFragment.ARG_TIMESTAMP_IN_SECS to timestampInSecs,
                     EpisodeContainerFragment.ARG_EPISODE_VIEW_SOURCE to source.value,
                     EpisodeContainerFragment.ARG_OVERRIDE_PODCAST_LINK to overridePodcastLink,
                     EpisodeContainerFragment.ARG_PODCAST_UUID to podcastUuid,
@@ -121,6 +123,9 @@ class EpisodeFragment : BaseFragment() {
 
     private val episodeUUID: String?
         get() = arguments?.getString(EpisodeContainerFragment.ARG_EPISODE_UUID)
+
+    private val timestampInSecs: Int?
+        get() = arguments?.getInt(EpisodeContainerFragment.ARG_TIMESTAMP_IN_SECS)
 
     private val episodeViewSource: EpisodeViewSource
         get() = EpisodeViewSource.fromString(arguments?.getString(EpisodeContainerFragment.ARG_EPISODE_VIEW_SOURCE))
@@ -207,7 +212,12 @@ class EpisodeFragment : BaseFragment() {
 
         binding?.loadingGroup?.isInvisible = true
 
-        viewModel.setup(episodeUUID!!, podcastUuid, forceDarkTheme)
+        viewModel.setup(
+            episodeUuid = episodeUUID!!,
+            podcastUuid = podcastUuid,
+            forceDark = forceDarkTheme,
+            timestampInSecs = timestampInSecs,
+        )
         viewModel.state.observe(
             viewLifecycleOwner,
             Observer { state ->

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -62,6 +62,8 @@ import au.com.shiftyjelly.pocketcasts.views.helper.WarningsHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.setLongStyleDate
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -85,12 +87,12 @@ class EpisodeFragment : BaseFragment() {
             podcastUuid: String? = null,
             fromListUuid: String? = null,
             forceDark: Boolean = false,
-            timestampInSecs: Int? = null,
+            timestampInSecs: Duration? = null,
         ): EpisodeFragment {
             return EpisodeFragment().apply {
                 arguments = bundleOf(
                     EpisodeContainerFragment.ARG_EPISODE_UUID to episodeUuid,
-                    EpisodeContainerFragment.ARG_TIMESTAMP_IN_SECS to timestampInSecs,
+                    EpisodeContainerFragment.ARG_TIMESTAMP_IN_SECS to timestampInSecs?.inWholeSeconds,
                     EpisodeContainerFragment.ARG_EPISODE_VIEW_SOURCE to source.value,
                     EpisodeContainerFragment.ARG_OVERRIDE_PODCAST_LINK to overridePodcastLink,
                     EpisodeContainerFragment.ARG_PODCAST_UUID to podcastUuid,
@@ -124,8 +126,8 @@ class EpisodeFragment : BaseFragment() {
     private val episodeUUID: String?
         get() = arguments?.getString(EpisodeContainerFragment.ARG_EPISODE_UUID)
 
-    private val timestampInSecs: Int?
-        get() = arguments?.getInt(EpisodeContainerFragment.ARG_TIMESTAMP_IN_SECS)
+    private val timestampInSecs: Duration?
+        get() = arguments?.getLong(EpisodeContainerFragment.ARG_TIMESTAMP_IN_SECS)?.seconds
 
     private val episodeViewSource: EpisodeViewSource
         get() = EpisodeViewSource.fromString(arguments?.getString(EpisodeContainerFragment.ARG_EPISODE_VIEW_SOURCE))

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -87,12 +87,12 @@ class EpisodeFragment : BaseFragment() {
             podcastUuid: String? = null,
             fromListUuid: String? = null,
             forceDark: Boolean = false,
-            timestampInSecs: Duration? = null,
+            timestamp: Duration? = null,
         ): EpisodeFragment {
             return EpisodeFragment().apply {
                 arguments = bundleOf(
                     EpisodeContainerFragment.ARG_EPISODE_UUID to episodeUuid,
-                    EpisodeContainerFragment.ARG_TIMESTAMP_IN_SECS to timestampInSecs?.inWholeSeconds,
+                    EpisodeContainerFragment.ARG_TIMESTAMP_IN_SECS to timestamp?.inWholeSeconds,
                     EpisodeContainerFragment.ARG_EPISODE_VIEW_SOURCE to source.value,
                     EpisodeContainerFragment.ARG_OVERRIDE_PODCAST_LINK to overridePodcastLink,
                     EpisodeContainerFragment.ARG_PODCAST_UUID to podcastUuid,
@@ -126,7 +126,7 @@ class EpisodeFragment : BaseFragment() {
     private val episodeUUID: String?
         get() = arguments?.getString(EpisodeContainerFragment.ARG_EPISODE_UUID)
 
-    private val timestampInSecs: Duration?
+    private val timestamp: Duration?
         get() = arguments?.getLong(EpisodeContainerFragment.ARG_TIMESTAMP_IN_SECS)?.seconds
 
     private val episodeViewSource: EpisodeViewSource
@@ -218,7 +218,7 @@ class EpisodeFragment : BaseFragment() {
             episodeUuid = episodeUUID!!,
             podcastUuid = podcastUuid,
             forceDark = forceDarkTheme,
-            timestampInSecs = timestampInSecs,
+            timestamp = timestamp,
         )
         viewModel.state.observe(
             viewLifecycleOwner,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -38,6 +38,8 @@ import io.reactivex.schedulers.Schedulers
 import java.util.Date
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -76,7 +78,7 @@ class EpisodeFragmentViewModel @Inject constructor(
         episodeUuid: String,
         podcastUuid: String?,
         forceDark: Boolean,
-        timestampInSecs: Int?,
+        timestampInSecs: Duration?,
     ) {
         val isDarkTheme = forceDark || theme.isDarkTheme
         val progressUpdatesObservable = downloadManager.progressUpdateRelay
@@ -128,12 +130,13 @@ class EpisodeFragmentViewModel @Inject constructor(
             .doOnNext {
                 if (it is EpisodeFragmentState.Loaded) {
                     episode = it.episode
-                    if (timestampInSecs != null &&
-                        it.episode.playedUpTo != timestampInSecs.toDouble() &&
+                    val timestampSecs = timestampInSecs?.toInt(DurationUnit.SECONDS)
+                    if (timestampSecs != null &&
+                        it.episode.playedUpTo.toInt() != timestampSecs &&
                         episode is PodcastEpisode
                     ) {
-                        episode?.playedUpTo = timestampInSecs.toDouble()
-                        seekToTimeMs(timestampInSecs * 1000)
+                        episode?.playedUpTo = timestampSecs.toDouble()
+                        seekToTimeMs(timestampSecs * 1000)
                     }
                 }
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -130,8 +130,8 @@ class EpisodeFragmentViewModel @Inject constructor(
             .doOnNext {
                 if (it is EpisodeFragmentState.Loaded) {
                     timestamp?.let { timestamp ->
-                        if (it.episode.playedUpTo.toInt() != timestamp.toInt(DurationUnit.SECONDS)
-                            && episode is PodcastEpisode
+                        if (it.episode.playedUpTo.toInt() != timestamp.toInt(DurationUnit.SECONDS) &&
+                            episode is PodcastEpisode
                         ) {
                             it.episode.playedUpTo = timestamp.toDouble(DurationUnit.SECONDS)
                             seekToTimeMs(timestamp.toInt(DurationUnit.MILLISECONDS))

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -78,7 +78,7 @@ class EpisodeFragmentViewModel @Inject constructor(
         episodeUuid: String,
         podcastUuid: String?,
         forceDark: Boolean,
-        timestampInSecs: Duration?,
+        timestamp: Duration?,
     ) {
         val isDarkTheme = forceDark || theme.isDarkTheme
         val progressUpdatesObservable = downloadManager.progressUpdateRelay
@@ -129,15 +129,15 @@ class EpisodeFragmentViewModel @Inject constructor(
             }
             .doOnNext {
                 if (it is EpisodeFragmentState.Loaded) {
-                    episode = it.episode
-                    val timestampSecs = timestampInSecs?.toInt(DurationUnit.SECONDS)
-                    if (timestampSecs != null &&
-                        it.episode.playedUpTo.toInt() != timestampSecs &&
-                        episode is PodcastEpisode
-                    ) {
-                        episode?.playedUpTo = timestampSecs.toDouble()
-                        seekToTimeMs(timestampSecs * 1000)
+                    timestamp?.let { timestamp ->
+                        if (it.episode.playedUpTo.toInt() != timestamp.toInt(DurationUnit.SECONDS)
+                            && episode is PodcastEpisode
+                        ) {
+                            it.episode.playedUpTo = timestamp.toDouble(DurationUnit.SECONDS)
+                            seekToTimeMs(timestamp.toInt(DurationUnit.MILLISECONDS))
+                        }
                     }
+                    episode = it.episode
                 }
             }
             .onErrorReturn { EpisodeFragmentState.Error(it) }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -77,6 +77,7 @@ import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutViewModel
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
+import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper.NavigationState
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -689,12 +690,19 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.multiSelectBookmarksHelper.showEditBookmarkPage
-                    .collect { show ->
-                        if (show) onEditBookmarkClick()
+                viewModel.multiSelectBookmarksHelper.navigationState
+                    .collect { navigationState ->
+                        when (navigationState) {
+                            NavigationState.ShareBookmark -> onShareBookmarkClick()
+                            NavigationState.EditBookmark -> onEditBookmarkClick()
+                        }
                     }
             }
         }
+    }
+
+    private fun onShareBookmarkClick() {
+        viewModel.onShareBookmarkClick(requireContext())
     }
 
     private fun onEditBookmarkClick() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -421,7 +421,7 @@ class PodcastViewModel
 
     fun onShareBookmarkClick(context: Context) {
         multiSelectBookmarksHelper.selectedListLive.value?.firstOrNull()?.let { bookmark ->
-            viewModelScope.launch(ioDispatcher) {
+            viewModelScope.launch {
                 val podcast = podcastManager.findPodcastByUuidSuspend(bookmark.podcastUuid)
                 val episode = episodeManager.findEpisodeByUuid(bookmark.episodeUuid)
                 if (podcast != null && episode is PodcastEpisode) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -34,6 +34,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.SharePodcastHelper
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.SharePodcastHelper.ShareType
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -414,6 +416,26 @@ class PodcastViewModel
                 }
             }
             playbackManager.seekToTimeMs(bookmark.timeSecs * 1000)
+        }
+    }
+
+    fun onShareBookmarkClick(context: Context) {
+        multiSelectBookmarksHelper.selectedListLive.value?.firstOrNull()?.let { bookmark ->
+            viewModelScope.launch(ioDispatcher) {
+                val podcast = podcastManager.findPodcastByUuidSuspend(bookmark.podcastUuid)
+                val episode = episodeManager.findEpisodeByUuid(bookmark.episodeUuid)
+                if (podcast != null && episode is PodcastEpisode) {
+                    SharePodcastHelper(
+                        podcast,
+                        episode,
+                        bookmark.timeSecs.toDouble(),
+                        context,
+                        ShareType.BOOKMARK_TIME,
+                        SourceView.PODCAST_SCREEN,
+                        analyticsTracker,
+                    ).showShareDialogDirect()
+                }
+            }
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SharePodcastHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SharePodcastHelper.kt
@@ -129,5 +129,6 @@ data class SharePodcastHelper(
         EPISODE("episode"),
         EPISODE_FILE("episode_file"),
         CURRENT_TIME("current_time"),
+        BOOKMARK_TIME("bookmark_time"),
     }
 }

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
@@ -25,7 +25,13 @@ interface FragmentHostListener {
     fun getPlayerBottomSheetState(): Int
     fun addPlayerBottomSheetCallback(callback: BottomSheetBehavior.BottomSheetCallback)
     fun removePlayerBottomSheetCallback(callback: BottomSheetBehavior.BottomSheetCallback)
-    fun openEpisodeDialog(episodeUuid: String?, source: EpisodeViewSource, podcastUuid: String?, forceDark: Boolean)
+    fun openEpisodeDialog(
+        episodeUuid: String?,
+        source: EpisodeViewSource,
+        podcastUuid: String?,
+        forceDark: Boolean,
+        timestampInSecs: Int? = null,
+    )
     fun lockPlayerBottomSheet(locked: Boolean)
     fun updateSystemColors()
     fun overrideNextRefreshTimer()

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
@@ -4,6 +4,7 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import kotlin.time.Duration
 
 interface FragmentHostListener {
     fun addFragment(fragment: Fragment, onTop: Boolean = false)
@@ -30,7 +31,7 @@ interface FragmentHostListener {
         source: EpisodeViewSource,
         podcastUuid: String?,
         forceDark: Boolean,
-        timestampInSecs: Int? = null,
+        timestampInSecs: Duration? = null,
     )
     fun lockPlayerBottomSheet(locked: Boolean)
     fun updateSystemColors()

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
@@ -31,7 +31,7 @@ interface FragmentHostListener {
         source: EpisodeViewSource,
         podcastUuid: String?,
         forceDark: Boolean,
-        timestampInSecs: Duration? = null,
+        timestamp: Duration? = null,
     )
     fun lockPlayerBottomSheet(locked: Boolean)
     fun updateSystemColors()

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarkAction.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarkAction.kt
@@ -22,7 +22,7 @@ sealed class MultiSelectBookmarkAction(
     analyticsValue,
     isVisible,
 ) {
-    object DeleteBookmark : MultiSelectBookmarkAction(
+    data object DeleteBookmark : MultiSelectBookmarkAction(
         R.id.menu_delete,
         R.id.menu_delete,
         LR.string.delete,
@@ -37,5 +37,13 @@ sealed class MultiSelectBookmarkAction(
         IR.drawable.ic_edit,
         "edit",
         isVisible = isVisible,
+    )
+
+    data class ShareBookmark(override val isVisible: Boolean) : MultiSelectBookmarkAction(
+        R.id.menu_share,
+        R.id.menu_share,
+        LR.string.share,
+        IR.drawable.ic_share,
+        "share",
     )
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
@@ -26,10 +26,10 @@ class MultiSelectBookmarksHelper @Inject constructor(
     private val bookmarkManager: BookmarkManager,
     private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : MultiSelectHelper<Bookmark>() {
-    override val maxToolbarIcons = 2
+    override val maxToolbarIcons = 3
 
-    private val _showEditBookmarkPage = MutableSharedFlow<Boolean>()
-    val showEditBookmarkPage = _showEditBookmarkPage.asSharedFlow()
+    private val _navigationState = MutableSharedFlow<NavigationState>()
+    val navigationState = _navigationState.asSharedFlow()
 
     override var source by bookmarkManager::sourceView
 
@@ -52,6 +52,11 @@ class MultiSelectBookmarksHelper @Inject constructor(
         activity: FragmentActivity,
     ): Boolean {
         return when (itemId) {
+            R.id.menu_share -> {
+                share()
+                true
+            }
+
             UR.id.menu_edit -> {
                 edit()
                 true
@@ -84,8 +89,12 @@ class MultiSelectBookmarksHelper @Inject constructor(
         }
     }
 
+    private fun share() {
+        launch { _navigationState.emit(NavigationState.ShareBookmark) }
+    }
+
     private fun edit() {
-        launch { _showEditBookmarkPage.emit(true) }
+        launch { _navigationState.emit(NavigationState.EditBookmark) }
     }
 
     fun delete(resources: Resources, fragmentManager: FragmentManager) {
@@ -139,5 +148,10 @@ class MultiSelectBookmarksHelper @Inject constructor(
                 closeMultiSelect()
             }
             .show(fragmentManager, "delete_bookmarks_warning")
+    }
+
+    sealed class NavigationState {
+        data object EditBookmark : NavigationState()
+        data object ShareBookmark : NavigationState()
     }
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
@@ -111,7 +111,7 @@ class MultiSelectBookmarksHelper @Inject constructor(
 
         val count = bookmarks.size
         ConfirmationDialog()
-            .setForceDarkTheme(true)
+            .setForceDarkTheme(source == SourceView.PLAYER)
             .setButtonType(
                 ConfirmationDialog.ButtonType.Danger(
                     resources.getStringPlural(

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.map
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
@@ -37,6 +38,10 @@ class MultiSelectBookmarksHelper @Inject constructor(
         .map {
             Sentry.addBreadcrumb("MultiSelectBookmarksHelper toolbarActions updated, ${it.size} bookmarks from $source")
             listOf(
+                MultiSelectBookmarkAction.ShareBookmark(
+                    isVisible = source != SourceView.FILES &&
+                        it.count() == 1,
+                ),
                 MultiSelectBookmarkAction.EditBookmark(isVisible = it.count() == 1),
                 MultiSelectBookmarkAction.DeleteBookmark,
                 MultiSelectAction.SelectAll,


### PR DESCRIPTION
## Description
This adds a share option for bookmarks.

## Testing Instructions

- Start the app using a user with a Patron Account on a device
- If you still don't have any Bookmarks please create some on the account on multiple podcasts
- Go a podcast with bookmarks
- Open Bookmarks tab for the podcast
- Tap on the options button
- Select one bookmark
- Tap on Share
- Copy the link
- Open the link that you copied from the other device on device browser
- Tap on Open In Pocket Casts
- Check that the link is opened on the correct Podcast -> Episode -> Time location
- Repeat the test above on the other locations where Bookmarks list are shown
    - Player full screen, tab bookmarks
    - Episode detail, tab bookmarks  

## Screenshots or Screencast 


https://github.com/Automattic/pocket-casts-android/assets/1405144/72ccd3dd-6f7b-4167-af4e-7138ce2fcd7f


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
