### PR TITLE
Store episode artwork granular settings

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/settings/advanced/AdvancedSettingsTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/settings/advanced/AdvancedSettingsTest.kt
@@ -5,6 +5,8 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.work.NetworkType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.SettingsImpl
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Element
 import au.com.shiftyjelly.pocketcasts.preferences.model.ShelfItem
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
@@ -99,5 +101,17 @@ class AdvancedSettingsTest {
         settings.shelfItems.set(items, updateModifiedAt = false)
 
         assertEquals(settings.shelfItems.value.take(5), items)
+    }
+
+    @Test
+    fun artworkConfigurationIsSavedCorrectly() {
+        val config = ArtworkConfiguration(
+            useEpisodeArtwork = true,
+            enabledElements = setOf(Element.Filters, Element.Downloads, Element.Bookmarks),
+        )
+
+        settings.artworkConfiguration.set(config, updateModifiedAt = false)
+
+        assertEquals(config, settings.artworkConfiguration.value)
     }
 }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -280,7 +280,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
         settings.useDynamicColorsForWidget.flow
             .onEach { widgetManager.updateWidgetFromSettings(playbackManager) }
             .launchIn(applicationScope)
-        settings.useEpisodeArtwork.flow
+        settings.artworkConfiguration.flow
             .onEach { widgetManager.updateWidgetEpisodeArtwork(playbackManager) }
             .launchIn(applicationScope)
         keepPlayerWidgetsUpdated()
@@ -289,8 +289,8 @@ class PocketCastsApplication : Application(), Configuration.Provider {
     }
 
     private fun keepPlayerWidgetsUpdated() {
-        settings.useEpisodeArtwork.flow
-            .onEach(playerWidgetManager::updateUseEpisodeArtwork)
+        settings.artworkConfiguration.flow
+            .onEach { playerWidgetManager.updateUseEpisodeArtwork(it.useEpisodeArtwork) }
             .launchIn(applicationScope)
         settings.useDynamicColorsForWidget.flow
             .onEach(playerWidgetManager::updateUseDynamicColors)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -756,17 +756,17 @@ class MainActivity :
         }
 
         val upNextQueueChanges = playbackManager.upNextQueue.getChangesFlowWithLiveCurrentEpisode(episodeManager, podcastManager)
-        val useEpisodeArtworkChanges = settings.useEpisodeArtwork.flow
+        val artworkConfigurationChanges = settings.artworkConfiguration.flow
 
