### PR TITLE
Do not take timestamp argument if it is missing

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -104,7 +104,7 @@ class EpisodeContainerFragment :
         get() = arguments?.getString(ARG_EPISODE_UUID)
 
     private val timestamp: Duration?
-        get() = arguments?.getLong(ARG_TIMESTAMP_IN_SECS)?.seconds
+        get() = arguments?.getLong(ARG_TIMESTAMP_IN_SECS, -1)?.takeIf { it >= 0 }?.seconds
 
     private val episodeViewSource: EpisodeViewSource
         get() = EpisodeViewSource.fromString(arguments?.getString(ARG_EPISODE_VIEW_SOURCE))

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -127,7 +127,7 @@ class EpisodeFragment : BaseFragment() {
         get() = arguments?.getString(EpisodeContainerFragment.ARG_EPISODE_UUID)
 
     private val timestamp: Duration?
-        get() = arguments?.getLong(EpisodeContainerFragment.ARG_TIMESTAMP_IN_SECS)?.seconds
+        get() = arguments?.getLong(EpisodeContainerFragment.ARG_TIMESTAMP_IN_SECS)?.takeIf { it >= 0 }?.seconds
 
     private val episodeViewSource: EpisodeViewSource
         get() = EpisodeViewSource.fromString(arguments?.getString(EpisodeContainerFragment.ARG_EPISODE_VIEW_SOURCE))


### PR DESCRIPTION
## Description

`getLong()` on a bundle returns `0` if the argument is missing. This causes playback reset when `EpisodeContainerFragment` is opened. Ideally we wouldn't be using primitives in bundles and switch to `Parcelable` to have a single argument property like here.

https://github.com/Automattic/pocket-casts-android/blob/7367e4b6624fe654058baaeb2ff01566811bda2b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/PodcastSelectFragment.kt#L280-L285

However I don't want to introduce too large of a change to fix this bug.

## Testing Instructions

The easiest way to test it is through a widget.

1. Add a medium widget to your home screen.
2. Play an episode.
3. Tap on an image in the widget.
4. The playback should not reset.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
