### PR TITLE
Do not take timestamp argument if it is missing for episode fragment

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -127,7 +127,7 @@ class EpisodeFragment : BaseFragment() {
         get() = arguments?.getString(EpisodeContainerFragment.ARG_EPISODE_UUID)
 
     private val timestamp: Duration?
-        get() = arguments?.getLong(EpisodeContainerFragment.ARG_TIMESTAMP_IN_SECS)?.takeIf { it >= 0 }?.seconds
+        get() = arguments?.getLong(EpisodeContainerFragment.ARG_TIMESTAMP_IN_SECS, -1)?.takeIf { it >= 0 }?.seconds
 
     private val episodeViewSource: EpisodeViewSource
         get() = EpisodeViewSource.fromString(arguments?.getString(EpisodeContainerFragment.ARG_EPISODE_VIEW_SOURCE))


### PR DESCRIPTION
## Description

Follow up to #2067

## Testing Instructions

The easiest way to test it is through a widget.

1. Add a large widget to your home screen.
2. Play an episode.
3. Tap on the large widget.
4. The playback should not reset or loop.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
