### PR TITLE
Select min dimension for small widget

### DIFF
--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/EpisodeImage.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/EpisodeImage.kt
@@ -33,7 +33,7 @@ internal fun EpisodeImage(
     backgroundColor: ((WidgetTheme) -> ColorProvider)? = null,
     onClick: Action? = null,
 ) {
-    var episodeBitmap by remember(episode?.uuid, useEpisodeArtwork) {
+    var episodeBitmap by remember(episode?.uuid, useEpisodeArtwork, size) {
         mutableStateOf<Bitmap?>(null)
     }
 
@@ -57,8 +57,12 @@ internal fun EpisodeImage(
 
     if (episode != null) {
         val context = LocalContext.current
-        LaunchedEffect(episode.uuid, useEpisodeArtwork) {
-            val requestFactory = PocketCastsImageRequestFactory(context, cornerRadius = if (isSystemCornerRadiusSupported) 0 else 6).smallSize()
+        LaunchedEffect(episode.uuid, useEpisodeArtwork, size) {
+            val requestFactory = PocketCastsImageRequestFactory(
+                context,
+                size = size.value.toInt(),
+                cornerRadius = if (isSystemCornerRadiusSupported) 0 else 6,
+            )
             val request = requestFactory.create(episode.toBaseEpisode(), useEpisodeArtwork)
             var drawable: Drawable? = null
             while (drawable == null) {

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SmallPlayer.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SmallPlayer.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.widget.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.min
 import androidx.glance.GlanceModifier
 import androidx.glance.LocalContext
 import androidx.glance.LocalSize
@@ -31,7 +32,7 @@ internal fun SmallPlayer(state: SmallPlayerWidgetState) {
         else -> LR.string.pause_episode
     }.let { LocalContext.current.getString(it) }
 
-    val width = LocalSize.current.width
+    val size = min(LocalSize.current.width, LocalSize.current.height)
 
     WidgetTheme(state.useDynamicColors) {
         Box(
@@ -46,15 +47,15 @@ internal fun SmallPlayer(state: SmallPlayerWidgetState) {
             EpisodeImage(
                 episode = state.episode,
                 useEpisodeArtwork = state.useEpisodeArtwork,
-                size = width,
+                size = size,
                 backgroundColor = { it.background },
                 onClick = controlPlayback,
             )
             if (state.episode != null) {
                 PlaybackButton(
                     isPlaying = state.isPlaying,
-                    iconPadding = width / 16,
-                    modifier = GlanceModifier.size(width / 2),
+                    iconPadding = size / 16,
+                    modifier = GlanceModifier.size(size / 2),
                 )
             }
         }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SmallPlayer.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SmallPlayer.kt
@@ -1,6 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.widget.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.coerceAtMost
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.min
 import androidx.glance.GlanceModifier
 import androidx.glance.LocalContext
@@ -52,10 +54,11 @@ internal fun SmallPlayer(state: SmallPlayerWidgetState) {
                 onClick = controlPlayback,
             )
             if (state.episode != null) {
+                val buttonSize = (size / 2.3f).coerceAtMost(48.dp)
                 PlaybackButton(
                     isPlaying = state.isPlaying,
-                    iconPadding = size / 16,
-                    modifier = GlanceModifier.size(size / 2),
+                    iconPadding = buttonSize / 4.75f,
+                    modifier = GlanceModifier.size(buttonSize),
                 )
             }
         }


### PR DESCRIPTION
## Description

Some launchers allow to resize widgets regardless of the configuration. This can lead to unexpected results for the small widget.

I also started using size for fetching artwork to account for big widget sizes.

## Testing Instructions

1. Install Nova Launcher.
2. Add the small widget to the Nova's home screen and play something.
3. Resize the widget and check that it looks correctly.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![1-before](https://github.com/Automattic/pocket-casts-android/assets/30936061/46d05923-beeb-45d7-b98d-5828ea337496) | ![1-after](https://github.com/Automattic/pocket-casts-android/assets/30936061/5d784767-2152-41c6-ab18-1674e1e075cb) |

| Before | After |
| - | - |
| ![2-before](https://github.com/Automattic/pocket-casts-android/assets/30936061/bbe724b0-8387-4ca4-aad7-992a37f05f39) | ![2-after](https://github.com/Automattic/pocket-casts-android/assets/30936061/cad5e1d4-bc88-4c54-88ae-3fbb48a767f0) |

| Before | After |
| - | - |
| ![3-before](https://github.com/Automattic/pocket-casts-android/assets/30936061/6740cf60-3446-40b7-95e5-f2059629e2c2) | ![3-after](https://github.com/Automattic/pocket-casts-android/assets/30936061/25c480e4-42f4-4342-a027-5fde800f89dc) |

## Checklist

- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
