### PR TITLE
Display ads in category view

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -16,6 +16,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.OnScrollListener
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent.DISCOVER_AD_CATEGORY_TAPPED
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.discover.R
@@ -35,6 +36,7 @@ import au.com.shiftyjelly.pocketcasts.discover.databinding.RowSinglePodcastBindi
 import au.com.shiftyjelly.pocketcasts.discover.extensions.updateSubscribeButtonIcon
 import au.com.shiftyjelly.pocketcasts.discover.util.AutoScrollHelper
 import au.com.shiftyjelly.pocketcasts.discover.util.ScrollingLinearLayoutManager
+import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.CATEGORY_ID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.EPISODE_UUID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.LIST_ID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.PODCAST_UUID_KEY
@@ -838,10 +840,10 @@ internal class DiscoverAdapter(
 
                     imageRequestFactory.createForPodcast(podcast.uuid).loadInto(adHolder.binding.imgPodcast)
                     adHolder.itemView.setOnClickListener {
-                        row.discoverRow.listUuid?.let { listUuid ->
-                            trackDiscoverListPodcastTapped(listUuid, podcast.uuid)
-                            listener.onPodcastClicked(podcast, row.discoverRow.listUuid)
+                        row.discoverRow.categoryId?.let { categoryId ->
+                            analyticsTracker.track(DISCOVER_AD_CATEGORY_TAPPED, mapOf(CATEGORY_ID_KEY to categoryId))
                         }
+                        listener.onPodcastClicked(podcast, row.discoverRow.listUuid)
                     }
 
                     val lblSponsored = adHolder.binding.lblSponsored

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -311,6 +311,7 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
         private const val REGION_KEY = "region"
         private const val MOST_POPULAR_PODCASTS = 5
         const val LIST_ID_KEY = "list_id"
+        const val CATEGORY_ID_KEY = "category_id"
         const val PODCAST_UUID_KEY = "podcast_uuid"
         const val EPISODE_UUID_KEY = "episode_uuid"
         const val SOURCE_KEY = "source"

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -211,7 +211,7 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
                         }
                         adapter?.onChangeRegion = onChangeRegion
 
-                        val updatedContent = addRegionToCategoryRow(content, state.selectedRegion.code)
+                        val updatedContent = updateDiscoverRowsAndRemoveCategoryAds(content, state.selectedRegion.code)
 
                         adapter?.submitList(updatedContent)
                     }
@@ -256,7 +256,7 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
             FirebaseAnalyticsTracker.navigatedToDiscover()
         }
     }
-    private fun addRegionToCategoryRow(content: List<Any>, region: String): MutableList<Any> {
+    private fun updateDiscoverRowsAndRemoveCategoryAds(content: List<Any>, region: String): MutableList<Any> {
         val mutableContentList = content.toMutableList()
 
         val categoriesIndex = mutableContentList.indexOfFirst { it is DiscoverRow && it.type is ListType.Categories }
@@ -265,6 +265,8 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
             val categoriesItem = mutableContentList[categoriesIndex] as DiscoverRow
             mutableContentList[categoriesIndex] = categoriesItem.copy(regionCode = region)
         }
+
+        mutableContentList.removeAll { it is DiscoverRow && it.categoryId != null } // Remove ads exclusive to category view
 
         return mutableContentList
     }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -135,7 +135,8 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
             val remainingPodcasts =
                 RemainingPodcastsByCategoryRow(it.listId, it.title, podcasts.drop(MOST_POPULAR_PODCASTS))
 
-            updateDiscover(mostPopularPodcasts, remainingPodcasts)
+            updateDiscoverWithCategorySelected(selectedCategory.discoverCategory.id, mostPopularPodcasts, remainingPodcasts)
+
             onCategorySelectionSuccess()
         }
     }
@@ -271,15 +272,22 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
         return mutableContentList
     }
 
