### PR TITLE
fix wrong Up Next removal message

### DIFF
--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -457,7 +457,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
             }
 
             withContext(Dispatchers.Main) {
-                val snackText = resources.getStringPlural(selectedList.size, LR.string.removed_from_up_next_singular, LR.string.removed_from_up_next_plural)
+                val snackText = resources.getStringPlural(list.size, LR.string.removed_from_up_next_singular, LR.string.removed_from_up_next_plural)
                 showSnackBar(snackText)
             }
         }


### PR DESCRIPTION
## Description
When removing Up Next queue, message will always 0 count even tho the queue is successfully removed. This is due to mutable list is already cleared outside of the coroutine scopr. Now it will use the temporary list instead of the mutableL lst.

Fixes #1918 

## Testing Instructions
1. Open your Up Next, make sure the queue is not empty.
2. Activate multi select and select episode you want to remove
3. Remove them, now it should show the correct amount of removed queue instead of 0.

## Screenshots or Screencast 
![remove-up-next](https://github.com/Automattic/pocket-casts-android/assets/26060382/10c7c887-b86f-40ea-aa1d-a967a12de269)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
