### PR TITLE
Account for 7.62.2 when migrating artwork settings

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
@@ -165,7 +165,8 @@ class VersionMigrationsJob : JobService() {
             consolidateEmbeddedArtworkSettings(applicationContext)
         }
 
-        if (previousVersionCode < 9226) {
+        // Exclude 7.63-rc-3 (9227) from the migration as it was already migrated.
+        if (previousVersionCode < 9230 && previousVersionCode != 9227) {
             migrateToGranularEpisodeArtworkSettings(applicationContext)
         }
     }


### PR DESCRIPTION
## Description

Need to take into account `7.62.2` version code bump for artwork settings migration.

## Testing Instructions

Verify in Play Console that `7.62.2` uses `9229` version code and that `7.63-rc-3` uses `9227` version code.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
