### PR TITLE
Sleep Timer: Update custom time row label

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
@@ -66,7 +66,7 @@ class SleepFragment : BaseDialogFragment() {
 
         binding.buttonMins15.setOnClickListener { startTimer(mins = 15) }
         binding.buttonMins30.setOnClickListener { startTimer(mins = 30) }
-        binding.buttonMins60.setOnClickListener { startTimer(mins = 60) }
+        binding.buttonOneHour.setOnClickListener { startTimer(mins = 60) }
         binding.customMinusButton.setOnClickListener { minusButtonClicked() }
         binding.endOfEpisodeMinusButton.setOnClickListener { minusEndOfEpisodeButtonClicked() }
         binding.endOfChapterMinusButton.setOnClickListener { minusEndOfChapterButtonClicked() }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
@@ -177,19 +177,19 @@ class SleepFragment : BaseDialogFragment() {
     }
 
     private fun startCustomTimer() {
-        viewModel.sleepTimerAfter(mins = viewModel.sleepCustomTimeMins)
-        binding?.root?.announceForAccessibility("Sleep timer set for ${viewModel.sleepCustomTimeMins} minutes")
-        analyticsTracker.track(AnalyticsEvent.PLAYER_SLEEP_TIMER_ENABLED, mapOf(TIME_KEY to TimeUnit.MILLISECONDS.toSeconds(viewModel.sleepCustomTimeMins.minutes())))
+        viewModel.sleepTimerAfter(mins = viewModel.sleepCustomTimeInMinutes)
+        binding?.root?.announceForAccessibility("Sleep timer set for ${viewModel.sleepCustomTimeInMinutes} minutes")
+        analyticsTracker.track(AnalyticsEvent.PLAYER_SLEEP_TIMER_ENABLED, mapOf(TIME_KEY to TimeUnit.MILLISECONDS.toSeconds(viewModel.sleepCustomTimeInMinutes.minutes())))
         close()
     }
 
     private fun plusButtonClicked() {
-        if (viewModel.sleepCustomTimeMins < 5) {
-            viewModel.sleepCustomTimeMins += 1
+        if (viewModel.sleepCustomTimeInMinutes < 5) {
+            viewModel.sleepCustomTimeInMinutes += 1
         } else {
-            viewModel.sleepCustomTimeMins += 5
+            viewModel.sleepCustomTimeInMinutes += 5
         }
-        binding?.root?.announceForAccessibility("Custom sleep time ${viewModel.sleepCustomTimeMins}")
+        binding?.root?.announceForAccessibility("Custom sleep time ${viewModel.sleepCustomTimeInMinutes}")
     }
 
     private fun plusEndOfEpisodeButtonClicked() {
@@ -203,12 +203,12 @@ class SleepFragment : BaseDialogFragment() {
     }
 
     private fun minusButtonClicked() {
-        if (viewModel.sleepCustomTimeMins <= 5) {
-            viewModel.sleepCustomTimeMins -= 1
+        if (viewModel.sleepCustomTimeInMinutes <= 5) {
+            viewModel.sleepCustomTimeInMinutes -= 1
         } else {
-            viewModel.sleepCustomTimeMins -= 5
+            viewModel.sleepCustomTimeInMinutes -= 5
         }
-        binding?.root?.announceForAccessibility("Custom sleep time ${viewModel.sleepCustomTimeMins}")
+        binding?.root?.announceForAccessibility("Custom sleep time ${viewModel.sleepCustomTimeInMinutes}")
     }
 
     private fun minusEndOfEpisodeButtonClicked() {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -542,6 +542,8 @@ class PlayerViewModel @Inject constructor(
 
         return if (hours == 1 && minutes == 0) {
             context.resources.getString(LR.string.hours_singular)
+        } else if (hours == 1 && minutes > 0) {
+            context.resources.getString(LR.string.hour_and_minutes, minutes)
         } else if (hours > 1 && minutes == 0) {
             context.resources.getString(LR.string.hours_plural, hours)
         } else if (hours > 0) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -284,7 +284,7 @@ class PlayerViewModel @Inject constructor(
     val sleepingInText = MutableLiveData<String>().apply {
         postValue(calcSleepingInEpisodesText())
     }
-    var sleepCustomTimeMins: Int = 5
+    var sleepCustomTimeInMinutes: Int = 5
         set(value) {
             field = value.coerceIn(1, 240)
             settings.setSleepTimerCustomMins(field)
@@ -537,7 +537,20 @@ class PlayerViewModel @Inject constructor(
     }
 
     private fun calcCustomTimeText(): String {
-        return context.resources.getString(LR.string.minutes_plural, sleepCustomTimeMins)
+        val hours = sleepCustomTimeInMinutes / 60
+        val minutes = sleepCustomTimeInMinutes % 60
+
+        return if (hours == 1 && minutes == 0) {
+            context.resources.getString(LR.string.hours_singular)
+        } else if (hours > 1 && minutes == 0) {
+            context.resources.getString(LR.string.hours_plural, hours)
+        } else if (hours > 0) {
+            context.resources.getString(LR.string.hours_and_minutes, hours, minutes)
+        } else if (hours == 0 && minutes == 1) {
+            context.resources.getString(LR.string.minutes_singular)
+        } else {
+            context.resources.getString(LR.string.minutes_plural, sleepCustomTimeInMinutes)
+        }
     }
 
     private fun calcEndOfEpisodeText(): String {

--- a/modules/features/player/src/main/res/layout/fragment_sleep.xml
+++ b/modules/features/player/src/main/res/layout/fragment_sleep.xml
@@ -16,7 +16,7 @@
             android:id="@+id/sleepSetup"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:constraint_referenced_ids="sleepTitle,labelMins15,buttonMins15,separator1,labelMins30,buttonMins30,separator2,labelMins60,buttonMins60,separator3,labelCustom,buttonCustom,customMinusButton,customPlusButton, separator5, labelEndOfEpisode, buttonEndOfEpisode, endOfEpisodeMinusButton, endOfEpisodePlusButton, separator4, labelEndOfChapter, buttonEndOfChapter, endOfChapterPlusButton, endOfChapterMinusButton"
+            app:constraint_referenced_ids="sleepTitle,labelMins15,buttonMins15,separator1,labelMins30,buttonMins30,separator2,labelOneHour,buttonOneHour,separator3,labelCustom,buttonCustom,customMinusButton,customPlusButton, separator5, labelEndOfEpisode, buttonEndOfEpisode, endOfEpisodeMinusButton, endOfEpisodePlusButton, separator4, labelEndOfChapter, buttonEndOfChapter, endOfChapterPlusButton, endOfChapterMinusButton"
             tools:ignore="MissingConstraints" />
 
         <androidx.constraintlayout.widget.Group
@@ -133,30 +133,30 @@
             app:layout_constraintTop_toBottomOf="@+id/labelMins30" />
 
         <TextView
-            android:id="@+id/labelMins60"
+            android:id="@+id/labelOneHour"
             style="@style/DarkSubtitle1"
             android:layout_width="wrap_content"
             android:layout_height="64dp"
             android:layout_marginStart="32dp"
             android:gravity="center_vertical"
             android:importantForAccessibility="no"
-            android:text="@string/player_sleep_60_minutes"
+            android:text="@string/hours_singular"
             android:textColor="?attr/player_contrast_01"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/separator2" />
 
         <View
-            android:id="@+id/buttonMins60"
+            android:id="@+id/buttonOneHour"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:background="?attr/selectableItemBackground"
             android:clickable="true"
-            android:contentDescription="@string/player_sleep_60_minutes"
+            android:contentDescription="@string/hours_singular"
             android:focusable="true"
-            app:layout_constraintBottom_toBottomOf="@+id/labelMins60"
+            app:layout_constraintBottom_toBottomOf="@+id/labelOneHour"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@+id/labelMins60" />
+            app:layout_constraintTop_toTopOf="@+id/labelOneHour" />
 
         <View
             android:id="@+id/separator3"
@@ -165,7 +165,7 @@
             android:background="?attr/player_contrast_05"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/buttonMins60" />
+            app:layout_constraintTop_toBottomOf="@+id/buttonOneHour" />
 
         <TextView
             android:id="@+id/labelCustom"

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -185,6 +185,7 @@
     <string name="hours_singular">1 hour</string>
     <string name="hours_plural">%d hours</string>
     <string name="hours_and_minutes">%d hours and %d minutes</string>
+    <string name="hour_and_minutes">1 hour and %d minutes</string>
     <string name="days_singular">1 day</string>
     <string name="days_plural">%d days</string>
     <string name="months_singular">1 month</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -184,6 +184,7 @@
     <string name="minutes_short_plural">%d mins</string>
     <string name="hours_singular">1 hour</string>
     <string name="hours_plural">%d hours</string>
+    <string name="hours_and_minutes">%d hours and %d minutes</string>
     <string name="days_singular">1 day</string>
     <string name="days_plural">%d days</string>
     <string name="months_singular">1 month</string>


### PR DESCRIPTION
## Description
- This updates the custom time row label to format the time to hours and minutes instead of minutes
- This is to match the iOS behavior. See internal slack reference: `pocket-casts-sleep-timer-p1714744437357789?thread_ts=1714737001.530139&cid=C071416NWE9`


## Testing Instructions
1. Play an episode
2. Open Sleep timer
3. Click on Custom minute as you can see in the video below
4. ✅ Ensure the label is formatted as 1 minute, x minutes, 1 hour, x hours or x hours and y minutes

Feel free to smoke the sleep timer custom time

## Screenshots or Screencast 
[Screen_recording_20240503_120704.webm](https://github.com/Automattic/pocket-casts-android/assets/42220351/00284181-b30e-4fa0-910c-d222bbcf6cda)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
