### PR TITLE
 Update settings only if remote timestamp is greater than the local one

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/preferences/UserSettingTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/preferences/UserSettingTest.kt
@@ -6,6 +6,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.utils.MutableClock
 import java.time.Instant
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -42,7 +43,7 @@ class UserSettingTest {
         userSetting.set("new_value", clock = clock, updateModifiedAt = false)
 
         assertEquals("new_value", userSetting.value)
-        assertEquals(Instant.EPOCH, userSetting.modifiedAt)
+        assertNull(userSetting.modifiedAt)
     }
 
     @Test
@@ -75,6 +76,27 @@ class UserSettingTest {
 
             cancel()
         }
+    }
+
+    @Test
+    fun useEpochPlusOneAsDefaultSyncTimestamp() {
+        lateinit var timestamp: Instant
+        userSetting.getSyncSetting { _, modifiedAt ->
+            timestamp = modifiedAt
+        }
+        assertEquals(Instant.EPOCH.plusMillis(1), timestamp)
+    }
+
+    @Test
+    fun useStoredSyncTimestamp() {
+        clock += 1.seconds
+        userSetting.set("new_value", clock = clock, updateModifiedAt = true)
+
+        lateinit var timestamp: Instant
+        userSetting.getSyncSetting { _, modifiedAt ->
+            timestamp = modifiedAt
+        }
+        assertEquals(clock.instant(), timestamp)
     }
 
     private class ReversingToSetting(

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -613,7 +613,7 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
             }
 
             val localModifiedAt = setting.modifiedAt
-            if (localModifiedAt > serverModifiedAt) {
+            if ((localModifiedAt ?: Instant.EPOCH) >= serverModifiedAt) {
                 Timber.i("Not syncing ${setting.sharedPrefKey} value of $newSettingValue from the server because setting was modified more recently locally")
                 return null
             }


### PR DESCRIPTION
## Description

This PR addresses two things.

1. Update local setting values only if remote timestamp is greater than the local one. Previously it was greater or equal.
2. Use `EPOCH +1 millisecond` as a default timestamp when syncing. This is to prevent a scenario where users sync their devices with settings changed before we started tracking modification timestamp, and then they switch to a new device. This way we compare local `EPOCH` to `EPOCH +1` which will update.

## Testing Instructions

Do some regressions tests for named settings syncing.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
