### PR TITLE
Sleep Timer: Fix automatic restart when sleep timer dialog is open

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
@@ -108,7 +108,9 @@ class SleepTimer @Inject constructor(
 
     fun cancelTimer() {
         getAlarmManager().cancel(getSleepIntent())
-        cleanUpSleepTimer()
+        cancelSleepTime()
+        cancelAutomaticSleepAfterTimeRestart()
+        cancelAutomaticSleepOnEpisodeEndRestart()
     }
 
     val isRunning: Boolean
@@ -119,7 +121,7 @@ class SleepTimer @Inject constructor(
 
         val timeLeft = sleepTimeMs - System.currentTimeMillis()
         if (timeLeft < 0) {
-            cleanUpSleepTimer()
+            cancelSleepTime()
             return null
         }
         return (timeLeft / DateUtils.SECOND_IN_MILLIS).toInt()
@@ -134,10 +136,8 @@ class SleepTimer @Inject constructor(
         return context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
     }
 
-    private fun cleanUpSleepTimer() {
+    private fun cancelSleepTime() {
         sleepTimeMs = null
-        cancelAutomaticSleepAfterTimeRestart()
-        cancelAutomaticSleepOnEpisodeEndRestart()
     }
 
     private fun cancelAutomaticSleepAfterTimeRestart() {


### PR DESCRIPTION
## Description
- [Automatic sleep timer](https://github.com/Automattic/pocket-casts-android/pull/2048) was not working when the sleep timer dialog was open
- This is because we were cancel the sleep timer restart variables when cleaning up sleep timer in `timeLeftInSecs`. We should only cancel sleep timer restart when we actual canceled the sleep timer

## Testing Instructions
1. Run the app
2. Play something
3. Open the full player, tap the sleep timer icon (zZz), select X minutes (You can select 1 minute using the last option)
4. Tap on sleep timer icon (zZz) again to open the sleep timer dialog
5. Wait for the sleep timer to finish with the dialog open
6. Close the sleep timer dialog and play the episode again right after that
7. ✅ The sleep timer should restart with X minutes you set

- If you want to smoke test the whole feature again you can follow the steps from https://github.com/Automattic/pocket-casts-android/pull/2048

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
