### PR TITLE
Include widgets in debug builds

### DIFF
--- a/modules/features/widgets/src/debug/AndroidManifest.xml
+++ b/modules/features/widgets/src/debug/AndroidManifest.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <receiver android:name="au.com.shiftyjelly.pocketcasts.widget.SmallPlayerWidgetReceiver"
+            android:label="@string/small_player_widget_label"
+            android:exported="true">
+
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/small_player_widget"/>
+        </receiver>
+
+        <receiver android:name="au.com.shiftyjelly.pocketcasts.widget.MediumPlayerWidgetReceiver"
+            android:label="@string/medium_player_widget_label"
+            android:exported="true">
+
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/medium_player_widget"/>
+        </receiver>
+
+        <receiver android:name="au.com.shiftyjelly.pocketcasts.widget.LargePlayerWidgetReceiver"
+            android:label="@string/large_player_widget_label"
+            android:exported="true">
+
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/large_player_widget"/>
+        </receiver>
+
+    </application>
+
+</manifest>

--- a/modules/features/widgets/src/debugProd/AndroidManifest.xml
+++ b/modules/features/widgets/src/debugProd/AndroidManifest.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <receiver android:name="au.com.shiftyjelly.pocketcasts.widget.SmallPlayerWidgetReceiver"
+            android:label="@string/small_player_widget_label"
+            android:exported="true">
+
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/small_player_widget"/>
+        </receiver>
+
+        <receiver android:name="au.com.shiftyjelly.pocketcasts.widget.MediumPlayerWidgetReceiver"
+            android:label="@string/medium_player_widget_label"
+            android:exported="true">
+
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/medium_player_widget"/>
+        </receiver>
+
+        <receiver android:name="au.com.shiftyjelly.pocketcasts.widget.LargePlayerWidgetReceiver"
+            android:label="@string/large_player_widget_label"
+            android:exported="true">
+
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/large_player_widget"/>
+        </receiver>
+
+    </application>
+
+</manifest>

--- a/modules/features/widgets/src/main/AndroidManifest.xml
+++ b/modules/features/widgets/src/main/AndroidManifest.xml
@@ -1,6 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest>
-
-    <application />
-
-</manifest>
+<manifest />


### PR DESCRIPTION
## Description

For easier widgets development include them by default in debug builds.

## Testing Instructions

1. Check that new widgets are not available in the `release` variant.
2. Check that new widgets are available in the `debug` variant.
3. Check that new widgets are available in the `debugProd` variant.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
