### PR TITLE
Update discover events tracks to match with Web Player

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoryPillListAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoryPillListAdapter.kt
@@ -16,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.discover.databinding.CategoryPillBinding
 import au.com.shiftyjelly.pocketcasts.discover.view.CategoryPillListAdapter.CategoryPillViewHolder
 import au.com.shiftyjelly.pocketcasts.localization.R.string.clear_all
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory.Companion.ALL_CATEGORIES_ID
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 
 val CATEGORY_PILL_DIFF = object : DiffUtil.ItemCallback<CategoryPill>() {
@@ -29,7 +30,7 @@ val CATEGORY_PILL_DIFF = object : DiffUtil.ItemCallback<CategoryPill>() {
 class CategoryPillListAdapter(
     private val onCategoryClick: (CategoryPill, (List<CategoryPill>) -> Unit) -> Unit,
     private val onAllCategoriesClick: (() -> Unit, (List<CategoryPill>) -> Unit) -> Unit,
-    private val onClearCategoryClick: () -> Unit,
+    private val onClearCategoryClick: (DiscoverCategory?) -> Unit,
 ) : ListAdapter<CategoryPill, CategoryPillViewHolder>(CATEGORY_PILL_DIFF) {
 
     class CategoryPillViewHolder(
@@ -44,7 +45,7 @@ class CategoryPillListAdapter(
         }
 
         fun bind(category: CategoryPill, context: Context) {
-            if (category.discoverCategory.id == DiscoverCategory.ALL_CATEGORIES_ID) {
+            if (category.discoverCategory.id == ALL_CATEGORIES_ID) {
                 setUpAllCategoriesAndClear(context, category)
             } else {
                 setUpCategories(context, category)
@@ -83,9 +84,10 @@ class CategoryPillListAdapter(
         val binding = CategoryPillBinding.inflate(inflater, parent, false)
         return CategoryPillViewHolder(binding) { position ->
             val category = getItem(position)
-            if (category.discoverCategory.id == DiscoverCategory.ALL_CATEGORIES_ID) {
+            if (category.discoverCategory.id == ALL_CATEGORIES_ID) {
                 if (category.isSelected) {
-                    onClearCategoryClick()
+                    val currentSelectedCategory = currentList.firstOrNull { it.discoverCategory.id != ALL_CATEGORIES_ID }
+                    onClearCategoryClick(currentSelectedCategory?.discoverCategory)
                 } else {
                     binding.categoryIcon.setImageResource(R.drawable.ic_arrow_up)
                     onAllCategoriesClick(

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -19,6 +19,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent.DISCOVER_AD_CATEGORY_TAPPED
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent.DISCOVER_CATEGORIES_PICKER_CLOSED
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent.DISCOVER_CATEGORIES_PICKER_SHOWN
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent.DISCOVER_CATEGORY_CLOSE_BUTTON_TAPPED
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.discover.R
@@ -398,7 +399,13 @@ internal class DiscoverAdapter(
                     },
                 )
             },
-            onClearCategoryClick = {
+            onClearCategoryClick = { selectedCategory ->
+                selectedCategory?.let {
+                    analyticsTracker.track(
+                        DISCOVER_CATEGORY_CLOSE_BUTTON_TAPPED,
+                        mapOf("name" to it.name, "region" to region, "id" to it.id),
+                    )
+                }
                 listener.onClearCategoryFilterClick(
                     source,
                     onCategoryClearSuccess = {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -17,6 +17,8 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.OnScrollListener
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent.DISCOVER_AD_CATEGORY_TAPPED
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent.DISCOVER_CATEGORIES_PICKER_CLOSED
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent.DISCOVER_CATEGORIES_PICKER_SHOWN
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.discover.R
@@ -385,12 +387,16 @@ internal class DiscoverAdapter(
                 )
             },
             onAllCategoriesClick = { onCategorySelectionCancel, onCategorySelectionSuccess ->
+                analyticsTracker.track(DISCOVER_CATEGORIES_PICKER_SHOWN, mapOf("region" to region))
                 listener.onAllCategoriesClick(
                     source = source,
                     onCategorySelectionSuccess = {
                         onCategorySelectionSuccess(listOf(allCategories.copy(isSelected = true), it.copy(isSelected = true)))
                     },
-                    onCategorySelectionCancel = onCategorySelectionCancel,
+                    onCategorySelectionCancel = {
+                        analyticsTracker.track(DISCOVER_CATEGORIES_PICKER_CLOSED, mapOf("region" to region))
+                        onCategorySelectionCancel.invoke()
+                    },
                 )
             },
             onClearCategoryClick = {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -139,8 +139,6 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
         }
     }
     override fun onAllCategoriesClick(source: String, onCategorySelectionSuccess: (CategoryPill) -> Unit, onCategorySelectionCancel: () -> Unit) {
-        trackDropDownListCategoryPickImpression(ALL_CATEGORIES_NAME_VALUE, ALL_CATEGORIES_ID_VALUE)
-
         viewModel.loadCategories(source) { categories ->
             CategoriesBottomSheet(
                 categories = categories,
@@ -335,7 +333,5 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
         const val EPISODE_UUID_KEY = "episode_uuid"
         const val SOURCE_KEY = "source"
         const val UUID_KEY = "uuid"
-        const val ALL_CATEGORIES_NAME_VALUE = "all"
-        const val ALL_CATEGORIES_ID_VALUE = -1
     }
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -137,6 +137,8 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
 
             onCategorySelectionSuccess()
         }
+
+        trackCategoryShownImpression(selectedCategory.discoverCategory)
     }
     override fun onAllCategoriesClick(source: String, onCategorySelectionSuccess: (CategoryPill) -> Unit, onCategorySelectionCancel: () -> Unit) {
         viewModel.loadCategories(source) { categories ->
@@ -286,15 +288,13 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
 
             // If there is ad, we add it.
             viewModel.getAdForCategoryView(category.id)?.let {
-                updatedList.add(CategoryAdRow(categoryId = category.id, categoryName = category.name, discoverRow = it))
+                updatedList.add(CategoryAdRow(categoryId = category.id, categoryName = category.name, region = viewModel.currentRegionCode, discoverRow = it))
             }
 
             // Lastly, we add the remaining podcast list.
             updatedList.add(remainingPodcasts)
 
             adapter?.submitList(updatedList)
-
-            trackCategoryShownImpression(category)
         }
     }
     private fun trackCategoryShownImpression(category: DiscoverCategory) {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -288,7 +288,9 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
             updatedList.add(mostPopularPodcasts)
 
             // If there is ad, we add it.
-            viewModel.getAdForCategoryView(category.id)?.let { updatedList.add(CategoryAdRow(it)) }
+            viewModel.getAdForCategoryView(category.id)?.let {
+                updatedList.add(CategoryAdRow(categoryId = category.id, categoryName = category.name, discoverRow = it))
+            }
 
             // Lastly, we add the remaining podcast list.
             updatedList.add(remainingPodcasts)
@@ -329,7 +331,6 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
         private const val REGION_KEY = "region"
         private const val MOST_POPULAR_PODCASTS = 5
         const val LIST_ID_KEY = "list_id"
-        const val CATEGORY_ID_KEY = "category_id"
         const val PODCAST_UUID_KEY = "podcast_uuid"
         const val EPISODE_UUID_KEY = "episode_uuid"
         const val SOURCE_KEY = "source"

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -151,7 +151,6 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
         }
     }
     override fun onClearCategoryFilterClick(source: String, onCategoryClearSuccess: (List<CategoryPill>) -> Unit) {
-        analyticsTracker.track(AnalyticsEvent.DISCOVER_CATEGORY_CLOSE_BUTTON_TAPPED)
         viewModel.loadCategories(source) { categories ->
             onCategoryClearSuccess(categories)
             viewModel.loadData(resources) // Reload discover

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -283,6 +283,8 @@ enum class AnalyticsEvent(val key: String) {
     DISCOVER_CATEGORIES_PICKER_PICK("discover_categories_picker_pick"),
     DISCOVER_CATEGORIES_PILL_TAPPED("discover_categories_pill_tapped"),
     DISCOVER_CATEGORY_CLOSE_BUTTON_TAPPED("discover_category_close_button_tapped"),
+    DISCOVER_CATEGORIES_PICKER_SHOWN("discover_categories_picker_shown"),
+    DISCOVER_CATEGORIES_PICKER_CLOSED("discover_categories_picker_closed"),
     DISCOVER_FEATURED_PODCAST_TAPPED("discover_featured_podcast_tapped"),
     DISCOVER_AD_CATEGORY_TAPPED("discover_ad_category_tapped"),
     DISCOVER_FEATURED_PODCAST_SUBSCRIBED("discover_featured_podcast_subscribed"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -287,6 +287,7 @@ enum class AnalyticsEvent(val key: String) {
     DISCOVER_CATEGORIES_PICKER_CLOSED("discover_categories_picker_closed"),
     DISCOVER_FEATURED_PODCAST_TAPPED("discover_featured_podcast_tapped"),
     DISCOVER_AD_CATEGORY_TAPPED("discover_ad_category_tapped"),
+    DISCOVER_AD_CATEGORY_SUBSCRIBED("discover_ad_category_subscribed"),
     DISCOVER_FEATURED_PODCAST_SUBSCRIBED("discover_featured_podcast_subscribed"),
     DISCOVER_SHOW_ALL_TAPPED("discover_show_all_tapped"),
     DISCOVER_LIST_SHOW_ALL_TAPPED("discover_list_show_all_tapped"),


### PR DESCRIPTION
## Description
- Adds `discover_categories_picker_shown`, `discover_categories_picker_closed` and `discover_ad_category_subscribed` tracks events
- Updates `discover_category_close_button_tapped` and `discover_ad_category_tapped` to include properties
- https://github.com/Automattic/pocket-casts-webplayer/pull/2664

Closes #2188

> [!NOTE]  
> We have only Music category with ads configured for this week


## Testing Instructions
1. Go to Discover
2. Tap on `All categories`
3. ✅ Ensure 🔵 Tracked: `discover_categories_picker_shown, Properties: {"region":"fr"` is tracked 
4. Dismiss category list
5. ✅ Ensure 🔵 Tracked: `discover_categories_picker_closed, Properties: {"region":"fr"` is tracked 
7. Open the categories list again and tap on Music from drop down list
8. ✅ Ensure 🔵 Tracked: `discover_categories_picker_pick, Properties: {"name":"Music","region":"fr","id":9` is tracked
9. ✅ Ensure 🔵 Tracked: `discover_category_shown, Properties: {"name":"Music","region":"fr","id":9` is tracked
10. Tap on Close button to clear the category selection
11. ✅ Ensure 🔵 Tracked: `discover_category_close_button_tapped, Properties: {"name":"Music","region":"fr","id":9` is tracked
12. Open Music Category again
13. Subscribe to ad
14. ✅ Ensure 🔵 Tracked: `discover_ad_category_subscribed, Properties: {"name":"Music","region":"fr","id":9` is tracked
15. Tap on the ad podcast 
16. ✅ Ensure 🔵 Tracked: `discover_ad_category_tapped, Properties: {"name":"Music","region":"fr","id":9` is tracked
17. Clear category selection and tap on True Crime 
18. ✅ Ensure 🔵 Tracked: `discover_categories_pill_tapped, Properties: {"name":"True Crime","region":"fr","id":19` is tracked

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
