### PR TITLE
Sync new releases with Nova Launcher

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
@@ -4,12 +4,18 @@ import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
+import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeDownloadFailureStatistics
+import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherNewEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.Date
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -19,6 +25,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class EpisodeDaoTest {
     lateinit var episodeDao: EpisodeDao
+    lateinit var podcastDao: PodcastDao
     lateinit var testDb: AppDatabase
 
     @Before
@@ -26,6 +33,7 @@ class EpisodeDaoTest {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
         episodeDao = testDb.episodeDao()
+        podcastDao = testDb.podcastDao()
     }
 
     @After
@@ -151,5 +159,318 @@ class EpisodeDaoTest {
             oldestTimestamp = Instant.EPOCH.plusMillis(EpisodeStatusEnum.DOWNLOAD_FAILED.ordinal.toLong()),
         )
         assertEquals(expected, statistics)
+    }
+
+    @Test
+    fun getNewReleasesForNovaLauncher() = runTest {
+        val now = Instant.now()
+        val publishedDate1 = Date.from(now)
+        val publishedDate2 = Date.from(now.minus(10, ChronoUnit.MINUTES))
+        val publishedDate3 = Date.from(now.minus(20, ChronoUnit.MINUTES))
+        val episodes = listOf(
+            PodcastEpisode(
+                uuid = "id-1",
+                podcastUuid = "p-id-1",
+                title = "title-1",
+                duration = 100.12,
+                playedUpTo = 50.0,
+                season = 0,
+                number = 11,
+                publishedDate = publishedDate1,
+                lastPlaybackInteraction = 20122,
+            ),
+            PodcastEpisode(
+                uuid = "id-2",
+                podcastUuid = "p-id-1",
+                title = "title-2",
+                duration = 4120.0,
+                playedUpTo = 2021.24,
+                season = 7,
+                number = null,
+                publishedDate = publishedDate2,
+                lastPlaybackInteraction = null,
+            ),
+            PodcastEpisode(
+                uuid = "id-3",
+                podcastUuid = "p-id-2",
+                title = "title-3",
+                duration = 2330.0,
+                playedUpTo = 0.0,
+                season = null,
+                number = 399,
+                publishedDate = publishedDate3,
+                lastPlaybackInteraction = 0,
+            ),
+        )
+        episodeDao.insertAll(episodes)
+        podcastDao.insert(Podcast(uuid = "p-id-1", isSubscribed = true))
+        podcastDao.insert(Podcast(uuid = "p-id-2", isSubscribed = true))
+
+        val newEpisodes = episodeDao.getNovaLauncherNewEpisodes()
+
+        val expected = listOf(
+            NovaLauncherNewEpisode(
+                id = "id-1",
+                podcastId = "p-id-1",
+                title = "title-1",
+                duration = 100,
+                currentPosition = 50,
+                seasonNumber = 0,
+                episodeNumber = 11,
+                releaseTimestamp = publishedDate1.time / 1000,
+                lastUsedTimestamp = 20,
+            ),
+            NovaLauncherNewEpisode(
+                id = "id-2",
+                podcastId = "p-id-1",
+                title = "title-2",
+                duration = 4120,
+                currentPosition = 2021,
+                seasonNumber = 7,
+                episodeNumber = null,
+                releaseTimestamp = publishedDate2.time / 1000,
+                lastUsedTimestamp = null,
+            ),
+            NovaLauncherNewEpisode(
+                id = "id-3",
+                podcastId = "p-id-2",
+                title = "title-3",
+                duration = 2330,
+                currentPosition = 0,
+                seasonNumber = null,
+                episodeNumber = 399,
+                releaseTimestamp = publishedDate3.time / 1000,
+                lastUsedTimestamp = 0,
+            ),
+        )
+        assertEquals(expected, newEpisodes)
+    }
+
+    @Test
+    fun ignoreNewReleasesForNovaLauncherThatAreArchived() = runTest {
+        val now = Instant.now()
+        val publishedDate1 = Date.from(now.minus(10, ChronoUnit.MINUTES))
+        val publishedDate2 = Date.from(now.minus(20, ChronoUnit.MINUTES))
+        val publishedDate3 = Date.from(now)
+        val episodes = listOf(
+            PodcastEpisode(
+                uuid = "id-1",
+                publishedDate = publishedDate1,
+            ),
+            PodcastEpisode(
+                uuid = "id-2",
+                publishedDate = publishedDate2,
+            ),
+            PodcastEpisode(
+                uuid = "id-3",
+                publishedDate = publishedDate3,
+            ),
+        )
+        episodeDao.insertAll(episodes)
+        podcastDao.insert(Podcast(uuid = "", isSubscribed = true))
+
+        val newEpisodes = episodeDao.getNovaLauncherNewEpisodes()
+
+        val expected = listOf(
+            NovaLauncherNewEpisode(
+                id = "id-3",
+                podcastId = "",
+                title = "",
+                duration = 0,
+                currentPosition = 0,
+                seasonNumber = null,
+                episodeNumber = null,
+                releaseTimestamp = publishedDate3.time / 1000,
+                lastUsedTimestamp = null,
+            ),
+            NovaLauncherNewEpisode(
+                id = "id-1",
+                podcastId = "",
+                title = "",
+                duration = 0,
+                currentPosition = 0,
+                seasonNumber = null,
+                episodeNumber = null,
+                releaseTimestamp = publishedDate1.time / 1000,
+                lastUsedTimestamp = null,
+            ),
+            NovaLauncherNewEpisode(
+                id = "id-2",
+                podcastId = "",
+                title = "",
+                duration = 0,
+                currentPosition = 0,
+                seasonNumber = null,
+                episodeNumber = null,
+                releaseTimestamp = publishedDate2.time / 1000,
+                lastUsedTimestamp = null,
+            ),
+        )
+        assertEquals(expected, newEpisodes)
+    }
+
+    @Test
+    fun limitNovaLauncherNewReleasesTo500Episodes() = runTest {
+        val episodes = List(550) {
+            PodcastEpisode(
+                uuid = "id-$it",
+                publishedDate = Date(),
+            )
+        }
+        episodeDao.insertAll(episodes)
+        podcastDao.insert(Podcast(uuid = "", isSubscribed = true))
+
+        val newEpisodes = episodeDao.getNovaLauncherNewEpisodes()
+
+        assertEquals(500, newEpisodes.size)
+    }
+
+    @Test
+    fun getNewReleasesForNovaLauncherSortedByReleaseDate() = runTest {
+        val publishedDate = Date()
+        val episodes = listOf(
+            PodcastEpisode(
+                uuid = "id-1",
+                isArchived = false,
+                publishedDate = publishedDate,
+            ),
+            PodcastEpisode(
+                uuid = "id-2",
+                isArchived = true,
+                publishedDate = publishedDate,
+            ),
+        )
+        episodeDao.insertAll(episodes)
+        podcastDao.insert(Podcast(uuid = "", isSubscribed = true))
+
+        val newEpisodes = episodeDao.getNovaLauncherNewEpisodes()
+
+        val expected = listOf(
+            NovaLauncherNewEpisode(
+                id = "id-1",
+                podcastId = "",
+                title = "",
+                duration = 0,
+                currentPosition = 0,
+                seasonNumber = null,
+                episodeNumber = null,
+                releaseTimestamp = publishedDate.time / 1000,
+                lastUsedTimestamp = null,
+            ),
+        )
+        assertEquals(expected, newEpisodes)
+    }
+
+    @Test
+    fun ignoreNewReleasesForNovaLauncherThatArePlayed() = runTest {
+        val publishedDate = Date()
+        val episodes = listOf(
+            PodcastEpisode(
+                uuid = "id-1",
+                playingStatus = EpisodePlayingStatus.NOT_PLAYED,
+                publishedDate = publishedDate,
+            ),
+            PodcastEpisode(
+                uuid = "id-2",
+                playingStatus = EpisodePlayingStatus.IN_PROGRESS,
+                publishedDate = publishedDate,
+            ),
+            PodcastEpisode(
+                uuid = "id-3",
+                playingStatus = EpisodePlayingStatus.COMPLETED,
+                publishedDate = publishedDate,
+            ),
+        )
+        episodeDao.insertAll(episodes)
+        podcastDao.insert(Podcast(uuid = "", isSubscribed = true))
+
+        val newEpisodes = episodeDao.getNovaLauncherNewEpisodes()
+
+        val expected = listOf(
+            NovaLauncherNewEpisode(
+                id = "id-1",
+                podcastId = "",
+                title = "",
+                duration = 0,
+                currentPosition = 0,
+                seasonNumber = null,
+                episodeNumber = null,
+                releaseTimestamp = publishedDate.time / 1000,
+                lastUsedTimestamp = null,
+            ),
+        )
+        assertEquals(expected, newEpisodes)
+    }
+
+    @Test
+    fun ignoreNewReleasesForNovaLauncherThatAreAtLeastTwoWeeksOld() = runTest {
+        val publishedDate1 = Date.from(Instant.now().minus(15, ChronoUnit.DAYS))
+        val publishedDate2 = Date.from(Instant.now().minus(13, ChronoUnit.DAYS))
+        val episodes = listOf(
+            PodcastEpisode(
+                uuid = "id-1",
+                publishedDate = publishedDate1,
+            ),
+            PodcastEpisode(
+                uuid = "id-2",
+                publishedDate = publishedDate2,
+            ),
+        )
+        episodeDao.insertAll(episodes)
+        podcastDao.insert(Podcast(uuid = "", isSubscribed = true))
+
+        val newEpisodes = episodeDao.getNovaLauncherNewEpisodes()
+
+        val expected = listOf(
+            NovaLauncherNewEpisode(
+                id = "id-2",
+                podcastId = "",
+                title = "",
+                duration = 0,
+                currentPosition = 0,
+                seasonNumber = null,
+                episodeNumber = null,
+                releaseTimestamp = publishedDate2.time / 1000,
+                lastUsedTimestamp = null,
+            ),
+        )
+        assertEquals(expected, newEpisodes)
+    }
+
+    @Test
+    fun ignoreNewReleasesForNovaLauncherForUnsubscribedPodcasts() = runTest {
+        val publishedDate = Date()
+        val episodes = listOf(
+            PodcastEpisode(
+                uuid = "id-1",
+                podcastUuid = "p-id-1",
+                publishedDate = publishedDate,
+            ),
+            PodcastEpisode(
+                uuid = "id-2",
+                podcastUuid = "p-id-2",
+                publishedDate = publishedDate,
+            ),
+        )
+        episodeDao.insertAll(episodes)
+        podcastDao.insert(Podcast(uuid = "p-id-1", isSubscribed = true))
+        podcastDao.insert(Podcast(uuid = "p-id-2", isSubscribed = false))
+
+        val newEpisodes = episodeDao.getNovaLauncherNewEpisodes()
+
+        val expected = listOf(
+            NovaLauncherNewEpisode(
+                id = "id-1",
+                podcastId = "p-id-1",
+                title = "",
+                duration = 0,
+                currentPosition = 0,
+                seasonNumber = null,
+                episodeNumber = null,
+                releaseTimestamp = publishedDate.time / 1000,
+                lastUsedTimestamp = null,
+            ),
+        )
+        assertEquals(expected, newEpisodes)
     }
 }

