### PR TITLE
Fix folder size on large screens

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderAdapter.kt
@@ -37,7 +37,6 @@ import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
-import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.adapter.FolderItemDiffCallback
@@ -95,11 +94,9 @@ class FolderAdapter(
 
             FolderItem.Folder.viewTypeId -> {
                 val podcastsLayout = settings.podcastGridLayout.value
-                val gridWidthDp = UiUtil.getGridImageWidthPx(smallArtwork = podcastsLayout == PodcastGridLayoutType.SMALL_ARTWORK, context = context).pxToDp(parent.context).toInt()
                 FolderViewHolder(
                     composeView = ComposeView(parent.context),
                     theme = theme,
-                    gridWidthDp = gridWidthDp,
                     podcastsLayout = podcastsLayout,
                     onFolderClick = { clickListener.onFolderClick(it.uuid, isUserInitiated = true) },
                     podcastGridLayout = podcastsLayout,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderViewHolder.kt
@@ -2,13 +2,12 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.podcasts
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.unit.dp
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
@@ -24,7 +23,6 @@ import kotlin.math.min
 class FolderViewHolder(
     val composeView: ComposeView,
     val theme: Theme,
-    val gridWidthDp: Int,
     val podcastsLayout: PodcastGridLayoutType,
     val onFolderClick: (Folder) -> Unit,
     val podcastGridLayout: PodcastGridLayoutType,
@@ -57,7 +55,7 @@ class FolderViewHolder(
                             badgeType = badgeType,
                             podcastGridLayout = podcastGridLayout,
                             onClick = { onFolderClick(folder) },
-                            modifier = Modifier.size(gridWidthDp.dp),
+                            modifier = Modifier.fillMaxSize(),
                         )
                     }
                 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -342,7 +342,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
     private fun adjustViewIfNeeded() {
         val context = activity ?: return
         val orientation = resources.configuration.orientation
-        val widthPx = UiUtil.getContentViewWidthPx(context)
+        val widthPx = UiUtil.getWindowWidthPx(context)
         if (orientation == lastOrientationRefreshed && lastWidthPx == widthPx) return
 
         // screen has rotated, redraw the grid to the right size

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImage.kt
@@ -71,13 +71,15 @@ fun FolderImage(
     val elevation = if (FeatureFlag.isEnabled(Feature.PODCASTS_GRID_VIEW_DESIGN_CHANGES)) 1.dp else 0.dp
     BoxWithConstraints(
         contentAlignment = Alignment.Center,
+        modifier = modifier,
     ) {
         val constraints = this
         Card(
             elevation = elevation,
             shape = RoundedCornerShape(cornerRadius),
             backgroundColor = color,
-            modifier = modifier
+            modifier = Modifier
+                .fillMaxSize()
                 .aspectRatio(1f),
         ) {
             Box(

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/UiUtil.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/UiUtil.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.views.helper
 
 import android.content.Context
-import android.content.res.Configuration
 import android.view.Menu
 import android.view.View
 import android.view.inputmethod.InputMethodManager
@@ -14,8 +13,6 @@ import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 object UiUtil {
-
-    private const val MINIMUM_DIMENSION_DP_FOR_NAVIGATION_DRAWER = 600
 
     fun hideKeyboard(view: View) {
         val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
@@ -86,14 +83,13 @@ object UiUtil {
 
     fun getGridColumnCount(smallArtwork: Boolean, context: Context?): Int {
         context ?: return 1
-        val contentViewWidthDp = getContentViewWidthDp(context)
-        val isDrawerHidden = isNavigationDrawerHidden(context)
-        return getGridColumnCount(contentViewWidthDp, context.resources.configuration.inPortrait(), isDrawerHidden, smallArtwork)
+        val contentViewWidthDp = getWindowWidthDp(context)
+        return getGridColumnCount(contentViewWidthDp, context.resources.configuration.inPortrait(), smallArtwork)
     }
 
     fun getDiscoverGridColumnCount(context: Context?): Int {
         context ?: return 2
-        val contentViewWidthDp = getContentViewWidthDp(context)
+        val contentViewWidthDp = getWindowWidthDp(context)
         val inPortrait = context.resources.configuration.inPortrait()
         return if (inPortrait) {
             when {
@@ -113,7 +109,7 @@ object UiUtil {
     fun getDiscoverGridImageWidthPx(context: Context): Int {
         val columns = getDiscoverGridColumnCount(context)
         val padding = (columns + 1) * (16f * context.resources.displayMetrics.density)
-        return ((getContentViewWidthPx(context) - padding) / columns).toInt()
+        return ((getWindowWidthPx(context) - padding) / columns).toInt()
     }
 
     fun getWindowWidthPx(context: Context): Int {
@@ -121,37 +117,14 @@ object UiUtil {
     }
 
     fun getWindowWidthDp(context: Context): Int {
-        val displayMetrics = context.resources.displayMetrics
-        return (displayMetrics.widthPixels * displayMetrics.density).toInt()
-    }
-
-    fun getWindowHeightPx(context: Context): Int {
-        return context.resources.displayMetrics.heightPixels
-    }
-
-    fun getWindowHeightDp(context: Context): Int {
-        val displayMetrics = context.resources.displayMetrics
-        return (displayMetrics.heightPixels * displayMetrics.density).toInt()
-    }
-
-    fun getContentViewWidthPx(context: Context): Int {
-        var windowWidthPx = getWindowWidthPx(context)
-        val drawerHidden = isNavigationDrawerHidden(context)
-        if (!drawerHidden) {
-            windowWidthPx -= getNavigationDrawerWidthPx(context)
-        }
-        return windowWidthPx
-    }
-
-    fun getContentViewWidthDp(context: Context): Int {
-        return (getContentViewWidthPx(context) / getDensity(context)).toInt()
+        return (getWindowWidthPx(context) / getDensity(context)).toInt()
     }
 
     fun getDensity(context: Context): Float {
         return context.resources.displayMetrics.density
     }
 
-    private fun getGridColumnCount(contentViewWidthDp: Int, portrait: Boolean, isNavigationDrawerHidden: Boolean, smallArtwork: Boolean): Int {
+    private fun getGridColumnCount(contentViewWidthDp: Int, portrait: Boolean, smallArtwork: Boolean): Int {
         val num: Int
 
         if (portrait) {
@@ -163,15 +136,7 @@ object UiUtil {
                 num = if (smallArtwork) 6 else 5
             }
         } else {
-            if (isNavigationDrawerHidden) {
-                num = if (smallArtwork) 6 else 5
-            } else {
-                if (contentViewWidthDp > 700) {
-                    num = if (smallArtwork) 7 else 6
-                } else {
-                    num = if (smallArtwork) 6 else 5
-                }
-            }
+            num = if (smallArtwork) 6 else 5
         }
 
         return num
@@ -179,41 +144,17 @@ object UiUtil {
 
     fun getGridImageWidthPx(smallArtwork: Boolean, context: Context): Int {
         val columnCount = getGridColumnCount(smallArtwork, context)
-        val contentWidthPx = getContentViewWidthPx(context)
+        val contentWidthPx = getWindowWidthPx(context)
         val spacingWidth = if (FeatureFlag.isEnabled(Feature.PODCASTS_GRID_VIEW_DESIGN_CHANGES)) {
-            2 * (columnCount * context.resources.getDimensionPixelSize(R.dimen.grid_item_padding) + context.resources.getDimensionPixelSize(R.dimen.grid_outer_padding))
+            // add the spacing between the columns and the padding on the sides of the grid
+            val resources = context.resources
+            val gridItemPadding = resources.getDimensionPixelSize(R.dimen.grid_item_padding)
+            val gridOuterPadding = resources.getDimensionPixelSize(R.dimen.grid_outer_padding)
+            ((columnCount - 1) * gridItemPadding) + (2 * gridOuterPadding)
         } else {
             0
         }
         return ((contentWidthPx.toFloat() - spacingWidth) / columnCount).toInt()
-    }
-
-    fun isNavigationDrawerHidden(context: Context): Boolean {
-        val config = context.resources.configuration
-        val displayMetrics = context.resources.displayMetrics
-        val width = (displayMetrics.widthPixels / displayMetrics.density).toInt()
-        val height = (displayMetrics.heightPixels / displayMetrics.density).toInt()
-        return width < MINIMUM_DIMENSION_DP_FOR_NAVIGATION_DRAWER || height < MINIMUM_DIMENSION_DP_FOR_NAVIGATION_DRAWER || config.orientation == Configuration.ORIENTATION_PORTRAIT
-    }
-
-    fun getNavigationDrawerWidthPx(context: Context): Int {
-        return getNavigationDrawerWidthPx(getWindowWidthPx(context), getDensity(context))
-    }
-
-    private fun getNavigationDrawerWidthPx(windowWidthPx: Int, density: Float): Int {
-        val windowWidthDp = (windowWidthPx / density).toInt()
-
-        val defaultDrawerWidthDp = 330
-        val defaultDrawerWidthPx = (defaultDrawerWidthDp * density).toInt()
-
-        // thin screen use most of the screen
-        if (windowWidthDp < 350) {
-            return (windowWidthPx * 0.9f).toInt()
-        } else if (windowWidthDp < 370) {
-            return (windowWidthPx * 0.85f).toInt()
-        }
-
-        return defaultDrawerWidthPx
     }
 
     fun displayDialogNoEmailApp(context: Context) {


### PR DESCRIPTION
## Description

This fixes the folder size issue on the Samsung Fold in landscape. 

The issue was that the logic was still assuming a navigation drawer was displayed on larger devices, which hasn't been the case for a while. I have removed this logic. I realised that it's probably best to try just filling the available space instead of using an exact size with the folders. This worked, which makes me wonder why we were setting it in the past. Hopefully, I haven't broken anything in the process. Please let me know if you can think of anything. 

The change has also fixed the slight folder size issue on a regular sized phone.

Fixes https://github.com/Automattic/pocket-casts-android/issues/2228

## Testing Instructions
1. Create an emulator with the virtual configuration of a Pixel Fold (if you haven't already)
2. Put the emulator in landscape 
3. Subscribe to some podcasts
4. Add a folder to the home screen with podcasts in it
5. ✅ Verify the folder size matches podcasts in the podcast grid
6. Rotate the emulator
7. ✅ Verify the folder size again
8. Change the layout to the small grid and list view
9. ✅ Verify the folder size again
10. Try the same on a regular sized phone device

## Screenshots 
| Before | After |
| --- | --- |
| ![Screenshot_20240515_105503](https://github.com/Automattic/pocket-casts-android/assets/308331/144bbbfb-f249-4bc4-8627-a5785eb5b796) | ![Screenshot_20240515_105418](https://github.com/Automattic/pocket-casts-android/assets/308331/d89f6d5c-6703-436a-8ce0-b9610efeb70b) |
| ![Screenshot_20240515_110454](https://github.com/Automattic/pocket-casts-android/assets/308331/ef1c332e-5754-4e1c-8d1b-034022a29888) | ![Screenshot_20240515_110421](https://github.com/Automattic/pocket-casts-android/assets/308331/c212b341-5322-49d6-9b8e-8adbac0c9a2b) |
