### PR TITLE
Trim search term 

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/search/BookmarkSearchHandler.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/search/BookmarkSearchHandler.kt
@@ -20,7 +20,7 @@ class BookmarkSearchHandler @Inject constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     suspend fun getBookmarkSearchResultsFlow() = searchQueryFlow.flatMapLatest { searchTerm ->
-        if (searchTerm.trim().isNotEmpty()) {
+        if (searchTerm.isNotEmpty()) {
             flow {
                 emit(bookmarkManager.searchByBookmarkOrEpisodeTitle(searchTerm))
             }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -178,7 +178,7 @@ class BookmarksViewModel
                 UiState.Empty(sourceView)
             } else {
                 val searchText = (_uiState.value as? UiState.Loaded)?.searchText ?: ""
-                val filteredBookmarks = if (searchText.isNotEmpty()) {
+                val filteredBookmarks = if (searchResults.searchTerm.isNotEmpty()) {
                     bookmarks.filter { bookmark -> searchResults.searchUuids?.contains(bookmark.uuid) == true }
                 } else {
                     bookmarks
@@ -201,7 +201,7 @@ class BookmarksViewModel
                     sourceView = sourceView,
                     showIcon = sourceView == SourceView.PROFILE,
                     searchEnabled = sourceView == SourceView.PROFILE,
-                    searchText = searchResults.searchTerm,
+                    searchText = searchText,
                 )
             }
         }.stateIn(viewModelScope)
@@ -289,7 +289,7 @@ class BookmarksViewModel
     fun onSearchTextChanged(searchText: String) {
         (uiState.value as? UiState.Loaded)?.let {
             _uiState.value = it.copy(searchText = searchText)
-            bookmarkSearchHandler.searchQueryUpdated(searchText)
+            bookmarkSearchHandler.searchQueryUpdated(searchText.trim())
         }
     }
 


### PR DESCRIPTION
## Description
This trims the search term before setting it to search handler.

## Testing Instructions
1. Start the app with a user that has Plus or Patron active and a few bookmarks
2. Go to profile
3. Scroll down and tap on Bookmarks
4. Notice that the screen now has a search field
5. Search for a bookmark or episode title with spaces before and at the end
6. Notice that spaces are ignored during search

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/decb233a-1fe1-4f80-a0e1-c881a1e7a6a6

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
