### PR TITLE
Remove categories redesign feature flag and discover endpoint clean up

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
@@ -12,8 +12,6 @@ import au.com.shiftyjelly.pocketcasts.discover.R
 import au.com.shiftyjelly.pocketcasts.discover.extensions.updateSubscribeButtonIcon
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private val differ: DiffUtil.ItemCallback<Any> = object : DiffUtil.ItemCallback<Any>() {
@@ -38,9 +36,7 @@ private val differ: DiffUtil.ItemCallback<Any> = object : DiffUtil.ItemCallback<
 
 internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, val onPodcastClicked: ((DiscoverPodcast, String?) -> Unit), val onPodcastSubscribe: ((DiscoverPodcast, String?) -> Unit), private val analyticsTracker: AnalyticsTrackerWrapper) : ListAdapter<Any, CarouselItemViewHolder>(differ) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CarouselItemViewHolder {
-        val layout =
-            if (FeatureFlag.isEnabled(Feature.CATEGORIES_REDESIGN)) R.layout.item_top_ranked else R.layout.item_carousel
-        val view = LayoutInflater.from(parent.context).inflate(layout, parent, false)
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_carousel, parent, false)
         return CarouselItemViewHolder(theme, view)
     }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -67,8 +67,6 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatPattern
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.extensions.showIf
 import coil.imageLoader
@@ -614,11 +612,6 @@ internal class DiscoverAdapter(
                             holder.binding.pageIndicatorView.count = it.count()
                         },
                     )