--- a/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
+++ b/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.nova
 
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherNewEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherSubscribedPodcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import io.branch.engage.conduit.source.Catalog
@@ -30,12 +31,35 @@ internal class CatalogFactory(
         },
     )
 
+    fun newEpisodes(data: List<NovaLauncherNewEpisode>) = Catalog(
+        id = "NewReleases",
+        label = context.getString(LR.string.nova_launcher_new_releases),
+        items = data.map { episode ->
+            CatalogItem.Base(
+                id = episode.id,
+                intent = context.launcherIntent,
+                lastUsedTimestamp = episode.lastUsedTimestamp,
+                typeData = TypeData.PodcastEpisode(
+                    name = episode.title,
+                    iconUrl = episode.coverUrl,
+                    seasonNumber = episode.seasonNumber,
+                    episodeNumber = episode.episodeNumber,
+                    releaseTimestamp = episode.releaseTimestamp,
+                    lengthSeconds = episode.duration,
+                    currentPositionSeconds = episode.currentPosition,
+                ),
+            )
+        },
+    )
+
     private val NovaLauncherSubscribedPodcast.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$id.webp"
 
     private val NovaLauncherSubscribedPodcast.intent get() = context.launcherIntent
         .setAction(Settings.INTENT_OPEN_APP_PODCAST_UUID)
         .putExtra(Settings.PODCAST_UUID, id)
         .putExtra(Settings.SOURCE_VIEW, SourceView.NOVA_LAUNCHER.analyticsValue)
