### PR TITLE
Add up next tab 

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -331,6 +331,8 @@ class MainActivity :
 
         if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
             binding.bottomNavigation.menu.removeItem(VR.id.navigation_profile)
+        } else {
+            binding.bottomNavigation.menu.removeItem(VR.id.navigation_upnext)
         }
 
         lifecycleScope.launch {
@@ -352,6 +354,17 @@ class MainActivity :
             put(VR.id.navigation_podcasts) { FragmentInfo(PodcastsFragment(), true) }
             put(VR.id.navigation_filters) { FragmentInfo(FiltersFragment(), true) }
             put(VR.id.navigation_discover) { FragmentInfo(DiscoverFragment(), false) }
+            if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+                put(VR.id.navigation_upnext) {
+                    FragmentInfo(
+                        UpNextFragment.newInstance(
+                            embedded = false,
+                            source = UpNextSource.UP_NEXT_TAB,
+                        ),
+                        true,
+                    )
+                }
+            }
             if (!FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
                 put(VR.id.navigation_profile) { FragmentInfo(ProfileFragment(), true) }
             }
@@ -1577,6 +1590,7 @@ class MainActivity :
     private fun trackTabOpened(tab: Int, isInitial: Boolean = false) {
         val event: AnalyticsEvent? = when (tab) {
             VR.id.navigation_podcasts -> AnalyticsEvent.PODCASTS_TAB_OPENED
+            VR.id.navigation_upnext -> AnalyticsEvent.UP_NEXT_TAB_OPENED
             VR.id.navigation_filters -> AnalyticsEvent.FILTERS_TAB_OPENED
             VR.id.navigation_discover -> AnalyticsEvent.DISCOVER_TAB_OPENED
             VR.id.navigation_profile -> AnalyticsEvent.PROFILE_TAB_OPENED

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -32,10 +32,14 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.extensions.tintIcons
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.ProfileButton
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeSource
+import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutViewModel
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
@@ -50,6 +54,7 @@ import kotlin.math.abs
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import au.com.shiftyjelly.pocketcasts.ui.R as UR
 import au.com.shiftyjelly.pocketcasts.views.R as VR
 
 @AndroidEntryPoint
@@ -243,12 +248,26 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
         super.onViewCreated(view, savedInstanceState)
 
         val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
-        toolbar.setTitle(LR.string.up_next)
-        toolbar.setNavigationOnClickListener {
-            close()
-        }
+        setupToolbarAndStatusBar(
+            toolbar = binding.toolbar,
+            title = getString(LR.string.up_next),
+            menu = R.menu.upnext,
+            navigationIcon = if (upNextSource != UpNextSource.UP_NEXT_TAB) {
+                NavigationIcon.Close
+            } else {
+                NavigationIcon.None
+            },
+            onNavigationClick = { close() },
+            profileButton = if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+                ProfileButton.Shown()
+            } else {
+                ProfileButton.None
+            },
+            toolbarColors = null,
+        )
+        binding.toolbar.menu.findItem(UR.id.menu_profile).isVisible = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR) &&
+            upNextSource == UpNextSource.UP_NEXT_TAB
         toolbar.navigationIcon?.setTint(ThemeColor.secondaryIcon01(overrideTheme))
-        toolbar.inflateMenu(R.menu.upnext)
         toolbar.menu.tintIcons(ThemeColor.secondaryIcon01(overrideTheme))
         toolbar.setOnMenuItemClickListener {
             when (it.itemId) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -265,6 +265,9 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
             },
             toolbarColors = null,
         )
+        if (upNextSource != UpNextSource.UP_NEXT_TAB) {
+            toolbar.setNavigationIcon(IR.drawable.ic_close)
+        }
         binding.toolbar.menu.findItem(UR.id.menu_profile).isVisible = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR) &&
             upNextSource == UpNextSource.UP_NEXT_TAB
         toolbar.navigationIcon?.setTint(ThemeColor.secondaryIcon01(overrideTheme))

--- a/modules/features/player/src/main/res/layout/fragment_upnext.xml
+++ b/modules/features/player/src/main/res/layout/fragment_upnext.xml
@@ -17,9 +17,7 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="?attr/secondary_ui_01"
-            app:navigationContentDescription="@string/close"
-            app:navigationIcon="@drawable/ic_close" />
+            android:background="?attr/secondary_ui_01" />
         <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
             android:id="@+id/multiSelectToolbar"
             android:layout_width="match_parent"

--- a/modules/features/player/src/main/res/menu/upnext.xml
+++ b/modules/features/player/src/main/res/menu/upnext.xml
@@ -5,4 +5,11 @@
         android:title="@string/player_up_next_select"
         android:icon="@drawable/ic_multiselect"
         app:showAsAction="always" />
+    <item
+        android:id="@id/menu_profile"
+        android:icon="@drawable/ic_profile"
+        android:title="@string/profile"
+        android:visible="false"
+        app:actionLayout="@layout/view_profile_circle"
+        app:showAsAction="always" />
 </menu>

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -107,6 +107,7 @@ enum class AnalyticsEvent(val key: String) {
 
     /* Tab bar items */
     PODCASTS_TAB_OPENED("podcasts_tab_opened"),
+    UP_NEXT_TAB_OPENED("up_next_tab_opened"),
     FILTERS_TAB_OPENED("filters_tab_opened"),
     DISCOVER_TAB_OPENED("discover_tab_opened"),
     PROFILE_TAB_OPENED("profile_tab_opened"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
@@ -150,6 +150,7 @@ enum class UpNextSource(val analyticsValue: String) {
     PLAYER("player"),
     NOW_PLAYING("now_playing"),
     UP_NEXT_SHORTCUT("up_next_shortcut"),
+    UP_NEXT_TAB("up_next_tab"),
     UNKNOWN("unknown"),
     ;
 

--- a/modules/services/views/src/main/res/layout/view_profile_circle.xml
+++ b/modules/services/views/src/main/res/layout/view_profile_circle.xml
@@ -8,6 +8,7 @@
         android:layout_width="@dimen/profile_menu_size"
         android:layout_height="@dimen/profile_menu_size"
         android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
         android:tag="profile_picture" />
 
 </FrameLayout>

--- a/modules/services/views/src/main/res/menu/navigation.xml
+++ b/modules/services/views/src/main/res/menu/navigation.xml
@@ -7,6 +7,11 @@
         android:title="@string/podcasts" />
 
     <item
+        android:id="@+id/navigation_upnext"
+        android:icon="@drawable/ic_upnext"
+        android:title="@string/up_next" />
+
+    <item
         android:id="@+id/navigation_filters"
         android:icon="@drawable/ic_filters"
         android:title="@string/filters" />


### PR DESCRIPTION
## Description
This adds Up Next tab to the bottom bar.

## Testing Instructions
#### Feature Flag ON
1. Open the app
2. ✅ Notice you can see the Up Next tab next to the Podcasts tab and it displays Profile menu 
3. Add a few episodes to the Up Next queue
4. ✅ Notice that you can see multi-select icon on the toolbar and it functions properly
5. Play an epsiode 
6. Open Up Next from the mini-player or the full-screen player
7.  ✅ Notice you can see the Up Next screen without the Profile menu 

#### Feature Flag OFF

## Screenshots or Screencast 

#### Feature Flag ON

<img src="https://github.com/Automattic/pocket-casts-android/assets/1405144/c0e12b80-7ced-42fe-8c0a-04d0197d85e4"/>

#### Feature Flag OFF

<img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/05e35a1b-697d-4988-a16f-1e9c0f84ee8e"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
