### PR TITLE
Change widget's button background color

### DIFF
--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/WidgetTheme.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/WidgetTheme.kt
@@ -90,7 +90,7 @@ private val DefaultColors = ColorProviders(
         onPrimaryContainer = UndefinedColor,
         inversePrimary = UndefinedColor,
         secondary = Color(0xFFFFFFFF),
-        onSecondary = Color(0xFF404247),
+        onSecondary = Color(0xFF333438),
         secondaryContainer = Color(0xFF292B2E),
         onSecondaryContainer = Color(0xFFFFFFFF),
         // Used as a trick for different Pocket Casts logo colors


### PR DESCRIPTION
## Description

This PR makes button background in dark mode a bit darker.

Internal ref: Lkt7fuf9Nq3XvfAFPCfpTD-fi-1530_3435

## Testing Instructions

1. Add widgets to the home screen and set their theme to non-dynamic dark.
2. The button's background color should match the designs.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![before](https://github.com/Automattic/pocket-casts-android/assets/30936061/b87ae91b-7a65-4fd4-a1d5-3461e3062a7e) | ![after](https://github.com/Automattic/pocket-casts-android/assets/30936061/a15df405-6dfb-49fa-aee0-14d30730ed91) |


## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~