### PR TITLE
Improve landscape player layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
         ([#2022](https://github.com/Automattic/pocket-casts-android/pull/2022))
     *   Add profile bookmark screen where all user bookmarks can be managed
         ([#2037](https://github.com/Automattic/pocket-casts-android/pull/2037))
+* Bug Fixes
+    *   Improved player view in landscape mode. Added chapter artwork, podcast title, and improved video experience.
+        ([#2044](https://github.com/Automattic/pocket-casts-android/pull/1944))
 
 7.61
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -216,20 +216,18 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
                 loadArtwork(episode, headerViewModel.useEpisodeArtwork, binding.artwork)
             }
 
-            binding.podcastTitle?.let { podcastTitle ->
-                podcastTitle.setOnClickListener {
-                    val podcastUuid = headerViewModel.podcastUuid ?: return@setOnClickListener
-                    analyticsTracker.track(
-                        AnalyticsEvent.EPISODE_DETAIL_PODCAST_NAME_TAPPED,
-                        mapOf(
-                            AnalyticsProp.Key.EPISODE_UUID to headerViewModel.episodeUuid,
-                            AnalyticsProp.Key.SOURCE to EpisodeViewSource.NOW_PLAYING.value,
-                        ),
-                    )
-                    (activity as? FragmentHostListener)?.let { listener ->
-                        listener.closePlayer()
-                        listener.openPodcastPage(podcastUuid)
-                    }
+            binding.podcastTitle.setOnClickListener {
+                val podcastUuid = headerViewModel.podcastUuid ?: return@setOnClickListener
+                analyticsTracker.track(
+                    AnalyticsEvent.EPISODE_DETAIL_PODCAST_NAME_TAPPED,
+                    mapOf(
+                        AnalyticsProp.Key.EPISODE_UUID to headerViewModel.episodeUuid,
+                        AnalyticsProp.Key.SOURCE to EpisodeViewSource.NOW_PLAYING.value,
+                    ),
+                )
+                (activity as? FragmentHostListener)?.let { listener ->
+                    listener.closePlayer()
+                    listener.openPodcastPage(podcastUuid)
                 }
             }
 
@@ -297,8 +295,8 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
             binding.chapterUrlFront?.showIfPresent(headerViewModel.chapter?.url)
             binding.videoView.isVisible = headerViewModel.isVideoVisible()
             binding.episodeTitle.text = headerViewModel.title
-            binding.podcastTitle?.text = headerViewModel.podcastTitle
-            binding.podcastTitle?.isVisible = headerViewModel.podcastTitle?.isNotBlank() == true
+            binding.podcastTitle.text = headerViewModel.podcastTitle
+            binding.podcastTitle.isVisible = headerViewModel.podcastTitle?.isNotBlank() == true
             binding.chapterSummary.text = headerViewModel.chapterSummary
             binding.chapterSummary.isVisible = headerViewModel.isChaptersPresent
             binding.previousChapter.alpha = if (headerViewModel.isFirstChapter) 0.5f else 1f

--- a/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
@@ -14,56 +14,75 @@
         android:clipChildren="false"
         android:clipToPadding="false">
 
-        <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/firstPage"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintGuide_begin="500dp"
-            android:orientation="horizontal" />
-
         <ImageView
             android:id="@+id/artwork"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="0dp"
-            app:layout_constraintWidth_max="192dp"
-            app:layout_constraintHeight_max="192dp"
-            android:background="@drawable/round_corners_8dp"
-            android:outlineProvider="background"
-            tools:src="@tools:sample/avatars"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
+            android:layout_margin="16dp"
             android:importantForAccessibility="no"
+            app:layout_constraintBottom_toTopOf="@+id/shelf"
             app:layout_constraintDimensionRatio="W,1:1"
+            app:layout_constraintHeight_max="192dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toTopOf="@+id/shelf" />
+            app:layout_constraintWidth_max="192dp"
+            tools:src="@tools:sample/avatars" />
 
         <ImageView
             android:id="@+id/chapterArtwork"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="0dp"
-            android:background="@drawable/round_corners_8dp"
-            android:outlineProvider="background"
-            tools:src="@tools:sample/avatars"
+            android:layout_margin="16dp"
             android:importantForAccessibility="no"
+            app:layout_constraintBottom_toTopOf="@+id/shelf"
             app:layout_constraintDimensionRatio="W,1:1"
-            app:layout_constraintStart_toStartOf="@id/artwork"
-            app:layout_constraintTop_toTopOf="@id/artwork"
-            app:layout_constraintBottom_toBottomOf="@id/artwork"
-            app:layout_constraintEnd_toEndOf="@id/artwork" />
+            app:layout_constraintHeight_max="192dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintWidth_max="192dp"
+            tools:src="@tools:sample/avatars" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/artworkStartBarrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierAllowsGoneWidgets="true"
+            app:barrierDirection="start"
+            app:constraint_referenced_ids="artwork,chapterArtwork" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/artworkTopBarrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="top"
+            app:constraint_referenced_ids="artwork,chapterArtwork" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/artworkEndBarrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierAllowsGoneWidgets="true"
+            app:barrierDirection="end"
+            app:constraint_referenced_ids="artwork,chapterArtwork" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/artworkBottomBarrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierAllowsGoneWidgets="true"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="artwork,chapterArtwork" />
 
         <FrameLayout
             android:id="@+id/chapterUrl"
             android:layout_width="36dp"
             android:layout_height="36dp"
             android:layout_gravity="center_vertical"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:layout_marginEnd="8dp"
             android:layout_marginTop="8dp"
-            app:layout_constraintTop_toTopOf="@id/artwork"
-            app:layout_constraintEnd_toEndOf="@id/artwork">
+            android:layout_marginEnd="8dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            app:layout_constraintEnd_toEndOf="@id/chapterArtwork"
+            app:layout_constraintTop_toTopOf="@id/chapterArtwork">
 
             <ImageView
                 android:layout_width="match_parent"
@@ -76,207 +95,220 @@
                 android:layout_height="20dp"
                 android:layout_gravity="center"
                 android:src="@drawable/ic_link" />
+
         </FrameLayout>
 
         <au.com.shiftyjelly.pocketcasts.player.view.video.VideoView
             android:id="@+id/videoView"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            app:layout_constraintStart_toStartOf="@id/artwork"
-            app:layout_constraintTop_toTopOf="@id/artwork"
-            app:layout_constraintBottom_toBottomOf="@id/artwork"
-            app:layout_constraintEnd_toEndOf="@id/artwork" />
+            app:layout_constraintBottom_toBottomOf="@id/artworkBottomBarrier"
+            app:layout_constraintEnd_toEndOf="@id/artworkEndBarrier"
+            app:layout_constraintStart_toStartOf="@id/artworkStartBarrier"
+            app:layout_constraintTop_toTopOf="@id/artworkTopBarrier" />
 
         <TextView
             android:id="@+id/episodeTitle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
+            android:layout_marginHorizontal="16dp"
             android:ellipsize="end"
-            android:fontFamily="sans-serif-medium"
             android:gravity="center"
-            android:includeFontPadding="false"
             android:lineSpacingMultiplier="1.2"
-            android:maxLines="2"
+            android:maxLines="1"
             android:textColor="#FFFFFFFF"
             android:textSize="18sp"
-            android:layout_marginTop="16dp"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/artwork"
-            app:layout_constraintBottom_toTopOf="@+id/chapterSummary"
-            tools:text="@tools:sample/lorem" />
-
-        <TextView
-            android:id="@+id/chapterSummary"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
-            android:gravity="center"
-            android:textAppearance="?attr/textCaption"
-            app:layout_constraintStart_toStartOf="@id/episodeTitle"
-            app:layout_constraintEnd_toEndOf="@id/episodeTitle"
-            app:layout_constraintBottom_toTopOf="@+id/seekBar"
-            app:layout_constraintTop_toBottomOf="@id/episodeTitle"
+            app:layout_constraintEnd_toStartOf="@+id/nextChapter"
+            app:layout_constraintStart_toEndOf="@+id/previousChapter"
+            app:layout_constraintTop_toTopOf="@id/artworkTopBarrier"
             tools:text="@tools:sample/lorem" />
 
         <ImageButton
             android:id="@+id/previousChapter"
             android:layout_width="44dp"
             android:layout_height="44dp"
-            android:src="@drawable/ic_chapter_skipbackwards"
             android:layout_marginStart="8dp"
-            app:layout_constraintStart_toStartOf="@id/episodeTitle"
-            app:layout_constraintTop_toTopOf="@+id/episodeTitle"
-            app:layout_constraintBottom_toBottomOf="@+id/episodeTitle"
+            android:background="?android:attr/actionBarItemBackground"
             android:contentDescription="@string/player_action_previous_chapter"
-            android:background="?android:attr/actionBarItemBackground" />
+            android:src="@drawable/ic_chapter_skipbackwards"
+            app:layout_constraintBottom_toBottomOf="@+id/episodeTitle"
+            app:layout_constraintStart_toEndOf="@id/artworkEndBarrier"
+            app:layout_constraintTop_toTopOf="@+id/episodeTitle" />
 
         <ImageButton
             android:id="@+id/nextChapter"
             android:layout_width="44dp"
             android:layout_height="44dp"
-            android:src="@drawable/ic_chapter_skipforward"
             android:layout_marginEnd="8dp"
+            android:background="?android:attr/actionBarItemBackground"
             android:contentDescription="@string/player_action_next_chapter"
+            android:src="@drawable/ic_chapter_skipforward"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@+id/episodeTitle"
-            app:layout_constraintBottom_toBottomOf="@+id/episodeTitle"
-            android:background="?android:attr/actionBarItemBackground" />
+            app:layout_constraintTop_toTopOf="@id/previousChapter" />
 
         <au.com.shiftyjelly.pocketcasts.player.view.ChapterProgressCircle
             android:id="@+id/chapterProgressCircle"
             android:layout_width="30dp"
             android:layout_height="30dp"
-            app:layout_constraintStart_toStartOf="@+id/nextChapter"
+            app:layout_constraintBottom_toBottomOf="@+id/nextChapter"
             app:layout_constraintEnd_toEndOf="@+id/nextChapter"
-            app:layout_constraintTop_toTopOf="@+id/nextChapter"
-            app:layout_constraintBottom_toBottomOf="@+id/nextChapter" />
+            app:layout_constraintStart_toStartOf="@+id/nextChapter"
+            app:layout_constraintTop_toTopOf="@+id/nextChapter" />
 
         <TextView
             android:id="@+id/chapterTimeRemaining"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="9m"
             android:layout_marginTop="6dp"
+            android:alpha="0.4"
             android:textAppearance="@style/H70"
             android:textColor="@color/white"
-            android:alpha="0.4"
-            app:layout_constraintStart_toStartOf="@+id/nextChapter"
             app:layout_constraintEnd_toEndOf="@+id/nextChapter"
-            app:layout_constraintTop_toBottomOf="@+id/nextChapter" />
+            app:layout_constraintStart_toStartOf="@+id/nextChapter"
+            app:layout_constraintTop_toBottomOf="@+id/nextChapter"
+            tools:text="9m" />
+
+        <TextView
+            android:id="@+id/podcastTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:ellipsize="end"
+            android:gravity="center"
+            android:maxLines="1"
+            android:textColor="?attr/player_contrast_02"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toEndOf="@id/episodeTitle"
+            app:layout_constraintStart_toStartOf="@id/episodeTitle"
+            app:layout_constraintTop_toBottomOf="@id/episodeTitle"
+            tools:text="@tools:sample/lorem" />
+
+        <TextView
+            android:id="@+id/chapterSummary"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:gravity="center"
+            android:maxLines="1"
+            android:textAppearance="?attr/textCaption"
+            app:layout_constraintEnd_toEndOf="@id/episodeTitle"
+            app:layout_constraintStart_toStartOf="@id/episodeTitle"
+            app:layout_constraintTop_toBottomOf="@id/episodeTitle"
+            tools:text="@tools:sample/lorem" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/secondaryTextTopBarrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierAllowsGoneWidgets="true"
+            app:barrierDirection="top"
+            app:constraint_referenced_ids="podcastTitle,chapterSummary" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/secondaryTextBottomBarrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierAllowsGoneWidgets="true"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="podcastTitle,chapterSummary" />
 
         <au.com.shiftyjelly.pocketcasts.player.view.PlayerSeekBar
             android:id="@+id/seekBar"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="10dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/episodeTitle"
-            app:layout_constraintBottom_toTopOf="@+id/largePlayButton"
-            app:layout_constraintTop_toBottomOf="@id/chapterSummary" />
+            android:layout_marginTop="8dp"
+            app:layout_constraintEnd_toEndOf="@+id/nextChapter"
+            app:layout_constraintStart_toStartOf="@+id/previousChapter"
+            app:layout_constraintTop_toBottomOf="@id/secondaryTextBottomBarrier" />
 
         <au.com.shiftyjelly.pocketcasts.views.buttons.AnimatedPlayButton
             android:id="@+id/largePlayButton"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
+            android:layout_width="80dp"
+            android:layout_height="80dp"
             app:icon_tint="?attr/player_contrast_06"
-            tools:src="@tools:sample/avatars"
-            android:layout_marginBottom="12dp"
-            app:layout_constraintWidth_min="44dp"
-            app:layout_constraintWidth_max="90dp"
-            app:layout_constraintDimensionRatio="1:1"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/episodeTitle"
+            app:layout_constraintEnd_toStartOf="@+id/skipForward"
+            app:layout_constraintStart_toEndOf="@+id/skipBack"
             app:layout_constraintTop_toBottomOf="@id/seekBar"
-            app:layout_constraintBottom_toTopOf="@+id/shelf" />
+            tools:src="@tools:sample/avatars" />
 
         <com.airbnb.lottie.LottieAnimationView
             android:id="@+id/skipForward"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginEnd="8dp"
-            android:scaleX="-1"
-            android:scaleType="centerInside"
             android:background="?android:attr/selectableItemBackgroundBorderless"
-            tools:src="@tools:sample/avatars"
             android:contentDescription="@string/skip_forward"
+            android:scaleType="centerInside"
+            android:scaleX="-1"
             app:layout_constraintBottom_toBottomOf="@+id/largePlayButton"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toEndOf="@+id/seekBar"
             app:layout_constraintStart_toEndOf="@+id/largePlayButton"
             app:layout_constraintTop_toTopOf="@+id/largePlayButton"
-            app:lottie_rawRes="@raw/skip_button" />
+            app:lottie_rawRes="@raw/skip_button"
+            tools:src="@tools:sample/avatars" />
 
         <TextView
             android:id="@+id/jumpForwardText"
             android:layout_width="45dp"
             android:layout_height="53dp"
-            android:gravity="center"
-            android:includeFontPadding="false"
             android:fontFamily="sans-serif-medium"
+            android:gravity="center"
+            android:importantForAccessibility="no"
+            android:includeFontPadding="false"
             android:paddingTop="8dp"
             android:textColor="#FFFFFF"
-            android:importantForAccessibility="no"
             android:textSize="15sp"
-            tools:text="30"
-            app:layout_constraintStart_toStartOf="@+id/skipForward"
+            app:layout_constraintBottom_toBottomOf="@+id/skipForward"
             app:layout_constraintEnd_toEndOf="@+id/skipForward"
+            app:layout_constraintStart_toStartOf="@+id/skipForward"
             app:layout_constraintTop_toTopOf="@+id/skipForward"
-            app:layout_constraintBottom_toBottomOf="@+id/skipForward" />
+            tools:text="30" />
 
         <com.airbnb.lottie.LottieAnimationView
             android:id="@+id/skipBack"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:layout_marginStart="8dp"
-            android:scaleType="centerInside"
             android:background="?android:attr/selectableItemBackgroundBorderless"
-            tools:src="@tools:sample/avatars"
             android:contentDescription="@string/skip_back"
+            android:scaleType="centerInside"
             app:layout_constraintBottom_toBottomOf="@+id/largePlayButton"
             app:layout_constraintEnd_toStartOf="@+id/largePlayButton"
-            app:layout_constraintStart_toStartOf="@id/episodeTitle"
+            app:layout_constraintStart_toStartOf="@+id/seekBar"
             app:layout_constraintTop_toTopOf="@+id/largePlayButton"
-            app:lottie_rawRes="@raw/skip_button" />
+            app:lottie_rawRes="@raw/skip_button"
+            tools:src="@tools:sample/avatars" />
 
         <TextView
             android:id="@+id/skipBackText"
             android:layout_width="45dp"
             android:layout_height="53dp"
-            android:gravity="center"
-            android:includeFontPadding="false"
             android:fontFamily="sans-serif-medium"
+            android:gravity="center"
+            android:importantForAccessibility="no"
+            android:includeFontPadding="false"
             android:paddingTop="8dp"
             android:textColor="#FFFFFF"
-            android:importantForAccessibility="no"
             android:textSize="15sp"
-            tools:text="15"
-            app:layout_constraintStart_toStartOf="@+id/skipBack"
+            app:layout_constraintBottom_toBottomOf="@+id/skipBack"
             app:layout_constraintEnd_toEndOf="@+id/skipBack"
+            app:layout_constraintStart_toStartOf="@+id/skipBack"
             app:layout_constraintTop_toTopOf="@+id/skipBack"
-            app:layout_constraintBottom_toBottomOf="@+id/skipBack" />
+            tools:text="15" />
 
         <LinearLayout
             android:id="@+id/shelf"
             android:layout_width="0dp"
             android:layout_height="56dp"
-            android:orientation="horizontal"
+            android:layout_margin="16dp"
             android:background="@drawable/player_shelf"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginStart="20dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginTop="30dp"
-            android:layout_marginBottom="16dp"
-            android:paddingLeft="8dp"
-            android:paddingRight="8dp"
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:paddingHorizontal="8dp"
             android:weightSum="5"
-            android:gravity="center">
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
 
             <ImageButton
                 android:id="@+id/effects"

--- a/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
@@ -42,36 +42,46 @@
             app:layout_constraintWidth_max="192dp"
             tools:src="@tools:sample/avatars" />
 
+        <au.com.shiftyjelly.pocketcasts.player.view.video.VideoView
+            android:id="@+id/videoView"
+            android:layout_width="wrap_content"
+            android:layout_height="192dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <androidx.constraintlayout.widget.Barrier
             android:id="@+id/artworkStartBarrier"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:barrierAllowsGoneWidgets="true"
+            app:barrierAllowsGoneWidgets="false"
             app:barrierDirection="start"
-            app:constraint_referenced_ids="artwork,chapterArtwork" />
+            app:constraint_referenced_ids="artwork,chapterArtwork,videoView" />
 
         <androidx.constraintlayout.widget.Barrier
             android:id="@+id/artworkTopBarrier"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            app:barrierAllowsGoneWidgets="false"
             app:barrierDirection="top"
-            app:constraint_referenced_ids="artwork,chapterArtwork" />
+            app:constraint_referenced_ids="artwork,chapterArtwork,videoView" />
 
         <androidx.constraintlayout.widget.Barrier
             android:id="@+id/artworkEndBarrier"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:barrierAllowsGoneWidgets="true"
+            app:barrierAllowsGoneWidgets="false"
             app:barrierDirection="end"
-            app:constraint_referenced_ids="artwork,chapterArtwork" />
+            app:constraint_referenced_ids="artwork,chapterArtwork,videoView" />
 
         <androidx.constraintlayout.widget.Barrier
             android:id="@+id/artworkBottomBarrier"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:barrierAllowsGoneWidgets="true"
+            app:barrierAllowsGoneWidgets="false"
             app:barrierDirection="bottom"
-            app:constraint_referenced_ids="artwork,chapterArtwork" />
+            app:constraint_referenced_ids="artwork,chapterArtwork,videoView" />
 
         <FrameLayout
             android:id="@+id/chapterUrl"
@@ -97,15 +107,6 @@
                 android:src="@drawable/ic_link" />
 
         </FrameLayout>
-
-        <au.com.shiftyjelly.pocketcasts.player.view.video.VideoView
-            android:id="@+id/videoView"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:layout_constraintBottom_toBottomOf="@id/artworkBottomBarrier"
-            app:layout_constraintEnd_toEndOf="@id/artworkEndBarrier"
-            app:layout_constraintStart_toStartOf="@id/artworkStartBarrier"
-            app:layout_constraintTop_toTopOf="@id/artworkTopBarrier" />
 
         <TextView
             android:id="@+id/episodeTitle"

--- a/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
@@ -307,6 +307,7 @@
             android:orientation="horizontal"
             android:paddingHorizontal="8dp"
             android:weightSum="5"
+            app:layout_constraintTop_toBottomOf="@+id/largePlayButton"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent">


### PR DESCRIPTION
## Description

Landscape player layout was missing chapter artwork, podcast title, and was mishandling video playback. This PR fixes this.

Closes #2015

## Testing Instructions

Test the player in landscape mode

## Screenshots or Screencast 

| Old episode | New episode |
| - | - |
| ![old-episode](https://github.com/Automattic/pocket-casts-android/assets/30936061/8fa97c71-eabe-46a9-a9b6-df725241c526) | ![new-episode](https://github.com/Automattic/pocket-casts-android/assets/30936061/954535f2-3f6c-4d74-90a9-d093fe5cac96) |

| Old chapters | New chapters |
| - | - |
| ![old-chapter](https://github.com/Automattic/pocket-casts-android/assets/30936061/812b32a7-a281-4da3-97dd-8ad724a5348d) | ![Screenshot_20240412_085803](https://github.com/Automattic/pocket-casts-android/assets/30936061/d87837db-657a-4612-9021-28a8459c9e62) |

| Old video | New video |
| - | - |
| ![old-video](https://github.com/Automattic/pocket-casts-android/assets/30936061/1b0744e1-3860-4dbe-ac42-c8d69eea4e8e) | ![new-video](https://github.com/Automattic/pocket-casts-android/assets/30936061/445df2f4-47cc-493a-8627-e52e205853e9) |

The content is scrollable.

| Small screen episode | Small screen video |
| - | - |
| ![small-episode](https://github.com/Automattic/pocket-casts-android/assets/30936061/13c5fa6c-da97-4cc2-9d65-3de0050b7ac5) | ![small-video](https://github.com/Automattic/pocket-casts-android/assets/30936061/1fa511bf-c833-4e99-a6b3-a268cf3deec2) |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
