### PR TITLE
Improve the folder label position

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditColorPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditColorPage.kt
@@ -142,6 +142,7 @@ private fun FolderPreview(layout: PodcastGridLayoutType, name: String, colorId: 
                     name = name,
                     color = backgroundColor,
                     podcastUuids = podcastUuids,
+                    textSpacing = true,
                     modifier = Modifier.size(gridImageWidthDp.dp),
                 )
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderAdapter.kt
@@ -102,6 +102,7 @@ class FolderAdapter(
                     gridWidthDp = gridWidthDp,
                     podcastsLayout = podcastsLayout,
                     onFolderClick = { clickListener.onFolderClick(it.uuid, isUserInitiated = true) },
+                    podcastGridLayout = podcastsLayout,
                 )
             }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderListRow.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderListRow.kt
@@ -45,7 +45,7 @@ fun FolderListRow(
             .padding(horizontal = 16.dp)
             .then(if (onClick == null) Modifier else Modifier.clickable { onClick() }),
     ) {
-        FolderImageSmall(color = color, podcastUuids = podcastUuids)
+        FolderImageSmall(color = color, podcastUuids = podcastUuids, folderImageSize = 64.dp)
         Column(
             modifier = Modifier
                 .padding(start = 16.dp)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderViewHolder.kt
@@ -27,6 +27,7 @@ class FolderViewHolder(
     val gridWidthDp: Int,
     val podcastsLayout: PodcastGridLayoutType,
     val onFolderClick: (Folder) -> Unit,
+    val podcastGridLayout: PodcastGridLayoutType,
 ) : RecyclerView.ViewHolder(composeView) {
 
     fun bind(folder: Folder, podcasts: List<Podcast>, badgeType: BadgeType, podcastUuidToBadge: Map<String, Int>) {
@@ -54,6 +55,7 @@ class FolderViewHolder(
                             podcastUuids = podcastUuids,
                             badgeCount = badgeCount,
                             badgeType = badgeType,
+                            podcastGridLayout = podcastGridLayout,
                             onClick = { onFolderClick(folder) },
                             modifier = Modifier.size(gridWidthDp.dp),
                         )
@@ -77,13 +79,14 @@ class FolderViewHolder(
 }
 
 @Composable
-private fun FolderGridAdapter(color: Color, name: String, podcastUuids: List<String>, badgeCount: Int, badgeType: BadgeType, modifier: Modifier = Modifier, onClick: () -> Unit) {
+private fun FolderGridAdapter(color: Color, name: String, podcastUuids: List<String>, badgeCount: Int, badgeType: BadgeType, podcastGridLayout: PodcastGridLayoutType, modifier: Modifier = Modifier, onClick: () -> Unit) {
     FolderImage(
         name = name,
         color = color,
         podcastUuids = podcastUuids,
         badgeCount = badgeCount,
         badgeType = badgeType,
+        textSpacing = podcastGridLayout == PodcastGridLayoutType.LARGE_ARTWORK,
         modifier = modifier.clickable { onClick() },
     )
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImage.kt
@@ -29,7 +29,9 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.TextUnit
@@ -37,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.extensions.nonScaledSp
 import au.com.shiftyjelly.pocketcasts.compose.images.CountBadge
 import au.com.shiftyjelly.pocketcasts.compose.images.CountBadgeStyle
 import au.com.shiftyjelly.pocketcasts.compose.theme
@@ -50,17 +53,17 @@ private val gradientTop = Color(0x00000000)
 private val gradientBottom = Color(0x33000000)
 private val topPodcastImageGradient = listOf(Color(0x00000000), Color(0x16000000))
 private val bottomPodcastImageGradient = listOf(Color(0x16000000), Color(0x33000000))
-private const val paddingBottomRatio = 120f / 1f
-private const val paddingImageRatio = 120f / 4f
-private const val imageSizeRatio = 120f / 44f
+private const val paddingImageRatio = 4f / 120f
+private const val imageSizeRatio = 44f / 120f
 
 @Composable
 fun FolderImage(
     name: String,
     color: Color,
     podcastUuids: List<String>,
+    textSpacing: Boolean,
     modifier: Modifier = Modifier,
-    fontSize: TextUnit = 11.sp,
+    fontSize: TextUnit = 11.nonScaledSp,
     badgeCount: Int = 0,
     badgeType: BadgeType = BadgeType.OFF,
 ) {
@@ -89,12 +92,12 @@ fun FolderImage(
                     )
                     .fillMaxSize(),
             ) {}
-            val podcastSize = (constraints.maxWidth.value / imageSizeRatio).dp
+            val podcastSize = (constraints.maxWidth.value * imageSizeRatio).dp
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                val imagePadding = (constraints.maxWidth.value / paddingImageRatio).dp
+                val imagePadding = (constraints.maxWidth.value * paddingImageRatio).dp
                 Spacer(modifier = Modifier.height(imagePadding))
                 Row(horizontalArrangement = Arrangement.Center) {
                     Column(horizontalAlignment = Alignment.End) {
@@ -130,7 +133,9 @@ fun FolderImage(
                     }
                 }
                 if (name.isNotBlank()) {
-                    Spacer(modifier = Modifier.height((constraints.maxWidth.value / paddingBottomRatio).dp))
+                    if (textSpacing) {
+                        Spacer(modifier = Modifier.height(imagePadding))
+                    }
                     Text(
                         text = name,
                         color = Color.White,
@@ -144,6 +149,13 @@ fun FolderImage(
                                 color = Color(0x33000000),
                                 offset = Offset(0f, 2f),
                                 blurRadius = 4f,
+                            ),
+                            platformStyle = PlatformTextStyle(
+                                includeFontPadding = false,
+                            ),
+                            lineHeightStyle = LineHeightStyle(
+                                alignment = LineHeightStyle.Alignment.Center,
+                                trim = LineHeightStyle.Trim.Both,
                             ),
                         ),
                     )
@@ -266,6 +278,7 @@ private fun FolderImagePreview() {
         podcastUuids = emptyList(),
         badgeCount = 1,
         badgeType = BadgeType.ALL_UNFINISHED,
+        textSpacing = true,
         modifier = Modifier.size(100.dp),
     )
 }


### PR DESCRIPTION
## Description

The folder label was being hidden off the image, this change improves this. This could look better but as we have the beta it's a quick fix. Thanks for your advice @MiSikora, I will give a constraint layout a try for a future version.

There's still an issue that the folder size is smaller than the podcast artwork but a fix for that will be in a separate pull request.

## Testing Instructions

1. Add a folder
2. Check the folder label in the three podcast layouts: large grid, small grid, and list.

## Screenshots

| Before | After |
| --- | --- |
| ![Screenshot_20240514_173220](https://github.com/Automattic/pocket-casts-android/assets/308331/72534b6c-3256-440b-bd58-5170c52ff43c) | ![Screenshot_20240514_172750](https://github.com/Automattic/pocket-casts-android/assets/308331/45a407db-9108-4e4d-8486-9684208fce2b) |
| ![Screenshot_20240514_173232](https://github.com/Automattic/pocket-casts-android/assets/308331/de505b72-2bd1-4117-8e2f-c93956c10add) | ![Screenshot_20240514_172743](https://github.com/Automattic/pocket-casts-android/assets/308331/dc30a49e-8dcd-4cee-86d4-ec807107448e) |
| ![Screenshot_20240514_173544](https://github.com/Automattic/pocket-casts-android/assets/308331/beccb42b-ddb4-4d2b-b1a9-2522b3f87c42) | ![Screenshot_20240514_173621](https://github.com/Automattic/pocket-casts-android/assets/308331/c6613280-3554-4c97-8a28-76f865fa2048) |
