### PR TITLE
Account for 7.62.1 when migrating artwork settings

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
@@ -165,7 +165,7 @@ class VersionMigrationsJob : JobService() {
             consolidateEmbeddedArtworkSettings(applicationContext)
         }
 
-        if (previousVersionCode < 9224) {
+        if (previousVersionCode < 9226) {
             migrateToGranularEpisodeArtworkSettings(applicationContext)
         }
     }


### PR DESCRIPTION
## Description

Need to take into account `7.62.1` version code bump for artwork settings migration.

## Testing Instructions

Verify in Play Console that `7.62.1` uses `9225` version code.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
