### PR TITLE
Fix bookmarks episode title display

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
@@ -231,6 +231,7 @@ private fun BookmarksView(
                 },
                 showIcon = state.showIcon,
                 useEpisodeArtwork = state.useEpisodeArtwork,
+                showEpisodeTitle = state.showEpisodeTitle,
             )
         }
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -202,6 +202,7 @@ class BookmarksViewModel
                     showIcon = sourceView == SourceView.PROFILE,
                     searchEnabled = sourceView == SourceView.PROFILE,
                     searchText = searchText,
+                    showEpisodeTitle = sourceView == SourceView.PROFILE,
                 )
             }
         }.stateIn(viewModelScope)
@@ -381,6 +382,7 @@ class BookmarksViewModel
             val showIcon: Boolean = false,
             val searchText: String = "",
             val searchEnabled: Boolean = false,
+            val showEpisodeTitle: Boolean = false,
         ) : UiState() {
             val headerRowColors: HeaderRowColors
                 get() = when (sourceView) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkViewHolder.kt
@@ -39,6 +39,7 @@ class BookmarkViewHolder(
                     timePlayButtonColors = TimePlayButtonColors.Default,
                     showIcon = true,
                     useEpisodeArtwork = data.useEpisodeArtwork,
+                    showEpisodeTitle = true,
                 )
             }
         }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkRow.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkRow.kt
@@ -13,8 +13,6 @@ import androidx.compose.material.Checkbox
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -113,6 +111,7 @@ fun BookmarkRow(
     timePlayButtonColors: TimePlayButtonColors,
     showIcon: Boolean,
     useEpisodeArtwork: Boolean,
+    showEpisodeTitle: Boolean = false,
 ) {
     Column(
         modifier = modifier,
@@ -162,7 +161,8 @@ fun BookmarkRow(
                     .weight(1f)
                     .padding(horizontal = 16.dp),
             ) {
-                if (bookmark.episodeTitle.isNotEmpty()) {
+                val shouldShowEpisodeTitle = showEpisodeTitle && bookmark.episodeTitle.isNotEmpty()
+                if (shouldShowEpisodeTitle) {
                     TextH70(
                         text = bookmark.episodeTitle,
                         color = colors.secondaryTextColor(),
@@ -173,7 +173,7 @@ fun BookmarkRow(
 
                 Spacer(
                     modifier = Modifier.padding(
-                        top = if (bookmark.episodeTitle.isNotEmpty()) 4.dp else 16.dp,
+                        top = if (shouldShowEpisodeTitle) 4.dp else 16.dp,
                     ),
                 )
 
@@ -192,7 +192,7 @@ fun BookmarkRow(
 
                 Spacer(
                     modifier = Modifier.padding(
-                        bottom = if (bookmark.episodeTitle.isNotEmpty()) 8.dp else 16.dp,
+                        bottom = if (shouldShowEpisodeTitle) 8.dp else 16.dp,
                     ),
                 )
             }


### PR DESCRIPTION
## Description
This fixes bookmarks episode title display. Episode title should not be displayed for Episode and Player bookmarks screens where bookmarks are shown only for the selected episode.


## Testing Instructions
1. Login with a paid account having a few bookmarks
2. Open bookmarks from different sources: `Episode`, `Player`, `Podcast` and `Profile`
3. ✅  Notice that the episode title is shown for Podcast and Profile bookmarks
4. ✅ Notice that the episode title is not shown for Episode and Player bookmarks

## Screenshots or Screencast 

Episode | Player | Podcast | Profile
---|---|----|----
![episode](https://github.com/Automattic/pocket-casts-android/assets/1405144/1f3edfc0-0431-48b6-86e8-c593df63478d)| ![player](https://github.com/Automattic/pocket-casts-android/assets/1405144/59983599-429a-4fd1-9aeb-27de32c94358)| ![podcast](https://github.com/Automattic/pocket-casts-android/assets/1405144/87b4a860-7557-4d9a-86ff-ac3e68ff9006)| ![profile](https://github.com/Automattic/pocket-casts-android/assets/1405144/db3c95c0-8264-477e-a5d7-184da86d2b2d)



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
