### PR TITLE
Allow medium widget to be resized to 3x1

### DIFF
--- a/modules/features/widgets/src/main/res/xml/medium_player_widget.xml
+++ b/modules/features/widgets/src/main/res/xml/medium_player_widget.xml
@@ -3,6 +3,7 @@
     android:initialLayout="@layout/glance_default_loading_layout"
     android:minWidth="260dp"
     android:minHeight="40dp"
+    android:minResizeWidth="195dp"
     android:previewImage="@drawable/widget_player_medium_preview"
     android:resizeMode="vertical|horizontal"
     android:targetCellWidth="4"


### PR DESCRIPTION
## Description

In my testing `3x1` medium widget didn't look well. The playback controls were always cutoff at the end. However we had this report (p1713353378687969-slack-C02A333D8LQ) from a user. Apparently `3x1` looks nice on their device. See the screenshot below.

![image](https://github.com/Automattic/pocket-casts-android/assets/30936061/8dd26ca3-3522-44ea-bafa-4e4fcfb7db3f)

## Testing Instructions

1. Add the medium widget to you home screen.
2. The widget should be added as 4x1 or anything that doesn't cut the content off.
3. You should be able to resize it horizontally. It is ok if it is cut off. On some devices it won't be.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack