### PR TITLE
Fix crash when chapters have 0 length durations

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ChapterDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ChapterDaoTest.kt
@@ -120,6 +120,78 @@ class ChapterDaoTest {
     }
 
     @Test
+    fun replaceAllChaptersIfExistingCountIsSmaller() = runBlocking {
+        val chapters1 = List(5) { index ->
+            Chapter(
+                title = "$index-0",
+                episodeUuid = "episode-id",
+                startTimeMs = 0L + index,
+            )
+        }
+        chapterDao.replaceAllChapters("episode-id", chapters1)
+
+        val chapters2 = List(6) { index ->
+            Chapter(
+                title = "$index-1",
+                episodeUuid = "episode-id",
+                startTimeMs = 0L + index,
+            )
+        }
+        chapterDao.replaceAllChaptersIfMoreIsPassed("episode-id", chapters2)
+
+        val result = chapterDao.findAll()
+        assertEquals(chapters2, result)
+    }
+
+    @Test
+    fun doNotReplaceAllChaptersIfExistingCountIsEqual() = runBlocking {
+        val chapters1 = List(5) { index ->
+            Chapter(
+                title = "$index-0",
+                episodeUuid = "episode-id",
+                startTimeMs = 0L + index,
+            )
+        }
+        chapterDao.replaceAllChapters("episode-id", chapters1)
+
+        val chapters2 = List(5) { index ->
+            Chapter(
+                title = "$index-1",
+                episodeUuid = "episode-id",
+                startTimeMs = 0L + index,
+            )
+        }
+        chapterDao.replaceAllChaptersIfMoreIsPassed("episode-id", chapters2)
+
+        val result = chapterDao.findAll()
+        assertEquals(chapters1, result)
+    }
+
+    @Test
+    fun doNotReplaceAllChaptersIfExistingCountIsLarger() = runBlocking {
+        val chapters1 = List(6) { index ->
+            Chapter(
+                title = "$index-0",
+                episodeUuid = "episode-id",
+                startTimeMs = 0L + index,
+            )
+        }
+        chapterDao.replaceAllChapters("episode-id", chapters1)
+
+        val chapters2 = List(5) { index ->
+            Chapter(
+                title = "$index-1",
+                episodeUuid = "episode-id",
+                startTimeMs = 0L + index,
+            )
+        }
+        chapterDao.replaceAllChaptersIfMoreIsPassed("episode-id", chapters2)
+
+        val result = chapterDao.findAll()
+        assertEquals(chapters1, result)
+    }
+
+    @Test
     fun doNotDeleteChaptersForOtherEpisodes() = runBlocking {
         val id1 = "episode-id-1"
         val id2 = "episode-id-2"

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -760,7 +760,6 @@ class MainActivity :
             upNextQueue to useEpisodeArtwork
         }
             .onEach { (upNextQueue, useEpisodeArtwork) ->
-                updatePlaybackStateDeselectedChapterIndices(upNextQueue)
                 binding.playerBottomSheet.setUpNext(
                     upNext = upNextQueue,
                     theme = theme,
@@ -886,22 +885,6 @@ class MainActivity :
                 }
             }
         })
