### PR TITLE
Resize large widget to available height

### DIFF
--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/LargePlayerWidget.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/LargePlayerWidget.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.glance.GlanceId
 import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.SizeMode
 import androidx.glance.appwidget.provideContent
 import androidx.glance.state.PreferencesGlanceStateDefinition
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
@@ -13,6 +14,8 @@ import au.com.shiftyjelly.pocketcasts.widget.ui.LargePlayer
 
 internal class LargePlayerWidget : GlanceAppWidget() {
     override val stateDefinition = PreferencesGlanceStateDefinition
+
+    override val sizeMode = SizeMode.Exact
 
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val adapter = LargePlayerWidgetState.Adapter(context)

--- a/modules/features/widgets/src/main/res/xml/large_player_widget.xml
+++ b/modules/features/widgets/src/main/res/xml/large_player_widget.xml
@@ -3,6 +3,7 @@
     android:initialLayout="@layout/glance_default_loading_layout"
     android:minWidth="300dp"
     android:minHeight="165dp"
+    android:minResizeHeight="140dp"
     android:previewImage="@drawable/widget_player_large_preview"
     android:resizeMode="vertical|horizontal"
     android:targetCellWidth="4"


### PR DESCRIPTION
## Description

Make large widget queue content resize to the available height.

## Testing Instructions

Do regression tests of large widget with different widget sizes and different queue states.

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/30936061/f3bd0c47-e8ae-49da-a847-4958695af348

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
