### PR TITLE
Sleep Timer: automatically restart if playback is resumed within 5 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
         ([#2022](https://github.com/Automattic/pocket-casts-android/pull/2022))
     *   Add profile bookmark screen where all user bookmarks can be managed
         ([#2037](https://github.com/Automattic/pocket-casts-android/pull/2037))
+    *   Sleep Timer restarts automatically if you play again within 5 minutes
+        ([#2048](https://github.com/Automattic/pocket-casts-android/pull/2048))
 *   Updates:
     *   Updated widget and added two new variants - small and large.
         ([#2043](https://github.com/Automattic/pocket-casts-android/pull/2043))

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -520,7 +520,7 @@ class PlayerViewModel @Inject constructor(
     }
 
     fun sleepTimerAfter(mins: Int) {
-        sleepTimer.sleepAfter(mins = mins) {
+        sleepTimer.sleepAfter(minutes = mins) {
             playbackManager.updateSleepTimerStatus(running = true, sleepAfterEpisode = false)
         }
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -60,6 +60,8 @@ import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.map
@@ -520,7 +522,7 @@ class PlayerViewModel @Inject constructor(
     }
 
     fun sleepTimerAfter(mins: Int) {
-        sleepTimer.sleepAfter(minutes = mins) {
+        sleepTimer.sleepAfter(duration = mins.toDuration(DurationUnit.MINUTES)) {
             playbackManager.updateSleepTimerStatus(running = true, sleepAfterEpisode = false)
         }
     }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -323,6 +323,7 @@ enum class AnalyticsEvent(val key: String) {
     PLAYER_SLEEP_TIMER_ENABLED("player_sleep_timer_enabled"),
     PLAYER_SLEEP_TIMER_EXTENDED("player_sleep_timer_extended"),
     PLAYER_SLEEP_TIMER_CANCELLED("player_sleep_timer_cancelled"),
+    PLAYER_SLEEP_TIMER_RESTARTED("player_sleep_timer_restarted"),
 
     /* Player - Playback effects */
     PLAYBACK_EFFECT_SPEED_CHANGED("playback_effect_speed_changed"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -129,6 +129,7 @@ open class PlaybackManager @Inject constructor(
     private val bookmarkManager: BookmarkManager,
     private val showNotesManager: ShowNotesManager,
     private val chapterManager: ChapterManager,
+    private val sleepTimer: SleepTimer,
     bookmarkFeature: BookmarkFeatureControl,
     private val playbackManagerNetworkWatcherFactory: PlaybackManagerNetworkWatcher.Factory,
     @ApplicationScope private val applicationScope: CoroutineScope,
@@ -2046,6 +2047,10 @@ open class PlaybackManager @Inject constructor(
         )
 
         player?.play(currentTimeMs)
+
+        sleepTimer.restartSleepTimerIfApplies {
+            updateSleepTimerStatus(running = true, sleepAfterEpisode = false)
+        }
 
         trackPlayback(AnalyticsEvent.PLAYBACK_PLAY, sourceView)
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1428,7 +1428,7 @@ open class PlaybackManager @Inject constructor(
     }
 
     private suspend fun sleep(episode: BaseEpisode?) {
-        sleepTimer.setEndOfEpisodeUuid(episode?.uuid)
+        episode?.uuid?.let { sleepTimer.setEndOfEpisodeUuid(it) }
         sleepAfterEpisode = false
 
         withContext(Dispatchers.Main) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1428,7 +1428,7 @@ open class PlaybackManager @Inject constructor(
     }
 
     private suspend fun sleep(episode: BaseEpisode?) {
-        sleepTimer.sleepTimerWasTriggeredForEndOfEpisode(episode?.uuid)
+        sleepTimer.setEndOfEpisodeUuid(episode?.uuid)
         sleepAfterEpisode = false
 
         withContext(Dispatchers.Main) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
@@ -29,7 +29,8 @@ class SleepTimer @Inject constructor(
         private var lastTimeHasFinishedInMillis: Long = 0
         private var lastEpisodeUuidAutomaticEnded: String? = null
         private const val MIN_TIME_TO_RESTART_SLEEP_TIMER_IN_MINUTES = 5
-        private const val TIME_IN_SECOND_KEY = "time"
+        private const val TIME_KEY = "time"
+        private const val END_OF_EPISODE_VALUE = "end_of_episode"
     }
 
     fun sleepAfter(mins: Int, onSuccess: () -> Unit) {
@@ -61,11 +62,9 @@ class SleepTimer @Inject constructor(
 
         if (diffInMinutes < MIN_TIME_TO_RESTART_SLEEP_TIMER_IN_MINUTES && !lastEpisodeUuidAutomaticEnded.isNullOrEmpty() && currentEpisodeUuid != lastEpisodeUuidAutomaticEnded) {
             onRestartSleepOnEpisodeEnd()
+            analyticsTracker.track(PLAYER_SLEEP_TIMER_RESTARTED, mapOf(TIME_KEY to END_OF_EPISODE_VALUE))
         } else if (diffInMinutes < MIN_TIME_TO_RESTART_SLEEP_TIMER_IN_MINUTES && lastSleepAfterTimeInMinutes != 0 && !isSleepTimerRunning) {
-            analyticsTracker.track(
-                PLAYER_SLEEP_TIMER_RESTARTED,
-                mapOf(TIME_IN_SECOND_KEY to lastSleepAfterTimeInMinutes * 60), // Convert to seconds
-            )
+            analyticsTracker.track(PLAYER_SLEEP_TIMER_RESTARTED, mapOf(TIME_KEY to lastSleepAfterTimeInMinutes * 60)) // Convert to seconds
             sleepAfter(lastSleepAfterTimeInMinutes, onRestartSleepAfterTime)
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
@@ -75,7 +75,7 @@ class SleepTimer @Inject constructor(
             }
         }
     }
-    fun setEndOfEpisodeUuid(uuid: String?) {
+    fun setEndOfEpisodeUuid(uuid: String) {
         lastEpisodeUuidAutomaticEnded = uuid
         lastTimeSleepTimeHasFinished = System.currentTimeMillis().toDuration(DurationUnit.MILLISECONDS)
         cancelAutomaticSleepAfterTimeRestart()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
@@ -29,7 +29,7 @@ class SleepTimer @Inject constructor(
     }
 
     private var sleepTimeMs: Long? = null
-    private var lastSleepAfterTimeInMinutes: Int = 0
+    private var lastSleepAfterTimeInMinutes: Int? = null
     private var lastTimeHasFinishedInMillis: Long = 0
     private var lastEpisodeUuidAutomaticEnded: String? = null
 
@@ -63,9 +63,11 @@ class SleepTimer @Inject constructor(
         if (diffInMinutes < MIN_TIME_TO_RESTART_SLEEP_TIMER_IN_MINUTES && !lastEpisodeUuidAutomaticEnded.isNullOrEmpty() && currentEpisodeUuid != lastEpisodeUuidAutomaticEnded) {
             onRestartSleepOnEpisodeEnd()
             analyticsTracker.track(PLAYER_SLEEP_TIMER_RESTARTED, mapOf(TIME_KEY to END_OF_EPISODE_VALUE))
-        } else if (diffInMinutes < MIN_TIME_TO_RESTART_SLEEP_TIMER_IN_MINUTES && lastSleepAfterTimeInMinutes != 0 && !isSleepTimerRunning) {
-            analyticsTracker.track(PLAYER_SLEEP_TIMER_RESTARTED, mapOf(TIME_KEY to lastSleepAfterTimeInMinutes * 60)) // Convert to seconds
-            sleepAfter(lastSleepAfterTimeInMinutes, onRestartSleepAfterTime)
+        } else if (diffInMinutes < MIN_TIME_TO_RESTART_SLEEP_TIMER_IN_MINUTES && lastSleepAfterTimeInMinutes != null && !isSleepTimerRunning) {
+            lastSleepAfterTimeInMinutes?.let {
+                analyticsTracker.track(PLAYER_SLEEP_TIMER_RESTARTED, mapOf(TIME_KEY to it * 60)) // Convert to seconds
+                sleepAfter(it, onRestartSleepAfterTime)
+            }
         }
     }
     fun setEndOfEpisodeUuid(uuid: String?) {
@@ -134,7 +136,7 @@ class SleepTimer @Inject constructor(
         cancelAutomaticSleepOnEpisodeEndRestart()
     }
     private fun cancelAutomaticSleepAfterTimeRestart() {
-        lastSleepAfterTimeInMinutes = 0
+        lastSleepAfterTimeInMinutes = null
     }
     private fun cancelAutomaticSleepOnEpisodeEndRestart() {
         lastEpisodeUuidAutomaticEnded = null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
@@ -57,6 +57,7 @@ class SleepTimer @Inject constructor(
         }
         createAlarm(time.timeInMillis)
     }
+
     fun restartSleepTimerIfApplies(currentEpisodeUuid: String, isSleepTimerRunning: Boolean, onRestartSleepAfterTime: () -> Unit, onRestartSleepOnEpisodeEnd: () -> Unit) {
         lastTimeSleepTimeHasFinished?.let { lastTimeHasFinished ->
             val diffTime = System.currentTimeMillis().milliseconds - lastTimeHasFinished
@@ -72,6 +73,7 @@ class SleepTimer @Inject constructor(
             }
         }
     }
+
     fun setEndOfEpisodeUuid(uuid: String) {
         lastEpisodeUuidAutomaticEnded = uuid
         lastTimeSleepTimeHasFinished = System.currentTimeMillis().milliseconds
@@ -137,9 +139,11 @@ class SleepTimer @Inject constructor(
         cancelAutomaticSleepAfterTimeRestart()
         cancelAutomaticSleepOnEpisodeEndRestart()
     }
+
     private fun cancelAutomaticSleepAfterTimeRestart() {
         lastSleepAfterTime = null
     }
+
     private fun cancelAutomaticSleepOnEpisodeEndRestart() {
         lastEpisodeUuidAutomaticEnded = null
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
@@ -22,37 +22,37 @@ class SleepTimer @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     @ApplicationContext private val context: Context,
 ) {
-
     companion object {
-        private var sleepTimeMs: Long? = null
-        private var lastSleepAfterTimeInMinutes: Int = 0
-        private var lastTimeHasFinishedInMillis: Long = 0
-        private var lastEpisodeUuidAutomaticEnded: String? = null
         private const val MIN_TIME_TO_RESTART_SLEEP_TIMER_IN_MINUTES = 5
         private const val TIME_KEY = "time"
         private const val END_OF_EPISODE_VALUE = "end_of_episode"
     }
 
-    fun sleepAfter(mins: Int, onSuccess: () -> Unit) {
+    private var sleepTimeMs: Long? = null
+    private var lastSleepAfterTimeInMinutes: Int = 0
+    private var lastTimeHasFinishedInMillis: Long = 0
+    private var lastEpisodeUuidAutomaticEnded: String? = null
+
+    fun sleepAfter(minutes: Int, onSuccess: () -> Unit) {
         val time = Calendar.getInstance().apply {
             timeInMillis = System.currentTimeMillis()
-            add(Calendar.MINUTE, mins)
+            add(Calendar.MINUTE, minutes)
         }
         if (createAlarm(time.timeInMillis)) {
-            lastSleepAfterTimeInMinutes = mins
+            lastSleepAfterTimeInMinutes = minutes
             cancelAutomaticSleepOnEpisodeEndRestart()
             onSuccess()
         }
     }
 
-    fun addExtraTime(mins: Int) {
+    fun addExtraTime(minutes: Int) {
         val currentTimeMs = sleepTimeMs
         if (currentTimeMs == null || currentTimeMs < 0) {
             return
         }
         val time = Calendar.getInstance().apply {
             timeInMillis = currentTimeMs
-            add(Calendar.MINUTE, mins)
+            add(Calendar.MINUTE, minutes)
         }
         createAlarm(time.timeInMillis)
     }
@@ -109,7 +109,7 @@ class SleepTimer @Inject constructor(
         get() = System.currentTimeMillis() < (sleepTimeMs ?: -1)
 
     fun timeLeftInSecs(): Int? {
-        val sleepTimeMs = SleepTimer.sleepTimeMs ?: return null
+        val sleepTimeMs = sleepTimeMs ?: return null
 
         val timeLeft = sleepTimeMs - System.currentTimeMillis()
         if (timeLeft < 0) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
@@ -56,7 +56,7 @@ class SleepTimer @Inject constructor(
         }
         createAlarm(time.timeInMillis)
     }
-    suspend fun restartSleepTimerIfApplies(currentEpisodeUuid: String, isSleepTimerRunning: Boolean, onRestartSleepAfterTime: () -> Unit, onRestartSleepOnEpisodeEnd: suspend () -> Unit) {
+    fun restartSleepTimerIfApplies(currentEpisodeUuid: String, isSleepTimerRunning: Boolean, onRestartSleepAfterTime: () -> Unit, onRestartSleepOnEpisodeEnd: () -> Unit) {
         val diffTimeInMillis = System.currentTimeMillis() - lastTimeHasFinishedInMillis
         val diffInMinutes = diffTimeInMillis / (1000 * 60) // Convert to minutes
 
@@ -68,7 +68,7 @@ class SleepTimer @Inject constructor(
             sleepAfter(lastSleepAfterTimeInMinutes, onRestartSleepAfterTime)
         }
     }
-    fun sleepTimerWasTriggeredForEndOfEpisode(uuid: String?) {
+    fun setEndOfEpisodeUuid(uuid: String?) {
         lastEpisodeUuidAutomaticEnded = uuid
         lastTimeHasFinishedInMillis = System.currentTimeMillis()
         cancelAutomaticSleepAfterTimeRestart()


### PR DESCRIPTION
## Description
This PR implements a mechanism to restart the sleep timer whenever the user restarts playback within 5 minutes.
- The sleep timer will restart with the same configuration as before same time initially set or end of episode
- If playing after more than 5 minutes, the sleep timer should not restart

While I was working on this, I have found two issues that I reported here:
- https://github.com/Automattic/pocket-casts-android/issues/2045
- https://github.com/Automattic/pocket-casts-android/issues/2047

## Testing Instructions

### Restarting timer for a given amount of time

1. Run the app
2. Add 5 to 10 podcasts to your Up Next
3. Play something
4. Open the full player, tap the sleep timer icon (zZz), select X minutes (You can select 1 minute using the last option)
5. After X minutes the playback should stop
6. Tap play again
7. ✅ The sleep timer should restart with X minutes you set
8. ✅ Ensure `🔵 Tracked: player_sleep_timer_restarted ["time": [time here]]` is tracked

### Not restarting timer
- You can change the value of `SleepTimer.MIN_TIME_TO_RESTART_SLEEP_TIMER_IN_MINUTES` to 1 so you don't need to wait for 5 minutes

1. Play something
4. Open the full player, tap the sleep timer icon (zZz), select X minutes (You can select 1 minute using the last option)
5. After X minutes the playback should stop
6. Wait for 5 minutes. (or the time you set)
7. Tap play again
9. ✅ The sleep timer should not restart

### Restarting timer for end of episode

1. Play something
4. Open the full player, tap the sleep timer icon (zZz), select end of episode
5. Drag the scrubber close to the end of the episode and wait till it's finished
7. Tap play again
8. ✅ The next episode should play and sleep timer should restart for end of episode
9. ✅ Ensure `🔵 Tracked: player_sleep_timer_restarted ["time": "end_of_episode"]` is tracked

### Canceling

1. Play something
4. Open the full player, tap the sleep timer icon (zZz), select any timer
5. Open the timer sheet again and cancel the timer
7. Pause and play again
9. ✅ The timer should not restart

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
