### PR TITLE
Sleep Timer: Add the option to select the number of chapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@
         ([#2054](https://github.com/Automattic/pocket-casts-android/pull/2054))
     *   Sleep timer: Start fading out audio when sleep timer has 5 seconds left
         ([#2069](https://github.com/Automattic/pocket-casts-android/pull/2069))
-    *   Sleep timer: Set sleep time end of episode for multiple episodes
+    *   Sleep timer: Add the option to select the number of episodes
         ([#2097](https://github.com/Automattic/pocket-casts-android/pull/2097))
     *   Enable toggling episode artwork separately in different contexts
         ([#2112](https://github.com/Automattic/pocket-casts-android/pull/2112))
+    *   Sleep timer: Add the option to select the number of chapters
+        ([#2115](https://github.com/Automattic/pocket-casts-android/pull/2115))
 *   Updates:
     *   Improved updating podcast episode when subscribed to thousands podcasts. 
         ([#2082](https://github.com/Automattic/pocket-casts-android/pull/2082))

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
@@ -64,7 +64,6 @@ class SleepFragment : BaseDialogFragment() {
         val binding = FragmentSleepBinding.inflate(inflater, container, false)
         this.binding = binding
 
-        binding.buttonMins5.setOnClickListener { startTimer(mins = 5) }
         binding.buttonMins15.setOnClickListener { startTimer(mins = 15) }
         binding.buttonMins30.setOnClickListener { startTimer(mins = 30) }
         binding.buttonMins60.setOnClickListener { startTimer(mins = 60) }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
@@ -81,6 +81,7 @@ class SleepFragment : BaseDialogFragment() {
         }
         binding.buttonEndOfChapter.setOnClickListener {
             val chapters = viewModel.getSleepEndOfChapters()
+            analyticsTracker.track(AnalyticsEvent.PLAYER_SLEEP_TIMER_ENABLED, mapOf(TIME_KEY to END_OF_CHAPTER, NUMBER_OF_CHAPTERS_KEY to chapters))
             startTimerEndOfChapter(chapters = chapters)
         }
         binding.buttonAdd5Minute.setOnClickListener { addExtra5minute() }
@@ -261,5 +262,7 @@ class SleepFragment : BaseDialogFragment() {
         private const val AMOUNT_KEY = "amount"
         private const val NUMBER_OF_EPISODES_KEY = "number_of_episodes"
         private const val END_OF_EPISODE = "end_of_episode"
+        private const val NUMBER_OF_CHAPTERS_KEY = "number_of_chapters"
+        private const val END_OF_CHAPTER = "end_of_chapter"
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
@@ -79,6 +79,10 @@ class SleepFragment : BaseDialogFragment() {
             analyticsTracker.track(AnalyticsEvent.PLAYER_SLEEP_TIMER_ENABLED, mapOf(TIME_KEY to END_OF_EPISODE, NUMBER_OF_EPISODES_KEY to episodes))
             startTimerEndOfEpisode(episodes = episodes)
         }
+        binding.buttonEndOfChapter.setOnClickListener {
+            val chapters = viewModel.getSleepEndOfChapters()
+            startTimerEndOfChapter(chapters = chapters)
+        }
         binding.buttonAdd5Minute.setOnClickListener { addExtra5minute() }
         binding.buttonAdd1Minute.setOnClickListener { addExtra1minute() }
         binding.buttonEndOfEpisode2.setOnClickListener {
@@ -225,6 +229,12 @@ class SleepFragment : BaseDialogFragment() {
     private fun startTimerEndOfEpisode(episodes: Int) {
         viewModel.sleepTimerAfterEpisode(episodes)
         binding?.root?.announceForAccessibility("Sleep timer set for end of episode")
+        close()
+    }
+
+    private fun startTimerEndOfChapter(chapters: Int) {
+        viewModel.sleepTimerAfterChapter(chapters)
+        binding?.root?.announceForAccessibility("Sleep timer set for end of chapter")
         close()
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
@@ -91,7 +91,7 @@ class SleepFragment : BaseDialogFragment() {
             startTimerEndOfEpisode(episodes = episodesAmountToExtend)
         }
         binding.buttonCancelTime.setOnClickListener { cancelTimer() }
-        binding.buttonCancelEndOfEpisode.setOnClickListener { cancelTimer() }
+        binding.buttonCancelEndOfEpisodeOrChapter.setOnClickListener { cancelTimer() }
 
         return binding.root
     }
@@ -116,8 +116,8 @@ class SleepFragment : BaseDialogFragment() {
             binding?.labelEndOfChapter?.text = text
         }
 
-        viewModel.sleepInEpisodesText.observe(viewLifecycleOwner) { text ->
-            binding?.sleepingEndOfEpisode?.text = text
+        viewModel.sleepingInText.observe(viewLifecycleOwner) { text ->
+            binding?.sleepingInText?.text = text
         }
 
         viewModel.isSleepRunning.observe(viewLifecycleOwner) { isSleepRunning ->
@@ -125,10 +125,10 @@ class SleepFragment : BaseDialogFragment() {
             binding?.sleepRunning?.isVisible = isSleepRunning
         }
 
-        viewModel.isSleepRunning.combineLatest(viewModel.isSleepAtEndOfEpisode)
+        viewModel.isSleepRunning.combineLatest(viewModel.isSleepAtEndOfEpisodeOrChapter)
             .observe(viewLifecycleOwner) { (isSleepRunning, isSleepAtEndOfEpisode) ->
                 binding?.sleepRunningTime?.isVisible = isSleepRunning && !isSleepAtEndOfEpisode
-                binding?.sleepRunningEndOfEpisode?.isVisible = isSleepRunning && isSleepAtEndOfEpisode
+                binding?.sleepRunningEndOfEpisodeOrChapter?.isVisible = isSleepRunning && isSleepAtEndOfEpisode
             }
 
         viewModel.playingEpisodeLive.observe(
@@ -143,8 +143,8 @@ class SleepFragment : BaseDialogFragment() {
                 binding.buttonAdd5Minute.setTextColor(tintColorStateList)
                 binding.buttonAdd1Minute.strokeColor = tintColorStateList
                 binding.buttonAdd1Minute.setTextColor(tintColorStateList)
-                binding.buttonCancelEndOfEpisode.strokeColor = tintColorStateList
-                binding.buttonCancelEndOfEpisode.setTextColor(tintColorStateList)
+                binding.buttonCancelEndOfEpisodeOrChapter.strokeColor = tintColorStateList
+                binding.buttonCancelEndOfEpisodeOrChapter.setTextColor(tintColorStateList)
                 binding.buttonCancelTime.strokeColor = tintColorStateList
                 binding.buttonCancelTime.setTextColor(tintColorStateList)
                 binding.buttonEndOfEpisode2.strokeColor = tintColorStateList

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
@@ -69,8 +69,10 @@ class SleepFragment : BaseDialogFragment() {
         binding.buttonMins60.setOnClickListener { startTimer(mins = 60) }
         binding.customMinusButton.setOnClickListener { minusButtonClicked() }
         binding.endOfEpisodeMinusButton.setOnClickListener { minusEndOfEpisodeButtonClicked() }
+        binding.endOfChapterMinusButton.setOnClickListener { minusEndOfChapterButtonClicked() }
         binding.customPlusButton.setOnClickListener { plusButtonClicked() }
         binding.endOfEpisodePlusButton.setOnClickListener { plusEndOfEpisodeButtonClicked() }
+        binding.endOfChapterPlusButton.setOnClickListener { plusEndOfChapterButtonClicked() }
         binding.buttonCustom.setOnClickListener { startCustomTimer() }
         binding.buttonEndOfEpisode.setOnClickListener {
             val episodes = viewModel.getSleepEndOfEpisodes()
@@ -104,6 +106,10 @@ class SleepFragment : BaseDialogFragment() {
 
         viewModel.sleepEndOfEpisodesText.observe(viewLifecycleOwner) { text ->
             binding?.labelEndOfEpisode?.text = text
+        }
+
+        viewModel.sleepEndOfChaptersText.observe(viewLifecycleOwner) { text ->
+            binding?.labelEndOfChapter?.text = text
         }
 
         viewModel.sleepInEpisodesText.observe(viewLifecycleOwner) { text ->
@@ -180,9 +186,15 @@ class SleepFragment : BaseDialogFragment() {
         }
         binding?.root?.announceForAccessibility("Custom sleep time ${viewModel.sleepCustomTimeMins}")
     }
+
     private fun plusEndOfEpisodeButtonClicked() {
         viewModel.setSleepEndOfEpisodes(viewModel.getSleepEndOfEpisodes() + 1)
         binding?.root?.announceForAccessibility("Sleep time end of episode ${viewModel.getSleepEndOfEpisodes()}")
+    }
+
+    private fun plusEndOfChapterButtonClicked() {
+        viewModel.setSleepEndOfChapters(viewModel.getSleepEndOfChapters() + 1)
+        binding?.root?.announceForAccessibility("Sleep time chapter ${viewModel.getSleepEndOfChapters()}")
     }
 
     private fun minusButtonClicked() {
@@ -200,6 +212,14 @@ class SleepFragment : BaseDialogFragment() {
             viewModel.setSleepEndOfEpisodes(endOfEpisodes - 1)
         }
         binding?.root?.announceForAccessibility("Sleep time end of episode ${viewModel.getSleepEndOfEpisodes() }")
+    }
+
+    private fun minusEndOfChapterButtonClicked() {
+        val endOfChapters = viewModel.getSleepEndOfChapters()
+        if (endOfChapters > 1) {
+            viewModel.setSleepEndOfChapters(endOfChapters - 1)
+        }
+        binding?.root?.announceForAccessibility("Sleep time end of chapter ${viewModel.getSleepEndOfChapters() }")
     }
 
     private fun startTimerEndOfEpisode(episodes: Int) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -278,6 +278,9 @@ class PlayerViewModel @Inject constructor(
     val sleepEndOfEpisodesText = MutableLiveData<String>().apply {
         postValue(calcEndOfEpisodeText())
     }
+    val sleepEndOfChaptersText = MutableLiveData<String>().apply {
+        postValue(calcEndOfChapterText())
+    }
     val sleepInEpisodesText = MutableLiveData<String>().apply {
         postValue(calcSleepInEpisodesText())
     }
@@ -291,6 +294,17 @@ class PlayerViewModel @Inject constructor(
         get() {
             return settings.getSleepTimerCustomMins()
         }
+
+    fun setSleepEndOfChapters(chapters: Int = 1, shouldCallUpdateTimer: Boolean = true) {
+        val newValue = chapters.coerceIn(1, 240)
+        settings.setSleepEndOfChapters(newValue)
+        sleepEndOfChaptersText.postValue(calcEndOfChapterText())
+        if (shouldCallUpdateTimer) {
+            updateSleepTimer()
+        }
+    }
+
+    fun getSleepEndOfChapters(): Int = settings.getSleepEndOfChapters()
 
     fun setSleepEndOfEpisodes(episodes: Int = 1, shouldCallUpdateTimer: Boolean = true) {
         val newValue = episodes.coerceIn(1, 240)
@@ -530,6 +544,14 @@ class PlayerViewModel @Inject constructor(
             context.resources.getString(LR.string.player_sleep_end_of_episode_singular)
         } else {
             context.resources.getString(LR.string.player_sleep_end_of_episode_plural, getSleepEndOfEpisodes())
+        }
+    }
+
+    private fun calcEndOfChapterText(): String {
+        return if (getSleepEndOfChapters() == 1) {
+            context.resources.getString(LR.string.player_sleep_end_of_chapter_singular)
+        } else {
+            context.resources.getString(LR.string.player_sleep_end_of_chapter_plural, getSleepEndOfChapters())
         }
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -577,11 +577,11 @@ class PlayerViewModel @Inject constructor(
         if ((sleepTimer.isSleepAfterTimerRunning && timeLeft != null && timeLeft.toInt() > 0) || playbackManager.isSleepAfterEpisodeEnabled()) {
             isSleepAtEndOfEpisodeOrChapter.postValue(playbackManager.isSleepAfterEpisodeEnabled())
             sleepTimeLeftText.postValue(if (timeLeft != null && timeLeft > 0) Util.formattedSeconds(timeLeft.toDouble()) else "")
-            setSleepEndOfEpisodes(playbackManager.sleepAfterEpisode, shouldCallUpdateTimer = false)
+            setSleepEndOfEpisodes(playbackManager.episodesUntilSleep, shouldCallUpdateTimer = false)
             sleepingInText.postValue(calcSleepingInEpisodesText())
         } else if (playbackManager.isSleepAfterChapterEnabled()) {
             isSleepAtEndOfEpisodeOrChapter.postValue(playbackManager.isSleepAfterChapterEnabled())
-            setSleepEndOfChapters(playbackManager.sleepAfterChapter, shouldCallUpdateTimer = false)
+            setSleepEndOfChapters(playbackManager.chaptersUntilSleep, shouldCallUpdateTimer = false)
             sleepingInText.postValue(calcSleepingInChaptersText())
         } else {
             isSleepAtEndOfEpisodeOrChapter.postValue(false)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -592,6 +592,11 @@ class PlayerViewModel @Inject constructor(
         sleepTimer.cancelTimer()
     }
 
+    fun sleepTimerAfterChapter(chapters: Int = 1) {
+        playbackManager.updateSleepTimerStatus(sleepTimeRunning = true, sleepAfterChapters = chapters)
+        sleepTimer.cancelTimer()
+    }
+
     fun cancelSleepTimer() {
         playbackManager.updateSleepTimerStatus(sleepTimeRunning = false)
         sleepTimer.cancelTimer()

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -542,17 +542,17 @@ class PlayerViewModel @Inject constructor(
 
     private fun calcEndOfEpisodeText(): String {
         return if (getSleepEndOfEpisodes() == 1) {
-            context.resources.getString(LR.string.player_sleep_end_of_episode_singular)
+            context.resources.getString(LR.string.player_sleep_timer_in_episode)
         } else {
-            context.resources.getString(LR.string.player_sleep_end_of_episode_plural, getSleepEndOfEpisodes())
+            context.resources.getString(LR.string.player_sleep_timer_in_episode_plural, getSleepEndOfEpisodes())
         }
     }
 
     private fun calcEndOfChapterText(): String {
         return if (getSleepEndOfChapters() == 1) {
-            context.resources.getString(LR.string.player_sleep_end_of_chapter_singular)
+            context.resources.getString(LR.string.player_sleep_timer_in_chapter)
         } else {
-            context.resources.getString(LR.string.player_sleep_end_of_chapter_plural, getSleepEndOfChapters())
+            context.resources.getString(LR.string.player_sleep_timer_in_chapter_plural, getSleepEndOfChapters())
         }
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -606,6 +606,7 @@ class PlayerViewModel @Inject constructor(
     }
 
     fun sleepTimerAfterChapter(chapters: Int = 1) {
+        settings.setlastSleepEndOfChapters(chapters)
         playbackManager.updateSleepTimerStatus(sleepTimeRunning = true, sleepAfterChapters = chapters)
         sleepTimer.cancelTimer()
     }

--- a/modules/features/player/src/main/res/layout/fragment_sleep.xml
+++ b/modules/features/player/src/main/res/layout/fragment_sleep.xml
@@ -16,7 +16,7 @@
             android:id="@+id/sleepSetup"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:constraint_referenced_ids="sleepTitle,labelMins5,buttonMins5,separator1,labelMins15,buttonMins15,separator2,labelMins30,buttonMins30,separator3,labelMins60,buttonMins60,separator5,labelCustom,buttonCustom,customMinusButton,customPlusButton, separator6, labelEndOfEpisode, buttonEndOfEpisode, endOfEpisodeMinusButton, endOfEpisodePlusButton"
+            app:constraint_referenced_ids="sleepTitle,labelMins15,buttonMins15,separator1,labelMins30,buttonMins30,separator2,labelMins60,buttonMins60,separator3,labelCustom,buttonCustom,customMinusButton,customPlusButton, separator4, labelEndOfEpisode, buttonEndOfEpisode, endOfEpisodeMinusButton, endOfEpisodePlusButton"
             tools:ignore="MissingConstraints" />
 
         <androidx.constraintlayout.widget.Group
@@ -62,7 +62,7 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
-            android:id="@+id/labelMins5"
+            android:id="@+id/labelMins15"
             style="@style/DarkSubtitle1"
             android:layout_width="wrap_content"
             android:layout_height="64dp"
@@ -70,45 +70,10 @@
             android:layout_marginTop="24dp"
             android:gravity="center_vertical"
             android:importantForAccessibility="no"
-            android:text="@string/player_sleep_5_minutes"
-            android:textColor="?attr/player_contrast_01"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/sleepTitle" />
-
-        <View
-            android:id="@+id/buttonMins5"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:background="?attr/selectableItemBackground"
-            android:clickable="true"
-            android:contentDescription="@string/player_sleep_5_minutes"
-            android:focusable="true"
-            app:layout_constraintBottom_toBottomOf="@+id/labelMins5"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@+id/labelMins5" />
-
-        <View
-            android:id="@+id/separator1"
-            android:layout_width="0dp"
-            android:layout_height="@dimen/divider_height"
-            android:background="?attr/player_contrast_05"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/labelMins5" />
-
-        <TextView
-            android:id="@+id/labelMins15"
-            style="@style/DarkSubtitle1"
-            android:layout_width="wrap_content"
-            android:layout_height="64dp"
-            android:layout_marginStart="32dp"
-            android:gravity="center_vertical"
-            android:importantForAccessibility="no"
             android:text="@string/player_sleep_15_minutes"
             android:textColor="?attr/player_contrast_01"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/separator1" />
+            app:layout_constraintTop_toBottomOf="@+id/sleepTitle" />
 
         <View
             android:id="@+id/buttonMins15"
@@ -124,7 +89,7 @@
             app:layout_constraintTop_toTopOf="@+id/labelMins15" />
 
         <View
-            android:id="@+id/separator2"
+            android:id="@+id/separator1"
             android:layout_width="0dp"
             android:layout_height="@dimen/divider_height"
             android:background="?attr/player_contrast_05"
@@ -143,7 +108,7 @@
             android:text="@string/player_sleep_30_minutes"
             android:textColor="?attr/player_contrast_01"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/separator2" />
+            app:layout_constraintTop_toBottomOf="@+id/separator1" />
 
         <View
             android:id="@+id/buttonMins30"
@@ -159,7 +124,7 @@
             app:layout_constraintTop_toTopOf="@+id/labelMins30" />
 
         <View
-            android:id="@+id/separator3"
+            android:id="@+id/separator2"
             android:layout_width="0dp"
             android:layout_height="@dimen/divider_height"
             android:background="?attr/player_contrast_05"
@@ -178,7 +143,7 @@
             android:text="@string/player_sleep_60_minutes"
             android:textColor="?attr/player_contrast_01"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/separator3" />
+            app:layout_constraintTop_toBottomOf="@+id/separator2" />
 
         <View
             android:id="@+id/buttonMins60"
@@ -194,7 +159,7 @@
             app:layout_constraintTop_toTopOf="@+id/labelMins60" />
 
         <View
-            android:id="@+id/separator5"
+            android:id="@+id/separator3"
             android:layout_width="0dp"
             android:layout_height="@dimen/divider_height"
             android:background="?attr/player_contrast_05"
@@ -211,7 +176,7 @@
             android:gravity="center_vertical"
             android:textColor="?attr/player_contrast_01"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/separator5" />
+            app:layout_constraintTop_toBottomOf="@+id/separator3" />
 
         <View
             android:id="@+id/buttonCustom"
@@ -251,7 +216,7 @@
             app:layout_constraintTop_toTopOf="@+id/labelCustom" />
 
         <View
-            android:id="@+id/separator6"
+            android:id="@+id/separator4"
             android:layout_width="0dp"
             android:layout_height="@dimen/divider_height"
             android:background="?attr/player_contrast_05"
@@ -268,7 +233,7 @@
             android:gravity="center_vertical"
             android:textColor="?attr/player_contrast_01"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/separator6" />
+            app:layout_constraintTop_toBottomOf="@+id/separator4" />
 
         <View
             android:id="@+id/buttonEndOfEpisode"

--- a/modules/features/player/src/main/res/layout/fragment_sleep.xml
+++ b/modules/features/player/src/main/res/layout/fragment_sleep.xml
@@ -16,7 +16,7 @@
             android:id="@+id/sleepSetup"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:constraint_referenced_ids="sleepTitle,labelMins15,buttonMins15,separator1,labelMins30,buttonMins30,separator2,labelMins60,buttonMins60,separator3,labelCustom,buttonCustom,customMinusButton,customPlusButton, separator4, labelEndOfEpisode, buttonEndOfEpisode, endOfEpisodeMinusButton, endOfEpisodePlusButton"
+            app:constraint_referenced_ids="sleepTitle,labelMins15,buttonMins15,separator1,labelMins30,buttonMins30,separator2,labelMins60,buttonMins60,separator3,labelCustom,buttonCustom,customMinusButton,customPlusButton, separator5, labelEndOfEpisode, buttonEndOfEpisode, endOfEpisodeMinusButton, endOfEpisodePlusButton, separator4, labelEndOfChapter, buttonEndOfChapter, endOfChapterPlusButton, endOfChapterMinusButton"
             tools:ignore="MissingConstraints" />
 
         <androidx.constraintlayout.widget.Group
@@ -225,7 +225,7 @@
             app:layout_constraintTop_toBottomOf="@+id/labelCustom" />
 
         <TextView
-            android:id="@+id/labelEndOfEpisode"
+            android:id="@+id/labelEndOfChapter"
             style="@style/DarkSubtitle1"
             android:layout_width="wrap_content"
             android:layout_height="64dp"
@@ -234,6 +234,63 @@
             android:textColor="?attr/player_contrast_01"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/separator4" />
+
+        <View
+            android:id="@+id/buttonEndOfChapter"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:focusable="true"
+            app:layout_constraintBottom_toBottomOf="@+id/labelEndOfChapter"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/labelEndOfChapter" />
+
+        <ImageView
+            android:id="@+id/endOfChapterMinusButton"
+            android:layout_width="44dp"
+            android:layout_height="0dp"
+            android:contentDescription="@string/player_sleep_custom_minus"
+            android:scaleType="center"
+            android:src="@drawable/ic_minus"
+            app:tint="?attr/player_contrast_01"
+            app:layout_constraintBottom_toBottomOf="@+id/labelEndOfChapter"
+            app:layout_constraintEnd_toStartOf="@+id/endOfChapterPlusButton"
+            app:layout_constraintTop_toTopOf="@+id/labelEndOfChapter" />
+
+        <ImageView
+            android:id="@+id/endOfChapterPlusButton"
+            android:layout_width="44dp"
+            android:layout_height="0dp"
+            android:layout_marginEnd="24dp"
+            android:contentDescription="@string/player_sleep_custom_plus"
+            android:scaleType="center"
+            android:src="@drawable/ic_effects_plus"
+            app:tint="?attr/player_contrast_01"
+            app:layout_constraintBottom_toBottomOf="@+id/labelEndOfChapter"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/labelEndOfChapter" />
+
+        <View
+            android:id="@+id/separator5"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/divider_height"
+            android:background="?attr/player_contrast_05"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/labelEndOfChapter" />
+
+        <TextView
+            android:id="@+id/labelEndOfEpisode"
+            style="@style/DarkSubtitle1"
+            android:layout_width="wrap_content"
+            android:layout_height="64dp"
+            android:layout_marginStart="32dp"
+            android:gravity="center_vertical"
+            android:textColor="?attr/player_contrast_01"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/separator5" />
 
         <View
             android:id="@+id/buttonEndOfEpisode"

--- a/modules/features/player/src/main/res/layout/fragment_sleep.xml
+++ b/modules/features/player/src/main/res/layout/fragment_sleep.xml
@@ -34,10 +34,10 @@
             tools:ignore="MissingConstraints" />
 
         <androidx.constraintlayout.widget.Group
-            android:id="@+id/sleepRunningEndOfEpisode"
+            android:id="@+id/sleepRunningEndOfEpisodeOrChapter"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:constraint_referenced_ids="sleepingEndOfEpisode,buttonCancelEndOfEpisode"
+            app:constraint_referenced_ids="sleepingInText,buttonCancelEndOfEpisodeOrChapter"
             tools:ignore="MissingConstraints" />
 
         <View
@@ -437,7 +437,7 @@
             app:textAllCaps="false" />
 
         <TextView
-            android:id="@+id/sleepingEndOfEpisode"
+            android:id="@+id/sleepingInText"
             style="@style/DarkSubtitle1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -448,7 +448,7 @@
             app:layout_constraintTop_toBottomOf="@+id/sleepAnimation" />
 
         <com.google.android.material.button.MaterialButton
-            android:id="@+id/buttonCancelEndOfEpisode"
+            android:id="@+id/buttonCancelEndOfEpisodeOrChapter"
             style="@style/Widget.MaterialComponents.Button.OutlinedButton"
             android:layout_width="match_parent"
             android:layout_height="56dp"
@@ -462,7 +462,7 @@
             android:textSize="16sp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/sleepingEndOfEpisode"
+            app:layout_constraintTop_toBottomOf="@+id/sleepingInText"
             app:strokeColor="?attr/player_contrast_01"
             app:textAllCaps="false" />
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -317,6 +317,8 @@
     <string name="player_sleep_timer_start_failed">Unable to start timer. Please allow \'Alarms &amp; reminders\' permission.</string>
     <string name="player_sleep_in_one_episode">Sleeping in 1 episode</string>
     <string name="player_sleep_in_episodes">Sleeping in %d episodes</string>
+up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
+    <string name="player_sleep_in_chapters">Sleeping in %d chapters</string>
     <string name="player_sleep_timer_restarted_after_device_shake">Sleep timer restarted after device shake</string>
     <string name="player_sleep_timer_stopped_your_podcast">Sleep timer stopped your podcast.</string>
     <string name="player_star" translatable="false">@string/star</string>
@@ -352,6 +354,7 @@
     <string name="player_actions_hidden_for_custom">Hidden for custom episodes</string>
     <string name="player_actions_show_as_delete_for_custom">Shown as delete for custom episodes</string>
     <string name="player_sleep_time_fired">Sleep timer stopped at the end of your episode.\nNight night!</string>
+    <string name="player_sleep_time_fired_end_of_chapter">Sleep timer stopped at the end of your chapter.</string>
     <string name="player_skipped_last">Skipped the last %d seconds</string>
     <string name="player_started_from">Starting podcast from %d seconds</string>
     <string name="player_open_full_size_player">Activate to open full size player</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -310,6 +310,8 @@
     <string name="player_sleep_end_of_episode">End of episode</string>
     <string name="player_sleep_end_of_episode_singular">End of 1 episode</string>
     <string name="player_sleep_end_of_episode_plural">End of %d episodes</string>
+    <string name="player_sleep_end_of_chapter_singular">End of 1 chapter</string>
+    <string name="player_sleep_end_of_chapter_plural">End of %d chapters</string>
     <string name="player_sleep_timer_title">Sleep Timer</string>
     <string name="player_sleep_timer">Sleep timer</string>
     <string name="player_sleep_timer_start_failed">Unable to start timer. Please allow \'Alarms &amp; reminders\' permission.</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -300,7 +300,6 @@
     <string name="player_pip">Enter Picture-in-picture</string>
     <string name="player_sleep_15_minutes">15 minutes</string>
     <string name="player_sleep_30_minutes">30 minutes</string>
-    <string name="player_sleep_5_minutes">5 minutes</string>
     <string name="player_sleep_1_minute">1 minute</string>
     <string name="player_sleep_60_minutes">60 minutes</string>
     <string name="player_sleep_add_5_minutes">+ 5 minutes</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -308,10 +308,10 @@
     <string name="player_sleep_custom_minus">Custom minus</string>
     <string name="player_sleep_custom_plus">Custom plus</string>
     <string name="player_sleep_end_of_episode">End of episode</string>
-    <string name="player_sleep_end_of_episode_singular">End of 1 episode</string>
-    <string name="player_sleep_end_of_episode_plural">End of %d episodes</string>
-    <string name="player_sleep_end_of_chapter_singular">End of 1 chapter</string>
-    <string name="player_sleep_end_of_chapter_plural">End of %d chapters</string>
+    <string name="player_sleep_timer_in_episode">In 1 episode</string>
+    <string name="player_sleep_timer_in_episode_plural">In %d episodes</string>
+    <string name="player_sleep_timer_in_chapter">In 1 chapter</string>
+    <string name="player_sleep_timer_in_chapter_plural">In %d chapters</string>
     <string name="player_sleep_timer_title">Sleep Timer</string>
     <string name="player_sleep_timer">Sleep timer</string>
     <string name="player_sleep_timer_start_failed">Unable to start timer. Please allow \'Alarms &amp; reminders\' permission.</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -354,9 +354,11 @@ interface Settings {
 
     fun setSleepTimerCustomMins(minutes: Int)
     fun setSleepEndOfEpisodes(episodes: Int)
+    fun setSleepEndOfChapters(chapters: Int)
     fun setlastSleepEndOfEpisodes(episodes: Int)
     fun getSleepTimerCustomMins(): Int
     fun getSleepEndOfEpisodes(): Int
+    fun getSleepEndOfChapters(): Int
     fun getlastSleepEndOfEpisodes(): Int
 
     fun setShowPlayedEpisodes(show: Boolean)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -356,10 +356,12 @@ interface Settings {
     fun setSleepEndOfEpisodes(episodes: Int)
     fun setSleepEndOfChapters(chapters: Int)
     fun setlastSleepEndOfEpisodes(episodes: Int)
+    fun setlastSleepEndOfChapters(chapters: Int)
     fun getSleepTimerCustomMins(): Int
     fun getSleepEndOfEpisodes(): Int
     fun getSleepEndOfChapters(): Int
     fun getlastSleepEndOfEpisodes(): Int
+    fun getlastSleepEndOfChapter(): Int
 
     fun setShowPlayedEpisodes(show: Boolean)
     fun showPlayedEpisodes(): Boolean

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -684,6 +684,10 @@ class SettingsImpl @Inject constructor(
         setInt("lastSleepEndOfEpisodes", episodes)
     }
 
+    override fun setlastSleepEndOfChapters(chapters: Int) {
+        setInt("lastSleepEndOfChapters", chapters)
+    }
+
     override fun setSleepEndOfChapters(chapters: Int) {
         setInt("sleepEndOfChapters", chapters)
     }
@@ -702,6 +706,10 @@ class SettingsImpl @Inject constructor(
 
     override fun getlastSleepEndOfEpisodes(): Int {
         return getInt("lastSleepEndOfEpisodes", 0)
+    }
+
+    override fun getlastSleepEndOfChapter(): Int {
+        return getInt("lastSleepEndOfChapters", 0)
     }
 
     override fun setShowPlayedEpisodes(show: Boolean) {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -684,12 +684,20 @@ class SettingsImpl @Inject constructor(
         setInt("lastSleepEndOfEpisodes", episodes)
     }
 
+    override fun setSleepEndOfChapters(chapters: Int) {
+        setInt("sleepEndOfChapters", chapters)
+    }
+
     override fun getSleepTimerCustomMins(): Int {
         return getInt("sleepTimerCustomMins", 5)
     }
 
     override fun getSleepEndOfEpisodes(): Int {
         return getInt("sleepEndOfEpisodes", 1)
+    }
+
+    override fun getSleepEndOfChapters(): Int {
+        return getInt("sleepEndOfChapters", 1)
     }
 
     override fun getlastSleepEndOfEpisodes(): Int {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -2118,11 +2118,12 @@ open class PlaybackManager @Inject constructor(
 
         sleepTimer.restartSleepTimerIfApplies(
             currentEpisodeUuid = episode.uuid,
-            sleepTimerState = SleepTimer.SleepTimerState(
+            timerState = SleepTimer.SleepTimerState(
                 isSleepTimerRunning = playbackStateRelay.blockingFirst().isSleepTimerRunning,
                 isSleepEndOfEpisodeRunning = isSleepAfterEpisodeEnabled(),
                 isSleepEndOfChapterRunning = isSleepAfterChapterEnabled(),
                 numberOfEpisodes = settings.getlastSleepEndOfEpisodes(),
+                numberOfChapters = settings.getlastSleepEndOfChapter(),
             ),
             onRestartSleepAfterTime = {
                 updateSleepTimerStatus(sleepTimeRunning = true)
@@ -2131,7 +2132,7 @@ open class PlaybackManager @Inject constructor(
                 updateSleepTimerStatus(sleepTimeRunning = true, sleepAfterEpisodes = settings.getlastSleepEndOfEpisodes())
             },
             onRestartSleepOnChapterEnd = {
-                updateSleepTimerStatus(sleepTimeRunning = true, sleepAfterChapters = settings.getSleepEndOfChapters())
+                updateSleepTimerStatus(sleepTimeRunning = true, sleepAfterChapters = settings.getlastSleepEndOfChapter())
             },
         )
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -2118,10 +2118,12 @@ open class PlaybackManager @Inject constructor(
 
         sleepTimer.restartSleepTimerIfApplies(
             currentEpisodeUuid = episode.uuid,
-            isSleepTimerRunning = playbackStateRelay.blockingFirst().isSleepTimerRunning,
-            isSleepEndOfEpisodeRunning = isSleepAfterEpisodeEnabled(),
-            isSleepEndOfChapterRunning = isSleepAfterChapterEnabled(),
-            numberOfEpisodes = settings.getlastSleepEndOfEpisodes(),
+            sleepTimerState = SleepTimer.SleepTimerState(
+                isSleepTimerRunning = playbackStateRelay.blockingFirst().isSleepTimerRunning,
+                isSleepEndOfEpisodeRunning = isSleepAfterEpisodeEnabled(),
+                isSleepEndOfChapterRunning = isSleepAfterChapterEnabled(),
+                numberOfEpisodes = settings.getlastSleepEndOfEpisodes(),
+            ),
             onRestartSleepAfterTime = {
                 updateSleepTimerStatus(sleepTimeRunning = true)
             },

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -220,6 +220,8 @@ open class PlaybackManager @Inject constructor(
 
     var sleepAfterEpisode: Int = 0
 
+    var sleepAfterChapter: Int = 0
+
     var player: Player? = null
 
     val mediaSession: MediaSessionCompat
@@ -300,8 +302,9 @@ open class PlaybackManager @Inject constructor(
         return player?.isStreaming ?: false
     }
 
-    fun updateSleepTimerStatus(sleepTimeRunning: Boolean, sleepAfterEpisodes: Int = 0) {
+    fun updateSleepTimerStatus(sleepTimeRunning: Boolean, sleepAfterEpisodes: Int = 0, sleepAfterChapters: Int = 0) {
         this.sleepAfterEpisode = sleepAfterEpisodes
+        this.sleepAfterChapter = sleepAfterChapters
         playbackStateRelay.blockingFirst().let {
             playbackStateRelay.accept(it.copy(isSleepTimerRunning = sleepTimeRunning, lastChangeFrom = LastChangeFrom.OnUpdateSleepTimerStatus.value))
         }
@@ -2462,6 +2465,8 @@ open class PlaybackManager @Inject constructor(
     }
 
     fun isSleepAfterEpisodeEnabled(): Boolean = sleepAfterEpisode != 0
+
+    fun isSleepAfterChapterEnabled(): Boolean = sleepAfterChapter != 0
 
     private enum class ContentType(val analyticsValue: String) {
         AUDIO("audio"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -223,8 +223,8 @@ open class PlaybackManager @Inject constructor(
     var chaptersUntilSleep: Int = 0
 
     private val lastListenedForEndOfChapter = mutableMapOf<String, String?>(
-        "chapterUui" to null,
-        "episodeUui" to null,
+        "chapterUuid" to null,
+        "episodeUuid" to null,
     )
 
     var player: Player? = null
@@ -2553,19 +2553,19 @@ open class PlaybackManager @Inject constructor(
     }
 
     private fun MutableMap<String, String?>.getlastListenedEpisodeUuid(): String? {
-        return this["episodeUui"]
+        return this["episodeUuid"]
     }
 
     private fun MutableMap<String, String?>.getlastListenedChapterUuid(): String? {
-        return this["chapterUui"]
+        return this["chapterUuid"]
     }
 
     private fun MutableMap<String, String?>.setlastListenedEpisodeUuid(value: String?) {
-        this["episodeUui"] = value
+        this["episodeUuid"] = value
     }
 
     private fun MutableMap<String, String?>.setlastListenedChapterUuid(value: String?) {
-        this["chapterUui"] = value
+        this["chapterUuid"] = value
     }
 
     private enum class ContentType(val analyticsValue: String) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1314,9 +1314,9 @@ open class PlaybackManager @Inject constructor(
             sleepEndOfEpisode(episode)
         }
 
-        if (!isSleepAfterEpisodeEnabled() && !isSleepAfterChapterEnabled()) return // keep sleep time running if still has end of episodes or chapters
-
-        cancelUpdateTimer()
+        if (!isSleepAfterEpisodeEnabled()) {
+            cancelUpdateTimer()
+        }
         cancelBufferUpdateTimer()
 
         if (episode != null) {
@@ -1472,7 +1472,7 @@ open class PlaybackManager @Inject constructor(
             episodesUntilSleep -= 1
         }
 
-        if (isSleepAfterEpisodeEnabled() || isSleepAfterChapterEnabled()) return
+        if (isSleepAfterEpisodeEnabled()) return
 
         withContext(Dispatchers.Main) {
             playbackStateRelay.blockingFirst().let {
@@ -1504,6 +1504,7 @@ open class PlaybackManager @Inject constructor(
     private suspend fun sleepEndOfChapter() {
         if (isSleepAfterChapterEnabled()) {
             chaptersUntilSleep -= 1
+            sleepTimer.setEndOfChapter()
         }
 
         if (isSleepAfterChapterEnabled()) return
@@ -2119,12 +2120,16 @@ open class PlaybackManager @Inject constructor(
             currentEpisodeUuid = episode.uuid,
             isSleepTimerRunning = playbackStateRelay.blockingFirst().isSleepTimerRunning,
             isSleepEndOfEpisodeRunning = isSleepAfterEpisodeEnabled(),
+            isSleepEndOfChapterRunning = isSleepAfterChapterEnabled(),
             numberOfEpisodes = settings.getlastSleepEndOfEpisodes(),
             onRestartSleepAfterTime = {
                 updateSleepTimerStatus(sleepTimeRunning = true)
             },
             onRestartSleepOnEpisodeEnd = {
                 updateSleepTimerStatus(sleepTimeRunning = true, sleepAfterEpisodes = settings.getlastSleepEndOfEpisodes())
+            },
+            onRestartSleepOnChapterEnd = {
+                updateSleepTimerStatus(sleepTimeRunning = true, sleepAfterChapters = settings.getSleepEndOfChapters())
             },
         )
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
@@ -72,10 +72,7 @@ class SleepTimer @Inject constructor(
 
     fun restartSleepTimerIfApplies(
         currentEpisodeUuid: String,
-        isSleepTimerRunning: Boolean,
-        isSleepEndOfEpisodeRunning: Boolean,
-        isSleepEndOfChapterRunning: Boolean,
-        numberOfEpisodes: Int,
+        sleepTimerState: SleepTimerState,
         onRestartSleepAfterTime: () -> Unit,
         onRestartSleepOnEpisodeEnd: () -> Unit,
         onRestartSleepOnChapterEnd: () -> Unit,
@@ -83,12 +80,12 @@ class SleepTimer @Inject constructor(
         lastTimeSleepTimeHasFinished?.let { lastTimeHasFinished ->
             val diffTime = System.currentTimeMillis().milliseconds - lastTimeHasFinished
 
-            if (shouldRestartSleepEndOfChapter(diffTime, isSleepEndOfChapterRunning)) {
+            if (shouldRestartSleepEndOfChapter(diffTime, sleepTimerState.isSleepEndOfChapterRunning)) {
                 onRestartSleepOnChapterEnd()
-            } else if (shouldRestartSleepEndOfEpisode(diffTime, currentEpisodeUuid, isSleepEndOfEpisodeRunning)) {
+            } else if (shouldRestartSleepEndOfEpisode(diffTime, currentEpisodeUuid, sleepTimerState.isSleepEndOfEpisodeRunning)) {
                 onRestartSleepOnEpisodeEnd()
-                analyticsTracker.track(PLAYER_SLEEP_TIMER_RESTARTED, mapOf(TIME_KEY to END_OF_EPISODE_VALUE, NUMBER_OF_EPISODES_KEY to numberOfEpisodes))
-            } else if (shouldRestartSleepAfterTime(diffTime, isSleepTimerRunning)) {
+                analyticsTracker.track(PLAYER_SLEEP_TIMER_RESTARTED, mapOf(TIME_KEY to END_OF_EPISODE_VALUE, NUMBER_OF_EPISODES_KEY to sleepTimerState.numberOfEpisodes))
+            } else if (shouldRestartSleepAfterTime(diffTime, sleepTimerState.isSleepTimerRunning)) {
                 lastSleepAfterTime?.let {
                     analyticsTracker.track(PLAYER_SLEEP_TIMER_RESTARTED, mapOf(TIME_KEY to it.inWholeSeconds))
                     sleepAfter(it, onRestartSleepAfterTime)
@@ -194,4 +191,11 @@ class SleepTimer @Inject constructor(
     private fun cancelAutomaticSleepOnChapterEndRestart() {
         lastSleepAfterEndOfChapterTime = null
     }
+
+    data class SleepTimerState(
+        val isSleepTimerRunning: Boolean,
+        val isSleepEndOfEpisodeRunning: Boolean,
+        val isSleepEndOfChapterRunning: Boolean,
+        val numberOfEpisodes: Int,
+    )
 }


### PR DESCRIPTION
## Description
- This adds the ability to select multiple chapters for sleep time
- Important: Since we have episodes with chapters and episodes without chapters, we are going to treat an episode without chapters as a single chapter.
- In this version, every time a user switches to another chapter or episode, we will decrease the number of chapters left before sleep.


## Testing Instructions

### End of Chapters
1. Run the app
2. Add 5/6 episodes to Up next. Try to add episodes that contain chapters and others that don't
3. Open the full player, tap the sleep timer icon (zZz)
4. Select X chapters for sleep timer
5. ✅ Ensure 🔵 Tracked: player_sleep_timer_enabled, Properties: {"time":"end_of_chapter","number_of_chapters": X
6. Tap the sleep timer icon (zZz) again
7.  ✅  You should see `Sleeping in X chapters` message and the cancel button
8. If your episodes has chapter, try to move to the next chapter
9. If you check the _sleep in_ message, it should be decreased by 1 since you changed the chapter
10. If your episodes does not have chapter, try to move to the next episode
11. If you check the _sleep in_ message, it should be decreased by 1 since you changed the episode
12. Once your sleep timer is triggered and you still have episodes on Up next you can tap on `Play` button again
13. ✅ Automatic sleep time should be triggered with X chapters set
14. ✅  Ensure  🔵 Tracked: player_sleep_timer_restarted, Properties: {"time":"end_of_chapter","number_of_chapters":X

### End of Chapters + Up Next
1. Run the app
2. Go Settings -> General -> Have `Play up next episode on tap` enabled
3. Add 5/6 episodes to Up next. Try to add episodes that contain chapters and others that don't
4. Open the full player, tap the sleep timer icon (zZz)
5. Select 5 chapters for sleep timer
6. Tap the sleep timer icon (zZz) again
7. ✅  You should see `Sleeping in 5 chapters` message and the cancel button
8. Tap to another episode from Up Next
9. Tap the sleep timer icon (zZz) again
10. ✅  You should see `Sleeping in 4 chapters` message and the cancel button

### Shake Device
1. Have sleep time set for chapters
2. Shake your device
3. ✅ Ensure the sleep timer was not restarted

### Auto Play
1. Add some episodes to Up next
2. Do not set sleep timer
3. Play an episode
4. Scroll to almost the end of the episode
5. Wait for episode to finish
6. ✅ Ensure the next episode from Up Next starts playing



## Screenshots or Screencast 
[Screen_recording_20240426_140654.webm](https://github.com/Automattic/pocket-casts-android/assets/42220351/2968d9e8-570e-4e95-9bc7-cf144dc71ea1)


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
