### PR TITLE
Revert order of widget playback buttons

### DIFF
--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlaybackControls.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/PlaybackControls.kt
@@ -23,7 +23,7 @@ internal fun PlaybackControls(
         verticalAlignment = Alignment.Vertical.Bottom,
         modifier = modifier.fillMaxWidth(),
     ) {
-        SkipForwardButton(
+        SkipBackButton(
             iconPadding = iconPadding,
             isClickable = isClickable,
             modifier = GlanceModifier.height(buttonHeight).defaultWeight(),
@@ -40,7 +40,7 @@ internal fun PlaybackControls(
         Spacer(
             modifier = GlanceModifier.width(4.dp),
         )
-        SkipBackButton(
+        SkipForwardButton(
             iconPadding = iconPadding,
             isClickable = isClickable,
             modifier = GlanceModifier.height(buttonHeight).defaultWeight(),


### PR DESCRIPTION
## Description

Reverts order of buttons in playback controls.

## Testing Instructions

1. Add large and medium widgets.
2. Check that the order of playback control buttons is: `skip back`, `play/pause`, `skip forward`. 

## Screenshots or Screencast 

![Screenshot_20240429-161707](https://github.com/Automattic/pocket-casts-android/assets/30936061/6f1ccb2a-96cb-4a16-ad5c-b17f8c393735)

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
