### PR TITLE
Add rounded corners on Android SDK < 31

### DIFF
--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/EpisodeImage.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/EpisodeImage.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import androidx.core.graphics.drawable.toBitmap
 import androidx.glance.GlanceModifier
 import androidx.glance.Image
@@ -17,9 +16,7 @@ import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
 import androidx.glance.action.Action
 import androidx.glance.action.clickable
-import androidx.glance.background
 import androidx.glance.layout.Alignment
-import androidx.glance.layout.Box
 import androidx.glance.layout.size
 import androidx.glance.unit.ColorProvider
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
@@ -40,13 +37,10 @@ internal fun EpisodeImage(
         mutableStateOf<Bitmap?>(null)
     }
 
-    Box(
+    RounderCornerBox(
         contentAlignment = Alignment.Center,
-        modifier = GlanceModifier
-            .applyIf(onClick != null) { it.clickable(onClick!!) }
-            .background(backgroundColor?.invoke(LocalWidgetTheme.current) ?: LocalWidgetTheme.current.buttonBackground)
-            .cornerRadiusCompat(6.dp)
-            .size(size),
+        backgroundTint = backgroundColor?.invoke(LocalWidgetTheme.current) ?: LocalWidgetTheme.current.buttonBackground,
+        modifier = GlanceModifier.size(size).applyIf(onClick != null) { it.clickable(onClick!!) },
     ) {
         PocketCastsLogo(
             size = size / 2.5f,
@@ -64,7 +58,7 @@ internal fun EpisodeImage(
     if (episode != null) {
         val context = LocalContext.current
         LaunchedEffect(episode.uuid, useEpisodeArtwork) {
-            val requestFactory = PocketCastsImageRequestFactory(context).smallSize()
+            val requestFactory = PocketCastsImageRequestFactory(context, cornerRadius = if (isSystemCornerRadiusSupported) 0 else 6).smallSize()
             val request = requestFactory.create(episode.toBaseEpisode(), useEpisodeArtwork)
             var drawable: Drawable? = null
             while (drawable == null) {

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/GlanceModifierExtensions.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/GlanceModifierExtensions.kt
@@ -1,15 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.widget.ui
 
-import android.os.Build
-import androidx.compose.ui.unit.Dp
 import androidx.glance.GlanceModifier
-import androidx.glance.appwidget.cornerRadius
-
-internal fun GlanceModifier.cornerRadiusCompat(radius: Dp) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-    cornerRadius(radius)
-} else {
-    this
-}
 
 internal fun GlanceModifier.applyIf(condition: Boolean, modify: (GlanceModifier) -> GlanceModifier) = if (condition) {
     modify(this)

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayer.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayer.kt
@@ -13,6 +13,7 @@ import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
 import androidx.glance.layout.wrapContentHeight
+import androidx.glance.layout.wrapContentSize
 import au.com.shiftyjelly.pocketcasts.widget.action.OpenPocketCastsAction
 import au.com.shiftyjelly.pocketcasts.widget.data.LargePlayerWidgetState
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -22,58 +23,65 @@ internal fun LargePlayer(state: LargePlayerWidgetState) {
     val upNextEpisodes = state.upNextEpisodes
 
     WidgetTheme(state.useDynamicColors) {
-        Column(
+        RounderCornerBox(
+            contentAlignment = Alignment.TopCenter,
+            backgroundTint = LocalWidgetTheme.current.background,
+            modifierCompat = GlanceModifier.fillMaxWidth().height(350.dp),
             modifier = GlanceModifier
                 .clickable(OpenPocketCastsAction.action())
                 .fillMaxWidth()
-                .wrapContentHeight()
-                .cornerRadiusCompat(6.dp)
-                .background(LocalWidgetTheme.current.background)
-                .padding(16.dp),
+                .wrapContentSize(),
         ) {
-            LargePlayerHeader(state = state)
-            if (upNextEpisodes.isNotEmpty()) {
-                Spacer(
-                    modifier = GlanceModifier.height(12.dp),
-                )
-                val expectedHeight = when (upNextEpisodes.size) {
-                    0 -> 0
-                    1 -> 58
-                    2 -> 124
-                    else -> 190
-                }.dp
-                LargePlayerQueue(
-                    queue = upNextEpisodes,
-                    useEpisodeArtwork = state.useEpisodeArtwork,
-                    useDynamicColors = state.useDynamicColors,
-                    modifier = GlanceModifier.height(expectedHeight),
-                )
-                Spacer(
-                    modifier = GlanceModifier.fillMaxWidth().height(190.dp - expectedHeight),
-                )
-            } else {
-                Column(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = GlanceModifier
-                        .fillMaxWidth()
-                        .height(190.dp),
-                ) {
-                    NonScalingText(
-                        text = LocalContext.current.getString(LR.string.widget_nothing_in_up_next),
-                        textSize = 16.dp,
+            Column(
+                modifier = GlanceModifier
+                    .fillMaxWidth()
+                    .wrapContentHeight()
+                    .padding(16.dp),
+            ) {
+                LargePlayerHeader(state = state)
+                if (upNextEpisodes.isNotEmpty()) {
+                    Spacer(
+                        modifier = GlanceModifier.height(12.dp),
+                    )
+                    val expectedHeight = when (upNextEpisodes.size) {
+                        0 -> 0
+                        1 -> 58
+                        2 -> 124
+                        else -> 190
+                    }.dp
+                    LargePlayerQueue(
+                        queue = upNextEpisodes,
+                        useEpisodeArtwork = state.useEpisodeArtwork,
                         useDynamicColors = state.useDynamicColors,
-                        isBold = true,
+                        modifier = GlanceModifier.height(expectedHeight),
                     )
                     Spacer(
-                        modifier = GlanceModifier.height(4.dp),
+                        modifier = GlanceModifier.fillMaxWidth().height(190.dp - expectedHeight),
                     )
-                    NonScalingText(
-                        text = LocalContext.current.getString(LR.string.widget_check_out_discover),
-                        textSize = 13.dp,
-                        useDynamicColors = state.useDynamicColors,
-                        isTransparent = true,
-                    )
+                } else {
+                    Column(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = GlanceModifier
+                            .fillMaxWidth()
+                            .height(202.dp),
+                    ) {
+                        NonScalingText(
+                            text = LocalContext.current.getString(LR.string.widget_nothing_in_up_next),
+                            textSize = 16.dp,
+                            useDynamicColors = state.useDynamicColors,
+                            isBold = true,
+                        )
+                        Spacer(
+                            modifier = GlanceModifier.height(4.dp),
+                        )
+                        NonScalingText(
+                            text = LocalContext.current.getString(LR.string.widget_check_out_discover),
+                            textSize = 13.dp,
+                            useDynamicColors = state.useDynamicColors,
+                            isTransparent = true,
+                        )
+                    }
                 }
             }
         }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayerQueue.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayerQueue.kt
@@ -34,10 +34,10 @@ internal fun LargePlayerQueue(
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = GlanceModifier
-                    .clickable(OpenPocketCastsAction.action())
                     .fillMaxWidth()
                     .height(if (index == lastIndex) 58.dp else 66.dp)
-                    .padding(bottom = if (index == lastIndex) 0.dp else 8.dp),
+                    .padding(bottom = if (index == lastIndex) 0.dp else 8.dp)
+                    .clickable(OpenPocketCastsAction.action()),
             ) {
                 EpisodeImage(
                     episode = episode,
@@ -67,7 +67,11 @@ internal fun LargePlayerQueue(
                         modifier = GlanceModifier.padding(end = 16.dp),
                     )
                 }
-                PlayButton(episode = episode)
+                PlayButton(
+                    episode = episode,
+                    iconPadding = 8.dp,
+                    modifier = GlanceModifier.size(38.dp),
+                )
             }
         }
     }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/MediumPlayer.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/MediumPlayer.kt
@@ -15,6 +15,7 @@ import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
 import androidx.glance.layout.width
+import androidx.glance.layout.wrapContentHeight
 import au.com.shiftyjelly.pocketcasts.widget.action.OpenPocketCastsAction
 import au.com.shiftyjelly.pocketcasts.widget.data.MediumPlayerWidgetState
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -22,52 +23,58 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 internal fun MediumPlayer(state: MediumPlayerWidgetState) {
     WidgetTheme(state.useDynamicColors) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
+        RounderCornerBox(
+            contentAlignment = Alignment.TopCenter,
+            backgroundTint = LocalWidgetTheme.current.background,
             modifier = GlanceModifier
                 .clickable(OpenPocketCastsAction.action())
                 .fillMaxWidth()
-                .height(90.dp)
-                .cornerRadiusCompat(6.dp)
-                .background(LocalWidgetTheme.current.background)
-                .padding(16.dp),
+                .height(90.dp),
         ) {
-            EpisodeImage(
-                episode = state.episode,
-                useEpisodeArtwork = state.useEpisodeArtwork,
-                size = 58.dp,
-            )
-            Spacer(
-                modifier = GlanceModifier.width(4.dp),
-            )
-            if (state.episode != null) {
-                PlaybackControls(
-                    isPlaying = state.isPlaying,
-                    buttonHeight = 58.dp,
-                    iconPadding = 16.dp,
-                    modifier = GlanceModifier.defaultWeight(),
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = GlanceModifier
+                    .fillMaxWidth()
+                    .wrapContentHeight()
+                    .padding(16.dp),
+            ) {
+                EpisodeImage(
+                    episode = state.episode,
+                    useEpisodeArtwork = state.useEpisodeArtwork,
+                    size = 58.dp,
                 )
-            } else {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = GlanceModifier.fillMaxSize(),
-                ) {
-                    NonScalingText(
-                        text = LocalContext.current.getString(LR.string.widget_no_episode_playing),
-                        textSize = 16.dp,
-                        useDynamicColors = state.useDynamicColors,
-                        isBold = true,
+                Spacer(
+                    modifier = GlanceModifier.width(4.dp),
+                )
+                if (state.episode != null) {
+                    PlaybackControls(
+                        isPlaying = state.isPlaying,
+                        buttonHeight = 58.dp,
+                        iconPadding = 16.dp,
+                        modifier = GlanceModifier.defaultWeight(),
                     )
-                    Spacer(
-                        modifier = GlanceModifier.height(2.dp),
-                    )
-                    NonScalingText(
-                        text = LocalContext.current.getString(LR.string.widget_check_out_discover),
-                        textSize = 13.dp,
-                        useDynamicColors = state.useDynamicColors,
-                        isTransparent = true,
-                    )
+                } else {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = GlanceModifier.fillMaxSize(),
+                    ) {
+                        NonScalingText(
+                            text = LocalContext.current.getString(LR.string.widget_no_episode_playing),
+                            textSize = 16.dp,
+                            useDynamicColors = state.useDynamicColors,
+                            isBold = true,
+                        )
+                        Spacer(
+                            modifier = GlanceModifier.height(2.dp),
+                        )
+                        NonScalingText(
+                            text = LocalContext.current.getString(LR.string.widget_check_out_discover),
+                            textSize = 13.dp,
+                            useDynamicColors = state.useDynamicColors,
+                            isTransparent = true,
+                        )
+                    }
                 }
             }
         }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlayButton.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlayButton.kt
@@ -2,16 +2,15 @@ package au.com.shiftyjelly.pocketcasts.widget.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import androidx.glance.ColorFilter
 import androidx.glance.GlanceModifier
 import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
 import androidx.glance.action.clickable
-import androidx.glance.layout.Box
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.padding
-import androidx.glance.layout.size
 import androidx.glance.semantics.contentDescription
 import androidx.glance.semantics.semantics
 import au.com.shiftyjelly.pocketcasts.widget.action.PlayEpisodeAction
@@ -23,27 +22,23 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 internal fun PlayButton(
     episode: PlayerWidgetEpisode,
-    size: Dp = 38.dp,
+    iconPadding: Dp,
+    modifier: GlanceModifier = GlanceModifier,
 ) {
     val contentDescription = LocalContext.current.getString(LR.string.play_episode)
 
-    Box(
-        modifier = GlanceModifier
-            .size(size)
+    RounderCornerBox(
+        contentAlignment = Alignment.Center,
+        backgroundTint = LocalWidgetTheme.current.buttonBackground,
+        modifier = modifier
             .clickable(PlayEpisodeAction.action(episode.uuid, LocalSource.current))
             .semantics { this.contentDescription = contentDescription },
     ) {
         Image(
-            provider = ImageProvider(IR.drawable.rounded_rectangle),
-            contentDescription = null,
-            colorFilter = ColorFilter.tint(LocalWidgetTheme.current.buttonBackground),
-            modifier = GlanceModifier.size(size),
-        )
-        Image(
             provider = ImageProvider(IR.drawable.ic_widget_play),
             contentDescription = null,
             colorFilter = ColorFilter.tint(LocalWidgetTheme.current.icon),
-            modifier = GlanceModifier.size(size).padding(size / 5),
+            modifier = GlanceModifier.fillMaxSize().padding(vertical = iconPadding),
         )
     }
 }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlaybackButton.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlaybackButton.kt
@@ -9,11 +9,8 @@ import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
 import androidx.glance.action.clickable
 import androidx.glance.layout.Alignment
-import androidx.glance.layout.Box
 import androidx.glance.layout.fillMaxSize
-import androidx.glance.layout.height
 import androidx.glance.layout.padding
-import androidx.glance.layout.size
 import androidx.glance.semantics.contentDescription
 import androidx.glance.semantics.semantics
 import au.com.shiftyjelly.pocketcasts.widget.action.controlPlaybackAction
@@ -24,7 +21,6 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 internal fun PlaybackButton(
     isPlaying: Boolean,
-    height: Dp,
     iconPadding: Dp,
     modifier: GlanceModifier = GlanceModifier,
     isClickable: Boolean = true,
@@ -32,27 +28,20 @@ internal fun PlaybackButton(
     val contentDescription = LocalContext.current.getString(if (isPlaying) LR.string.play_episode else LR.string.pause_episode)
     val source = LocalSource.current
 
-    Box(
+    RounderCornerBox(
         contentAlignment = Alignment.Center,
-        modifier = modifier
-            .height(height)
-            .applyIf(isClickable) { continuation ->
-                continuation
-                    .clickable(controlPlaybackAction(isPlaying, source))
-                    .semantics { this.contentDescription = contentDescription }
-            },
+        backgroundTint = LocalWidgetTheme.current.buttonBackground,
+        modifier = modifier.applyIf(isClickable) { ifModifier ->
+            ifModifier
+                .clickable(controlPlaybackAction(isPlaying, source))
+                .semantics { this.contentDescription = contentDescription }
+        },
     ) {
-        Image(
-            provider = ImageProvider(IR.drawable.rounded_rectangle),
-            contentDescription = null,
-            colorFilter = ColorFilter.tint(LocalWidgetTheme.current.buttonBackground),
-            modifier = GlanceModifier.fillMaxSize(),
-        )
         Image(
             provider = ImageProvider(if (isPlaying) IR.drawable.ic_widget_pause else IR.drawable.ic_widget_play),
             contentDescription = null,
             colorFilter = ColorFilter.tint(LocalWidgetTheme.current.icon),
-            modifier = GlanceModifier.size(height).padding(iconPadding),
+            modifier = GlanceModifier.fillMaxSize().padding(vertical = iconPadding),
         )
     }
 }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlaybackControls.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlaybackControls.kt
@@ -8,6 +8,7 @@ import androidx.glance.layout.Alignment
 import androidx.glance.layout.Row
 import androidx.glance.layout.Spacer
 import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
 import androidx.glance.layout.width
 
 @Composable
@@ -23,30 +24,26 @@ internal fun PlaybackControls(
         modifier = modifier.fillMaxWidth(),
     ) {
         SkipForwardButton(
-            height = buttonHeight,
             iconPadding = iconPadding,
             isClickable = isClickable,
-            modifier = GlanceModifier.defaultWeight(),
+            modifier = GlanceModifier.height(buttonHeight).defaultWeight(),
         )
         Spacer(
             modifier = GlanceModifier.width(4.dp),
         )
         PlaybackButton(
             isPlaying = isPlaying,
-            height = buttonHeight,
             iconPadding = iconPadding,
             isClickable = isClickable,
-            modifier = GlanceModifier.defaultWeight(),
+            modifier = GlanceModifier.height(buttonHeight).defaultWeight(),
         )
         Spacer(
             modifier = GlanceModifier.width(4.dp),
         )
         SkipBackButton(
-            height = buttonHeight,
             iconPadding = iconPadding,
             isClickable = isClickable,
-            modifier = GlanceModifier.defaultWeight(),
-
+            modifier = GlanceModifier.height(buttonHeight).defaultWeight(),
         )
     }
 }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/RounderCornerBox.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/RounderCornerBox.kt
@@ -1,0 +1,47 @@
+package au.com.shiftyjelly.pocketcasts.widget.ui
+
+import android.os.Build
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.glance.ColorFilter
+import androidx.glance.GlanceModifier
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.unit.ColorProvider
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+
+@Composable
+internal fun RounderCornerBox(
+    modifier: GlanceModifier = GlanceModifier,
+    modifierCompat: GlanceModifier = GlanceModifier.fillMaxSize(),
+    contentAlignment: Alignment = Alignment.Center,
+    backgroundTint: ColorProvider? = null,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        contentAlignment = contentAlignment,
+        modifier = modifier
+            .cornerRadiusCompat(6.dp)
+            .applyIf(isSystemCornerRadiusSupported && backgroundTint != null) { it.background(backgroundTint!!) },
+    ) {
+        if (!isSystemCornerRadiusSupported) {
+            Image(
+                provider = ImageProvider(IR.drawable.rounded_rectangle),
+                contentDescription = null,
+                colorFilter = backgroundTint?.let(ColorFilter::tint),
+                modifier = modifierCompat,
+            )
+        }
+        content()
+    }
+}
+
+internal val isSystemCornerRadiusSupported get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+
+private fun GlanceModifier.cornerRadiusCompat(radius: Dp) = applyIf(isSystemCornerRadiusSupported) { it.cornerRadius(radius) }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SkipBackButton.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SkipBackButton.kt
@@ -9,11 +9,8 @@ import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
 import androidx.glance.action.clickable
 import androidx.glance.layout.Alignment
-import androidx.glance.layout.Box
 import androidx.glance.layout.fillMaxSize
-import androidx.glance.layout.height
 import androidx.glance.layout.padding
-import androidx.glance.layout.size
 import androidx.glance.semantics.contentDescription
 import androidx.glance.semantics.semantics
 import au.com.shiftyjelly.pocketcasts.widget.action.SkipBackAction
@@ -23,7 +20,6 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun SkipBackButton(
-    height: Dp,
     iconPadding: Dp,
     modifier: GlanceModifier = GlanceModifier,
     isClickable: Boolean = true,
@@ -31,27 +27,20 @@ internal fun SkipBackButton(
     val contentDescription = LocalContext.current.getString(LR.string.skip_back)
     val source = LocalSource.current
 
-    Box(
+    RounderCornerBox(
         contentAlignment = Alignment.Center,
-        modifier = modifier
-            .height(height)
-            .applyIf(isClickable) { continuation ->
-                continuation
-                    .clickable(SkipBackAction.action(source))
-                    .semantics { this.contentDescription = contentDescription }
-            },
+        backgroundTint = LocalWidgetTheme.current.buttonBackground,
+        modifier = modifier.applyIf(isClickable) { ifModifier ->
+            ifModifier
+                .clickable(SkipBackAction.action(source))
+                .semantics { this.contentDescription = contentDescription }
+        },
     ) {
-        Image(
-            provider = ImageProvider(IR.drawable.rounded_rectangle),
-            contentDescription = null,
-            colorFilter = ColorFilter.tint(LocalWidgetTheme.current.buttonBackground),
-            modifier = GlanceModifier.fillMaxSize(),
-        )
         Image(
             provider = ImageProvider(IR.drawable.ic_widget_skip_back),
             contentDescription = null,
             colorFilter = ColorFilter.tint(LocalWidgetTheme.current.icon),
-            modifier = GlanceModifier.size(height).padding(iconPadding),
+            modifier = GlanceModifier.fillMaxSize().padding(vertical = iconPadding),
         )
     }
 }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SkipForwardButton.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SkipForwardButton.kt
@@ -9,11 +9,8 @@ import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
 import androidx.glance.action.clickable
 import androidx.glance.layout.Alignment
-import androidx.glance.layout.Box
 import androidx.glance.layout.fillMaxSize
-import androidx.glance.layout.height
 import androidx.glance.layout.padding
-import androidx.glance.layout.size
 import androidx.glance.semantics.contentDescription
 import androidx.glance.semantics.semantics
 import au.com.shiftyjelly.pocketcasts.widget.action.SkipForwardAction
@@ -23,7 +20,6 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun SkipForwardButton(
-    height: Dp,
     iconPadding: Dp,
     modifier: GlanceModifier = GlanceModifier,
     isClickable: Boolean = true,
@@ -31,27 +27,20 @@ internal fun SkipForwardButton(
     val contentDescription = LocalContext.current.getString(LR.string.skip_forward)
     val source = LocalSource.current
 
-    Box(
+    RounderCornerBox(
         contentAlignment = Alignment.Center,
-        modifier = modifier
-            .height(height)
-            .applyIf(isClickable) { continuation ->
-                continuation
-                    .clickable(SkipForwardAction.action(source))
-                    .semantics { this.contentDescription = contentDescription }
-            },
+        backgroundTint = LocalWidgetTheme.current.buttonBackground,
+        modifier = modifier.applyIf(isClickable) { ifModifier ->
+            ifModifier
+                .clickable(SkipForwardAction.action(source))
+                .semantics { this.contentDescription = contentDescription }
+        },
     ) {
-        Image(
-            provider = ImageProvider(IR.drawable.rounded_rectangle),
-            contentDescription = null,
-            colorFilter = ColorFilter.tint(LocalWidgetTheme.current.buttonBackground),
-            modifier = GlanceModifier.fillMaxSize(),
-        )
         Image(
             provider = ImageProvider(IR.drawable.ic_widget_skip_forward),
             contentDescription = null,
             colorFilter = ColorFilter.tint(LocalWidgetTheme.current.icon),
-            modifier = GlanceModifier.size(height).padding(iconPadding),
+            modifier = GlanceModifier.fillMaxSize().padding(vertical = iconPadding),
         )
     }
 }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SmallPlayer.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SmallPlayer.kt
@@ -8,6 +8,7 @@ import androidx.glance.action.clickable
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
 import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.size
 import androidx.glance.layout.width
 import androidx.glance.semantics.contentDescription
 import androidx.glance.semantics.semantics
@@ -52,9 +53,8 @@ internal fun SmallPlayer(state: SmallPlayerWidgetState) {
             if (state.episode != null) {
                 PlaybackButton(
                     isPlaying = state.isPlaying,
-                    height = width / 2,
                     iconPadding = width / 16,
-                    modifier = GlanceModifier.width(width / 2),
+                    modifier = GlanceModifier.size(width / 2),
                 )
             }
         }


### PR DESCRIPTION
## Description

Android below SDK 31 does not support rounding corners from the Kotlin code. It has to be done with XML. I added `RounderCornerBox` composable that decides whether to handle it from the code or from the XML.

## Testing Instructions

### Corner radius

1. Install the app on a device below SDK 31.
2. Add widgets to the home screen.
3. They should have rounded corners.

### Regressions

Do regression tests of widgets on devices with different SDK versions.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![before](https://github.com/Automattic/pocket-casts-android/assets/30936061/e5955307-9592-47ce-bc6b-6fbf66608ada) | ![after](https://github.com/Automattic/pocket-casts-android/assets/30936061/8412ac83-9c40-4a06-8462-1a768c3e59d5) |

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
