### PR TITLE
Search bar reduce height

### DIFF
--- a/modules/features/discover/src/main/res/layout/row_carousel_list.xml
+++ b/modules/features/discover/src/main/res/layout/row_carousel_list.xml
@@ -15,7 +15,7 @@
     <LinearLayout
         android:id="@+id/layoutSearch"
         android:layout_width="match_parent"
-        android:layout_height="56dp"
+        android:layout_height="48dp"
         android:orientation="horizontal"
         android:background="@drawable/search_background"
         android:foreground="?attr/selectableItemBackground"
@@ -25,9 +25,7 @@
         android:focusable="true"
         android:contentDescription="@string/search_podcasts_or_add_url"
         android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        android:paddingTop="12dp"
-        android:paddingBottom="12dp">
+        android:paddingEnd="16dp">
         <ImageView
             android:layout_width="wrap_content"
             android:layout_height="match_parent"

--- a/modules/features/discover/src/main/res/layout/row_category_pills.xml
+++ b/modules/features/discover/src/main/res/layout/row_category_pills.xml
@@ -9,7 +9,7 @@
     <LinearLayout
         android:id="@+id/layoutSearch"
         android:layout_width="match_parent"
-        android:layout_height="56dp"
+        android:layout_height="48dp"
         android:orientation="horizontal"
         android:background="@drawable/search_with_category_pills_background"
         android:foreground="?attr/selectableItemBackground"

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -161,6 +161,8 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
             }
 
             toolbar.menu.findItem(R.id.create_folder)?.isVisible = rootFolder && isSignedInAsPlusOrPatron
+            toolbar.menu.findItem(R.id.search_podcasts)?.isVisible = rootFolder && !FeatureFlag.isEnabled(Feature.PODCASTS_TAB_SEARCH_BAR)
+
             binding.layoutSearch.showIf(rootFolder)
 
             adapter?.setFolderItems(folderState.items)
@@ -213,6 +215,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         )
         toolbar.setOnMenuItemClickListener(this)
         toolbar.menu.findItem(R.id.media_route_menu_item).isVisible = !FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)
+        toolbar.menu.findItem(R.id.search_podcasts).isVisible = !FeatureFlag.isEnabled(Feature.PODCASTS_TAB_SEARCH_BAR)
         toolbar.menu.findItem(R.id.folders_locked).setOnMenuItemClickListener {
             OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
             true
@@ -270,6 +273,11 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
                 val event = folderUuid?.let { AnalyticsEvent.FOLDER_OPTIONS_BUTTON_TAPPED } ?: AnalyticsEvent.PODCASTS_LIST_OPTIONS_BUTTON_TAPPED
                 analyticsTracker.track(event)
                 openOptions()
+                true
+            }
+
+            R.id.search_podcasts -> {
+                search()
                 true
             }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -163,7 +163,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
             toolbar.menu.findItem(R.id.create_folder)?.isVisible = rootFolder && isSignedInAsPlusOrPatron
             toolbar.menu.findItem(R.id.search_podcasts)?.isVisible = rootFolder && !FeatureFlag.isEnabled(Feature.PODCASTS_TAB_SEARCH_BAR)
 
-            binding.layoutSearch.showIf(rootFolder)
+            binding.layoutSearch.showIf(rootFolder && FeatureFlag.isEnabled(Feature.PODCASTS_TAB_SEARCH_BAR))
 
             adapter?.setFolderItems(folderState.items)
 
@@ -220,6 +220,8 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
             OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
             true
         }