-    private fun updateDiscover(
+    private fun updateDiscoverWithCategorySelected(
+        categoryId: Int,
         mostPopularPodcasts: MostPopularPodcastsByCategoryRow,
         remainingPodcasts: RemainingPodcastsByCategoryRow,
     ) {
         adapter?.currentList?.let { discoverList ->
             val updatedList = discoverList.filter { it is DiscoverRow && it.type is ListType.Categories }.toMutableList()
 
-            updatedList.add(MOST_POPULAR_PODCASTS_ROW_INDEX, mostPopularPodcasts)
-            updatedList.add(REMAINING_PODCASTS_ROW_INDEX, remainingPodcasts)
+            // First, we insert the most popular podcasts.
+            updatedList.add(mostPopularPodcasts)
+
+            // If there is ad, we add it.
+            viewModel.getAdForCategoryView(categoryId)?.let { updatedList.add(CategoryAdRow(it)) }
+
+            // Lastly, we add the remaining podcast list.
+            updatedList.add(remainingPodcasts)
 
             adapter?.submitList(updatedList)
         }
@@ -301,8 +309,6 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
         private const val ID_KEY = "id"
         private const val NAME_KEY = "name"
         private const val REGION_KEY = "region"
-        private const val MOST_POPULAR_PODCASTS_ROW_INDEX = 1
-        private const val REMAINING_PODCASTS_ROW_INDEX = 2
         private const val MOST_POPULAR_PODCASTS = 5
         const val LIST_ID_KEY = "list_id"
         const val PODCAST_UUID_KEY = "podcast_uuid"

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -55,6 +55,7 @@ class DiscoverViewModel @Inject constructor(
     val state = MutableLiveData<DiscoverState>().apply { value = DiscoverState.Loading }
     var currentRegionCode: String? = settings.discoverCountryCode.value
     private var replacements = emptyMap<String, String>()
+    private var adsForCategoryView = emptyList<DiscoverRow>()
     private var isFragmentChangingConfigurations: Boolean = false
 
     fun onShown() {
@@ -97,6 +98,9 @@ class DiscoverViewModel @Inject constructor(
 
                     // Update the list with the correct region substituted in where needed
                     val updatedList = it.layout.transformWithRegion(region, replacements, resources)
+
+                    // Save ads to display in category view
+                    adsForCategoryView = updatedList.filter { discoverRow -> discoverRow.categoryId != null }
 
                     state.postValue(DiscoverState.DataLoaded(updatedList, region, it.regions.values.toList()))
                 },
@@ -304,6 +308,9 @@ class DiscoverViewModel @Inject constructor(
 
     fun stopPlayback() {
         playbackManager.stopAsync(sourceView = sourceView)
+    }
+    fun getAdForCategoryView(categoryInt: Int): DiscoverRow? {
+        return adsForCategoryView.firstOrNull { it.categoryId == categoryInt }
     }
 }
 

--- a/modules/features/discover/src/main/res/layout/row_category_ad.xml
+++ b/modules/features/discover/src/main/res/layout/row_category_ad.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground">
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/cardImage"
+        android:layout_width="108dp"
+        android:layout_height="108dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:elevation="2dp"
+        app:cardCornerRadius="4dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/imgPodcast"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="?attr/defaultArtworkSmall" />
+
+    </androidx.cardview.widget.CardView>
+
+    <TextView
+        android:id="@+id/lblSponsored"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:textAppearance="@style/C50"
+        app:layout_constraintStart_toEndOf="@id/cardImage"
+        app:layout_constraintTop_toTopOf="@id/cardImage"
+        tools:text="Sponsored" />
+
+    <TextView
+        android:id="@+id/lblTitle"
+        style="@style/H20"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginEnd="16dp"
+        android:ellipsize="end"
+        android:maxLines="2"
+        android:singleLine="false"
+        android:textColor="?attr/primary_text_01"
+        android:textSize="15sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/cardImage"
+        app:layout_constraintTop_toBottomOf="@id/lblSponsored"
+        tools:text="Title" />
+
+    <TextView
+        android:id="@+id/lblBody"
+        style="@style/P40"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:layout_marginEnd="16dp"
+        android:ellipsize="end"
+        android:gravity="top"
+        android:lineSpacingExtra="3sp"
+        android:maxLines="2"
+        android:textColor="?attr/primary_text_02"
+        android:textSize="@dimen/discover_single_podcast_body_text_size"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/lblTitle"
+        app:layout_constraintTop_toBottomOf="@id/lblTitle"
+        tools:text="Title" />
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/barrierImageText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="cardImage,lblBody" />
+
+    <View
+        style="@style/row_divider"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/barrierImageText" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -279,6 +279,7 @@ enum class AnalyticsEvent(val key: String) {
     DISCOVER_SHOWN("discover_shown"),
     DISCOVER_CATEGORY_SHOWN("discover_category_shown"),
     DISCOVER_FEATURED_PODCAST_TAPPED("discover_featured_podcast_tapped"),
+    DISCOVER_AD_CATEGORY_TAPPED("discover_ad_category_tapped"),
     DISCOVER_FEATURED_PODCAST_SUBSCRIBED("discover_featured_podcast_subscribed"),
     DISCOVER_SHOW_ALL_TAPPED("discover_show_all_tapped"),
     DISCOVER_LIST_SHOW_ALL_TAPPED("discover_list_show_all_tapped"),

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModel.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModel.kt
@@ -60,6 +60,7 @@ data class DiscoverRow(
     @field:Json(name = "title") override val title: String,
     @field:Json(name = "source") override val source: String,
     @field:Json(name = "uuid") override val listUuid: String?,
+    @field:Json(name = "category_id") val categoryId: Int?,
     @field:Json(name = "regions") val regions: List<String>,
     @field:Json(name = "sponsored") val sponsored: Boolean = false,
     @field:Json(name = "curated") override val curated: Boolean = false,
@@ -98,6 +99,7 @@ data class DiscoverRow(
             regions = regions,
             sponsored = sponsored,
             curated = curated,
+            categoryId = categoryId,
             sponsoredPodcasts = sponsoredPodcasts,
             mostPopularCategoriesId = mostPopularCategoriesId,
         )


### PR DESCRIPTION
## Description
- This PR displays ads in category view. Our discover API will let us know which ad we should display for each category selected.
- Adds `discover_ad_category_tapped` event for when user taps on this new ad in category view
- You can see the API implementation here: https://github.com/Automattic/pocket-casts-node-server/pull/631
- You can find references and figma here in our internal reference: `pdeCcb-4tv-p2`
- You can see the post about the creation of ads here: `pdeCcb-4Zb-p2`

> [!note]
> Our discover API is updated only in staging

> [!note]
> Only `Arts` and `Sports` category have ads


## Testing Instructions
- Make sure you have the `Podcasts by category shown in discover view` feature enabled in Beta features and run the app in `debug`

1. Run the App
2. Go to discover and scroll to the bottom
3. You should not see this new ad. The only one you should see is the existing ad one such as featured carousel ✅
4. Select any category other than `Arts` or `Sports`
5. You should not see any ad in category view ✅
6. Select `Arts` or `Sports` category
7. You should see the ad in category view ✅
8. Tap on ad
9. You should see the `🔵 Tracked: discover_ad_category_tapped, Properties: {"category_id":[category_id]...` event in logs ✅

## Screenshots or Screencast 
<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/ce57ff18-143d-41e6-b753-d013458336b3" height="600">

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack

cc: @david-gonzalez-a8c 
