### PR TITLE
Up Next design updates

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -16,6 +16,9 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
+import au.com.shiftyjelly.pocketcasts.utils.extensions.hideShadow
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.ChromeCastButton.Shown
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.None
@@ -65,6 +68,10 @@ class FiltersFragment : BaseFragment(), CoroutineScope, Toolbar.OnMenuItemClickL
         super.onViewCreated(view, savedInstanceState)
 
         val binding = binding ?: return
+
+        if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+            binding.appBarLayout.hideShadow()
+        }
 
         setupToolbarAndStatusBar(
             toolbar = binding.toolbar,

--- a/modules/features/filters/src/main/res/layout/fragment_filters.xml
+++ b/modules/features/filters/src/main/res/layout/fragment_filters.xml
@@ -9,6 +9,7 @@
         android:layout_height="match_parent"
         android:importantForAccessibility="no">
         <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/appBarLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <androidx.appcompat.widget.Toolbar

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -34,6 +34,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
 import au.com.shiftyjelly.pocketcasts.views.helper.setEpisodeTimeLeft
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
@@ -58,7 +60,10 @@ class UpNextAdapter(
     private val playbackManager: PlaybackManager,
 ) : ListAdapter<Any, RecyclerView.ViewHolder>(UPNEXT_ADAPTER_DIFF) {
     private val dateFormatter = RelativeDateFormatter(context)
-    private val imageRequestFactory = PocketCastsImageRequestFactory(context, cornerRadius = 3).themed()
+    private val imageRequestFactory = PocketCastsImageRequestFactory(
+        context,
+        cornerRadius = if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) 4 else 3,
+    ).themed()
 
     var isPlaying: Boolean = false
         set(value) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -167,7 +167,16 @@ class UpNextAdapter(
                 val time = TimeHelper.getTimeDurationShortString(timeMs = (header.totalTimeSecs * 1000).toLong(), context = root.context)
                 btnClear.isVisible = playbackManager.getCurrentEpisode() != null
                 lblUpNextTime.isVisible = playbackManager.getCurrentEpisode() != null
-                lblUpNextTime.text = root.resources.getString(LR.string.player_up_next_time_remaining, time)
+                lblUpNextTime.text = if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+                    if (header.episodeCount == 0) {
+                        root.resources.getString(LR.string.player_up_next_time_left, time)
+                    } else {
+                        root.resources.getQuantityString(LR.plurals.player_up_next_header_title, header.episodeCount, header.episodeCount, time)
+                    }
+                } else {
+                    root.resources.getString(LR.string.player_up_next_time_remaining, time)
+                }
+
                 root.layoutParams.height = ViewGroup.LayoutParams.WRAP_CONTENT
             }
         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -34,6 +34,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
+import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
@@ -173,7 +174,9 @@ class UpNextAdapter(
     }
 
     inner class PlayingViewHolder(val binding: AdapterUpNextPlayingBinding) : RecyclerView.ViewHolder(binding.root) {
-        var loadedUuid: String? = null
+        private var loadedUuid: String? = null
+        private val cardCornerRadius: Float = 4.dpToPx(itemView.context.resources.displayMetrics).toFloat()
+        private val cardElevation: Float = 2.dpToPx(itemView.context.resources.displayMetrics).toFloat()
 
         init {
             binding.root.setOnClickListener {
@@ -207,6 +210,9 @@ class UpNextAdapter(
                 isVisible = isPlaying
                 applyColorFilter(ThemeColor.primaryText01(theme))
             }
+
+            binding.imageCardView.radius = if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) cardCornerRadius else 0f
+            binding.imageCardView.elevation = if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) cardElevation else 0f
         }
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
@@ -29,7 +29,10 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getAttrTextStyleColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.extensions.setRippleBackground
+import au.com.shiftyjelly.pocketcasts.views.extensions.showIf
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.RowSwipeable
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayout
@@ -54,8 +57,13 @@ class UpNextEpisodeViewHolder(
 ) : RecyclerView.ViewHolder(binding.root),
     UpNextTouchCallback.ItemTouchHelperViewHolder,
     RowSwipeable {
+    private val cardCornerRadius: Float = 4.dpToPx(itemView.context.resources.displayMetrics).toFloat()
+    private val cardElevation: Float = 2.dpToPx(itemView.context.resources.displayMetrics).toFloat()
     private val elevatedBackground = ContextCompat.getColor(binding.root.context, R.color.elevatedBackground)
     private val selectedBackground = ContextCompat.getColor(binding.root.context, R.color.selectedBackground)
+    private val unselectedColor = itemView.context.getThemeColor(
+        if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) UR.attr.primary_ui_04 else UR.attr.primary_ui_02,
+    )
 
     private var episodeInstance: BaseEpisode? = null
 
