### PR TITLE
[Tooling] Update `release-toolkit` to `11.0.1` in `release/7.62` branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gem 'danger-dangermattic', '~> 1.0'
 gem 'fastlane', '~> 2.216'
 # These lines are kept to help with testing Release Toolkit changes
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 10.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 11.0'
 # gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
 # gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: ''
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
-    fastlane-plugin-wpmreleasetoolkit (10.0.0)
+    fastlane-plugin-wpmreleasetoolkit (11.0.1)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
@@ -346,7 +346,7 @@ PLATFORMS
 DEPENDENCIES
   danger-dangermattic (~> 1.0)
   fastlane (~> 2.216)
-  fastlane-plugin-wpmreleasetoolkit (~> 10.0)
+  fastlane-plugin-wpmreleasetoolkit (~> 11.0)
 
 BUNDLED WITH
    2.4.21


### PR DESCRIPTION
Update `release-toolkit` from `10.0.0` to `11.0.1`, in particular to get the fix for `To call another action from an action use 'other_action.git_submodule_update' instead` error.

Same as https://github.com/Automattic/pocket-casts-android/pull/2055, but targeting `release/7.62` branch.