### PR TITLE
Fix status page crash

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/status/StatusFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/status/StatusFragment.kt
@@ -15,8 +15,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
@@ -101,10 +99,8 @@ fun StatusPage(
 
 @Composable
 fun StatusPageContent(viewModel: StatusViewModel) {
-    val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
-            .verticalScroll(scrollState)
             .padding(16.dp)
             .fillMaxWidth(),
     ) {


### PR DESCRIPTION
## Description
This fixes status page crash.

## Testing Instructions
1. Go to Profile -> Help & feedback -> Status page
2. ✅ Notice that it loads properly
3. Tap Run now, wait till status is shown
4. Scroll the screen
5. ✅ Notice that the content can be scrolled properly
6. Test on landscape mode

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/d34e6de4-4e1f-4a8a-8952-91c5ebcc63c5



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
