### PR TITLE
Do not clear named setting modification timestamp

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/preferences/UserSettingTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/preferences/UserSettingTest.kt
@@ -6,6 +6,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.utils.MutableClock
 import java.time.Instant
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -42,7 +43,7 @@ class UserSettingTest {
         userSetting.set("new_value", clock = clock, updateModifiedAt = false)
 
         assertEquals("new_value", userSetting.value)
-        assertEquals(Instant.EPOCH, userSetting.modifiedAt)
+        assertNull(userSetting.modifiedAt)
     }
 
     @Test
@@ -75,6 +76,27 @@ class UserSettingTest {
 
             cancel()
         }
+    }
+
+    @Test
+    fun useEpochPlusOneAsDefaultSyncTimestamp() {
+        lateinit var timestamp: Instant
+        userSetting.getSyncSetting { _, modifiedAt ->
+            timestamp = modifiedAt
+        }
+        assertEquals(Instant.EPOCH.plusMillis(1), timestamp)
+    }
+
+    @Test
+    fun useStoredSyncTimestamp() {
+        clock += 1.seconds
+        userSetting.set("new_value", clock = clock, updateModifiedAt = true)
+
+        lateinit var timestamp: Instant
+        userSetting.getSyncSetting { _, modifiedAt ->
+            timestamp = modifiedAt
+        }
+        assertEquals(clock.instant(), timestamp)
     }
 
     private class ReversingToSetting(

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/settings/advanced/AdvancedSettingsTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/settings/advanced/AdvancedSettingsTest.kt
@@ -76,7 +76,7 @@ class AdvancedSettingsTest {
 
     @Test
     fun shelfItemsSettingsAlwaysSavesAllEntries() {
-        settings.shelfItems.set(listOf(ShelfItem.Archive), needsSync = false)
+        settings.shelfItems.set(listOf(ShelfItem.Archive), updateModifiedAt = false)
 
         val items = settings.shelfItems.value
 
@@ -85,7 +85,7 @@ class AdvancedSettingsTest {
 
     @Test
     fun shelfItemsDoNotSaveDuplicates() {
-        settings.shelfItems.set(listOf(ShelfItem.Cast, ShelfItem.Cast), needsSync = false)
+        settings.shelfItems.set(listOf(ShelfItem.Cast, ShelfItem.Cast), updateModifiedAt = false)
 
         val items = settings.shelfItems.value
 
@@ -96,7 +96,7 @@ class AdvancedSettingsTest {
     fun shelfItemsAreSavedInOrder() {
         val items = listOf(ShelfItem.Archive, ShelfItem.Bookmark, ShelfItem.Star, ShelfItem.Played, ShelfItem.Sleep)
 
-        settings.shelfItems.set(items, needsSync = false)
+        settings.shelfItems.set(items, updateModifiedAt = false)
 
         assertEquals(settings.shelfItems.value.take(5), items)
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/utils/MutableClock.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/utils/MutableClock.kt
@@ -1,0 +1,25 @@
+package au.com.shiftyjelly.pocketcasts.utils
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import kotlin.time.Duration
+
+class MutableClock(
+    private var instant: Instant = Instant.EPOCH,
+    private val zoneId: ZoneId = ZoneId.of("UTC"),
+) : Clock() {
+    override fun instant() = instant
+
+    override fun getZone() = zoneId
+
+    override fun withZone(zone: ZoneId) = MutableClock(instant, zone)
+
+    operator fun plusAssign(duration: Duration) {
+        instant = instant.plusMillis(duration.inWholeMilliseconds)
+    }
+
+    operator fun minusAssign(duration: Duration) {
+        instant = instant.minusMillis(duration.inWholeMilliseconds)
+    }
+}

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -64,7 +64,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
 
     private fun setupAutoPlay() {
         preferenceAutoPlay.setOnPreferenceChangeListener { _, newValue ->
-            settings.autoPlayNextEpisodeOnEmpty.set(newValue as Boolean, needsSync = true)
+            settings.autoPlayNextEpisodeOnEmpty.set(newValue as Boolean, updateModifiedAt = true)
             true
         }
         settings.autoPlayNextEpisodeOnEmpty.flow
@@ -74,7 +74,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
 
     private fun setupAutoSubscribeToPlayed() {
         preferenceAutoSubscribeToPlayed.setOnPreferenceChangeListener { _, newValue ->
-            settings.autoSubscribeToPlayed.set(newValue as Boolean, needsSync = true)
+            settings.autoSubscribeToPlayed.set(newValue as Boolean, updateModifiedAt = true)
             true
         }
         settings.autoSubscribeToPlayed.flow
@@ -84,7 +84,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
 
     private fun setupAutoShowPlayed() {
         preferenceAutoShowPlayed.setOnPreferenceChangeListener { _, newValue ->
-            settings.autoShowPlayed.set(newValue as Boolean, needsSync = true)
+            settings.autoShowPlayed.set(newValue as Boolean, updateModifiedAt = true)
             true
         }
         settings.autoShowPlayed.flow
@@ -97,7 +97,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
         preferenceSkipForward.setOnPreferenceChangeListener { _, newValue ->
             val value = newValue.toString().toIntOrNull() ?: 0
             if (value > 0) {
-                settings.skipForwardInSecs.set(value, needsSync = true)
+                settings.skipForwardInSecs.set(value, updateModifiedAt = true)
                 true
             } else {
                 false
@@ -116,7 +116,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
         preferenceSkipBackward.setOnPreferenceChangeListener { _, newValue ->
             val value = newValue.toString().toIntOrNull() ?: 0
             if (value > 0) {
-                settings.skipBackInSecs.set(value, needsSync = true)
+                settings.skipBackInSecs.set(value, updateModifiedAt = true)
                 true
             } else {
                 false

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/PromoCodeFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/PromoCodeFragment.kt
@@ -64,7 +64,7 @@ class PromoCodeFragment : BaseFragment() {
                         binding.loadedGroup.isVisible = false
                         // We need to set this to true here so we know not to show the gift dialog.
                         // There is no way to know what type of gift the upgrade came via the API
-                        settings.freeGiftAcknowledged.set(true, needsSync = true)
+                        settings.freeGiftAcknowledged.set(true, updateModifiedAt = true)
 
                         val result = Intent()
                         result.putExtra(AccountActivity.PROMO_CODE_RETURN_DESCRIPTION, it.response.description)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
@@ -184,7 +184,7 @@ class CreateAccountViewModel
         )
         newsletter.value = isChecked
         newsletter.value?.let {
-            settings.marketingOptIn.set(it, needsSync = true)
+            settings.marketingOptIn.set(it, updateModifiedAt = true)
         }
     }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingWelcomeViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingWelcomeViewModel.kt
@@ -34,7 +34,7 @@ class OnboardingWelcomeViewModel @Inject constructor(
             ),
         )
 
-        settings.marketingOptIn.set(newsletter, needsSync = true)
+        settings.marketingOptIn.set(newsletter, updateModifiedAt = true)
     }
 
     fun onShown(flow: OnboardingFlow) {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -109,7 +109,7 @@ class DiscoverViewModel @Inject constructor(
     }
 
     fun changeRegion(region: DiscoverRegion, resources: Resources) {
-        settings.discoverCountryCode.set(region.code, needsSync = false)
+        settings.discoverCountryCode.set(region.code, updateModifiedAt = false)
         currentRegionCode = region.code
         loadData(resources)
     }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -187,7 +187,7 @@ class FilterEpisodeListFragment : BaseFragment() {
         recyclerView.adapter = adapter
         listSavedState?.let { recyclerView.layoutManager?.onRestoreInstanceState(it) }
         setShowFilterOptions(showingFilterOptionsBeforeModal)
-        settings.trackingAutoPlaySource.set(AutoPlaySource.fromId(viewModel.playlistUUID), needsSync = false)
+        settings.trackingAutoPlaySource.set(AutoPlaySource.fromId(viewModel.playlistUUID), updateModifiedAt = false)
     }
 
     override fun onDestroyView() {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
@@ -157,7 +157,7 @@ class ShelfFragment : BaseFragment(), ShelfTouchCallback.ItemTouchHelperAdapter 
 
     override fun onShelfItemTouchHelperFinished(position: Int) {
         trackShelfItemMovedEvent(position)
-        settings.shelfItems.set(items.filterIsInstance<ShelfItem>(), needsSync = true)
+        settings.shelfItems.set(items.filterIsInstance<ShelfItem>(), updateModifiedAt = true)
     }
 
     private fun sectionTitleAt(position: Int) =

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -245,7 +245,7 @@ class BookmarksViewModel
 
     fun changeSortOrder(order: BookmarksSortType) {
         if (order !is BookmarksSortTypeDefault) return
-        sourceView.mapToBookmarksSortTypeUserSetting().set(order, needsSync = true)
+        sourceView.mapToBookmarksSortTypeUserSetting().set(order, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.BOOKMARKS_SORT_BY_CHANGED,
             mapOf(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -559,7 +559,7 @@ class PlayerViewModel @Inject constructor(
             if (podcast.overrideGlobalEffects) {
                 podcastManager.updateEffects(podcast, effects)
             } else {
-                settings.globalPlaybackEffects.set(effects, needsSync = true)
+                settings.globalPlaybackEffects.set(effects, updateModifiedAt = true)
             }
             playbackManager.updatePlayerEffects(effects)
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -195,7 +195,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             Mode.Downloaded -> AutoPlaySource.Downloads
             Mode.History -> AutoPlaySource.None
             Mode.Starred -> AutoPlaySource.Starred
-        }.let { settings.trackingAutoPlaySource.set(it, needsSync = false) }
+        }.let { settings.trackingAutoPlaySource.set(it, updateModifiedAt = false) }
     }
 
     override fun onDestroyView() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -546,7 +546,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
     override fun onResume() {
         super.onResume()
-        settings.trackingAutoPlaySource.set(AutoPlaySource.fromId(podcastUuid), needsSync = false)
+        settings.trackingAutoPlaySource.set(AutoPlaySource.fromId(podcastUuid), updateModifiedAt = false)
     }
 
     override fun onPause() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
@@ -46,7 +46,7 @@ class PodcastsOptionsDialog(
                     descriptionId = LR.string.podcasts_layout_large_grid,
                     isOn = { settings.podcastGridLayout.value == PodcastGridLayoutType.LARGE_ARTWORK },
                     click = {
-                        settings.podcastGridLayout.set(PodcastGridLayoutType.LARGE_ARTWORK, needsSync = true)
+                        settings.podcastGridLayout.set(PodcastGridLayoutType.LARGE_ARTWORK, updateModifiedAt = true)
                         trackTapOnModalOption(ModalOption.LAYOUT)
                         trackLayoutChanged(PodcastGridLayoutType.LARGE_ARTWORK)
                     },
@@ -56,7 +56,7 @@ class PodcastsOptionsDialog(
                     descriptionId = LR.string.podcasts_layout_small_grid,
                     isOn = { settings.podcastGridLayout.value == PodcastGridLayoutType.SMALL_ARTWORK },
                     click = {
-                        settings.podcastGridLayout.set(PodcastGridLayoutType.SMALL_ARTWORK, needsSync = true)
+                        settings.podcastGridLayout.set(PodcastGridLayoutType.SMALL_ARTWORK, updateModifiedAt = true)
                         trackTapOnModalOption(ModalOption.LAYOUT)
                         trackLayoutChanged(PodcastGridLayoutType.SMALL_ARTWORK)
                     },
@@ -66,7 +66,7 @@ class PodcastsOptionsDialog(
                     descriptionId = LR.string.podcasts_layout_list_view,
                     isOn = { settings.podcastGridLayout.value == PodcastGridLayoutType.LIST_VIEW },
                     click = {
-                        settings.podcastGridLayout.set(PodcastGridLayoutType.LIST_VIEW, needsSync = true)
+                        settings.podcastGridLayout.set(PodcastGridLayoutType.LIST_VIEW, updateModifiedAt = true)
                         trackTapOnModalOption(ModalOption.LAYOUT)
                         trackLayoutChanged(PodcastGridLayoutType.LIST_VIEW)
                     },
@@ -109,7 +109,7 @@ class PodcastsOptionsDialog(
                 titleId = order.labelId,
                 checked = order.clientId == sortOrder.clientId,
                 click = {
-                    settings.podcastsSortType.set(order, needsSync = true)
+                    settings.podcastsSortType.set(order, updateModifiedAt = true)
                     trackSortByChanged(order)
                 },
             )
@@ -130,7 +130,7 @@ class PodcastsOptionsDialog(
                 checked = badgeType == BadgeType.OFF,
                 click = {
                     val newBadgeType = BadgeType.OFF
-                    settings.podcastBadgeType.set(newBadgeType, needsSync = true)
+                    settings.podcastBadgeType.set(newBadgeType, updateModifiedAt = true)
                     trackBadgeChanged(newBadgeType)
                 },
             )
@@ -139,7 +139,7 @@ class PodcastsOptionsDialog(
                 checked = badgeType == BadgeType.ALL_UNFINISHED,
                 click = {
                     val newBadgeType = BadgeType.ALL_UNFINISHED
-                    settings.podcastBadgeType.set(newBadgeType, needsSync = true)
+                    settings.podcastBadgeType.set(newBadgeType, updateModifiedAt = true)
                     trackBadgeChanged(newBadgeType)
                 },
             )
@@ -148,7 +148,7 @@ class PodcastsOptionsDialog(
                 checked = badgeType == BadgeType.LATEST_EPISODE,
                 click = {
                     val newBadgeType = BadgeType.LATEST_EPISODE
-                    settings.podcastBadgeType.set(newBadgeType, needsSync = true)
+                    settings.podcastBadgeType.set(newBadgeType, updateModifiedAt = true)
                     trackBadgeChanged(newBadgeType)
                 },
             )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -395,7 +395,7 @@ class PodcastViewModel
 
     fun changeSortOrder(order: BookmarksSortType) {
         if (order !is BookmarksSortTypeForPodcast) return
-        settings.podcastBookmarksSortType.set(order, needsSync = true)
+        settings.podcastBookmarksSortType.set(order, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.BOOKMARKS_SORT_BY_CHANGED,
             mapOf(

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -244,7 +244,7 @@ class PodcastsViewModel
 
         val folder = folder
         if (folder == null) {
-            settings.podcastsSortType.set(PodcastsSortType.DRAG_DROP, needsSync = true)
+            settings.podcastsSortType.set(PodcastsSortType.DRAG_DROP, updateModifiedAt = true)
         } else {
             folderManager.updateSortType(folderUuid = folder.uuid, podcastsSortType = PodcastsSortType.DRAG_DROP)
         }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
@@ -108,7 +108,7 @@ class AccountDetailsViewModel
             AnalyticsEvent.NEWSLETTER_OPT_IN_CHANGED,
             mapOf(SOURCE_KEY to NewsletterSource.PROFILE.analyticsValue, ENABLED_KEY to isChecked),
         )
-        settings.marketingOptIn.set(isChecked, needsSync = true)
+        settings.marketingOptIn.set(isChecked, updateModifiedAt = true)
     }
 
     override fun onCleared() {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -141,7 +141,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
     override fun onResume() {
         super.onResume()
-        settings.trackingAutoPlaySource.set(AutoPlaySource.Files, needsSync = false)
+        settings.trackingAutoPlaySource.set(AutoPlaySource.Files, updateModifiedAt = false)
     }
 
     override fun onPause() {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
@@ -81,7 +81,7 @@ class CloudFilesViewModel @Inject constructor(
             AnalyticsEvent.UPLOADED_FILES_SORT_BY_CHANGED,
             mapOf(SORT_BY to sortOrder.analyticsValue),
         )
-        settings.cloudSortOrder.set(sortOrder, needsSync = true)
+        settings.cloudSortOrder.set(sortOrder, updateModifiedAt = true)
     }
 
     fun getSortOrder(): Settings.CloudSortOrder {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
@@ -33,7 +33,7 @@ class CloudSettingsViewModel @Inject constructor(
     }
 
     fun setAddToUpNext(enabled: Boolean) {
-        settings.cloudAddToUpNext.set(enabled, needsSync = true)
+        settings.cloudAddToUpNext.set(enabled, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_FILES_AUTO_ADD_UP_NEXT_TOGGLED,
             mapOf("enabled" to enabled),
@@ -41,7 +41,7 @@ class CloudSettingsViewModel @Inject constructor(
     }
 
     fun setDeleteLocalFileAfterPlaying(enabled: Boolean) {
-        settings.deleteLocalFileAfterPlaying.set(enabled, needsSync = true)
+        settings.deleteLocalFileAfterPlaying.set(enabled, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_FILES_DELETE_LOCAL_FILE_AFTER_PLAYING_TOGGLED,
             mapOf("enabled" to enabled),
@@ -49,7 +49,7 @@ class CloudSettingsViewModel @Inject constructor(
     }
 
     fun setDeleteCloudFileAfterPlaying(enabled: Boolean) {
-        settings.deleteCloudFileAfterPlaying.set(enabled, needsSync = true)
+        settings.deleteCloudFileAfterPlaying.set(enabled, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_FILES_DELETE_CLOUD_FILE_AFTER_PLAYING_TOGGLED,
             mapOf("enabled" to enabled),
@@ -57,7 +57,7 @@ class CloudSettingsViewModel @Inject constructor(
     }
 
     fun setCloudAutoUpload(enabled: Boolean) {
-        settings.cloudAutoUpload.set(enabled, needsSync = true)
+        settings.cloudAutoUpload.set(enabled, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_FILES_AUTO_UPLOAD_TO_CLOUD_TOGGLED,
             mapOf("enabled" to enabled),
@@ -65,7 +65,7 @@ class CloudSettingsViewModel @Inject constructor(
     }
 
     fun setCloudAutoDownload(enabled: Boolean) {
-        settings.cloudAutoDownload.set(enabled, needsSync = true)
+        settings.cloudAutoDownload.set(enabled, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_FILES_AUTO_DOWNLOAD_FROM_CLOUD_TOGGLED,
             mapOf("enabled" to enabled),
@@ -73,7 +73,7 @@ class CloudSettingsViewModel @Inject constructor(
     }
 
     fun setCloudOnlyWifi(enabled: Boolean) {
-        settings.cloudDownloadOnlyOnWifi.set(enabled, needsSync = true)
+        settings.cloudDownloadOnlyOnWifi.set(enabled, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_FILES_ONLY_ON_WIFI_TOGGLED,
             mapOf("enabled" to enabled),

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsFragment.kt
@@ -102,7 +102,7 @@ class HeadphoneControlsSettingsFragment : BaseFragment() {
             onNextActionSave = { viewModel.onNextActionSave(it) },
             onPreviousActionSave = { viewModel.onPreviousActionSave(it) },
             onConfirmationSoundSave = { newValue ->
-                settings.headphoneControlsPlayBookmarkConfirmationSound.set(newValue, needsSync = true)
+                settings.headphoneControlsPlayBookmarkConfirmationSound.set(newValue, updateModifiedAt = true)
                 if (newValue) {
                     playbackManager.playTone()
                 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
@@ -81,7 +81,7 @@ class HeadphoneControlsSettingsPageViewModel @Inject constructor(
 
     fun onNextActionSave(action: HeadphoneAction) {
         if (action.canSave()) {
-            settings.headphoneControlsNextAction.set(action, needsSync = true)
+            settings.headphoneControlsNextAction.set(action, updateModifiedAt = true)
             trackHeadphoneAction(action, AnalyticsEvent.SETTINGS_HEADPHONE_CONTROLS_NEXT_CHANGED)
         } else {
             _state.update { it.copy(startUpsellFromSource = UpsellSourceAction.NEXT) }
@@ -90,7 +90,7 @@ class HeadphoneControlsSettingsPageViewModel @Inject constructor(
 
     fun onPreviousActionSave(action: HeadphoneAction) {
         if (action.canSave()) {
-            settings.headphoneControlsPreviousAction.set(action, needsSync = true)
+            settings.headphoneControlsPreviousAction.set(action, updateModifiedAt = true)
             trackHeadphoneAction(action, AnalyticsEvent.SETTINGS_HEADPHONE_CONTROLS_PREVIOUS_CHANGED)
         } else {
             _state.update { it.copy(startUpsellFromSource = UpsellSourceAction.PREVIOUS) }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/MediaNotificationControlsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/MediaNotificationControlsFragment.kt
@@ -139,7 +139,7 @@ class MediaNotificationControlsFragment : BaseFragment(), MediaActionTouchCallba
                     ShowCustomMediaActionsSettingsRow(
                         shouldShowCustomMediaActions = settings.customMediaActionsVisibility.flow.collectAsState().value,
                         onShowCustomMediaActionsToggled = { showCustomActions ->
-                            settings.customMediaActionsVisibility.set(showCustomActions, needsSync = true)
+                            settings.customMediaActionsVisibility.set(showCustomActions, updateModifiedAt = true)
                             updateMediaActionsVisibility(showCustomActions)
                         },
                     )
@@ -282,7 +282,7 @@ class MediaNotificationControlsFragment : BaseFragment(), MediaActionTouchCallba
         // Reset mediaActionMove now that we've tracked it
         mediaActionMove = null
 
-        settings.mediaControlItems.set(items.filterIsInstance<Settings.MediaNotificationControls>(), needsSync = true)
+        settings.mediaControlItems.set(items.filterIsInstance<Settings.MediaNotificationControls>(), updateModifiedAt = true)
     }
 }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
@@ -117,7 +117,7 @@ class NotificationsSettingsFragment :
 
         hidePlaybackNotificationsPreference?.setOnPreferenceChangeListener { _, newValue ->
             val newBool = (newValue as? Boolean) ?: throw IllegalStateException("Invalid value for hide notification on pause preference: $newValue")
-            settings.hideNotificationOnPause.set(newBool, needsSync = true)
+            settings.hideNotificationOnPause.set(newBool, updateModifiedAt = true)
             analyticsTracker.track(
                 AnalyticsEvent.SETTINGS_NOTIFICATIONS_HIDE_PLAYBACK_NOTIFICATION_ON_PAUSE,
                 mapOf("enabled" to newBool),
@@ -131,7 +131,7 @@ class NotificationsSettingsFragment :
             }
             settings.notificationVibrate.set(
                 value = newSetting ?: NotificationVibrateSetting.DEFAULT,
-                needsSync = false,
+                updateModifiedAt = false,
             )
             changeVibrateSummary()
             analyticsTracker.track(
@@ -145,7 +145,7 @@ class NotificationsSettingsFragment :
                 ?.let { PlayOverNotificationSetting.fromPreferenceString(it) }
                 ?: throw IllegalStateException("Invalid value for play over notification preference: $newValue")
 
-            settings.playOverNotification.set(playOverNotificationSetting, needsSync = true)
+            settings.playOverNotification.set(playOverNotificationSetting, updateModifiedAt = true)
             changePlayOverNotificationSummary()
 
             analyticsTracker.track(
@@ -224,7 +224,7 @@ class NotificationsSettingsFragment :
             val ringtone = data.getParcelableExtra<Uri>(RingtoneManager.EXTRA_RINGTONE_PICKED_URI)
             val value = ringtone?.toString() ?: ""
             context?.let {
-                settings.notificationSound.set(NotificationSound(value, it), needsSync = false)
+                settings.notificationSound.set(NotificationSound(value, it), updateModifiedAt = false)
                 ringtonePreference?.summary = getRingtoneValue(value)
                 analyticsTracker.track(AnalyticsEvent.SETTINGS_NOTIFICATIONS_SOUND_CHANGED)
             } ?: Timber.e("Context was null when trying to set notification sound")
@@ -263,7 +263,7 @@ class NotificationsSettingsFragment :
                                 if (madeChange) {
                                     trackActionsChange(selectedActions)
                                 }
-                                settings.newEpisodeNotificationActions.set(selectedActions, needsSync = true)
+                                settings.newEpisodeNotificationActions.set(selectedActions, updateModifiedAt = true)
                                 changeActionsSummary()
                             },
                         )
@@ -420,7 +420,7 @@ class NotificationsSettingsFragment :
 
                 enabledPreference?.setOnPreferenceChangeListener { _, newValue ->
                     val checked = newValue as Boolean
-                    settings.notifyRefreshPodcast.set(checked, needsSync = true)
+                    settings.notifyRefreshPodcast.set(checked, updateModifiedAt = true)
 
                     analyticsTracker.track(
                         AnalyticsEvent.SETTINGS_NOTIFICATIONS_NEW_EPISODES_TOGGLED,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -153,7 +153,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                     },
                                 ),
                             )
-                            settings.streamingMode.set(it, needsSync = true)
+                            settings.streamingMode.set(it, updateModifiedAt = true)
                         },
                     )
 
@@ -169,7 +169,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                     },
                                 ),
                             )
-                            settings.upNextSwipe.set(it, needsSync = true)
+                            settings.upNextSwipe.set(it, updateModifiedAt = true)
                         },
                     )
 
@@ -188,7 +188,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                     },
                                 ),
                             )
-                            settings.podcastGroupingDefault.set(it, needsSync = true)
+                            settings.podcastGroupingDefault.set(it, updateModifiedAt = true)
                             showSetAllGroupingDialog(it)
                         },
                     )
@@ -205,7 +205,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                     },
                                 ),
                             )
-                            settings.showArchivedDefault.set(it, needsSync = true)
+                            settings.showArchivedDefault.set(it, updateModifiedAt = true)
                             showSetAllArchiveDialog(it)
                         },
                     )
@@ -231,7 +231,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                 AnalyticsEvent.SETTINGS_GENERAL_SKIP_FORWARD_CHANGED,
                                 mapOf("value" to it),
                             )
-                            settings.skipForwardInSecs.set(it, needsSync = true)
+                            settings.skipForwardInSecs.set(it, updateModifiedAt = true)
                         },
                     )
 
@@ -244,7 +244,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                 AnalyticsEvent.SETTINGS_GENERAL_SKIP_BACK_CHANGED,
                                 mapOf("value" to it),
                             )
-                            settings.skipBackInSecs.set(it, needsSync = true)
+                            settings.skipBackInSecs.set(it, updateModifiedAt = true)
                         },
                     )
 
@@ -255,7 +255,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                 AnalyticsEvent.SETTINGS_GENERAL_KEEP_SCREEN_AWAKE_TOGGLED,
                                 mapOf("enabled" to it),
                             )
-                            settings.keepScreenAwake.set(it, needsSync = true)
+                            settings.keepScreenAwake.set(it, updateModifiedAt = true)
                         },
                     )
 
@@ -266,7 +266,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                 AnalyticsEvent.SETTINGS_GENERAL_OPEN_PLAYER_AUTOMATICALLY_TOGGLED,
                                 mapOf("enabled" to it),
                             )
-                            settings.openPlayerAutomatically.set(it, needsSync = true)
+                            settings.openPlayerAutomatically.set(it, updateModifiedAt = true)
                         },
                     )
 
@@ -277,7 +277,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                 AnalyticsEvent.SETTINGS_GENERAL_INTELLIGENT_PLAYBACK_TOGGLED,
                                 mapOf("enabled" to it),
                             )
-                            settings.intelligentPlaybackResumption.set(it, needsSync = true)
+                            settings.intelligentPlaybackResumption.set(it, updateModifiedAt = true)
                         },
                     )
 
@@ -288,7 +288,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                 AnalyticsEvent.SETTINGS_GENERAL_PLAY_UP_NEXT_ON_TAP_TOGGLED,
                                 mapOf("enabled" to it),
                             )
-                            settings.tapOnUpNextShouldPlay.set(it, needsSync = true)
+                            settings.tapOnUpNextShouldPlay.set(it, updateModifiedAt = true)
                         },
                     )
 
@@ -308,7 +308,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                                 AnalyticsEvent.SETTINGS_GENERAL_AUTOPLAY_TOGGLED,
                                 mapOf("enabled" to it),
                             )
-                            settings.autoPlayNextEpisodeOnEmpty.set(it, needsSync = true)
+                            settings.autoPlayNextEpisodeOnEmpty.set(it, updateModifiedAt = true)
                         },
                     )
                 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
@@ -34,13 +34,13 @@ class UserAnalyticsSettings @Inject constructor(
         } else {
             SentryAndroid.init(context) { it.dsn = "" }
         }
-        settings.sendCrashReports.set(enabled, needsSync = true)
+        settings.sendCrashReports.set(enabled, updateModifiedAt = true)
     }
 
     fun updateLinkAccountSetting(enabled: Boolean) {
         val user = if (enabled) User().apply { email = syncManager.getEmail() } else null
         Sentry.setUser(user)
 
-        settings.linkCrashReportsToUser.set(enabled, needsSync = true)
+        settings.linkCrashReportsToUser.set(enabled, updateModifiedAt = true)
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoAddSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoAddSettingsViewModel.kt
@@ -73,7 +73,7 @@ class AutoAddSettingsViewModel @Inject constructor(
     }
 
     fun autoAddUpNextLimitChanged(limit: Int) {
-        settings.autoAddUpNextLimit.set(limit, needsSync = true)
+        settings.autoAddUpNextLimit.set(limit, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_ADD_UP_NEXT_AUTO_ADD_LIMIT_CHANGED,
             mapOf("value" to limit),
@@ -81,7 +81,7 @@ class AutoAddSettingsViewModel @Inject constructor(
     }
 
     fun autoAddUpNextLimitBehaviorChanged(behavior: AutoAddUpNextLimitBehaviour) {
-        settings.autoAddUpNextLimitBehaviour.set(behavior, needsSync = true)
+        settings.autoAddUpNextLimitBehaviour.set(behavior, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_ADD_UP_NEXT_LIMIT_REACHED_CHANGED,
             mapOf(

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoArchiveFragmentViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoArchiveFragmentViewModel.kt
@@ -26,7 +26,7 @@ class AutoArchiveFragmentViewModel @Inject constructor(
     }
 
     fun onStarredChanged(newValue: Boolean) {
-        settings.autoArchiveIncludesStarred.set(newValue, needsSync = true)
+        settings.autoArchiveIncludesStarred.set(newValue, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_ARCHIVE_INCLUDE_STARRED_TOGGLED,
             mapOf("enabled" to newValue),
@@ -35,7 +35,7 @@ class AutoArchiveFragmentViewModel @Inject constructor(
 
     fun onPlayedEpisodesAfterChanged(newStringValue: String) {
         val newValue = AutoArchiveAfterPlaying.fromString(newStringValue, context)
-        settings.autoArchiveAfterPlaying.set(newValue, needsSync = true)
+        settings.autoArchiveAfterPlaying.set(newValue, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_ARCHIVE_PLAYED_CHANGED,
             mapOf("value" to newValue.analyticsValue),
@@ -44,7 +44,7 @@ class AutoArchiveFragmentViewModel @Inject constructor(
 
     fun onInactiveChanged(newStringValue: String) {
         val newValue = AutoArchiveInactive.fromString(newStringValue, context)
-        settings.autoArchiveInactive.set(newValue, needsSync = true)
+        settings.autoArchiveInactive.set(newValue, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_ARCHIVE_INACTIVE_CHANGED,
             mapOf("value" to newValue.analyticsValue),

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -34,7 +34,7 @@ class AutoDownloadSettingsViewModel @Inject constructor(
     }
 
     fun onUpNextChange(newValue: Boolean) {
-        settings.autoDownloadUpNext.set(newValue, needsSync = true)
+        settings.autoDownloadUpNext.set(newValue, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_UP_NEXT_TOGGLED,
             mapOf("enabled" to newValue),
@@ -63,7 +63,7 @@ class AutoDownloadSettingsViewModel @Inject constructor(
     }
 
     fun onDownloadOnlyOnUnmeteredChange(enabled: Boolean) {
-        settings.autoDownloadUnmeteredOnly.set(enabled, needsSync = true)
+        settings.autoDownloadUnmeteredOnly.set(enabled, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_ONLY_ON_WIFI_TOGGLED,
             mapOf("enabled" to enabled),
@@ -73,7 +73,7 @@ class AutoDownloadSettingsViewModel @Inject constructor(
     fun getAutoDownloadUnmeteredOnly() = settings.autoDownloadUnmeteredOnly.value
 
     fun onDownloadOnlyWhenChargingChange(enabled: Boolean) {
-        settings.autoDownloadOnlyWhenCharging.set(enabled, needsSync = true)
+        settings.autoDownloadOnlyWhenCharging.set(enabled, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_ONLY_WHEN_CHARGING_TOGGLED,
             mapOf("enabled" to enabled),

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
@@ -108,7 +108,7 @@ class SettingsAppearanceViewModel @Inject constructor(
     }
 
     fun updateUpNextDarkTheme(value: Boolean) {
-        settings.useDarkUpNextTheme.set(value, needsSync = true)
+        settings.useDarkUpNextTheme.set(value, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_APPEARANCE_USE_DARK_UP_NEXT_TOGGLED,
             mapOf("enabled" to value),
@@ -116,7 +116,7 @@ class SettingsAppearanceViewModel @Inject constructor(
     }
 
     fun updateWidgetForDynamicColors(value: Boolean) {
-        settings.useDynamicColorsForWidget.set(value, needsSync = true)
+        settings.useDynamicColorsForWidget.set(value, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_APPEARANCE_USE_DYNAMIC_COLORS_WIDGET_TOGGLED,
             mapOf("enabled" to value),
@@ -124,7 +124,7 @@ class SettingsAppearanceViewModel @Inject constructor(
     }
 
     fun updateShowArtworkOnLockScreen(value: Boolean) {
-        settings.showArtworkOnLockScreen.set(value, needsSync = true)
+        settings.showArtworkOnLockScreen.set(value, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_APPEARANCE_SHOW_ARTWORK_ON_LOCK_SCREEN_TOGGLED,
             mapOf("enabled" to value),
@@ -132,7 +132,7 @@ class SettingsAppearanceViewModel @Inject constructor(
     }
 
     fun updateUseEpisodeArtwork(value: Boolean) {
-        settings.useEpisodeArtwork.set(value, needsSync = true)
+        settings.useEpisodeArtwork.set(value, updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_APPEARANCE_USE_EPISODE_ARTWORK_TOGGLED,
             mapOf("enabled" to value),

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
@@ -159,7 +159,7 @@ class StorageSettingsViewModel
     }
 
     private fun onStorageDataWarningCheckedChange(isChecked: Boolean) {
-        settings.warnOnMeteredNetwork.set(isChecked, needsSync = true)
+        settings.warnOnMeteredNetwork.set(isChecked, updateModifiedAt = true)
         updateMobileDataWarningState()
     }
 
@@ -172,7 +172,7 @@ class StorageSettingsViewModel
     }
 
     private fun onBackgroundRefreshCheckedChange(isChecked: Boolean) {
-        settings.backgroundRefreshPodcasts.set(isChecked, needsSync = true)
+        settings.backgroundRefreshPodcasts.set(isChecked, updateModifiedAt = true)
         updateBackgroundRefreshState()
     }
 

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -103,7 +103,7 @@ class AppLifecycleObserver constructor(
             appLifecycleAnalytics.onNewApplicationInstall()
 
             // new installs default to not forcing up next to use the dark theme
-            settings.useDarkUpNextTheme.set(false, needsSync = false)
+            settings.useDarkUpNextTheme.set(false, updateModifiedAt = false)
 
             when (getAppPlatform()) {
                 // do nothing because this already defaults to true for all users on automotive
@@ -113,7 +113,7 @@ class AppLifecycleObserver constructor(
                 AppPlatform.WearOs -> {}
 
                 // For new users we want to auto play when the queue is empty by default
-                AppPlatform.Phone -> settings.autoPlayNextEpisodeOnEmpty.set(true, needsSync = false)
+                AppPlatform.Phone -> settings.autoPlayNextEpisodeOnEmpty.set(true, updateModifiedAt = false)
             }
         } else if (previousVersionCode < versionCode) {
             appLifecycleAnalytics.onApplicationUpgrade(previousVersionCode)

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
@@ -93,8 +93,8 @@ class AppLifecycleObserverTest {
         appLifecycleObserver.setup()
 
         verify(appLifecycleAnalytics).onNewApplicationInstall()
-        verify(autoPlayNextEpisodeSetting).set(true, needsSync = false)
-        verify(useUpNextDarkThemeSetting).set(false, needsSync = false)
+        verify(autoPlayNextEpisodeSetting).set(true, updateModifiedAt = false)
+        verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
 
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
     }
@@ -111,7 +111,7 @@ class AppLifecycleObserverTest {
         verify(appLifecycleAnalytics).onNewApplicationInstall()
 
         verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
-        verify(useUpNextDarkThemeSetting).set(false, needsSync = false)
+        verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
     }
 
@@ -127,7 +127,7 @@ class AppLifecycleObserverTest {
         verify(appLifecycleAnalytics).onNewApplicationInstall()
 
         verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
-        verify(useUpNextDarkThemeSetting).set(false, needsSync = false)
+        verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
     }
 

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
@@ -86,7 +86,7 @@ class ActionRunnerControlPlayback : TaskerPluginRunnerActionNoOutput<InputContro
         if (overrideGlobalEffects) {
             podcastManager.updateEffects(currentPodcast, playbackEffects)
         } else {
-            settings.globalPlaybackEffects.set(playbackEffects, needsSync = true)
+            settings.globalPlaybackEffects.set(playbackEffects, updateModifiedAt = true)
         }
         playbackManager.updatePlayerEffects(playbackEffects)
     }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTracker.kt
@@ -35,7 +35,7 @@ object AnalyticsTracker {
 
     fun setSendUsageStats(send: Boolean) {
         if (send != getSendUsageStats()) {
-            settings.collectAnalytics.set(send, needsSync = true)
+            settings.collectAnalytics.set(send, updateModifiedAt = true)
             if (!send) {
                 trackers.forEach { it.clearAllData() }
             }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -463,10 +463,10 @@ class SettingsImpl @Inject constructor(
     }
 
     override fun clearPlusPreferences() {
-        deleteCloudFileAfterPlaying.set(false, needsSync = false)
-        cloudAutoUpload.set(false, needsSync = false)
-        cloudAutoDownload.set(false, needsSync = false)
-        cloudDownloadOnlyOnWifi.set(false, needsSync = false)
+        deleteCloudFileAfterPlaying.set(false, updateModifiedAt = false)
+        cloudAutoUpload.set(false, updateModifiedAt = false)
+        cloudAutoDownload.set(false, updateModifiedAt = false)
+        cloudDownloadOnlyOnWifi.set(false, updateModifiedAt = false)
         setCancelledAcknowledged(false)
     }
 
@@ -555,9 +555,9 @@ class SettingsImpl @Inject constructor(
         }
 
         override fun persist(value: PlaybackEffects, commit: Boolean) {
-            globalPlaybackSpeed.set(value.playbackSpeed, needsSync = false)
-            globalAudioEffectRemoveSilence.set(value.trimMode, needsSync = false)
-            globalAudioEffectVolumeBoost.set(value.isVolumeBoosted, needsSync = false)
+            globalPlaybackSpeed.set(value.playbackSpeed, updateModifiedAt = false)
+            globalAudioEffectRemoveSilence.set(value.trimMode, updateModifiedAt = false)
+            globalAudioEffectVolumeBoost.set(value.isVolumeBoosted, updateModifiedAt = false)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
@@ -191,11 +191,11 @@ class VersionMigrationsJob : JobService() {
     private fun performV7Migration() {
         // We want v6 users to keep defaulting to download, new users should get the new stream default
         val currentStreamingPreference = if (settings.contains(Settings.PREFERENCE_GLOBAL_STREAMING_MODE)) settings.streamingMode.value else false
-        settings.streamingMode.set(currentStreamingPreference, needsSync = false)
+        settings.streamingMode.set(currentStreamingPreference, updateModifiedAt = false)
     }
 
     private fun addUpNextAutoDownload() {
-        settings.autoDownloadUpNext.set(!settings.streamingMode.value, needsSync = false)
+        settings.autoDownloadUpNext.set(!settings.streamingMode.value, updateModifiedAt = false)
     }
 
     private fun deletePodcastImages() {
@@ -245,7 +245,7 @@ class VersionMigrationsJob : JobService() {
         if (!Util.isWearOs(context) && !Util.isAutomotive(context)) {
             val useEpisodeArtwork = settings.getBooleanForKey("useEpisodeArtwork", false)
             val useFileArtwork = settings.getBooleanForKey("useEmbeddedArtwork", false)
-            settings.useEpisodeArtwork.set(useEpisodeArtwork || useFileArtwork, needsSync = true)
+            settings.useEpisodeArtwork.set(useEpisodeArtwork || useFileArtwork, updateModifiedAt = true)
         }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -763,7 +763,7 @@ class MediaSessionManager(
             // update global playback speed
             val effects = settings.globalPlaybackEffects.value
             effects.playbackSpeed = newSpeed
-            settings.globalPlaybackEffects.set(effects, needsSync = true)
+            settings.globalPlaybackEffects.set(effects, updateModifiedAt = true)
             playbackManager.updatePlayerEffects(effects = effects)
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -552,7 +552,7 @@ open class PlaybackManager @Inject constructor(
             -> {
                 val source = (episode as? PodcastEpisode)?.let { AutoPlaySource.fromId(it.uuid) }
                 if (source != null) {
-                    settings.trackingAutoPlaySource.set(source, needsSync = false)
+                    settings.trackingAutoPlaySource.set(source, updateModifiedAt = false)
                 }
                 source
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
@@ -168,7 +168,7 @@ class UpNextQueueImpl @Inject constructor(
         if (queueEpisodes.isEmpty()) {
             // when the upNextQueue is empty, save the source for auto playing the next episode
             automaticUpNextSource?.let {
-                settings.lastAutoPlaySource.set(value = it, needsSync = true)
+                settings.lastAutoPlaySource.set(value = it, updateModifiedAt = true)
             }
             saveChanges(UpNextAction.ClearAll)
         }
@@ -312,8 +312,8 @@ class UpNextQueueImpl @Inject constructor(
         // clear last loaded uuid if anything gets added to the up next queue
         val hasQueuedItems = currentEpisode != null
         if (hasQueuedItems) {
-            settings.trackingAutoPlaySource.set(AutoPlaySource.None, needsSync = false)
-            settings.lastAutoPlaySource.set(AutoPlaySource.None, needsSync = true)
+            settings.trackingAutoPlaySource.set(AutoPlaySource.None, updateModifiedAt = false)
+            settings.lastAutoPlaySource.set(AutoPlaySource.None, updateModifiedAt = true)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -594,7 +594,7 @@ class PodcastManagerImpl @Inject constructor(
 
     override suspend fun updateAllShowNotifications(showNotifications: Boolean) {
         if (showNotifications) {
-            settings.notifyRefreshPodcast.set(true, needsSync = true)
+            settings.notifyRefreshPodcast.set(true, updateModifiedAt = true)
         }
         podcastDao.updateAllShowNotifications(showNotifications)
     }
@@ -656,7 +656,7 @@ class PodcastManagerImpl @Inject constructor(
 
     override fun updateShowNotifications(podcast: Podcast, show: Boolean) {
         if (show) {
-            settings.notifyRefreshPodcast.set(true, needsSync = true)
+            settings.notifyRefreshPodcast.set(true, updateModifiedAt = true)
         }
         podcastDao.updateShowNotifications(show, podcast.uuid)
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -68,7 +68,7 @@ class SubscriptionManagerImpl @Inject constructor(
 
     private var cachedSubscriptionStatus: SubscriptionStatus?
         get() = settings.cachedSubscriptionStatus.value
-        set(value) = settings.cachedSubscriptionStatus.set(value, needsSync = false)
+        set(value) = settings.cachedSubscriptionStatus.set(value, updateModifiedAt = false)
 
     private var subscriptionStatus = BehaviorRelay.create<Optional<SubscriptionStatus>>().apply {
         val cachedStatus = cachedSubscriptionStatus

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -113,7 +113,7 @@ class UserManagerImpl @Inject constructor(
                     userEpisodeManager.removeCloudStatusFromFiles(playbackManager)
                 }
 
-                settings.marketingOptIn.set(false, needsSync = false)
+                settings.marketingOptIn.set(false, updateModifiedAt = false)
                 settings.setEndOfYearShowModal(true)
 
                 analyticsTracker.track(

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -613,7 +613,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
             }
 
             val localModifiedAt = setting.modifiedAt
-            if (localModifiedAt > serverModifiedAt) {
+            if ((localModifiedAt ?: Instant.EPOCH) >= serverModifiedAt) {
                 Timber.i("Not syncing ${setting.sharedPrefKey} value of $newSettingValue from the server because setting was modified more recently locally")
                 return null
             }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -496,7 +496,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                             newSettingValue = (changedSettingResponse.value as? String)?.let(AutoPlaySource::fromServerId),
                         )
                         if (syncedValue != null) {
-                            settings.trackingAutoPlaySource.set(syncedValue, needsSync = false)
+                            settings.trackingAutoPlaySource.set(syncedValue, updateModifiedAt = false)
                         }
                     }
                     "notificationActions" -> updateSettingIfPossible(
@@ -620,7 +620,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
 
             setting.set(
                 value = newSettingValue,
-                needsSync = false,
+                updateModifiedAt = false,
             )
             return newSettingValue
         }
@@ -648,17 +648,17 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
 
                     if (value.value is Number) { // Probably will have to change this when we do other settings, but for now just Number is fine
                         when (key) {
-                            "skipForward" -> settings.skipForwardInSecs.set(value.value.toInt(), needsSync = false)
-                            "skipBack" -> settings.skipBackInSecs.set(value.value.toInt(), needsSync = false)
+                            "skipForward" -> settings.skipForwardInSecs.set(value.value.toInt(), updateModifiedAt = false)
+                            "skipBack" -> settings.skipBackInSecs.set(value.value.toInt(), updateModifiedAt = false)
                             "gridOrder" -> {
                                 val sortType = PodcastsSortType.fromServerId(value.value.toInt())
-                                settings.podcastsSortType.set(sortType, needsSync = false)
+                                settings.podcastsSortType.set(sortType, updateModifiedAt = false)
                             }
                         }
                     } else if (value.value is Boolean) {
                         when (key) {
-                            "marketingOptIn" -> settings.marketingOptIn.set(value.value, needsSync = false)
-                            "freeGiftAcknowledgement" -> settings.freeGiftAcknowledged.set(value.value, needsSync = false)
+                            "marketingOptIn" -> settings.marketingOptIn.set(value.value, updateModifiedAt = false)
+                            "freeGiftAcknowledgement" -> settings.freeGiftAcknowledged.set(value.value, updateModifiedAt = false)
                         }
                     }
                 } else {

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/AppIcon.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/AppIcon.kt
@@ -213,7 +213,7 @@ class AppIcon @Inject constructor(
     var activeAppIcon: AppIconType = AppIconType.fromSetting(settings.appIcon.value)
         set(value) {
             field = value
-            settings.appIcon.set(value.setting, needsSync = false)
+            settings.appIcon.set(value.setting, updateModifiedAt = false)
         }
 
     val allAppIconTypes = AppIconType.values()

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
@@ -271,7 +271,7 @@ class Theme @Inject constructor(private val settings: Settings) {
         ThemeType.fromThemeSetting(settings.theme.value)
 
     private fun setThemeToPreferences(theme: ThemeType) {
-        settings.theme.set(theme.themeSetting, needsSync = true)
+        settings.theme.set(theme.themeSetting, updateModifiedAt = true)
     }
 
     private fun getPreferredDarkThemeFromPreferences(): ThemeType =
@@ -281,15 +281,15 @@ class Theme @Inject constructor(private val settings: Settings) {
         ThemeType.fromThemeSetting(settings.lightThemePreference.value)
 
     private fun setPreferredDarkThemeToPreferences(theme: ThemeType) {
-        settings.darkThemePreference.set(theme.themeSetting, needsSync = true)
+        settings.darkThemePreference.set(theme.themeSetting, updateModifiedAt = true)
     }
 
     private fun setPreferredLightThemeToPreferences(theme: ThemeType) {
-        settings.lightThemePreference.set(theme.themeSetting, needsSync = true)
+        settings.lightThemePreference.set(theme.themeSetting, updateModifiedAt = true)
     }
 
     fun setUseSystemTheme(value: Boolean, activity: AppCompatActivity?) {
-        settings.useSystemTheme.set(value, commit = true, needsSync = true)
+        settings.useSystemTheme.set(value, commit = true, updateModifiedAt = true)
 
         if (value && activity != null) {
             setupThemeForConfig(activity, activity.resources.configuration)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/EffectsViewModel.kt
@@ -66,7 +66,7 @@ class EffectsViewModel
         val effects = effectsData.toEffects()
         viewModelScope.launch {
             playbackManager.updatePlayerEffects(effects)
-            settings.globalPlaybackEffects.set(effects, needsSync = true)
+            settings.globalPlaybackEffects.set(effects, updateModifiedAt = true)
         }
     }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsViewModel.kt
@@ -72,11 +72,11 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun setWarnOnMeteredNetwork(warnOnMeteredNetwork: Boolean) {
-        settings.warnOnMeteredNetwork.set(warnOnMeteredNetwork, needsSync = true)
+        settings.warnOnMeteredNetwork.set(warnOnMeteredNetwork, updateModifiedAt = true)
     }
 
     fun setRefreshPodcastsInBackground(isChecked: Boolean) {
-        settings.backgroundRefreshPodcasts.set(isChecked, needsSync = true)
+        settings.backgroundRefreshPodcasts.set(isChecked, updateModifiedAt = true)
     }
 
     fun signOut() {


### PR DESCRIPTION
## Description

`needsSync` property on `UserSetting` lost its meaning when we switched to always syncing all settings due to legacy reasons. This PR changes behavior of modification timestamp so it never gets cleared - only not updated.

## Testing Instructions

Smoke test named settings syncing.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
