### PR TITLE
Account for a hotfix for artwork settings migration

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
@@ -160,7 +160,7 @@ class VersionMigrationsJob : JobService() {
             upgradeTrimSilenceMode()
         }
 
-        if (previousVersionCode < 9207) {
+        if (previousVersionCode < 9209) {
             consolidateEmbeddedArtworkSettings(applicationContext)
         }
     }


### PR DESCRIPTION
## Description

We had a hotfix for `7.60` due to #2001. Because of that user's app versions no longer align with the expected migration of episode artwork setting.

## Testing Instructions

You can run a migration test with this branch mentioned in #1987. Though CI check and verification that latest prod version code is `9208` should be enough.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
