### PR TITLE
Do not truncate ads description

### DIFF
--- a/modules/features/discover/src/main/res/layout/row_category_ad.xml
+++ b/modules/features/discover/src/main/res/layout/row_category_ad.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -10,11 +11,9 @@
         android:id="@+id/cardImage"
         android:layout_width="108dp"
         android:layout_height="108dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
+        android:layout_margin="16dp"
         android:elevation="2dp"
         app:cardCornerRadius="4dp"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
@@ -32,8 +31,9 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:textAppearance="@style/C50"
+        android:layout_marginTop="12dp"
         app:layout_constraintStart_toEndOf="@id/cardImage"
-        app:layout_constraintTop_toTopOf="@id/cardImage"
+        app:layout_constraintTop_toTopOf="parent"
         tools:text="Sponsored" />
 
     <TextView
@@ -45,11 +45,9 @@
         android:layout_marginTop="4dp"
         android:layout_marginEnd="16dp"
         android:ellipsize="end"
-        android:maxLines="2"
-        android:singleLine="false"
         android:textColor="?attr/primary_text_01"
         android:textSize="15sp"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/btnSubscribe"
         app:layout_constraintStart_toEndOf="@id/cardImage"
         app:layout_constraintTop_toBottomOf="@id/lblSponsored"
         tools:text="Title" />
@@ -78,10 +76,8 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
         android:layout_marginEnd="16dp"
-        android:ellipsize="end"
         android:gravity="top"
         android:lineSpacingExtra="3sp"
-        android:maxLines="2"
         android:textColor="?attr/primary_text_02"
         android:textSize="@dimen/discover_single_podcast_body_text_size"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
## Description
- Removes the description line limit
- This implements the same single podcast row view

## Testing Instructions
1. Run the app in debugProd
2. Tap on `True Crime` category
3. See the ad description has more than 2 lines

## Screenshots or Screencast
I mocked the description to see how it will look like with long description

<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/26a20027-3eb4-4565-8e85-5ad67129cedb" width="400">
 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
