### PR TITLE
Set yearly subscription as default selected

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
@@ -155,11 +155,16 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
         val lastSelectedFrequency = settings.getLastSelectedSubscriptionFrequency().takeIf { source in listOf(OnboardingUpgradeSource.LOGIN, OnboardingUpgradeSource.PROFILE) }
 
         val fromProfile = source == OnboardingUpgradeSource.PROFILE
-        val defaultSelected = subscriptionManager.getDefaultSubscription(
-            subscriptions = subscriptions,
-            tier = lastSelectedTier,
-            frequency = lastSelectedFrequency,
-        )
+        val defaultSelected = if (source == OnboardingUpgradeSource.LOGIN) {
+            subscriptionManager.getDefaultSubscription(
+                subscriptions = subscriptions,
+                tier = lastSelectedTier,
+                frequency = lastSelectedFrequency,
+            )
+        } else {
+            subscriptionManager.getDefaultSubscription(subscriptions = subscriptions)
+        }
+
         return if (defaultSelected == null) {
             NoSubscriptions
         } else {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -78,6 +78,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
         val lastSelectedFrequency = settings.getLastSelectedSubscriptionFrequency().takeIf { source in listOf(OnboardingUpgradeSource.LOGIN, OnboardingUpgradeSource.PROFILE) }
 
         val showPatronOnly = source == OnboardingUpgradeSource.ACCOUNT_DETAILS || showPatronOnly == true
+        val fromLogin = source == OnboardingUpgradeSource.LOGIN
         val updatedSubscriptions =
             if (showPatronOnly) {
                 subscriptions.filter { it.tier == Subscription.SubscriptionTier.PATRON }
@@ -87,8 +88,8 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
 
         val selectedSubscription = subscriptionManager.getDefaultSubscription(
             subscriptions = updatedSubscriptions,
-            tier = if (showPatronOnly) Subscription.SubscriptionTier.PATRON else lastSelectedTier,
-            frequency = lastSelectedFrequency,
+            tier = if (showPatronOnly) Subscription.SubscriptionTier.PATRON else { if (fromLogin) lastSelectedTier else null },
+            frequency = if (fromLogin) lastSelectedFrequency else null,
         )
 
         val showNotNow = source == OnboardingUpgradeSource.RECOMMENDATIONS


### PR DESCRIPTION
## Description
- This PR sets the Yearly subscription as default selected by removing the existing logic to select the last selected subscription
- See: p1715362112981289/1715288540.470539-slack-C028JAG44VD

> [!NOTE]  
> You may encounter a Play Store caching issue when attempting to check your subscriptions. If you receive a message indicating that you don't have any subscriptions, you will need to clear the cache for both the Play Store and Pocket Casts app

Closes #2209

## Testing Instructions
1. `git apply` [subscription.patch](https://github.com/Automattic/pocket-casts-android/files/15294065/subscription.patch)
2. Run the app in `debugProd`
3. Login with a free account that never had any subscription before
4. Have this account logged in Play Store
5. ✅ Ensure every upsell we have opens with `Yearly Subscription` selected as default 

> [!TIP]
> You can find upsell in:
> 1 - Podcasts Tab -> Folder Icon
> 2 - Tap on any podcast -> Bookmarks tab
> 3 - Tap on any podcast -> Play an episode -> Bookmarks
> 4 - Profile -> Scroll to the bottom
> 5 - Settings -> Pocket Casts plus


## Screenshots or Screencast 
[Screen_recording_20240513_085337.webm](https://github.com/Automattic/pocket-casts-android/assets/42220351/593a6178-dce3-45f2-825d-2bf40323a552)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack