### PR TITLE
Use epoch +1 second as a default sync timestamp

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/preferences/UserSettingTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/preferences/UserSettingTest.kt
@@ -39,7 +39,7 @@ class UserSettingTest {
 
     @Test
     fun handlesSetWithoutTimestampUpdate() {
-        clock += 1.seconds
+        clock += 10.seconds
         userSetting.set("new_value", clock = clock, updateModifiedAt = false)
 
         assertEquals("new_value", userSetting.value)
@@ -59,7 +59,7 @@ class UserSettingTest {
         val currentTime = clock.instant()
 
         userSetting.set("first_value", clock = clock, updateModifiedAt = true)
-        clock += 1.seconds
+        clock += 10.seconds
         userSetting.set("second_value", clock = clock, updateModifiedAt = false)
 
         assertEquals("second_value", userSetting.value)
@@ -79,17 +79,17 @@ class UserSettingTest {
     }
 
     @Test
-    fun useEpochPlusOneAsDefaultSyncTimestamp() {
+    fun useEpochPlusOneSecondAsDefaultSyncTimestamp() {
         lateinit var timestamp: Instant
         userSetting.getSyncSetting { _, modifiedAt ->
             timestamp = modifiedAt
         }
-        assertEquals(Instant.EPOCH.plusMillis(1), timestamp)
+        assertEquals(Instant.EPOCH.plusSeconds(1), timestamp)
     }
 
     @Test
     fun useStoredSyncTimestamp() {
-        clock += 1.seconds
+        clock += 10.seconds
         userSetting.set("new_value", clock = clock, updateModifiedAt = true)
 
         lateinit var timestamp: Instant

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -25,7 +25,7 @@ abstract class UserSetting<T>(
      * it provides [Instant.EPOCH] plus one millisecond as the modification timestamp.
      */
     fun <U> getSyncSetting(f: (T, Instant) -> U): U {
-        return f(value, modifiedAt ?: fallbackTimestamp)
+        return f(value, modifiedAt ?: DefaultFallbackTimestamp)
     }
 
     // Returns the value to sync if sync is needed. Returns null if sync is not needed.
@@ -286,10 +286,10 @@ abstract class UserSetting<T>(
         override fun set(value: T, updateModifiedAt: Boolean, commit: Boolean, clock: Clock) = Unit
     }
 
-    private companion object {
-        // We use EPOCH +1 millisecond as a default timestamp for updates because initial values of when app is installed are null.
+    companion object {
+        // We use EPOCH +1 second as a default timestamp for updates because initial values of when app is installed are null.
         // This means that if a user syncs settings that were set before we started tracking timestamps
         // they would not update on a new device because we update settings only if the local timestamp is before remote timestamp.
-        val fallbackTimestamp: Instant = Instant.EPOCH.plusMillis(1)
+        val DefaultFallbackTimestamp: Instant = Instant.EPOCH.plusSeconds(1)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -21,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.repositories.BuildConfig
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
@@ -1105,67 +1106,67 @@ class PodcastSyncProcess(
                     settings = podcastSettings {
                         autoStartFrom = int32Setting {
                             value = int32Value { value = podcast.startFromSecs }
-                            modifiedAt = podcast.startFromModified.toProtobufTimestampOrEpoch()
+                            modifiedAt = podcast.startFromModified.toProtobufTimestampOrFallback()
                         }
                         autoSkipLast = int32Setting {
                             value = int32Value { value = podcast.skipLastSecs }
-                            modifiedAt = podcast.skipLastModified.toProtobufTimestampOrEpoch()
+                            modifiedAt = podcast.skipLastModified.toProtobufTimestampOrFallback()
                         }
                         addToUpNext = boolSetting {
                             value = boolValue { value = podcast.addToUpNextSyncSetting }
-                            modifiedAt = podcast.autoAddToUpNextModified.toProtobufTimestampOrEpoch()
+                            modifiedAt = podcast.autoAddToUpNextModified.toProtobufTimestampOrFallback()
                         }
                         episodesSortOrder = int32Setting {
                             value = int32Value { value = podcast.episodesSortType.serverId }
-                            modifiedAt = podcast.episodesSortTypeModified.toProtobufTimestampOrEpoch()
+                            modifiedAt = podcast.episodesSortTypeModified.toProtobufTimestampOrFallback()
                         }
                         addToUpNextPosition = int32Setting {
                             value = int32Value { value = podcast.addToUpNextPositionSyncSetting }
-                            modifiedAt = podcast.autoAddToUpNextModified.toProtobufTimestampOrEpoch()
+                            modifiedAt = podcast.autoAddToUpNextModified.toProtobufTimestampOrFallback()
                         }
                         playbackEffects = boolSetting {
                             value = boolValue { value = podcast.overrideGlobalEffects }
-                            modifiedAt = podcast.overrideGlobalEffectsModified.toProtobufTimestampOrEpoch()
+                            modifiedAt = podcast.overrideGlobalEffectsModified.toProtobufTimestampOrFallback()
                         }
                         playbackSpeed = doubleSetting {
                             value = doubleValue { value = podcast.playbackSpeed }
-                            modifiedAt = podcast.playbackSpeedModified.toProtobufTimestampOrEpoch()
+                            modifiedAt = podcast.playbackSpeedModified.toProtobufTimestampOrFallback()
                         }
                         trimSilence = int32Setting {
                             value = int32Value { value = podcast.trimMode.serverId }
-                            modifiedAt = podcast.trimModeModified.toProtobufTimestampOrEpoch()
+                            modifiedAt = podcast.trimModeModified.toProtobufTimestampOrFallback()
                         }
                         volumeBoost = boolSetting {
                             value = boolValue { value = podcast.isVolumeBoosted }
-                            modifiedAt = podcast.volumeBoostedModified.toProtobufTimestampOrEpoch()
+                            modifiedAt = podcast.volumeBoostedModified.toProtobufTimestampOrFallback()
                         }
                         notification = boolSetting {
                             value = boolValue { value = podcast.isShowNotifications }
-                            modifiedAt = podcast.showNotificationsModified.toProtobufTimestampOrEpoch()
+                            modifiedAt = podcast.showNotificationsModified.toProtobufTimestampOrFallback()
                         }
                         autoArchive = boolSetting {
                             value = boolValue { value = podcast.overrideGlobalArchive }
-                            modifiedAt = podcast.overrideGlobalArchiveModified.toProtobufTimestampOrEpoch()
+                            modifiedAt = podcast.overrideGlobalArchiveModified.toProtobufTimestampOrFallback()
                         }
                         autoArchivePlayed = int32Setting {
                             value = int32Value { value = podcast.autoArchiveAfterPlaying.serverId }
-                            modifiedAt = podcast.autoArchiveAfterPlayingModified.toProtobufTimestampOrEpoch()
+                            modifiedAt = podcast.autoArchiveAfterPlayingModified.toProtobufTimestampOrFallback()
                         }
                         autoArchiveInactive = int32Setting {
                             value = int32Value { value = podcast.autoArchiveInactive.serverId }
-                            modifiedAt = podcast.autoArchiveInactiveModified.toProtobufTimestampOrEpoch()
+                            modifiedAt = podcast.autoArchiveInactiveModified.toProtobufTimestampOrFallback()
                         }
                         autoArchiveEpisodeLimit = int32Setting {
                             value = int32Value { value = podcast.autoArchiveEpisodeLimit ?: 0 }
-                            modifiedAt = podcast.autoArchiveEpisodeLimitModified.toProtobufTimestampOrEpoch()
+                            modifiedAt = podcast.autoArchiveEpisodeLimitModified.toProtobufTimestampOrFallback()
                         }
                         episodeGrouping = int32Setting {
                             value = int32Value { value = podcast.grouping.serverId }
-                            modifiedAt = podcast.groupingModified.toProtobufTimestampOrEpoch()
+                            modifiedAt = podcast.groupingModified.toProtobufTimestampOrFallback()
                         }
                         showArchived = boolSetting {
                             value = boolValue { value = podcast.showArchived }
-                            modifiedAt = podcast.showArchivedModified.toProtobufTimestampOrEpoch()
+                            modifiedAt = podcast.showArchivedModified.toProtobufTimestampOrFallback()
                         }
                     }
 
@@ -1290,18 +1291,13 @@ private fun Date.toProtobufTimestamp(): Timestamp {
     }
 }
 
-private fun Date?.toProtobufTimestampOrEpoch(): Timestamp {
-    val instant = this?.toInstant() ?: fallbackTimestamp
+private fun Date?.toProtobufTimestampOrFallback(): Timestamp {
+    val instant = this?.toInstant() ?: UserSetting.DefaultFallbackTimestamp
     return timestamp {
         seconds = instant.epochSecond
         nanos = instant.nano
     }
 }
-
-// We use EPOCH +1 millisecond as a default timestamp for updates because initial values of when app is installed are null.
-// This means that if a user syncs settings that were set before we started tracking timestamps
-// they would not update on a new device because we update settings only if the local timestamp is before remote timestamp.
-private val fallbackTimestamp: Instant = Instant.EPOCH.plusMillis(1)
 
 private val Podcast.addToUpNextSyncSetting get() = autoAddToUpNext != Podcast.AutoAddUpNext.OFF
 private val Podcast.addToUpNextPositionSyncSetting get() = when (autoAddToUpNext) {


### PR DESCRIPTION
## Description

There are issues on iOS when using `epoch +1 millisecond` as a default sync timestamps. This PR changes it to `epoch +1 second` to align with iOS.

## Testing Instructions

No need to test it. CI checks and automated tests are enough.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
