### PR TITLE
Toggle episode artwork in different sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
         ([#2069](https://github.com/Automattic/pocket-casts-android/pull/2069))
     *   Sleep timer: Set sleep time end of episode for multiple episodes
         ([#2097](https://github.com/Automattic/pocket-casts-android/pull/2097))
+    *   Enable toggling episode artwork separately in different contexts
+        ([#2112](https://github.com/Automattic/pocket-casts-android/pull/2112))
 *   Updates:
     *   Improved updating podcast episode when subscribed to thousands podcasts. 
         ([#2082](https://github.com/Automattic/pocket-casts-android/pull/2082))

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -32,6 +32,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeContainerFrag
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.EpisodeListAdapter
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.EpisodeListBookmarkViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Element
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoPlaySource
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
@@ -131,6 +132,7 @@ class FilterEpisodeListFragment : BaseFragment() {
                 fragmentManager = parentFragmentManager,
                 swipeSource = EpisodeItemTouchHelper.SwipeSource.FILTERS,
             ),
+            artworkContext = Element.Filters,
         )
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -24,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.player.databinding.AdapterUpNextFooterBind
 import au.com.shiftyjelly.pocketcasts.player.databinding.AdapterUpNextPlayingBinding
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Element
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getSummaryText
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
 import au.com.shiftyjelly.pocketcasts.repositories.images.loadInto
@@ -193,7 +194,7 @@ class UpNextAdapter(
             binding.reorder.imageTintList = ColorStateList.valueOf(ThemeColor.primaryInteractive01(theme))
 
             if (loadedUuid != playingState.episode.uuid) {
-                imageRequestFactory.create(playingState.episode, settings.artworkConfiguration.value.useEpisodeArtwork).loadInto(binding.image)
+                imageRequestFactory.create(playingState.episode, settings.artworkConfiguration.value.useEpisodeArtwork(Element.UpNext)).loadInto(binding.image)
                 loadedUuid = playingState.episode.uuid
             }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
@@ -21,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.player.databinding.AdapterUpNextBinding
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Element
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getSummaryText
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
 import au.com.shiftyjelly.pocketcasts.repositories.images.loadInto
@@ -118,7 +119,7 @@ class UpNextEpisodeViewHolder(
             false
         }
 
-        imageRequestFactory.create(episode, settings.artworkConfiguration.value.useEpisodeArtwork).loadInto(binding.image)
+        imageRequestFactory.create(episode, settings.artworkConfiguration.value.useEpisodeArtwork(Element.UpNext)).loadInto(binding.image)
 
         val context = binding.itemContainer.context
         val transition = AutoTransition()

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -20,6 +20,7 @@ import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.NoBookmark
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.search.BookmarkSearchHandler
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Element
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortType
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeDefault
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeForProfile
@@ -192,7 +193,7 @@ class BookmarksViewModel
                     bookmarks = filteredBookmarks,
                     bookmarkIdAndEpisodeMap = bookmarkIdAndEpisodeMap,
                     isMultiSelecting = isMultiSelecting,
-                    useEpisodeArtwork = artworkConfiguration.useEpisodeArtwork,
+                    useEpisodeArtwork = artworkConfiguration.useEpisodeArtwork(Element.Bookmarks),
                     isSelected = { selectedBookmark ->
                         selectedList.map { bookmark -> bookmark.uuid }
                             .contains(selectedBookmark.uuid)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -30,6 +30,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeContainerFrag
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.EpisodeListAdapter
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.EpisodeListBookmarkViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Element
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoPlaySource
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
@@ -154,6 +155,11 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
                     Mode.Starred -> EpisodeItemTouchHelper.SwipeSource.STARRED
                 },
             ),
+            artworkContext = when (mode) {
+                Mode.Downloaded -> Element.Downloads
+                Mode.History -> Element.ListeningHistory
+                Mode.Starred -> Element.Starred
+            },
         )
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
@@ -16,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.databinding.AdapterEpisodeBinding
 import au.com.shiftyjelly.pocketcasts.podcasts.databinding.AdapterUserEpisodeBinding
 import au.com.shiftyjelly.pocketcasts.podcasts.view.components.PlayButton
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeForProfile
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
@@ -53,6 +54,7 @@ class EpisodeListAdapter(
     val fragmentManager: FragmentManager,
     val fromListUuid: String? = null,
     val swipeButtonLayoutFactory: SwipeButtonLayoutFactory,
+    private val artworkContext: ArtworkConfiguration.Element,
 ) : ListAdapter<BaseEpisode, RecyclerView.ViewHolder>(PLAYBACK_DIFF) {
 
     val disposables = CompositeDisposable()
@@ -81,6 +83,7 @@ class EpisodeListAdapter(
                 imageRequestFactory = imageRequestFactory,
                 settings = settings,
                 swipeButtonLayoutFactory = swipeButtonLayoutFactory,
+                artworkContext = artworkContext,
             )
             R.layout.adapter_user_episode -> UserEpisodeViewHolder(
                 binding = AdapterUserEpisodeBinding.inflate(inflater, parent, false),
@@ -91,6 +94,7 @@ class EpisodeListAdapter(
                 imageRequestFactory = imageRequestFactory,
                 swipeButtonLayoutFactory = swipeButtonLayoutFactory,
                 userBookmarksObservable = bookmarkManager.findUserEpisodesBookmarksFlow().asObservable(),
+                artworkContext = artworkContext,
             )
             else -> throw IllegalStateException("Unknown playable type")
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
@@ -24,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.podcasts.databinding.AdapterEpisodeBinding
 import au.com.shiftyjelly.pocketcasts.podcasts.view.components.PlayButton
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadProgressUpdate
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getSummaryText
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
@@ -61,6 +62,7 @@ class EpisodeViewHolder(
     val imageRequestFactory: PocketCastsImageRequestFactory,
     val settings: Settings,
     private val swipeButtonLayoutFactory: SwipeButtonLayoutFactory,
+    private val artworkContext: ArtworkConfiguration.Element?,
 ) : RecyclerView.ViewHolder(binding.root), RowSwipeable {
     override val episodeRow: ViewGroup
         get() = binding.episodeRow
@@ -290,7 +292,9 @@ class EpisodeViewHolder(
         val artworkVisible = viewMode is ViewMode.Artwork
         imgArtwork.isVisible = artworkVisible
         if (!sameEpisode && artworkVisible) {
-            imageRequestFactory.create(episode, settings.artworkConfiguration.value.useEpisodeArtwork).loadInto(imgArtwork)
+            val artworkConfiguration = settings.artworkConfiguration.value
+            val useEpisodeArtwork = artworkContext?.let(artworkConfiguration::useEpisodeArtwork) ?: artworkConfiguration.useEpisodeArtwork
+            imageRequestFactory.create(episode, useEpisodeArtwork).loadInto(imgArtwork)
         }
 
         val transition = AutoTransition()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -233,6 +233,7 @@ class PodcastAdapter(
                 imageRequestFactory = imageRequestFactory.smallSize(),
                 settings = settings,
                 swipeButtonLayoutFactory = swipeButtonLayoutFactory,
+                artworkContext = null,
             )
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -53,6 +53,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.adapter.TabsViewHold
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastRatingsViewModel
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastViewModel.PodcastTab
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Element
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
 import au.com.shiftyjelly.pocketcasts.repositories.images.loadInto
@@ -573,7 +574,7 @@ class PodcastAdapter(
                                         bookmark,
                                     )
                                 },
-                                useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork,
+                                useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork(Element.Bookmarks),
                             )
                         },
                     )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/UserEpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/UserEpisodeViewHolder.kt
@@ -20,6 +20,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.podcasts.databinding.AdapterUserEpisodeBinding
 import au.com.shiftyjelly.pocketcasts.podcasts.view.components.PlayButton
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadProgressUpdate
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getSummaryText
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
@@ -57,6 +58,7 @@ class UserEpisodeViewHolder(
     val imageRequestFactory: PocketCastsImageRequestFactory,
     private val swipeButtonLayoutFactory: SwipeButtonLayoutFactory,
     private val userBookmarksObservable: Observable<List<Bookmark>>,
+    private val artworkContext: ArtworkConfiguration.Element,
 ) : RecyclerView.ViewHolder(binding.root), RowSwipeable {
 
     private var episodeInstance: BaseEpisode? = null
@@ -218,7 +220,7 @@ class UserEpisodeViewHolder(
 
         titleTextView.text = episode.title
 
-        imageRequestFactory.create(episode, settings.artworkConfiguration.value.useEpisodeArtwork).loadInto(artworkImageView)
+        imageRequestFactory.create(episode, settings.artworkConfiguration.value.useEpisodeArtwork(artworkContext)).loadInto(artworkImageView)
 
         val checkbox = binding.checkbox
         if (checkbox.isVisible != multiSelectEnabled) {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -26,6 +26,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.components.PlayButton
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.EpisodeListAdapter
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.EpisodeListBookmarkViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Element
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoPlaySource
 import au.com.shiftyjelly.pocketcasts.profile.R
 import au.com.shiftyjelly.pocketcasts.profile.databinding.FragmentCloudFilesBinding
@@ -106,6 +107,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                 fragmentManager = parentFragmentManager,
                 swipeSource = EpisodeItemTouchHelper.SwipeSource.FILES,
             ),
+            artworkContext = Element.Files,
         )
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
@@ -21,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.SettingsAppearanceState
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.SettingsAppearanceViewModel
+import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.worker.RefreshArtworkWorker
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -207,6 +208,10 @@ class AppearanceSettingsFragment : BaseFragment() {
             binding.swtUseEpisodeArtwork.isChecked = !binding.swtUseEpisodeArtwork.isChecked
         }
 
+        binding.lblEpisodeArtworkConfiguration.setOnClickListener {
+            showEpisodeArtworkConfigurationFragment()
+        }
+
         binding.lblRefreshAllPodcastArtwork.setOnClickListener {
             refreshArtwork()
         }
@@ -242,6 +247,10 @@ class AppearanceSettingsFragment : BaseFragment() {
             val selectedIndex = adapter.selectedIconIndex() ?: 0
             binding?.appIconRecyclerView?.scrollToPosition(selectedIndex)
         }
+    }
+
+    private fun showEpisodeArtworkConfigurationFragment() {
+        (activity as? FragmentHostListener)?.addFragment(EpisodeArtworkConfigurationFragment())
     }
 
     private fun refreshArtwork() {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
@@ -85,7 +85,7 @@ class EpisodeArtworkConfigurationFragment : BaseFragment() {
                 showDivider = false,
             ) {
                 elements.forEach { element ->
-                    EnableFeature(artworkConfiguration, element, onUpdateConfiguration)
+                    ArtworkElement(artworkConfiguration, element, onUpdateConfiguration)
                 }
             }
         }
@@ -107,7 +107,7 @@ class EpisodeArtworkConfigurationFragment : BaseFragment() {
     }
 
     @Composable
-    private fun EnableFeature(
+    private fun ArtworkElement(
         configuration: ArtworkConfiguration,
         element: ArtworkConfiguration.Element,
         onUpdateConfiguration: (ArtworkConfiguration) -> Unit,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
@@ -6,7 +6,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -64,7 +66,11 @@ class EpisodeArtworkConfigurationFragment : BaseFragment() {
         onUpdateConfiguration: (ArtworkConfiguration) -> Unit,
         onBackPressed: () -> Unit,
     ) {
-        Column(modifier = Modifier.background(MaterialTheme.theme.colors.primaryUi02)) {
+        Column(
+            modifier = Modifier
+                .background(MaterialTheme.theme.colors.primaryUi02)
+                .verticalScroll(rememberScrollState()),
+        ) {
             ThemedTopAppBar(
                 title = stringResource(LR.string.settings_use_episode_artwork_title),
                 onNavigationClick = onBackPressed,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
@@ -1,0 +1,127 @@
+package au.com.shiftyjelly.pocketcasts.settings
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
+import au.com.shiftyjelly.pocketcasts.compose.components.SettingRow
+import au.com.shiftyjelly.pocketcasts.compose.components.SettingRowToggle
+import au.com.shiftyjelly.pocketcasts.compose.components.SettingSection
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@AndroidEntryPoint
+class EpisodeArtworkConfigurationFragment : BaseFragment() {
+    @Inject lateinit var settings: Settings
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = ComposeView(requireContext()).apply {
+        val sortedElements = ArtworkConfiguration.Element.entries.sortedBy { getString(it.titleId) }
+        setContent {
+            AppThemeWithBackground(theme.activeTheme) {
+                val artworkConfiguration by settings.artworkConfiguration.flow.collectAsState()
+
+                EpisodeArtworkSettings(
+                    artworkConfiguration = artworkConfiguration,
+                    elements = sortedElements,
+                    onUpdateConfiguration = { configuration ->
+                        settings.artworkConfiguration.set(configuration, updateModifiedAt = true)
+                    },
+                    onBackPressed = {
+                        @Suppress("DEPRECATION")
+                        activity?.onBackPressed()
+                    },
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun EpisodeArtworkSettings(
+        artworkConfiguration: ArtworkConfiguration,
+        elements: List<ArtworkConfiguration.Element>,
+        onUpdateConfiguration: (ArtworkConfiguration) -> Unit,
+        onBackPressed: () -> Unit,
+    ) {
+        Column(modifier = Modifier.background(MaterialTheme.theme.colors.primaryUi02)) {
+            ThemedTopAppBar(
+                title = stringResource(LR.string.settings_use_episode_artwork_title),
+                onNavigationClick = onBackPressed,
+                bottomShadow = true,
+            )
+            SettingSection {
+                UseEpisodeArtwork(artworkConfiguration, onUpdateConfiguration)
+            }
+            SettingSection(
+                heading = stringResource(LR.string.settings_use_episode_artwork_customization_section),
+                subHeading = stringResource(LR.string.settings_use_episode_artwork_customization_description),
+                showDivider = false,
+            ) {
+                elements.forEach { element ->
+                    EnableFeature(artworkConfiguration, element, onUpdateConfiguration)
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun UseEpisodeArtwork(
+        configuration: ArtworkConfiguration,
+        onUpdateConfiguration: (ArtworkConfiguration) -> Unit,
+    ) {
+        SettingRow(
+            primaryText = stringResource(LR.string.settings_use_episode_artwork),
+            secondaryText = stringResource(LR.string.settings_use_episode_artwork_details),
+            toggle = SettingRowToggle.Switch(checked = configuration.useEpisodeArtwork),
+            modifier = Modifier.toggleable(value = configuration.useEpisodeArtwork, role = Role.Switch) { newValue ->
+                onUpdateConfiguration(configuration.copy(useEpisodeArtwork = newValue))
+            },
+        )
+    }
+
+    @Composable
+    private fun EnableFeature(
+        configuration: ArtworkConfiguration,
+        element: ArtworkConfiguration.Element,
+        onUpdateConfiguration: (ArtworkConfiguration) -> Unit,
+    ) {
+        SettingRow(
+            primaryText = stringResource(element.titleId),
+            toggle = SettingRowToggle.Checkbox(checked = configuration.useEpisodeArtwork(element), enabled = configuration.useEpisodeArtwork),
+            modifier = Modifier.toggleable(value = configuration.useEpisodeArtwork(element), role = Role.Checkbox) { newValue ->
+                onUpdateConfiguration(if (newValue) configuration.enable(element) else configuration.disable(element))
+            },
+        )
+    }
+
+    private val ArtworkConfiguration.Element.titleId get() = when (this) {
+        ArtworkConfiguration.Element.Filters -> LR.string.filters
+        ArtworkConfiguration.Element.UpNext -> LR.string.up_next
+        ArtworkConfiguration.Element.Downloads -> LR.string.profile_navigation_downloads
+        ArtworkConfiguration.Element.Files -> LR.string.profile_navigation_files
+        ArtworkConfiguration.Element.Starred -> LR.string.profile_navigation_starred
+        ArtworkConfiguration.Element.Bookmarks -> LR.string.bookmarks
+        ArtworkConfiguration.Element.ListeningHistory -> LR.string.profile_navigation_listening_history
+    }
+}

--- a/modules/features/settings/src/main/res/layout/fragment_settings_appearance.xml
+++ b/modules/features/settings/src/main/res/layout/fragment_settings_appearance.xml
@@ -20,6 +20,7 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.core.widget.NestedScrollView
+        android:id="@+id/nestedScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="?attr/primary_ui_04"
@@ -233,6 +234,7 @@
                 android:layout_marginTop="4dp"
                 android:layout_marginEnd="24dp"
                 android:contentDescription="@string/settings_use_episode_artwork"
+                android:saveEnabled="false"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="@+id/lblUseEpisodeArtwork" />
 
@@ -252,6 +254,22 @@
                 app:layout_constraintTop_toBottomOf="@+id/lblUseEpisodeArtwork" />
 
             <TextView
+                android:id="@+id/lblEpisodeArtworkConfiguration"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_use_episode_artwork_advanced"
+                android:textAppearance="@style/H40"
+                android:textColor="?attr/primary_text_01"
+                android:paddingStart="72dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="16dp"
+                android:paddingBottom="16dp"
+                android:background="?android:attr/selectableItemBackground"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/lblUseEpisodeArtworkDetails" />
+
+            <TextView
                 android:id="@+id/lblRefreshAllPodcastArtwork"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
@@ -265,7 +283,7 @@
                 android:background="?android:attr/selectableItemBackground"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/lblUseEpisodeArtworkDetails" />
+                app:layout_constraintTop_toBottomOf="@+id/lblEpisodeArtworkConfiguration" />
 
             <View
                 android:id="@+id/dividerViewUpNext"

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Settings.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Settings.kt
@@ -67,7 +67,9 @@ sealed class SettingRowToggle {
 fun SettingSection(
     modifier: Modifier = Modifier,
     heading: String? = null,
+    subHeading: String? = null,
     indent: Boolean = true,
+    showDivider: Boolean = true,
     content: @Composable () -> Unit = {},
 ) {
     Column(modifier = modifier) {
@@ -86,9 +88,24 @@ fun SettingSection(
                     ),
                 )
             }
+            if (subHeading != null) {
+                TextP50(
+                    text = subHeading,
+                    style = MaterialTheme.typography.body1,
+                    color = MaterialTheme.theme.colors.primaryText02,
+                    modifier = Modifier.padding(
+                        start = if (indent) indentedStartPadding else horizontalPadding,
+                        end = horizontalPadding,
+                        top = if (heading == null) verticalPadding else 0.dp,
+                        bottom = verticalPadding,
+                    ),
+                )
+            }
             content()
         }
-        HorizontalDivider()
+        if (showDivider) {
+            HorizontalDivider()
+        }
     }
 }
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1298,6 +1298,10 @@
     <string name="settings_use_dynamic_colors_widget_details">When enabled, widget colors will change based on the device theme colors.</string>
     <string name="settings_use_episode_artwork">Use episode artwork</string>
     <string name="settings_use_episode_artwork_details">Some shows have custom artwork for certain episodes. Enable this option and Pocket Casts will display them instead of the show’s artwork.</string>
+    <string name="settings_use_episode_artwork_advanced">Advanced episode artwork settings</string>
+    <string name="settings_use_episode_artwork_title">Episode Artwork</string>
+    <string name="settings_use_episode_artwork_customization_section">Customization</string>
+    <string name="settings_use_episode_artwork_customization_description">Select if you want to see episode artwork in these sections of the app</string>
     <string name="settings_version">Version %1$s (%2$s)</string>
     <string name="settings_view">View</string>
     <string name="settings_website_link">website link</string>

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesScreen.kt
@@ -14,6 +14,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Element
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.EpisodeChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
@@ -49,7 +50,7 @@ fun FilesScreen(
                 items(userEpisodes) { episode ->
                     EpisodeChip(
                         episode = episode,
-                        useEpisodeArtwork = artworkCollection.useEpisodeArtwork,
+                        useEpisodeArtwork = artworkCollection.useEpisodeArtwork(Element.Files),
                         onClick = { navigateToEpisode(episode.uuid) },
                     )
                 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.items
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Element
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearAppTheme
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.EpisodeChip
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ScreenHeaderChip
@@ -29,7 +30,7 @@ fun DownloadsScreen(
     val state by viewModel.stateFlow.collectAsState()
     val artworkConfiguration by viewModel.artworkConfiguration.collectAsState()
 
-    Content(columnState, state, artworkConfiguration.useEpisodeArtwork, onItemClick)
+    Content(columnState, state, artworkConfiguration.useEpisodeArtwork(Element.Downloads), onItemClick)
 }
 
 @Composable


### PR DESCRIPTION
## Description

Add an advances user setting for controlling episode artwork.

Internal ref: p1714032295029379-slack-C05RR9P9RAT

## Testing Instructions

1. Go to appearance settings.
2. Go to `Advanced episode artwork settings`.
3. Enable the setting.
4. Disable all customizations.
5. Check one by one that each customization enables episode artwork in its context.

## Screenshots or Screencast 

| Settings | Advanced settings |
| - | - |
| ![Screenshot_20240425-162108](https://github.com/Automattic/pocket-casts-android/assets/30936061/51e9affb-0dd5-4c44-ac5b-e6c6c5931785) | ![Screenshot_20240425-162115](https://github.com/Automattic/pocket-casts-android/assets/30936061/6c290feb-7467-4727-bb0f-3f6bb9630e6e) |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
