### PR TITLE
Move badge overlay outside card view

### DIFF
--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImage.kt
@@ -66,17 +66,17 @@ fun FolderImage(
 ) {
     val cornerRadius = if (FeatureFlag.isEnabled(Feature.PODCASTS_GRID_VIEW_DESIGN_CHANGES)) 4.dp else 0.dp
     val elevation = if (FeatureFlag.isEnabled(Feature.PODCASTS_GRID_VIEW_DESIGN_CHANGES)) 4.dp else 0.dp
-    Card(
-        elevation = elevation,
-        shape = RoundedCornerShape(cornerRadius),
-        backgroundColor = color,
-        modifier = modifier
-            .aspectRatio(1f),
+    BoxWithConstraints(
+        contentAlignment = Alignment.Center,
     ) {
-        BoxWithConstraints(
-            contentAlignment = Alignment.Center,
+        val constraints = this
+        Card(
+            elevation = elevation,
+            shape = RoundedCornerShape(cornerRadius),
+            backgroundColor = color,
+            modifier = modifier
+                .aspectRatio(1f),
         ) {
-            val constraints = this
             Box(
                 modifier = Modifier
                     .background(
@@ -149,21 +149,21 @@ fun FolderImage(
                     )
                 }
             }
-            if (FeatureFlag.isEnabled(Feature.PODCASTS_GRID_VIEW_DESIGN_CHANGES)) {
-                CountBadge(
-                    count = badgeCount,
-                    style = if (badgeType == BadgeType.LATEST_EPISODE) CountBadgeStyle.Small else CountBadgeStyle.Medium,
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .offset(x = 6.dp, y = (-6).dp),
-                )
-            } else {
-                PodcastBadge(
-                    count = badgeCount,
-                    modifier = Modifier.align(Alignment.TopEnd),
-                    badgeType = badgeType,
-                )
-            }
+        }
+        if (FeatureFlag.isEnabled(Feature.PODCASTS_GRID_VIEW_DESIGN_CHANGES)) {
+            CountBadge(
+                count = badgeCount,
+                style = if (badgeType == BadgeType.LATEST_EPISODE) CountBadgeStyle.Small else CountBadgeStyle.Medium,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .offset(x = 6.dp, y = (-6).dp),
+            )
+        } else {
+            PodcastBadge(
+                count = badgeCount,
+                modifier = Modifier.align(Alignment.TopEnd),
+                badgeType = badgeType,
+            )
         }
     }
 }


### PR DESCRIPTION
## Description
This fixes folder badge overlay getting cropped due to changes in https://github.com/Automattic/pocket-casts-android/pull/2204

## Testing Instructions

1. Create a folder and subscribe to a podcast
2. Go to the podcasts list
3. Enable badge
4. Compare the drop shadow on the podcast artwork and a folder 
5. Notice that badge is not cropped

<img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/8107654b-88df-47b2-ae76-dab29db16b1e"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
