### PR TITLE
Make large widget header padding smaller

### DIFF
--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayerHeader.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayerHeader.kt
@@ -41,7 +41,7 @@ internal fun LargePlayerHeader(
                 size = 116.dp,
             )
             Spacer(
-                modifier = GlanceModifier.width(12.dp),
+                modifier = GlanceModifier.width(8.dp),
             )
             Column(
                 verticalAlignment = Alignment.Vertical.Top,


### PR DESCRIPTION
## Description

Large player widget header padding was a little bit too big.

Internal ref: Lkt7fuf9Nq3XvfAFPCfpTD-fi-1530_3473

## Testing Instructions

Reviewing screenshots should be enough but you can test the large widget.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![before](https://github.com/Automattic/pocket-casts-android/assets/30936061/1f8f95b7-6abb-4cac-9583-61a61b65fe33) | ![after](https://github.com/Automattic/pocket-casts-android/assets/30936061/90e621fb-41e1-45bc-b6e6-f7666455b64c) |

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] ~Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)~
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~