### PR TITLE
Profile bookmarks - Add search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   New Features
     *   Allow sharing of bookmarks from bookmarks list
         ([#2022](https://github.com/Automattic/pocket-casts-android/pull/2022))
+    *   Add profile bookmark screen where all user bookmarks can be managed
+        ([#2037](https://github.com/Automattic/pocket-casts-android/pull/2037))
 
 7.61
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
@@ -37,6 +37,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.HeaderRow
+import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.NoBookmarksInSearchView
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.NoBookmarksView
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.UpsellView
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel
@@ -176,7 +177,6 @@ private fun BookmarksView(
                     text = state.searchText,
                     placeholder = stringResource(LR.string.search),
                     onTextChanged = onSearchTextChanged,
-                    onSearch = {},
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp, vertical = 8.dp)
@@ -184,21 +184,28 @@ private fun BookmarksView(
                 )
             }
         }
-        item {
-            val title = stringResource(
-                id = if (state.bookmarks.size > 1) {
-                    LR.string.bookmarks_plural
-                } else {
-                    LR.string.bookmarks_singular
-                },
-                state.bookmarks.size,
-            )
+        if (state.searchEnabled &&
+            state.searchText.isNotEmpty() &&
+            state.bookmarks.isEmpty()
+        ) {
+            item { NoBookmarksInSearchView(onActionClick = { onSearchTextChanged("") }) }
+        } else {
+            item {
+                val title = stringResource(
+                    id = if (state.bookmarks.size > 1) {
+                        LR.string.bookmarks_plural
+                    } else {
+                        LR.string.bookmarks_singular
+                    },
+                    state.bookmarks.size,
+                )
 
-            HeaderRow(
-                title = title,
-                onOptionsMenuClicked = onOptionsMenuClicked,
-                style = state.headerRowColors,
-            )
+                HeaderRow(
+                    title = title,
+                    onOptionsMenuClicked = onOptionsMenuClicked,
+                    style = state.headerRowColors,
+                )
+            }
         }
         items(state.bookmarks, key = { it }) { bookmark ->
             val episode = state.bookmarkIdAndEpisodeMap[bookmark.uuid]

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -14,7 +15,10 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
@@ -27,6 +31,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.bookmark.BookmarkRow
 import au.com.shiftyjelly.pocketcasts.compose.buttons.TimePlayButtonColors
+import au.com.shiftyjelly.pocketcasts.compose.components.SearchBar
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -76,6 +81,7 @@ fun BookmarksPage(
             ).show()
             bookmarksViewModel.play(bookmark)
         },
+        onSearchTextChanged = { bookmarksViewModel.onSearchTextChanged(it) },
         onUpgradeClicked = onUpgradeClicked,
         openFragment = openFragment,
     )
@@ -110,6 +116,7 @@ private fun Content(
     onRowLongPressed: (Bookmark) -> Unit,
     onPlayClick: (Bookmark) -> Unit,
     onBookmarksOptionsMenuClicked: () -> Unit,
+    onSearchTextChanged: (String) -> Unit,
     onUpgradeClicked: () -> Unit,
     openFragment: (Fragment) -> Unit,
 ) {
@@ -126,6 +133,7 @@ private fun Content(
                 onRowLongPressed = onRowLongPressed,
                 onOptionsMenuClicked = onBookmarksOptionsMenuClicked,
                 onPlayClick = onPlayClick,
+                onSearchTextChanged = onSearchTextChanged,
             )
 
             is UiState.Empty -> NoBookmarksView(
@@ -155,11 +163,27 @@ private fun BookmarksView(
     onRowLongPressed: (Bookmark) -> Unit,
     onOptionsMenuClicked: () -> Unit,
     onPlayClick: (Bookmark) -> Unit,
+    onSearchTextChanged: (String) -> Unit,
 ) {
+    val focusRequester = remember { FocusRequester() }
     LazyColumn(
         modifier = Modifier
             .fillMaxSize(),
     ) {
+        if (state.searchEnabled) {
+            item {
+                SearchBar(
+                    text = state.searchText,
+                    placeholder = stringResource(LR.string.search),
+                    onTextChanged = onSearchTextChanged,
+                    onSearch = {},
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .focusRequester(focusRequester),
+                )
+            }
+        }
         item {
             val title = stringResource(
                 id = if (state.bookmarks.size > 1) {
@@ -242,6 +266,7 @@ private fun BookmarksPreview(
             onPlayClick = {},
             onRowLongPressed = {},
             onBookmarksOptionsMenuClicked = {},
+            onSearchTextChanged = {},
             onUpgradeClicked = {},
             openFragment = {},
         )

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/NoBookmarksInSearchView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/NoBookmarksInSearchView.kt
@@ -1,0 +1,57 @@
+package au.com.shiftyjelly.pocketcasts.player.view.bookmark.components
+
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun NoBookmarksInSearchView(
+    onActionClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Content(
+        onClick = onActionClick,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun Content(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    MessageView(
+        titleView = {
+            TextH20(
+                text = stringResource(LR.string.podcast_no_bookmarks_found),
+                color = MaterialTheme.theme.colors.primaryText01,
+            )
+        },
+        message = stringResource(LR.string.bookmarks_search_results_not_found),
+        buttonTitle = stringResource(LR.string.clear_search),
+        buttonAction = onClick,
+        style = MessageViewColors.Default,
+        modifier = modifier,
+    )
+}
+
+@Preview
+@Composable
+private fun NoBookmarksInSearchPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppTheme(themeType) {
+        Content(
+            onClick = {},
+        )
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/search/BookmarkSearchHandler.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/search/BookmarkSearchHandler.kt
@@ -1,0 +1,43 @@
+package au.com.shiftyjelly.pocketcasts.player.view.bookmark.search
+
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
+import javax.inject.Inject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+
+class BookmarkSearchHandler @Inject constructor(
+    private val bookmarkManager: BookmarkManager,
+) {
+    private var searchTerm = ""
+    private val searchQueryFlow = MutableStateFlow("")
+    private val noSearchResult = SearchResult("", null)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    suspend fun getBookmarkSearchResultsFlow() = searchQueryFlow.flatMapLatest { searchTerm ->
+        if (searchTerm.isNotEmpty()) {
+            flow {
+                emit(bookmarkManager.searchByBookmarkOrEpisodeTitle(searchTerm))
+            }
+                .map { SearchResult(searchTerm, it) }
+                .catch { emit(noSearchResult) }
+        } else {
+            flowOf(noSearchResult)
+        }
+    }.distinctUntilChanged()
+
+    fun searchQueryUpdated(newValue: String) {
+        searchTerm = newValue
+        searchQueryFlow.value = newValue
+    }
+
+    data class SearchResult(
+        val searchTerm: String,
+        val searchUuids: List<String>?,
+    )
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/search/BookmarkSearchHandler.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/search/BookmarkSearchHandler.kt
@@ -20,7 +20,7 @@ class BookmarkSearchHandler @Inject constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     suspend fun getBookmarkSearchResultsFlow() = searchQueryFlow.flatMapLatest { searchTerm ->
-        if (searchTerm.isNotEmpty()) {
+        if (searchTerm.trim().isNotEmpty()) {
             flow {
                 emit(bookmarkManager.searchByBookmarkOrEpisodeTitle(searchTerm))
             }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -190,6 +190,7 @@ class BookmarksViewModel
                     onRowClick = ::onRowClick,
                     sourceView = sourceView,
                     showIcon = sourceView == SourceView.PROFILE,
+                    searchEnabled = sourceView == SourceView.PROFILE,
                 )
             }
         }.stateIn(viewModelScope)
@@ -271,6 +272,12 @@ class BookmarksViewModel
                     }
                 }
             }
+        }
+    }
+
+    fun onSearchTextChanged(searchText: String) {
+        (uiState.value as? UiState.Loaded)?.let {
+            _uiState.value = it.copy(searchText = searchText)
         }
     }
 
@@ -360,6 +367,8 @@ class BookmarksViewModel
             val onRowClick: (Bookmark) -> Unit,
             val sourceView: SourceView,
             val showIcon: Boolean = false,
+            val searchText: String = "",
+            val searchEnabled: Boolean = false,
         ) : UiState() {
             val headerRowColors: HeaderRowColors
                 get() = when (sourceView) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarkArguments
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.HeaderRowColors
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.MessageViewColors
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.NoBookmarksViewColors
+import au.com.shiftyjelly.pocketcasts.player.view.bookmark.search.BookmarkSearchHandler
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortType
@@ -30,6 +31,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SharePodcastHelper
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SharePodcastHelper.ShareType
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.extensions.combine6
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -45,7 +47,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
@@ -65,6 +66,7 @@ class BookmarksViewModel
     private val theme: Theme,
     private val bookmarkFeature: BookmarkFeatureControl,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    private val bookmarkSearchHandler: BookmarkSearchHandler,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Loading)
@@ -160,26 +162,34 @@ class BookmarksViewModel
         val episode = episodeUuid?.let { episodeManager.findEpisodeByUuid(episodeUuid) }
         val isMultiSelectingFlow = multiSelectHelper.isMultiSelectingLive.asFlow()
         val selectedListFlow = multiSelectHelper.selectedListLive.asFlow()
-        combine(
+        val bookmarkSearchResults = bookmarkSearchHandler.getBookmarkSearchResultsFlow()
+        combine6(
             bookmarksFlow,
             isMultiSelectingFlow,
             selectedListFlow,
             settings.cachedSubscriptionStatus.flow,
             settings.useEpisodeArtwork.flow,
-        ) { bookmarks, isMultiSelecting, selectedList, cachedSubscriptionStatus, useEpisodeArtwork ->
+            bookmarkSearchResults,
+        ) { bookmarks, isMultiSelecting, selectedList, cachedSubscriptionStatus, useEpisodeArtwork, searchResults ->
             val userTier = (cachedSubscriptionStatus as? SubscriptionStatus.Paid)?.tier?.toUserTier() ?: UserTier.Free
             _uiState.value = if (!bookmarkFeature.isAvailable(userTier)) {
                 UiState.Upsell(sourceView)
             } else if (bookmarks.isEmpty()) {
                 UiState.Empty(sourceView)
             } else {
+                val searchText = (_uiState.value as? UiState.Loaded)?.searchText ?: ""
+                val filteredBookmarks = if (searchText.isNotEmpty()) {
+                    bookmarks.filter { bookmark -> searchResults.searchUuids?.contains(bookmark.uuid) == true }
+                } else {
+                    bookmarks
+                }
                 val episodes = episode?.let { listOf(it) }
-                    ?: episodeManager.findEpisodesByUuids(bookmarks.map { it.episodeUuid }.distinct())
-                val bookmarkIdAndEpisodeMap = bookmarks.associate { bookmark ->
+                    ?: episodeManager.findEpisodesByUuids(filteredBookmarks.map { it.episodeUuid }.distinct())
+                val bookmarkIdAndEpisodeMap = filteredBookmarks.associate { bookmark ->
                     bookmark.uuid to episodes.firstOrNull { it.uuid == bookmark.episodeUuid }
                 }
                 UiState.Loaded(
-                    bookmarks = bookmarks,
+                    bookmarks = filteredBookmarks,
                     bookmarkIdAndEpisodeMap = bookmarkIdAndEpisodeMap,
                     isMultiSelecting = isMultiSelecting,
                     useEpisodeArtwork = useEpisodeArtwork,
@@ -191,6 +201,7 @@ class BookmarksViewModel
                     sourceView = sourceView,
                     showIcon = sourceView == SourceView.PROFILE,
                     searchEnabled = sourceView == SourceView.PROFILE,
+                    searchText = searchResults.searchTerm,
                 )
             }
         }.stateIn(viewModelScope)
@@ -278,6 +289,7 @@ class BookmarksViewModel
     fun onSearchTextChanged(searchText: String) {
         (uiState.value as? UiState.Loaded)?.let {
             _uiState.value = it.copy(searchText = searchText)
+            bookmarkSearchHandler.searchQueryUpdated(searchText)
         }
     }
 
@@ -357,7 +369,7 @@ class BookmarksViewModel
                 }
         }
 
-        object Loading : UiState()
+        data object Loading : UiState()
         data class Loaded(
             val bookmarks: List<Bookmark> = emptyList(),
             val bookmarkIdAndEpisodeMap: Map<String, BaseEpisode?>,

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/search/BookmarkSearchHandlerTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/search/BookmarkSearchHandlerTest.kt
@@ -1,0 +1,70 @@
+package au.com.shiftyjelly.pocketcasts.player.view.bookmark.search
+
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class BookmarkSearchHandlerTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    @Mock
+    private lateinit var bookmarkManager: BookmarkManager
+
+    private lateinit var bookmarkSearchHandler: BookmarkSearchHandler
+
+    @Before
+    fun setUp() {
+        bookmarkSearchHandler = BookmarkSearchHandler(bookmarkManager)
+    }
+
+    @Test
+    fun `given non-empty search term, when search query updated, then search results flow emits correct value`() = runTest {
+        val searchTerm = "test"
+        val searchUuids = listOf("uuid1", "uuid2")
+        whenever(bookmarkManager.searchByBookmarkOrEpisodeTitle(searchTerm)).thenReturn(searchUuids)
+
+        bookmarkSearchHandler.searchQueryUpdated(searchTerm)
+
+        val result = bookmarkSearchHandler.getBookmarkSearchResultsFlow().first()
+        assertEquals(searchTerm, result.searchTerm)
+        assertEquals(searchUuids, result.searchUuids)
+    }
+
+    @Test
+    fun `given empty search term, when search query updated, then search results flow emits no search result`() = runTest {
+        val searchTerm = ""
+
+        bookmarkSearchHandler.searchQueryUpdated(searchTerm)
+
+        val result = bookmarkSearchHandler.getBookmarkSearchResultsFlow().first()
+        assertEquals(searchTerm, result.searchTerm)
+        assertNull(result.searchUuids)
+    }
+
+    @Test
+    fun `given search term causes error, when search query updated, then search results flow emits no search result`() = runTest {
+        val searchTerm = "test"
+        whenever(bookmarkManager.searchByBookmarkOrEpisodeTitle(searchTerm)).thenThrow(RuntimeException())
+
+        bookmarkSearchHandler.searchQueryUpdated(searchTerm)
+
+        val result = bookmarkSearchHandler.getBookmarkSearchResultsFlow().first()
+        assertEquals(searchTerm, result.searchTerm)
+        assertNull(result.searchUuids)
+    }
+}

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/search/BookmarkSearchHandlerTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/search/BookmarkSearchHandlerTest.kt
@@ -64,7 +64,7 @@ class BookmarkSearchHandlerTest {
         bookmarkSearchHandler.searchQueryUpdated(searchTerm)
 
         val result = bookmarkSearchHandler.getBookmarkSearchResultsFlow().first()
-        assertEquals(searchTerm, result.searchTerm)
+        assertEquals("", result.searchTerm)
         assertNull(result.searchUuids)
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1822,6 +1822,7 @@
     <string name="bookmark_notification_action_delete_title" translatable="false">@string/delete</string>
     <string name="bookmarks_upsell_instructions">Save timestamps of your favorite episodes and unlock many more features with Pocket&#160;Casts Plus.</string>
     <string name="bookmarks_upsell_instructions_early_access">Get early access to this feature with Pocket&#160;Casts Patron and save timestamps of your favorite episodes. Available for Plus subscribers soon.</string>
+    <string name="bookmarks_search_results_not_found">We couldn\'t find any bookmark for that search.</string>
 
     <!--    Tasker Plugin-->
 
@@ -1872,6 +1873,7 @@
     <string name="dont_clear">Don\'t Clear</string>
     <string name="clear_up_next">Clear Up Next</string>
     <string name="clear_all">Clear All</string>
+    <string name="clear_search">Clear Search</string>
     <string name="add_mode">Add Mode</string>
     <string name="start_playing">Start Playing</string>
     <string name="last">Last</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -151,6 +151,25 @@ abstract class BookmarkDao {
         deleted: Boolean = false,
     ): List<Bookmark>
 
+    @Query(
+        """
+        SELECT 
+          bookmarks.* 
+        FROM 
+          bookmarks 
+          LEFT JOIN podcast_episodes ON bookmarks.episode_uuid = podcast_episodes.uuid 
+        WHERE 
+          (
+            UPPER(bookmarks.title) LIKE UPPER(:title) 
+            OR UPPER(podcast_episodes.title) LIKE UPPER(:title)
+          ) 
+          AND deleted = :deleted""",
+    )
+    abstract suspend fun searchByBookmarkOrEpisodeTitle(
+        title: String,
+        deleted: Boolean = false,
+    ): List<Bookmark>
+
     @Query("UPDATE bookmarks SET deleted = :deleted, deleted_modified = :deletedModified, sync_status = :syncStatus WHERE uuid = :uuid")
     abstract suspend fun updateDeleted(uuid: String, deleted: Boolean, deletedModified: Long, syncStatus: SyncStatus)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
@@ -26,6 +26,7 @@ interface BookmarkManager {
     suspend fun upsertSynced(bookmark: Bookmark): Bookmark
     fun findBookmarksToSync(): List<Bookmark>
     suspend fun searchInPodcastByTitle(podcastUuid: String, title: String): List<String>
+    suspend fun searchByBookmarkOrEpisodeTitle(title: String): List<String>
     fun findUserEpisodesBookmarksFlow(): Flow<List<Bookmark>>
     fun findBookmarksFlow(
         sortType: BookmarksSortTypeForProfile,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -174,6 +174,9 @@ class BookmarkManagerImpl @Inject constructor(
     override suspend fun searchInPodcastByTitle(podcastUuid: String, title: String) =
         bookmarkDao.searchInPodcastByTitle(podcastUuid, "%$title%").map { it.uuid }
 
+    override suspend fun searchByBookmarkOrEpisodeTitle(title: String) =
+        bookmarkDao.searchByBookmarkOrEpisodeTitle("%$title%").map { it.uuid }
+
     /**
      * Mark the bookmark as deleted so it can be synced to other devices.
      */


### PR DESCRIPTION
## Description
This adds search to the profile bookmarks screen.


## Testing Instructions
1. Start the app with a user that has Plus or Patron active and a few bookmarks
3. Go to profile
4. Scroll down and check if you see a Bookmarks option
5. Tap on Bookmarks
6. Notice that the screen now has a search field
7. Search for a bookmark or episode title 
8. Notice that search results are filtered based on searched term or display a no bookmark view

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/f7209ff9-86b7-4b88-b3ac-00b5fcd8a226


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
