### PR TITLE
Add feature flag for search bar in Podcasts tab

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -161,6 +161,8 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
             }
 
             toolbar.menu.findItem(R.id.create_folder)?.isVisible = rootFolder && isSignedInAsPlusOrPatron
+            toolbar.menu.findItem(R.id.search_podcasts)?.isVisible = rootFolder && !FeatureFlag.isEnabled(Feature.PODCASTS_TAB_SEARCH_BAR)
+
             binding.layoutSearch.showIf(rootFolder)
 
             adapter?.setFolderItems(folderState.items)
@@ -213,6 +215,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         )
         toolbar.setOnMenuItemClickListener(this)
         toolbar.menu.findItem(R.id.media_route_menu_item).isVisible = !FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)
+        toolbar.menu.findItem(R.id.search_podcasts).isVisible = !FeatureFlag.isEnabled(Feature.PODCASTS_TAB_SEARCH_BAR)
         toolbar.menu.findItem(R.id.folders_locked).setOnMenuItemClickListener {
             OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
             true
@@ -270,6 +273,11 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
                 val event = folderUuid?.let { AnalyticsEvent.FOLDER_OPTIONS_BUTTON_TAPPED } ?: AnalyticsEvent.PODCASTS_LIST_OPTIONS_BUTTON_TAPPED
                 analyticsTracker.track(event)
                 openOptions()
+                true
+            }
+
+            R.id.search_podcasts -> {
+                search()
                 true
             }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -163,7 +163,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
             toolbar.menu.findItem(R.id.create_folder)?.isVisible = rootFolder && isSignedInAsPlusOrPatron
             toolbar.menu.findItem(R.id.search_podcasts)?.isVisible = rootFolder && !FeatureFlag.isEnabled(Feature.PODCASTS_TAB_SEARCH_BAR)
 
-            binding.layoutSearch.showIf(rootFolder)
+            binding.layoutSearch.showIf(rootFolder && FeatureFlag.isEnabled(Feature.PODCASTS_TAB_SEARCH_BAR))
 
             adapter?.setFolderItems(folderState.items)
 
@@ -220,6 +220,8 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
             OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
             true
         }
+
+        binding.layoutSearch.showIf(FeatureFlag.isEnabled(Feature.PODCASTS_TAB_SEARCH_BAR))
 
         binding.swipeRefreshLayout.setOnRefreshListener {
             viewModel.refreshPodcasts()

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcasts.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcasts.xml
@@ -22,6 +22,7 @@
                 android:id="@+id/layoutSearch"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:visibility="gone"
                 android:layout_marginTop="?attr/actionBarSize"/>
 
             <androidx.appcompat.widget.Toolbar

--- a/modules/features/podcasts/src/main/res/menu/podcasts_menu.xml
+++ b/modules/features/podcasts/src/main/res/menu/podcasts_menu.xml
@@ -23,6 +23,13 @@
         app:showAsAction="always" />
 
     <item
+        android:id="@+id/search_podcasts"
+        android:icon="@drawable/ic_search_black_24dp"
+        app:showAsAction="always"
+        android:visible="false"
+        android:title="@string/podcasts_menu_search_podcasts" />
+
+    <item
         android:id="@+id/more_options"
         android:icon="@drawable/ic_more_vert_black_24dp"
         app:showAsAction="always"

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -91,6 +91,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),
+    PODCASTS_TAB_SEARCH_BAR(
+        key = "podcasts_tab_search_bar",
+        title = "Replace Podcasts tab search menu in toolbar with search bar",
+        defaultValue = true,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = true,
+        hasDevToggle = true,
+    ),
     ;
 
     companion object {


### PR DESCRIPTION
## Description

This adds a feature flag for the search bar in the Podcasts tab.

## Testing Instructions

1. Open the Podcasts tab
2. ✅ Notice that the search bar is visible below the toolbar
3. Turn off `PODCASTS_TAB_SEARCH_BAR` feature flag under `Profile` -> `Settings` -> `Beta features`
4. Kill and restart the app
5. ✅ Notice that search bar is replaced by search menu

## Screenshots or Screencast 

FF Enabled | FF Disabled
---|----
<img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/a547325c-e5fe-4554-9af0-9d8c7013e084"/>| <img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/2a083486-21c9-4330-a508-92838a1c79f3"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
