### PR TITLE
Add empty state mini player

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -923,8 +923,9 @@ class MainActivity :
                     supportFragmentManager.findFragmentByTag(bottomSheetTag)?.let {
                         removeBottomSheetFragment(it)
                     }
-
-                    binding.playerBottomSheet.isDragEnabled = true
+                    if (!FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR) || !playbackManager.upNextQueue.isEmpty) {
+                        binding.playerBottomSheet.isDragEnabled = true
+                    }
 
                     updateNavAndStatusColors(playerOpen = viewModel.isPlayerOpen, viewModel.lastPlaybackState?.podcast)
                 } else {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -985,9 +985,11 @@ class MainActivity :
 
         // Handle up next shortcut
         if (intent.getStringExtra(INTENT_EXTRA_PAGE) == "upnext") {
-            intent.putExtra(INTENT_EXTRA_PAGE, null as String?)
-            binding.playerBottomSheet.openPlayer()
-            showUpNextFragment(UpNextSource.UP_NEXT_SHORTCUT)
+            if (!playbackManager.upNextQueue.isEmpty) {
+                intent.putExtra(INTENT_EXTRA_PAGE, null as String?)
+                binding.playerBottomSheet.openPlayer()
+                showUpNextFragment(UpNextSource.UP_NEXT_SHORTCUT)
+            }
         }
     }
 

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -394,7 +394,11 @@ class MainActivity :
             activity = this,
         )
 
-        val showMiniPlayerImmediately = savedInstanceState?.getBoolean(SAVEDSTATE_MINIPLAYER_SHOWN, false) ?: false
+        val showMiniPlayerImmediately = if (!FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+            savedInstanceState?.getBoolean(SAVEDSTATE_MINIPLAYER_SHOWN, false) ?: false
+        } else {
+            true
+        }
         binding.playerBottomSheet.isVisible = showMiniPlayerImmediately
 
         setupPlayerViews(showMiniPlayerImmediately)