@@ -130,7 +138,6 @@ class UpNextEpisodeViewHolder(
         binding.checkbox.setOnClickListener { binding.itemContainer.performClick() }
 
         val selectedColor = context.getThemeColor(UR.attr.primary_ui_02_selected)
-        val unselectedColor = context.getThemeColor(UR.attr.primary_ui_02)
         binding.checkbox.setOnCheckedChangeListener { _, isChecked ->
             binding.itemContainer.setBackgroundColor(if (isMultiSelecting && isChecked) selectedColor else unselectedColor)
         }
@@ -141,6 +148,9 @@ class UpNextEpisodeViewHolder(
             rightMargin = if (isMultiSelecting) -binding.checkbox.marginLeft else 0.dpToPx(itemView.context)
             width = if (isMultiSelecting) 16.dpToPx(itemView.context) else 52.dpToPx(itemView.context)
         }
+        binding.dividerView.showIf(FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR))
+        binding.imageCardView.radius = if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) cardCornerRadius else 0f
+        binding.imageCardView.elevation = if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) cardElevation else 0f
     }
 
     private fun bindEpisode(episode: BaseEpisode) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -32,6 +32,9 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
+import au.com.shiftyjelly.pocketcasts.utils.extensions.hideShadow
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.extensions.tintIcons
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.ChromeCastButton
@@ -254,6 +257,10 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+            binding.appBarLayout.hideShadow()
+        }
 
         val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
         setupToolbarAndStatusBar(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -676,7 +676,8 @@ class PlayerViewModel @Inject constructor(
             analyticsTracker = analyticsTracker,
             context = context,
         )
-        dialog.setForceDarkTheme(true)
+        val forceDarkTheme = settings.useDarkUpNextTheme.value && upNextSource != UpNextSource.UP_NEXT_TAB
+        dialog.setForceDarkTheme(forceDarkTheme)
         return dialog
     }
 

--- a/modules/features/player/src/main/res/color/player_button_text_color.xml
+++ b/modules/features/player/src/main/res/color/player_button_text_color.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_enabled="false"
-        android:color="?attr/primary_text_02"
+        android:color="?attr/primary_interactive_01"
         android:alpha="0.5"/>
-    <item android:color="?attr/primary_text_02" />
+    <item android:color="?attr/primary_interactive_01" />
 </selector>

--- a/modules/features/player/src/main/res/layout/adapter_up_next.xml
+++ b/modules/features/player/src/main/res/layout/adapter_up_next.xml
@@ -100,17 +100,30 @@
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <ImageView
-            android:id="@+id/image"
-            android:layout_width="72dp"
-            android:layout_height="56dp"
-            android:layout_marginStart="16dp"
-            android:paddingEnd="16dp"
-            android:scaleType="centerInside"
+        <androidx.cardview.widget.CardView
+                android:id="@+id/imageCardView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginVertical="4dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@id/checkbox"
+                app:layout_constraintTop_toTopOf="parent">
+                <ImageView
+                    android:id="@+id/image"
+                    android:layout_width="56dp"
+                    android:layout_height="56dp"
+                    android:scaleType="centerInside"
+                    tools:src="@tools:sample/avatars" />
+        </androidx.cardview.widget.CardView>
+
+        <View
+            android:id="@+id/imageSpacer"
+            android:layout_width="16dp"
+            android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintLeft_toRightOf="@id/checkbox"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:src="@tools:sample/avatars" />
+            app:layout_constraintStart_toEndOf="@+id/imageCardView"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/date"
@@ -121,7 +134,7 @@
             android:layout_marginEnd="16dp"
             android:paddingBottom="2dp"
             android:textAllCaps="true"
-            app:layout_constraintLeft_toRightOf="@+id/image"
+            app:layout_constraintLeft_toRightOf="@+id/imageSpacer"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="TODAY" />
@@ -137,7 +150,7 @@
             android:textAppearance="@style/DarkSubtitle1"
             app:layout_constraintBottom_toTopOf="@+id/info"
             app:layout_constraintEnd_toStartOf="@+id/reorder"
-            app:layout_constraintStart_toEndOf="@+id/image"
+            app:layout_constraintStart_toEndOf="@+id/imageSpacer"
             app:layout_constraintTop_toBottomOf="@+id/date"
             app:layout_constraintVertical_chainStyle="packed"
             tools:text="Episode description" />