+
+    private val NovaLauncherNewEpisode.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$podcastId.webp"
 
     private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
         "Missing launcher intent for $packageName"

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1928,4 +1928,5 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
 
     <!-- Nova Launcher -->
     <string name="nova_launcher_subscribed_podcasts">Subscribed Podcasts</string>
+    <string name="nova_launcher_new_releases">New Releases</string>
 </resources>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -557,12 +557,12 @@ abstract class EpisodeDao {
           -- Check that the episode is not played
           AND episode.playing_status IS 0
           -- Select only episodes that were released at most 2 weeks ago
-          AND episode.published_date / 1000 >= (UNIXEPOCH() - 1209600)
+          AND episode.published_date >= (:currentTime - 1209600000)
         ORDER BY
           episode.published_date DESC
         LIMIT
           500
         """,
     )
-    abstract suspend fun getNovaLauncherNewEpisodes(): List<NovaLauncherNewEpisode>
+    abstract suspend fun getNovaLauncherNewEpisodes(currentTime: Long = System.currentTimeMillis()): List<NovaLauncherNewEpisode>
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -16,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.models.db.helper.LongestEpisode
 import au.com.shiftyjelly.pocketcasts.models.db.helper.QueryHelper
 import au.com.shiftyjelly.pocketcasts.models.db.helper.UuidCount
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeDownloadFailureStatistics
+import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherNewEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
@@ -533,4 +534,35 @@ abstract class EpisodeDao {
         """,
     )
     abstract suspend fun getFailedDownloadsStatistics(): EpisodeDownloadFailureStatistics
