### PR TITLE
Fix media center low resolution image preview

### DIFF
--- a/modules/services/repositories/src/main/AndroidManifest.xml
+++ b/modules/services/repositories/src/main/AndroidManifest.xml
@@ -4,6 +4,11 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
-    <application android:usesCleartextTraffic="true" />
+    <application android:usesCleartextTraffic="true">
+        <provider
+            android:name="au.com.shiftyjelly.pocketcasts.repositories.playback.auto.AlbumArtContentProvider"
+            android:authorities="${applicationId}.media.library.provider"
+            android:exported="true" />
+    </application>
 
 </manifest>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawer.kt
@@ -5,5 +5,8 @@ import android.support.v4.media.session.MediaSessionCompat
 
 interface NotificationDrawer {
 
-    fun buildPlayingNotification(sessionToken: MediaSessionCompat.Token): Notification
+    fun buildPlayingNotification(
+        sessionToken: MediaSessionCompat.Token,
+        useEpisodeArtwork: Boolean,
+    ): Notification
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
@@ -17,7 +17,6 @@ import androidx.media.session.MediaButtonReceiver
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.isPlaying
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
@@ -33,7 +32,7 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 class NotificationDrawerImpl @Inject constructor(
-    private val settings: Settings,
+    settings: Settings,
     private val notificationHelper: NotificationHelper,
     private val episodeManager: EpisodeManager,
     private val podcastManager: PodcastManager,
@@ -55,11 +54,14 @@ class NotificationDrawerImpl @Inject constructor(
         placeholderType = PlaceholderType.Small,
     )
 
-    override fun buildPlayingNotification(sessionToken: MediaSessionCompat.Token): Notification {
+    override fun buildPlayingNotification(
+        sessionToken: MediaSessionCompat.Token,
+        useEpisodeArtwork: Boolean,
+    ): Notification {
         val controller = MediaControllerCompat(context, sessionToken)
         val description = controller.metadata.description
         val playbackState = controller.playbackState
-        val data = getNotificationData(description.mediaId)
+        val data = getNotificationData(description.mediaId, useEpisodeArtwork)
 
         val builder = notificationHelper.playbackChannelBuilder()
 
@@ -86,13 +88,8 @@ class NotificationDrawerImpl @Inject constructor(
             .build()
     }
 
-    private fun loadArtwork(podcast: Podcast): Bitmap? {
-        val request = imageRequestFactory.create(podcast)
-        return context.imageLoader.executeBlocking(request).drawable?.toBitmap() ?: loadPlaceholderBitmap()
-    }
-
-    private fun loadUserEpisodeArtwork(episode: UserEpisode): Bitmap? {
-        val request = imageRequestFactory.create(episode, settings.useEpisodeArtwork.value)
+    private fun loadArtwork(episode: BaseEpisode, useEpisodeArtwork: Boolean): Bitmap? {
+        val request = imageRequestFactory.create(episode, useEpisodeArtwork)
         return context.imageLoader.executeBlocking(request).drawable?.toBitmap() ?: loadPlaceholderBitmap()
     }
 
@@ -101,7 +98,7 @@ class NotificationDrawerImpl @Inject constructor(
         return context.imageLoader.executeBlocking(request).drawable?.toBitmap()
     }
 
-    private fun getNotificationData(episodeUuid: String?): NotificationData {
+    private fun getNotificationData(episodeUuid: String?, useEpisodeArtwork: Boolean): NotificationData {
         val episode: BaseEpisode? = if (episodeUuid == null) null else runBlocking { episodeManager.findEpisodeByUuid(episodeUuid) }
         val podcast: Podcast? = if (episode == null || episode !is PodcastEpisode) null else podcastManager.findPodcastByUuid(episode.podcastUuid)
 
@@ -111,11 +108,12 @@ class NotificationDrawerImpl @Inject constructor(
 
         val currentNotificationData = notificationData
         val currentEpisodeUuid = currentNotificationData?.episodeUuid
-        if (currentEpisodeUuid != null && currentEpisodeUuid == episodeUuid) {
+        val currentUseEpisodeArtwork = currentNotificationData?.useEpisodeArtwork
+        if (currentEpisodeUuid != null && currentEpisodeUuid == episodeUuid && currentUseEpisodeArtwork == useEpisodeArtwork) {
             return currentNotificationData
         }
 
-        val bitmap = if (episode is UserEpisode) loadUserEpisodeArtwork(episode) else if (podcast != null) loadArtwork(podcast) else null
+        val bitmap = loadArtwork(episode, useEpisodeArtwork)
         val podcastTitle = (if (episode is PodcastEpisode) podcast?.title else Podcast.userPodcast.title) ?: ""
 
         val data = NotificationData(
@@ -123,15 +121,17 @@ class NotificationDrawerImpl @Inject constructor(
             title = podcastTitle,
             text = episode.title,
             icon = bitmap,
+            useEpisodeArtwork = useEpisodeArtwork,
         )
         notificationData = data
         return data
     }
 
     data class NotificationData(
-        var episodeUuid: String = "",
-        var title: String = "",
-        var text: String = "",
-        var icon: Bitmap? = null,
+        val episodeUuid: String = "",
+        val title: String = "",
+        val text: String = "",
+        val icon: Bitmap? = null,
+        val useEpisodeArtwork: Boolean? = null,
     )
 }


### PR DESCRIPTION
## Description

While removing old widget I accidentally removed provider for images from the manifest. 0db5ee4e8ce14516e2bedfa7236ee46a36d4499e brings it back which fixes images low resolution.

2362845cf6c1f2b9762282e0ea2330a29fc01ef1 improves media notification center by making it react dynamically to `Use episode artwork` setting. Previously it was updated only during play/pause cycle. Now it reacts to settings toggle.

Closes #2087

## Testing Instructions

### Fix

1. Play any episode.
2. Look at Media Notification.
3. Image should not be low resolution.

### Settings toggle

1. Play any episode with an episode cover.
2. Toggle `Use episode artwork` setting in the settings.
3. Check that Media Notification reacts to the setting.


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
