### PR TITLE
Fetch episodes refresh batch size from remote config

### DIFF
--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -391,6 +391,7 @@ interface Settings {
     fun getReportViolationUrl(): String
     fun getSlumberStudiosPromoCode(): String
     fun getSleepTimerDeviceShakeThreshold(): Long
+    fun getRefreshPodcastsBatchSize(): Long
 
     val podcastGroupingDefault: UserSetting<PodcastGrouping>
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -929,6 +929,10 @@ class SettingsImpl @Inject constructor(
         return getRemoteConfigLong(FirebaseConfig.SLEEP_TIMER_DEVICE_SHAKE_THRESHOLD)
     }
 
+    override fun getRefreshPodcastsBatchSize(): Long {
+        return getRemoteConfigLong(FirebaseConfig.REFRESH_PODCASTS_BATCH_SIZE)
+    }
+
     private fun getRemoteConfigLong(key: String): Long {
         val value = firebaseRemoteConfig.getLong(key)
         return if (value == 0L) (FirebaseConfig.defaults[key] as? Long ?: 0L) else value

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerManager.kt
@@ -125,7 +125,8 @@ open class ServerManager @Inject constructor(
     }
 
     suspend fun refreshPodcastsSync(podcasts: List<Podcast>): Result<RefreshResponse?> {
-        val batcher = RefreshPodcastBatcher(batchSize = 200)
+        val batchSize = settings.getRefreshPodcastsBatchSize().coerceIn(100L, Int.MAX_VALUE.toLong()).toInt()
+        val batcher = RefreshPodcastBatcher(batchSize)
         return batcher.refreshPodcasts(podcasts) { parameters ->
             suspendCancellableCoroutine { continuation ->
                 val call = postToMainServer(

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
@@ -11,6 +11,7 @@ object FirebaseConfig {
     const val REPORT_VIOLATION_URL = "report_violation_url"
     const val SLUMBER_STUDIOS_YEARLY_PROMO_CODE = "slumber_studios_yearly_promo_code"
     const val SLEEP_TIMER_DEVICE_SHAKE_THRESHOLD = "sleep_timer_device_shake_threshold"
+    const val REFRESH_PODCASTS_BATCH_SIZE = "refresh_podcasts_batch_size"
     val defaults = mapOf(
         PERIODIC_SAVE_TIME_MS to 60000L,
         PLAYER_RELEASE_TIME_OUT_MS to 500L,
@@ -18,6 +19,7 @@ object FirebaseConfig {
         EPISODE_SEARCH_DEBOUNCE_MS to 2000L,
         CLOUD_STORAGE_LIMIT to 10L,
         SLEEP_TIMER_DEVICE_SHAKE_THRESHOLD to 30L,
+        REFRESH_PODCASTS_BATCH_SIZE to 200L,
     ) + Feature.values()
         .filter { it.hasFirebaseRemoteFlag }
         .associate { it.key to it.defaultValue }


### PR DESCRIPTION
## Description

As a precaution before batching goes to production I'm putting batch size behind remote configuration. This will allow us to bring back the old behavior by increasing batch size if somethings doesn't behave as expected.

## Testing Instructions

> [!note]
> Test this with the `release` variant.

1. Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/15264364/batch.patch).
2. Go to the Firebase remote config.
3. Change `refresh_podcasts_batch_size` to a negative number.
4. Install and open the app.
5. Go to podcasts tab.
6. Pull to refresh a couple of times. Be cautious of #2164 that is not fixed in `7.63` so you'll need to do 20 seconds pauses between refreshes including the one that happens on app init.
7. You shouldn't observe anything special. Podcasts should refresh. 
8. Change `refresh_podcasts_batch_size` to some big number like 10000.
9. Close the app.
11. Open the app.
12. Go to podcasts tab.
13. Pull to refresh a couple of times. Be cautious of #2164 that is not fixed in `7.63` so you'll need to do 20 seconds pauses between refreshes including the one that happens on app init.
14. You shouldn't observe anything special. Podcasts should refresh. 

> [!note]
> After the test change `refresh_podcasts_batch_size` in Firebase remote config back to 200.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