+
+    @Query(
+        """
+        SELECT
+          episode.uuid AS id,
+          episode.podcast_id AS podcast_id,
+          episode.title AS title,
+          episode.duration AS duration,
+          episode.played_up_to AS current_position,
+          episode.season AS season_number,
+          episode.number AS episode_number,
+          -- Divide by 1000 to convert milliseconds that we store to seconds that Nova Launcher expects
+          episode.published_date / 1000 AS release_timestamp,
+          episode.last_playback_interaction_date / 1000 AS last_used_timestamp
+        FROM
+          podcast_episodes AS episode
+          JOIN podcasts AS podcast ON podcast.uuid IS episode.podcast_id
+        WHERE
+          episode.archived IS 0
+          AND podcast.subscribed IS 1
+          -- Check that the episode is not played
+          AND episode.playing_status IS 0
+          -- Select only episodes that were released at most 2 weeks ago
+          AND episode.published_date / 1000 >= (UNIXEPOCH() - 1209600)
+        ORDER BY
+          episode.published_date DESC
+        LIMIT
+          500
+        """,
+    )
+    abstract suspend fun getNovaLauncherNewEpisodes(): List<NovaLauncherNewEpisode>
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/NovaLauncherNewEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/NovaLauncherNewEpisode.kt
@@ -1,0 +1,15 @@
+package au.com.shiftyjelly.pocketcasts.models.entity
+
+import androidx.room.ColumnInfo
+
+data class NovaLauncherNewEpisode(
+    @ColumnInfo(name = "id") val id: String,
+    @ColumnInfo(name = "podcast_id") val podcastId: String,
+    @ColumnInfo(name = "title") val title: String,
+    @ColumnInfo(name = "duration") val duration: Long,
+    @ColumnInfo(name = "current_position") val currentPosition: Long,
+    @ColumnInfo(name = "season_number") val seasonNumber: Int?,
+    @ColumnInfo(name = "episode_number") val episodeNumber: Int?,
+    @ColumnInfo(name = "release_timestamp") val releaseTimestamp: Long,
+    @ColumnInfo(name = "last_used_timestamp") val lastUsedTimestamp: Long?,
+)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManager.kt
@@ -1,7 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.repositories.nova
 
+import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherNewEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherSubscribedPodcast
 
 interface NovaLauncherManager {
     suspend fun getSubscribedPodcasts(): List<NovaLauncherSubscribedPodcast>
+    suspend fun getNewEpisodes(): List<NovaLauncherNewEpisode>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
@@ -1,10 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.repositories.nova
 
+import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import javax.inject.Inject
 
 class NovaLauncherManagerImpl @Inject constructor(
     private val podcastDao: PodcastDao,
+    private val episodeDao: EpisodeDao,
 ) : NovaLauncherManager {
     override suspend fun getSubscribedPodcasts() = podcastDao.getNovaLauncherSubscribedPodcasts()
+    override suspend fun getNewEpisodes() = episodeDao.getNovaLauncherNewEpisodes()
 }


### PR DESCRIPTION
## Description

This sync new releases with Nova Launcher. Unfortunately, at the moment Nova doesn't support displaying them so the only verification we can do is through the logs. We will revisit testing once we have a Nova build that handles more use cases.

## Testing Instructions

1. Install this version of the Nova Launcher: p1715685124487099-slack-C028JAG44VD
2. Install Pocket Casts.
3. Open the app and be subscribed to podcasts where you have new episodes that are at most 2 weeks old.
4. Minimize the app.
5. Verify in the logs that new episodes are synced.
```
Nova Launcher sync complete. Success: [Subscribed podcasts: 25, New episodes: 56], Failure: []
```
6. If you notice the message below in the logs. Maximize and minimize the app again. It can happen if Nova fails to fetch verification signatures.
```
Nova Launcher sync failed
java.lang.SecurityException: Failed to verify Source calling package au.com.shiftyjelly.pocketcasts.debug
```

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
