### PR TITLE
Include podcasts with corrupted folders when sorting by release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 *   Bug Fixes
     *   Fix flashing artwork
         ([#2086](https://github.com/Automattic/pocket-casts-android/pull/2086))
+    *   Fix an issue when sorting podcast by episodes could hide some podcasts
+        ([#2125](https://github.com/Automattic/pocket-casts-android/pull/2125))
 
 7.62
 -----

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -128,10 +128,11 @@ class PodcastsViewModel
 
     private fun buildHomeFolderItems(podcasts: List<Podcast>, folders: List<FolderItem>, podcastSortType: PodcastsSortType): List<FolderItem> {
         if (podcastSortType == PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST) {
+            val folderUuids = folders.mapTo(mutableSetOf()) { it.uuid }
             val items = mutableListOf<FolderItem>()
-            val uuidToFolder = folders.associateBy({ it.uuid }, { it }).toMutableMap()
+            val uuidToFolder = folders.associateByTo(mutableMapOf(), FolderItem::uuid)
             for (podcast in podcasts) {
-                if (podcast.folderUuid == null) {
+                if (podcast.folderUuid == null || !folderUuids.contains(podcast.folderUuid)) {
                     items.add(FolderItem.Podcast(podcast))
                 } else {
                     // add the folder in the position of the podcast with the latest release date


### PR DESCRIPTION
## Description

Sorting by `Episode release date` did not account for podcasts that have `folder_uuid` set but folders with that ID no longer exist. I'm not sure how such a state can occur. Possibly some syncing issue or non-transactional updates that fail or are interrupted. Regardless, we should make sure that all podcasts are visible.

We do a similar thing for other types of sorting here so it only makes sense to do it for the release date.

https://github.com/Automattic/pocket-casts-android/blob/8275b2d3c006df19ebfcd7eabc345235bbc94967/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt#L149-L152

Bug ref: https://pocketcastsbeta.slack.com/archives/C013F9S9C2W/p1714234988836729

## Testing Instructions

### Bug fix

1. Open the app.
2. Run `UPDATE podcasts SET folder_uuid = '11111111-1111-1111-1111-111111111111' WHERE uuid IN (SELECT uuid FROM podcasts WHERE folder_uuid IS NULL)` in the `Database Inspector`. This assumes you don't have a folder with `11111111-1111-1111-1111-111111111111` uuid.
3. Sort podcasts by `Episode release date`.
4. You should see all podcasts.
5. You can run `UPDATE podcasts SET folder_uuid = NULL WHERE uuid IN (SELECT uuid FROM podcasts WHERE folder_uuid IS '11111111-1111-1111-1111-111111111111')` to clean up podcasts state.

You should also test this with the changes before a8b55237e9b9ec55dbd086cda77318a5df1214a6 to reproduce the bug.

### Regression

1. Have a combination of podcasts grouped into different folders and without folders.
2. Sort podcasts by `Episode release date`.
3. You should see all podcasts and folders.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
