### PR TITLE
Sleep timer: Start fading out audio when sleep timer has 5 seconds left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   New Features
     *   Sleep timer: Restart timer when shaking phone
         ([#2054](https://github.com/Automattic/pocket-casts-android/pull/2054))
+    *   Sleep timer: Start fading out audio when sleep timer has 5 seconds left
+        ([#2069](https://github.com/Automattic/pocket-casts-android/pull/2069))
 
 7.62
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -6,8 +6,6 @@ import android.content.Context
 import android.content.Intent
 import android.media.MediaPlayer
 import android.net.Uri
-import android.os.Handler
-import android.os.Looper
 import android.support.v4.media.session.MediaSessionCompat
 import android.util.Log
 import android.widget.Toast
@@ -2237,8 +2235,8 @@ open class PlaybackManager @Inject constructor(
     }
 
     private fun setupFadeOutWhenFinishingSleepTimer() {
-        // Needs to run in main thread because of player getVolume
-        Handler(Looper.getMainLooper()).post {
+        // it needs to run in the main thread because of player getVolume
+        applicationScope.launch(Dispatchers.Main) {
             val timeLeft = sleepTimer.timeLeftInSecs()
             timeLeft?.let {
                 val fadeDuration = 5

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -2242,15 +2242,14 @@ open class PlaybackManager @Inject constructor(
             val timeLeft = sleepTimer.timeLeftInSecs()
             timeLeft?.let {
                 val fadeDuration = 5
-                val maxVolume = (player as? SimplePlayer)?.getVolume() ?: 1.0f
-                val minVolume = 0.0f
+                val startVolume = (player as? SimplePlayer)?.getVolume() ?: 1.0f
 
                 if (timeLeft <= fadeDuration) {
                     val fraction = timeLeft.toFloat() / fadeDuration
-                    val newVolume = minVolume + (maxVolume - minVolume) * fraction
+                    val newVolume = startVolume * fraction
                     player?.setVolume(newVolume)
                 } else {
-                    player?.setVolume(maxVolume)
+                    player?.setVolume(startVolume)
                 }
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -185,6 +185,10 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
         player?.volume = volume
     }
 
+    fun getVolume(): Float? {
+        return player?.volume
+    }
+
     override fun setPodcast(podcast: Podcast?) {}
 
     @OptIn(UnstableApi::class)


### PR DESCRIPTION
## Description
- This implements audio fade out when we have a sleep time set
- The fade out starts when sleep timer has 5 seconds left
- This does not apply to end of episode sleep timer case

## Testing Instructions

### Fade out for a time set
1. Run the app
2. Play something
3. Open the full player, tap the sleep timer icon (zZz), select X minutes (You can select 1 minute using the last option)
4. Wait until sleep timer has 5 seconds left
5. ✅ Audio should start fading out until end episode

### End of episode
1. Run the app
2. Play something
3. Open the full player, tap the sleep timer icon (zZz), select end of episode
4. Seek episode to almost the end
5. Wait for the episode end
6. ✅ You should not hear any fade out

## Screenshots or Screencast 
[Screen_recording_20240416_140608.webm](https://github.com/Automattic/pocket-casts-android/assets/42220351/94191fd3-4045-410a-b5f0-36d1e94efff5)


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack

cc: @leandroalonso 
