### PR TITLE
Fix auto archiving episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 *   Bug Fixes
     *   Fix pull to refresh icon sometimes being stuck in a loading state
         ([#2164](https://github.com/Automattic/pocket-casts-android/pull/2164))
+    *   Fix cases where podcasts were ignoring 'Never archive' setting in some cases
+        ([#2194](https://github.com/Automattic/pocket-casts-android/pull/2194))
 
 7.63
 -----

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
@@ -358,7 +358,7 @@ class AutoArchiveTest {
     @Test
     fun testPlayed24HoursPodcastOverride() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlaying.Never, AutoArchiveInactive.Never, testDispatcher = testDispatcher)
-        val podcast = Podcast(UUID.randomUUID().toString(), overrideGlobalArchive = true, autoArchiveAfterPlaying = AutoArchiveAfterPlaying.Hours24)
+        val podcast = Podcast(UUID.randomUUID().toString(), overrideGlobalArchive = true, rawAutoArchiveAfterPlaying = AutoArchiveAfterPlaying.Hours24)
         val podcastManager = podcastManagerThatReturns(podcast)
         val calendar = Calendar.getInstance()
         calendar.add(Calendar.DATE, -2)
@@ -384,7 +384,7 @@ class AutoArchiveTest {
     fun testInactive30DaysPodcastOverride() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlaying.Never, AutoArchiveInactive.Never, testDispatcher = testDispatcher)
         val podcastUUID = UUID.randomUUID().toString()
-        val podcast = Podcast(uuid = podcastUUID, isSubscribed = true, overrideGlobalArchive = true, autoArchiveInactive = AutoArchiveInactive.Days30)
+        val podcast = Podcast(uuid = podcastUUID, isSubscribed = true, overrideGlobalArchive = true, rawAutoArchiveInactive = AutoArchiveInactive.Days30)
         val podcastManager = podcastManagerThatReturns(podcast)
         val calendar = Calendar.getInstance()
         calendar.add(Calendar.DATE, -31)
@@ -410,7 +410,7 @@ class AutoArchiveTest {
     fun testInactive24HoursAddedRecentlyPodcastOverride() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlaying.Never, AutoArchiveInactive.Never, testDispatcher = testDispatcher)
         val podcastUUID = UUID.randomUUID().toString()
-        val podcast = Podcast(uuid = podcastUUID, isSubscribed = true, overrideGlobalArchive = true, autoArchiveInactive = AutoArchiveInactive.Hours24)
+        val podcast = Podcast(uuid = podcastUUID, isSubscribed = true, overrideGlobalArchive = true, rawAutoArchiveInactive = AutoArchiveInactive.Hours24)
         val podcastManager = podcastManagerThatReturns(podcast)
         val calendar = Calendar.getInstance()
         calendar.add(Calendar.HOUR, -30)
@@ -436,7 +436,7 @@ class AutoArchiveTest {
     fun testInactive2DaysAndAfterPlayingPodcastOverride() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlaying.AfterPlaying, AutoArchiveInactive.Weeks2, testDispatcher = testDispatcher)
         val podcastUUID = UUID.randomUUID().toString()
-        val podcast = Podcast(uuid = podcastUUID, isSubscribed = true, overrideGlobalArchive = true, autoArchiveInactive = AutoArchiveInactive.Days2, autoArchiveAfterPlaying = AutoArchiveAfterPlaying.AfterPlaying)
+        val podcast = Podcast(uuid = podcastUUID, isSubscribed = true, overrideGlobalArchive = true, rawAutoArchiveInactive = AutoArchiveInactive.Days2, rawAutoArchiveAfterPlaying = AutoArchiveAfterPlaying.AfterPlaying)
         val podcastManager = podcastManagerThatReturns(podcast)
         val calendar = Calendar.getInstance()
         calendar.set(2019, 0, 24, 11, 30)
@@ -461,7 +461,7 @@ class AutoArchiveTest {
     @Test
     fun testEpisodeLimit() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlaying.Never, AutoArchiveInactive.Never, testDispatcher = testDispatcher)
-        val podcast = Podcast(UUID.randomUUID().toString(), autoArchiveEpisodeLimit = 1, overrideGlobalArchive = true)
+        val podcast = Podcast(UUID.randomUUID().toString(), rawAutoArchiveEpisodeLimit = 1, overrideGlobalArchive = true)
         val podcastManager = podcastManagerThatReturns(podcast)
         val calendar = Calendar.getInstance()
         calendar.add(Calendar.DATE, -2)
@@ -486,7 +486,7 @@ class AutoArchiveTest {
     @Test
     fun testEpisodeLimitIgnoresManualUnarchiveInCount() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlaying.Never, AutoArchiveInactive.Never, testDispatcher = testDispatcher)
-        val podcast = Podcast(UUID.randomUUID().toString(), autoArchiveEpisodeLimit = 0, overrideGlobalArchive = true)
+        val podcast = Podcast(UUID.randomUUID().toString(), rawAutoArchiveEpisodeLimit = 0, overrideGlobalArchive = true)
         val podcastManager = podcastManagerThatReturns(podcast)
         val calendar = Calendar.getInstance()
         calendar.add(Calendar.DATE, -2)
@@ -511,7 +511,7 @@ class AutoArchiveTest {
     @Test
     fun testEpisodeLimitRespectsIgnoreGlobal() = runTest {
         val episodeManager = episodeManagerFor(testDb, AutoArchiveAfterPlaying.Never, AutoArchiveInactive.Never, testDispatcher = testDispatcher)
-        val podcast = Podcast(UUID.randomUUID().toString(), autoArchiveEpisodeLimit = 0, overrideGlobalArchive = false)
+        val podcast = Podcast(UUID.randomUUID().toString(), rawAutoArchiveEpisodeLimit = 0, overrideGlobalArchive = false)
         val podcastManager = podcastManagerThatReturns(podcast)
         val calendar = Calendar.getInstance()
         calendar.add(Calendar.DATE, -2)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveFragment.kt
@@ -107,8 +107,8 @@ class PodcastAutoArchiveFragment : PreferenceFragmentCompat() {
                     preferenceCustomCategory?.isVisible = podcast.overrideGlobalArchive
                     preferenceEpisodeLimitCategory?.isVisible = podcast.overrideGlobalArchive
 
-                    preferenceAutoArchivePodcastPlayedEpisodes?.value = afterPlayingValues[podcast.autoArchiveAfterPlaying.index]
-                    preferenceAutoArchivePodcastInactiveEpisodes?.value = inactiveValues[podcast.autoArchiveInactive.index]
+                    preferenceAutoArchivePodcastPlayedEpisodes?.value = afterPlayingValues[podcast.autoArchiveAfterPlaying?.index ?: 0]
+                    preferenceAutoArchivePodcastInactiveEpisodes?.value = inactiveValues[podcast.autoArchiveInactive?.index ?: 0]
                     val limitIndex = EpisodeLimits.indexOf(podcast.autoArchiveEpisodeLimit).takeIf { it != -1 } ?: 0
                     preferenceAutoArchiveEpisodeLimit?.value = episodeLimitValues[limitIndex]
                 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
@@ -73,11 +73,26 @@ data class Podcast(
     @ColumnInfo(name = "exclude_from_auto_archive") var excludeFromAutoArchive: Boolean = false, // Not used anymore
     @ColumnInfo(name = "override_global_archive") var overrideGlobalArchive: Boolean = false,
     @ColumnInfo(name = "override_global_archive_modified") var overrideGlobalArchiveModified: Date? = null,
-    @ColumnInfo(name = "auto_archive_played_after") var autoArchiveAfterPlaying: AutoArchiveAfterPlaying = AutoArchiveAfterPlaying.Never,
+    @Deprecated(
+        message = "This property doesn't account for global override. Use 'autoArchiveAfterPlaying' instead.",
+        level = DeprecationLevel.ERROR,
+        replaceWith = ReplaceWith(expression = "autoArchiveAfterPlaying"),
+    )
+    @ColumnInfo(name = "auto_archive_played_after") internal var rawAutoArchiveAfterPlaying: AutoArchiveAfterPlaying = AutoArchiveAfterPlaying.Never,
     @ColumnInfo(name = "auto_archive_played_after_modified") var autoArchiveAfterPlayingModified: Date? = null,
-    @ColumnInfo(name = "auto_archive_inactive_after") var autoArchiveInactive: AutoArchiveInactive = AutoArchiveInactive.Default,
+    @Deprecated(
+        message = "This property doesn't account for global override. Use 'autoArchiveInactive' instead.",
+        level = DeprecationLevel.ERROR,
+        replaceWith = ReplaceWith(expression = "autoArchiveInactive"),
+    )
+    @ColumnInfo(name = "auto_archive_inactive_after") internal var rawAutoArchiveInactive: AutoArchiveInactive = AutoArchiveInactive.Default,
     @ColumnInfo(name = "auto_archive_inactive_after_modified") var autoArchiveInactiveModified: Date? = null,
-    @ColumnInfo(name = "auto_archive_episode_limit") var autoArchiveEpisodeLimit: Int? = null,
+    @Deprecated(
+        message = "This property doesn't account for global override. Use 'autoArchiveEpisodeLimit' instead.",
+        level = DeprecationLevel.ERROR,
+        replaceWith = ReplaceWith(expression = "autoArchiveEpisodeLimit"),
+    )
+    @ColumnInfo(name = "auto_archive_episode_limit") internal var rawAutoArchiveEpisodeLimit: Int? = null,
     @ColumnInfo(name = "auto_archive_episode_limit_modified") var autoArchiveEpisodeLimitModified: Date? = null,
     @ColumnInfo(name = "estimated_next_episode") var estimatedNextEpisode: Date? = null,
     @ColumnInfo(name = "episode_frequency") var episodeFrequency: String? = null,
@@ -171,6 +186,33 @@ data class Podcast(
         get() = rawFolderUuid?.takeIf { it != Folder.homeFolderUuid }
         set(value) {
             rawFolderUuid = value?.takeIf { it != Folder.homeFolderUuid }
+        }
+
+    @Suppress("DEPRECATION_ERROR")
+    var autoArchiveAfterPlaying: AutoArchiveAfterPlaying?
+        get() = rawAutoArchiveAfterPlaying.takeIf { overrideGlobalArchive }
+        set(value) {
+            if (value != null) {
+                rawAutoArchiveAfterPlaying = value
+            }
+        }
+
+    @Suppress("DEPRECATION_ERROR")
+    var autoArchiveInactive: AutoArchiveInactive?
+        get() = rawAutoArchiveInactive.takeIf { overrideGlobalArchive }
+        set(value) {
+            if (value != null) {
+                rawAutoArchiveInactive = value
+            }
+        }
+
+    @Suppress("DEPRECATION_ERROR")
+    var autoArchiveEpisodeLimit: Int?
+        get() = rawAutoArchiveEpisodeLimit.takeIf { overrideGlobalArchive }
+        set(value) {
+            if (value != null) {
+                rawAutoArchiveEpisodeLimit = value
+            }
         }
 
     enum class Licensing {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -295,8 +295,8 @@ class Support @Inject constructor(
                     podcastsOutput.append("Custom auto archive: ").append(podcast.overrideGlobalArchive.toString()).append(eol)
                     if (podcast.overrideGlobalArchive) {
                         podcastsOutput.append("Episode limit: ").append(podcast.autoArchiveEpisodeLimit).append(eol)
-                        podcastsOutput.append("Archive after playing: ").append(afterPlayingValues[podcast.autoArchiveAfterPlaying.index]).append(eol)
-                        podcastsOutput.append("Archive inactive: ").append(inactiveValues[podcast.autoArchiveInactive.index]).append(eol)
+                        podcastsOutput.append("Archive after playing: ").append(podcast.autoArchiveAfterPlaying?.index?.let(afterPlayingValues::get)).append(eol)
+                        podcastsOutput.append("Archive inactive: ").append(podcast.autoArchiveInactive?.index?.let(inactiveValues::get)).append(eol)
                     }
                     podcastsOutput.append("Auto add to up next: ").append(autoAddToUpNextToString(podcast.autoAddToUpNext)).append(eol)
                     podcastsOutput.append(eol)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -1148,13 +1148,17 @@ class PodcastSyncProcess(
                             value = boolValue { value = podcast.overrideGlobalArchive }
                             modifiedAt = podcast.overrideGlobalArchiveModified.toProtobufTimestampOrFallback()
                         }
-                        autoArchivePlayed = int32Setting {
-                            value = int32Value { value = podcast.autoArchiveAfterPlaying.serverId }
-                            modifiedAt = podcast.autoArchiveAfterPlayingModified.toProtobufTimestampOrFallback()
+                        podcast.autoArchiveAfterPlaying?.serverId?.let { serverId ->
+                            autoArchivePlayed = int32Setting {
+                                value = int32Value { value = serverId }
+                                modifiedAt = podcast.autoArchiveAfterPlayingModified.toProtobufTimestampOrFallback()
+                            }
                         }
-                        autoArchiveInactive = int32Setting {
-                            value = int32Value { value = podcast.autoArchiveInactive.serverId }
-                            modifiedAt = podcast.autoArchiveInactiveModified.toProtobufTimestampOrFallback()
+                        podcast.autoArchiveInactive?.serverId?.let { serverId ->
+                            autoArchiveInactive = int32Setting {
+                                value = int32Value { value = serverId }
+                                modifiedAt = podcast.autoArchiveInactiveModified.toProtobufTimestampOrFallback()
+                            }
                         }
                         autoArchiveEpisodeLimit = int32Setting {
                             value = int32Value { value = podcast.autoArchiveEpisodeLimit ?: 0 }


### PR DESCRIPTION
## Description

Episodes were being archived after playing even when global settings was set to never and podcasts wasn't technically overriding the value. Some users were affected by it during settings sync test.

Internal ref: p1713427004164729-slack-C02A333D8LQ

## Testing Instructions

### Bug fix

1. Open the app.
2. Go to global auto archive settings and set `Archive played episodes` to `Never`.
3. Run `UPDATE podcasts SET auto_archive_played_after = 1, override_global_archive = 0` in the `Database Inspector`.
4. Play an episode from any podcast.
5. Skip to the end.
6. Podcast should not be archived.

### Regressions

Test that episode playback respects all custom auto archive settings. Both global and podcast specific ones. You might want to clear you DB after the previous test before conducting this test.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~