@@ -532,7 +536,9 @@ class MainActivity :
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putBoolean(SAVEDSTATE_PLAYER_OPEN, binding.playerBottomSheet.isPlayerOpen)
-        outState.putBoolean(SAVEDSTATE_MINIPLAYER_SHOWN, binding.playerBottomSheet.isShown)
+        if (!FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+            outState.putBoolean(SAVEDSTATE_MINIPLAYER_SHOWN, binding.playerBottomSheet.isShown)
+        }
     }
 
     override fun overrideNextRefreshTimer() {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -171,6 +171,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
             }
 
             is UpNextQueue.State.Empty  -> {
+                binding.artwork.setImageDrawable(null)
                 binding.artwork.setBackgroundColor(ThemeColor.primaryUi05(theme.activeTheme))
                 binding.nothingPlayingText.isVisible = true
                 binding.skipBack.isVisible = false
@@ -259,7 +260,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
         useEpisodeArtwork: Boolean,
         imageView: ImageView,
     ): Disposable? {
-        if (lastLoadedBaseEpisodeId == baseEpisode.uuid && lastUseEpisodeArtwork == useEpisodeArtwork) {
+        if (lastLoadedBaseEpisodeId == baseEpisode.uuid && lastUseEpisodeArtwork == useEpisodeArtwork && imageView.drawable != null) {
             return null
         }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -169,6 +169,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
                 binding.skipBack.isVisible = true
                 binding.skipForward.isVisible = true
                 binding.miniPlayButton.isVisible = true
+                binding.progressBar.isVisible = true
                 binding.root.isClickable = true
                 binding.root.isFocusable = true
             }
@@ -176,10 +177,12 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
             is UpNextQueue.State.Empty -> {
                 binding.artwork.setImageDrawable(null)
                 binding.artwork.setBackgroundColor(ThemeColor.primaryUi05(theme.activeTheme))
+                binding.miniPlayerTint.setBackgroundColor(ThemeColor.primaryUi01(theme.activeTheme))
                 binding.nothingPlayingText.isVisible = true
                 binding.skipBack.isVisible = false
                 binding.skipForward.isVisible = false
                 binding.miniPlayButton.isVisible = false
+                binding.progressBar.isVisible = false
                 binding.root.isClickable = false
                 binding.root.isFocusable = false
             }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -69,6 +69,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
         // open full screen player on click
         binding.root.setOnClickListener { openPlayer() }
         binding.root.setOnLongClickListener {
+            if (binding.root.isClickable.not()) return@setOnLongClickListener false
             clickListener?.onLongClick()
             true
         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -154,14 +154,28 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
     }
 
     fun setUpNext(upNextState: UpNextQueue.State, theme: Theme, useEpisodeArtwork: Boolean) {
-        if (upNextState is UpNextQueue.State.Loaded) {
-            loadEpisodeArtwork(upNextState.episode, useEpisodeArtwork, binding.artwork)
+        when (upNextState) {
+            is UpNextQueue.State.Loaded -> {
+                loadEpisodeArtwork(upNextState.episode, useEpisodeArtwork, binding.artwork)
 
-            val podcast = upNextState.podcast
-            if (podcast != null) {
-                updateTintColor(podcast.getPlayerTintColor(theme.isDarkTheme), theme)
-            } else {
-                updateTintColor(context.getThemeColor(androidx.appcompat.R.attr.colorAccent), theme)
+                val podcast = upNextState.podcast
+                if (podcast != null) {
+                    updateTintColor(podcast.getPlayerTintColor(theme.isDarkTheme), theme)
+                } else {
+                    updateTintColor(context.getThemeColor(androidx.appcompat.R.attr.colorAccent), theme)
+                }
+                binding.nothingPlayingText.isVisible = false
+                binding.skipBack.isVisible = true
+                binding.skipForward.isVisible = true
+                binding.miniPlayButton.isVisible = true
+            }
+
+            is UpNextQueue.State.Empty  -> {
+                binding.artwork.setBackgroundColor(ThemeColor.primaryUi05(theme.activeTheme))
+                binding.nothingPlayingText.isVisible = true
+                binding.skipBack.isVisible = false
+                binding.skipForward.isVisible = false
+                binding.miniPlayButton.isVisible = false
             }
         }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -168,15 +168,19 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
                 binding.skipBack.isVisible = true
                 binding.skipForward.isVisible = true
                 binding.miniPlayButton.isVisible = true
+                binding.root.isClickable = true
+                binding.root.isFocusable = true
             }
 
-            is UpNextQueue.State.Empty  -> {
+            is UpNextQueue.State.Empty -> {
                 binding.artwork.setImageDrawable(null)
                 binding.artwork.setBackgroundColor(ThemeColor.primaryUi05(theme.activeTheme))
                 binding.nothingPlayingText.isVisible = true
                 binding.skipBack.isVisible = false
                 binding.skipForward.isVisible = false
                 binding.miniPlayButton.isVisible = false
+                binding.root.isClickable = false
+                binding.root.isFocusable = false
             }
         }
 
@@ -202,6 +206,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
     }
 
     private fun openPlayer() {
+        if (binding.root.isClickable.not()) return
         clickListener?.onPlayerClicked()
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerBottomSheet.kt
@@ -117,6 +117,7 @@ class PlayerBottomSheet @JvmOverloads constructor(context: Context, attrs: Attri
         sheetBehavior = BottomSheetBehavior.from(this).apply {
             addBottomSheetCallback(bottomSheetCallback!!)
         }
+        sheetBehavior?.isDraggable = false
 
         if (shouldPlayerOpenOnAttach) {
             shouldPlayerOpenOnAttach = false
@@ -138,6 +139,7 @@ class PlayerBottomSheet @JvmOverloads constructor(context: Context, attrs: Attri
 
         when (upNext) {
             is UpNextQueue.State.Loaded -> {
+                sheetBehavior?.isDraggable = true
                 if ((isHidden() || !hasLoadedFirstTime)) {
                     show()
                     if (!shouldPlayerOpenOnAttach && shouldAnimateOnAttach) {
@@ -160,6 +162,7 @@ class PlayerBottomSheet @JvmOverloads constructor(context: Context, attrs: Attri
 
             is UpNextQueue.State.Empty -> {
                 if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+                    sheetBehavior?.isDraggable = false
                     listener?.onMiniPlayerVisible()
                     closePlayer()
                 } else if (isVisible()) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerBottomSheet.kt
@@ -22,6 +22,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.extensions.hide
 import au.com.shiftyjelly.pocketcasts.views.extensions.isHidden
 import au.com.shiftyjelly.pocketcasts.views.extensions.isVisible
@@ -134,31 +136,37 @@ class PlayerBottomSheet @JvmOverloads constructor(context: Context, attrs: Attri
     fun setUpNext(upNext: UpNextQueue.State, theme: Theme, shouldAnimateOnAttach: Boolean, useEpisodeArtwork: Boolean) {
         binding.miniPlayer.setUpNext(upNext, theme, useEpisodeArtwork)
 
-        // only show the mini player when an episode is loaded
-        if (upNext is UpNextQueue.State.Loaded) {
-            if ((isHidden() || !hasLoadedFirstTime)) {
-                show()
-                if (!shouldPlayerOpenOnAttach && shouldAnimateOnAttach) {
-                    translationY = 68.dpToPx(context).toFloat()
-                    animate().translationY(0f).setListener(object : AnimatorListenerAdapter() {
-                        override fun onAnimationEnd(animation: Animator) {
+        when (upNext) {
+            is UpNextQueue.State.Loaded -> {
+                if ((isHidden() || !hasLoadedFirstTime)) {
+                    show()
+                    if (!shouldPlayerOpenOnAttach && shouldAnimateOnAttach) {
+                        translationY = 68.dpToPx(context).toFloat()
+                        animate().translationY(0f).setListener(object : AnimatorListenerAdapter() {
+                            override fun onAnimationEnd(animation: Animator) {
+                                listener?.onMiniPlayerVisible()
+                                hasLoadedFirstTime = true
+                            }
+                        })
+                    } else {
+                        translationY = 0f
+                        if (!shouldAnimateOnAttach) {
                             listener?.onMiniPlayerVisible()
                             hasLoadedFirstTime = true
                         }
-                    })
-                } else {
-                    translationY = 0f
-                    if (!shouldAnimateOnAttach) {
-                        listener?.onMiniPlayerVisible()
-                        hasLoadedFirstTime = true
                     }
                 }
             }
-        } else {
-            if (isVisible()) {
-                hide()
-                closePlayer()
-                listener?.onMiniPlayerHidden()
+
+            is UpNextQueue.State.Empty -> {
+                if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+                    listener?.onMiniPlayerVisible()
+                    closePlayer()
+                } else if (isVisible()) {
+                    hide()
+                    closePlayer()
+                    listener?.onMiniPlayerHidden()
+                }
             }
         }
     }

--- a/modules/features/player/src/main/res/layout/view_mini_player.xml
+++ b/modules/features/player/src/main/res/layout/view_mini_player.xml
@@ -3,8 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="68dp"
-    android:focusable="true"
-    android:clickable="true"
     android:contentDescription="@string/player_open_full_size_player">
 
     <View

--- a/modules/features/player/src/main/res/layout/view_mini_player.xml
+++ b/modules/features/player/src/main/res/layout/view_mini_player.xml
@@ -23,6 +23,17 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <TextView
+        android:id="@+id/nothingPlayingText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:visibility="gone"
+        android:text="@string/nothing_is_playing"
+        app:layout_constraintBottom_toTopOf="@+id/progressBar"
+        app:layout_constraintStart_toEndOf="@id/artwork"
+        app:layout_constraintTop_toTopOf="parent"/>
+
     <ImageButton
         android:id="@+id/skipForward"
         android:layout_width="68dp"

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
     <string name="more">More</string>
     <string name="more_options">More options</string>
     <string name="next_episode">Next episode</string>
+    <string name="nothing_is_playing">Nothing is playing</string>
     <string name="notifications_blocked_warning">Notifications are blocked. You can update permission through Settings.</string>
     <string name="notifications_blocked_warning_snackbar_action" translatable="false">@string/update</string>
     <string name="ok">OK</string>


### PR DESCRIPTION
Part of #2081 

## Description
This adds an empty-state mini-player.

P.S.:  The scope of this PR is only to display the empty-state mini-player. UI will be fine-tuned as part of design changes.

** I considered renaming "Close and clear Up Next" mini-player long press menu item to "Clear Up Next" as the mini-player is always visible. But "Clear Up Next" appears to be the same as "Clear Queue" on the Up Next screen which retains the current playing episode and only clears the Up Next queue.  But right now, the menu option clears even the now-playing episode. I'll check about the intended behavior and update this part.

## Testing Instructions

#### Feature Flag ON

1. Fresh install the app 
2. ✅ Notice that an empty-state mini-player is shown
3. ✅ Notice that nothing happens on tap, long press, and drag on the empty-state mini-player  
4. Go to Discover tab
5. Scroll to the end of the Discover scree
6. Notice that you can see the last elements on the screen (`Select Content Region` label and dropdown)
7. Play an episode
8. ✅ Notice that mini-player is loaded with the current episode state
9. ✅ Notice that tap, long press, and drag work as before in the loaded state mini-player
10. Long press on the loaded state mini-player
11. Tap "Close and clear Up Next" **
12. ✅ Notice that an empty-state mini-player is shown **
13. Add a few episodes to Up Next queue
14. ✅ Notice that mini-player is loaded with the current episode state
15. Open Up Next screen and tap clear queue
16. ✅ Notice that the current episode is still shown on the mini-player
17. Long press the mini player and  tap "Close and clear Up Next"
18. Close the app
19. Long press the app icon and tap Up Next shortcut
20. ✅ Notice that empty up next queue is not shown


#### Feature Flag OFF

1. Turn off `Show Up Next in tab bar` feature flag in `Profile` -> `Settings` -> `Beta features`
2. Kill and restart the app
3. ✅ Notice that the mini-player does not display an empty state and works as before

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/89766ba0-809e-4768-a3c6-cd507b4f9732

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
