### PR TITLE
Fix toolbar and title colors for profile bookmarks

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksContainerFragment.kt
@@ -16,11 +16,15 @@ import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentBookmarksContainerBinding
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
+import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeTintedDrawable
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import dagger.hilt.android.AndroidEntryPoint
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @AndroidEntryPoint
@@ -47,11 +51,15 @@ class BookmarksContainerFragment :
         get() = SourceView.fromString(arguments?.getString(ARG_SOURCE_VIEW))
 
     override val statusBarColor: StatusBarColor
-        get() = StatusBarColor.Custom(
-            context?.getThemeColor(UR.attr.primary_ui_01)
-                ?: Color.WHITE,
-            theme.isDarkTheme,
-        )
+        get() = if (sourceView == SourceView.PROFILE) {
+            StatusBarColor.Light
+        } else {
+            StatusBarColor.Custom(
+                context?.getThemeColor(UR.attr.primary_ui_01)
+                    ?: Color.WHITE,
+                theme.isDarkTheme,
+            )
+        }
 
     var binding: FragmentBookmarksContainerBinding? = null
     private val bookmarksViewModel: BookmarksViewModel by viewModels()
@@ -110,13 +118,30 @@ class BookmarksContainerFragment :
             .addToBackStack(null)
             .commit()
 
+        binding.toolbar.setup(
+            title = getString(LR.string.bookmarks),
+            navigationIcon = if (dialog == null) {
+                NavigationIcon.BackArrow
+            } else {
+                NavigationIcon.Close
+            },
+            onNavigationClick = {
+                if (dialog == null) {
+                    @Suppress("DEPRECATION")
+                    activity?.onBackPressed()
+                } else {
+                    dismiss()
+                }
+            },
+            activity = activity,
+            theme = theme,
+        )
+
         dialog?.let {
-            binding.btnClose.setOnClickListener { dismiss() }
-        } ?: run {
-            binding.btnClose.setImageResource(R.drawable.ic_arrow_back)
-            binding.btnClose.setOnClickListener {
-                @Suppress("DEPRECATION")
-                activity?.onBackPressed()
+            with(binding.toolbar) {
+                navigationIcon = requireContext().getThemeTintedDrawable(R.drawable.ic_close, UR.attr.primary_icon_01)
+                setTitleTextColor(requireContext().getThemeColor(UR.attr.primary_text_01))
+                setBackgroundColor(requireContext().getThemeColor(UR.attr.primary_ui_01))
             }
         }
     }
@@ -124,6 +149,7 @@ class BookmarksContainerFragment :
     private fun FragmentBookmarksContainerBinding.setupMultiSelectHelper() {
         bookmarksViewModel.multiSelectHelper.isMultiSelectingLive.observe(viewLifecycleOwner) { isMultiSelecting ->
             multiSelectToolbar.isVisible = isMultiSelecting
+            toolbar.isVisible = !isMultiSelecting
             multiSelectToolbar.setNavigationIcon(R.drawable.ic_arrow_back)
         }
         bookmarksViewModel.multiSelectHelper.context = context

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
@@ -179,7 +179,8 @@ private fun BookmarksView(
                     onTextChanged = onSearchTextChanged,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .padding(horizontal = 16.dp)
+                        .padding(top = 16.dp)
                         .focusRequester(focusRequester),
                 )
             }

--- a/modules/features/player/src/main/res/layout/fragment_bookmarks_container.xml
+++ b/modules/features/player/src/main/res/layout/fragment_bookmarks_container.xml
@@ -1,53 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:background="?attr/primary_ui_02">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="?attr/primary_ui_01"
-        android:clickable="true"
-        android:focusable="true">
+        android:layout_height="wrap_content">
 
-        <ImageButton
-            android:id="@+id/btnClose"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:contentDescription="@string/close"
-            android:paddingStart="16dp"
-            android:paddingEnd="16dp"
-            android:src="@drawable/ic_chevron"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:tint="?attr/secondary_icon_01" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/title"
-            android:layout_width="wrap_content"
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/bookmarks"
-            style="@style/H30"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/btnClose"
-            app:layout_constraintBottom_toBottomOf="@id/btnClose"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:textColor="?attr/secondary_text_01" />
+            android:background="?attr/secondary_ui_01"/>
 
         <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
             android:id="@+id/multiSelectToolbar"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:minHeight="?android:attr/actionBarSize"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:visibility="gone"/>
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout
         android:id="@+id/fragmentContainer"


### PR DESCRIPTION
## Description

This fixes toolbar/ title colors for profile bookmarks screen.

## Testing Instructions
1. Login using a paid account having a few bookmarks for podcasts and user files
3. Go to `Profile` and tap `Bookmarks`
5. ✅ Notice that the title and navigation icon are shown properly for the bookmark screen
6. Go to `Profile` -> `Files` and tap a user file
4. Tap Bookmarks from the bottom sheet dialog
8. ✅ Notice that the title and navigation icon are shown properly for the bookmark screen

## Screenshots or Screencast 
![out](https://github.com/Automattic/pocket-casts-android/assets/1405144/96caa2e4-f189-418b-9031-5c071fd8eef3)


![out](https://github.com/Automattic/pocket-casts-android/assets/1405144/6109295d-0caa-4a5c-bfc3-0828c46d0d24)

** Status bar icon color is incorrect for the light-themed bookmarks container for cloud files. It is tracked under a separate issue https://github.com/Automattic/pocket-casts-android/issues/2127. 


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack