### PR TITLE
Update Firebase emulator model

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -415,7 +415,7 @@ platform :android do
       project_id: firebase_secret(name: 'project_id'),
       key_file: GOOGLE_FIREBASE_SECRETS_PATH,
       model: 'Pixel2.arm',
-      version: 23,
+      version: 30,
       test_apk_path: File.join(apk_dir, 'androidTest', 'debug', 'app-debug-androidTest.apk'),
       apk_path: File.join(apk_dir, 'debug', 'app-debug.apk'),
       results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -414,7 +414,7 @@ platform :android do
     android_firebase_test(
       project_id: firebase_secret(name: 'project_id'),
       key_file: GOOGLE_FIREBASE_SECRETS_PATH,
-      model: 'Nexus5',
+      model: 'Pixel2.arm',
       version: 23,
       test_apk_path: File.join(apk_dir, 'androidTest', 'debug', 'app-debug-androidTest.apk'),
       apk_path: File.join(apk_dir, 'debug', 'app-debug.apk'),


### PR DESCRIPTION
## Description
Instrumented tests stopped running after the `Nexus5` emulator was deprecated from Firebase, causing the CI step to fail. This PR updates the emulator used in Firebase tests as well as the SDK version so that tests can run.

| Before | 
|--------|
| <img width="1152" alt="image" src="https://github.com/Automattic/pocket-casts-android/assets/42008628/7b66e25e-b99d-4d07-8706-89fac1f25033"> |
| <img width="1080" alt="image" src="https://github.com/Automattic/pocket-casts-android/assets/42008628/cb01e1d3-180a-4d13-9b44-f5fba82532b8"> | 

| After | 
|--------|
| <img width="1152" alt="image" src="https://github.com/Automattic/pocket-casts-android/assets/42008628/13af5ed7-9771-4c22-a10f-51023edbcfe0"> |
| <img width="1080" alt="image" src="https://github.com/Automattic/pocket-casts-android/assets/42008628/faad8637-229c-4777-a7a8-c6c9d72877f4"> | 

## Testing Instructions
If CI is 🟢 , we're good.

