### PR TITLE
Update profile navigation

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -600,9 +600,12 @@ class MainActivity :
             }
         }
 
-        if (frameBottomSheetBehavior.state != BottomSheetBehavior.STATE_COLLAPSED) {
-            frameBottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
-            return
+        val fragment = supportFragmentManager.findFragmentById(R.id.fragmentOverBottomSheet)
+        if (fragment == null) {
+            if (frameBottomSheetBehavior.state != BottomSheetBehavior.STATE_COLLAPSED) {
+                frameBottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+                return
+            }
         }
 
         if (navigator.isShowingModal()) {
@@ -1147,7 +1150,14 @@ class MainActivity :
     }
 
     override fun addFragment(fragment: Fragment, onTop: Boolean, overTabs: Boolean) {
-        navigator.addFragment(fragment, onTop = onTop, modal = overTabs)
+        if (overTabs) {
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.fragmentOverBottomSheet, fragment)
+                .addToBackStack(null)
+                .commitAllowingStateLoss()
+        } else {
+            navigator.addFragment(fragment, onTop = onTop)
+        }
     }
 
     override fun replaceFragment(fragment: Fragment) {
@@ -1395,6 +1405,7 @@ class MainActivity :
     override fun openProfile() {
         FirebaseAnalyticsTracker.navigatedToProfile()
         showBottomSheet(ProfileFragment())
+//        addFragment(ProfileFragment(), overTabs = true)
     }
 
     override fun openPodcastPage(uuid: String, sourceView: String?) {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -110,6 +110,7 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewFragment
 import au.com.shiftyjelly.pocketcasts.ui.MainActivityViewModel.NavigationState
+import au.com.shiftyjelly.pocketcasts.ui.helper.CloseOnTabSwitch
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -417,6 +418,7 @@ class MainActivity :
                 if (it is NavigatorAction.TabSwitched) {
                     val currentTab = navigator.currentTab()
                     if (settings.selectedTab() != currentTab) {
+                        popToRootFragmentIfNeeded(currentTab)
                         trackTabOpened(currentTab)
                         when (currentTab) {
                             VR.id.navigation_podcasts -> FirebaseAnalyticsTracker.navigatedToPodcasts()
@@ -449,6 +451,15 @@ class MainActivity :
         mediaRouter = MediaRouter.getInstance(this)
 
         ThemeSettingObserver(this, theme, settings.themeReconfigurationEvents).observeThemeChanges()
+    }
+
+    private fun popToRootFragmentIfNeeded(currentTab: Int) {
+        if (!FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) return
+        if (navigator.stackSize(currentTab) > 1 &&
+            navigator.currentFragment() is CloseOnTabSwitch
+        ) {
+            navigator.reset(currentTab, resetRootFragment = false)
+        }
     }
 
     private fun resetEoYBadgeIfNeeded() {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1405,7 +1405,6 @@ class MainActivity :
     override fun openProfile() {
         FirebaseAnalyticsTracker.navigatedToProfile()
         showBottomSheet(ProfileFragment())
-//        addFragment(ProfileFragment(), overTabs = true)
     }
 
     override fun openPodcastPage(uuid: String, sourceView: String?) {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1383,7 +1383,7 @@ class MainActivity :
 
     override fun openProfile() {
         FirebaseAnalyticsTracker.navigatedToProfile()
-        addFragment(ProfileFragment())
+        showBottomSheet(ProfileFragment())
     }
 
     override fun openPodcastPage(uuid: String, sourceView: String?) {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1149,8 +1149,8 @@ class MainActivity :
         playbackManager.skipForward(sourceView = SourceView.MINIPLAYER)
     }
 
-    override fun addFragment(fragment: Fragment, onTop: Boolean, overTabs: Boolean) {
-        if (overTabs) {
+    override fun addFragment(fragment: Fragment, onTop: Boolean, overBottomSheet: Boolean) {
+        if (overBottomSheet) {
             supportFragmentManager.beginTransaction()
                 .replace(R.id.fragmentOverBottomSheet, fragment)
                 .addToBackStack(null)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1135,8 +1135,8 @@ class MainActivity :
         playbackManager.skipForward(sourceView = SourceView.MINIPLAYER)
     }
 
-    override fun addFragment(fragment: Fragment, onTop: Boolean) {
-        navigator.addFragment(fragment, onTop = onTop)
+    override fun addFragment(fragment: Fragment, onTop: Boolean, overTabs: Boolean) {
+        navigator.addFragment(fragment, onTop = onTop, modal = overTabs)
     }
 
     override fun replaceFragment(fragment: Fragment) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -68,6 +68,12 @@
             android:layout_height="wrap_content"
             android:translationZ="200dp"/>
 
+        <FrameLayout
+            android:id="@+id/fragmentOverBottomSheet"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:translationZ="300dp"/>
+
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
     <au.com.shiftyjelly.pocketcasts.views.component.RadioactiveLineView

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
@@ -60,7 +60,7 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
 
     // TODO: Refactor FragmentHostListener in to something more generic so it can be used
     // cleaner between automotive and main
-    override fun addFragment(fragment: Fragment, onTop: Boolean, overTabs: Boolean) {
+    override fun addFragment(fragment: Fragment, onTop: Boolean, overBottomSheet: Boolean) {
         addFragment(fragment)
     }
 

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
@@ -60,7 +60,7 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
 
     // TODO: Refactor FragmentHostListener in to something more generic so it can be used
     // cleaner between automotive and main
-    override fun addFragment(fragment: Fragment, onTop: Boolean) {
+    override fun addFragment(fragment: Fragment, onTop: Boolean, overTabs: Boolean) {
         addFragment(fragment)
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksContainerFragment.kt
@@ -16,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentBookmarksContainerBinding
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.CloseOnTabSwitch
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -25,7 +26,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @AndroidEntryPoint
 class BookmarksContainerFragment :
-    BaseDialogFragment() {
+    BaseDialogFragment(), CloseOnTabSwitch {
     companion object {
         private const val ARG_EPISODE_UUID = "episodeUUID"
         private const val ARG_SOURCE_VIEW = "sourceView"

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
@@ -30,6 +30,8 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.R
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -125,9 +127,14 @@ class BookmarksFragment : BaseFragment() {
                             val fragmentHostListener = (activity as? FragmentHostListener)
                             fragmentHostListener?.apply {
                                 closePlayer() // Closes player if open
-                                openTab(R.id.navigation_profile)
-                                addFragment(SettingsFragment())
-                                addFragment(fragment)
+                                if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+                                    addFragment(SettingsFragment(), overTabs = true)
+                                    addFragment(fragment, overTabs = true)
+                                } else {
+                                    openTab(R.id.navigation_profile)
+                                    addFragment(SettingsFragment())
+                                    addFragment(fragment)
+                                }
                             }
                         },
                     )

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
@@ -128,8 +128,8 @@ class BookmarksFragment : BaseFragment() {
                             fragmentHostListener?.apply {
                                 closePlayer() // Closes player if open
                                 if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
-                                    addFragment(SettingsFragment(), overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
-                                    addFragment(fragment, overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
+                                    addFragment(SettingsFragment(), overBottomSheet = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
+                                    addFragment(fragment, overBottomSheet = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
                                 } else {
                                     openTab(R.id.navigation_profile)
                                     addFragment(SettingsFragment())

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
@@ -128,8 +128,8 @@ class BookmarksFragment : BaseFragment() {
                             fragmentHostListener?.apply {
                                 closePlayer() // Closes player if open
                                 if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
-                                    addFragment(SettingsFragment(), overTabs = true)
-                                    addFragment(fragment, overTabs = true)
+                                    addFragment(SettingsFragment(), overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
+                                    addFragment(fragment, overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
                                 } else {
                                     openTab(R.id.navigation_profile)
                                     addFragment(SettingsFragment())

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -40,6 +40,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.settings.AutoDownloadSettingsFragment
 import au.com.shiftyjelly.pocketcasts.settings.ManualCleanupFragment
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
+import au.com.shiftyjelly.pocketcasts.ui.helper.CloseOnTabSwitch
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
@@ -61,7 +62,7 @@ import au.com.shiftyjelly.pocketcasts.views.R as VR
 private const val ARG_MODE = "profile_list_mode"
 
 @AndroidEntryPoint
-class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
+class ProfileEpisodeListFragment : BaseFragment(), CloseOnTabSwitch, Toolbar.OnMenuItemClickListener {
     sealed class Mode(val index: Int, val showMenu: Boolean) {
         object Downloaded : Mode(0, true)
         object Starred : Mode(1, false)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -528,8 +528,8 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         val fragmentHostListener = (activity as? FragmentHostListener)
         fragmentHostListener?.apply {
             if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
-                addFragment(SettingsFragment(), overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
-                addFragment(HeadphoneControlsSettingsFragment(), overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
+                addFragment(SettingsFragment(), overBottomSheet = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
+                addFragment(HeadphoneControlsSettingsFragment(), overBottomSheet = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
             } else {
                 openTab(VR.id.navigation_profile)
                 addFragment(SettingsFragment())

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -91,7 +91,6 @@ import kotlinx.parcelize.Parcelize
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
-import au.com.shiftyjelly.pocketcasts.views.R as VR
 
 @AndroidEntryPoint
 class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
@@ -527,9 +526,14 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
     private fun onHeadsetSettingsClicked() {
         val fragmentHostListener = (activity as? FragmentHostListener)
         fragmentHostListener?.apply {
-            openTab(VR.id.navigation_profile)
-            addFragment(SettingsFragment())
-            addFragment(HeadphoneControlsSettingsFragment())
+            if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+                addFragment(SettingsFragment(), overTabs = true)
+                addFragment(HeadphoneControlsSettingsFragment(), overTabs = true)
+            } else {
+                openTab(au.com.shiftyjelly.pocketcasts.views.R.id.navigation_profile)
+                addFragment(SettingsFragment())
+                addFragment(HeadphoneControlsSettingsFragment())
+            }
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -91,6 +91,7 @@ import kotlinx.parcelize.Parcelize
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
+import au.com.shiftyjelly.pocketcasts.views.R as VR
 
 @AndroidEntryPoint
 class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
@@ -527,10 +528,10 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         val fragmentHostListener = (activity as? FragmentHostListener)
         fragmentHostListener?.apply {
             if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
-                addFragment(SettingsFragment(), overTabs = true)
-                addFragment(HeadphoneControlsSettingsFragment(), overTabs = true)
+                addFragment(SettingsFragment(), overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
+                addFragment(HeadphoneControlsSettingsFragment(), overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
             } else {
-                openTab(au.com.shiftyjelly.pocketcasts.views.R.id.navigation_profile)
+                openTab(VR.id.navigation_profile)
                 addFragment(SettingsFragment())
                 addFragment(HeadphoneControlsSettingsFragment())
             }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.unit.dp
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import androidx.transition.TransitionInflater
 import au.com.shiftyjelly.pocketcasts.account.ChangeEmailFragment
 import au.com.shiftyjelly.pocketcasts.account.ChangePwdFragment
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.ProfileUpgradeBanner
@@ -40,8 +41,11 @@ import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
+import au.com.shiftyjelly.pocketcasts.ui.R
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.Util
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -88,6 +92,14 @@ class AccountDetailsFragment : BaseFragment() {
     private val viewModel: AccountDetailsViewModel by viewModels()
     private var binding: FragmentAccountDetailsBinding? = null
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+            val inflater = TransitionInflater.from(requireContext())
+            enterTransition = inflater.inflateTransition(R.transition.slide_in)
+        }
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentAccountDetailsBinding.inflate(inflater, container, false)
         return binding?.root
@@ -96,6 +108,7 @@ class AccountDetailsFragment : BaseFragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         binding = null
+        enterTransition = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -176,7 +176,7 @@ class AccountDetailsFragment : BaseFragment() {
 
         binding.btnChangeEmail?.setOnClickListener {
             val fragment = ChangeEmailFragment.newInstance()
-            (activity as FragmentHostListener).addFragment(fragment, overTabs = true)
+            (activity as FragmentHostListener).addFragment(fragment, overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
         }
 
         val showChangeButtons = !syncManager.isGoogleLogin()
@@ -184,7 +184,7 @@ class AccountDetailsFragment : BaseFragment() {
 
         binding.btnChangePwd?.setOnClickListener {
             val fragment = ChangePwdFragment.newInstance()
-            (this.activity as FragmentHostListener).addFragment(fragment, overTabs = true)
+            (this.activity as FragmentHostListener).addFragment(fragment, overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
         }
 
         binding.btnUpgradeAccount?.setOnClickListener {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -176,7 +176,7 @@ class AccountDetailsFragment : BaseFragment() {
 
         binding.btnChangeEmail?.setOnClickListener {
             val fragment = ChangeEmailFragment.newInstance()
-            (activity as FragmentHostListener).addFragment(fragment, overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
+            (activity as FragmentHostListener).addFragment(fragment, overBottomSheet = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
         }
 
         val showChangeButtons = !syncManager.isGoogleLogin()
@@ -184,7 +184,7 @@ class AccountDetailsFragment : BaseFragment() {
 
         binding.btnChangePwd?.setOnClickListener {
             val fragment = ChangePwdFragment.newInstance()
-            (this.activity as FragmentHostListener).addFragment(fragment, overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
+            (this.activity as FragmentHostListener).addFragment(fragment, overBottomSheet = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
         }
 
         binding.btnUpgradeAccount?.setOnClickListener {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -163,7 +163,7 @@ class AccountDetailsFragment : BaseFragment() {
 
         binding.btnChangeEmail?.setOnClickListener {
             val fragment = ChangeEmailFragment.newInstance()
-            (activity as FragmentHostListener).addFragment(fragment)
+            (activity as FragmentHostListener).addFragment(fragment, overTabs = true)
         }
 
         val showChangeButtons = !syncManager.isGoogleLogin()
@@ -171,7 +171,7 @@ class AccountDetailsFragment : BaseFragment() {
 
         binding.btnChangePwd?.setOnClickListener {
             val fragment = ChangePwdFragment.newInstance()
-            (this.activity as FragmentHostListener).addFragment(fragment)
+            (this.activity as FragmentHostListener).addFragment(fragment, overTabs = true)
         }
 
         binding.btnUpgradeAccount?.setOnClickListener {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -112,7 +112,7 @@ class ProfileFragment : BaseFragment() {
         val binding = binding ?: return
 
         val addFragmentOverTabs = { fragment: Fragment ->
-            (activity as? FragmentHostListener)?.addFragment(fragment, overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
+            (activity as? FragmentHostListener)?.addFragment(fragment, overBottomSheet = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
         }
 
         val addFragmentBehindTabs = { fragment: Fragment ->
@@ -263,7 +263,7 @@ class ProfileFragment : BaseFragment() {
         if (viewModel.isSignedIn) {
             val fragment = AccountDetailsFragment.newInstance()
             val fragmentHostListener = (activity as FragmentHostListener)
-            fragmentHostListener.addFragment(fragment, overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
+            fragmentHostListener.addFragment(fragment, overBottomSheet = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
         } else {
             OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.LoggedOut)
         }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -110,10 +110,9 @@ class ProfileFragment : BaseFragment() {
 
         val binding = binding ?: return
 
-        binding.backButton?.showIf(FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
-        binding.backButton?.setOnClickListener {
-            @Suppress("DEPRECATION")
-            activity?.onBackPressed()
+        binding.closeButton?.showIf(FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
+        binding.closeButton?.setOnClickListener {
+            (activity as? FragmentHostListener)?.bottomSheetClosePressed(this)
         }
 
         binding.btnSettings.setOnClickListener {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -120,6 +120,15 @@ class ProfileFragment : BaseFragment() {
             }
         }
 
+        val addFragmentBehindTabs = { fragment: Fragment ->
+            (activity as? FragmentHostListener)?.let {
+                if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+                    it.bottomSheetClosePressed(this)
+                }
+                it.addFragment(fragment)
+            }
+        }
+
         binding.closeButton?.showIf(FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
         binding.closeButton?.setOnClickListener {
             (activity as? FragmentHostListener)?.bottomSheetClosePressed(this)
@@ -147,7 +156,7 @@ class ProfileFragment : BaseFragment() {
                     }
                     CloudFilesFragment::class.java -> {
                         analyticsTracker.track(AnalyticsEvent.UPLOADED_FILES_SHOWN)
-                        (activity as? FragmentHostListener)?.addFragment(fragmentClass.getDeclaredConstructor().newInstance())
+                        addFragmentBehindTabs(fragmentClass.getDeclaredConstructor().newInstance())
                     }
                     ProfileEpisodeListFragment::class.java -> {
                         val fragment = when (section.title) {
@@ -165,14 +174,14 @@ class ProfileFragment : BaseFragment() {
                             }
                             else -> throw IllegalStateException("Unknown row")
                         }
-                        (activity as? FragmentHostListener)?.addFragment(fragment)
+                        addFragmentBehindTabs(fragment)
                     }
                     BookmarksContainerFragment::class.java -> {
                         analyticsTracker.track(AnalyticsEvent.PROFILE_BOOKMARKS_SHOWN)
                         val fragment = BookmarksContainerFragment.newInstance(
                             sourceView = SourceView.PROFILE,
                         )
-                        (activity as? FragmentHostListener)?.addFragment(fragment)
+                        addFragmentBehindTabs(fragment)
                     }
                     HelpFragment::class.java -> {
                         addFragmentOverTabs(fragmentClass.getDeclaredConstructor().newInstance())

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -112,12 +112,7 @@ class ProfileFragment : BaseFragment() {
         val binding = binding ?: return
 
         val addFragmentOverTabs = { fragment: Fragment ->
-            (activity as? FragmentHostListener)?.let {
-                if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
-                    it.bottomSheetClosePressed(this)
-                }
-                it.addFragment(fragment, overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
-            }
+            (activity as? FragmentHostListener)?.addFragment(fragment, overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
         }
 
         val addFragmentBehindTabs = { fragment: Fragment ->
@@ -268,14 +263,7 @@ class ProfileFragment : BaseFragment() {
         if (viewModel.isSignedIn) {
             val fragment = AccountDetailsFragment.newInstance()
             val fragmentHostListener = (activity as FragmentHostListener)
-            with(fragmentHostListener) {
-                if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
-                    bottomSheetClosePressed(this@ProfileFragment)
-                    addFragment(fragment, overTabs = true)
-                } else {
-                    addFragment(fragment)
-                }
-            }
+            fragmentHostListener.addFragment(fragment, overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
         } else {
             OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.LoggedOut)
         }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -36,6 +36,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageReques
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
+import au.com.shiftyjelly.pocketcasts.ui.helper.CloseOnTabSwitch
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.Util
@@ -59,7 +60,7 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @AndroidEntryPoint
-class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
+class CloudFilesFragment : BaseFragment(), CloseOnTabSwitch, Toolbar.OnMenuItemClickListener {
     @Inject lateinit var downloadManager: DownloadManager
 
     @Inject lateinit var playbackManager: PlaybackManager

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
@@ -15,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.profile.databinding.FragmentCloudSettingsB
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
+import au.com.shiftyjelly.pocketcasts.ui.helper.CloseOnTabSwitch
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
@@ -24,7 +25,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @AndroidEntryPoint
-class CloudSettingsFragment : BaseFragment() {
+class CloudSettingsFragment : BaseFragment(), CloseOnTabSwitch {
     companion object {
         fun newInstance(): CloudSettingsFragment {
             return CloudSettingsFragment()

--- a/modules/features/profile/src/main/res/layout/fragment_account_details.xml
+++ b/modules/features/profile/src/main/res/layout/fragment_account_details.xml
@@ -14,7 +14,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="?attr/secondary_ui_01"
-            android:minHeight="?android:attr/actionBarSize" />
+            android:minHeight="?android:attr/actionBarSize"
+            app:navigationIcon="@drawable/ic_arrow_back"
+            app:contentDescription="@string/back"/>
 
         <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
             android:id="@+id/multiSelectToolbar"

--- a/modules/features/profile/src/main/res/layout/fragment_profile.xml
+++ b/modules/features/profile/src/main/res/layout/fragment_profile.xml
@@ -159,14 +159,14 @@
                 app:layout_constraintBottom_toBottomOf="parent"/>
 
             <ImageButton
-                android:id="@+id/backButton"
+                android:id="@+id/closeButton"
                 android:layout_width="44dp"
                 android:layout_height="44dp"
                 android:layout_marginTop="7dp"
                 android:layout_marginStart="7dp"
                 android:background="?android:attr/actionBarItemBackground"
-                android:contentDescription="@string/back"
-                android:src="@drawable/ic_arrow_back_24dp"
+                android:contentDescription="@string/close"
+                android:src="@drawable/ic_close"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 android:visible="false"

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -25,6 +25,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistUpdateSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserPlaylistUpdate
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.AutoDownloadSettingsViewModel
+import au.com.shiftyjelly.pocketcasts.ui.helper.CloseOnTabSwitch
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.fragments.FilterSelectFragment
@@ -58,7 +59,8 @@ class AutoDownloadSettingsFragment :
     CoroutineScope,
     PodcastSelectFragment.Listener,
     FilterSelectFragment.Listener,
-    HasBackstack {
+    HasBackstack,
+    CloseOnTabSwitch {
 
     companion object {
         const val PREFERENCE_PODCASTS_CATEGORY = "podcasts_category"

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
@@ -118,13 +118,13 @@ class HelpFragment : BaseFragment(), HasBackstack, Toolbar.OnMenuItemClickListen
         when (item.itemId) {
             R.id.menu_logs -> {
                 val fragment = LogsFragment()
-                (activity as? FragmentHostListener)?.addFragment(fragment)
+                (activity as? FragmentHostListener)?.addFragment(fragment, overTabs = true)
                 true
             }
 
             R.id.menu_status_page -> {
                 val fragment = StatusFragment()
-                (activity as? FragmentHostListener)?.addFragment(fragment)
+                (activity as? FragmentHostListener)?.addFragment(fragment, overTabs = true)
                 true
             }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
@@ -19,6 +19,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import androidx.transition.TransitionInflater
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
@@ -29,6 +30,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.support.Support
 import au.com.shiftyjelly.pocketcasts.settings.status.StatusFragment
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.HelpViewModel
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.extensions.findToolbar
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -81,6 +84,10 @@ class HelpFragment : BaseFragment(), HasBackstack, Toolbar.OnMenuItemClickListen
         super.onCreate(savedInstanceState)
         savedInstanceState?.let {
             loadedUrl = savedInstanceState.getString("url")
+        }
+        if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+            val inflater = TransitionInflater.from(requireContext())
+            enterTransition = inflater.inflateTransition(au.com.shiftyjelly.pocketcasts.ui.R.transition.slide_in)
         }
         viewModel.onShown()
     }
@@ -263,5 +270,10 @@ class HelpFragment : BaseFragment(), HasBackstack, Toolbar.OnMenuItemClickListen
                 UiUtil.displayDialogNoEmailApp(context)
             }
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        enterTransition = null
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
@@ -125,13 +125,13 @@ class HelpFragment : BaseFragment(), HasBackstack, Toolbar.OnMenuItemClickListen
         when (item.itemId) {
             R.id.menu_logs -> {
                 val fragment = LogsFragment()
-                (activity as? FragmentHostListener)?.addFragment(fragment, overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
+                (activity as? FragmentHostListener)?.addFragment(fragment, overBottomSheet = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
                 true
             }
 
             R.id.menu_status_page -> {
                 val fragment = StatusFragment()
-                (activity as? FragmentHostListener)?.addFragment(fragment, overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
+                (activity as? FragmentHostListener)?.addFragment(fragment, overBottomSheet = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
                 true
             }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
@@ -125,13 +125,13 @@ class HelpFragment : BaseFragment(), HasBackstack, Toolbar.OnMenuItemClickListen
         when (item.itemId) {
             R.id.menu_logs -> {
                 val fragment = LogsFragment()
-                (activity as? FragmentHostListener)?.addFragment(fragment, overTabs = true)
+                (activity as? FragmentHostListener)?.addFragment(fragment, overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
                 true
             }
 
             R.id.menu_status_page -> {
                 val fragment = StatusFragment()
-                (activity as? FragmentHostListener)?.addFragment(fragment, overTabs = true)
+                (activity as? FragmentHostListener)?.addFragment(fragment, overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
                 true
             }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/ManualCleanupFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/ManualCleanupFragment.kt
@@ -9,11 +9,14 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.ManualCleanupViewModel
+import au.com.shiftyjelly.pocketcasts.ui.helper.CloseOnTabSwitch
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class ManualCleanupFragment : BaseFragment() {
+class ManualCleanupFragment :
+    BaseFragment(),
+    CloseOnTabSwitch {
     companion object {
         private const val CLEAN_UP_CONFIRMATION_DIALOG_TAG = "clean-up-confirmation-dialog"
         fun newInstance() = ManualCleanupFragment()

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragment.kt
@@ -79,7 +79,7 @@ class SettingsFragment : BaseFragment() {
                                 isDebug = BuildConfig.DEBUG,
                                 isUnrestrictedBattery = isUnrestrictedBattery,
                                 openFragment = { fragment ->
-                                    (activity as? FragmentHostListener)?.addFragment(fragment, overTabs = true)
+                                    (activity as? FragmentHostListener)?.addFragment(fragment, overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
                                 },
                             )
                         }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragment.kt
@@ -79,7 +79,7 @@ class SettingsFragment : BaseFragment() {
                                 isDebug = BuildConfig.DEBUG,
                                 isUnrestrictedBattery = isUnrestrictedBattery,
                                 openFragment = { fragment ->
-                                    (activity as? FragmentHostListener)?.addFragment(fragment, overTabs = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
+                                    (activity as? FragmentHostListener)?.addFragment(fragment, overBottomSheet = FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
                                 },
                             )
                         }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragment.kt
@@ -67,7 +67,7 @@ class SettingsFragment : BaseFragment() {
                                 isDebug = BuildConfig.DEBUG,
                                 isUnrestrictedBattery = isUnrestrictedBattery,
                                 openFragment = { fragment ->
-                                    (activity as? FragmentHostListener)?.addFragment(fragment)
+                                    (activity as? FragmentHostListener)?.addFragment(fragment, overTabs = true)
                                 },
                             )
                         }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragment.kt
@@ -13,10 +13,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.transition.TransitionInflater
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.ui.R
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.SystemBatteryRestrictions
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -29,6 +33,14 @@ class SettingsFragment : BaseFragment() {
 
     @Inject
     lateinit var batteryRestrictions: SystemBatteryRestrictions
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+            val inflater = TransitionInflater.from(requireContext())
+            enterTransition = inflater.inflateTransition(R.transition.slide_in)
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -74,4 +86,9 @@ class SettingsFragment : BaseFragment() {
                 }
             }
         }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        enterTransition = null
+    }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsFragment.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.fragment.app.viewModels
+import androidx.transition.TransitionInflater
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -57,6 +58,8 @@ import au.com.shiftyjelly.pocketcasts.settings.R
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatLongStyle
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Date
@@ -67,6 +70,14 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 class StatsFragment : BaseFragment() {
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
     private val viewModel: StatsViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+            val inflater = TransitionInflater.from(requireContext())
+            enterTransition = inflater.inflateTransition(au.com.shiftyjelly.pocketcasts.ui.R.transition.slide_in)
+        }
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View = ComposeView(requireContext()).apply {
         setContent {
@@ -94,6 +105,11 @@ class StatsFragment : BaseFragment() {
     override fun onBackPressed(): Boolean {
         analyticsTracker.track(AnalyticsEvent.STATS_DISMISSED)
         return super.onBackPressed()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        enterTransition = false
     }
 }
 

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/CloseOnTabSwitch.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/CloseOnTabSwitch.kt
@@ -1,0 +1,3 @@
+package au.com.shiftyjelly.pocketcasts.ui.helper
+
+interface CloseOnTabSwitch

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
@@ -10,7 +10,7 @@ interface FragmentHostListener {
     fun addFragment(
         fragment: Fragment,
         onTop: Boolean = false,
-        overTabs: Boolean = false,
+        overBottomSheet: Boolean = false,
     )
     fun replaceFragment(fragment: Fragment)
     fun showBottomSheet(fragment: Fragment)

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
@@ -7,7 +7,11 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import kotlin.time.Duration
 
 interface FragmentHostListener {
-    fun addFragment(fragment: Fragment, onTop: Boolean = false)
+    fun addFragment(
+        fragment: Fragment,
+        onTop: Boolean = false,
+        overTabs: Boolean = false,
+    )
     fun replaceFragment(fragment: Fragment)
     fun showBottomSheet(fragment: Fragment)
     fun bottomSheetClosePressed(fragment: Fragment)

--- a/modules/services/ui/src/main/res/transition/slide_in.xml
+++ b/modules/services/ui/src/main/res/transition/slide_in.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<slide xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@android:integer/config_shortAnimTime"
+    android:slideEdge="right" />

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/Toolbar.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/Toolbar.kt
@@ -8,6 +8,7 @@ import androidx.annotation.MenuRes
 import androidx.annotation.OptIn
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.doOnLayout
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getTintedDrawable
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -113,7 +114,9 @@ fun Toolbar.updateProfileMenuBadge(
                 badgeGravity = BadgeDrawable.BOTTOM_END
             }
             it.setTag(UR.id.menu_profile_badge, profileIconBadge)
-            BadgeUtils.attachBadgeDrawable(profileIconBadge, it)
+            it.doOnLayout {
+                BadgeUtils.attachBadgeDrawable(profileIconBadge, it)
+            }
         } else {
             val badge = it.getTag(UR.id.menu_profile_badge) as? BadgeDrawable
             BadgeUtils.detachBadgeDrawable(badge, it)


### PR DESCRIPTION
Part of: #2081 

## Description
This updates profile navigation from the profile menu.




## Testing Instructions

#### Feature Flag ON

1. Open the app
2. Tap Profile menu
3. ✅ Notice that Profile screen opens with a close button
4. Tap on close button
5. ✅ Notice that Profile screen is closed
6. Re open Profile screen
7. Navigate to another screen from Profile screen
8.  ✅ Notice fragments are added as follows:
- Added over tabs
   - Account Details
   - Help & feedback
   - Setttings
   - Stats

- Added behind tabs so that playing an episode from these screen is reflected on the mini player
   - Downloads
   - Files
   - Starred
   - Bookmarks

    These are removed from back stack on switching to another tab to prevent weired state noticed in https://github.com/Automattic/pocket-casts-android/pull/2102#pullrequestreview-2019549512.

#### Feature Flag OFF

1. Turn off `Show Up Next in tab bar` feature flag in Profile -> Settings -> Beta features
2. Kill and restart the app
3. ✅ Notice that navigation from profile tab work as before

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/984a4852-d135-4353-973a-74793fec0b28

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack