### PR TITLE
Check episode ID instead of episode before loading artwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
         ([#2054](https://github.com/Automattic/pocket-casts-android/pull/2054))
     *   Sleep timer: Start fading out audio when sleep timer has 5 seconds left
         ([#2069](https://github.com/Automattic/pocket-casts-android/pull/2069))
+*   Bug Fixes
+    *   Fix flashing artwork
+        ([#2086](https://github.com/Automattic/pocket-casts-android/pull/2086))
 
 7.62
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -213,7 +213,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
         button.contentDescription = if (isPlaying) stringPause else stringPlay
     }
 
-    private var lastLoadedBaseEpisode: BaseEpisode? = null
+    private var lastLoadedBaseEpisodeId: String? = null
     private var lastUseEpisodeArtwork: Boolean? = null
 
     private fun loadEpisodeArtwork(
@@ -221,11 +221,11 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
         useEpisodeArtwork: Boolean,
         imageView: ImageView,
     ): Disposable? {
-        if (lastLoadedBaseEpisode == baseEpisode && lastUseEpisodeArtwork == useEpisodeArtwork) {
+        if (lastLoadedBaseEpisodeId == baseEpisode.uuid && lastUseEpisodeArtwork == useEpisodeArtwork) {
             return null
         }
 
-        lastLoadedBaseEpisode = baseEpisode
+        lastLoadedBaseEpisodeId = baseEpisode.uuid
         lastUseEpisodeArtwork = useEpisodeArtwork
         return imageRequestFactory.create(baseEpisode, useEpisodeArtwork).loadInto(imageView)
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -363,24 +363,30 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         return ThemeColor.playerHighlight01(viewModel.theme, viewModel.iconTintColor)
     }
 
-    private var lastLoadedBaseEpisode: BaseEpisode? = null
+    private var lastLoadedBaseEpisodeId: String? = null
     private var lastUseEpisodeArtwork: Boolean? = null
+    private var lastLoadedChapterPath: String? = null
 
     private fun loadArtwork(
         baseEpisode: BaseEpisode,
         useEpisodeArtwork: Boolean,
         imageView: ImageView,
     ) {
-        if (lastLoadedBaseEpisode == baseEpisode && lastUseEpisodeArtwork == useEpisodeArtwork) {
+        if (lastLoadedBaseEpisodeId == baseEpisode.uuid && lastUseEpisodeArtwork == useEpisodeArtwork) {
             return
         }
 
-        lastLoadedBaseEpisode = baseEpisode
+        lastLoadedBaseEpisodeId = baseEpisode.uuid
         lastUseEpisodeArtwork = useEpisodeArtwork
         imageRequestFactory.create(baseEpisode, useEpisodeArtwork).loadInto(imageView)
     }
 
     private fun loadChapterArtwork(chapter: Chapter?, imageView: ImageView) {
+        if (lastLoadedChapterPath == chapter?.imagePath) {
+            return
+        }
+
+        lastLoadedChapterPath = chapter?.imagePath
         chapter?.imagePath?.let { pathOrUrl ->
             imageRequestFactory.createForFileOrUrl(pathOrUrl).loadInto(imageView)
         } ?: run {


### PR DESCRIPTION
## Description

We were checking episode instead of episode ID before loading a new artwork. I'm not sure why it failed only when `Use episode artwork` was enabled. I added a similar check for loading chapters as well. 

Closes: #2085

## Testing Instructions

1. Enable `Use episode artwork` setting.
2. Play an episode like [this one](https://pca.st/episode/90659d04-2a3b-4b12-b641-beb75dc0326a).
3. Open the player view.
4. Artwork should not flash.
5. Minimize the player.
6. Artwork on the mini player should not flash.

---

1. Smoke test that chapters artwork is displayed with podcast like [this one](https://pca.st/upgrade).

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
