### PR TITLE
Up Next - Minor tweaks

### DIFF
--- a/modules/features/podcasts/src/main/res/layout/fragment_podcasts.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcasts.xml
@@ -164,6 +164,7 @@
                 android:layout_height="match_parent"
                 android:clipToPadding="false"
                 android:clipChildren="false"
+                android:scrollbarStyle="outsideOverlay"
                 android:scrollbars="vertical" />
 
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImage.kt
@@ -65,103 +65,105 @@ fun FolderImage(
     badgeType: BadgeType = BadgeType.OFF,
 ) {
     val cornerRadius = if (FeatureFlag.isEnabled(Feature.PODCASTS_GRID_VIEW_DESIGN_CHANGES)) 4.dp else 0.dp
-    BoxWithConstraints(
-        contentAlignment = Alignment.Center,
+    val elevation = if (FeatureFlag.isEnabled(Feature.PODCASTS_GRID_VIEW_DESIGN_CHANGES)) 4.dp else 0.dp
+    Card(
+        elevation = elevation,
+        shape = RoundedCornerShape(cornerRadius),
+        backgroundColor = color,
         modifier = modifier
-            .background(
-                color = color,
-                shape = RoundedCornerShape(cornerRadius),
-            )
             .aspectRatio(1f),
     ) {
-        val constraints = this
-
-        Box(
-            modifier = Modifier
-                .background(
-                    brush = Brush.verticalGradient(
-                        colors = listOf(
-                            gradientTop,
-                            gradientBottom,
-                        ),
-                    ),
-                )
-                .fillMaxSize(),
-        ) {}
-        val podcastSize = (constraints.maxWidth.value / imageSizeRatio).dp
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.fillMaxWidth(),
+        BoxWithConstraints(
+            contentAlignment = Alignment.Center,
         ) {
-            val imagePadding = (constraints.maxWidth.value / paddingImageRatio).dp
-            Spacer(modifier = Modifier.height(imagePadding))
-            Row(horizontalArrangement = Arrangement.Center) {
-                Column(horizontalAlignment = Alignment.End) {
-                    FolderPodcastImage(
-                        uuid = podcastUuids.getOrNull(0),
-                        color = color,
-                        gradientColor = topPodcastImageGradient,
-                        modifier = Modifier.size(podcastSize),
+            val constraints = this
+            Box(
+                modifier = Modifier
+                    .background(
+                        brush = Brush.verticalGradient(
+                            colors = listOf(
+                                gradientTop,
+                                gradientBottom,
+                            ),
+                        ),
                     )
-                    Spacer(modifier = Modifier.height(imagePadding))
-                    FolderPodcastImage(
-                        uuid = podcastUuids.getOrNull(2),
-                        color = color,
-                        gradientColor = bottomPodcastImageGradient,
-                        modifier = Modifier.size(podcastSize),
-                    )
+                    .fillMaxSize(),
+            ) {}
+            val podcastSize = (constraints.maxWidth.value / imageSizeRatio).dp
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                val imagePadding = (constraints.maxWidth.value / paddingImageRatio).dp
+                Spacer(modifier = Modifier.height(imagePadding))
+                Row(horizontalArrangement = Arrangement.Center) {
+                    Column(horizontalAlignment = Alignment.End) {
+                        FolderPodcastImage(
+                            uuid = podcastUuids.getOrNull(0),
+                            color = color,
+                            gradientColor = topPodcastImageGradient,
+                            modifier = Modifier.size(podcastSize),
+                        )
+                        Spacer(modifier = Modifier.height(imagePadding))
+                        FolderPodcastImage(
+                            uuid = podcastUuids.getOrNull(2),
+                            color = color,
+                            gradientColor = bottomPodcastImageGradient,
+                            modifier = Modifier.size(podcastSize),
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(imagePadding))
+                    Column(horizontalAlignment = Alignment.Start) {
+                        FolderPodcastImage(
+                            uuid = podcastUuids.getOrNull(1),
+                            color = color,
+                            gradientColor = topPodcastImageGradient,
+                            modifier = Modifier.size(podcastSize),
+                        )
+                        Spacer(modifier = Modifier.height(imagePadding))
+                        FolderPodcastImage(
+                            uuid = podcastUuids.getOrNull(3),
+                            color = color,
+                            gradientColor = bottomPodcastImageGradient,
+                            modifier = Modifier.size(podcastSize),
+                        )
+                    }
                 }
-                Spacer(modifier = Modifier.width(imagePadding))
-                Column(horizontalAlignment = Alignment.Start) {
-                    FolderPodcastImage(
-                        uuid = podcastUuids.getOrNull(1),
-                        color = color,
-                        gradientColor = topPodcastImageGradient,
-                        modifier = Modifier.size(podcastSize),
-                    )
-                    Spacer(modifier = Modifier.height(imagePadding))
-                    FolderPodcastImage(
-                        uuid = podcastUuids.getOrNull(3),
-                        color = color,
-                        gradientColor = bottomPodcastImageGradient,
-                        modifier = Modifier.size(podcastSize),
+                if (name.isNotBlank()) {
+                    Spacer(modifier = Modifier.height((constraints.maxWidth.value / paddingBottomRatio).dp))
+                    Text(
+                        text = name,
+                        color = Color.White,
+                        fontSize = fontSize,
+                        fontWeight = FontWeight(500),
+                        letterSpacing = 0.25.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        style = LocalTextStyle.current.copy(
+                            shadow = Shadow(
+                                color = Color(0x33000000),
+                                offset = Offset(0f, 2f),
+                                blurRadius = 4f,
+                            ),
+                        ),
                     )
                 }
             }
-            if (name.isNotBlank()) {
-                Spacer(modifier = Modifier.height((constraints.maxWidth.value / paddingBottomRatio).dp))
-                Text(
-                    text = name,
-                    color = Color.White,
-                    fontSize = fontSize,
-                    fontWeight = FontWeight(500),
-                    letterSpacing = 0.25.sp,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    style = LocalTextStyle.current.copy(
-                        shadow = Shadow(
-                            color = Color(0x33000000),
-                            offset = Offset(0f, 2f),
-                            blurRadius = 4f,
-                        ),
-                    ),
+            if (FeatureFlag.isEnabled(Feature.PODCASTS_GRID_VIEW_DESIGN_CHANGES)) {
+                CountBadge(
+                    count = badgeCount,
+                    style = if (badgeType == BadgeType.LATEST_EPISODE) CountBadgeStyle.Small else CountBadgeStyle.Medium,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .offset(x = 6.dp, y = (-6).dp),
+                )
+            } else {
+                PodcastBadge(
+                    count = badgeCount,
+                    modifier = Modifier.align(Alignment.TopEnd),
+                    badgeType = badgeType,
                 )
             }
-        }
-        if (FeatureFlag.isEnabled(Feature.PODCASTS_GRID_VIEW_DESIGN_CHANGES)) {
-            CountBadge(
-                count = badgeCount,
-                style = if (badgeType == BadgeType.LATEST_EPISODE) CountBadgeStyle.Small else CountBadgeStyle.Medium,
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .offset(x = 6.dp, y = (-6).dp),
-            )
-        } else {
-            PodcastBadge(
-                count = badgeCount,
-                modifier = Modifier.align(Alignment.TopEnd),
-                badgeType = badgeType,
-            )
         }
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -349,7 +349,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="player_up_next_move_to_top">Move to top</string>
     <string name="player_up_next_select">Select</string>
     <string name="player_up_next_time_remaining">Total time remaining %s</string>
-    <string name="player_up_next_time_left">@string/time_left</string>
+    <string name="player_up_next_time_left" translatable="false">@string/time_left</string>
     <plurals name="player_up_next_header_title">
         <item quantity="one" formatted="true">%1$d episode - %2$s left</item>
         <item quantity="other" formatted="true">%1$d episodes - %2$s left</item>


### PR DESCRIPTION
## Description
- The scroll bar on the podcasts page is now on the side of the screen.
- Adds elevation to folder

Partly Fixes https://github.com/Automattic/pocket-casts-android/issues/2193

## Testing Instructions

Scrollbar 



## Screenshots or Screencast 

Scrollbar

1. Subscribe to lots of podcasts
2. Go to the podcasts grid
3. Scroll the page

Folder Image

1. Create a folder and subscribe to a podcast
2. Go to the podcasts list
3. Compare the drop shadow on the podcast artwork and a folder (I changed the color to White in the captured screenshot)

https://github.com/Automattic/pocket-casts-android/assets/1405144/daa8e4cc-5ad1-44a2-af1c-0b0c05e91acc

Folder Image

<img width = 300 src = "https://github.com/Automattic/pocket-casts-android/assets/1405144/6dd682a4-0dbf-498a-9788-9070e10088a6"/>



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