@@ -152,7 +165,7 @@
             app:tint="?attr/support_02"
             app:layout_constraintBottom_toBottomOf="@+id/info"
             app:layout_constraintEnd_toStartOf="@+id/info"
-            app:layout_constraintStart_toEndOf="@+id/image"
+            app:layout_constraintStart_toEndOf="@+id/imageSpacer"
             app:layout_constraintTop_toTopOf="@+id/info" />
 
         <TextView
@@ -184,4 +197,13 @@
             app:tint="?attr/primary_icon_02"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <View
+        android:id="@+id/dividerView"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/divider_height"
+        android:background="?attr/primary_ui_05"
+        android:layout_marginHorizontal="16dp"
+        android:layout_gravity="bottom"/>
+
 </FrameLayout>

--- a/modules/features/player/src/main/res/layout/adapter_up_next_footer.xml
+++ b/modules/features/player/src/main/res/layout/adapter_up_next_footer.xml
@@ -32,7 +32,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
             android:textColor="?attr/primary_text_02"
-            tools:text="23 min." />
+            tools:text="2 episodes - 23 min." />
 
 
         <com.google.android.material.button.MaterialButton

--- a/modules/features/player/src/main/res/layout/adapter_up_next_playing.xml
+++ b/modules/features/player/src/main/res/layout/adapter_up_next_playing.xml
@@ -19,19 +19,30 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"/>
 
-    <ImageView
-        android:id="@+id/image"
-        android:layout_width="72dp"
+    <androidx.cardview.widget.CardView
+        android:id="@+id/imageCardView"
+        android:layout_width="56dp"
         android:layout_height="56dp"
         android:layout_marginStart="16dp"
-        android:scaleType="centerInside"
-        android:paddingEnd="16dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp"
+        android:layout_marginVertical="8dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:src="@tools:sample/avatars" />
+        app:layout_constraintTop_toTopOf="parent">
+        <ImageView
+            android:id="@+id/image"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="centerInside"
+            tools:src="@tools:sample/avatars" />
+    </androidx.cardview.widget.CardView>
+
+    <View
+        android:id="@+id/imageSpacer"
+        android:layout_width="16dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/imageCardView"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/date"
@@ -44,7 +55,7 @@
         android:textColor="?attr/primary_text_02"
         tools:text="TODAY"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintLeft_toRightOf="@+id/image"
+        app:layout_constraintLeft_toRightOf="@+id/imageSpacer"
         app:layout_constraintRight_toRightOf="parent"/>
 
     <TextView
@@ -59,7 +70,7 @@
         app:layout_constraintVertical_chainStyle="packed"
         app:layout_constraintBottom_toTopOf="@+id/info"
         app:layout_constraintEnd_toStartOf="@+id/playingAnimation"
-        app:layout_constraintStart_toEndOf="@+id/image"
+        app:layout_constraintStart_toEndOf="@+id/imageSpacer"
         app:layout_constraintTop_toBottomOf="@+id/date"
         tools:text="Episode description" />
 
@@ -72,7 +83,7 @@
         app:tint="?attr/support_02"
         app:layout_constraintBottom_toBottomOf="@+id/info"
         app:layout_constraintEnd_toStartOf="@+id/info"
