### PR TITLE
Fix: Most Popular section missing padding top

### DIFF
--- a/modules/features/discover/src/main/res/layout/row_most_popular_podcasts.xml
+++ b/modules/features/discover/src/main/res/layout/row_most_popular_podcasts.xml
@@ -12,6 +12,7 @@
         android:layout_marginBottom="8dp"
         android:paddingLeft="16dp"
         android:paddingRight="16dp"
+        android:paddingTop="9dp"
         android:textAppearance="@style/H20"
         android:textColor="?attr/primary_text_01"
         tools:text="Most Popular in True Crime" />


### PR DESCRIPTION
## Description
Adding padding top in most popular section that was missing

## Testing Instructions
1. Have redesign beta feature enabled
2. Go to Discover
3. Select a category
4. Check if the most popular in [category] has padding top

## Screenshots or Screencast 
| Before | After |
|--------|--------|
|<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/fd70829a-74a0-40fe-80db-185187bbf9a9" width=400> |<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/85e6365a-d9b5-46dc-802b-166e3b66e407" width=400> | 



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
