### PR TITLE
Align widgets with design feedback

### DIFF
--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/EpisodeImage.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/EpisodeImage.kt
@@ -31,7 +31,7 @@ internal fun EpisodeImage(
     }
 
     if (episode != null) {
-        LaunchedEffect(episode.artworkUrl, useEpisodeArtwork) {
+        LaunchedEffect(episode.uuid, useEpisodeArtwork) {
             val requestFactory = PocketCastsImageRequestFactory(context, cornerRadius = 16).smallSize()
             val request = requestFactory.create(episode.toBaseEpisode(), useEpisodeArtwork)
             var drawable: Drawable? = null

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayer.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayer.kt
@@ -7,7 +7,7 @@ import androidx.glance.GlanceTheme
 import androidx.glance.background
 import androidx.glance.layout.Column
 import androidx.glance.layout.Spacer
-import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
 import au.com.shiftyjelly.pocketcasts.widget.data.LargePlayerWidgetState
@@ -19,9 +19,10 @@ internal fun LargePlayer(state: LargePlayerWidgetState) {
     WidgetTheme(state.useDynamicColors) {
         Column(
             modifier = GlanceModifier
-                .fillMaxSize()
+                .fillMaxWidth()
+                .height(350.dp)
                 .background(GlanceTheme.colors.primaryContainer)
-                .padding(top = 12.dp, start = 12.dp, end = 12.dp, bottom = 0.dp),
+                .padding(16.dp),
         ) {
             LargePlayerHeader(state = state)
             if (upNextEpisodes.isNotEmpty()) {

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayerHeader.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayerHeader.kt
@@ -40,7 +40,7 @@ internal fun LargePlayerHeader(
         verticalAlignment = Alignment.Top,
         modifier = modifier
             .fillMaxWidth()
-            .height(132.dp)
+            .height(116.dp)
             .background(GlanceTheme.colors.primaryContainer),
 
     ) {
@@ -48,7 +48,7 @@ internal fun LargePlayerHeader(
             episode = episode,
             useEpisodeArtwork = state.useEpisodeArtwork,
             modifier = GlanceModifier
-                .size(132.dp)
+                .size(116.dp)
                 .clickable(action),
         )
 
@@ -58,17 +58,20 @@ internal fun LargePlayerHeader(
             )
             Column(
                 verticalAlignment = Alignment.Vertical.Top,
-                modifier = GlanceModifier.defaultWeight().height(132.dp),
+                modifier = GlanceModifier.defaultWeight().height(116.dp),
             ) {
+                Spacer(
+                    modifier = GlanceModifier.height(4.dp),
+                )
                 Text(
                     text = LocalContext.current.getString(LR.string.player_tab_playing_wide),
                     maxLines = 1,
-                    style = TextStyle(color = GlanceTheme.colors.onPrimaryContainer, fontSize = 16.sp),
+                    style = TextStyle(color = GlanceTheme.colors.onPrimaryContainer, fontSize = 12.sp),
                 )
                 Text(
                     text = episode.title,
                     maxLines = 1,
-                    style = TextStyle(color = GlanceTheme.colors.onPrimaryContainer, fontSize = 22.sp, fontWeight = FontWeight.Bold),
+                    style = TextStyle(color = GlanceTheme.colors.onPrimaryContainer, fontSize = 14.sp, fontWeight = FontWeight.Bold),
                 )
                 Spacer(
                     modifier = GlanceModifier.height(4.dp),
@@ -76,12 +79,14 @@ internal fun LargePlayerHeader(
                 Text(
                     text = episode.getTimeLeft(LocalContext.current),
                     maxLines = 1,
-                    style = TextStyle(color = GlanceTheme.colors.onPrimaryContainer, fontSize = 16.sp),
+                    style = TextStyle(color = GlanceTheme.colors.onPrimaryContainer, fontSize = 12.sp),
                 )
-
                 PlaybackControls(
                     isPlaying = state.isPlaying,
                     modifier = GlanceModifier.defaultWeight(),
+                )
+                Spacer(
+                    modifier = GlanceModifier.height(4.dp),
                 )
             }
         } else {
@@ -89,6 +94,9 @@ internal fun LargePlayerHeader(
                 modifier = GlanceModifier.defaultWeight(),
             )
         }
+        Spacer(
+            modifier = GlanceModifier.width(16.dp),
+        )
         PocketCastsLogo()
     }
 }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayerQueue.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayerQueue.kt
@@ -8,7 +8,7 @@ import androidx.glance.GlanceTheme
 import androidx.glance.LocalContext
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.lazy.LazyColumn
-import androidx.glance.appwidget.lazy.items
+import androidx.glance.appwidget.lazy.itemsIndexed
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Column
 import androidx.glance.layout.Row
@@ -17,6 +17,7 @@ import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
 import androidx.glance.layout.size
+import androidx.glance.layout.width
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
@@ -29,22 +30,23 @@ internal fun LargePlayerQueue(
     useEpisodeArtwork: Boolean,
     modifier: GlanceModifier = GlanceModifier,
 ) {
+    val lastIndex = queue.lastIndex
     LazyColumn(
         modifier = modifier.fillMaxWidth(),
     ) {
-        items(queue, PlayerWidgetEpisode::longId) { episode ->
+        itemsIndexed(queue, { _, episode -> episode.longId }) { index, episode ->
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = GlanceModifier
                     .fillMaxWidth()
-                    .height(78.dp)
-                    .padding(bottom = 12.dp),
+                    .height(if (index == lastIndex) 58.dp else 66.dp)
+                    .padding(bottom = if (index == lastIndex) 0.dp else 8.dp),
             ) {
                 EpisodeImage(
                     episode = episode,
                     useEpisodeArtwork = useEpisodeArtwork,
                     modifier = GlanceModifier
-                        .size(66.dp)
+                        .size(58.dp)
                         .clickable(OpenEpisodeDetailsAction.action(episode.uuid)),
                 )
                 Column(
@@ -53,28 +55,29 @@ internal fun LargePlayerQueue(
                 ) {
                     Text(
                         text = episode.title,
-                        maxLines = 1,
+                        maxLines = 2,
                         style = TextStyle(
                             color = GlanceTheme.colors.onPrimaryContainer,
-                            fontSize = 16.sp,
+                            fontSize = 12.sp,
                             fontWeight = FontWeight.Bold,
                         ),
                     )
                     Spacer(
-                        modifier = GlanceModifier.height(4.dp),
+                        modifier = GlanceModifier.height(2.dp),
                     )
                     Text(
                         text = episode.getTimeLeft(LocalContext.current),
                         maxLines = 1,
                         style = TextStyle(
                             color = GlanceTheme.colors.onPrimaryContainer,
-                            fontSize = 16.sp,
+                            fontSize = 12.sp,
                         ),
                     )
                 }
-                PlayButton(
-                    episode = episode,
+                Spacer(
+                    modifier = GlanceModifier.width(16.dp),
                 )
+                PlayButton(episode = episode)
             }
         }
     }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/MediumPlayer.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/MediumPlayer.kt
@@ -38,30 +38,30 @@ internal fun MediumPlayer(state: MediumPlayerWidgetState) {
                 .fillMaxWidth()
                 .height(90.dp)
                 .background(GlanceTheme.colors.primaryContainer)
-                .padding(12.dp),
+                .padding(16.dp),
         ) {
             EpisodeImage(
                 episode = state.episode,
                 useEpisodeArtwork = state.useEpisodeArtwork,
                 modifier = GlanceModifier
-                    .size(66.dp)
+                    .size(58.dp)
                     .clickable(action),
             )
 
             if (state.episode != null) {
                 Spacer(
-                    modifier = GlanceModifier.width(12.dp),
+                    modifier = GlanceModifier.width(16.dp),
                 )
                 Column(
                     verticalAlignment = Alignment.Vertical.Top,
-                    modifier = GlanceModifier.height(66.dp),
+                    modifier = GlanceModifier.height(58.dp),
                 ) {
                     Text(
                         text = state.episode.title,
                         maxLines = 1,
                         style = TextStyle(
                             color = GlanceTheme.colors.onPrimaryContainer,
-                            fontSize = 16.sp,
+                            fontSize = 12.sp,
                             fontWeight = FontWeight.Bold,
                         ),
                     )

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlayButton.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlayButton.kt
@@ -44,7 +44,7 @@ internal fun PlayButton(
             provider = ImageProvider(IR.drawable.ic_widget_play),
             contentDescription = null,
             colorFilter = ColorFilter.tint(GlanceTheme.colors.onPrimary),
-            modifier = GlanceModifier.size(size).padding(size / 8),
+            modifier = GlanceModifier.size(size).padding(size / 5),
         )
     }
 }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlayButton.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlayButton.kt
@@ -24,7 +24,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 internal fun PlayButton(
     episode: PlayerWidgetEpisode,
-    size: Dp = 42.dp,
+    size: Dp = 38.dp,
 ) {
     val contentDescription = LocalContext.current.getString(LR.string.play_episode)
 

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlaybackButton.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlaybackButton.kt
@@ -43,7 +43,7 @@ internal fun PlaybackButton(
             provider = ImageProvider(if (isPlaying) IR.drawable.ic_widget_pause else IR.drawable.ic_widget_play),
             contentDescription = null,
             colorFilter = ColorFilter.tint(GlanceTheme.colors.onPrimary),
-            modifier = GlanceModifier.size(size).padding(size / 8),
+            modifier = GlanceModifier.size(size).padding(size / if (isPlaying) 8 else 5),
         )
     }
 }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlaybackButton.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlaybackButton.kt
@@ -23,7 +23,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 internal fun PlaybackButton(
     isPlaying: Boolean,
-    size: Dp = 42.dp,
+    size: Dp = 36.dp,
 ) {
     val contentDescription = LocalContext.current.getString(if (isPlaying) LR.string.play_episode else LR.string.pause_episode)
 

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PocketCastsLogo.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PocketCastsLogo.kt
@@ -17,7 +17,7 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 
 @Composable
 internal fun PocketCastsLogo(
-    size: Dp = 32.dp,
+    size: Dp = 28.dp,
     modifier: GlanceModifier = GlanceModifier,
 ) {
     Box(

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SkipBackButton.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SkipBackButton.kt
@@ -22,7 +22,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun SkipBackButton(
-    size: Dp = 42.dp,
+    size: Dp = 36.dp,
 ) {
     val contentDescription = LocalContext.current.getString(LR.string.skip_back)
 

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SkipBackButton.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SkipBackButton.kt
@@ -42,7 +42,7 @@ internal fun SkipBackButton(
             provider = ImageProvider(IR.drawable.ic_widget_skip_back),
             contentDescription = null,
             colorFilter = ColorFilter.tint(GlanceTheme.colors.onPrimary),
-            modifier = GlanceModifier.size(size).padding(size / 6),
+            modifier = GlanceModifier.size(size).padding(size / 5),
         )
     }
 }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SkipForwardButton.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SkipForwardButton.kt
@@ -42,7 +42,7 @@ internal fun SkipForwardButton(
             provider = ImageProvider(IR.drawable.ic_widget_skip_forward),
             contentDescription = null,
             colorFilter = ColorFilter.tint(GlanceTheme.colors.onPrimary),
-            modifier = GlanceModifier.size(size).padding(size / 6),
+            modifier = GlanceModifier.size(size).padding(size / 5),
         )
     }
 }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SkipForwardButton.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SkipForwardButton.kt
@@ -22,7 +22,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun SkipForwardButton(
-    size: Dp = 42.dp,
+    size: Dp = 36.dp,
 ) {
     val contentDescription = LocalContext.current.getString(LR.string.skip_forward)
 

--- a/modules/features/widgets/src/main/res/xml/large_player_widget.xml
+++ b/modules/features/widgets/src/main/res/xml/large_player_widget.xml
@@ -3,7 +3,5 @@
     android:initialLayout="@layout/glance_default_loading_layout"
     android:minWidth="300dp"
     android:minHeight="165dp"
-    android:minResizeHeight="165dp"
-    android:resizeMode="vertical"
     android:targetCellWidth="4"
     android:targetCellHeight="3" />

--- a/modules/services/images/src/main/res/drawable/ic_widget_play.xml
+++ b/modules/services/images/src/main/res/drawable/ic_widget_play.xml
@@ -1,12 +1,15 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:tint="#000000"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:width="14dp"
+    android:height="14dp"
+    android:viewportWidth="14"
+    android:viewportHeight="14">
 
-    <path
-        android:fillColor="@android:color/white"
-        android:pathData="M8,5v14l11,-7z" />
+    <group android:translateX="0.75">
+
+        <path
+            android:fillColor="#000000"
+            android:pathData="M2.917,3.51C2.917,2.737 3.757,2.256 4.424,2.649L10.354,6.138C11.011,6.525 11.011,7.475 10.354,7.862L4.424,11.352C3.757,11.744 2.917,11.263 2.917,10.49V3.51Z" />
+
+    </group>
 
 </vector>

--- a/modules/services/images/src/main/res/drawable/ic_widget_skip_back.xml
+++ b/modules/services/images/src/main/res/drawable/ic_widget_skip_back.xml
@@ -1,13 +1,17 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="15dp"
+    android:height="14dp"
+    android:viewportWidth="15"
+    android:viewportHeight="14">
 
-    android:tint="#000000"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+    <group
+        android:translateX="0.35"
+        android:translateY="-0.4">
 
-    <path
-        android:fillColor="@android:color/white"
-        android:pathData="M12,5V1L7,6l5,5V7c3.31,0 6,2.69 6,6s-2.69,6 -6,6 -6,-2.69 -6,-6H4c0,4.42 3.58,8 8,8s8,-3.58 8,-8 -3.58,-8 -8,-8z" />
+        <path
+            android:fillColor="#000000"
+            android:pathData="M7.632,1.629C7.86,1.857 7.86,2.227 7.632,2.454L6.586,3.5H7.27C9.847,3.5 11.936,5.589 11.936,8.167C11.936,10.744 9.847,12.833 7.27,12.833C4.692,12.833 2.603,10.744 2.603,8.167C2.603,7.845 2.864,7.583 3.186,7.583C3.509,7.583 3.77,7.845 3.77,8.167C3.77,10.1 5.337,11.667 7.27,11.667C9.203,11.667 10.77,10.1 10.77,8.167C10.77,6.234 9.203,4.667 7.27,4.667H6.586L7.632,5.713C7.86,5.94 7.86,6.31 7.632,6.538C7.404,6.765 7.035,6.765 6.807,6.538L4.353,4.083L6.807,1.629C7.035,1.402 7.404,1.402 7.632,1.629Z" />
+
+    </group>
 
 </vector>

--- a/modules/services/images/src/main/res/drawable/ic_widget_skip_forward.xml
+++ b/modules/services/images/src/main/res/drawable/ic_widget_skip_forward.xml
@@ -1,17 +1,16 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:tint="#000000"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:width="15dp"
+    android:height="14dp"
+    android:viewportWidth="15"
+    android:viewportHeight="14">
 
     <group
-        android:scaleX="-1"
-        android:translateX="24">
+        android:translateX="0.1"
+        android:translateY="0.3">
 
         <path
-            android:fillColor="@android:color/white"
-            android:pathData="M12,5V1L7,6l5,5V7c3.31,0 6,2.69 6,6s-2.69,6 -6,6 -6,-2.69 -6,-6H4c0,4.42 3.58,8 8,8s8,-3.58 8,-8 -3.58,-8 -8,-8z" />
+            android:fillColor="#000000"
+            android:pathData="M11.353,1.75C11.675,1.75 11.936,2.011 11.936,2.333V5.833H10.77H8.436C8.114,5.833 7.853,5.572 7.853,5.25C7.853,4.928 8.114,4.667 8.436,4.667H10.151C9.47,3.938 8.489,3.5 7.426,3.5C5.402,3.5 3.77,5.072 3.77,7C3.77,8.928 5.402,10.5 7.426,10.5C8.931,10.5 10.262,9.622 10.816,8.312C10.941,8.016 11.284,7.877 11.58,8.002C11.877,8.128 12.016,8.47 11.89,8.767C11.154,10.509 9.399,11.667 7.426,11.667C4.767,11.667 2.603,9.582 2.603,7C2.603,4.418 4.767,2.333 7.426,2.333C8.7,2.333 9.888,2.816 10.77,3.637L10.77,2.333C10.77,2.011 11.031,1.75 11.353,1.75Z" />
 
     </group>
 


### PR DESCRIPTION
## Description

Align design with most of the feedback. Internal ref: pdeCcb-4VF-p2#comment-3893

1. Increases padding on the widgets.
2. Uses different icon set for play, skip back, and skip forward.
3. Makes buttons and Pocket Casts logo smaller.
4. Makes text fonts smaller.
5. Makes titles for queued episodes two lines high.
6. Add padding to the top and the bottom of the large player controls.

It doesn't make buttons background white, and it doesn't make Pocket Casts logo lines white. Adding it wouldn't work with dynamic themes and I'm waiting for the feedback on it (see the internal ref).

It also doesn't implement empty states yet as I'm waiting for the feedback on this as well.

## Testing Instructions

Add widgets to your home screen and inspect the designs. Internal ref: Lkt7fuf9Nq3XvfAFPCfpTD-fi-1044_7170

## Screenshots or Screencast 

![Screenshot_20240410_071309](https://github.com/Automattic/pocket-casts-android/assets/30936061/704ab3f6-2433-431d-b426-f5293ec4fb15)

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack