### PR TITLE
Update Search bar colors in Discover

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoryPillListAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoryPillListAdapter.kt
@@ -127,7 +127,7 @@ private fun TextView.setCategory(category: String) {
 }
 private fun TextView.setCategoryColor(isSelected: Boolean) {
     if (isSelected) {
-        this.setTextColor(context.getThemeColor(au.com.shiftyjelly.pocketcasts.ui.R.attr.primary_ui_02_selected))
+        this.setTextColor(context.getThemeColor(au.com.shiftyjelly.pocketcasts.ui.R.attr.secondary_ui_01))
     } else {
         this.setTextColor(context.getThemeColor(au.com.shiftyjelly.pocketcasts.ui.R.attr.primary_text_01))
     }

--- a/modules/features/discover/src/main/res/drawable/category_clear_all_pill_background.xml
+++ b/modules/features/discover/src/main/res/drawable/category_clear_all_pill_background.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android" >
     <stroke
         android:width="1dp"
-        android:color="?attr/primary_icon_02" />
+        android:color="?attr/primary_field_03" />
 
     <solid android:color="?attr/primary_ui_01" />
 

--- a/modules/features/discover/src/main/res/drawable/category_pill_background.xml
+++ b/modules/features/discover/src/main/res/drawable/category_pill_background.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android" >
     <stroke
         android:width="1dp"
-        android:color="?attr/primary_icon_02" />
+        android:color="?attr/primary_field_03" />
 
     <solid android:color="?attr/primary_ui_01" />
 

--- a/modules/features/discover/src/main/res/drawable/category_pill_selected_background.xml
+++ b/modules/features/discover/src/main/res/drawable/category_pill_selected_background.xml
@@ -2,9 +2,9 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android" >
     <stroke
         android:width="1dp"
-        android:color="?attr/primary_icon_01" />
+        android:color="?attr/primary_field_03" />
 
-    <solid android:color="?attr/primary_icon_01" />
+    <solid android:color="?attr/secondary_icon_01" />
 
     <padding
         android:left="20dp"

--- a/modules/features/discover/src/main/res/drawable/search_with_category_pills_background.xml
+++ b/modules/features/discover/src/main/res/drawable/search_with_category_pills_background.xml
@@ -5,7 +5,4 @@
 
     <corners android:radius="10dp" />
 
-    <stroke
-        android:width="1dp"
-        android:color="?attr/primary_icon_02" />
 </shape>

--- a/modules/features/discover/src/main/res/layout/fragment_discover.xml
+++ b/modules/features/discover/src/main/res/layout/fragment_discover.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context=".discover.view.DiscoverFragment"
     android:background="?attr/primary_ui_02">
 
@@ -10,7 +11,8 @@
         android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:visibility="gone">
+        android:visibility="gone"
+        app:elevation="0dp">
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"

--- a/modules/features/discover/src/main/res/layout/row_category_pills.xml
+++ b/modules/features/discover/src/main/res/layout/row_category_pills.xml
@@ -23,7 +23,7 @@
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:src="@drawable/ic_search"
-            app:tint="?attr/primary_text_01"
+            app:tint="?attr/primary_text_02"
             android:layout_marginEnd="16dp"/>
         <TextView
             android:layout_width="match_parent"
@@ -31,7 +31,7 @@
             android:layout_gravity="center_vertical"
             android:textAppearance="?attr/textBody1"
             android:importantForAccessibility="no"
-            android:textColor="?attr/primary_text_01"
+            android:textColor="?attr/primary_text_02"
             android:maxLines="1"
             android:ellipsize="end"
             android:text="@string/search_podcasts_or_add_url"

--- a/modules/features/discover/src/main/res/layout/row_category_pills.xml
+++ b/modules/features/discover/src/main/res/layout/row_category_pills.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
+    android:background="?attr/secondary_ui_01"
     android:paddingBottom="16dp">
 
     <LinearLayout


### PR DESCRIPTION
## Description
- This just removes the border color from search and makes the icon and text in search lighter to match with the existing search in Podcasts tab

## Testing Instructions
- Just check if the search bar colors in discover matches with the same colors from podcasts tab
- You can try with different themes

## Screenshots or Screencast

| Discover Before Changes |
|--------|
|<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/5ebb6fe9-3761-442c-a32e-291f46dedb0a" width="400"> |  




| Discover after changes | Podcasts tab to compare |
|--------|--------|
|<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/4acedc12-4c6e-40c1-93a2-678d0d2d77c5" width="400"> | <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/dda8f9cc-be7b-4964-9027-ceb1709cec2a" width="400"> | 


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
