### PR TITLE
Extract embedded image from a file when uploading it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 *   Bug Fixes
     *   Fix flashing artwork
         ([#2086](https://github.com/Automattic/pocket-casts-android/pull/2086))
+    *   Fix embedded artwork not being extracted when adding files
+        ([#2124](https://github.com/Automattic/pocket-casts-android/pull/2124))
 
 7.62
 -----

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -692,7 +692,7 @@ class AddFileActivity :
         player.addListener(object : Player.Listener {
             override fun onTracksChanged(tracks: Tracks) {
                 val episodeMetadata = EpisodeFileMetadata()
-                episodeMetadata.read(tracks, useEpisodeArtwork = false, this@AddFileActivity)
+                episodeMetadata.read(tracks, useEpisodeArtwork = true, this@AddFileActivity)
                 episodeMetadata.embeddedArtworkPath?.let {
                     val artworkUri = Uri.parse(it)
                     loadImageFromUri(artworkUri, isFile = true)


### PR DESCRIPTION
## Description

While unifying artwork loading in #1987 I accidentally changed the value whether artwork should be extracted from files when adding them. This fixes it.

Closes #2122

## Testing Instructions

1. Add a file with an embedded artwork like [this one](https://www.podtrac.com/pts/redirect.mp3/traffic.libsyn.com/secure/upgrade/upgrade418.mp3).
2. Make sure that the artwork is visible when file is being added.
3. File in the files list should show the artwork.

## Screenshots or Screencast 

| Adding | Listing |
| - | - |
| ![Screenshot_20240428-205609](https://github.com/Automattic/pocket-casts-android/assets/30936061/1c52dbd4-059c-4b70-9e25-3f9aa3ac6944) | ![Screenshot_20240428-205601](https://github.com/Automattic/pocket-casts-android/assets/30936061/caebb2fd-0d29-40f9-9216-17dcc1646a04) |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
