### PR TITLE
Fix: Android doesn't handle timestamp parameter in share links properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.65
 -----
-
+*   Bug Fixes
+    *   Fix timestamp parameter handling in shared links
+        ([#2235](https://github.com/Automattic/pocket-casts-android/pull/2235))
 
 7.64
 -----

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -115,7 +115,6 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.Network
-import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
 import au.com.shiftyjelly.pocketcasts.utils.SharingUrlTimestampParser
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -115,6 +115,8 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.Network
+import au.com.shiftyjelly.pocketcasts.utils.SentryHelper
+import au.com.shiftyjelly.pocketcasts.utils.SharingUrlTimestampParser
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -141,7 +143,6 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -1463,7 +1464,8 @@ class MainActivity :
         if (intent.data?.pathSegments?.size == 1) {
             sharePath = "$SOCIAL_SHARE_PATH$sharePath"
         }
-        val timestamp = intent.data?.getQueryParameter("t")?.toIntOrNull()
+        val parser = SharingUrlTimestampParser()
+        val timestamp = intent.data?.getQueryParameter("t")?.let { parser.parseTimestamp(it) }
         val dialog = android.app.ProgressDialog.show(this, getString(LR.string.loading), getString(LR.string.please_wait), true)
         serverManager.getSharedItemDetails(
             sharePath,
@@ -1490,7 +1492,7 @@ class MainActivity :
                             source = EpisodeViewSource.SHARE,
                             podcastUuid = podcastUuid,
                             forceDark = false,
-                            timestamp = timestamp?.seconds,
+                            timestamp = timestamp?.first, // Start time in seconds
                         )
                     } else {
                         openPodcastPage(podcastUuid)

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
@@ -22,8 +22,8 @@ class SharingUrlTimestampParser {
             val hours = match.groups[1]?.value?.toLong() ?: 0
             val minutes = match.groups[2]?.value?.toLong() ?: 0
             val seconds = match.groups[3]?.value?.toLong() ?: 0
-            val fraction = match.groups[4]?.value?.toDouble() ?: 0.0
-            val totalSeconds = (hours * 3600) + (minutes * 60) + seconds + (fraction / 1000.0)
+            val fractionInMilliseconds = match.groups[4]?.value?.take(3)?.toDouble() ?: 0.0 // Extract first three digits
+            val totalSeconds = (hours * 3600) + (minutes * 60) + seconds + (fractionInMilliseconds / 1000.0)
             return Pair(totalSeconds.seconds, null)
         }
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
@@ -1,0 +1,18 @@
+package au.com.shiftyjelly.pocketcasts.utils
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class SharingUrlTimestampParser {
+    fun parseTimestamp(t: String): Pair<Duration?, Duration?> {
+        val intervalPattern = Regex("""(\d*\.?\d*)?,?(\d*\.?\d*)?""") // t=10,20 or t=,20 or t=10
+
+        intervalPattern.find(t)?.let { match ->
+            val startTime = match.groups[1]?.value?.takeIf { it.isNotEmpty() }?.toDouble()?.toInt() ?: 0
+            val endTime = match.groups[2]?.value?.takeIf { it.isNotEmpty() }?.toDouble()?.toInt() ?: 0
+            return Pair(startTime.seconds, endTime.seconds)
+        }
+
+        return Pair(null, null)
+    }
+}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
@@ -18,7 +18,7 @@ class SharingUrlTimestampParser {
             return Pair(extractTimeFrom(startParsedTime)?.seconds, extractTimeFrom(endParsedTime)?.seconds)
         }
         val result = parseTime(timestamp)
-        return Pair((result.first ?: 0.0).seconds, (result.second ?: 0.0).seconds)
+        return Pair(result.first?.seconds, result.second?.seconds)
     }
 
     private fun parseTime(t: String): Pair<Double?, Double?> {
@@ -27,9 +27,6 @@ class SharingUrlTimestampParser {
             val minutes = match.groups[2]?.value?.toInt() ?: 0
             val seconds = match.groups[3]?.value?.toDouble() ?: 0.0
             val totalSeconds = ((hours * 3600) + (minutes * 60) + seconds)
-            if (totalSeconds == 0.0) {
-                return Pair(0.0, null)
-            }
             return Pair(totalSeconds, null)
         }
 
@@ -39,15 +36,12 @@ class SharingUrlTimestampParser {
             val seconds = match.groups[3]?.value?.toLong() ?: 0
             val fractionInMilliseconds = match.groups[4]?.value?.take(3)?.toDouble() ?: 0.0 // Extract first three digits
             val totalSeconds = (hours * 3600) + (minutes * 60) + seconds + (fractionInMilliseconds / 1000.0)
-            if (totalSeconds == 0.0) {
-                return Pair(0.0, null)
-            }
             return Pair(totalSeconds, null)
         }
 
         intervalPattern.find(t)?.let { match ->
-            val startTime = match.groups[1]?.value?.takeIf { it.isNotEmpty() }?.toDouble()?.toInt()
-            val endTime = match.groups[2]?.value?.takeIf { it.isNotEmpty() }?.toDouble()?.toInt()
+            val startTime = match.groups[1]?.value?.takeIf { it.isNotEmpty() }?.toDouble()?.toInt()?.takeIf { it != 0 }
+            val endTime = match.groups[2]?.value?.takeIf { it.isNotEmpty() }?.toDouble()?.toInt()?.takeIf { it != 0 }
             return Pair(startTime?.toDouble(), endTime?.toDouble())
         }
 
@@ -55,7 +49,7 @@ class SharingUrlTimestampParser {
     }
 
     private fun extractTimeFrom(startParsedTime: Pair<Double?, Double?>) = if (startParsedTime.first == null && startParsedTime.second == null) {
-        0.0
+        null
     } else if (startParsedTime.first != null) {
         startParsedTime.first
     } else {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
@@ -7,7 +7,7 @@ class SharingUrlTimestampParser {
     companion object {
         val intervalPattern = Regex("""(\d*\.?\d*)?,?(\d*\.?\d*)?""")
         val hmsPattern = Regex("""(?:(\d+)h)?(?:(0?[0-5]?\d)m)?(?:(0?[0-5]?\d)s)?""")
-        val hhmmssFractionPattern = Regex("""(\d+):(0[0-9]|[1-5][0-9]):(0[0-9]|[1-5][0-9])(?:\.(\d+))?""")
+        val hhmmssFractionPattern = Regex("""(?:(\d+):)?(0[0-9]|[1-5][0-9]):(0[0-9]|[1-5][0-9])(?:\.(\d+))?""")
     }
 
     fun parseTimestamp(timestamp: String): Pair<Duration?, Duration?> {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
@@ -4,11 +4,12 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 class SharingUrlTimestampParser {
-    fun parseTimestamp(t: String): Pair<Duration?, Duration?> {
+    companion object {
         val intervalPattern = Regex("""(\d*\.?\d*)?,?(\d*\.?\d*)?""") // t=10,20 or t=,20 or t=10
         val hmsPattern = Regex("""(?:(\d+)h)?(?:(\d+)m)?(?:(\d+(?:\.\d+)?)s)?""") // t=10h20m30s or t=10m30s or or 10m or t=10s
         val hhmmssFractionPattern = Regex("""(\d+):(\d{2}):(\d{2})(?:\.(\d+))?""") // t=10:20:30.456
-
+    }
+    fun parseTimestamp(t: String): Pair<Duration?, Duration?> {
         hmsPattern.matchEntire(t)?.let { match ->
             val hours = match.groups[1]?.value?.toInt() ?: 0
             val minutes = match.groups[2]?.value?.toInt() ?: 0

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
@@ -5,17 +5,32 @@ import kotlin.time.Duration.Companion.seconds
 
 class SharingUrlTimestampParser {
     companion object {
-        val intervalPattern = Regex("""(\d*\.?\d*)?,?(\d*\.?\d*)?""") // t=10,20 or t=,20 or t=10
-        val hmsPattern = Regex("""(?:(\d+)h)?(?:(0?[0-5]?\d)m)?(?:(0?[0-5]?\d(?:\.\d+)?)s)?""") // t=10h20m30s or t=10m30s or or 10m or t=10s
-        val hhmmssFractionPattern = Regex("""(\d+):(\d{2}):(\d{2})(?:\.(\d+))?""") // t=10:20:30.456
+        val intervalPattern = Regex("""(\d*\.?\d*)?,?(\d*\.?\d*)?""")
+        val hmsPattern = Regex("""(?:(\d+)h)?(?:(0?[0-5]?\d)m)?(?:(0?[0-5]?\d)s)?""")
+        val hhmmssFractionPattern = Regex("""(\d+):(\d{2}):(\d{2})(?:\.(\d+))?""")
     }
-    fun parseTimestamp(t: String): Pair<Duration?, Duration?> {
+
+    fun parseTimestamp(timestamp: String): Pair<Duration?, Duration?> {
+        if (timestamp.contains(",")) {
+            val (part1, part2) = timestamp.split(",")
+            val startParsedTime: Pair<Double?, Double?> = parseTime(part1)
+            val endParsedTime: Pair<Double?, Double?> = parseTime(part2)
+            return Pair(extractTimeFrom(startParsedTime)?.seconds, extractTimeFrom(endParsedTime)?.seconds)
+        }
+        val result = parseTime(timestamp)
+        return Pair((result.first ?: 0.0).seconds, (result.second ?: 0.0).seconds)
+    }
+
+    private fun parseTime(t: String): Pair<Double?, Double?> {
         hmsPattern.matchEntire(t)?.let { match ->
             val hours = match.groups[1]?.value?.toInt() ?: 0
             val minutes = match.groups[2]?.value?.toInt() ?: 0
             val seconds = match.groups[3]?.value?.toDouble() ?: 0.0
             val totalSeconds = ((hours * 3600) + (minutes * 60) + seconds)
-            return Pair(totalSeconds.seconds, null)
+            if (totalSeconds == 0.0) {
+                return Pair(0.0, null)
+            }
+            return Pair(totalSeconds, null)
         }
 
         hhmmssFractionPattern.matchEntire(t)?.let { match ->
@@ -24,15 +39,26 @@ class SharingUrlTimestampParser {
             val seconds = match.groups[3]?.value?.toLong() ?: 0
             val fractionInMilliseconds = match.groups[4]?.value?.take(3)?.toDouble() ?: 0.0 // Extract first three digits
             val totalSeconds = (hours * 3600) + (minutes * 60) + seconds + (fractionInMilliseconds / 1000.0)
-            return Pair(totalSeconds.seconds, null)
+            if (totalSeconds == 0.0) {
+                return Pair(0.0, null)
+            }
+            return Pair(totalSeconds, null)
         }
 
         intervalPattern.find(t)?.let { match ->
-            val startTime = match.groups[1]?.value?.takeIf { it.isNotEmpty() }?.toDouble()?.toInt() ?: 0
-            val endTime = match.groups[2]?.value?.takeIf { it.isNotEmpty() }?.toDouble()?.toInt() ?: 0
-            return Pair(startTime.seconds, endTime.seconds)
+            val startTime = match.groups[1]?.value?.takeIf { it.isNotEmpty() }?.toDouble()?.toInt()
+            val endTime = match.groups[2]?.value?.takeIf { it.isNotEmpty() }?.toDouble()?.toInt()
+            return Pair(startTime?.toDouble(), endTime?.toDouble())
         }
 
         return Pair(null, null)
+    }
+
+    private fun extractTimeFrom(startParsedTime: Pair<Double?, Double?>) = if (startParsedTime.first == null && startParsedTime.second == null) {
+        0.0
+    } else if (startParsedTime.first != null) {
+        startParsedTime.first
+    } else {
+        startParsedTime.second
     }
 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
@@ -6,6 +6,15 @@ import kotlin.time.Duration.Companion.seconds
 class SharingUrlTimestampParser {
     fun parseTimestamp(t: String): Pair<Duration?, Duration?> {
         val intervalPattern = Regex("""(\d*\.?\d*)?,?(\d*\.?\d*)?""") // t=10,20 or t=,20 or t=10
+        val hmsPattern = Regex("""(?:(\d+)h)?(?:(\d+)m)?(?:(\d+(?:\.\d+)?)s)?""") // t=10h20m30s or t=10m30s or or 10m or t=10s
+
+        hmsPattern.matchEntire(t)?.let { match ->
+            val hours = match.groups[1]?.value?.toInt() ?: 0
+            val minutes = match.groups[2]?.value?.toInt() ?: 0
+            val seconds = match.groups[3]?.value?.toDouble() ?: 0.0
+            val totalSeconds = ((hours * 3600) + (minutes * 60) + seconds)
+            return Pair(totalSeconds.seconds, null)
+        }
 
         intervalPattern.find(t)?.let { match ->
             val startTime = match.groups[1]?.value?.takeIf { it.isNotEmpty() }?.toDouble()?.toInt() ?: 0

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
@@ -7,7 +7,7 @@ class SharingUrlTimestampParser {
     companion object {
         val intervalPattern = Regex("""(\d*\.?\d*)?,?(\d*\.?\d*)?""")
         val hmsPattern = Regex("""(?:(\d+)h)?(?:(0?[0-5]?\d)m)?(?:(0?[0-5]?\d)s)?""")
-        val hhmmssFractionPattern = Regex("""(\d+):(\d{2}):(\d{2})(?:\.(\d+))?""")
+        val hhmmssFractionPattern = Regex("""(\d+):(0[0-9]|[1-5][0-9]):(0[0-9]|[1-5][0-9])(?:\.(\d+))?""")
     }
 
     fun parseTimestamp(timestamp: String): Pair<Duration?, Duration?> {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
@@ -6,7 +6,7 @@ import kotlin.time.Duration.Companion.seconds
 class SharingUrlTimestampParser {
     companion object {
         val intervalPattern = Regex("""(\d*\.?\d*)?,?(\d*\.?\d*)?""") // t=10,20 or t=,20 or t=10
-        val hmsPattern = Regex("""(?:(\d+)h)?(?:(\d+)m)?(?:(\d+(?:\.\d+)?)s)?""") // t=10h20m30s or t=10m30s or or 10m or t=10s
+        val hmsPattern = Regex("""(?:(\d+)h)?(?:(0?[0-5]?\d)m)?(?:(0?[0-5]?\d(?:\.\d+)?)s)?""") // t=10h20m30s or t=10m30s or or 10m or t=10s
         val hhmmssFractionPattern = Regex("""(\d+):(\d{2}):(\d{2})(?:\.(\d+))?""") // t=10:20:30.456
     }
     fun parseTimestamp(t: String): Pair<Duration?, Duration?> {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParser.kt
@@ -7,12 +7,22 @@ class SharingUrlTimestampParser {
     fun parseTimestamp(t: String): Pair<Duration?, Duration?> {
         val intervalPattern = Regex("""(\d*\.?\d*)?,?(\d*\.?\d*)?""") // t=10,20 or t=,20 or t=10
         val hmsPattern = Regex("""(?:(\d+)h)?(?:(\d+)m)?(?:(\d+(?:\.\d+)?)s)?""") // t=10h20m30s or t=10m30s or or 10m or t=10s
+        val hhmmssFractionPattern = Regex("""(\d+):(\d{2}):(\d{2})(?:\.(\d+))?""") // t=10:20:30.456
 
         hmsPattern.matchEntire(t)?.let { match ->
             val hours = match.groups[1]?.value?.toInt() ?: 0
             val minutes = match.groups[2]?.value?.toInt() ?: 0
             val seconds = match.groups[3]?.value?.toDouble() ?: 0.0
             val totalSeconds = ((hours * 3600) + (minutes * 60) + seconds)
+            return Pair(totalSeconds.seconds, null)
+        }
+
+        hhmmssFractionPattern.matchEntire(t)?.let { match ->
+            val hours = match.groups[1]?.value?.toLong() ?: 0
+            val minutes = match.groups[2]?.value?.toLong() ?: 0
+            val seconds = match.groups[3]?.value?.toLong() ?: 0
+            val fraction = match.groups[4]?.value?.toDouble() ?: 0.0
+            val totalSeconds = (hours * 3600) + (minutes * 60) + seconds + (fraction / 1000.0)
             return Pair(totalSeconds.seconds, null)
         }
 

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
@@ -22,6 +22,9 @@ class SharingUrlTimestampParserTest {
         assertEquals(Pair(60.seconds, null), parser.parseTimestamp("1m"))
         assertEquals(Pair(1.seconds, null), parser.parseTimestamp("1s"))
         assertEquals(Pair(3661.seconds, null), parser.parseTimestamp("1h1m1s"))
+        assertEquals(Pair(5400.seconds, null), parser.parseTimestamp("1h30m"))
+        assertEquals(Pair(3605.seconds, null), parser.parseTimestamp("1h5s"))
+        assertEquals(Pair(1805.seconds, null), parser.parseTimestamp("30m5s"))
     }
 
     @Test

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
@@ -16,11 +16,18 @@ class SharingUrlTimestampParserTest {
     }
 
     @Test
-    fun testParseTimestamp_hms() {
+    fun testParseTimestampHoursMinutesSeconds() {
         assertEquals(Pair(454070.seconds, null), parser.parseTimestamp("125h67m50s"))
         assertEquals(Pair(3600.seconds, null), parser.parseTimestamp("1h"))
         assertEquals(Pair(60.seconds, null), parser.parseTimestamp("1m"))
         assertEquals(Pair(1.seconds, null), parser.parseTimestamp("1s"))
         assertEquals(Pair(3661.seconds, null), parser.parseTimestamp("1h1m1s"))
+    }
+
+    @Test
+    fun testParseTimestampHoursMinutesSecondsFraction() {
+        assertEquals(Pair(3723.seconds, null), parser.parseTimestamp("1:02:03"))
+        assertEquals(Pair(3728.seconds, null), parser.parseTimestamp("1:02:03.5000"))
+        assertEquals(Pair(120.seconds, null), parser.parseTimestamp("0:02:00"))
     }
 }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
@@ -17,7 +17,7 @@ class SharingUrlTimestampParserTest {
 
     @Test
     fun testParseTimestampHoursMinutesSeconds() {
-        assertEquals(Pair(454070.seconds, null), parser.parseTimestamp("125h67m50s"))
+        assertEquals(Pair(453590.seconds, null), parser.parseTimestamp("125h59m50s"))
         assertEquals(Pair(3600.seconds, null), parser.parseTimestamp("1h"))
         assertEquals(Pair(60.seconds, null), parser.parseTimestamp("1m"))
         assertEquals(Pair(1.seconds, null), parser.parseTimestamp("1s"))

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
@@ -1,0 +1,17 @@
+package au.com.shiftyjelly.pocketcasts.utils
+
+import kotlin.time.Duration.Companion.seconds
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SharingUrlTimestampParserTest {
+
+    private val parser = SharingUrlTimestampParser()
+
+    @Test
+    fun parseTimestampInterval() {
+        assertEquals(Pair(28.seconds, 60.seconds), parser.parseTimestamp("28,60"))
+        assertEquals(Pair(0.seconds, 20.seconds), parser.parseTimestamp(",20"))
+        assertEquals(Pair(10.seconds, 0.seconds), parser.parseTimestamp("10"))
+    }
+}

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
@@ -15,27 +15,27 @@ class SharingUrlTimestampParserTest {
     fun parseTimestampInterval() {
         assertEquals(Pair(28.seconds, 60.seconds), parser.parseTimestamp("28,60"))
         assertEquals(Pair(0.seconds, 20.seconds), parser.parseTimestamp(",20"))
-        assertEquals(Pair(10.seconds, 0.seconds), parser.parseTimestamp("10"))
+        assertEquals(Pair(10.seconds, null), parser.parseTimestamp("10"))
     }
 
     @Test
     fun testParseTimestampHoursMinutesSeconds() {
-        assertEquals(Pair(453590.seconds, 0.seconds), parser.parseTimestamp("125h59m50s"))
-        assertEquals(Pair(3600.seconds, 0.seconds), parser.parseTimestamp("1h"))
-        assertEquals(Pair(60.seconds, 0.seconds), parser.parseTimestamp("1m"))
-        assertEquals(Pair(1.seconds, 0.seconds), parser.parseTimestamp("1s"))
-        assertEquals(Pair(3661.seconds, 0.seconds), parser.parseTimestamp("1h1m1s"))
-        assertEquals(Pair(5400.seconds, 0.seconds), parser.parseTimestamp("1h30m"))
-        assertEquals(Pair(3605.seconds, 0.seconds), parser.parseTimestamp("1h5s"))
-        assertEquals(Pair(1805.seconds, 0.seconds), parser.parseTimestamp("30m5s"))
+        assertEquals(Pair(453590.seconds, null), parser.parseTimestamp("125h59m50s"))
+        assertEquals(Pair(3600.seconds, null), parser.parseTimestamp("1h"))
+        assertEquals(Pair(60.seconds, null), parser.parseTimestamp("1m"))
+        assertEquals(Pair(1.seconds, null), parser.parseTimestamp("1s"))
+        assertEquals(Pair(3661.seconds, null), parser.parseTimestamp("1h1m1s"))
+        assertEquals(Pair(5400.seconds, null), parser.parseTimestamp("1h30m"))
+        assertEquals(Pair(3605.seconds, null), parser.parseTimestamp("1h5s"))
+        assertEquals(Pair(1805.seconds, null), parser.parseTimestamp("30m5s"))
     }
 
     @Test
     fun testParseTimestampHoursMinutesSecondsFraction() {
-        assertEquals(Pair(3723.seconds, 0.seconds), parser.parseTimestamp("1:02:03"))
-        assertEquals(Pair(120.seconds, 0.seconds), parser.parseTimestamp("0:02:00"))
-        assertEquals(Pair(1500.milliseconds, 0.seconds), parser.parseTimestamp("00:00:01.500000000"))
-        assertEquals(Pair(1.hours + 2.minutes + 3.seconds + 500.milliseconds, 0.seconds), parser.parseTimestamp("1:02:03.5000"))
+        assertEquals(Pair(3723.seconds, null), parser.parseTimestamp("1:02:03"))
+        assertEquals(Pair(120.seconds, null), parser.parseTimestamp("0:02:00"))
+        assertEquals(Pair(1500.milliseconds, null), parser.parseTimestamp("00:00:01.500000000"))
+        assertEquals(Pair(1.hours + 2.minutes + 3.seconds + 500.milliseconds, null), parser.parseTimestamp("1:02:03.5000"))
     }
 
     @Test
@@ -50,9 +50,9 @@ class SharingUrlTimestampParserTest {
 
     @Test
     fun testParseTimestampMinutesAndSecondsShouldNotBeGreaterThan60() {
-        assertEquals(Pair(0.seconds, 0.seconds), parser.parseTimestamp("0:60:00"))
-        assertEquals(Pair(0.seconds, 0.seconds), parser.parseTimestamp("0:00:60"))
-        assertEquals(Pair(0.seconds, 0.seconds), parser.parseTimestamp("00h60m00s"))
-        assertEquals(Pair(0.seconds, 0.seconds), parser.parseTimestamp("00h00m60s"))
+        assertEquals(Pair(null, null), parser.parseTimestamp("0:60:00"))
+        assertEquals(Pair(null, null), parser.parseTimestamp("0:00:60"))
+        assertEquals(Pair(null, null), parser.parseTimestamp("00h60m00s"))
+        assertEquals(Pair(null, null), parser.parseTimestamp("00h00m60s"))
     }
 }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
@@ -1,5 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.utils
 
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -30,7 +33,8 @@ class SharingUrlTimestampParserTest {
     @Test
     fun testParseTimestampHoursMinutesSecondsFraction() {
         assertEquals(Pair(3723.seconds, null), parser.parseTimestamp("1:02:03"))
-        assertEquals(Pair(3728.seconds, null), parser.parseTimestamp("1:02:03.5000"))
         assertEquals(Pair(120.seconds, null), parser.parseTimestamp("0:02:00"))
+        assertEquals(Pair(1500.milliseconds, null), parser.parseTimestamp("00:00:01.500000000"))
+        assertEquals(Pair(1.hours + 2.minutes + 3.seconds + 500.milliseconds, null), parser.parseTimestamp("1:02:03.5000"))
     }
 }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
@@ -20,21 +20,26 @@ class SharingUrlTimestampParserTest {
 
     @Test
     fun testParseTimestampHoursMinutesSeconds() {
-        assertEquals(Pair(453590.seconds, null), parser.parseTimestamp("125h59m50s"))
-        assertEquals(Pair(3600.seconds, null), parser.parseTimestamp("1h"))
-        assertEquals(Pair(60.seconds, null), parser.parseTimestamp("1m"))
-        assertEquals(Pair(1.seconds, null), parser.parseTimestamp("1s"))
-        assertEquals(Pair(3661.seconds, null), parser.parseTimestamp("1h1m1s"))
-        assertEquals(Pair(5400.seconds, null), parser.parseTimestamp("1h30m"))
-        assertEquals(Pair(3605.seconds, null), parser.parseTimestamp("1h5s"))
-        assertEquals(Pair(1805.seconds, null), parser.parseTimestamp("30m5s"))
+        assertEquals(Pair(453590.seconds, 0.seconds), parser.parseTimestamp("125h59m50s"))
+        assertEquals(Pair(3600.seconds, 0.seconds), parser.parseTimestamp("1h"))
+        assertEquals(Pair(60.seconds, 0.seconds), parser.parseTimestamp("1m"))
+        assertEquals(Pair(1.seconds, 0.seconds), parser.parseTimestamp("1s"))
+        assertEquals(Pair(3661.seconds, 0.seconds), parser.parseTimestamp("1h1m1s"))
+        assertEquals(Pair(5400.seconds, 0.seconds), parser.parseTimestamp("1h30m"))
+        assertEquals(Pair(3605.seconds, 0.seconds), parser.parseTimestamp("1h5s"))
+        assertEquals(Pair(1805.seconds, 0.seconds), parser.parseTimestamp("30m5s"))
     }
 
     @Test
     fun testParseTimestampHoursMinutesSecondsFraction() {
-        assertEquals(Pair(3723.seconds, null), parser.parseTimestamp("1:02:03"))
-        assertEquals(Pair(120.seconds, null), parser.parseTimestamp("0:02:00"))
-        assertEquals(Pair(1500.milliseconds, null), parser.parseTimestamp("00:00:01.500000000"))
-        assertEquals(Pair(1.hours + 2.minutes + 3.seconds + 500.milliseconds, null), parser.parseTimestamp("1:02:03.5000"))
+        assertEquals(Pair(3723.seconds, 0.seconds), parser.parseTimestamp("1:02:03"))
+        assertEquals(Pair(120.seconds, 0.seconds), parser.parseTimestamp("0:02:00"))
+        assertEquals(Pair(1500.milliseconds, 0.seconds), parser.parseTimestamp("00:00:01.500000000"))
+        assertEquals(Pair(1.hours + 2.minutes + 3.seconds + 500.milliseconds, 0.seconds), parser.parseTimestamp("1:02:03.5000"))
+    }
+
+    @Test
+    fun testParseTimestampMixedPatterns() {
+        assertEquals(Pair(120.seconds, 2.minutes + 1.seconds + 5.milliseconds), parser.parseTimestamp("120,0:02:01.5"))
     }
 }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
@@ -42,4 +42,12 @@ class SharingUrlTimestampParserTest {
     fun testParseTimestampMixedPatterns() {
         assertEquals(Pair(120.seconds, 2.minutes + 1.seconds + 5.milliseconds), parser.parseTimestamp("120,0:02:01.5"))
     }
+
+    @Test
+    fun testParseTimestampMinutesAndSecondsShouldNotBeGreaterThan60() {
+        assertEquals(Pair(0.seconds, 0.seconds), parser.parseTimestamp("0:60:00"))
+        assertEquals(Pair(0.seconds, 0.seconds), parser.parseTimestamp("0:00:60"))
+        assertEquals(Pair(0.seconds, 0.seconds), parser.parseTimestamp("00h60m00s"))
+        assertEquals(Pair(0.seconds, 0.seconds), parser.parseTimestamp("00h00m60s"))
+    }
 }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
@@ -14,4 +14,13 @@ class SharingUrlTimestampParserTest {
         assertEquals(Pair(0.seconds, 20.seconds), parser.parseTimestamp(",20"))
         assertEquals(Pair(10.seconds, 0.seconds), parser.parseTimestamp("10"))
     }
+
+    @Test
+    fun testParseTimestamp_hms() {
+        assertEquals(Pair(454070.seconds, null), parser.parseTimestamp("125h67m50s"))
+        assertEquals(Pair(3600.seconds, null), parser.parseTimestamp("1h"))
+        assertEquals(Pair(60.seconds, null), parser.parseTimestamp("1m"))
+        assertEquals(Pair(1.seconds, null), parser.parseTimestamp("1s"))
+        assertEquals(Pair(3661.seconds, null), parser.parseTimestamp("1h1m1s"))
+    }
 }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
@@ -41,6 +41,11 @@ class SharingUrlTimestampParserTest {
     @Test
     fun testParseTimestampMixedPatterns() {
         assertEquals(Pair(120.seconds, 2.minutes + 1.seconds + 5.milliseconds), parser.parseTimestamp("120,0:02:01.5"))
+        assertEquals(Pair(2.minutes + 1.seconds + 5.milliseconds, 120.seconds), parser.parseTimestamp("0:02:01.5,120"))
+        assertEquals(Pair(1805.seconds, 120.seconds), parser.parseTimestamp("30m5s,120"))
+        assertEquals(Pair(120.seconds, 1805.seconds), parser.parseTimestamp("120,30m5s"))
+        assertEquals(Pair(1805.seconds, 2.minutes + 1.seconds + 5.milliseconds), parser.parseTimestamp("30m5s,0:02:01.5"))
+        assertEquals(Pair(2.minutes + 1.seconds + 5.milliseconds, 1805.seconds), parser.parseTimestamp("0:02:01.5,30m5s"))
     }
 
     @Test

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/SharingUrlTimestampParserTest.kt
@@ -35,6 +35,7 @@ class SharingUrlTimestampParserTest {
         assertEquals(Pair(3723.seconds, null), parser.parseTimestamp("1:02:03"))
         assertEquals(Pair(120.seconds, null), parser.parseTimestamp("0:02:00"))
         assertEquals(Pair(1500.milliseconds, null), parser.parseTimestamp("00:00:01.500000000"))
+        assertEquals(Pair(1513.seconds, null), parser.parseTimestamp("25:13"))
         assertEquals(Pair(1.hours + 2.minutes + 3.seconds + 500.milliseconds, null), parser.parseTimestamp("1:02:03.5000"))
     }
 


### PR DESCRIPTION
## Description
- This PR fixes the timestamp parsing when opening Pocket Casts from shared URL. It will support:

```
https://pca.st/sb2ksvqv?t=28,60

Either one or both parameters may be omitted, with the begin time defaulting to 0 seconds and the end time defaulting to the duration of the source media

t=10,20   # => results in the time interval [10,20)
t=,20     # => results in the time interval [0,20)
t=10      # => results in the time interval [10,end)

```

```
https://pca.st/y0ebrkcc?t=1:02:03

hh:mm:ss.fraction - Either be specified as seconds, with an optional fractional part to indicate miliseconds, or as colon-separated hours, minutes and seconds (again with an optional fraction). Minutes and seconds must be specified as exactly two digits, hours and fractional seconds can be any number of digits

```

```
https://pca.st/y0ebrkcc?t=10m15s

[hour]h[minute]m[second]s

```

Closes #2227
Closes #21

## Testing Instructions
1. Use https://pca.st/4adhfj4d?t=7m15s to open Pocket Casts.
2. ✅ Ensure the app start playback of the episode at 07:15
3. Use https://pca.st/sb2ksvqv?t=28,60 to open Pocket Casts
4. ✅ Ensure the app start playback of the episode at 28 seconds
5. Use https://pca.st/sb2ksvqv?t=,60 to open Pocket Casts
6. ✅ Ensure the app start playback of the episode at 0 seconds
7. Use https://pca.st/p9ipuzdr?t=10s to open Pocket Casts
8. ✅ Ensure the app start playback of the episode at 10 seconds
9. Use https://pca.st/p9ipuzdr?t=0:02:00 to open Pocket Casts
10. ✅ Ensure the app start playback of the episode at 2 minutes

## Screenshots or Screencast 
[Screen_recording_20240515_141048.webm](https://github.com/Automattic/pocket-casts-android/assets/42220351/d1b6fa5d-14e1-4fd5-a1a7-9807c5b71287)


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
