### PR TITLE
Fix: Subscribe to a podcast makes the page jumps after a few seconds

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -962,6 +962,8 @@ private class DiscoverRowDiffCallback : DiffUtil.ItemCallback<Any>() {
             true
         } else if (old is RemainingPodcastsByCategoryRow && new is RemainingPodcastsByCategoryRow) {
             true
+        } else if (old is MostPopularPodcastsByCategoryRow && new is MostPopularPodcastsByCategoryRow) {
+            true
         } else {
             old == new
         }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -960,6 +960,8 @@ private class DiscoverRowDiffCallback : DiffUtil.ItemCallback<Any>() {
             old.source == new.source
         } else if (old is ChangeRegionRow && new is ChangeRegionRow) {
             true
+        } else if (old is RemainingPodcastsByCategoryRow && new is RemainingPodcastsByCategoryRow) {
+            true
         } else {
             old == new
         }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/MostPopularPodcastsAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/MostPopularPodcastsAdapter.kt
@@ -9,7 +9,6 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.discover.databinding.ItemMostPopularPodcastsBinding
 import au.com.shiftyjelly.pocketcasts.discover.extensions.updateSubscribeButtonIcon
-import au.com.shiftyjelly.pocketcasts.discover.util.DISCOVER_PODCAST_DIFF_CALLBACK
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.LIST_ID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.PODCAST_UUID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.MostPopularPodcastsAdapter.MostPopularPodcastsViewHolder
@@ -24,7 +23,7 @@ internal class MostPopularPodcastsAdapter(
     val onPodcastClicked: (DiscoverPodcast, String?) -> Unit,
     val onPodcastSubscribe: (DiscoverPodcast, String?) -> Unit,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-) : ListAdapter<Any, MostPopularPodcastsViewHolder>(DISCOVER_PODCAST_DIFF_CALLBACK) {
+) : ListAdapter<DiscoverPodcast, MostPopularPodcastsViewHolder>(PODCASTS_FILTERED_DIFF) {
 
     private var fromListId: String? = null
 
@@ -85,20 +84,25 @@ internal class MostPopularPodcastsAdapter(
             },
         )
     }
-    override fun onBindViewHolder(holder: MostPopularPodcastsViewHolder, position: Int) {
-        val podcast = getItem(position)
 
-        if (podcast is DiscoverPodcast) {
-            holder.bind(podcast)
-        }
+    override fun onBindViewHolder(holder: MostPopularPodcastsViewHolder, position: Int) {
+        holder.bind(getItem(position))
     }
+
     fun replaceList(list: List<DiscoverPodcast>) {
-        submitList(null) // We need this to avoid displaying the previous category list when switching from a different category
+        val changedPodcastList = currentList.map { it.uuid } != list.map { it.uuid }
+
+        if (changedPodcastList) {
+            submitList(null) // We need this to avoid displaying the previous category list when switching from a different category
+        }
+
         submitList(list)
     }
+
     fun setFromListId(value: String) {
         this.fromListId = value
     }
+
     private fun trackImpression(podcast: DiscoverPodcast) {
         fromListId?.let {
             FirebaseAnalyticsTracker.podcastTappedFromList(it, podcast.uuid)

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/RemainingPodcastsAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/RemainingPodcastsAdapter.kt
@@ -7,7 +7,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
 
-private val diff = object : DiffUtil.ItemCallback<DiscoverPodcast>() {
+val PODCASTS_FILTERED_DIFF = object : DiffUtil.ItemCallback<DiscoverPodcast>() {
     override fun areItemsTheSame(oldItem: DiscoverPodcast, newItem: DiscoverPodcast): Boolean {
         return oldItem.uuid == newItem.uuid
     }
@@ -20,7 +20,7 @@ private val diff = object : DiffUtil.ItemCallback<DiscoverPodcast>() {
 class RemainingPodcastsAdapter(
     val onPodcastClick: (DiscoverPodcast, String?) -> Unit,
     val onPodcastSubscribe: (DiscoverPodcast, String?) -> Unit,
-) : ListAdapter<DiscoverPodcast, RemainingPodcastsAdapter.PodcastViewHolder>(diff) {
+) : ListAdapter<DiscoverPodcast, RemainingPodcastsAdapter.PodcastViewHolder>(PODCASTS_FILTERED_DIFF) {
 
     inner class PodcastViewHolder(
         itemView: View,


### PR DESCRIPTION
## Description
- This PR fixes the pages jumps issue when you subscribe to a podcast from the filtered podcasts list
- While I was working on this issue I also noticed the most popular section had the same problem, so I addressed to this PR

Fixes #2199

## Testing Instructions
1. Go to Discover
2. Filter a category
3. Subscribe to any podcast from Most Popular in [category] section
4. ✅ Ensure the list does not "jump"
5. Go to the remaining category list and scroll a bit
6. Try to subscribe to any podcast from this section
7. ✅ Ensure the list does not "jump"

## Screenshots or Screencast 
[Screen_recording_20240514_080806.webm](https://github.com/Automattic/pocket-casts-android/assets/42220351/193f6503-0747-4816-8771-983091ff370f)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
