### PR TITLE
Update DurationParceler.kt

### DIFF
--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/parceler/DurationParceler.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/parceler/DurationParceler.kt
@@ -7,7 +7,7 @@ import kotlinx.parcelize.Parceler
 
 object DurationParceler : Parceler<Duration?> {
     override fun create(parcel: Parcel): Duration? {
-        val isPresent = parcel.readByte() == 0.toByte()
+        val isPresent = parcel.readByte() == 1.toByte()
         return if (isPresent) parcel.readLong().milliseconds else null
     }
 


### PR DESCRIPTION
## Description

In https://github.com/Automattic/pocket-casts-android/pull/2080#discussion_r1570426897 I suggested a solution with a typo.

The reason the app worked is because `Duration` didn't go through a real parcelization and was being read from a runtime memory map. Actual pacelization occurs only with process death and during IPC.

## Testing Instructions

Check that the present byte matches with writing it. CI checks are enough for actual testing.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