-        app:layout_constraintStart_toEndOf="@+id/image"
+        app:layout_constraintStart_toEndOf="@+id/imageSpacer"
         app:layout_constraintTop_toTopOf="@+id/info"
         android:layout_marginEnd="6dp"/>
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -40,6 +40,7 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
+import au.com.shiftyjelly.pocketcasts.utils.extensions.hideShadow
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.adapter.PodcastTouchCallback
@@ -107,6 +108,10 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
 
         if (adapter == null) {
             adapter = FolderAdapter(this, settings, context, theme)
+        }
+
+        if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+            binding.appBarLayout.hideShadow()
         }
 
         binding.recyclerView.let {

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcasts.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcasts.xml
@@ -8,6 +8,7 @@
     android:importantForAccessibility="no">
 
     <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/CountBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/CountBadge.kt
@@ -24,6 +24,8 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 
 @Composable
@@ -40,7 +42,11 @@ fun CountBadge(
             .defaultMinSize(minSize, minSize)
             .badgeBackground(
                 color = MaterialTheme.theme.colors.primaryInteractive01,
-                borderColor = MaterialTheme.theme.colors.primaryUi04,
+                borderColor = if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) {
+                    MaterialTheme.theme.colors.primaryUi01
+                } else {
+                    MaterialTheme.theme.colors.primaryUi04
+                },
                 borderWidth = borderWidthPx.toFloat(),
             ),
         contentAlignment = Alignment.Center,

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -343,7 +343,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="player_up_next_move_to_top">Move to top</string>
     <string name="player_up_next_select">Select</string>
     <string name="player_up_next_time_remaining">Total time remaining %s</string>
-    <string name="player_up_next_time_left">%s left</string>
+    <string name="player_up_next_time_left">@string/time_left</string>
     <plurals name="player_up_next_header_title">
         <item quantity="one" formatted="true">%1$d episode - %2$s left</item>
         <item quantity="other" formatted="true">%1$d episodes - %2$s left</item>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -343,6 +343,11 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="player_up_next_move_to_top">Move to top</string>
     <string name="player_up_next_select">Select</string>
     <string name="player_up_next_time_remaining">Total time remaining %s</string>
+    <string name="player_up_next_time_left">%s left</string>
+    <plurals name="player_up_next_header_title">
+        <item quantity="one" formatted="true">One episode - %2$s left</item>
+        <item quantity="other" formatted="true">%1$d episodes - %2$s left</item>
+    </plurals>
     <string name="player_open_url_failed">Could not find a browser to open %s.</string>
     <string name="player_archive_title" translatable="false">@string/archive</string>
     <string name="player_archive_summary">Are you sure you want to archive this episode?</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -345,7 +345,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="player_up_next_time_remaining">Total time remaining %s</string>
     <string name="player_up_next_time_left">%s left</string>
     <plurals name="player_up_next_header_title">
-        <item quantity="one" formatted="true">One episode - %2$s left</item>
+        <item quantity="one" formatted="true">%1$d episode - %2$s left</item>
         <item quantity="other" formatted="true">%1$d episodes - %2$s left</item>
     </plurals>
     <string name="player_open_url_failed">Could not find a browser to open %s.</string>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/AppBarLayout.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/AppBarLayout.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.utils.extensions
+
+import com.google.android.material.appbar.AppBarLayout
+
+fun AppBarLayout.hideShadow() {
+    stateListAnimator = null
+}

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseFragment.kt
@@ -12,6 +12,8 @@ import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.extensions.tintIcons
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.ChromeCastButton
@@ -41,7 +43,8 @@ open class BaseFragment : Fragment(), CoroutineScope, HasBackstack {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         if (view.background == null) {
-            view.setBackgroundColor(view.context.getThemeColor(UR.attr.primary_ui_04))
+            val backgroundColor = if (FeatureFlag.isEnabled(Feature.UPNEXT_IN_TAB_BAR)) UR.attr.primary_ui_01 else UR.attr.primary_ui_04
+            view.setBackgroundColor(view.context.getThemeColor(backgroundColor))
         }
         view.isClickable = true
         view.isFocusable = true


### PR DESCRIPTION
Part of: #2081 

## Description

Figma Design: G60UqxPhTynbalo0Vfr1NC-fi-1584_17364

This applies following updates to the Up Next screen:

1. Add divider between queue items
2. Update queue item background color to match existing screen background **
3. Add image shadow so that (white) thumbnails are shown properly on certain themes like `Light Contrast`
4. Update header title to include episode count
5. Update Clear Queue dialog theme
6. Update Clear Queue text color to `primary_interactive_01`

** Existing screen background is still `primary_ui_04` instead of `primary_ui_01`. I have to apply an appropriate theme to the Now Playing item before I switch to the new background color.

*** Font sizes and styles for texts shown in Figma are not yet applied as they need to be used throughout the app. They're kept outside the scope of this PR.

## Testing Instructions

### FF enabled

1. Open the app
2. Notice that the above changes are applied 
3. Smoke test theme changes on Up Next screen for tab and Up Next screen on the Player screen

### FF disabled

1. Disable feature flag UPNEXT_IN_TAB_BAR 
2. Kill and restart the app
4. Notice that the original design is shown

## Screenshots or Screencast 


Up Next Tab | Up Next - Clear Queue Light | Up Next - BottomSheet Dark | Up Next - Clear Queue Dark
---|---|---|---
<img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/573119d2-2db2-4725-8538-240870c29244"/> |  <img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/e9b3740b-90a3-4866-99ce-94898680d16e"/>  | <img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/de958798-d155-40ea-bc90-7e371fc2fa76"/> |<img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/dae79fa2-af11-47de-b65a-566c2f622549"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack