### PR TITLE
Push large widget content to the bottom

### DIFF
--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayer.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayer.kt
@@ -11,10 +11,10 @@ import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Column
 import androidx.glance.layout.Spacer
-import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
+import androidx.glance.layout.wrapContentHeight
 import au.com.shiftyjelly.pocketcasts.widget.action.OpenPocketCastsAction
 import au.com.shiftyjelly.pocketcasts.widget.data.LargePlayerWidgetState
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -27,7 +27,7 @@ internal fun LargePlayer(state: LargePlayerWidgetState) {
         Column(
             modifier = GlanceModifier
                 .fillMaxWidth()
-                .height(350.dp)
+                .wrapContentHeight()
                 .cornerRadius(6.dp)
                 .background(GlanceTheme.colors.primaryContainer)
                 .padding(16.dp),
@@ -46,7 +46,10 @@ internal fun LargePlayer(state: LargePlayerWidgetState) {
                 Column(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = GlanceModifier.fillMaxSize().clickable(OpenPocketCastsAction.action()),
+                    modifier = GlanceModifier
+                        .fillMaxWidth()
+                        .height(190.dp)
+                        .clickable(OpenPocketCastsAction.action()),
                 ) {
                     NonScalingText(
                         text = LocalContext.current.getString(LR.string.widget_nothing_in_up_next),

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayerQueue.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayerQueue.kt
@@ -25,7 +25,9 @@ internal fun LargePlayerQueue(
 ) {
     val lastIndex = queue.lastIndex
     LazyColumn(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .height(190.dp),
     ) {
         itemsIndexed(queue, { _, episode -> episode.longId }) { index, episode ->
             Row(


### PR DESCRIPTION
## Description

When large player widget was too big for the current screen it was clipped both at the top and the bottom. While we can't control the grid size that will be applied by the system due to different screen sizes we can control content of the widget. This PR pushes the content to the bottom so only queue part is initially clipped if anything must be clipped.

## Testing Instructions

> [!note]
> Use a device that would clip content vertically. You can use a small screen device or scale your device screen size. I tested it with this emulator:
> `Resolution (px): 720 x 1280`
> `Resolution (dp): 360 x 640`

1. Add a large widget and noticed that it is clipped only at the bottom.
2. Test that you can resize the widget.

## Screenshots or Screencast 

| Old | New |
| - | - |
| ![Screenshot_20240417_115539](https://github.com/Automattic/pocket-casts-android/assets/30936061/a9362397-7900-4064-9933-3c143027460d) | ![Screenshot_20240417_115522](https://github.com/Automattic/pocket-casts-android/assets/30936061/e2bcdc1a-4200-40f8-8ba9-0739ec2860bb) |

| 0 episodes | 1 episode | 2 episodes | 3 episodes | 4+ episodes |
| - | - | - | - | - |
| ![Screenshot_20240417_115350](https://github.com/Automattic/pocket-casts-android/assets/30936061/78c44170-0d00-49cf-a46a-65c2bd2e5f61) | ![Screenshot_20240417_115331](https://github.com/Automattic/pocket-casts-android/assets/30936061/91e3c69f-4494-4771-af3a-08e44bb72656) | ![Screenshot_20240417_115317](https://github.com/Automattic/pocket-casts-android/assets/30936061/93e5d154-7314-4fb6-b692-3c4679275e6d) | ![Screenshot_20240417_115304](https://github.com/Automattic/pocket-casts-android/assets/30936061/f9a573df-cd97-4d8f-825a-73c8f85f3c7e) | ![Screenshot_20240417_115251](https://github.com/Automattic/pocket-casts-android/assets/30936061/dce30ffb-0b20-4e5e-959e-878b85650550) |

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
