### PR TITLE
Dispatch refresh state when refresh task is throttled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.64
 -----
-
+*   Bug Fixes
+    *   Fix pull to refresh icon sometimes being stuck in a loading state
+        ([#2164](https://github.com/Automattic/pocket-casts-android/pull/2164))
 
 7.63
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsTask.kt
@@ -103,9 +103,6 @@ class RefreshPodcastsTask @AssistedInject constructor(
                     applicationScope = applicationScope,
                     runNow = true,
                 )
-                if (!refreshThread.isAllowedToRun(runNow = true)) {
-                    return@withContext
-                }
                 refreshJob = async { refreshThread.run() }
             }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -275,7 +275,7 @@ class RefreshPodcastsThread(
 
     private fun dispatchCurrentRefreshedState() {
         val settings = getEntryPoint().settings()
-        (settings.getLastSuccessRefreshState() ?: RefreshState.Never).let(settings::setRefreshState)
+        settings.setRefreshState(settings.getLastSuccessRefreshState() ?: RefreshState.Never)
     }
 
     private fun updatePodcasts(result: RefreshResponse?): List<String> {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -55,6 +55,8 @@ import dagger.hilt.EntryPoints
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import java.util.Date
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 import timber.log.Timber
@@ -92,7 +94,7 @@ class RefreshPodcastsThread(
     @Volatile
     private var taskHasBeenCancelled = false
 
-    fun isAllowedToRun(runNow: Boolean = false): Boolean {
+    private fun isAllowedToRun(runNow: Boolean = false): Boolean {
         val now = System.currentTimeMillis()
         return now > lastRefreshAllowedTime + if (runNow) THROTTLE_RUN_NOW_MS else THROTTLE_PERIODIC_MS
     }
@@ -128,6 +130,7 @@ class RefreshPodcastsThread(
                 } catch (e: InterruptedException) {
                 }
 
+                dispatchCurrentRefreshedState()
                 return ListenableWorker.Result.success()
             }
             lastRefreshAllowedTime = System.currentTimeMillis()
@@ -270,6 +273,11 @@ class RefreshPodcastsThread(
         getEntryPoint().settings().setRefreshState(RefreshState.Failed(message))
     }
 
+    private fun dispatchCurrentRefreshedState() {
+        val settings = getEntryPoint().settings()
+        (settings.getLastSuccessRefreshState() ?: RefreshState.Never).let(settings::setRefreshState)
+    }
+
     private fun updatePodcasts(result: RefreshResponse?): List<String> {
         if (result == null) {
             return emptyList()
@@ -364,8 +372,8 @@ class RefreshPodcastsThread(
 
         private const val GROUP_NEW_EPISODES = "group_new_episodes"
 
-        private val THROTTLE_RUN_NOW_MS: Long = if (BuildConfig.DEBUG) 0 else 15000 // 15 seconds
-        private val THROTTLE_PERIODIC_MS: Long = if (BuildConfig.DEBUG) 0 else 5L * 60L * 1000L // 5 minutes
+        private val THROTTLE_RUN_NOW_MS: Long = if (BuildConfig.DEBUG) 0 else 15.seconds.inWholeMilliseconds
+        private val THROTTLE_PERIODIC_MS: Long = if (BuildConfig.DEBUG) 0 else 5.minutes.inWholeMilliseconds
         private var lastRefreshAllowedTime: Long = -10000
 
         fun clearLastRefreshTime() {


### PR DESCRIPTION
## Description

This PR addresses an issue with our manual refresh task, which implements a 15-second throttle in pull-to-refresh scenarios. Previously, we did not dispatch a "refreshed" state upon task completion due to this throttling mechanism. Additionally, throttling is disabled in debug builds, rendering this bug non-reproducible in those environments.

I have prepared a patch that enables throttling in debug builds to facilitate testing of this fix.
Closes #2153

## Testing Instructions

1. Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/15219568/refresh.patch).
2. Install the app.
3. Go to the podcasts tab.
4. Pull to refresh and wait for the sync to finish.
5. Pull to refresh again.
6. Spinner should disappear.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
