### PR TITLE
Account for updated prod version during settings migration

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
@@ -165,7 +165,7 @@ class VersionMigrationsJob : JobService() {
             consolidateEmbeddedArtworkSettings(applicationContext)
         }
 
-        if (previousVersionCode < 9220) {
+        if (previousVersionCode < 9224) {
             migrateToGranularEpisodeArtworkSettings(applicationContext)
         }
     }


### PR DESCRIPTION
## Description

Account for 192cd483900eff8558aac0c3188d5006a115ce6c during migration.

`7.63-rc-1` will use `9224` which means that `7.63` will be at least `9225`.

Internal ref: p1714157442745779/1714153209.768229-slack-CC7L49W13

## Testing Instructions

Verify in Play Console that `7.62` uses `9223` version code.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack