### PR TITLE
Sleep timer: Restart timer when shaking phone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.63
 -----
-
+*   New Features
+    *   Sleep timer: Restart timer when shaking phone
+        ([#2054](https://github.com/Automattic/pocket-casts-android/pull/2054))
 
 7.62
 -----

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -19,6 +19,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.file.StorageOptions
 import au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsJob
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.SleepTimerRestartWhenShakingDevice
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -113,6 +114,8 @@ class PocketCastsApplication : Application(), Configuration.Provider {
     @Inject lateinit var playerWidgetManager: PlayerWidgetManager
 
     @Inject lateinit var upNextDao: UpNextDao
+
+    @Inject lateinit var sleepTimerRestartWhenShakingDevice: SleepTimerRestartWhenShakingDevice
 
     override fun onCreate() {
         if (BuildConfig.DEBUG) {
@@ -260,6 +263,8 @@ class PocketCastsApplication : Application(), Configuration.Provider {
                 statsManager.initStatsEngine()
 
                 subscriptionManager.connectToGooglePlay(this@PocketCastsApplication)
+
+                sleepTimerRestartWhenShakingDevice.init() // Begin detecting when the device has been shaken to restart the sleep timer.
             }
         }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -508,7 +508,7 @@ class PlayerViewModel @Inject constructor(
 
     fun updateSleepTimer() {
         val timeLeft = sleepTimer.timeLeftInSecs()
-        if ((sleepTimer.isRunning && timeLeft != null && timeLeft.toInt() > 0) || playbackManager.sleepAfterEpisode) {
+        if ((sleepTimer.isSleepAfterTimerRunning && timeLeft != null && timeLeft.toInt() > 0) || playbackManager.sleepAfterEpisode) {
             isSleepAtEndOfEpisode.postValue(playbackManager.sleepAfterEpisode)
             sleepTimeLeftText.postValue(if (timeLeft != null && timeLeft > 0) Util.formattedSeconds(timeLeft.toDouble()) else "")
         } else {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -312,6 +312,7 @@
     <string name="player_sleep_timer">Sleep timer</string>
     <string name="player_sleep_timer_start_failed">Unable to start timer. Please allow \'Alarms &amp; reminders\' permission.</string>
     <string name="player_sleep_when_episode_ends">Sleeping when episode ends</string>
+    <string name="player_sleep_timer_restarted_after_device_shake">Sleep timer restarted after device shake</string>
     <string name="player_star" translatable="false">@string/star</string>
     <string name="player_tab_bookmarks" translatable="false">@string/bookmarks</string>
     <string name="player_tab_chapters" translatable="false">@string/chapters</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -313,6 +313,7 @@
     <string name="player_sleep_timer_start_failed">Unable to start timer. Please allow \'Alarms &amp; reminders\' permission.</string>
     <string name="player_sleep_when_episode_ends">Sleeping when episode ends</string>
     <string name="player_sleep_timer_restarted_after_device_shake">Sleep timer restarted after device shake</string>
+    <string name="player_sleep_timer_stopped_your_podcast">Sleep timer stopped your podcast.</string>
     <string name="player_star" translatable="false">@string/star</string>
     <string name="player_tab_bookmarks" translatable="false">@string/bookmarks</string>
     <string name="player_tab_chapters" translatable="false">@string/chapters</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -385,6 +385,8 @@ interface Settings {
     fun getEpisodeSearchDebounceMs(): Long
     fun getReportViolationUrl(): String
     fun getSlumberStudiosPromoCode(): String
+    fun getSleepTimerDeviceShakeThreshold(): Long
+
     val podcastGroupingDefault: UserSetting<PodcastGrouping>
 
     val marketingOptIn: UserSetting<Boolean>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -889,6 +889,10 @@ class SettingsImpl @Inject constructor(
         return firebaseRemoteConfig.getString(FirebaseConfig.SLUMBER_STUDIOS_YEARLY_PROMO_CODE)
     }
 
+    override fun getSleepTimerDeviceShakeThreshold(): Long {
+        return getRemoteConfigLong(FirebaseConfig.SLEEP_TIMER_DEVICE_SHAKE_THRESHOLD)
+    }
+
     private fun getRemoteConfigLong(key: String): Long {
         val value = firebaseRemoteConfig.getLong(key)
         return if (value == 0L) (FirebaseConfig.defaults[key] as? Long ?: 0L) else value

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
@@ -59,7 +59,7 @@ class SleepTimer @Inject constructor(
     }
 
     fun restartTimerIfIsRunning(onSuccess: () -> Unit) {
-        if (isRunning) {
+        if (isSleepAfterTimerRunning) {
             lastSleepAfterTime?.let { sleepAfter(it, onSuccess) }
         }
     }
@@ -117,7 +117,7 @@ class SleepTimer @Inject constructor(
         cleanUpSleepTimer()
     }
 
-    val isRunning: Boolean
+    val isSleepAfterTimerRunning: Boolean
         get() = System.currentTimeMillis() < (sleepTimeMs ?: -1)
 
     fun timeLeftInSecs(): Int? {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
@@ -58,6 +58,12 @@ class SleepTimer @Inject constructor(
         createAlarm(time.timeInMillis)
     }
 
+    fun restartTimerIfIsRunning(onSuccess: () -> Unit) {
+        if (isRunning) {
+            lastSleepAfterTime?.let { sleepAfter(it, onSuccess) }
+        }
+    }
+
     fun restartSleepTimerIfApplies(currentEpisodeUuid: String, isSleepTimerRunning: Boolean, onRestartSleepAfterTime: () -> Unit, onRestartSleepOnEpisodeEnd: () -> Unit) {
         lastTimeSleepTimeHasFinished?.let { lastTimeHasFinished ->
             val diffTime = System.currentTimeMillis().milliseconds - lastTimeHasFinished

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.widget.Toast
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -16,7 +17,7 @@ class SleepTimerReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Paused from sleep timer.")
-        Toast.makeText(context, "Sleep timer stopped your podcast.\nNight night!", Toast.LENGTH_LONG).show()
+        Toast.makeText(context, context.getString(R.string.player_sleep_timer_stopped_your_podcast), Toast.LENGTH_LONG).show()
         playbackManager.pause(sourceView = SourceView.AUTO_PAUSE)
         playbackManager.updateSleepTimerStatus(running = false)
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerRestartWhenShakingDevice.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerRestartWhenShakingDevice.kt
@@ -9,6 +9,7 @@ import android.widget.Toast
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.localization.R
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isAppForeground
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -20,6 +21,7 @@ class SleepTimerRestartWhenShakingDevice @Inject constructor(
     private val sleepTimer: SleepTimer,
     private var playbackManager: PlaybackManager,
     private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val settings: Settings,
     @ApplicationContext private val context: Context,
 ) : SensorEventListener {
 
@@ -46,7 +48,7 @@ class SleepTimerRestartWhenShakingDevice @Inject constructor(
                 val acceleration = sqrt((x * x + y * y + z * z).toDouble())
 
                 // If acceleration is above a certain threshold, consider it a shake
-                if (acceleration > SHAKE_THRESHOLD) {
+                if (acceleration > settings.getSleepTimerDeviceShakeThreshold()) {
                     onDeviceShaken()
                 }
             }
@@ -70,7 +72,6 @@ class SleepTimerRestartWhenShakingDevice @Inject constructor(
     }
 
     companion object {
-        private const val SHAKE_THRESHOLD = 30 // A higher value for SHAKE_THRESHOLD makes the detection less sensitive
         private const val TIME_KEY = "time"
         private const val SHAKING_PHONE_VALUE = "shaking_phone"
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerRestartWhenShakingDevice.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerRestartWhenShakingDevice.kt
@@ -1,0 +1,70 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.widget.Toast
+import au.com.shiftyjelly.pocketcasts.localization.R
+import au.com.shiftyjelly.pocketcasts.utils.extensions.isAppForeground
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.sqrt
+
+@Singleton
+class SleepTimerRestartWhenShakingDevice @Inject constructor(
+    private val sleepTimer: SleepTimer,
+    private var playbackManager: PlaybackManager,
+    @ApplicationContext private val context: Context,
+) : SensorEventListener {
+
+    private val sensorManager by lazy {
+        context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager?
+    }
+    fun init() {
+        val accelerometer = sensorManager?.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+        sensorManager?.registerListener(this, accelerometer, SensorManager.SENSOR_DELAY_NORMAL)
+    }
+
+    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
+        // Do nothing
+    }
+
+    override fun onSensorChanged(event: SensorEvent?) {
+        event?.let {
+            if (it.sensor.type == Sensor.TYPE_ACCELEROMETER) {
+                val x = event.values[0]
+                val y = event.values[1]
+                val z = event.values[2]
+
+                // Calculate acceleration magnitude
+                val acceleration = sqrt((x * x + y * y + z * z).toDouble())
+
+                // If acceleration is above a certain threshold, consider it a shake
+                if (acceleration > SHAKE_THRESHOLD) {
+                    onDeviceShaken()
+                }
+            }
+        }
+    }
+    private fun onDeviceShaken() {
+        sleepTimer.restartTimerIfIsRunning onSuccess@{
+            playbackManager.updateSleepTimerStatus(running = true, sleepAfterEpisode = false)
+
+            if (context.isAppForeground()) {
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.player_sleep_timer_restarted_after_device_shake),
+                    Toast.LENGTH_SHORT,
+                ).show()
+            }
+        }
+    }
+
+    companion object {
+        // A higher value for SHAKE_THRESHOLD makes the detection less sensitive
+        private const val SHAKE_THRESHOLD = 30
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerRestartWhenShakingDevice.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerRestartWhenShakingDevice.kt
@@ -6,6 +6,8 @@ import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.widget.Toast
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isAppForeground
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -17,6 +19,7 @@ import kotlin.math.sqrt
 class SleepTimerRestartWhenShakingDevice @Inject constructor(
     private val sleepTimer: SleepTimer,
     private var playbackManager: PlaybackManager,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
     @ApplicationContext private val context: Context,
 ) : SensorEventListener {
 
@@ -49,9 +52,12 @@ class SleepTimerRestartWhenShakingDevice @Inject constructor(
             }
         }
     }
+
     private fun onDeviceShaken() {
         sleepTimer.restartTimerIfIsRunning onSuccess@{
             playbackManager.updateSleepTimerStatus(running = true, sleepAfterEpisode = false)
+
+            analyticsTracker.track(AnalyticsEvent.PLAYER_SLEEP_TIMER_RESTARTED, mapOf(TIME_KEY to SHAKING_PHONE_VALUE))
 
             if (context.isAppForeground()) {
                 Toast.makeText(
@@ -64,7 +70,8 @@ class SleepTimerRestartWhenShakingDevice @Inject constructor(
     }
 
     companion object {
-        // A higher value for SHAKE_THRESHOLD makes the detection less sensitive
-        private const val SHAKE_THRESHOLD = 30
+        private const val SHAKE_THRESHOLD = 30 // A higher value for SHAKE_THRESHOLD makes the detection less sensitive
+        private const val TIME_KEY = "time"
+        private const val SHAKING_PHONE_VALUE = "shaking_phone"
     }
 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
@@ -10,12 +10,14 @@ object FirebaseConfig {
     const val CLOUD_STORAGE_LIMIT = "custom_storage_limit_gb"
     const val REPORT_VIOLATION_URL = "report_violation_url"
     const val SLUMBER_STUDIOS_YEARLY_PROMO_CODE = "slumber_studios_yearly_promo_code"
+    const val SLEEP_TIMER_DEVICE_SHAKE_THRESHOLD = "sleep_timer_device_shake_threshold"
     val defaults = mapOf(
         PERIODIC_SAVE_TIME_MS to 60000L,
         PLAYER_RELEASE_TIME_OUT_MS to 500L,
         PODCAST_SEARCH_DEBOUNCE_MS to 2000L,
         EPISODE_SEARCH_DEBOUNCE_MS to 2000L,
         CLOUD_STORAGE_LIMIT to 10L,
+        SLEEP_TIMER_DEVICE_SHAKE_THRESHOLD to 30L,
     ) + Feature.values()
         .filter { it.hasFirebaseRemoteFlag }
         .associate { it.key to it.defaultValue }


### PR DESCRIPTION
## Description
- This PR adds the ability to restart the sleep timer If a playback is going on with a timer and the user shakes the device
- This works with both foreground and background app.
- This applies for when the sleep timer was set with a time


## Testing Instructions

### Restarting timer after shaking phone in foreground
1. Run the app
2. Play something
3. Open the full player, tap the sleep timer icon (zZz), select X minutes (You can select 1 minute using the last option)
4. Shake your device
5. ✅ The sleep timer should restart with X minutes you set
6. ✅ You should see the toast with `Sleep timer restarted after device shake` message
7. ✅ Ensure `🔵 Tracked: player_sleep_timer_restarted ["time": "shaking_phone"]` is tracked

### Restarting timer after shaking phone in background
1. Run the app
2. Play something
3. Open the full player, tap the sleep timer icon (zZz), select X minutes (You can select 1 minute using the last option)
4. Put your device in background
5. Shake your device
6. Go back to Pocket Casts App
7. ✅ The sleep timer should have restarted with X minutes you set
8. ✅ You should did **not** see the toast with `Sleep timer restarted after device shake` message
9. ✅ Ensure `🔵 Tracked: player_sleep_timer_restarted ["time": "shaking_phone"]` is tracked

### Do not restart timer after shaking phone when there is no sleep timer running for a time set
1. Run the app
2. Play something
3. Shake your device
4. ✅ The sleep timer should not restart

### Do not restart timer after shaking phone when sleep timer is configured for end of episode
1. Run the app
2. Play something
3. Open the full player, tap the sleep timer icon (zZz), select end of episode
4. Shake your device
5. ✅ The sleep timer should not restart

### Automatically restart if playback is resumed within 5 minutes
1. Run the app
2. Add 5 to 10 podcasts to your Up Next
3. Play something
4. Open the full player, tap the sleep timer icon (zZz), select end of episode
5. Shake your device
6. ✅ The sleep timer should not restart
7. Drag the scrubber close to the end of the episode and wait till it's finished
8. Tap play again
9. ✅ The next episode should play and sleep timer should restart for end of episode


## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/42220351/92bf9868-da04-4f99-bf23-d40bcae454f1



## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
