### PR TITLE
Fix: All categories text color sometimes getting painted with wrong color

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoryPillListAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoryPillListAdapter.kt
@@ -62,6 +62,7 @@ class CategoryPillListAdapter(
                 binding.categoryIcon.setIcon(R.drawable.ic_arrow_down)
                 binding.categoryPill.background = getDrawable(context, R.drawable.category_pill_background)
             }
+            binding.categoryName.setCategoryColor(category.isSelected)
         }
 
         private fun setUpCategories(context: Context, category: CategoryPill) {
@@ -90,6 +91,8 @@ class CategoryPillListAdapter(
                     onClearCategoryClick(currentSelectedCategory?.discoverCategory)
                 } else {
                     binding.categoryIcon.setImageResource(R.drawable.ic_arrow_up)
+                    binding.categoryName.setCategory(category.discoverCategory.name)
+                    binding.categoryName.setCategoryColor(isSelected = false)
                     onAllCategoriesClick(
                         onCategorySelectionCancel@{
                             binding.categoryName.setCategory(category.discoverCategory.name)
@@ -99,7 +102,7 @@ class CategoryPillListAdapter(
                         onCategorySelectionSuccess@{
                             binding.categoryIcon.setIcon(R.drawable.ic_arrow_down)
                             binding.categoryName.setCategory(category.discoverCategory.name)
-                            updateCategoryStatus(position, isSelected = false)
+                            updateAllCategoryButton()
                             loadCategories(it)
                         },
                     )
@@ -119,8 +122,18 @@ class CategoryPillListAdapter(
         submitList(categoryPills)
     }
     private fun updateCategoryStatus(position: Int, isSelected: Boolean) {
-        getItem(position).isSelected = isSelected
-        notifyItemChanged(position)
+        if (getItem(position).isSelected != isSelected) { // This is to avoid UI flickering
+            getItem(position).isSelected = isSelected
+            notifyItemChanged(position)
+        }
+    }
+
+    private fun updateAllCategoryButton() {
+        if (currentList.size == 2) { // Has category already selected
+            updateCategoryStatus(0, isSelected = true) // Keep all categories pill as selected
+        } else {
+            updateCategoryStatus(0, isSelected = false) // Keep close pill as selected
+        }
     }
 }
 private fun TextView.setCategory(category: String) {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoryPillListAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CategoryPillListAdapter.kt
@@ -129,11 +129,7 @@ class CategoryPillListAdapter(
     }
 
     private fun updateAllCategoryButton() {
-        if (currentList.size == 2) { // Has category already selected
-            updateCategoryStatus(0, isSelected = true) // Keep all categories pill as selected
-        } else {
-            updateCategoryStatus(0, isSelected = false) // Keep close pill as selected
-        }
+        updateCategoryStatus(0, isSelected = currentList.size == 2)
     }
 }
 private fun TextView.setCategory(category: String) {


### PR DESCRIPTION
## Description
- The text color of `All categories` something was not getting set with the correct color when subscribing to podcasts

> [!NOTE]  
> We have only Music category with ads configured for this week

Closes: #2198

## Testing Instructions

1. Go to Discover.
2. Select a category from All categories that has add.
3. Tap on subscription button.
4. Close the categories.
5. Select a category from All categories that has add again.
6. Tap on subscription button again.
7. Close the categories.
8. All categories title must have the correct color. You can compare with the others pills colors

## Screenshots or Screencast 
See the video in #2198

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
