### PR TITLE
Make large widget non-scrollable

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -302,7 +302,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
             .launchIn(applicationScope)
         val queueFlow = flow {
             while (true) {
-                emit(upNextDao.findUpNextEpisodes(limit = 10))
+                emit(upNextDao.findUpNextEpisodes(limit = PlayerWidgetManager.EPISODE_LIMIT))
                 // Emit every second to update playback durations
                 delay(1.seconds)
             }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/PlayerWidgetManager.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/PlayerWidgetManager.kt
@@ -71,4 +71,8 @@ class PlayerWidgetManager @Inject constructor(
     }
 
     private suspend inline fun <reified T : GlanceAppWidget> glanceIds() = widgetManager.getGlanceIds(T::class.java)
+
+    companion object {
+        const val EPISODE_LIMIT = LargePlayerWidgetState.EPISODE_LIMIT
+    }
 }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/data/LargePlayerWidgetState.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/data/LargePlayerWidgetState.kt
@@ -47,11 +47,14 @@ internal data class LargePlayerWidgetState(
     }
 
     companion object {
+        const val EPISODE_LIMIT = 10
+        const val QUEUE_LIMIT = EPISODE_LIMIT - 1
+
         suspend fun getInitialState(context: Context): LargePlayerWidgetState {
             val upNextDao = context.widgetEntryPoint().upNextDao()
             val settings = context.widgetEntryPoint().settings()
             val playbackManager = context.widgetEntryPoint().playbackManager()
-            val queue = upNextDao.findUpNextEpisodes(limit = 10).map(PlayerWidgetEpisode::fromBaseEpisode)
+            val queue = upNextDao.findUpNextEpisodes(limit = EPISODE_LIMIT).map(PlayerWidgetEpisode::fromBaseEpisode)
             return LargePlayerWidgetState(
                 queue = queue,
                 isPlaying = playbackManager.isPlaying(),

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayer.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayer.kt
@@ -20,11 +20,11 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun LargePlayer(state: LargePlayerWidgetState) {
-    val upNextEpisodes = state.upNextEpisodes
     val headerAndPaddingHeight = 160.dp
     val availableContentHeight = LocalSize.current.height - headerAndPaddingHeight
-    val fittingItemCount = ((availableContentHeight - 58.dp) / 66.dp).toInt().coerceAtLeast(0) + 1
-    val actualDisplayedItemCount = upNextEpisodes.size.coerceAtMost(fittingItemCount)
+    val fittingItemCount = (((availableContentHeight - 58.dp) / 66.dp).toInt().coerceAtLeast(0) + 1).coerceAtMost(LargePlayerWidgetState.QUEUE_LIMIT)
+    val upNextEpisodes = state.upNextEpisodes.take(fittingItemCount)
+    val actualDisplayedItemCount = upNextEpisodes.size
     val expectedContentHeight = contentHeight(fittingItemCount)
     val actualContentHeight = contentHeight(actualDisplayedItemCount)
 

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayerQueue.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/LargePlayerQueue.kt
@@ -5,8 +5,6 @@ import androidx.compose.ui.unit.dp
 import androidx.glance.GlanceModifier
 import androidx.glance.LocalContext
 import androidx.glance.action.clickable
-import androidx.glance.appwidget.lazy.LazyColumn
-import androidx.glance.appwidget.lazy.itemsIndexed
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Column
 import androidx.glance.layout.Row
@@ -27,10 +25,10 @@ internal fun LargePlayerQueue(
 ) {
     val lastIndex = queue.lastIndex
 
-    LazyColumn(
-        modifier = modifier.fillMaxWidth(),
+    Column(
+        modifier.fillMaxWidth(),
     ) {
-        itemsIndexed(queue, { _, episode -> episode.longId }) { index, episode ->
+        queue.forEachIndexed { index, episode ->
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = GlanceModifier


### PR DESCRIPTION
## Description

Make large widget content not scrollable.

## Testing Instructions

1. Add at least 10 episodes to your queue.
2. Add large widget to your home screen.
3. Make sure that the queue is not scrollable in the widget.
4. When you resize the widget the number of displayed items should adapt to the size.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
