### PR TITLE
Update search bar colors for new category design

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoryPillListAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoryPillListAdapter.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.discover.view
 
 import android.content.Context
-import android.graphics.Color.WHITE
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.ImageView
@@ -17,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.discover.databinding.CategoryPillBinding
 import au.com.shiftyjelly.pocketcasts.discover.view.CategoryPillListAdapter.CategoryPillViewHolder
 import au.com.shiftyjelly.pocketcasts.localization.R.string.clear_all
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 
 val CATEGORY_PILL_DIFF = object : DiffUtil.ItemCallback<CategoryPill>() {
     override fun areItemsTheSame(oldItem: CategoryPill, newItem: CategoryPill): Boolean =
@@ -65,14 +65,12 @@ class CategoryPillListAdapter(
 
         private fun setUpCategories(context: Context, category: CategoryPill) {
             if (category.isSelected) {
-                binding.categoryPill.background =
-                    getDrawable(context, R.drawable.category_pill_selected_background)
-                binding.categoryName.setTextColor(WHITE)
+                binding.categoryPill.background = getDrawable(context, R.drawable.category_pill_selected_background)
             } else {
                 binding.categoryPill.background = getDrawable(context, R.drawable.category_pill_background)
-                binding.categoryName.setTextAppearance(au.com.shiftyjelly.pocketcasts.ui.R.style.H40)
             }
             binding.categoryName.setCategory(category.discoverCategory.name)
+            binding.categoryName.setCategoryColor(category.isSelected)
             binding.categoryIcon.isVisible = false
         }
     }
@@ -93,6 +91,7 @@ class CategoryPillListAdapter(
                     onAllCategoriesClick(
                         onCategorySelectionCancel@{
                             binding.categoryName.setCategory(category.discoverCategory.name)
+                            binding.categoryName.setCategoryColor(isSelected = false)
                             binding.categoryIcon.setIcon(R.drawable.ic_arrow_down)
                         },
                         onCategorySelectionSuccess@{
@@ -125,6 +124,13 @@ private fun TextView.setCategory(category: String) {
     isVisible = true
     text = category
     contentDescription = category
+}
+private fun TextView.setCategoryColor(isSelected: Boolean) {
+    if (isSelected) {
+        this.setTextColor(context.getThemeColor(au.com.shiftyjelly.pocketcasts.ui.R.attr.primary_ui_02_selected))
+    } else {
+        this.setTextColor(context.getThemeColor(au.com.shiftyjelly.pocketcasts.ui.R.attr.primary_text_01))
+    }
 }
 
 private fun ImageView.setIcon(resourceId: Int, contentDescription: CharSequence? = null) {

--- a/modules/features/discover/src/main/res/drawable/category_clear_all_pill_background.xml
+++ b/modules/features/discover/src/main/res/drawable/category_clear_all_pill_background.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android" >
     <stroke
         android:width="1dp"
-        android:color="@color/coolgrey_50" />
+        android:color="?attr/primary_icon_02" />
 
     <solid android:color="?attr/primary_ui_01" />
 

--- a/modules/features/discover/src/main/res/drawable/category_pill_background.xml
+++ b/modules/features/discover/src/main/res/drawable/category_pill_background.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android" >
     <stroke
         android:width="1dp"
-        android:color="@color/coolgrey_50" />
+        android:color="?attr/primary_icon_02" />
 
     <solid android:color="?attr/primary_ui_01" />
 

--- a/modules/features/discover/src/main/res/drawable/category_pill_selected_background.xml
+++ b/modules/features/discover/src/main/res/drawable/category_pill_selected_background.xml
@@ -4,7 +4,7 @@
         android:width="1dp"
         android:color="@color/coolgrey_50" />
 
-    <solid android:color="@color/select_categories_tittle_color" />
+    <solid android:color="?attr/primary_icon_01" />
 
     <padding
         android:left="20dp"

--- a/modules/features/discover/src/main/res/drawable/category_pill_selected_background.xml
+++ b/modules/features/discover/src/main/res/drawable/category_pill_selected_background.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android" >
     <stroke
         android:width="1dp"
-        android:color="@color/coolgrey_50" />
+        android:color="?attr/primary_icon_02" />
 
     <solid android:color="?attr/primary_icon_01" />
 

--- a/modules/features/discover/src/main/res/drawable/search_with_category_pills_background.xml
+++ b/modules/features/discover/src/main/res/drawable/search_with_category_pills_background.xml
@@ -1,0 +1,10 @@
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle"   >
+
+    <solid android:color="?attr/primary_ui_01" />
+
+    <stroke
+        android:width="1dp"
+        android:color="?attr/primary_icon_02" />
+</shape>

--- a/modules/features/discover/src/main/res/layout/row_category_pills.xml
+++ b/modules/features/discover/src/main/res/layout/row_category_pills.xml
@@ -43,6 +43,7 @@
         android:id="@+id/rowRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:clipToPadding="false"
         android:paddingStart="16dp" />
 
 </LinearLayout>

--- a/modules/features/discover/src/main/res/layout/row_category_pills.xml
+++ b/modules/features/discover/src/main/res/layout/row_category_pills.xml
@@ -12,7 +12,7 @@
         android:layout_width="match_parent"
         android:layout_height="56dp"
         android:orientation="horizontal"
-        android:background="?attr/primary_ui_01"
+        android:background="@drawable/search_with_category_pills_background"
         android:foreground="?attr/selectableItemBackground"
         android:layout_margin="16dp"
         android:clickable="true"

--- a/modules/features/discover/src/main/res/layout/row_category_pills.xml
+++ b/modules/features/discover/src/main/res/layout/row_category_pills.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
+    android:background="?attr/secondary_ui_02"
     android:paddingBottom="16dp">
 
     <LinearLayout
@@ -11,7 +12,7 @@
         android:layout_width="match_parent"
         android:layout_height="56dp"
         android:orientation="horizontal"
-        android:background="?attr/primary_ui_04"
+        android:background="?attr/primary_ui_01"
         android:foreground="?attr/selectableItemBackground"
         android:layout_margin="16dp"
         android:clickable="true"
@@ -23,7 +24,7 @@
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:src="@drawable/ic_search"
-            app:tint="?attr/primary_icon_03"
+            app:tint="?attr/primary_text_01"
             android:layout_marginEnd="16dp"/>
         <TextView
             android:layout_width="match_parent"
@@ -31,7 +32,7 @@
             android:layout_gravity="center_vertical"
             android:textAppearance="?attr/textBody1"
             android:importantForAccessibility="no"
-            android:textColor="?attr/primary_icon_03"
+            android:textColor="?attr/primary_text_01"
             android:maxLines="1"
             android:ellipsize="end"
             android:text="@string/search_podcasts_or_add_url"


### PR DESCRIPTION
## Description
- It just updates both text and background color for search bar and list of category pills
- Internal slack reference: pocket-casts-design p1712595053116089

## Testing Instructions
- Play around the themes and see how they look like in discover view for search bar and category pills menu

## Screenshots or Screencast 

| Light | Dark | Rosé |
|-------|------|------|
| <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/0be76404-b75d-44e2-84cc-d6c18db93284" height="400"> | <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/96ff932c-35e3-4d4f-a612-ab76dfefe918" height="400"> | <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/69c56631-539f-4024-b0da-0fde545101f6" height="400"> |


| Indigo | Extra Dark | Dark Contrast |
|-------|------|------|
| <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/36f13c96-37d4-4d4b-bb14-067b00928ce6" height="400"> | <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/ae1cb1e0-6c40-4f6a-b7fc-c654a65176be" height="400"> | <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/43c473fd-0d02-423d-b790-b76d80786909" height="400"> |


| Light Contrast | Electricity | Classic | Radiotivity |
|-------|------|------|------------|
| <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/c16bbb13-bb9e-43d9-97e9-805ec1d25782" height="400"> | <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/7b80455e-1c53-412c-8bae-1e30f96b5437" height="400"> | <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/00112f4f-1320-45ab-98be-6cf9e57e7ff9" height="400"> | <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/76aac9a1-6b38-4e00-b586-88fab589d7b8" height="400"> |



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