+
+        binding.layoutSearch.showIf(FeatureFlag.isEnabled(Feature.PODCASTS_TAB_SEARCH_BAR))
 
         binding.swipeRefreshLayout.setOnRefreshListener {
             viewModel.refreshPodcasts()

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcasts.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcasts.xml
@@ -22,6 +22,7 @@
                 android:id="@+id/layoutSearch"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:visibility="gone"
                 android:layout_marginTop="?attr/actionBarSize"/>
 
             <androidx.appcompat.widget.Toolbar

--- a/modules/features/podcasts/src/main/res/menu/podcasts_menu.xml
+++ b/modules/features/podcasts/src/main/res/menu/podcasts_menu.xml
@@ -23,6 +23,13 @@
         app:showAsAction="always" />
 
     <item
+        android:id="@+id/search_podcasts"
+        android:icon="@drawable/ic_search_black_24dp"
+        app:showAsAction="always"
+        android:visible="false"
+        android:title="@string/podcasts_menu_search_podcasts" />
+
+    <item
         android:id="@+id/more_options"
         android:icon="@drawable/ic_more_vert_black_24dp"
         app:showAsAction="always"

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
@@ -23,6 +24,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
@@ -32,6 +35,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.role
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
@@ -53,6 +57,7 @@ fun SearchBar(
     onSearch: () -> Unit = {},
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    textStyle: TextStyle = LocalTextStyle.current,
 ) {
     val focusManager = LocalFocusManager.current
     val colors = TextFieldDefaults.outlinedTextFieldColors(
@@ -70,6 +75,11 @@ fun SearchBar(
         unfocusedBorderColor = Color.Transparent,
         disabledBorderColor = Color.Transparent,
     )
+    val textColor = textStyle.color.takeOrElse {
+        colors.textColor(enabled).value
+    }
+    val mergedTextStyle = textStyle.merge(TextStyle(color = textColor))
+
     val shape = RoundedCornerShape(10.dp)
     BasicTextField(
         value = text,
@@ -85,6 +95,8 @@ fun SearchBar(
         ),
         maxLines = 1,
         enabled = enabled,
+        textStyle = mergedTextStyle,
+        cursorBrush = SolidColor(colors.cursorColor(false).value),
         modifier = modifier
             .onKeyEvent {
                 // close the keyboard on enter

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
@@ -1,21 +1,26 @@
 package au.com.shiftyjelly.pocketcasts.compose.components
 
 import android.view.KeyEvent
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.onKeyEvent
@@ -28,6 +33,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -38,6 +44,7 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.removeNewLines
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun SearchBar(
     text: String,
@@ -48,34 +55,27 @@ fun SearchBar(
     enabled: Boolean = true,
 ) {
     val focusManager = LocalFocusManager.current
-    OutlinedTextField(
+    val colors = TextFieldDefaults.outlinedTextFieldColors(
+        cursorColor = MaterialTheme.theme.colors.primaryText02,
+        textColor = MaterialTheme.theme.colors.primaryText01,
+        disabledTextColor = MaterialTheme.theme.colors.primaryText01,
+        placeholderColor = MaterialTheme.theme.colors.primaryText02,
+        disabledPlaceholderColor = MaterialTheme.theme.colors.primaryText02,
+        leadingIconColor = MaterialTheme.theme.colors.primaryIcon02,
+        disabledLeadingIconColor = MaterialTheme.theme.colors.primaryIcon02,
+        trailingIconColor = MaterialTheme.theme.colors.primaryIcon02,
+        disabledTrailingIconColor = MaterialTheme.theme.colors.primaryIcon02,
+        backgroundColor = MaterialTheme.theme.colors.primaryField01,
+        focusedBorderColor = Color.Transparent,
+        unfocusedBorderColor = Color.Transparent,
+        disabledBorderColor = Color.Transparent,
+    )
+    val shape = RoundedCornerShape(10.dp)
+    BasicTextField(
         value = text,
         onValueChange = {
             onTextChanged(it.removeNewLines())
         },
-        placeholder = {
-            Text(
-                placeholder,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        },
-        colors = TextFieldDefaults.outlinedTextFieldColors(
-            cursorColor = MaterialTheme.theme.colors.primaryText02,
-            textColor = MaterialTheme.theme.colors.primaryText01,
-            disabledTextColor = MaterialTheme.theme.colors.primaryText01,
-            placeholderColor = MaterialTheme.theme.colors.primaryText02,
-            disabledPlaceholderColor = MaterialTheme.theme.colors.primaryText02,
-            leadingIconColor = MaterialTheme.theme.colors.primaryIcon02,
-            disabledLeadingIconColor = MaterialTheme.theme.colors.primaryIcon02,
-            trailingIconColor = MaterialTheme.theme.colors.primaryIcon02,
-            disabledTrailingIconColor = MaterialTheme.theme.colors.primaryIcon02,
-            backgroundColor = MaterialTheme.theme.colors.primaryField01,
-            focusedBorderColor = Color.Transparent,
-            unfocusedBorderColor = Color.Transparent,
-            disabledBorderColor = Color.Transparent,
-        ),
-        shape = RoundedCornerShape(10.dp),
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
         keyboardActions = KeyboardActions(
             onSearch = {
@@ -84,36 +84,64 @@ fun SearchBar(
             },
         ),
         maxLines = 1,
-        leadingIcon = {
-            Icon(
-                painter = painterResource(IR.drawable.ic_search),
-                contentDescription = null,
-            )
-        },
-        trailingIcon = {
-            if (text.isNotEmpty()) {
-                IconButton(
-                    onClick = {
-                        onTextChanged("")
-                        focusManager.clearFocus()
-                    },
-                ) {
-                    Icon(
-                        painter = painterResource(IR.drawable.ic_cancel),
-                        contentDescription = stringResource(LR.string.cancel),
-                    )
+        enabled = enabled,
+        modifier = modifier
+            .onKeyEvent {
+                // close the keyboard on enter
+                if (it.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_ENTER) {
+                    focusManager.clearFocus()
+                    true
+                } else {
+                    false
                 }
             }
-        },
-        enabled = enabled,
-        modifier = modifier.onKeyEvent {
-            // close the keyboard on enter
-            if (it.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_ENTER) {
-                focusManager.clearFocus()
-                true
-            } else {
-                false
-            }
+            .background(colors.backgroundColor(enabled).value, shape)
+            .defaultMinSize(
+                minWidth = TextFieldDefaults.MinWidth,
+                minHeight = 50.dp,
+            ),
+        decorationBox = @Composable { innerTextField ->
+            TextFieldDefaults.OutlinedTextFieldDecorationBox(
+                value = text,
+                innerTextField = innerTextField,
+                placeholder = {
+                    Text(
+                        placeholder,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                },
+                leadingIcon = {
+                    Icon(
+                        painter = painterResource(IR.drawable.ic_search),
+                        contentDescription = null,
+                    )
+                },
+                trailingIcon = {
+                    if (text.isNotEmpty()) {
+                        IconButton(
+                            onClick = {
+                                onTextChanged("")
+                                focusManager.clearFocus()
+                            },
+                        ) {
+                            Icon(
+                                painter = painterResource(IR.drawable.ic_cancel),
+                                contentDescription = stringResource(LR.string.cancel),
+                            )
+                        }
+                    }
+                },
+                enabled = enabled,
+                colors = colors,
+                singleLine = true,
+                interactionSource = remember { MutableInteractionSource() },
+                visualTransformation = VisualTransformation.None,
+                contentPadding = TextFieldDefaults.textFieldWithoutLabelPadding(
+                    top = 0.dp,
+                    bottom = 0.dp,
+                ),
+            )
         },
     )
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
@@ -110,7 +110,7 @@ fun SearchBar(
             .background(colors.backgroundColor(enabled).value, shape)
             .defaultMinSize(
                 minWidth = TextFieldDefaults.MinWidth,
-                minHeight = 50.dp,
+                minHeight = 42.dp,
             ),
         decorationBox = @Composable { innerTextField ->
             TextFieldDefaults.OutlinedTextFieldDecorationBox(

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -91,6 +91,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),
+    PODCASTS_TAB_SEARCH_BAR(
+        key = "podcasts_tab_search_bar",
+        title = "Replace Podcasts tab search menu in toolbar with search bar",
+        defaultValue = true,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = true,
+        hasDevToggle = true,
+    ),
     ;
 
     companion object {


### PR DESCRIPTION
## Description

This reduces search bar height.

## Testing Instructions
1. Open profile tab
2. Notice that search bar height is reduced

## Screenshots or Screencast 

Before | After | 
----|---|
<img width= 300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/c3d49b1e-f99e-4125-a79f-a1b8bd1e9ddf"/> | <img width= 300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/9ffe4c9d-d576-4f55-9d07-b0a62ce00df4"/>

After with text | After with text large size
----|---
<img width= 300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/28f8c76a-34e6-40be-8813-54826aa19922"/> |  <img width= 300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/bf8c3797-da55-4ecb-b364-cf1cb7f170fd"/>



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
