### PR TITLE
Fix: Send ads event to firebase and Add subscribe button to category ad

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -841,6 +841,10 @@ internal class DiscoverAdapter(
                     adHolder.itemView.setOnClickListener {
                         row.discoverRow.categoryId?.let { categoryId ->
                             analyticsTracker.track(DISCOVER_AD_CATEGORY_TAPPED, mapOf(CATEGORY_ID_KEY to categoryId))
+                            row.discoverRow.listUuid?.let { listUuid ->
+                                FirebaseAnalyticsTracker.podcastTappedFromList(listUuid, podcast.uuid)
+                                analyticsTracker.track(AnalyticsEvent.DISCOVER_LIST_PODCAST_TAPPED, mapOf(LIST_ID_KEY to listUuid, PODCAST_UUID_KEY to podcast.uuid))
+                            }
                         }
                         listener.onPodcastClicked(podcast, row.discoverRow.listUuid)
                     }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -464,7 +464,21 @@ internal class DiscoverAdapter(
 
     class ErrorViewHolder(val binding: RowErrorBinding) : RecyclerView.ViewHolder(binding.root)
     class ChangeRegionViewHolder(val binding: RowChangeRegionBinding) : RecyclerView.ViewHolder(binding.root)
-    class CategoryAdViewHolder(val binding: RowCategoryAdBinding) : NetworkLoadableViewHolder(binding.root)
+    inner class CategoryAdViewHolder(val binding: RowCategoryAdBinding) : NetworkLoadableViewHolder(binding.root) {
+
+        private var listIdImpressionTracked = mutableListOf<String>()
+
+        fun trackSponsoredListImpression(listId: String) {
+            if (listIdImpressionTracked.contains(listId)) return
+
+            FirebaseAnalyticsTracker.listImpression(listId)
+            analyticsTracker.track(
+                AnalyticsEvent.DISCOVER_LIST_IMPRESSION,
+                mapOf(LIST_ID to listId),
+            )
+            listIdImpressionTracked.add(listId)
+        }
+    }
     class SinglePodcastViewHolder(val binding: RowSinglePodcastBinding) : NetworkLoadableViewHolder(binding.root)
     class SingleEpisodeViewHolder(val binding: RowSingleEpisodeBinding) : NetworkLoadableViewHolder(binding.root)
     class CollectionListViewHolder(val binding: RowCollectionListBinding) : NetworkLoadableViewHolder(binding.root)
@@ -871,6 +885,7 @@ internal class DiscoverAdapter(
                     onRestoreInstanceState(adHolder)
                 },
             )
+            row.discoverRow.listUuid?.let { adHolder.trackSponsoredListImpression(it) }
         }
     }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -845,6 +845,14 @@ internal class DiscoverAdapter(
                         listener.onPodcastClicked(podcast, row.discoverRow.listUuid)
                     }
 
+                    val btnSubscribe = adHolder.binding.btnSubscribe
+                    btnSubscribe.updateSubscribeButtonIcon(podcast.isSubscribed)
+                    btnSubscribe.setOnClickListener {
+                        btnSubscribe.updateSubscribeButtonIcon(true)
+                        listener.onPodcastSubscribe(podcast = podcast, listUuid = row.discoverRow.listUuid)
+                        row.discoverRow.listUuid?.let { listUuid -> trackDiscoverListPodcastSubscribed(listUuid, podcast.uuid) }
+                    }
+
                     val lblSponsored = adHolder.binding.lblSponsored
                     if (row.discoverRow.sponsored) {
                         lblSponsored.setTextColor(context.getThemeColor(UR.attr.primary_text_02))

--- a/modules/features/discover/src/main/res/layout/row_category_ad.xml
+++ b/modules/features/discover/src/main/res/layout/row_category_ad.xml
@@ -54,6 +54,23 @@
         app:layout_constraintTop_toBottomOf="@id/lblSponsored"
         tools:text="Title" />
 
+    <ImageView
+        android:id="@+id/btnSubscribe"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="center_vertical|end"
+        android:background="?android:attr/actionBarItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:scaleType="centerInside"
+        android:layout_marginEnd="4dp"
+        android:layout_marginStart="4dp"
+        android:layout_marginBottom="4dp"
+        android:contentDescription="@string/subscribe"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:tint="?attr/primary_icon_02" />
+
     <TextView
         android:id="@+id/lblBody"
         style="@style/P40"


### PR DESCRIPTION
## Description
- This PR sends `discover_list_impression ` and `discover_list_podcast_tap ` to Firebase
- Also adds subscribe button to category ad 

```
- discover_list_impression with the parameter “list_id”. When the user views the list on the screen (it must be visible to the user).

- discover_list_podcast_tap with parameters “list_id” and “podcast_uuid”. When a podcast in a discover list is tapped.
``` 
> [!NOTE]  
> `discover_list_impression` is tracked once per session following the existing logic 

> [!IMPORTANT]  
> Currently `Sports` category has an ad set in Stagging. These ads are not available to every category selected

## Testing Instructions
1. Run the app
2. Select `Sports` category
3. ✅ Ensure 🔵 Tracked: `discover_category_shown, Properties: {"name":"Sports","region":"your_region","id":14,` is tracked
4. ✅ Ensure 🔵 Tracked: `discover_list_impression, Properties: {"list_id":list_id` is tracked
5. Close the category filter
6. Select `Sports` category again
7. ✅ Ensure only 🔵 Tracked: `discover_category_shown, Properties: {"name":"Sports","region":"your_region","id":14,` is tracked
8. Tap on Sponsored Podcast
9. ✅ Ensure 🔵 Tracked: `discover_list_podcast_tapped, Properties: {"list_id":"list_id` is tracked
10. ✅ Ensure 🔵 Tracked: `discover_ad_category_tapped, Properties: {"category_id":14` is tracked
11. ✅ Ensure 🔵 Tracked: `podcast_screen_shown` is tracked
12. Go back to category view filter
13. Tap on Category Ad Subscribe Button
14. ✅ Ensure 🔵 Tracked: `discover_list_podcast_subscribed` is tracked
15. ✅ Ensure 🔵 Tracked: `podcast_subscribed` is tracked


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