-
-                    if (!FeatureFlag.isEnabled(Feature.CATEGORIES_REDESIGN)) {
-                        holder.binding.layoutSearch.visibility = View.VISIBLE
-                        holder.binding.layoutSearch.setOnClickListener { listener.onSearchClicked() }
-                    }
                 }
                 is SmallListViewHolder -> {
                     holder.binding.lblTitle.text = row.title.tryToLocalise(resources)

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -27,8 +27,6 @@ import au.com.shiftyjelly.pocketcasts.servers.model.SponsoredPodcast
 import au.com.shiftyjelly.pocketcasts.servers.model.transformWithRegion
 import au.com.shiftyjelly.pocketcasts.servers.server.ListRepository
 import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
@@ -72,12 +70,7 @@ class DiscoverViewModel @Inject constructor(
     }
 
     fun loadData(resources: Resources) {
-        val feed =
-            if (FeatureFlag.isEnabled(Feature.CATEGORIES_REDESIGN)) {
-                repository.getDiscoverFeedWithCategoriesAtTheTop()
-            } else {
-                repository.getDiscoverFeed()
-            }
+        val feed = repository.getDiscoverFeedWithCategoriesAtTheTop()
 
         feed.toFlowable()
             .subscribeBy(

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -70,7 +70,7 @@ class DiscoverViewModel @Inject constructor(
     }
 
     fun loadData(resources: Resources) {
-        val feed = repository.getDiscoverFeedWithCategoriesAtTheTop()
+        val feed = repository.getDiscoverFeed()
 
         feed.toFlowable()
             .subscribeBy(

--- a/modules/features/discover/src/main/res/layout-h560dp/item_carousel.xml
+++ b/modules/features/discover/src/main/res/layout-h560dp/item_carousel.xml
@@ -10,17 +10,14 @@
         android:id="@+id/cardBack"
         android:orientation="horizontal"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/carousel_height"
-        android:paddingTop="88dp"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        android:paddingBottom="16dp"
+        android:layout_height="197dp"
+        android:padding="16dp"
         android:foreground="?attr/selectableItemBackground">
         <TextView
             android:id="@+id/lblRank"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="?attr/primary_text_01"
+            android:textColor="?attr/contrast_01"
             android:layout_marginEnd="16dp"
             android:visibility="gone"
             tools:text="1"/>
@@ -45,12 +42,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="20dp"
                 android:layout_marginBottom="8dp"
-                android:layout_marginEnd="28dp"
                 style="@style/Widget.MaterialComponents.Chip.Action"
                 android:textAppearance="@style/ChipTextStyle"
                 android:letterSpacing="0.16"
-                android:singleLine="true"
-                android:ellipsize="end"
                 android:importantForAccessibility="no"
                 app:chipSurfaceColor="@color/transparent"
                 app:chipMinTouchTargetSize="0dp"
@@ -79,6 +73,6 @@
         android:layout_gravity="end"
         app:srcCompat="@drawable/ic_add_black_24dp"
         app:tint="?attr/contrast_02"
-        android:layout_marginTop="72dp"
+        android:layout_marginTop="4dp"
         android:layout_marginEnd="4dp"/>
 </FrameLayout>

--- a/modules/features/discover/src/main/res/layout/item_carousel.xml
+++ b/modules/features/discover/src/main/res/layout/item_carousel.xml
@@ -10,17 +10,14 @@
         android:id="@+id/cardBack"
         android:orientation="horizontal"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/carousel_height"
-        android:paddingTop="88dp"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        android:paddingBottom="16dp"
+        android:layout_height="132dp"
+        android:padding="16dp"
         android:foreground="?attr/selectableItemBackground">
         <TextView
             android:id="@+id/lblRank"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="?attr/primary_text_01"
+            android:textColor="?attr/contrast_01"
             android:layout_marginEnd="16dp"
             android:visibility="gone"
             tools:text="1"/>
@@ -34,7 +31,7 @@
                 android:id="@+id/imageView"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:background="?attr/defaultArtworkSmall"/>
+                android:background="?attr/primary_ui_01"/>
         </androidx.cardview.widget.CardView>
         <LinearLayout
             android:layout_width="match_parent"
@@ -45,12 +42,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="20dp"
                 android:layout_marginBottom="8dp"
-                android:layout_marginEnd="28dp"
                 style="@style/Widget.MaterialComponents.Chip.Action"
                 android:textAppearance="@style/ChipTextStyle"
                 android:letterSpacing="0.16"
-                android:singleLine="true"
-                android:ellipsize="end"
                 android:importantForAccessibility="no"
                 app:chipSurfaceColor="@color/transparent"
                 app:chipMinTouchTargetSize="0dp"
@@ -78,6 +72,7 @@
         android:layout_height="44dp"
         android:layout_gravity="end"
         app:srcCompat="@drawable/ic_add_black_24dp"
-        android:layout_marginTop="72dp"
+        app:tint="?attr/contrast_02"
+        android:layout_marginTop="4dp"
         android:layout_marginEnd="4dp"/>
 </FrameLayout>

--- a/modules/features/discover/src/main/res/layout/row_carousel_list.xml
+++ b/modules/features/discover/src/main/res/layout/row_carousel_list.xml
@@ -1,49 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/carousel"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:id="@+id/carousel">
+    android:layout_height="wrap_content">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rowRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/secondary_ui_01"
-        android:layout_marginBottom="20dp"/>
-
-    <LinearLayout
-        android:id="@+id/layoutSearch"
-        android:layout_width="match_parent"
-        android:layout_height="48dp"
-        android:orientation="horizontal"
-        android:background="@drawable/search_background"
-        android:foreground="?attr/selectableItemBackground"
-        android:layout_margin="16dp"
-        android:visibility="gone"
-        android:clickable="true"
-        android:focusable="true"
-        android:contentDescription="@string/search_podcasts_or_add_url"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp">
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:src="@drawable/ic_search"
-            app:tint="?attr/contrast_01"
-            android:layout_marginEnd="16dp"/>
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            style="?attr/textBody1"
-            android:importantForAccessibility="no"
-            android:textColor="?attr/contrast_01"
-            android:maxLines="1"
-            android:ellipsize="end"
-            app:autoSizeTextType="uniform"
-            android:text="@string/search_podcasts_or_add_url"/>
-    </LinearLayout>
+        android:layout_marginBottom="20dp"
+        android:background="?attr/secondary_ui_01" />
 
     <au.com.shiftyjelly.pocketcasts.views.component.PagerIndicator
         android:id="@+id/pageIndicatorView"

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/server/ListRepository.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/server/ListRepository.kt
@@ -15,11 +15,6 @@ class ListRepository(private val listWebService: ListWebService, private val pla
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
     }
-    fun getDiscoverFeedWithCategoriesAtTheTop(): Single<Discover> {
-        return listWebService.getDiscoverFeedWithCategoriesAtTheTop(platform)
-            .subscribeOn(Schedulers.io())
-            .observeOn(AndroidSchedulers.mainThread())
-    }
 
     suspend fun getDiscoverFeedSuspend(): Discover {
         return listWebService.getDiscoverFeedSuspend(platform)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/server/ListWebService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/server/ListWebService.kt
@@ -9,11 +9,8 @@ import retrofit2.http.Path
 import retrofit2.http.Url
 
 interface ListWebService {
-    @GET("/discover/{platform}/content.json")
-    fun getDiscoverFeed(@Path("platform") platform: String): Single<Discover>
-
     @GET("/discover/{platform}/content_v2.json")
-    fun getDiscoverFeedWithCategoriesAtTheTop(@Path("platform") platform: String): Single<Discover>
+    fun getDiscoverFeed(@Path("platform") platform: String): Single<Discover>
 
     @GET("/discover/{platform}/content.json")
     suspend fun getDiscoverFeedSuspend(@Path("platform") platform: String): Discover

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/server/ListWebService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/server/ListWebService.kt
@@ -12,7 +12,7 @@ interface ListWebService {
     @GET("/discover/{platform}/content_v2.json")
     fun getDiscoverFeed(@Path("platform") platform: String): Single<Discover>
 
-    @GET("/discover/{platform}/content.json")
+    @GET("/discover/{platform}/content_v2.json")
     suspend fun getDiscoverFeedSuspend(@Path("platform") platform: String): Discover
 
     @GET


### PR DESCRIPTION
## Description
- Remove categories redesign feature flag. See: p1715084766395629/1715062226.510869-slack-C02A333D8LQ
- Deprecate `/discover/{platform}/content.json` to use `/discover/{platform}/content_v2.json`. See: p1715085882399969/1715084981.108589-slack-C029BMW150R

## Testing Instructions
### Sign in
1.  Run the app
2. Tap on Sign in Button
3. Create an account
4. ✅ In Find your favorite podcasts screen, ensure you get the `Featured` and categories list

### Categories redesign
1. Run the app
2. Go to discover
3. ✅ Ensure categories are displayed at the top

### AutoPlaybackService 🚨
- Since we need to remove all old endpoint usages, I had to do it for the suspend function too: https://github.com/Automattic/pocket-casts-android/commit/f51a85e939e3d17f64dce0e153e28ed8e146c48b, but I can't find a way to test it. This is being called only in [PlaybackService.kt](https://github.com/Automattic/pocket-casts-android/blob/6a1ca714e37e0b03009d369f4c9f524d0b014b10/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt) line 163
- I tried to put breakpoints, but it did not help. Does anyone know how can I test this? @Automattic/pocket-casts-android 


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack