### PR TITLE
 Sync trending podcasts Nova Launcher

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
@@ -7,8 +7,10 @@ import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherSubscribedPodcast
+import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.TrendingPodcast
 import java.util.Date
 import java.util.UUID
 import kotlinx.coroutines.test.runTest
@@ -186,6 +188,41 @@ class PodcastDaoTest {
                 latestReleaseTimestamp = 0,
                 lastUsedTimestamp = null,
             ),
+        )
+        assertEquals(expected, podcasts)
+    }
+
+    @Test
+    fun getAllTrendingPodcastsForNovaLauncher() = runTest {
+        val trendingPodcasts = List(65) {
+            TrendingPodcast("id-$it", "title-$it")
+        }
+        podcastDao.replaceAllTrendingPodcasts(trendingPodcasts)
+
+        val podcasts = podcastDao.getNovaLauncherTrendingPodcasts()
+
+        val expected = List(65) {
+            NovaLauncherTrendingPodcast("id-$it", "title-$it")
+        }
+        assertEquals(expected, podcasts)
+    }
+
+    @Test
+    fun doNotIncludeTrendingPodcastsThatAreTrendingForNovaLauncher() = runTest {
+        val trendingPodcasts = listOf(
+            TrendingPodcast("id-1", "title-1"),
+            TrendingPodcast("id-2", "title-2"),
+            TrendingPodcast("id-3", "title-3"),
+        )
+        podcastDao.replaceAllTrendingPodcasts(trendingPodcasts)
+        podcastDao.insert(Podcast("id-1", isSubscribed = true))
+        podcastDao.insert(Podcast("id-2", isSubscribed = false))
+
+        val podcasts = podcastDao.getNovaLauncherTrendingPodcasts()
+
+        val expected = listOf(
+            NovaLauncherTrendingPodcast("id-2", "title-2"),
+            NovaLauncherTrendingPodcast("id-3", "title-3"),
         )
         assertEquals(expected, podcasts)
     }

--- a/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
+++ b/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
@@ -4,9 +4,11 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherNewEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherSubscribedPodcast
+import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import io.branch.engage.conduit.source.Catalog
 import io.branch.engage.conduit.source.CatalogItem
+import io.branch.engage.conduit.source.CatalogType
 import io.branch.engage.conduit.source.TypeData
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -26,6 +28,24 @@ internal class CatalogFactory(
                     iconUrl = podcast.coverUrl,
                     originalReleaseTimestamp = podcast.initialReleaseTimestamp,
                     latestReleaseTimestamp = podcast.latestReleaseTimestamp,
+                ),
+            )
+        },
+    )
+
+    fun trendingPodcasts(data: List<NovaLauncherTrendingPodcast>) = Catalog(
+        id = "TrendingPodcasts",
+        label = context.getString(LR.string.nova_launcher_trending),
+        type = CatalogType.TRENDING,
+        items = data.map { podcast ->
+            CatalogItem.Base(
+                id = podcast.id,
+                intent = podcast.intent,
+                typeData = TypeData.Podcast(
+                    name = podcast.title,
+                    iconUrl = podcast.coverUrl,
+                    originalReleaseTimestamp = null,
+                    latestReleaseTimestamp = null,
                 ),
             )
         },
@@ -55,6 +75,13 @@ internal class CatalogFactory(
     private val NovaLauncherSubscribedPodcast.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$id.webp"
 
     private val NovaLauncherSubscribedPodcast.intent get() = context.launcherIntent
+        .setAction(Settings.INTENT_OPEN_APP_PODCAST_UUID)
+        .putExtra(Settings.PODCAST_UUID, id)
+        .putExtra(Settings.SOURCE_VIEW, SourceView.NOVA_LAUNCHER.analyticsValue)
+
+    private val NovaLauncherTrendingPodcast.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$id.webp"
+
+    private val NovaLauncherTrendingPodcast.intent get() = context.launcherIntent
         .setAction(Settings.INTENT_OPEN_APP_PODCAST_UUID)
         .putExtra(Settings.PODCAST_UUID, id)
         .putExtra(Settings.SOURCE_VIEW, SourceView.NOVA_LAUNCHER.analyticsValue)

--- a/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/NovaLauncherSyncWorker.kt
+++ b/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/NovaLauncherSyncWorker.kt
@@ -46,17 +46,23 @@ internal class NovaLauncherSyncWorker @AssistedInject constructor(
 
         return coroutineScope {
             val subscribedPodcasts = async { catalogFactory.subscribedPodcasts(manager.getSubscribedPodcasts()) }
+            val trendingPodcasts = async { catalogFactory.trendingPodcasts(manager.getTrendingPodcasts()) }
             val newEpisodes = async { catalogFactory.newEpisodes(manager.getNewEpisodes()) }
 
             try {
                 val isUserDataSubmitted = launcherBridge.submitUserData(listOf(subscribedPodcasts.await())).isSuccess
-                val isRecommendationsSubmitted = launcherBridge.submitRecommendations(listOf(newEpisodes.await())).isSuccess
+                val isRecommendationsSubmitted = launcherBridge.submitRecommendations(listOf(trendingPodcasts.await(), newEpisodes.await())).isSuccess
 
                 val results = listOf(
                     SubmissionResult(
                         isUserDataSubmitted,
                         "Subscribed podcasts",
                         subscribedPodcasts.await().items.size,
+                    ),
+                    SubmissionResult(
+                        isRecommendationsSubmitted,
+                        "Trending podcasts",
+                        trendingPodcasts.await().items.size,
                     ),
                     SubmissionResult(
                         isRecommendationsSubmitted,

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1929,4 +1929,5 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <!-- Nova Launcher -->
     <string name="nova_launcher_subscribed_podcasts">Subscribed Podcasts</string>
     <string name="nova_launcher_new_releases">New Releases</string>
+    <string name="nova_launcher_trending">Trending</string>
 </resources>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1929,5 +1929,5 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <!-- Nova Launcher -->
     <string name="nova_launcher_subscribed_podcasts">Subscribed Podcasts</string>
     <string name="nova_launcher_new_releases">New Releases</string>
-    <string name="nova_launcher_trending">Trending</string>
+<string name="nova_launcher_trending" translatable="false">@string/discover_trending</string>
 </resources>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -9,6 +9,7 @@ import androidx.room.Transaction
 import androidx.room.Update
 import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherSubscribedPodcast
+import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.TrendingPodcast
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
@@ -417,4 +418,18 @@ abstract class PodcastDao {
         """,
     )
     abstract suspend fun getNovaLauncherSubscribedPodcasts(): List<NovaLauncherSubscribedPodcast>
+
+    @Query(
+        """
+        SELECT 
+          trending_podcast.uuid AS id, 
+          trending_podcast.title AS title 
+        FROM 
+          trending_podcasts as trending_podcast 
+          LEFT JOIN podcasts AS podcast ON podcast.uuid = trending_podcast.uuid 
+        WHERE 
+          IFNULL(podcast.subscribed, 0) IS 0
+        """,
+    )
+    abstract suspend fun getNovaLauncherTrendingPodcasts(): List<NovaLauncherTrendingPodcast>
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/NovaLauncherTrendingPodcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/NovaLauncherTrendingPodcast.kt
@@ -1,0 +1,8 @@
+package au.com.shiftyjelly.pocketcasts.models.entity
+
+import androidx.room.ColumnInfo
+
+data class NovaLauncherTrendingPodcast(
+    @ColumnInfo(name = "id") val id: String,
+    @ColumnInfo(name = "title") val title: String,
+)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManager.kt
@@ -2,8 +2,10 @@ package au.com.shiftyjelly.pocketcasts.repositories.nova
 
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherNewEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherSubscribedPodcast
+import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
 
 interface NovaLauncherManager {
     suspend fun getSubscribedPodcasts(): List<NovaLauncherSubscribedPodcast>
+    suspend fun getTrendingPodcasts(): List<NovaLauncherTrendingPodcast>
     suspend fun getNewEpisodes(): List<NovaLauncherNewEpisode>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.repositories.nova
 
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
-import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
 import javax.inject.Inject
 
 class NovaLauncherManagerImpl @Inject constructor(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.nova
 
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
+import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
 import javax.inject.Inject
 
 class NovaLauncherManagerImpl @Inject constructor(
@@ -9,5 +10,6 @@ class NovaLauncherManagerImpl @Inject constructor(
     private val episodeDao: EpisodeDao,
 ) : NovaLauncherManager {
     override suspend fun getSubscribedPodcasts() = podcastDao.getNovaLauncherSubscribedPodcasts()
+    override suspend fun getTrendingPodcasts() = podcastDao.getNovaLauncherTrendingPodcasts()
     override suspend fun getNewEpisodes() = episodeDao.getNovaLauncherNewEpisodes()
 }


### PR DESCRIPTION
## Description

This sync trending podcasts with Nova Launcher. Unfortunately, at the moment Nova doesn't support displaying them so the only verification we can do is through the logs. We will revisit testing once we have a Nova build that handles more use cases.

## Testing Instructions

1. Install this version of the Nova Launcher: p1715685124487099-slack-C028JAG44VD
2. Install Pocket Casts.
3. Open the app and visit Discover page.
4. Minimize the app.
5. Verify in the logs that trending podcasts are synced.
```
Nova Launcher sync complete. Success: [Subscribed podcasts: 25, Trending podcasts: 79, New episodes: 57], Failure: []
```
6. If you notice the message below in the logs. Maximize and minimize the app again. It can happen if Nova fails to fetch verification signatures.
```
Nova Launcher sync failed
java.lang.SecurityException: Failed to verify Source calling package au.com.shiftyjelly.pocketcasts.debug
```

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
