### PR TITLE
Fix play button drawable update

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -79,7 +79,9 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
 
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
         super.onLayout(changed, left, top, right, bottom)
-        updatePlayButton(isPlaying = playing, animate = false)
+        if (changed) {
+            updatePlayButton(isPlaying = playing, animate = false)
+        }
     }
 
     override fun onSaveInstanceState(): Parcelable {


### PR DESCRIPTION
## Description

This fixes the play button sometimes showing incorrect drawable in the mini-player. 

Fixes #2017

## Testing Instructions
1. Play an episode
2. Tap the play button in the mini-player a few times
3. Notice that the play button displays a drawable that matches the actual play state

## Screenshots or Screencast 
 
https://github.com/Automattic/pocket-casts-android/assets/1405144/1bd4faed-428b-4e3d-8ccf-6c0ec46ec6c7


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
