### PR TITLE
Update widget themes to use secondary colors

### DIFF
--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/EpisodeImage.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/EpisodeImage.kt
@@ -11,19 +11,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.drawable.toBitmap
-import androidx.glance.ColorFilter
 import androidx.glance.GlanceModifier
-import androidx.glance.GlanceTheme
 import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
 import androidx.glance.action.Action
 import androidx.glance.action.clickable
 import androidx.glance.background
-import androidx.glance.color.ColorProviders
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
-import androidx.glance.layout.padding
 import androidx.glance.layout.size
 import androidx.glance.unit.ColorProvider
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
@@ -33,15 +29,13 @@ import au.com.shiftyjelly.pocketcasts.widget.data.PlayerWidgetEpisode
 import coil.imageLoader
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import au.com.shiftyjelly.pocketcasts.images.R as IR
 
 @Composable
 internal fun EpisodeImage(
     episode: PlayerWidgetEpisode?,
     useEpisodeArtwork: Boolean,
     size: Dp,
-    backgroundColor: ((ColorProviders) -> ColorProvider)? = null,
-    iconColor: ((ColorProviders) -> ColorProvider)? = null,
+    backgroundColor: ((WidgetTheme) -> ColorProvider)? = null,
     onClick: (PlayerWidgetEpisode?) -> Action = { currentEpisode ->
         if (currentEpisode == null) {
             OpenPocketCastsAction.action()
@@ -58,15 +52,12 @@ internal fun EpisodeImage(
         contentAlignment = Alignment.Center,
         modifier = GlanceModifier
             .clickable(onClick(episode))
-            .background(backgroundColor?.invoke(GlanceTheme.colors) ?: GlanceTheme.colors.primary)
+            .background(backgroundColor?.invoke(LocalWidgetTheme.current) ?: LocalWidgetTheme.current.buttonBackground)
             .cornerRadiusCompat(6.dp)
             .size(size),
     ) {
-        Image(
-            provider = ImageProvider(IR.drawable.ic_logo_background),
-            contentDescription = null,
-            colorFilter = ColorFilter.tint(iconColor?.invoke(GlanceTheme.colors) ?: GlanceTheme.colors.onPrimary),
-            modifier = GlanceModifier.padding(size / 6),
+        PocketCastsLogo(
+            size = size / 2.5f,
         )
 
         val bitmap = episodeBitmap

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayer.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayer.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.widget.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import androidx.glance.GlanceModifier
-import androidx.glance.GlanceTheme
 import androidx.glance.LocalContext
 import androidx.glance.action.clickable
 import androidx.glance.background
@@ -28,7 +27,7 @@ internal fun LargePlayer(state: LargePlayerWidgetState) {
                 .fillMaxWidth()
                 .wrapContentHeight()
                 .cornerRadiusCompat(6.dp)
-                .background(GlanceTheme.colors.primaryContainer)
+                .background(LocalWidgetTheme.current.background)
                 .padding(16.dp),
         ) {
             LargePlayerHeader(state = state)

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayerHeader.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayerHeader.kt
@@ -3,9 +3,7 @@ package au.com.shiftyjelly.pocketcasts.widget.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import androidx.glance.GlanceModifier
-import androidx.glance.GlanceTheme
 import androidx.glance.LocalContext
-import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
 import androidx.glance.layout.Column
@@ -31,8 +29,7 @@ internal fun LargePlayerHeader(
         contentAlignment = Alignment.TopEnd,
         modifier = modifier
             .fillMaxWidth()
-            .height(116.dp)
-            .background(GlanceTheme.colors.primaryContainer),
+            .height(116.dp),
     ) {
         Row(
             verticalAlignment = Alignment.Top,

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/MediumPlayer.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/MediumPlayer.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.widget.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import androidx.glance.GlanceModifier
-import androidx.glance.GlanceTheme
 import androidx.glance.LocalContext
 import androidx.glance.background
 import androidx.glance.layout.Alignment
@@ -26,7 +25,7 @@ internal fun MediumPlayer(state: MediumPlayerWidgetState) {
                 .fillMaxWidth()
                 .height(90.dp)
                 .cornerRadiusCompat(6.dp)
-                .background(GlanceTheme.colors.primaryContainer)
+                .background(LocalWidgetTheme.current.background)
                 .padding(16.dp),
         ) {
             EpisodeImage(

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/NonScalingText.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/NonScalingText.kt
@@ -3,8 +3,6 @@ package au.com.shiftyjelly.pocketcasts.widget.ui
 import android.util.TypedValue.COMPLEX_UNIT_DIP
 import android.widget.RemoteViews
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.Dp
 import androidx.glance.GlanceModifier
 import androidx.glance.LocalContext
@@ -18,7 +16,6 @@ internal fun NonScalingText(
     textSize: Dp,
     useDynamicColors: Boolean,
     modifier: GlanceModifier = GlanceModifier,
-    nonDynamicTextColor: Color? = null,
     isTransparent: Boolean = false,
     isSingleLine: Boolean = true,
     isBold: Boolean = false,
@@ -28,9 +25,6 @@ internal fun NonScalingText(
     with(remoteView) {
         setTextViewText(R.id.nonScalingText, text)
         setTextViewTextSize(R.id.nonScalingText, COMPLEX_UNIT_DIP, textSize.value)
-        if (!useDynamicColors && nonDynamicTextColor != null) {
-            setTextColor(R.id.nonScalingText, nonDynamicTextColor.toArgb())
-        }
     }
     AndroidRemoteViews(
         remoteViews = remoteView,

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlayButton.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlayButton.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.glance.ColorFilter
 import androidx.glance.GlanceModifier
-import androidx.glance.GlanceTheme
 import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
@@ -37,13 +36,13 @@ internal fun PlayButton(
         Image(
             provider = ImageProvider(IR.drawable.ic_circle),
             contentDescription = null,
-            colorFilter = ColorFilter.tint(GlanceTheme.colors.primary),
+            colorFilter = ColorFilter.tint(LocalWidgetTheme.current.buttonBackground),
             modifier = GlanceModifier.size(size),
         )
         Image(
             provider = ImageProvider(IR.drawable.ic_widget_play),
             contentDescription = null,
-            colorFilter = ColorFilter.tint(GlanceTheme.colors.onPrimary),
+            colorFilter = ColorFilter.tint(LocalWidgetTheme.current.icon),
             modifier = GlanceModifier.size(size).padding(size / 5),
         )
     }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlaybackButton.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlaybackButton.kt
@@ -5,18 +5,15 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.glance.ColorFilter
 import androidx.glance.GlanceModifier
-import androidx.glance.GlanceTheme
 import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
 import androidx.glance.action.clickable
-import androidx.glance.color.ColorProviders
 import androidx.glance.layout.Box
 import androidx.glance.layout.padding
 import androidx.glance.layout.size
 import androidx.glance.semantics.contentDescription
 import androidx.glance.semantics.semantics
-import androidx.glance.unit.ColorProvider
 import au.com.shiftyjelly.pocketcasts.widget.action.controlPlaybackAction
 import au.com.shiftyjelly.pocketcasts.widget.data.LocalSource
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -26,8 +23,6 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 internal fun PlaybackButton(
     isPlaying: Boolean,
     size: Dp = 36.dp,
-    backgroundColor: ((ColorProviders) -> ColorProvider)? = null,
-    iconColor: ((ColorProviders) -> ColorProvider)? = null,
 ) {
     val contentDescription = LocalContext.current.getString(if (isPlaying) LR.string.play_episode else LR.string.pause_episode)
 
@@ -40,13 +35,13 @@ internal fun PlaybackButton(
         Image(
             provider = ImageProvider(IR.drawable.ic_circle),
             contentDescription = null,
-            colorFilter = ColorFilter.tint(backgroundColor?.invoke(GlanceTheme.colors) ?: GlanceTheme.colors.primary),
+            colorFilter = ColorFilter.tint(LocalWidgetTheme.current.buttonBackground),
             modifier = GlanceModifier.size(size),
         )
         Image(
             provider = ImageProvider(if (isPlaying) IR.drawable.ic_widget_pause else IR.drawable.ic_widget_play),
             contentDescription = null,
-            colorFilter = ColorFilter.tint(iconColor?.invoke(GlanceTheme.colors) ?: GlanceTheme.colors.onPrimary),
+            colorFilter = ColorFilter.tint(LocalWidgetTheme.current.icon),
             modifier = GlanceModifier.size(size).padding(size / if (isPlaying) 8 else 5),
         )
     }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PocketCastsLogo.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PocketCastsLogo.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.glance.ColorFilter
 import androidx.glance.GlanceModifier
-import androidx.glance.GlanceTheme
 import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.action.clickable
@@ -26,13 +25,13 @@ internal fun PocketCastsLogo(
         Image(
             provider = ImageProvider(IR.drawable.ic_circle),
             contentDescription = null,
-            colorFilter = ColorFilter.tint(GlanceTheme.colors.primary),
+            colorFilter = ColorFilter.tint(LocalWidgetTheme.current.logoBackground),
             modifier = GlanceModifier.size(size),
         )
         Image(
             provider = ImageProvider(IR.drawable.ic_logo_foreground),
             contentDescription = null,
-            colorFilter = ColorFilter.tint(GlanceTheme.colors.onPrimary),
+            colorFilter = ColorFilter.tint(LocalWidgetTheme.current.logoLines),
             modifier = GlanceModifier.size(size),
         )
     }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SkipBackButton.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SkipBackButton.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.glance.ColorFilter
 import androidx.glance.GlanceModifier
-import androidx.glance.GlanceTheme
 import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
@@ -35,13 +34,13 @@ internal fun SkipBackButton(
         Image(
             provider = ImageProvider(IR.drawable.ic_circle),
             contentDescription = null,
-            colorFilter = ColorFilter.tint(GlanceTheme.colors.primary),
+            colorFilter = ColorFilter.tint(LocalWidgetTheme.current.buttonBackground),
             modifier = GlanceModifier.size(size),
         )
         Image(
             provider = ImageProvider(IR.drawable.ic_widget_skip_back),
             contentDescription = null,
-            colorFilter = ColorFilter.tint(GlanceTheme.colors.onPrimary),
+            colorFilter = ColorFilter.tint(LocalWidgetTheme.current.icon),
             modifier = GlanceModifier.size(size).padding(size / 5),
         )
     }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SkipForwardButton.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SkipForwardButton.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.glance.ColorFilter
 import androidx.glance.GlanceModifier
-import androidx.glance.GlanceTheme
 import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
@@ -35,13 +34,13 @@ internal fun SkipForwardButton(
         Image(
             provider = ImageProvider(IR.drawable.ic_circle),
             contentDescription = null,
-            colorFilter = ColorFilter.tint(GlanceTheme.colors.primary),
+            colorFilter = ColorFilter.tint(LocalWidgetTheme.current.buttonBackground),
             modifier = GlanceModifier.size(size),
         )
         Image(
             provider = ImageProvider(IR.drawable.ic_widget_skip_forward),
             contentDescription = null,
-            colorFilter = ColorFilter.tint(GlanceTheme.colors.onPrimary),
+            colorFilter = ColorFilter.tint(LocalWidgetTheme.current.icon),
             modifier = GlanceModifier.size(size).padding(size / 5),
         )
     }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SmallPlayer.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SmallPlayer.kt
@@ -45,16 +45,13 @@ internal fun SmallPlayer(state: SmallPlayerWidgetState) {
                 episode = state.episode,
                 useEpisodeArtwork = state.useEpisodeArtwork,
                 size = width,
-                backgroundColor = if (!state.useDynamicColors) { { it.secondary } } else null,
-                iconColor = if (!state.useDynamicColors) { { it.onSecondary } } else null,
+                backgroundColor = { it.background },
                 onClick = { controlPlayback },
             )
             if (state.episode != null) {
                 PlaybackButton(
-                    state.isPlaying,
+                    isPlaying = state.isPlaying,
                     size = width / 2,
-                    backgroundColor = if (!state.useDynamicColors) { { it.surface } } else null,
-                    iconColor = if (!state.useDynamicColors) { { it.onSurface } } else null,
                 )
             }
         }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/WidgetTheme.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/WidgetTheme.kt
@@ -3,10 +3,13 @@ package au.com.shiftyjelly.pocketcasts.widget.ui
 import android.os.Build
 import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.glance.GlanceComposable
 import androidx.glance.GlanceTheme
 import androidx.glance.material3.ColorProviders
+import androidx.glance.unit.ColorProvider
 
 @Composable
 internal fun WidgetTheme(
@@ -20,32 +23,53 @@ internal fun WidgetTheme(
     } else {
         DefaultColors
     }
-    GlanceTheme(colors, content)
+    GlanceTheme(colors) {
+        val glanceColors = GlanceTheme.colors
+        val widgetColors = WidgetTheme(
+            background = glanceColors.secondaryContainer,
+            text = glanceColors.onSecondaryContainer,
+            buttonBackground = glanceColors.onSecondary,
+            icon = glanceColors.secondary,
+            logoBackground = if (useDynamicColors) glanceColors.secondary else glanceColors.tertiary,
+            logoLines = if (useDynamicColors) glanceColors.onSecondary else glanceColors.onTertiary,
+        )
+        CompositionLocalProvider(LocalWidgetTheme provides widgetColors, content)
+    }
 }
+
+internal val LocalWidgetTheme = staticCompositionLocalOf<WidgetTheme> { error("No default widget colors") }
+
+internal data class WidgetTheme(
+    val background: ColorProvider,
+    val text: ColorProvider,
+    val buttonBackground: ColorProvider,
+    val icon: ColorProvider,
+    val logoBackground: ColorProvider,
+    val logoLines: ColorProvider,
+)
 
 private val UndefinedColor = Color.Magenta
 
 private val DefaultColors = ColorProviders(
     light = ColorScheme(
-        primary = Color(0xFFF8FAF6),
-        onPrimary = Color(0xFFF43E37),
-        primaryContainer = Color(0xFFF43E37),
+        primary = UndefinedColor,
+        onPrimary = UndefinedColor,
+        primaryContainer = UndefinedColor,
         onPrimaryContainer = UndefinedColor,
         inversePrimary = UndefinedColor,
-        // Used as a trick to have different small player placeholder colors.
-        secondary = Color(0xFFF43E37),
-        onSecondary = Color(0xFFF8FAF6),
-        secondaryContainer = UndefinedColor,
-        onSecondaryContainer = UndefinedColor,
-        tertiary = UndefinedColor,
-        onTertiary = UndefinedColor,
+        secondary = Color(0xFF292B2E),
+        onSecondary = Color(0xFFE0E6EA),
+        secondaryContainer = Color(0xFFFAFAF9),
+        onSecondaryContainer = Color(0xFF292B2E),
+        // Used as a trick for different Pocket Casts logo colors
+        tertiary = Color(0xFFF43E37),
+        onTertiary = Color(0xFFFAFAF9),
         tertiaryContainer = UndefinedColor,
         onTertiaryContainer = UndefinedColor,
         background = UndefinedColor,
         onBackground = UndefinedColor,
-        // Used as a trick to have different small player button colors for small widget with non dynamic themes in dark mode.
-        surface = Color(0xFFF8FAF6),
-        onSurface = Color(0xFFF43E37),
+        surface = UndefinedColor,
+        onSurface = UndefinedColor,
         surfaceVariant = UndefinedColor,
         onSurfaceVariant = UndefinedColor,
         surfaceTint = UndefinedColor,
@@ -60,25 +84,24 @@ private val DefaultColors = ColorProviders(
         scrim = UndefinedColor,
     ),
     dark = ColorScheme(
-        primary = Color(0xFFD9201C),
-        onPrimary = Color(0xFFFFFFFF),
-        primaryContainer = Color(0xFF292B2E),
+        primary = UndefinedColor,
+        onPrimary = UndefinedColor,
+        primaryContainer = UndefinedColor,
         onPrimaryContainer = UndefinedColor,
         inversePrimary = UndefinedColor,
-        // Used as a trick to have different small player placeholder colors.
-        secondary = Color(0xFFD9201C),
-        onSecondary = Color(0xFFFFFFFF),
-        secondaryContainer = UndefinedColor,
-        onSecondaryContainer = UndefinedColor,
-        tertiary = UndefinedColor,
-        onTertiary = UndefinedColor,
+        secondary = Color(0xFFFFFFFF),
+        onSecondary = Color(0xFF404247),
+        secondaryContainer = Color(0xFF292B2E),
+        onSecondaryContainer = Color(0xFFFFFFFF),
+        // Used as a trick for different Pocket Casts logo colors
+        tertiary = Color(0xFFD9201C),
+        onTertiary = Color(0xFFFAFAF9),
         tertiaryContainer = UndefinedColor,
         onTertiaryContainer = UndefinedColor,
         background = UndefinedColor,
         onBackground = UndefinedColor,
-        // Used as a trick to have different small player button colors for small widget with non dynamic themes.
-        surface = Color(0xFFF8FAF6),
-        onSurface = Color(0xFFD9201C),
+        surface = UndefinedColor,
+        onSurface = UndefinedColor,
         surfaceVariant = UndefinedColor,
         onSurfaceVariant = UndefinedColor,
         surfaceTint = UndefinedColor,

--- a/modules/features/widgets/src/main/res/layout/non_scaling_text_bold_dynamic_oneline_opaque.xml
+++ b/modules/features/widgets/src/main/res/layout/non_scaling_text_bold_dynamic_oneline_opaque.xml
@@ -7,6 +7,6 @@
     android:alpha="1.0"
     android:ellipsize="end"
     android:maxLines="1"
-    android:textColor="?colorOnPrimaryContainer"
+    android:textColor="?colorOnSecondaryContainer"
     android:textStyle="bold"
     android:theme="@style/Theme.Material3.DynamicColors.DayNight" />

--- a/modules/features/widgets/src/main/res/layout/non_scaling_text_bold_dynamic_oneline_transparent.xml
+++ b/modules/features/widgets/src/main/res/layout/non_scaling_text_bold_dynamic_oneline_transparent.xml
@@ -7,6 +7,6 @@
     android:alpha="0.8"
     android:ellipsize="end"
     android:maxLines="1"
-    android:textColor="?colorOnPrimaryContainer"
+    android:textColor="?colorOnSecondaryContainer"
     android:textStyle="bold"
     android:theme="@style/Theme.Material3.DynamicColors.DayNight" />

--- a/modules/features/widgets/src/main/res/layout/non_scaling_text_bold_dynamic_twolines_opaque.xml
+++ b/modules/features/widgets/src/main/res/layout/non_scaling_text_bold_dynamic_twolines_opaque.xml
@@ -7,6 +7,6 @@
     android:alpha="1.0"
     android:ellipsize="end"
     android:maxLines="2"
-    android:textColor="?colorOnPrimaryContainer"
+    android:textColor="?colorOnSecondaryContainer"
     android:textStyle="bold"
     android:theme="@style/Theme.Material3.DynamicColors.DayNight" />

--- a/modules/features/widgets/src/main/res/layout/non_scaling_text_bold_dynamic_twolines_transparent.xml
+++ b/modules/features/widgets/src/main/res/layout/non_scaling_text_bold_dynamic_twolines_transparent.xml
@@ -7,6 +7,6 @@
     android:alpha="0.8"
     android:ellipsize="end"
     android:maxLines="2"
-    android:textColor="?colorOnPrimaryContainer"
+    android:textColor="?colorOnSecondaryContainer"
     android:textStyle="bold"
     android:theme="@style/Theme.Material3.DynamicColors.DayNight" />

--- a/modules/features/widgets/src/main/res/layout/non_scaling_text_regular_dynamic_oneline_opaque.xml
+++ b/modules/features/widgets/src/main/res/layout/non_scaling_text_regular_dynamic_oneline_opaque.xml
@@ -7,6 +7,6 @@
     android:alpha="1.0"
     android:ellipsize="end"
     android:maxLines="1"
-    android:textColor="?colorOnPrimaryContainer"
+    android:textColor="?colorOnSecondaryContainer"
     android:textStyle="normal"
     android:theme="@style/Theme.Material3.DynamicColors.DayNight" />

--- a/modules/features/widgets/src/main/res/layout/non_scaling_text_regular_dynamic_oneline_transparent.xml
+++ b/modules/features/widgets/src/main/res/layout/non_scaling_text_regular_dynamic_oneline_transparent.xml
@@ -7,6 +7,6 @@
     android:alpha="0.8"
     android:ellipsize="end"
     android:maxLines="1"
-    android:textColor="?colorOnPrimaryContainer"
+    android:textColor="?colorOnSecondaryContainer"
     android:textStyle="normal"
     android:theme="@style/Theme.Material3.DynamicColors.DayNight" />

--- a/modules/features/widgets/src/main/res/layout/non_scaling_text_regular_dynamic_twolines_opaque.xml
+++ b/modules/features/widgets/src/main/res/layout/non_scaling_text_regular_dynamic_twolines_opaque.xml
@@ -7,6 +7,6 @@
     android:alpha="1.0"
     android:ellipsize="end"
     android:maxLines="2"
-    android:textColor="?colorOnPrimaryContainer"
+    android:textColor="?colorOnSecondaryContainer"
     android:textStyle="normal"
     android:theme="@style/Theme.Material3.DynamicColors.DayNight" />

--- a/modules/features/widgets/src/main/res/layout/non_scaling_text_regular_dynamic_twolines_transparent.xml
+++ b/modules/features/widgets/src/main/res/layout/non_scaling_text_regular_dynamic_twolines_transparent.xml
@@ -7,6 +7,6 @@
     android:alpha="0.8"
     android:ellipsize="end"
     android:maxLines="2"
-    android:textColor="?colorOnPrimaryContainer"
+    android:textColor="?colorOnSecondaryContainer"
     android:textStyle="normal"
     android:theme="@style/Theme.Material3.DynamicColors.DayNight" />

--- a/modules/features/widgets/src/main/res/values/colors.xml
+++ b/modules/features/widgets/src/main/res/values/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="widget_text_color">#F8FAF6</color>
+    <color name="widget_text_color">#292B2E</color>
 </resources>


### PR DESCRIPTION
## Description

This PR changes new widgets theming from primary to secondary colors. Our custom dark theme uses a bit different red color for logo and darker background for buttons but I aligned this with David.

I've also simplified handling colors by introducing `WidgetTheme` type.

Internal ref: Lkt7fuf9Nq3XvfAFPCfpTD-fi-1422_1732

## Testing Instructions

1. Add widgets to the home screen.
2. Test them with different themes and wallpapers.

## Screenshots or Screencast 

### Empty state

| Non-dynamic Light | Non-dynamic dark | Dynamic light | Dynamic dark |
| - | - | - | - |
| ![empty-custom-light](https://github.com/Automattic/pocket-casts-android/assets/30936061/96f2ddf0-338f-48e0-aa17-a34f1a687dff) | ![empty-custom-dark](https://github.com/Automattic/pocket-casts-android/assets/30936061/14a778b5-5c97-470c-95a7-064b157fdf43) | ![empty-dynamic-light](https://github.com/Automattic/pocket-casts-android/assets/30936061/f2598dcd-92a4-4a88-849f-ba40d625a15e) | ![empty-dynamic-dark](https://github.com/Automattic/pocket-casts-android/assets/30936061/df92dec1-f745-4335-8a13-9ea92dd46f39) |

### Filled state

| Non-dynamic Light | Non-dynamic dark | Dynamic light | Dynamic dark |
| - | - | - | - |
| ![full-custom-light](https://github.com/Automattic/pocket-casts-android/assets/30936061/394b23e4-4bea-4822-9f4c-7001b25b2514) | ![full-custom-dark](https://github.com/Automattic/pocket-casts-android/assets/30936061/835ce70f-696d-441b-84f6-c1aecf5d8a2b) | ![full-dynamic-light](https://github.com/Automattic/pocket-casts-android/assets/30936061/2edea347-d767-4e45-b0ac-9e17cd122560) | ![full-dynamic-dark](https://github.com/Automattic/pocket-casts-android/assets/30936061/50308650-20c2-4096-8b58-c3b839aaf0d1) |


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack