### PR TITLE
Introduce `CrashLoggingDataProvider`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,7 +39,6 @@ android {
             applicationIdSuffix = ".debug"
 
             manifestPlaceholders["appIcon"] = "@mipmap/ic_launcher_radioactive"
-            manifestPlaceholders["sentryDsn"] = ""
         }
 
         named("debugProd") {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,13 +49,6 @@ android {
 
         named("release") {
             manifestPlaceholders["appIcon"] = "@mipmap/ic_launcher"
-            val pocketcastsSentryDsn: String by project
-            if (pocketcastsSentryDsn.isNotBlank()) {
-                manifestPlaceholders["sentryDsn"] = pocketcastsSentryDsn
-            }
-            else {
-                println("WARNING: Sentry DSN gradle property 'pocketcastsSentryDsn' not found. Crash reporting won't work without this.")
-            }
 
             if (!file("${project.rootDir}/sentry.properties").exists()) {
                 println("WARNING: Sentry configuration file 'sentry.properties' not found. The ProGuard mapping files won't be uploaded.")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -637,8 +637,6 @@
 
         <!-- Disable Sentry exception tracking so we can turn it on based on the user preference -->
         <meta-data android:name="io.sentry.auto-init" android:value="false" />
-        <!-- Pass in the Sentry DSN -->
-        <meta-data android:name="au.com.shiftyjelly.pocketcasts.sentryDsn" android:value="${sentryDsn}"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -42,9 +42,7 @@ import coil.ImageLoader
 import com.google.firebase.FirebaseApp
 import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.HiltAndroidApp
-import io.sentry.Sentry
 import io.sentry.android.core.SentryAndroid
-import io.sentry.protocol.User
 import java.io.File
 import java.util.concurrent.Executors
 import javax.inject.Inject

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -161,14 +161,6 @@ class PocketCastsApplication : Application(), Configuration.Provider {
             options.sampleRate = 0.3
         }
 
-        // Link email to Sentry crash reports only if the user has opted in
-        if (settings.linkCrashReportsToUser.value) {
-            syncManager.getEmail()?.let { syncEmail ->
-                val user = User().apply { email = syncEmail }
-                Sentry.setUser(user)
-            }
-        }
-
         // Setup the Firebase, the documentation says this isn't needed but in production we sometimes get the following error "FirebaseApp is not initialized in this process au.com.shiftyjelly.pocketcasts. Make sure to call FirebaseApp.initializeApp(Context) first."
         FirebaseApp.initializeApp(this)
     }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -42,7 +42,6 @@ import coil.ImageLoader
 import com.google.firebase.FirebaseApp
 import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.HiltAndroidApp
-import io.sentry.android.core.SentryAndroid
 import java.io.File
 import java.util.concurrent.Executors
 import javax.inject.Inject
@@ -155,9 +154,9 @@ class PocketCastsApplication : Application(), Configuration.Provider {
             Thread.setDefaultUncaughtExceptionHandler(LogBufferUncaughtExceptionHandler(it))
         }
 
-        SentryAndroid.init(this) { options ->
-            options.sampleRate = 0.3
-        }
+//        SentryAndroid.init(this) { options ->
+//            options.sampleRate = 0.3
+//        }
 
         // Setup the Firebase, the documentation says this isn't needed but in production we sometimes get the following error "FirebaseApp is not initialized in this process au.com.shiftyjelly.pocketcasts. Make sure to call FirebaseApp.initializeApp(Context) first."
         FirebaseApp.initializeApp(this)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -32,8 +32,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.widget.WidgetManager
 import au.com.shiftyjelly.pocketcasts.shared.AppLifecycleObserver
 import au.com.shiftyjelly.pocketcasts.shared.DownloadStatisticsReporter
 import au.com.shiftyjelly.pocketcasts.ui.helper.AppIcon
-import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
-import au.com.shiftyjelly.pocketcasts.utils.SentryHelper.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBufferUncaughtExceptionHandler
@@ -161,7 +159,6 @@ class PocketCastsApplication : Application(), Configuration.Provider {
 
         SentryAndroid.init(this) { options ->
             options.dsn = if (settings.sendCrashReports.value) settings.getSentryDsn() else ""
-            options.setTag(SentryHelper.GLOBAL_TAG_APP_PLATFORM, AppPlatform.MOBILE.value)
             options.sampleRate = 0.3
         }
 

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -158,7 +158,6 @@ class PocketCastsApplication : Application(), Configuration.Provider {
         }
 
         SentryAndroid.init(this) { options ->
-            options.dsn = if (settings.sendCrashReports.value) settings.getSentryDsn() else ""
             options.sampleRate = 0.3
         }
 

--- a/automotive/build.gradle.kts
+++ b/automotive/build.gradle.kts
@@ -39,13 +39,6 @@ android {
 
         named("release") {
             manifestPlaceholders["appIcon"] = "@mipmap/ic_launcher"
-            val pocketcastsSentryDsn: String by project
-            if (pocketcastsSentryDsn.isNotBlank()) {
-                manifestPlaceholders["sentryDsn"] = pocketcastsSentryDsn
-            }
-            else {
-                println("WARNING: Sentry DSN gradle property 'pocketcastsSentryDsn' not found. Crash reporting won't work without this.")
-            }
 
             proguardFiles.addAll(
                 listOf(

--- a/automotive/build.gradle.kts
+++ b/automotive/build.gradle.kts
@@ -29,7 +29,6 @@ android {
             applicationIdSuffix = ".debug"
 
             manifestPlaceholders["appIcon"] = "@mipmap/ic_launcher_radioactive"
-            manifestPlaceholders["sentryDsn"] = ""
         }
 
         named("debugProd") {

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -80,9 +80,6 @@
         <meta-data
             android:name="pocketcasts_automotive"
             android:value="true" />
-        <meta-data
-            android:name="au.com.shiftyjelly.pocketcasts.sentryDsn"
-            android:value="${sentryDsn}" />
     </application>
 
 </manifest>

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
@@ -26,7 +26,6 @@ import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.HiltAndroidApp
-import io.sentry.android.core.SentryAndroid
 import java.io.File
 import java.util.concurrent.Executors
 import javax.inject.Inject
@@ -65,7 +64,6 @@ class AutomotiveApplication : Application(), Configuration.Provider {
         super.onCreate()
 
         RxJavaUncaughtExceptionHandling.setUp()
-        setupSentry()
         setupLogging()
         setupAnalytics()
         setupApp()
@@ -106,12 +104,6 @@ class AutomotiveApplication : Application(), Configuration.Provider {
     override fun onTerminate() {
         super.onTerminate()
         Log.d(Settings.LOG_TAG_AUTO, "Terminate")
-    }
-
-    private fun setupSentry() {
-        SentryAndroid.init(this) { options ->
-            options.dsn = settings.getSentryDsn()
-        }
     }
 
     private fun setupLogging() {

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
@@ -19,8 +19,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsTask
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
-import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
-import au.com.shiftyjelly.pocketcasts.utils.SentryHelper.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.log.RxJavaUncaughtExceptionHandling
@@ -113,7 +111,6 @@ class AutomotiveApplication : Application(), Configuration.Provider {
     private fun setupSentry() {
         SentryAndroid.init(this) { options ->
             options.dsn = settings.getSentryDsn()
-            options.setTag(SentryHelper.GLOBAL_TAG_APP_PLATFORM, AppPlatform.AUTOMOTIVE.value)
         }
     }
 

--- a/base.gradle
+++ b/base.gradle
@@ -26,7 +26,7 @@ android {
         buildConfigField "String", "SETTINGS_ENCRYPT_SECRET", "\"${project.settingsEncryptSecret}\""
         buildConfigField "String", "SHARING_SERVER_SECRET", "\"${project.sharingServerSecret}\""
         buildConfigField "String", "GOOGLE_SIGN_IN_SERVER_CLIENT_ID", "\"${project.googleSignInServerClientId}\""
-        buildConfigField "String", "SENTRY_DSN", "\"${project.sentryDsn}\""
+        buildConfigField "String", "SENTRY_DSN", "\"${project.pocketcastsSentryDsn}\""
         buildConfigField "String", "BUILD_PLATFORM", "\"${project.buildPlatform}\""
 
         testInstrumentationRunner project.testInstrumentationRunner

--- a/base.gradle
+++ b/base.gradle
@@ -26,6 +26,7 @@ android {
         buildConfigField "String", "SETTINGS_ENCRYPT_SECRET", "\"${project.settingsEncryptSecret}\""
         buildConfigField "String", "SHARING_SERVER_SECRET", "\"${project.sharingServerSecret}\""
         buildConfigField "String", "GOOGLE_SIGN_IN_SERVER_CLIENT_ID", "\"${project.googleSignInServerClientId}\""
+        buildConfigField "String", "SENTRY_DSN", "\"${project.sentryDsn}\""
         buildConfigField "String", "BUILD_PLATFORM", "\"${project.buildPlatform}\""
 
         testInstrumentationRunner project.testInstrumentationRunner

--- a/base.gradle
+++ b/base.gradle
@@ -26,6 +26,7 @@ android {
         buildConfigField "String", "SETTINGS_ENCRYPT_SECRET", "\"${project.settingsEncryptSecret}\""
         buildConfigField "String", "SHARING_SERVER_SECRET", "\"${project.sharingServerSecret}\""
         buildConfigField "String", "GOOGLE_SIGN_IN_SERVER_CLIENT_ID", "\"${project.googleSignInServerClientId}\""
+        buildConfigField "String", "BUILD_PLATFORM", "\"${project.buildPlatform}\""
 
         testInstrumentationRunner project.testInstrumentationRunner
         testApplicationId "au.com.shiftyjelly.pocketcasts.test" + project.name.replace("-", "_")

--- a/dependencies.gradle.kts
+++ b/dependencies.gradle.kts
@@ -98,6 +98,7 @@ project.apply {
         set("sharingServerSecret", secretProperties.getProperty("pocketcastsSharingServerSecret", ""))
         set("pocketcastsSentryDsn", secretProperties.getProperty("pocketcastsSentryDsn", ""))
         set("googleSignInServerClientId", secretProperties.getProperty("googleSignInServerClientId", ""))
+        set("sentryDsn", secretProperties.getProperty("pocketcastsSentryDsn", ""))
         set("measureBuildsEnabled", secretProperties.getProperty("measureBuildsEnabled", ""))
         set("appsMetricsToken", secretProperties.getProperty("appsMetricsToken", ""))
     }

--- a/dependencies.gradle.kts
+++ b/dependencies.gradle.kts
@@ -98,7 +98,6 @@ project.apply {
         set("sharingServerSecret", secretProperties.getProperty("pocketcastsSharingServerSecret", ""))
         set("pocketcastsSentryDsn", secretProperties.getProperty("pocketcastsSentryDsn", ""))
         set("googleSignInServerClientId", secretProperties.getProperty("googleSignInServerClientId", ""))
-        set("sentryDsn", secretProperties.getProperty("pocketcastsSentryDsn", ""))
         set("measureBuildsEnabled", secretProperties.getProperty("measureBuildsEnabled", ""))
         set("appsMetricsToken", secretProperties.getProperty("appsMetricsToken", ""))
     }

--- a/dependencies.gradle.kts
+++ b/dependencies.gradle.kts
@@ -43,6 +43,13 @@ val getVersionName = {
         else -> versionName
     }
 }
+val getBuildPlatform = {
+    when {
+        isAutomotiveBuild -> "automotive"
+        isWearBuild -> "wear"
+        else -> "mobile"
+    }
+}
 
 project.apply {
     extra.apply {
@@ -51,6 +58,7 @@ project.apply {
 
         set("versionName", getVersionName())
         set("versionCode", getVersionCode())
+        set("buildPlatform", getBuildPlatform())
 
         // Android
         set("minSdkVersion", 23)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ sentry = "6.28.0"
 sentry-plugin = "3.10.0"
 showkase = "1.0.2"
 test = "1.5.0"
+tracks = "5.0.0"
 wear-compose = "1.3.0"
 work = "2.8.1"
 java = "17"
@@ -222,6 +223,10 @@ test-core = { module = "androidx.test:core", version.ref = "test" }
 test-rules = { module = "androidx.test:rules", version.ref = "test" }
 test-runner = { module = "androidx.test:runner", version.ref = "test" }
 
+# Tracks
+tracks = { module = "com.automattic:Automattic-Tracks-Android", version.ref = "tracks" }
+crashlogging = { module = "com.automattic.tracks:crashlogging", version.ref = "tracks" }
+
 # Wear Compose
 wear-compose-material = { module = "androidx.wear.compose:compose-material", version.ref = "wear-compose" }
 wear-compose-foundation = { module = "androidx.wear.compose:compose-foundation", version.ref = "wear-compose" }
@@ -239,7 +244,6 @@ annotation = "androidx.annotation:annotation:1.3.0"
 appcompat = "androidx.appcompat:appcompat:1.5.0"
 arch-core = "androidx.arch.core:core-testing:2.2.0"
 auth = "com.google.android.gms:play-services-auth:20.4.0"
-automattic-tracks = "com.automattic:Automattic-Tracks-Android:trunk-b3655d42123501a1d9a304789b738610ab4403c8"
 barista = "com.adevinta.android:barista:4.2.0"
 browser = "androidx.browser:browser:1.4.0"
 browser-helper = "com.google.androidbrowserhelper:androidbrowserhelper:2.3.0"

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
@@ -7,7 +7,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.sentry.Sentry
-import io.sentry.android.core.SentryAndroid
 import io.sentry.protocol.User
 import javax.inject.Inject
 
@@ -29,11 +28,6 @@ class UserAnalyticsSettings @Inject constructor(
     }
 
     fun updateCrashReportsSetting(enabled: Boolean) {
-        if (enabled) {
-            SentryAndroid.init(context) { it.dsn = settings.getSentryDsn() }
-        } else {
-            SentryAndroid.init(context) { it.dsn = "" }
-        }
         settings.sendCrashReports.set(enabled, updateModifiedAt = true)
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
@@ -32,9 +32,6 @@ class UserAnalyticsSettings @Inject constructor(
     }
 
     fun updateLinkAccountSetting(enabled: Boolean) {
-        val user = if (enabled) User().apply { email = syncManager.getEmail() } else null
-        Sentry.setUser(user)
-
         settings.linkCrashReportsToUser.set(enabled, updateModifiedAt = true)
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
@@ -6,8 +6,6 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import dagger.hilt.android.qualifiers.ApplicationContext
-import io.sentry.Sentry
-import io.sentry.protocol.User
 import javax.inject.Inject
 
 class UserAnalyticsSettings @Inject constructor(

--- a/modules/services/analytics/build.gradle.kts
+++ b/modules/services/analytics/build.gradle.kts
@@ -16,7 +16,7 @@ android {
 }
 
 dependencies {
-    implementation(libs.automattic.tracks)
+    implementation(libs.tracks)
     implementation(project(":modules:services:utils"))
     implementation(project(":modules:services:preferences"))
     implementation(project(":modules:services:model"))

--- a/modules/services/crashlogging/build.gradle.kts
+++ b/modules/services/crashlogging/build.gradle.kts
@@ -16,5 +16,6 @@ android {
 
 dependencies {
     implementation(project(":modules:services:utils")) //temporarily
+    implementation(project(":modules:services:preferences"))
     implementation("com.automattic.tracks:crashlogging:5.0.0")
 }

--- a/modules/services/crashlogging/build.gradle.kts
+++ b/modules/services/crashlogging/build.gradle.kts
@@ -15,7 +15,6 @@ android {
 }
 
 dependencies {
-    implementation(project(":modules:services:utils")) //temporarily
     implementation(project(":modules:services:analytics"))
     implementation(project(":modules:services:preferences"))
     implementation(project(":modules:services:repositories"))

--- a/modules/services/crashlogging/build.gradle.kts
+++ b/modules/services/crashlogging/build.gradle.kts
@@ -16,6 +16,9 @@ android {
 
 dependencies {
     implementation(project(":modules:services:utils")) //temporarily
+    implementation(project(":modules:services:analytics"))
     implementation(project(":modules:services:preferences"))
+    implementation(project(":modules:services:repositories"))
+    implementation(project(":modules:services:servers"))
     implementation("com.automattic.tracks:crashlogging:5.0.0")
 }

--- a/modules/services/crashlogging/build.gradle.kts
+++ b/modules/services/crashlogging/build.gradle.kts
@@ -19,5 +19,5 @@ dependencies {
     implementation(project(":modules:services:preferences"))
     implementation(project(":modules:services:repositories"))
     implementation(project(":modules:services:servers"))
-    implementation("com.automattic.tracks:crashlogging:5.0.0")
+    implementation(libs.crashlogging)
 }

--- a/modules/services/crashlogging/build.gradle.kts
+++ b/modules/services/crashlogging/build.gradle.kts
@@ -3,16 +3,18 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
-    alias(libs.plugins.kotlin.parcelize)
 }
 
 apply(from = "${project.rootDir}/base.gradle")
 
-// utils should have no other module dependencies
-
 android {
-    namespace = "au.com.shiftyjelly.pocketcasts.helper"
+    namespace = "au.com.shiftyjelly.pocketcasts.crashlogging"
     buildFeatures {
         buildConfig = true
     }
+}
+
+dependencies {
+    implementation(project(":modules:services:utils")) //temporarily
+    implementation("com.automattic.tracks:crashlogging:5.0.0")
 }

--- a/modules/services/crashlogging/src/main/java/au/com/shiftyjelly/pocketcasts/crashlogging/PocketCastsCrashLoggingDataProvider.kt
+++ b/modules/services/crashlogging/src/main/java/au/com/shiftyjelly/pocketcasts/crashlogging/PocketCastsCrashLoggingDataProvider.kt
@@ -36,7 +36,7 @@ class PocketCastsCrashLoggingDataProvider @Inject constructor(
 
     override val releaseName = ReleaseName.SetByTracksLibrary
 
-    override val sentryDSN: String = settings.getSentryDsn()
+    override val sentryDSN: String = BuildConfig.SENTRY_DSN
 
     override val user: Flow<CrashLoggingUser?> = settings.linkCrashReportsToUser.flow.map { linkCrashReportsToUser ->
         if (linkCrashReportsToUser) {

--- a/modules/services/crashlogging/src/main/java/au/com/shiftyjelly/pocketcasts/crashlogging/PocketCastsCrashLoggingDataProvider.kt
+++ b/modules/services/crashlogging/src/main/java/au/com/shiftyjelly/pocketcasts/crashlogging/PocketCastsCrashLoggingDataProvider.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.crashlogging
 
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
-import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import com.automattic.android.tracks.crashlogging.CrashLoggingDataProvider
 import com.automattic.android.tracks.crashlogging.CrashLoggingUser
 import com.automattic.android.tracks.crashlogging.EventLevel
@@ -22,7 +21,7 @@ class PocketCastsCrashLoggingDataProvider @Inject constructor(
 
     override val applicationContextProvider: Flow<Map<String, String>> = flowOf(
         mapOf(
-            SentryHelper.GLOBAL_TAG_APP_PLATFORM to BuildConfig.BUILD_PLATFORM,
+            GLOBAL_TAG_APP_PLATFORM to BuildConfig.BUILD_PLATFORM,
         ),
     )
 
@@ -69,5 +68,9 @@ class PocketCastsCrashLoggingDataProvider @Inject constructor(
 
     override fun shouldDropWrappingException(module: String, type: String, value: String): Boolean {
         return false
+    }
+
+    companion object {
+        const val GLOBAL_TAG_APP_PLATFORM = "app.platform"
     }
 }

--- a/modules/services/crashlogging/src/main/java/au/com/shiftyjelly/pocketcasts/crashlogging/PocketCastsCrashLoggingDataProvider.kt
+++ b/modules/services/crashlogging/src/main/java/au/com/shiftyjelly/pocketcasts/crashlogging/PocketCastsCrashLoggingDataProvider.kt
@@ -1,6 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.crashlogging
 
-import au.com.shiftyjelly.pocketcasts.crashlogging.BuildConfig
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import com.automattic.android.tracks.crashlogging.CrashLoggingDataProvider
 import com.automattic.android.tracks.crashlogging.CrashLoggingUser
@@ -13,7 +13,9 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
-class PocketCastsCrashLoggingDataProvider @Inject constructor() : CrashLoggingDataProvider {
+class PocketCastsCrashLoggingDataProvider @Inject constructor(
+    private val settings: Settings
+) : CrashLoggingDataProvider {
 
     override val applicationContextProvider: Flow<Map<String, String>> = flowOf(
         mapOf(
@@ -31,13 +33,13 @@ class PocketCastsCrashLoggingDataProvider @Inject constructor() : CrashLoggingDa
 
     override val releaseName = ReleaseName.SetByTracksLibrary
 
-    override val sentryDSN: String
-        get() = TODO("Not yet implemented")
+    override val sentryDSN: String = settings.getSentryDsn()
+
     override val user: Flow<CrashLoggingUser?>
         get() = TODO("Not yet implemented")
 
     override fun crashLoggingEnabled(): Boolean {
-        TODO("Not yet implemented")
+        return settings.sendCrashReports.value
     }
 
     override fun extraKnownKeys(): List<ExtraKnownKey> {

--- a/modules/services/crashlogging/src/main/java/au/com/shiftyjelly/pocketcasts/crashlogging/PocketCastsCrashLoggingDataProvider.kt
+++ b/modules/services/crashlogging/src/main/java/au/com/shiftyjelly/pocketcasts/crashlogging/PocketCastsCrashLoggingDataProvider.kt
@@ -57,17 +57,17 @@ class PocketCastsCrashLoggingDataProvider @Inject constructor(
     }
 
     override fun extraKnownKeys(): List<ExtraKnownKey> {
-        TODO("Not yet implemented")
+        return emptyList()
     }
 
     override fun provideExtrasForEvent(
         currentExtras: Map<ExtraKnownKey, String>,
         eventLevel: EventLevel,
     ): Map<ExtraKnownKey, String> {
-        TODO("Not yet implemented")
+        return emptyMap()
     }
 
     override fun shouldDropWrappingException(module: String, type: String, value: String): Boolean {
-        TODO("Not yet implemented")
+        return false
     }
 }

--- a/modules/services/crashlogging/src/main/java/au/com/shiftyjelly/pocketcasts/crashlogging/PocketCastsCrashLoggingDataProvider.kt
+++ b/modules/services/crashlogging/src/main/java/au/com/shiftyjelly/pocketcasts/crashlogging/PocketCastsCrashLoggingDataProvider.kt
@@ -1,6 +1,6 @@
-package au.com.shiftyjelly.pocketcasts.utils.crashlogging
+package au.com.shiftyjelly.pocketcasts.crashlogging
 
-import au.com.shiftyjelly.pocketcasts.helper.BuildConfig
+import au.com.shiftyjelly.pocketcasts.crashlogging.BuildConfig
 import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import com.automattic.android.tracks.crashlogging.CrashLoggingDataProvider
 import com.automattic.android.tracks.crashlogging.CrashLoggingUser

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -265,8 +265,6 @@ interface Settings {
     fun getVersion(): String
     fun getVersionCode(): Int
 
-    fun getSentryDsn(): String
-
     val skipForwardInSecs: UserSetting<Int>
     val skipBackInSecs: UserSetting<Int>
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -125,20 +125,6 @@ class SettingsImpl @Inject constructor(
         return BuildConfig.VERSION_CODE
     }
 
-    override fun getSentryDsn(): String {
-        return try {
-            val applicationInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                context.packageManager.getApplicationInfo(context.packageName, PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA.toLong()))
-            } else {
-                @Suppress("DEPRECATION")
-                context.packageManager.getApplicationInfo(context.packageName, PackageManager.GET_META_DATA)
-            }
-            applicationInfo.metaData.getString("au.com.shiftyjelly.pocketcasts.sentryDsn", "")
-        } catch (e: NameNotFoundException) {
-            ""
-        }
-    }
-
     override val skipBackInSecs = UserSetting.SkipAmountPref(
         sharedPrefKey = Settings.PREFERENCE_SKIP_BACKWARD,
         defaultValue = 10,

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -3,8 +3,6 @@ package au.com.shiftyjelly.pocketcasts.preferences
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
-import android.content.pm.PackageManager
-import android.content.pm.PackageManager.NameNotFoundException
 import android.os.Build
 import android.util.Base64
 import androidx.core.content.edit

--- a/modules/services/utils/build.gradle.kts
+++ b/modules/services/utils/build.gradle.kts
@@ -16,3 +16,7 @@ android {
         buildConfig = true
     }
 }
+
+dependencies {
+    implementation("com.automattic.tracks:crashlogging:5.0.0")
+}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SentryHelper.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SentryHelper.kt
@@ -6,7 +6,6 @@ import java.util.concurrent.CancellationException
 import javax.net.ssl.SSLException
 
 object SentryHelper {
-    const val GLOBAL_TAG_APP_PLATFORM = "app.platform"
 
     fun recordException(throwable: Throwable) {
         if (shouldIgnoreExceptions(throwable)) {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SentryHelper.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SentryHelper.kt
@@ -45,10 +45,4 @@ object SentryHelper {
                 throwable is SSLException
             )
     }
-
-    enum class AppPlatform(val value: String) {
-        MOBILE("mobile"),
-        AUTOMOTIVE("automotive"),
-        WEAR("wear"),
-    }
 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/crashlogging/PocketCastsCrashLoggingDataProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/crashlogging/PocketCastsCrashLoggingDataProvider.kt
@@ -25,8 +25,8 @@ class PocketCastsCrashLoggingDataProvider @Inject constructor() : CrashLoggingDa
 
     override val enableCrashLoggingLogs: Boolean = false
 
-    override val locale: Locale?
-        get() = TODO("Not yet implemented")
+    override val locale: Locale = Locale.getDefault()
+
     override val performanceMonitoringConfig: PerformanceMonitoringConfig
         get() = TODO("Not yet implemented")
     override val releaseName: ReleaseName

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/crashlogging/PocketCastsCrashLoggingDataProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/crashlogging/PocketCastsCrashLoggingDataProvider.kt
@@ -22,9 +22,9 @@ class PocketCastsCrashLoggingDataProvider @Inject constructor() : CrashLoggingDa
     )
 
     override val buildType: String = BuildConfig.BUILD_TYPE
-    
-    override val enableCrashLoggingLogs: Boolean
-        get() = TODO("Not yet implemented")
+
+    override val enableCrashLoggingLogs: Boolean = false
+
     override val locale: Locale?
         get() = TODO("Not yet implemented")
     override val performanceMonitoringConfig: PerformanceMonitoringConfig

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/crashlogging/PocketCastsCrashLoggingDataProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/crashlogging/PocketCastsCrashLoggingDataProvider.kt
@@ -21,8 +21,8 @@ class PocketCastsCrashLoggingDataProvider @Inject constructor() : CrashLoggingDa
         ),
     )
 
-    override val buildType: String
-        get() = TODO("Not yet implemented")
+    override val buildType: String = BuildConfig.BUILD_TYPE
+    
     override val enableCrashLoggingLogs: Boolean
         get() = TODO("Not yet implemented")
     override val locale: Locale?

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/crashlogging/PocketCastsCrashLoggingDataProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/crashlogging/PocketCastsCrashLoggingDataProvider.kt
@@ -29,8 +29,8 @@ class PocketCastsCrashLoggingDataProvider @Inject constructor() : CrashLoggingDa
 
     override val performanceMonitoringConfig = PerformanceMonitoringConfig.Disabled
 
-    override val releaseName: ReleaseName
-        get() = TODO("Not yet implemented")
+    override val releaseName = ReleaseName.SetByTracksLibrary
+
     override val sentryDSN: String
         get() = TODO("Not yet implemented")
     override val user: Flow<CrashLoggingUser?>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/crashlogging/PocketCastsCrashLoggingDataProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/crashlogging/PocketCastsCrashLoggingDataProvider.kt
@@ -1,0 +1,57 @@
+package au.com.shiftyjelly.pocketcasts.utils.crashlogging
+
+import au.com.shiftyjelly.pocketcasts.helper.BuildConfig
+import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
+import com.automattic.android.tracks.crashlogging.CrashLoggingDataProvider
+import com.automattic.android.tracks.crashlogging.CrashLoggingUser
+import com.automattic.android.tracks.crashlogging.EventLevel
+import com.automattic.android.tracks.crashlogging.ExtraKnownKey
+import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig
+import com.automattic.android.tracks.crashlogging.ReleaseName
+import java.util.Locale
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class PocketCastsCrashLoggingDataProvider @Inject constructor() : CrashLoggingDataProvider {
+
+    override val applicationContextProvider: Flow<Map<String, String>> = flowOf(
+        mapOf(
+            SentryHelper.GLOBAL_TAG_APP_PLATFORM to BuildConfig.BUILD_PLATFORM,
+        ),
+    )
+
+    override val buildType: String
+        get() = TODO("Not yet implemented")
+    override val enableCrashLoggingLogs: Boolean
+        get() = TODO("Not yet implemented")
+    override val locale: Locale?
+        get() = TODO("Not yet implemented")
+    override val performanceMonitoringConfig: PerformanceMonitoringConfig
+        get() = TODO("Not yet implemented")
+    override val releaseName: ReleaseName
+        get() = TODO("Not yet implemented")
+    override val sentryDSN: String
+        get() = TODO("Not yet implemented")
+    override val user: Flow<CrashLoggingUser?>
+        get() = TODO("Not yet implemented")
+
+    override fun crashLoggingEnabled(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun extraKnownKeys(): List<ExtraKnownKey> {
+        TODO("Not yet implemented")
+    }
+
+    override fun provideExtrasForEvent(
+        currentExtras: Map<ExtraKnownKey, String>,
+        eventLevel: EventLevel,
+    ): Map<ExtraKnownKey, String> {
+        TODO("Not yet implemented")
+    }
+
+    override fun shouldDropWrappingException(module: String, type: String, value: String): Boolean {
+        TODO("Not yet implemented")
+    }
+}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/crashlogging/PocketCastsCrashLoggingDataProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/crashlogging/PocketCastsCrashLoggingDataProvider.kt
@@ -27,8 +27,8 @@ class PocketCastsCrashLoggingDataProvider @Inject constructor() : CrashLoggingDa
 
     override val locale: Locale = Locale.getDefault()
 
-    override val performanceMonitoringConfig: PerformanceMonitoringConfig
-        get() = TODO("Not yet implemented")
+    override val performanceMonitoringConfig = PerformanceMonitoringConfig.Disabled
+
     override val releaseName: ReleaseName
         get() = TODO("Not yet implemented")
     override val sentryDSN: String

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -57,6 +57,7 @@ include(":modules:features:widgets")
 // services
 include(":modules:services:analytics")
 include(":modules:services:compose")
+include(":modules:services:crashlogging")
 include(":modules:services:images")
 include(":modules:services:localization")
 include(":modules:services:model")

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -26,7 +26,6 @@ android {
             applicationIdSuffix = ".debug"
 
             manifestPlaceholders["appIcon"] = "@mipmap/ic_launcher_radioactive"
-            manifestPlaceholders["sentryDsn"] = ""
         }
 
         named("debugProd") {

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -35,13 +35,6 @@ android {
 
         named("release") {
             manifestPlaceholders["appIcon"] = "@mipmap/ic_launcher"
-            val pocketcastsSentryDsn: String by project
-            if (pocketcastsSentryDsn.isNotBlank()) {
-                manifestPlaceholders["sentryDsn"] = pocketcastsSentryDsn
-            }
-            else {
-                println("WARNING: Sentry DSN gradle property 'pocketcastsSentryDsn' not found. Crash reporting won't work without this.")
-            }
 
             if (!file("${project.rootDir}/sentry.properties").exists()) {
                 println("WARNING: Sentry configuration file 'sentry.properties' not found. The ProGuard mapping files won't be uploaded.")

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -39,10 +39,6 @@
             android:name="pocketcasts_wear_os"
             android:value="true" />
 
-        <meta-data
-            android:name="au.com.shiftyjelly.pocketcasts.sentryDsn"
-            android:value="${sentryDsn}" />
-
         <activity
             android:name=".wear.MainActivity"
             android:exported="true">

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -28,7 +28,6 @@ import com.google.firebase.FirebaseApp
 import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.HiltAndroidApp
 import io.sentry.Sentry
-import io.sentry.android.core.SentryAndroid
 import io.sentry.protocol.User
 import java.io.File
 import java.util.concurrent.Executors
@@ -79,10 +78,6 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
     }
 
     private fun setupSentry() {
-        SentryAndroid.init(this) { options ->
-            options.dsn = if (settings.sendCrashReports.value) settings.getSentryDsn() else ""
-        }
-
         // Link email to Sentry crash reports only if the user has opted in
         if (settings.linkCrashReportsToUser.value) {
             syncManager.getEmail()?.let { syncEmail ->

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -27,8 +27,6 @@ import au.com.shiftyjelly.pocketcasts.utils.log.RxJavaUncaughtExceptionHandling
 import com.google.firebase.FirebaseApp
 import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.HiltAndroidApp
-import io.sentry.Sentry
-import io.sentry.protocol.User
 import java.io.File
 import java.util.concurrent.Executors
 import javax.inject.Inject

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -21,8 +21,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.shared.AppLifecycleObserver
 import au.com.shiftyjelly.pocketcasts.shared.DownloadStatisticsReporter
-import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
-import au.com.shiftyjelly.pocketcasts.utils.SentryHelper.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.log.RxJavaUncaughtExceptionHandling
@@ -83,7 +81,6 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
     private fun setupSentry() {
         SentryAndroid.init(this) { options ->
             options.dsn = if (settings.sendCrashReports.value) settings.getSentryDsn() else ""
-            options.setTag(SentryHelper.GLOBAL_TAG_APP_PLATFORM, AppPlatform.WEAR.value)
         }
 
         // Link email to Sentry crash reports only if the user has opted in

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -78,14 +78,6 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
     }
 
     private fun setupSentry() {
-        // Link email to Sentry crash reports only if the user has opted in
-        if (settings.linkCrashReportsToUser.value) {
-            syncManager.getEmail()?.let { syncEmail ->
-                val user = User().apply { email = syncEmail }
-                Sentry.setUser(user)
-            }
-        }
-
         // Setup the Firebase, the documentation says this isn't needed but in production we sometimes get the following error "FirebaseApp is not initialized in this process au.com.shiftyjelly.pocketcasts. Make sure to call FirebaseApp.initializeApp(Context) first."
         FirebaseApp.initializeApp(this)
     }


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR introduces a new module, `crashlogging`, and "feeds" `PocketCastsCrashLoggingDataProvider` with data needed to initialize and operate `CrashLogging` object later. 

> [!NOTE]
> Note: This is a PR aiming at a feature branch.

To see more context on the changes, please see commits messages - I've tried to explain my reasoning and arguments there.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->
Not needed - we'll test the integration later.


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
