### PR TITLE
Update toolbar

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -16,6 +16,9 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
+import au.com.shiftyjelly.pocketcasts.utils.extensions.hideShadow
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.ChromeCastButton.Shown
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.None
@@ -65,6 +68,10 @@ class FiltersFragment : BaseFragment(), CoroutineScope, Toolbar.OnMenuItemClickL
         super.onViewCreated(view, savedInstanceState)
 
         val binding = binding ?: return
+
+        if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+            binding.appBarLayout.hideShadow()
+        }
 
         setupToolbarAndStatusBar(
             toolbar = binding.toolbar,

--- a/modules/features/filters/src/main/res/layout/fragment_filters.xml
+++ b/modules/features/filters/src/main/res/layout/fragment_filters.xml
@@ -9,6 +9,7 @@
         android:layout_height="match_parent"
         android:importantForAccessibility="no">
         <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/appBarLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <androidx.appcompat.widget.Toolbar

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -32,6 +32,9 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
+import au.com.shiftyjelly.pocketcasts.utils.extensions.hideShadow
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.extensions.tintIcons
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.ChromeCastButton
@@ -254,6 +257,10 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+            binding.appBarLayout.hideShadow()
+        }
 
         val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
         setupToolbarAndStatusBar(

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -40,6 +40,7 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
+import au.com.shiftyjelly.pocketcasts.utils.extensions.hideShadow
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.adapter.PodcastTouchCallback
@@ -107,6 +108,10 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
 
         if (adapter == null) {
             adapter = FolderAdapter(this, settings, context, theme)
+        }
+
+        if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+            binding.appBarLayout.hideShadow()
         }
 
         binding.recyclerView.let {

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcasts.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcasts.xml
@@ -8,6 +8,7 @@
     android:importantForAccessibility="no">
 
     <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/CountBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/CountBadge.kt
@@ -24,6 +24,8 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 
 @Composable
@@ -40,7 +42,11 @@ fun CountBadge(
             .defaultMinSize(minSize, minSize)
             .badgeBackground(
                 color = MaterialTheme.theme.colors.primaryInteractive01,
-                borderColor = MaterialTheme.theme.colors.primaryUi04,
+                borderColor = if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+                    MaterialTheme.theme.colors.primaryUi01
+                } else {
+                    MaterialTheme.theme.colors.primaryUi04
+                },
                 borderWidth = borderWidthPx.toFloat(),
             ),
         contentAlignment = Alignment.Center,

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/AppBarLayout.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/AppBarLayout.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.utils.extensions
+
+import com.google.android.material.appbar.AppBarLayout
+
+fun AppBarLayout.hideShadow() {
+    stateListAnimator = null
+}

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseFragment.kt
@@ -12,6 +12,8 @@ import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.extensions.tintIcons
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.ChromeCastButton
@@ -41,7 +43,8 @@ open class BaseFragment : Fragment(), CoroutineScope, HasBackstack {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         if (view.background == null) {
-            view.setBackgroundColor(view.context.getThemeColor(UR.attr.primary_ui_04))
+            val backgroundColor = if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) UR.attr.primary_ui_01 else UR.attr.primary_ui_04
+            view.setBackgroundColor(view.context.getThemeColor(backgroundColor))
         }
         view.isClickable = true
         view.isFocusable = true


### PR DESCRIPTION
Part of: #2081 

## Description

Design: G60UqxPhTynbalo0Vfr1NC-fi-1584_17675

This PR

1. Removes drop-shadow for Podcasts, Up Next, and Filters tab screens (not sure if Filters screen needs it but I went ahead to have consistency between tabs screens). I have not removed the toolbar shadow for other screens as we may need a separator between the toolbar and content similar to iOS. 
2. Updates default screen background from `primary-ui-04`  to `primary-ui-01` (applied to all screens) - I can limit the changes to the above screens only.
3. ~~Changes toolbar font to match Figma (G60UqxPhTynbalo0Vfr1NC-fi-1584_17675 - in discussion)~~

## Testing Instructions

#### FF enabled
1. Open the app
2. Notice the toolbar shadow changes on Podcasts, UpNext, and Filters tab match the design: G60UqxPhTynbalo0Vfr1NC-fi-1584_17675

#### FF disabled
1. Disable FF `UPNEXT_IN_TAB_BAR`
2. Kill and restart the app
3. Notice the changes are reverted to original

## Screenshots or Screencast 

Light | Rose | Filters
----|----|----
<img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/af5c1536-b89d-414f-bd29-7ceaf099737a"/> | <img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/b1935370-cfa2-4e1a-8a0d-8ecc2cb02b97"/> | <img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/cce2b1bc-bd66-47b5-a273-761cc569bf33"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes (I have not tested background changes on all screens in the app)
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack