### PR TITLE
Add subscribe button to most popular section and search bar color updates

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -410,7 +410,6 @@ internal class DiscoverAdapter(
         init {
             recyclerView?.layoutManager = LinearLayoutManager(itemView.context, RecyclerView.HORIZONTAL, false)
             recyclerView?.adapter = adapter
-            recyclerView?.itemAnimator = null
         }
         fun submitCategories(categories: List<CategoryPill>, source: String, context: Context, clearFilter: Boolean = false, region: String? = null) {
             this.source = source

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/MostPopularPodcastsAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/MostPopularPodcastsAdapter.kt
@@ -8,6 +8,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.discover.databinding.ItemMostPopularPodcastsBinding
+import au.com.shiftyjelly.pocketcasts.discover.extensions.updateSubscribeButtonIcon
 import au.com.shiftyjelly.pocketcasts.discover.util.DISCOVER_PODCAST_DIFF_CALLBACK
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.LIST_ID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.PODCAST_UUID_KEY
@@ -16,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageReques
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory.PlaceholderType
 import au.com.shiftyjelly.pocketcasts.repositories.images.loadInto
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
+import au.com.shiftyjelly.pocketcasts.ui.R
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 
 internal class MostPopularPodcastsAdapter(
@@ -29,6 +31,7 @@ internal class MostPopularPodcastsAdapter(
     class MostPopularPodcastsViewHolder(
         val binding: ItemMostPopularPodcastsBinding,
         private val onItemClicked: (Int) -> Unit,
+        private val onSubscribeButtonClicked: (Int) -> Unit,
     ) : RecyclerView.ViewHolder(binding.root) {
         private val imageRequestFactory = PocketCastsImageRequestFactory(
             binding.root.context,
@@ -36,8 +39,12 @@ internal class MostPopularPodcastsAdapter(
         ).themed()
 
         init {
-            binding.podcast.setOnClickListener {
+            binding.imageView.setOnClickListener {
                 onItemClicked(bindingAdapterPosition)
+            }
+
+            binding.btnSubscribe.setOnClickListener {
+                onSubscribeButtonClicked(bindingAdapterPosition)
             }
         }
 
@@ -49,6 +56,8 @@ internal class MostPopularPodcastsAdapter(
 
             binding.lblSubtitle.text = podcast.author
             binding.lblSubtitle.contentDescription = podcast.author
+
+            binding.btnSubscribe.updateSubscribeButtonIcon(subscribed = podcast.isSubscribed, colorSubscribed = R.attr.contrast_01, colorUnsubscribed = R.attr.contrast_01)
         }
     }
 
@@ -58,11 +67,23 @@ internal class MostPopularPodcastsAdapter(
     ): MostPopularPodcastsViewHolder {
         val inflater = LayoutInflater.from(parent.context)
         val binding = ItemMostPopularPodcastsBinding.inflate(inflater, parent, false)
-        return MostPopularPodcastsViewHolder(binding) { position ->
-            val podcast = getItem(position) as DiscoverPodcast
-            trackImpression(podcast)
-            onPodcastClicked(podcast, fromListId)
-        }
+        return MostPopularPodcastsViewHolder(
+            binding,
+            onItemClicked = { position ->
+                val podcast = getItem(position) as DiscoverPodcast
+                trackImpression(podcast)
+                onPodcastClicked(podcast, fromListId)
+            },
+            onSubscribeButtonClicked = { position ->
+                val podcast = getItem(position) as DiscoverPodcast
+                binding.btnSubscribe.updateSubscribeButtonIcon(subscribed = true, colorSubscribed = R.attr.contrast_01, colorUnsubscribed = R.attr.contrast_01)
+                fromListId?.let {
+                    FirebaseAnalyticsTracker.podcastSubscribedFromList(it, podcast.uuid)
+                    analyticsTracker.track(AnalyticsEvent.DISCOVER_LIST_PODCAST_SUBSCRIBED, mapOf(LIST_ID_KEY to it, PODCAST_UUID_KEY to podcast.uuid))
+                }
+                onPodcastSubscribe(podcast, fromListId)
+            },
+        )
     }
     override fun onBindViewHolder(holder: MostPopularPodcastsViewHolder, position: Int) {
         val podcast = getItem(position)

--- a/modules/features/discover/src/main/res/drawable/category_clear_all_pill_background.xml
+++ b/modules/features/discover/src/main/res/drawable/category_clear_all_pill_background.xml
@@ -7,7 +7,8 @@
     <solid android:color="?attr/primary_ui_01" />
 
     <padding
-        android:right="8dp"
+        android:right="12dp"
+        android:left="4dp"
         android:bottom="8dp"
         android:top="8dp" />
 

--- a/modules/features/discover/src/main/res/drawable/category_pill_selected_background.xml
+++ b/modules/features/discover/src/main/res/drawable/category_pill_selected_background.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android" >
     <stroke
         android:width="1dp"
-        android:color="?attr/primary_icon_02" />
+        android:color="?attr/primary_icon_01" />
 
     <solid android:color="?attr/primary_icon_01" />
 

--- a/modules/features/discover/src/main/res/drawable/search_with_category_pills_background.xml
+++ b/modules/features/discover/src/main/res/drawable/search_with_category_pills_background.xml
@@ -1,8 +1,9 @@
-<shape
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle"   >
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
 
-    <solid android:color="?attr/primary_ui_01" />
+    <solid android:color="?attr/primary_field_01" />
+
+    <corners android:radius="10dp" />
 
     <stroke
         android:width="1dp"

--- a/modules/features/discover/src/main/res/layout/item_most_popular_podcasts.xml
+++ b/modules/features/discover/src/main/res/layout/item_most_popular_podcasts.xml
@@ -24,6 +24,15 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:background="?attr/defaultArtworkSmall" />
+
+        <ImageButton
+            android:id="@+id/btnSubscribe"
+            android:layout_width="28dp"
+            android:layout_height="28dp"
+            android:layout_gravity="bottom|end"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="8dp"
+            android:background="@drawable/background_large_item_subscribe" />
     </androidx.cardview.widget.CardView>
 
     <TextView

--- a/modules/features/discover/src/main/res/layout/row_category_pills.xml
+++ b/modules/features/discover/src/main/res/layout/row_category_pills.xml
@@ -4,7 +4,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:background="?attr/secondary_ui_02"
     android:paddingBottom="16dp">
 
     <LinearLayout


### PR DESCRIPTION
## Description
- Adds subscribe button to podcasts listed in most popular section
- Removes the header background color in discover view
- Updates category cancel pill menu format 

## Testing Instructions
1. Run the app
2. Go to Discover
3. ✅ Header must be white for default theme
4. Select a category
5. ✅ You should see the subscribe button in the podcast from most popular section
6. Tap on subscribe button
7. ✅ You should be subscribed to this podcast

## Screenshots or Screencast 
| Before | After |
|--------|--------|
|<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/d2deda80-dcf7-454e-9be0-4852294a5288" width="300"> |<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/ac2b2a22-2f7b-40c5-9deb-0014fd5e05f5" width="300"> | 


| Light | Dark |
|--------|--------|
|<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/c9aa302a-4ec4-43bd-bc1b-007a0ecd4485" width="300"> |<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/e3243d7b-74d7-473a-8568-65eec43eb109" width="300"> | 


| Rosé | Indigo |
|--------|--------|
|<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/a22ea8b2-2b65-4b03-9fdc-34459204a3a1" width="300"> |<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/628cf4b2-4839-4217-95ac-4e71142e5bca" width="300"> | 







## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
