### PR TITLE
Fix: End of episode option is not being preserved when switching to another episode from Up Next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 *   Bug Fixes
     *   Improved player view in landscape mode. Added chapter artwork, podcast title, and improved video experience.
         ([#2044](https://github.com/Automattic/pocket-casts-android/pull/1944))
+    *   Sleep Timer: End of episode option was not being preserved after switching to another episode from Up Next
+        ([#2075](https://github.com/Automattic/pocket-casts-android/pull/2075))
 
 7.61
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1691,8 +1691,6 @@ open class PlaybackManager @Inject constructor(
         val currentPlayer = this.player
         val sameEpisode = currentPlayer != null && episode.uuid == currentPlayer.episodeUuid
 
-        sleepAfterEpisode = sleepAfterEpisode && playbackStateRelay.blockingFirst().episodeUuid == episode.uuid
-
         // completed episodes should play from the start
         if (episode.isFinished) {
             episodeManager.markAsNotPlayed(episode)


### PR DESCRIPTION
## Description
- This PR fixes: End of episode (sleep timer) option was not being preserved after switching to another episode from Up Next

Fixes #2047

## Testing Instructions
1. Add at least two episodes to Up Next
2. Go Settings -> General -> Have `Play up next episode on tap` enabled
3. Set `End of Episode` in `Sleep timer`
4. Open the Sleep timer again
5. You will see the `End of episode` option is set ✅
6. Open Up next queue
7. Tap on another episode
8. Open the Sleep timer again
9. You should see the `End of episode` option is set ✅

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