-    }
-
-    private fun updatePlaybackStateDeselectedChapterIndices(upNextQueue: UpNextQueue.State) {
-        (upNextQueue as? UpNextQueue.State.Loaded)?.let {
-            val lastPlaybackState = viewModel.lastPlaybackState
-            if (lastPlaybackState?.chapters?.getList()?.isEmpty() == true) return
-            val currentEpisodeDeselectedChapterIndicesChanged = playbackManager.getCurrentEpisode()?.let { currentEpisode ->
-                currentEpisode.uuid == it.episode.uuid &&
-                    lastPlaybackState != null &&
-                    it.episode.deselectedChapters.sorted() !=
-                    lastPlaybackState.chapters.getList().filterNot { it.selected }.map { it.index }.sorted()
-            } ?: false
-            if (currentEpisodeDeselectedChapterIndicesChanged) {
-                playbackManager.updatePlaybackStateDeselectedChapterIndices()
-            }
-        }
     }
 
     override fun whatsNewDismissed(fromConfirmAction: Boolean) {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -414,8 +414,8 @@ platform :android do
     android_firebase_test(
       project_id: firebase_secret(name: 'project_id'),
       key_file: GOOGLE_FIREBASE_SECRETS_PATH,
-      model: 'Nexus5',
-      version: 23,
+      model: 'Pixel2.arm',
+      version: 30,
       test_apk_path: File.join(apk_dir, 'androidTest', 'debug', 'app-debug-androidTest.apk'),
       apk_path: File.join(apk_dir, 'debug', 'app-debug.apk'),
       results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests')

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/ChapterDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/ChapterDao.kt
@@ -26,6 +26,19 @@ abstract class ChapterDao {
         insertAll(chapters.filter { it.episodeUuid == episodeUuid })
     }
 
+    @Transaction
+    open suspend fun replaceAllChaptersIfMoreIsPassed(episodeUuid: String, chapters: List<Chapter>) {
+        val storedChapters = findEpisodeChapters(episodeUuid)
+        if (storedChapters.size >= chapters.size) {
+            return
+        }
+        deleteForEpisode(episodeUuid)
+        insertAll(chapters.filter { it.episodeUuid == episodeUuid })
+    }
+
+    @Query("SELECT * FROM episode_chapters WHERE episode_uuid IS :episodeUuid ORDER BY start_time ASC")
+    protected abstract suspend fun findEpisodeChapters(episodeUuid: String): List<Chapter>
+
     @Query("SELECT * FROM episode_chapters WHERE episode_uuid IS :episodeUuid ORDER BY start_time ASC")
     protected abstract fun _observerChaptersForEpisode(episodeUuid: String): Flow<List<Chapter>>
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapter.kt
@@ -34,9 +34,9 @@ data class Chapter(
         }
     }
 
-    fun calculateProgress(playbackPosition: Duration): Float = if (playbackPosition == Duration.ZERO || playbackPosition !in this) {
-        0f
-    } else {
-        (playbackPosition - startTime).inWholeMilliseconds.toFloat() / duration.inWholeMilliseconds.toFloat()
+    fun calculateProgress(playbackPosition: Duration): Float = when {
+        playbackPosition == Duration.ZERO || playbackPosition !in this -> 0f
+        duration.inWholeMilliseconds == 0L -> 0f
+        else -> (playbackPosition - startTime).inWholeMilliseconds.toFloat() / duration.inWholeMilliseconds
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapters.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapters.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.models.to
 
-import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import kotlin.time.Duration
@@ -82,19 +81,14 @@ data class Chapters(
         return getChapterIndex(time) == items.size - 1
     }
 
-    fun updateChaptersTimes(episodeDuration: Duration) = copy(
-        items = items.mapIndexed { index, chapter ->
-            when (index) {
-                0 -> chapter.copy(startTime = Duration.ZERO)
-                items.lastIndex -> chapter.copy(endTime = episodeDuration)
-                else -> chapter
-            }
-        },
-    )
-
-    fun updateDeselectedState(currentEpisode: BaseEpisode?) = copy(
-        items = items.map { chapter ->
-            chapter.copy(selected = currentEpisode?.deselectedChapters?.contains(chapter.index) == false)
-        },
-    )
+    fun toDbChapters(episodeId: String) = items.map { chapter ->
+        DbChapter(
+            episodeUuid = episodeId,
+            startTimeMs = chapter.startTime.inWholeMilliseconds,
+            endTimeMs = chapter.endTime.inWholeMilliseconds,
+            title = chapter.title,
+            imageUrl = chapter.imagePath,
+            url = chapter.url?.toString(),
+        )
+    }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManager.kt
@@ -5,7 +5,11 @@ import kotlinx.coroutines.flow.Flow
 import au.com.shiftyjelly.pocketcasts.models.to.DbChapter as Chapter
 
 interface ChapterManager {
-    suspend fun updateChapters(episodeUuid: String, chapters: List<Chapter>)
+    suspend fun updateChapters(
+        episodeUuid: String,
+        chapters: List<Chapter>,
+        forceUpdate: Boolean = true,
+    )
 
     fun observerChaptersForEpisode(episodeUuid: String): Flow<Chapters>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
@@ -1,46 +1,56 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import au.com.shiftyjelly.pocketcasts.models.db.dao.ChapterDao
-import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.models.to.Chapters
 import au.com.shiftyjelly.pocketcasts.models.to.DbChapter
 import javax.inject.Inject
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 
 class ChapterManagerImpl @Inject constructor(
     private val chapterDao: ChapterDao,
-    private val episodeDao: EpisodeDao,
+    private val episodeManager: EpisodeManager,
 ) : ChapterManager {
-    override suspend fun updateChapters(episodeUuid: String, chapters: List<DbChapter>) {
-        chapterDao.replaceAllChapters(episodeUuid, chapters)
+    override suspend fun updateChapters(
+        episodeUuid: String,
+        chapters: List<DbChapter>,
+        forceUpdate: Boolean,
+    ) {
+        if (forceUpdate) {
+            chapterDao.replaceAllChapters(episodeUuid, chapters)
+        } else {
+            chapterDao.replaceAllChaptersIfMoreIsPassed(episodeUuid, chapters)
+        }
     }
 
-    override fun observerChaptersForEpisode(episodeUuid: String) = chapterDao
-        .observerChaptersForEpisode(episodeUuid)
-        .map { it.toChapters(episodeUuid) }
+    override fun observerChaptersForEpisode(episodeUuid: String) = combine(
+        episodeManager.observeEpisodeByUuid(episodeUuid).distinctUntilChangedBy(BaseEpisode::deselectedChapters),
+        chapterDao.observerChaptersForEpisode(episodeUuid),
+    ) { episode, dbChapters -> dbChapters.toChapters(episode) }
 
-    private suspend fun List<DbChapter>.toChapters(episodeUuid: String): Chapters {
-        val deselectedChapters = episodeDao.findByUuid(episodeUuid)?.deselectedChapters.orEmpty()
+    private fun List<DbChapter>.toChapters(episode: BaseEpisode): Chapters {
         val chaptersList = withIndex().windowed(size = 2, partialWindows = true) { window ->
-            val index = window[0].index + 1
+            val index = window[0].index
+            val chapterIndex = window[0].index + 1
             val firstChapter = window[0].value
             val secondChapter = window.getOrNull(1)?.value
 
-            val secondEndTime = secondChapter?.startTimeMs?.milliseconds ?: Duration.INFINITE
+            val secondEndTime = secondChapter?.startTimeMs?.milliseconds ?: episode.durationMs.milliseconds
             val fixedEndTime = firstChapter.endTimeMs?.milliseconds?.takeIf { it <= secondEndTime } ?: secondEndTime
 
             Chapter(
                 title = firstChapter.title.orEmpty(),
-                startTime = firstChapter.startTimeMs.milliseconds,
+                startTime = if (index == 0) Duration.ZERO else firstChapter.startTimeMs.milliseconds,
                 endTime = fixedEndTime,
                 url = firstChapter.url?.toHttpUrlOrNull(),
                 imagePath = firstChapter.imageUrl,
-                index = index,
-                selected = index !in deselectedChapters,
+                index = chapterIndex,
+                selected = chapterIndex !in episode.deselectedChapters,
             )
         }
         return Chapters(chaptersList)

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
@@ -2,37 +2,37 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.models.db.dao.ChapterDao
-import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.models.to.Chapters
 import au.com.shiftyjelly.pocketcasts.models.to.DbChapter
 import java.util.Date
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 class ChapterManagerImplTest {
     private val chapterDao = mock<ChapterDao>()
-    private val episodeDao = mock<EpisodeDao>()
+    private val episodeManager = mock<EpisodeManager>()
 
-    private val chapterManager = ChapterManagerImpl(chapterDao, episodeDao)
+    private val chapterManager = ChapterManagerImpl(chapterDao, episodeManager)
 
     @Test
     fun `observe no chapters`() = runBlocking {
+        val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.001)
+
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(emptyList()))
-        whenever(episodeDao.findByUuid("id")).doSuspendableAnswer { null }
+        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
-            assertEquals(Chapters(emptyList<Chapter>()), awaitItem())
+            assertEquals(Chapters(emptyList()), awaitItem())
 
             awaitComplete()
         }
@@ -40,6 +40,7 @@ class ChapterManagerImplTest {
 
     @Test
     fun `observe single chapter`() = runBlocking {
+        val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.001)
         val dbChapter = DbChapter(
             episodeUuid = "id",
             startTimeMs = 0,
@@ -50,7 +51,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(listOf(dbChapter)))
-        whenever(episodeDao.findByUuid("id")).doSuspendableAnswer { null }
+        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = Chapter(
@@ -70,6 +71,7 @@ class ChapterManagerImplTest {
 
     @Test
     fun `observe multiple chapters`() = runBlocking {
+        val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.003)
         val dbChapters = listOf(
             DbChapter(
                 episodeUuid = "id",
@@ -92,7 +94,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(dbChapters))
-        whenever(episodeDao.findByUuid("id")).doSuspendableAnswer { null }
+        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = listOf(
@@ -126,6 +128,7 @@ class ChapterManagerImplTest {
 
     @Test
     fun `observe chapter without title`() = runBlocking {
+        val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.001)
         val dbChapter = DbChapter(
             episodeUuid = "id",
             startTimeMs = 0,
@@ -136,7 +139,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(listOf(dbChapter)))
-        whenever(episodeDao.findByUuid("id")).doSuspendableAnswer { null }
+        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = Chapter(
@@ -156,6 +159,7 @@ class ChapterManagerImplTest {
 
     @Test
     fun `observe chapter without image URL`() = runBlocking {
+        val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.001)
         val dbChapter = DbChapter(
             episodeUuid = "id",
             startTimeMs = 0,
@@ -166,7 +170,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(listOf(dbChapter)))
-        whenever(episodeDao.findByUuid("id")).doSuspendableAnswer { null }
+        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = Chapter(
@@ -186,6 +190,7 @@ class ChapterManagerImplTest {
 
     @Test
     fun `observe chapter without URL`() = runBlocking {
+        val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.001)
         val dbChapter = DbChapter(
             episodeUuid = "id",
             startTimeMs = 0,
@@ -196,7 +201,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(listOf(dbChapter)))
-        whenever(episodeDao.findByUuid("id")).doSuspendableAnswer { null }
+        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = Chapter(
@@ -216,6 +221,7 @@ class ChapterManagerImplTest {
 
     @Test
     fun `observe chapter with invalid URL`() = runBlocking {
+        val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.001)
         val dbChapter = DbChapter(
             episodeUuid = "id",
             startTimeMs = 0,
@@ -226,7 +232,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(listOf(dbChapter)))
-        whenever(episodeDao.findByUuid("id")).doSuspendableAnswer { null }
+        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = Chapter(
@@ -246,6 +252,7 @@ class ChapterManagerImplTest {
 
     @Test
     fun `observe deselected chapters`() = runBlocking {
+        val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.004, deselectedChapters = ChapterIndices(listOf(1, 4)))
         val dbChapters = listOf(
             DbChapter(
                 episodeUuid = "id",
@@ -274,7 +281,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(dbChapters))
-        whenever(episodeDao.findByUuid("id")).doSuspendableAnswer { PodcastEpisode("id", publishedDate = Date(), deselectedChapters = ChapterIndices(listOf(1, 4))) }
+        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = listOf(
@@ -315,6 +322,7 @@ class ChapterManagerImplTest {
 
     @Test
     fun `observe chapters with unknown end timestamps`() = runBlocking {
+        val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.003)
         val dbChapters = listOf(
             DbChapter(
                 episodeUuid = "id",
@@ -337,7 +345,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(dbChapters))
-        whenever(episodeDao.findByUuid("id")).doSuspendableAnswer { null }
+        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = listOf(
@@ -359,7 +367,7 @@ class ChapterManagerImplTest {
                     index = 3,
                     title = "Title 3",
                     startTime = 2.milliseconds,
-                    endTime = Duration.INFINITE,
+                    endTime = 3.milliseconds,
                     selected = true,
                 ),
             )
@@ -371,6 +379,7 @@ class ChapterManagerImplTest {
 
     @Test
     fun `observe chapters with invalid timestamps`() = runBlocking {
+        val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.003)
         val dbChapters = listOf(
             DbChapter(
                 episodeUuid = "id",
@@ -387,7 +396,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(dbChapters))
-        whenever(episodeDao.findByUuid("id")).doSuspendableAnswer { null }
+        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = listOf(
@@ -409,6 +418,39 @@ class ChapterManagerImplTest {
             assertEquals(Chapters(expected), awaitItem())
 
             awaitComplete()
+        }
+    }
+
+    @Test
+    fun `observe chapter selection changes`() = runBlocking {
+        val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.001)
+        val episodesFlow = MutableStateFlow(episode)
+        val dbChapter = DbChapter(
+            episodeUuid = "id",
+            startTimeMs = 0,
+            endTimeMs = 1,
+            title = "Title",
+        )
+
+        whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(listOf(dbChapter)))
+        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(episodesFlow)
+
+        chapterManager.observerChaptersForEpisode("id").test {
+            val expectedSelected = Chapter(
+                index = 1,
+                title = "Title",
+                startTime = 0.milliseconds,
+                endTime = 1.milliseconds,
+                selected = true,
+            )
+            assertEquals(Chapters(listOf(expectedSelected)), awaitItem())
+
+            episodesFlow.value = episode.copy(deselectedChapters = ChapterIndices(listOf(1)))
+
+            val expectedNotSelected = expectedSelected.copy(selected = false)
+            assertEquals(Chapters(listOf(expectedNotSelected)), awaitItem())
+
+            cancel()
         }
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
@@ -453,4 +453,161 @@ class ChapterManagerImplTest {
             cancel()
         }
     }
+
+    @Test
+    fun `observe chapters with 0 duration`() = runBlocking {
+        val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.003)
+        val dbChapters = listOf(
+            DbChapter(
+                episodeUuid = "id",
+                startTimeMs = 0,
+                endTimeMs = 0,
+                title = "Title 1",
+            ),
+            DbChapter(
+                episodeUuid = "id",
+                startTimeMs = 1,
+                endTimeMs = 1,
+                title = "Title 2",
+            ),
+        )
+
+        whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(dbChapters))
+        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
+
+        chapterManager.observerChaptersForEpisode("id").test {
+            val expected = listOf(
+                Chapter(
+                    index = 1,
+                    title = "Title 1",
+                    startTime = 0.milliseconds,
+                    endTime = 1.milliseconds,
+                    selected = true,
+                ),
+                Chapter(
+                    index = 2,
+                    title = "Title 2",
+                    startTime = 1.milliseconds,
+                    endTime = 3.milliseconds,
+                    selected = true,
+                ),
+            )
+            assertEquals(Chapters(expected), awaitItem())
+
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `observe chapters with negative duration`() = runBlocking {
+        val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.003)
+        val dbChapters = listOf(
+            DbChapter(
+                episodeUuid = "id",
+                startTimeMs = 0,
+                endTimeMs = -2,
+                title = "Title 1",
+            ),
+            DbChapter(
+                episodeUuid = "id",
+                startTimeMs = 1,
+                endTimeMs = 1,
+                title = "Title 2",
+            ),
+        )
+
+        whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(dbChapters))
+        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
+
+        chapterManager.observerChaptersForEpisode("id").test {
+            val expected = listOf(
+                Chapter(
+                    index = 1,
+                    title = "Title 1",
+                    startTime = 0.milliseconds,
+                    endTime = 1.milliseconds,
+                    selected = true,
+                ),
+                Chapter(
+                    index = 2,
+                    title = "Title 2",
+                    startTime = 1.milliseconds,
+                    endTime = 3.milliseconds,
+                    selected = true,
+                ),
+            )
+            assertEquals(Chapters(expected), awaitItem())
+
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `filter chapters with no duration`() = runBlocking {
+        val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.003)
+        val dbChapters = listOf(
+            DbChapter(
+                episodeUuid = "id",
+                startTimeMs = 0,
+                endTimeMs = 0,
+                title = "Title 1",
+            ),
+            DbChapter(
+                episodeUuid = "id",
+                startTimeMs = 0,
+                endTimeMs = 0,
+                title = "Title 2",
+            ),
+            DbChapter(
+                episodeUuid = "id",
+                startTimeMs = 1,
+                endTimeMs = 1,
+                title = "Title 3",
+            ),
+            DbChapter(
+                episodeUuid = "id",
+                startTimeMs = 2,
+                endTimeMs = 2,
+                title = "Title 4",
+            ),
+            DbChapter(
+                episodeUuid = "id",
+                startTimeMs = 2,
+                endTimeMs = 2,
+                title = "Title 5",
+            ),
+        )
+
+        whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(dbChapters))
+        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
+
+        chapterManager.observerChaptersForEpisode("id").test {
+            val expected = listOf(
+                Chapter(
+                    index = 1,
+                    title = "Title 2",
+                    startTime = 0.milliseconds,
+                    endTime = 1.milliseconds,
+                    selected = true,
+                ),
+                Chapter(
+                    index = 2,
+                    title = "Title 3",
+                    startTime = 1.milliseconds,
+                    endTime = 2.milliseconds,
+                    selected = true,
+                ),
+                Chapter(
+                    index = 3,
+                    title = "Title 5",
+                    startTime = 2.milliseconds,
+                    endTime = 3.milliseconds,
+                    selected = true,
+                ),
+            )
+            assertEquals(Chapters(expected), awaitItem())
+
+            awaitComplete()
+        }
+    }
 }


### PR DESCRIPTION
## Description

This is a hotfix that accounts for a possibility that a chapter can have 0 duration.

I cherry picked 90d55e3f8c24bb080456ee372bcc108bcb1d9f79 to fix this. Otherwise I'd have to make the same fix in two places and fight merging conflicts. This way we have a fix in a single place that is covered by unit tests.

When doing the review you should focus on e2f9419b0883d1bc802af2b9ef2cd4622acaf0d7 and 4da7135e96cd900efdcfe8ecfa2676970f092026.

Closes #2059
Closes #2056

## Testing Instructions

### Fix

1. Play an episode from https://pca.st/v0UDSh.
2. It should not crash.
3. Check that you can interact with chapters. Chapters are gibberish. They come from the episode metadata. Maybe it is a bug in our chapters processing but this is what we currently get from the `EpisodeFileMetadata`.

### Regressions

#### Podlove

1. Subscribe to a podcast with chapters from Podlove like [this one](https://pca.st/chaosradio).
2. Play an episode from this podcast.
3. You should be able to interact with the chapters from that episode. Switch them, deselect them, and so on.

#### Podcast Index

1. Subscribe to a podcast with chapters from Podcast Index like [this one](https://pca.st/changelog).
2. Play an episode from this podcast.
3. You should be able to interact with the chapters from that episode. Switch them, deselect them, and so on.

#### Embedded

1. Subscribe to a podcast with chapters from a file like [this one](https://pca.st/upgrade).
2. Play an episode from this podcast.
3. You should be able to interact with the chapters from that episode. Switch them, deselect them, and so on.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
