### PR TITLE
Fix bookmark sharing can loop audio

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -11,7 +11,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.annotation.StringRes
-import androidx.core.os.bundleOf
+import androidx.core.os.BundleCompat
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
@@ -27,6 +27,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarksFragment
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel
 import au.com.shiftyjelly.pocketcasts.podcasts.databinding.FragmentEpisodeContainerBinding
+import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeFragment.EpisodeFragmentArgs
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -37,7 +38,6 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
@@ -47,13 +47,7 @@ class EpisodeContainerFragment :
     BaseDialogFragment(),
     EpisodeFragment.EpisodeLoadedListener {
     companion object {
-        const val ARG_EPISODE_UUID = "episodeUUID"
-        const val ARG_TIMESTAMP_IN_SECS = "timestamp_in_secs"
-        const val ARG_EPISODE_VIEW_SOURCE = "episode_view_source"
-        const val ARG_OVERRIDE_PODCAST_LINK = "override_podcast_link"
-        const val ARG_PODCAST_UUID = "podcastUUID"
-        const val ARG_FROMLIST_UUID = "fromListUUID"
-        const val ARG_FORCE_DARK = "forceDark"
+        private const val NEW_INSTANCE_ARG = "EpisodeContainerFragmentArg"
 
         fun newInstance(
             episode: PodcastEpisode,
@@ -79,16 +73,23 @@ class EpisodeContainerFragment :
             forceDark: Boolean = false,
             timestamp: Duration? = null,
         ) = EpisodeContainerFragment().apply {
-            arguments = bundleOf(
-                ARG_EPISODE_UUID to episodeUuid,
-                ARG_TIMESTAMP_IN_SECS to timestamp?.inWholeSeconds,
-                ARG_EPISODE_VIEW_SOURCE to source.value,
-                ARG_OVERRIDE_PODCAST_LINK to overridePodcastLink,
-                ARG_PODCAST_UUID to podcastUuid,
-                ARG_FROMLIST_UUID to fromListUuid,
-                ARG_FORCE_DARK to forceDark,
-            )
+            arguments = Bundle().apply {
+                putParcelable(
+                    NEW_INSTANCE_ARG,
+                    EpisodeFragmentArgs(
+                        episodeUuid = episodeUuid,
+                        source = source,
+                        overridePodcastLink = overridePodcastLink,
+                        podcastUuid = podcastUuid,
+                        fromListUuid = fromListUuid,
+                        forceDark = forceDark,
+                        timestamp = timestamp,
+                    ),
+                )
+            }
         }
+        private fun extractArgs(bundle: Bundle?): EpisodeFragmentArgs? =
+            bundle?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, EpisodeFragmentArgs::class.java) }
     }
 
     override val statusBarColor: StatusBarColor
@@ -100,26 +101,29 @@ class EpisodeContainerFragment :
 
     var binding: FragmentEpisodeContainerBinding? = null
 
-    private val episodeUUID: String?
-        get() = arguments?.getString(ARG_EPISODE_UUID)
+    private val args: EpisodeFragmentArgs
+        get() = extractArgs(arguments) ?: throw IllegalStateException("${this::class.java.simpleName} is missing arguments. It must be created with newInstance function")
+
+    private val episodeUUID: String
+        get() = args.episodeUuid
 
     private val timestamp: Duration?
-        get() = arguments?.getLong(ARG_TIMESTAMP_IN_SECS, -1)?.takeIf { it >= 0 }?.seconds
+        get() = args.timestamp
 
     private val episodeViewSource: EpisodeViewSource
-        get() = EpisodeViewSource.fromString(arguments?.getString(ARG_EPISODE_VIEW_SOURCE))
+        get() = args.source
 
     private val overridePodcastLink: Boolean
-        get() = arguments?.getBoolean(ARG_OVERRIDE_PODCAST_LINK) ?: false
+        get() = args.overridePodcastLink
 
     val podcastUuid: String?
-        get() = arguments?.getString(ARG_PODCAST_UUID)
+        get() = args.podcastUuid
 
     val fromListUuid: String?
-        get() = arguments?.getString(ARG_FROMLIST_UUID)
+        get() = args.fromListUuid
 
     private val forceDarkTheme: Boolean
-        get() = arguments?.getBoolean(ARG_FORCE_DARK) ?: false
+        get() = args.forceDark
 
     val activeTheme: Theme.ThemeType
         get() = if (forceDarkTheme && theme.isLightTheme) Theme.ThemeType.DARK else theme.activeTheme

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -80,6 +81,7 @@ class EpisodeFragmentViewModel @Inject constructor(
         forceDark: Boolean,
         timestamp: Duration?,
     ) {
+        var playAtTimestamp = timestamp != null
         val isDarkTheme = forceDark || theme.isDarkTheme
         val progressUpdatesObservable = downloadManager.progressUpdateRelay
             .filter { it.episodeUuid == episodeUuid }
@@ -130,12 +132,9 @@ class EpisodeFragmentViewModel @Inject constructor(
             .doOnNext {
                 if (it is EpisodeFragmentState.Loaded) {
                     timestamp?.let { timestamp ->
-                        if (it.episode.playedUpTo.toInt() != timestamp.toInt(DurationUnit.SECONDS) &&
-                            episode is PodcastEpisode
-                        ) {
-                            it.episode.playedUpTo = timestamp.toDouble(DurationUnit.SECONDS)
-                            seekToTimeMs(timestamp.toInt(DurationUnit.MILLISECONDS))
-                        }
+                        if (!playAtTimestamp) return@let
+                        playAtTimestamp(it.episode, timestamp)
+                        playAtTimestamp = false
                     }
                     episode = it.episode
                 }
@@ -299,6 +298,20 @@ class EpisodeFragmentViewModel @Inject constructor(
         }
 
         return false
+    }
+
+    private fun playAtTimestamp(
+        episode: BaseEpisode,
+        timestamp: Duration,
+    ) {
+        viewModelScope.launch {
+            val shouldLoadOrSwitchEpisode = !playbackManager.isPlaying() ||
+                playbackManager.getCurrentEpisode()?.uuid != episode.uuid
+            if (shouldLoadOrSwitchEpisode) {
+                playbackManager.playNowSync(episode, sourceView = source)
+            }
+            playbackManager.seekToTimeMs(positionMs = timestamp.toInt(DurationUnit.MILLISECONDS))
+        }
     }
 
     fun starClicked() {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/parceler/DurationParceler.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/parceler/DurationParceler.kt
@@ -1,0 +1,21 @@
+package au.com.shiftyjelly.pocketcasts.utils.parceler
+
+import android.os.Parcel
+import kotlinx.parcelize.Parceler
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+object DurationParceler : Parceler<Duration?> {
+    override fun create(parcel: Parcel) =
+        if (parcel.dataSize() > 0) {
+            parcel.readLong().seconds
+        } else {
+            null
+        }
+
+    override fun Duration?.write(parcel: Parcel, flags: Int) {
+        if (this != null) {
+            parcel.writeLong(inWholeSeconds)
+        }
+    }
+}


### PR DESCRIPTION
## Description

This fixes audio loop while sharing a bookmark.

Fixes #2066

## Testing Instructions

#### Test.1 No audio looping
1. Play an episode for which you have a bookmark
2. Share a bookmark link and paste it into the browser
3. Tap `Open in Pocket Casts`
4. The episode should not loop at the bookmark timestamp

#### Test.2 Opening from widget should not reset episode playback
1. Add a medium widget 
2. Play an episode
3. Tap on widget artwork
4. Episode playback should not be reset to start

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
