### PR TITLE
[Tooling] Fix `new_beta_release` prompt, which can be misleading after a hotfix

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -143,7 +143,7 @@ platform :android do
   end
 
   # @option [String] base_version The "x.y" version number to create a beta from. Defaults to the current version as defined in the version file of `main` branch
-  # @option [Integer] version_code The versionCode to use for the new beta. Defaults to the versionCode defined in the version file of the `release/<base_version>` branch
+  # @option [Integer] version_code The versionCode to use for the new beta. Defaults to one more than the versionCode defined in the version file of the `release/<base_version>` branch
   lane :new_beta_release do |options|
     ensure_git_status_clean
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -142,9 +142,23 @@ platform :android do
     trigger_release_build(branch_to_build: "release/#{new_version}")
   end
 
+  # @option [String] base_version The "x.y" version number to create a beta from. Defaults to the current version as defined in the version file of `main` branch
+  # @option [Integer] version_code The versionCode to use for the new beta. Defaults to the versionCode defined in the version file of the `release/<base_version>` branch
   lane :new_beta_release do |options|
     ensure_git_status_clean
-    Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
+
+    base_version = options[:base_version]
+    if base_version.nil?
+      # If no base_version provided, read it from the version file from `main`
+      Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
+      base_version = release_version_current
+    end
+
+    # Checkout release branch first, so that all computations of `beta_version_*`` and `build_code_*`` are based on the
+    # current values in the current `release/*`` branch, not the values from `main` (which is important in cases like
+    # hotfixes for example, where `main` doesn't have the new versionCode used by the hotfix yet but release/* branch do)
+    checkout_success = Fastlane::Helper::GitHelper.checkout_and_pull(release: base_version)
+    UI.user_error!("Release branch for version #{base_version} doesn't exist.") unless checkout_success
 
     # Check versions
     message = <<-MESSAGE
@@ -153,17 +167,9 @@ platform :android do
       New beta version: #{beta_version_next}
 
       Current build code: #{build_code_current}
-      New build code: #{build_code_next}
+      New build code: #{options[:version_code] || build_code_next}
 
     MESSAGE
-
-    # Check branch
-    unless !options[:base_version].nil? || Fastlane::Helper::GitHelper.checkout_and_pull(release: release_version_current)
-      UI.user_error!("Release branch for version #{release_version_current} doesn't exist.")
-    end
-
-    # Check user override
-    override_default_release_branch(options[:base_version]) unless options[:base_version].nil?
 
     UI.important(message)
     unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
@@ -175,7 +181,7 @@ platform :android do
     ensure_git_branch(branch: '^release/') # Match branch names that begin with `release/`
     VERSION_FILE.write_version(
       version_name: beta_version_next,
-      version_code: build_code_next
+      version_code: options[:version_code] || build_code_next
     )
     commit_version_bump
     UI.success("Done! New Beta Version: #{beta_version_current}. New Build Code: #{build_code_current}")
@@ -465,13 +471,6 @@ platform :android do
 
   def beta_version?(version)
     version.include? '-rc-'
-  end
-
-  def override_default_release_branch(version)
-    success = Fastlane::Helper::GitHelper.checkout_and_pull(release: version)
-    UI.user_error!("Release branch for version #{version} doesn't exist. Abort.") unless success
-
-    UI.message("Checked out branch `#{git_branch}` as requested by user.\n")
   end
 
   #####################################################################################


### PR DESCRIPTION
## Why?

As discussed in Slack in p1713279787498399/1713274980.521569-slack-CC7L49W13

When running the `new_beta_release` lane, the lane started by checking out `main` then printing a prompt based on the values of the `versions.properties` file's state in `main`. While in practice the code would bump the version in the version file based on the the values of the version file's state in the `release/*` branch where the bump will happen.

While most of the time those two states of the version file are the same (because we usually back-merge `release/*` into `main` after every new beta), this can lead to inconsistencies and misleading prompt, in particular:
 - If, during the previous beta, the PR back-merging `release/*` to `main` was not merged
 - Or If there has been a hotfix happening, in which case one would trigger the hotfix build, back-merge the `release/7.61.1` branch into `release/7.62`… but then would want to do a new beta at that stage before back-merging `release/7.62` into `main`.

## How?

This PR switches to the `release/*` branch before setting the prompt message, so that the `beta_version_current`, `beta_version_next`, `build_code_current` and `build_code_next` values it prints would use the version file of the `release/*` branch, not `main`, and would thus match the actual value that we will end up update the version file to.

 - By default, the lane will still switch to `main` at the start, but only to get the `release_version_current`, so that it can then know which `release/#{release_version_current}` branch to check out and do the new beta from. And only from then will all the rest of the code (including the values computed for the prompt) run
 - The lane optionally accepts a `base_version` parameter which, is set, tells which `release/#{base_version}` branch to use to do the beta, instead of letting the lane checkout `main` to guess it from the version file.
 - Additionally, the lane now also accepts a `version_code` optional parameter which, if provided, will be used for the versionCode of the beta, instead of letting `build_code_next` bump the current value by one. This can be used as a manual override if it happens that, for some reason, despite the fix from this PR, we still need to skip a version code already in use in GooglePlay.

## Testing Instructions

> [!NOTE]
> At the time of writing those instructions, [the current value of `versionCode` in the `versions.properties` file on the `release/7.62` branch (which we'll call `C` in below instructions) is `9215`](https://github.com/Automattic/pocket-casts-android/commit/0541f2a83c2ca2218a7567798244bbd88e1195b9#diff-457882d18de16474577f72103de0f91a12c2729570f798987e932191695d5baeR2). It if has evolved to a further value by the time you review this PR, adjust the instructions accordingly.

 - Edit the `Fastile` and comment the `push_to_git_remote(tags: false)` and `trigger_release_build(branch_to_build: "release/#{release_version_current}")` lines (189–191) from the end of the `new_beta_release` lane—so that we will commit the bump but not push it nor really trigger a true release—, as well as the `ensure_git_status_clean` call at the start on line 148
 - Call `bundle exec fastlane new_beta_release`
 - Confirm that the prompt tells it will update the build code to `9216`(= `C` + 1)
 - Approve the prompt and let it bump the version file and commit. Check that the commit was made on top of the `release/7.62` branch and that the change indeed updated `versionCode` to `9216` (`C` + 1)
 - Run `bundle exec fastlane new_beta_release` once again
 - Confirm that the prompt tells it will update the next build code, aka `9217` (= `C` + 2) — even if the previous bump was not merged to `main`. This is where the previous implementation was misleading.
 - Approve the prompt, check the commit on `release/7.62` indeed updated `versionCode` to `9217`
 - Cancel the 2 commits you created for this test (`git checkout release/7.62 && git reset --hard origin/release/7.62`), to avoid pushing them to the remote by accident

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~