-        val combinedFlow = combine(upNextQueueChanges, useEpisodeArtworkChanges) { upNextQueue, useEpisodeArtwork ->
-            upNextQueue to useEpisodeArtwork
+        val combinedFlow = combine(upNextQueueChanges, artworkConfigurationChanges) { upNextQueue, artworkConfiguration ->
+            upNextQueue to artworkConfiguration
         }
-            .onEach { (upNextQueue, useEpisodeArtwork) ->
+            .onEach { (upNextQueue, artworkConfiguration) ->
                 binding.playerBottomSheet.setUpNext(
                     upNext = upNextQueue,
                     theme = theme,
                     shouldAnimateOnAttach = !showMiniPlayerImmediately,
-                    useEpisodeArtwork = useEpisodeArtwork,
+                    useEpisodeArtwork = artworkConfiguration.useEpisodeArtwork,
                 )
             }
             .catch { Timber.e(it) }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterChipFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterChipFragment.kt
@@ -245,7 +245,7 @@ private class SimpleEpisodeListAdapter(
         holder.binding.lblSubtitle.text = timeLeft.text
         holder.binding.lblSubtitle.contentDescription = timeLeft.description
 
-        imageRequestFactory.create(item, settings.useEpisodeArtwork.value).loadInto(holder.binding.imageView)
+        imageRequestFactory.create(item, settings.artworkConfiguration.value.useEpisodeArtwork).loadInto(holder.binding.imageView)
     }
 }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -189,7 +189,7 @@ class UpNextAdapter(
             binding.reorder.imageTintList = ColorStateList.valueOf(ThemeColor.primaryInteractive01(theme))
 
             if (loadedUuid != playingState.episode.uuid) {
-                imageRequestFactory.create(playingState.episode, settings.useEpisodeArtwork.value).loadInto(binding.image)
+                imageRequestFactory.create(playingState.episode, settings.artworkConfiguration.value.useEpisodeArtwork).loadInto(binding.image)
                 loadedUuid = playingState.episode.uuid
             }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
@@ -118,7 +118,7 @@ class UpNextEpisodeViewHolder(
             false
         }
 
-        imageRequestFactory.create(episode, settings.useEpisodeArtwork.value).loadInto(binding.image)
+        imageRequestFactory.create(episode, settings.artworkConfiguration.value.useEpisodeArtwork).loadInto(binding.image)
 
         val context = binding.itemContainer.context
         val transition = AutoTransition()

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -168,9 +168,9 @@ class BookmarksViewModel
             isMultiSelectingFlow,
             selectedListFlow,
             settings.cachedSubscriptionStatus.flow,
-            settings.useEpisodeArtwork.flow,
+            settings.artworkConfiguration.flow,
             bookmarkSearchResults,
-        ) { bookmarks, isMultiSelecting, selectedList, cachedSubscriptionStatus, useEpisodeArtwork, searchResults ->
+        ) { bookmarks, isMultiSelecting, selectedList, cachedSubscriptionStatus, artworkConfiguration, searchResults ->
             val userTier = (cachedSubscriptionStatus as? SubscriptionStatus.Paid)?.tier?.toUserTier() ?: UserTier.Free
             _uiState.value = if (!bookmarkFeature.isAvailable(userTier)) {
                 UiState.Upsell(sourceView)
@@ -192,7 +192,7 @@ class BookmarksViewModel
                     bookmarks = filteredBookmarks,
                     bookmarkIdAndEpisodeMap = bookmarkIdAndEpisodeMap,
                     isMultiSelecting = isMultiSelecting,
-                    useEpisodeArtwork = useEpisodeArtwork,
+                    useEpisodeArtwork = artworkConfiguration.useEpisodeArtwork,
                     isSelected = { selectedBookmark ->
                         selectedList.map { bookmark -> bookmark.uuid }
                             .contains(selectedBookmark.uuid)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -24,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.player.view.UpNextPlaying
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarkArguments
 import au.com.shiftyjelly.pocketcasts.player.view.dialog.ClearUpNextDialog
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.preferences.model.ShelfItem
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
@@ -177,7 +178,7 @@ class PlayerViewModel @Inject constructor(
         upNextExpandedObservable,
         chaptersExpandedObservable,
         settings.globalPlaybackEffects.flow.asObservable(coroutineContext),
-        settings.useEpisodeArtwork.flow.asObservable(coroutineContext),
+        settings.artworkConfiguration.flow.asObservable(coroutineContext),
         this::mergeListData,
     )
         .distinctUntilChanged()
@@ -322,7 +323,7 @@ class PlayerViewModel @Inject constructor(
             }
     }
 
-    private fun mergeListData(upNextState: UpNextQueue.State, playbackState: PlaybackState, skipBackwardInSecs: Int, skipForwardInSecs: Int, upNextExpanded: Boolean, chaptersExpanded: Boolean, globalPlaybackEffects: PlaybackEffects, useEpisodeArtwork: Boolean): ListData {
+    private fun mergeListData(upNextState: UpNextQueue.State, playbackState: PlaybackState, skipBackwardInSecs: Int, skipForwardInSecs: Int, upNextExpanded: Boolean, chaptersExpanded: Boolean, globalPlaybackEffects: PlaybackEffects, artworkConfiguration: ArtworkConfiguration): ListData {
         val podcast: Podcast? = (upNextState as? UpNextQueue.State.Loaded)?.podcast
         val episode = (upNextState as? UpNextQueue.State.Loaded)?.episode
 
@@ -357,7 +358,7 @@ class PlayerViewModel @Inject constructor(
                 isBuffering = playbackState.isBuffering,
                 bufferedUpToMs = playbackState.bufferedMs,
                 theme = theme.activeTheme,
-                useEpisodeArtwork = useEpisodeArtwork,
+                useEpisodeArtwork = artworkConfiguration.useEpisodeArtwork,
             )
         }
         val chapters = playbackState.chapters

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.search.BookmarkSearchHandler
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeDefault
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeForProfile
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
@@ -108,10 +109,10 @@ class BookmarksViewModelTest {
             .thenReturn(MutableLiveData<Boolean>().apply { value = false })
         whenever(multiSelectHelper.selectedListLive)
             .thenReturn(MutableLiveData<List<Bookmark>>().apply { value = emptyList() })
-        val useEpisodeArtwork = mock<UserSetting<Boolean>> {
-            on { flow } doReturn MutableStateFlow(false)
+        val artworkConfiguration = mock<UserSetting<ArtworkConfiguration>> {
+            on { flow } doReturn MutableStateFlow(ArtworkConfiguration(false))
         }
-        whenever(settings.useEpisodeArtwork).thenReturn(useEpisodeArtwork)
+        whenever(settings.artworkConfiguration).thenReturn(artworkConfiguration)
         bookmarkSearchHandler = BookmarkSearchHandler(bookmarkManager)
         bookmarksViewModel = BookmarksViewModel(
             analyticsTracker = analyticsTracker,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -366,7 +366,7 @@ class EpisodeFragment : BaseFragment() {
                                 .show()
                             true
                         }
-                        imageRequestFactory.create(state.episode, settings.useEpisodeArtwork.value).loadInto(binding.podcastArtwork)
+                        imageRequestFactory.create(state.episode, settings.artworkConfiguration.value.useEpisodeArtwork).loadInto(binding.podcastArtwork)
 
                         binding.btnPlay.setOnPlayClicked {
                             val context = binding.root.context

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
@@ -290,7 +290,7 @@ class EpisodeViewHolder(
         val artworkVisible = viewMode is ViewMode.Artwork
         imgArtwork.isVisible = artworkVisible
         if (!sameEpisode && artworkVisible) {
-            imageRequestFactory.create(episode, settings.useEpisodeArtwork.value).loadInto(imgArtwork)
+            imageRequestFactory.create(episode, settings.artworkConfiguration.value.useEpisodeArtwork).loadInto(imgArtwork)
         }
 
         val transition = AutoTransition()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -573,7 +573,7 @@ class PodcastAdapter(
                                         bookmark,
                                     )
                                 },
-                                useEpisodeArtwork = settings.useEpisodeArtwork.value,
+                                useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork,
                             )
                         },
                     )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/UserEpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/UserEpisodeViewHolder.kt
@@ -218,7 +218,7 @@ class UserEpisodeViewHolder(
 
         titleTextView.text = episode.title
 
-        imageRequestFactory.create(episode, settings.useEpisodeArtwork.value).loadInto(artworkImageView)
+        imageRequestFactory.create(episode, settings.artworkConfiguration.value.useEpisodeArtwork).loadInto(artworkImageView)
 
         val checkbox = binding.checkbox
         if (checkbox.isVisible != multiSelectEnabled) {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
@@ -199,7 +199,7 @@ class AppearanceSettingsFragment : BaseFragment() {
             binding.swtShowArtwork.isChecked = !binding.swtShowArtwork.isChecked
         }
 
-        binding.swtUseEpisodeArtwork.isChecked = viewModel.useEpisodeArtwork.value
+        binding.swtUseEpisodeArtwork.isChecked = viewModel.artworkConfiguration.value.useEpisodeArtwork
         binding.swtUseEpisodeArtwork.setOnCheckedChangeListener { _, isChecked ->
             viewModel.updateUseEpisodeArtwork(isChecked)
         }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
@@ -29,7 +29,7 @@ class SettingsAppearanceViewModel @Inject constructor(
     val signInState: LiveData<SignInState> = userManager.getSignInState().toLiveData()
     val createAccountState = MutableLiveData<SettingsAppearanceState>().apply { value = SettingsAppearanceState.Empty }
     val showArtworkOnLockScreen = settings.showArtworkOnLockScreen.flow
-    val useEpisodeArtwork = settings.useEpisodeArtwork.flow
+    val artworkConfiguration = settings.artworkConfiguration.flow
 
     var changeThemeType: Pair<Theme.ThemeType?, Theme.ThemeType?> = Pair(null, null)
     var changeAppIconType: Pair<AppIcon.AppIconType?, AppIcon.AppIconType?> = Pair(null, null)
@@ -132,7 +132,8 @@ class SettingsAppearanceViewModel @Inject constructor(
     }
 
     fun updateUseEpisodeArtwork(value: Boolean) {
-        settings.useEpisodeArtwork.set(value, updateModifiedAt = true)
+        val currentConfiguration = settings.artworkConfiguration.value
+        settings.artworkConfiguration.set(currentConfiguration.copy(useEpisodeArtwork = value), updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_APPEARANCE_USE_EPISODE_ARTWORK_TOGGLED,
             mapOf("enabled" to value),

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/data/LargePlayerWidgetState.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/data/LargePlayerWidgetState.kt
@@ -55,7 +55,7 @@ internal data class LargePlayerWidgetState(
             return LargePlayerWidgetState(
                 queue = queue,
                 isPlaying = playbackManager.isPlaying(),
-                useEpisodeArtwork = settings.useEpisodeArtwork.value,
+                useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork,
                 useDynamicColors = settings.useDynamicColorsForWidget.value,
             )
         }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/data/MediumPlayerWidgetState.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/data/MediumPlayerWidgetState.kt
@@ -52,7 +52,7 @@ internal data class MediumPlayerWidgetState(
             return MediumPlayerWidgetState(
                 episode = episode,
                 isPlaying = playbackManager.isPlaying(),
-                useEpisodeArtwork = settings.useEpisodeArtwork.value,
+                useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork,
                 useDynamicColors = settings.useDynamicColorsForWidget.value,
             )
         }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/data/SmallPlayerWidgetState.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/data/SmallPlayerWidgetState.kt
@@ -7,7 +7,6 @@ import androidx.glance.GlanceId
 import androidx.glance.appwidget.state.updateAppWidgetState
 import au.com.shiftyjelly.pocketcasts.widget.di.widgetEntryPoint
 import com.squareup.moshi.JsonClass
-import kotlinx.coroutines.flow.firstOrNull
 
 @JsonClass(generateAdapter = true)
 internal data class SmallPlayerWidgetState(
@@ -53,7 +52,7 @@ internal data class SmallPlayerWidgetState(
             return SmallPlayerWidgetState(
                 episode = episode,
                 isPlaying = playbackManager.isPlaying(),
-                useEpisodeArtwork = settings.useEpisodeArtwork.value,
+                useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork,
                 useDynamicColors = settings.useDynamicColorsForWidget.value,
             )
         }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -13,13 +13,13 @@ import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.preferences.model.AppIconSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoAddUpNextLimitBehaviour
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoPlaySource
 import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeDefault
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeForPodcast
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeForProfile
-import au.com.shiftyjelly.pocketcasts.preferences.model.EpisodeArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
 import au.com.shiftyjelly.pocketcasts.preferences.model.NewEpisodeNotificationAction
 import au.com.shiftyjelly.pocketcasts.preferences.model.NotificationVibrateSetting
@@ -330,8 +330,7 @@ interface Settings {
     val autoDownloadOnlyWhenCharging: UserSetting<Boolean>
     val autoDownloadUpNext: UserSetting<Boolean>
 
-    val useEpisodeArtwork: UserSetting<Boolean>
-    val episodeArtworkConfiguration: UserSetting<EpisodeArtworkConfiguration>
+    val artworkConfiguration: UserSetting<ArtworkConfiguration>
 
     val globalPlaybackEffects: UserSetting<PlaybackEffects>
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -19,6 +19,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeDefault
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeForPodcast
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeForProfile
+import au.com.shiftyjelly.pocketcasts.preferences.model.EpisodeArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
 import au.com.shiftyjelly.pocketcasts.preferences.model.NewEpisodeNotificationAction
 import au.com.shiftyjelly.pocketcasts.preferences.model.NotificationVibrateSetting
@@ -330,6 +331,7 @@ interface Settings {
     val autoDownloadUpNext: UserSetting<Boolean>
 
     val useEpisodeArtwork: UserSetting<Boolean>
+    val episodeArtworkConfiguration: UserSetting<EpisodeArtworkConfiguration>
 
     val globalPlaybackEffects: UserSetting<PlaybackEffects>
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager
 import android.content.pm.PackageManager.NameNotFoundException
 import android.os.Build
 import android.util.Base64
+import androidx.core.content.edit
 import androidx.work.NetworkType
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveInactive
@@ -25,6 +26,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationCont
 import au.com.shiftyjelly.pocketcasts.preferences.di.PrivateSharedPreferences
 import au.com.shiftyjelly.pocketcasts.preferences.di.PublicSharedPreferences
 import au.com.shiftyjelly.pocketcasts.preferences.model.AppIconSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoAddUpNextLimitBehaviour
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoPlaySource
 import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
@@ -42,6 +44,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.ThemeSetting
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.config.FirebaseConfig
+import au.com.shiftyjelly.pocketcasts.utils.extensions.getString
 import au.com.shiftyjelly.pocketcasts.utils.extensions.splitIgnoreEmpty
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
@@ -539,11 +542,28 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override val useEpisodeArtwork = UserSetting.BoolPref(
-        sharedPrefKey = "useEpisodeArtwork",
-        defaultValue = false,
+    override val artworkConfiguration = object : UserSetting<ArtworkConfiguration>(
+        sharedPrefKey = "artworkConfiguration",
         sharedPrefs = sharedPreferences,
-    )
+    ) {
+        override fun get(): ArtworkConfiguration {
+            return sharedPreferences.getString(sharedPrefKey)?.split(",")?.let { stringValues ->
+                val isEnabled = stringValues.getOrNull(0)?.toBooleanStrictOrNull() ?: return@let null
+                val elements = stringValues.drop(1).mapNotNullTo(mutableSetOf(), ArtworkConfiguration.Element::fromKey)
+                ArtworkConfiguration(isEnabled, elements)
+            } ?: ArtworkConfiguration(false)
+        }
+
+        override fun persist(value: ArtworkConfiguration, commit: Boolean) {
+            val stringValue = buildList {
+                add(value.useEpisodeArtwork.toString())
+                addAll(value.enabledElements.map(ArtworkConfiguration.Element::key))
+            }.joinToString(",")
+            sharedPrefs.edit(commit) {
+                putString(sharedPrefKey, stringValue)
+            }
+        }
+    }
 
     override val globalPlaybackEffects = object : UserSetting<PlaybackEffects>(
         sharedPrefKey = "globalPlaybackEffects",

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ArtworkConfiguration.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ArtworkConfiguration.kt
@@ -1,0 +1,29 @@
+package au.com.shiftyjelly.pocketcasts.preferences.model
+
+data class ArtworkConfiguration(
+    val useEpisodeArtwork: Boolean,
+    internal val enabledElements: Set<Element> = Element.entries.toSet(),
+) {
+    fun useEpisodeArtwork(element: Element) = useEpisodeArtwork && element in enabledElements
+
+    fun enable(element: Element) = copy(enabledElements = enabledElements + element)
+
+    fun disable(element: Element) = copy(enabledElements = enabledElements - element)
+
+    enum class Element(
+        internal val key: String,
+    ) {
+        Filters("filters"),
+        UpNext("up_next"),
+        Downloads("downloads"),
+        Files("files"),
+        Starred("starred"),
+        Bookmarks("bookmarks"),
+        ListeningHistory("listening_history"),
+        ;
+
+        companion object {
+            internal fun fromKey(key: String) = entries.find { it.key == key }
+        }
+    }
+}

--- a/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/model/ArtworkConfigurationTest.kt
+++ b/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/model/ArtworkConfigurationTest.kt
@@ -1,0 +1,60 @@
+package au.com.shiftyjelly.pocketcasts.preferences.model
+
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Element
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ArtworkConfigurationTest {
+    @Test
+    fun `all elements are enabled by default`() {
+        val config = ArtworkConfiguration(useEpisodeArtwork = true)
+
+        val value = Element.entries.map(config::useEpisodeArtwork)
+
+        assertEquals(true, value.all { it })
+    }
+
+    @Test
+    fun `elements can be initialized as disabled`() {
+        val config = ArtworkConfiguration(
+            useEpisodeArtwork = true,
+            enabledElements = emptySet(),
+        )
+
+        val value = Element.entries.map(config::useEpisodeArtwork)
+
+        assertEquals(true, value.none { it })
+    }
+
+    @Test
+    fun `elements can be disabled`() {
+        val config = ArtworkConfiguration(useEpisodeArtwork = true).disable(Element.Filters)
+
+        val value = config.useEpisodeArtwork(Element.Filters)
+
+        assertEquals(false, value)
+    }
+
+    @Test
+    fun `elements can be enabled`() {
+        val config = ArtworkConfiguration(
+            useEpisodeArtwork = true,
+            enabledElements = emptySet(),
+        ).enable(Element.Starred)
+
+        val value = config.useEpisodeArtwork(Element.Starred)
+
+        assertEquals(true, value)
+    }
+
+    @Test
+    fun `elements are enabled only if global property is enabled`() {
+        val config = ArtworkConfiguration(
+            useEpisodeArtwork = false,
+            enabledElements = emptySet(),
+        ).enable(Element.Starred)
+
+        val value = config.useEpisodeArtwork(Element.Starred)
+        assertEquals(false, value)
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -163,6 +164,10 @@ class VersionMigrationsJob : JobService() {
         if (previousVersionCode < 9209) {
             consolidateEmbeddedArtworkSettings(applicationContext)
         }
+
+        if (previousVersionCode < 9220) {
+            migrateToGranularEpisodeArtworkSettings(applicationContext)
+        }
     }
 
     private fun removeOldTempPodcastDirectory() {
@@ -245,7 +250,14 @@ class VersionMigrationsJob : JobService() {
         if (!Util.isWearOs(context) && !Util.isAutomotive(context)) {
             val useEpisodeArtwork = settings.getBooleanForKey("useEpisodeArtwork", false)
             val useFileArtwork = settings.getBooleanForKey("useEmbeddedArtwork", false)
-            settings.useEpisodeArtwork.set(useEpisodeArtwork || useFileArtwork, updateModifiedAt = true)
+            settings.setBooleanForKey("useEpisodeArtwork", useEpisodeArtwork || useFileArtwork)
+        }
+    }
+
+    private fun migrateToGranularEpisodeArtworkSettings(context: Context) {
+        if (!Util.isWearOs(context) && !Util.isAutomotive(context)) {
+            val useEpisodeArtwork = settings.getBooleanForKey("useEpisodeArtwork", false)
+            settings.artworkConfiguration.set(ArtworkConfiguration((useEpisodeArtwork)), updateModifiedAt = true)
         }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -172,10 +172,9 @@ class MediaSessionManager(
                     episodeOne.uuid == episodeTwo.uuid && episodeOne.duration == episodeTwo.duration
                 }
             }
-        val useEpisodeArtworkChanges = settings.useEpisodeArtwork.flow
 
-        combine(upNextQueueChanges, useEpisodeArtworkChanges) { queueState, useEpisodeArtwork -> queueState to useEpisodeArtwork }
-            .onEach { (queueState, useEpisodeArtwork) -> updateUpNext(queueState, useEpisodeArtwork) }
+        combine(upNextQueueChanges, settings.artworkConfiguration.flow) { queueState, artworkConfiguration -> queueState to artworkConfiguration }
+            .onEach { (queueState, artworkConfiguration) -> updateUpNext(queueState, artworkConfiguration.useEpisodeArtwork) }
             .catch { Timber.e(it) }
             .launchIn(this)
     }
@@ -306,7 +305,7 @@ class MediaSessionManager(
                     val podcastUuid = if (episode is PodcastEpisode) episode.podcastUuid else null
                     val podcast = podcastUuid?.let { podcastManager.findPodcastByUuid(it) }
                     val podcastTitle = episode.displaySubtitle(podcast)
-                    val localUri = AutoConverter.getBitmapUriForPodcast(podcast, episode, context, settings.useEpisodeArtwork.value)
+                    val localUri = AutoConverter.getBitmapUriForPodcast(podcast, episode, context, settings.artworkConfiguration.value.useEpisodeArtwork)
                     val description = MediaDescriptionCompat.Builder()
                         .setDescription(episode.episodeDescription)
                         .setTitle(episode.title)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -229,7 +229,7 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
             override fun onTracksChanged(tracks: Tracks) {
                 episodeUuid?.let { onEpisodeChanged(it) }
                 val episodeMetadata = EpisodeFileMetadata(filenamePrefix = episodeUuid)
-                episodeMetadata.read(tracks, settings.useEpisodeArtwork.value, context)
+                episodeMetadata.read(tracks, settings.artworkConfiguration.value.useEpisodeArtwork, context)
                 onMetadataAvailable(episodeMetadata)
             }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -661,7 +661,7 @@ class RefreshPodcastsThread(
             val resources = context.resources
             val width = resources.getDimension(android.R.dimen.notification_large_icon_width).toInt()
 
-            val imageRequest = PocketCastsImageRequestFactory(context, isDarkTheme = true, size = width).create(episode, settings.useEpisodeArtwork.value)
+            val imageRequest = PocketCastsImageRequestFactory(context, isDarkTheme = true, size = width).create(episode, settings.artworkConfiguration.value.useEpisodeArtwork)
             return context.imageLoader.executeBlocking(imageRequest).drawable?.toBitmap()
         }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
@@ -98,7 +98,7 @@ class WidgetManagerImpl @Inject constructor(
             RemoteViews(context.packageName, remoteViewsLayoutId),
             R.id.widget_artwork,
         )
-        imageRequestFactory.create(currentEpisode, settings.useEpisodeArtwork.value).loadInto(target)
+        imageRequestFactory.create(currentEpisode, settings.artworkConfiguration.value.useEpisodeArtwork).loadInto(target)
     }
 
     override fun updateWidgetFromPlaybackState(playbackManager: PlaybackManager?) {
@@ -198,7 +198,7 @@ class WidgetManagerImpl @Inject constructor(
             views,
             R.id.widget_artwork,
         )
-        imageRequestFactory.create(playingEpisode, settings.useEpisodeArtwork.value).loadInto(target)
+        imageRequestFactory.create(playingEpisode, settings.artworkConfiguration.value.useEpisodeArtwork).loadInto(target)
     }
 
     private fun showPlayButton(playing: Boolean, views: RemoteViews) {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -186,7 +186,12 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                         modifiedAt = modifiedAt,
                     )
                 },
-                useEpisodeArtwork = settings.useEpisodeArtwork.getSyncSetting(::NamedChangedSettingBool),
+                useEpisodeArtwork = settings.artworkConfiguration.getSyncSetting { configuration, modifiedAt ->
+                    NamedChangedSettingBool(
+                        value = configuration.useEpisodeArtwork,
+                        modifiedAt = modifiedAt,
+                    )
+                },
                 notificationSettingActions = settings.newEpisodeNotificationActions.getSyncSetting { setting, modifiedAt ->
                     NamedChangedSettingString(
                         value = setting.joinToString(separator = ",", transform = NewEpisodeNotificationAction::serverId),
@@ -443,8 +448,10 @@ class SyncSettingsTask(val context: Context, val parameters: WorkerParameters) :
                     )
                     "useEmbeddedArtworkGlobal" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,
-                        setting = settings.useEpisodeArtwork,
-                        newSettingValue = (changedSettingResponse.value as? Boolean),
+                        setting = settings.artworkConfiguration,
+                        newSettingValue = (changedSettingResponse.value as? Boolean)?.let { newValue ->
+                            settings.artworkConfiguration.value.copy(useEpisodeArtwork = newValue)
+                        },
                     )
                     "privacyCrashReports" -> updateSettingIfPossible(
                         changedSettingResponse = changedSettingResponse,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesScreen.kt
@@ -32,7 +32,7 @@ fun FilesScreen(
     val viewModel = hiltViewModel<FilesViewModel>()
     val userEpisodesState = viewModel.userEpisodes.collectAsState(null)
     val userEpisodes = userEpisodesState.value
-    val useEpisodeArtwork by viewModel.useEpisodeArtwork.collectAsState()
+    val artworkCollection by viewModel.artworkConfiguration.collectAsState()
 
     when {
         // Show nothing while screen is loading
@@ -49,7 +49,7 @@ fun FilesScreen(
                 items(userEpisodes) { episode ->
                     EpisodeChip(
                         episode = episode,
-                        useEpisodeArtwork = useEpisodeArtwork,
+                        useEpisodeArtwork = artworkCollection.useEpisodeArtwork,
                         onClick = { navigateToEpisode(episode.uuid) },
                     )
                 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesViewModel.kt
@@ -17,5 +17,5 @@ class FilesViewModel @Inject constructor(
         .observeUserEpisodesSorted(settings.cloudSortOrder.value)
         .asFlow()
 
-    val useEpisodeArtwork = settings.useEpisodeArtwork.flow
+    val artworkConfiguration = settings.artworkConfiguration.flow
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/NowPlayingChip.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/NowPlayingChip.kt
@@ -47,7 +47,7 @@ fun NowPlayingChip(
 
     val state by viewModel.state.collectAsState()
     val playbackState = state.playbackState
-    val useEpisodeArtwork by viewModel.useEpisodeArtwork.collectAsState()
+    val artworkConfiguration by viewModel.artworkConfiguration.collectAsState()
 
     val upNextQueue = state.upNextQueue
     val podcast = (upNextQueue as? UpNextQueue.State.Loaded)?.podcast
@@ -57,7 +57,7 @@ fun NowPlayingChip(
         podcast = podcast,
         episode = episode,
         isPlaying = playbackState?.isPlaying == true,
-        useEpisodeArtwork = useEpisodeArtwork,
+        useEpisodeArtwork = artworkConfiguration.useEpisodeArtwork,
         onClick = onClick,
     )
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/NowPlayingChipViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/NowPlayingChipViewModel.kt
@@ -34,7 +34,7 @@ class NowPlayingChipViewModel @Inject constructor(
     private val _state = MutableStateFlow(State())
     val state = _state.asStateFlow()
 
-    val useEpisodeArtwork = settings.useEpisodeArtwork.flow
+    val artworkConfiguration = settings.artworkConfiguration.flow
 
     init {
         viewModelScope.launch {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextScreen.kt
@@ -41,7 +41,7 @@ fun UpNextScreen(
     columnState: ScalingLazyColumnState,
 ) {
     val queueState by viewModel.upNextQueue.subscribeAsState(initial = null)
-    val useEpisodeArtwork by viewModel.useEpisodeArtwork.collectAsState()
+    val artworkConfiguration by viewModel.artworkConfiguration.collectAsState()
 
     when (queueState) {
         null -> { /* Show nothing while loading */ }
@@ -65,7 +65,7 @@ fun UpNextScreen(
                         items(list) { episode ->
                             EpisodeChip(
                                 episode = episode,
-                                useEpisodeArtwork = useEpisodeArtwork,
+                                useEpisodeArtwork = artworkConfiguration.useEpisodeArtwork,
                                 useUpNextIcon = false,
                                 onClick = {
                                     navigateToEpisode(episode.uuid)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/UpNextViewModel.kt
@@ -20,5 +20,5 @@ class UpNextViewModel @Inject constructor(
 
     val upNextQueue: Observable<UpNextQueue.State> = playbackManager.upNextQueue.getChangesObservableWithLiveCurrentEpisode(episodeManager, podcastManager)
 
-    val useEpisodeArtwork = settings.useEpisodeArtwork.flow
+    val artworkConfiguration = settings.artworkConfiguration.flow
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreen.kt
@@ -27,9 +27,9 @@ fun DownloadsScreen(
 ) {
     val viewModel = hiltViewModel<DownloadsScreenViewModel>()
     val state by viewModel.stateFlow.collectAsState()
-    val useEpisodeArtwork by viewModel.useEpisodeArtwork.collectAsState()
+    val artworkConfiguration by viewModel.artworkConfiguration.collectAsState()
 
-    Content(columnState, state, useEpisodeArtwork, onItemClick)
+    Content(columnState, state, artworkConfiguration.useEpisodeArtwork, onItemClick)
 }
 
 @Composable

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreenViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreenViewModel.kt
@@ -20,5 +20,5 @@ class DownloadsScreenViewModel @Inject constructor(
         .asFlow()
         .stateIn(viewModelScope, SharingStarted.Lazily, null)
 
-    val useEpisodeArtwork = settings.useEpisodeArtwork.flow
+    val artworkConfiguration = settings.artworkConfiguration.flow
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterScreen.kt
@@ -41,12 +41,12 @@ fun FilterScreen(
     columnState: ScalingLazyColumnState,
 ) {
     val uiState by viewModel.uiState.collectAsState(UiState.Loading)
-    val useEpisodeArtwork by viewModel.useEpisodeArtwork.collectAsState()
+    val artworkConfiguration by viewModel.artworkConfiguration.collectAsState()
 
     when (val state = uiState) {
         is UiState.Loaded -> Content(
             state = state,
-            useEpisodeArtwork = useEpisodeArtwork,
+            useEpisodeArtwork = artworkConfiguration.useEpisodeArtwork,
             onEpisodeTap = onEpisodeTap,
             modifier = modifier,
             listState = columnState,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterViewModel.kt
@@ -57,5 +57,5 @@ class FilterViewModel @Inject constructor(
         .asFlow()
         .stateIn(viewModelScope, SharingStarted.Lazily, FiltersViewModel.UiState.Loading)
 
-    val useEpisodeArtwork = settings.useEpisodeArtwork.flow
+    val artworkConfiguration = settings.artworkConfiguration.flow
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
@@ -48,12 +48,12 @@ fun PodcastScreen(
     viewModel: PodcastViewModel = hiltViewModel(),
     columnState: ScalingLazyColumnState,
 ) {
-    val useEpisodeArtwork by viewModel.useEpisodeArtwork.collectAsState()
+    val artworkConfiguration by viewModel.artworkConfiguration.collectAsState()
 
     when (val state = viewModel.uiState) {
         is UiState.Loaded -> Content(
             state = state,
-            useEpisodeArtwork = useEpisodeArtwork,
+            useEpisodeArtwork = artworkConfiguration.useEpisodeArtwork,
             onEpisodeTap = onEpisodeTap,
             modifier = modifier,
             columnState = columnState,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastViewModel.kt
@@ -40,7 +40,7 @@ class PodcastViewModel @Inject constructor(
         ) : UiState()
     }
 
-    val useEpisodeArtwork = settings.useEpisodeArtwork.flow
+    val artworkConfiguration = settings.artworkConfiguration.flow
 
     var uiState: UiState by mutableStateOf(UiState.Empty)
         private set


### PR DESCRIPTION
## Description

This PR is only code changes. It doesn't affect the user. It migrates boolean flag for episode artwork to a setting that allows disabling episode artwork in particular contexts:

* Filters
* UpNext
* Downloads
* FIles
* Starred
* Bookmarks
* Listening History

## Testing Instructions

1. Install the app from 4a41c33bd1db36a823a2ea2605dfd3fc7aca6c51.
2. Enable the `Use episode artwork setting`.
3. Install the app from this PR.
4. Check that the `Use episode artwork setting` is still enabled.
5. Smoke test the episode artwork shows on different screens.
6. Disable the `Use episode artwork setting` setting.
7. Smoke test that the episode artwork does not show on different screens.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
