### PR TITLE
Update status bar for discover

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -47,7 +47,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @AndroidEntryPoint
 class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectFragment.Listener {
-    override var statusBarColor: StatusBarColor = StatusBarColor.Dark
+    override var statusBarColor: StatusBarColor = StatusBarColor.Light
 
     @Inject lateinit var settings: Settings
 


### PR DESCRIPTION
## Description
- Updates status bar color for discover tab


## Testing Instructions
- The status bar cor should match with discover header color with `Show up next tab bar` feature flag enabled and disabled
- I tested using Pixel 7

1. Run the app with `Show Up Next in tab bar` enabled
2. ✅ Check if the Status Bar color matches with the discover header color
3. Try with different themes
4. Disable `Show Up Next in tab bar`
5. Restart the app
6. ✅ Check if the Status Bar color matches with the discover header color
7. Try with different themes


## Screenshots or Screencast 

| Before | After |
|--------|--------|
|![Screenshot_20240501_100550](https://github.com/Automattic/pocket-casts-android/assets/42220351/4de86638-d620-4fe6-a749-5b6853b1fbf6) |![Screenshot_20240501_100627](https://github.com/Automattic/pocket-casts-android/assets/42220351/323a7fc7-3118-47c4-a36b-a6cc4ed146e2)
 | 




## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
