### PR TITLE
Enable up next in tab bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Updates:
     *   New design for the Podcasts grid layout
         ([#2165](https://github.com/Automattic/pocket-casts-android/pull/2165))
+    *   Adds new dedicated tab for up next
+        ([#2213](https://github.com/Automattic/pocket-casts-android/pull/2213))
 *   Bug Fixes
     *   Fix pull to refresh icon sometimes being stuck in a loading state
         ([#2164](https://github.com/Automattic/pocket-casts-android/pull/2164))

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -86,9 +86,9 @@ enum class Feature(
     UPNEXT_IN_TAB_BAR(
         key = "upnext_in_tab_bar",
         title = "Show Up Next in tab bar",
-        defaultValue = BuildConfig.DEBUG,
+        defaultValue = true,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = false,
+        hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
     PODCASTS_GRID_VIEW_DESIGN_CHANGES(


### PR DESCRIPTION
## Description
Enabled FF for Up Next in tab bar.

## Testing Instructions
Make sure that `upnext_in_tab_bar` feature flag has correct values in `Feature.kt` and in Firebase remote config.

## Screenshots or Screencast 
<img width = 300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/087f9ec3-b4e6-40f7-bf6e-67f17b7f1b27"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
