### PR TITLE
Sync in progress episodes with Nova Launcher

### DIFF
--- a/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
+++ b/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.nova
 
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherInProgressEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherNewEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherSubscribedPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
@@ -72,6 +73,28 @@ internal class CatalogFactory(
         },
     )
 
+    fun inProgressEpisodes(data: List<NovaLauncherInProgressEpisode>) = Catalog(
+        id = "ContinueListening",
+        label = context.getString(LR.string.nova_launcher_continue_listening),
+        type = CatalogType.CONTINUE,
+        items = data.map { episode ->
+            CatalogItem.Base(
+                id = episode.id,
+                intent = context.launcherIntent,
+                lastUsedTimestamp = episode.lastUsedTimestamp,
+                typeData = TypeData.PodcastEpisode(
+                    name = episode.title,
+                    iconUrl = episode.coverUrl,
+                    seasonNumber = episode.seasonNumber,
+                    episodeNumber = episode.episodeNumber,
+                    releaseTimestamp = episode.releaseTimestamp,
+                    lengthSeconds = episode.duration,
+                    currentPositionSeconds = episode.currentPosition,
+                ),
+            )
+        },
+    )
+
     private val NovaLauncherSubscribedPodcast.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$id.webp"
 
     private val NovaLauncherSubscribedPodcast.intent get() = context.launcherIntent
@@ -87,6 +110,8 @@ internal class CatalogFactory(
         .putExtra(Settings.SOURCE_VIEW, SourceView.NOVA_LAUNCHER.analyticsValue)
 
     private val NovaLauncherNewEpisode.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$podcastId.webp"
+
+    private val NovaLauncherInProgressEpisode.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$podcastId.webp"
 
     private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
         "Missing launcher intent for $packageName"

--- a/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/NovaLauncherSyncWorker.kt
+++ b/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/NovaLauncherSyncWorker.kt
@@ -48,10 +48,11 @@ internal class NovaLauncherSyncWorker @AssistedInject constructor(
             val subscribedPodcasts = async { catalogFactory.subscribedPodcasts(manager.getSubscribedPodcasts()) }
             val trendingPodcasts = async { catalogFactory.trendingPodcasts(manager.getTrendingPodcasts()) }
             val newEpisodes = async { catalogFactory.newEpisodes(manager.getNewEpisodes()) }
+            val inProgressEpisodes = async { catalogFactory.inProgressEpisodes(manager.getInProgressEpisodes()) }
 
             try {
                 val isUserDataSubmitted = launcherBridge.submitUserData(listOf(subscribedPodcasts.await())).isSuccess
-                val isRecommendationsSubmitted = launcherBridge.submitRecommendations(listOf(trendingPodcasts.await(), newEpisodes.await())).isSuccess
+                val isRecommendationsSubmitted = launcherBridge.submitRecommendations(listOf(trendingPodcasts.await(), newEpisodes.await(), inProgressEpisodes.await())).isSuccess
 
                 val results = listOf(
                     SubmissionResult(
@@ -68,6 +69,11 @@ internal class NovaLauncherSyncWorker @AssistedInject constructor(
                         isRecommendationsSubmitted,
                         "New episodes",
                         newEpisodes.await().items.size,
+                    ),
+                    SubmissionResult(
+                        isRecommendationsSubmitted,
+                        "In progress episodes",
+                        inProgressEpisodes.await().items.size,
                     ),
                 )
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1934,4 +1934,5 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="nova_launcher_subscribed_podcasts">Subscribed Podcasts</string>
     <string name="nova_launcher_new_releases">New Releases</string>
 <string name="nova_launcher_trending" translatable="false">@string/discover_trending</string>
+    <string name="nova_launcher_continue_listening">Continue listening</string>
 </resources>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/NovaLauncherInProgressEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/NovaLauncherInProgressEpisode.kt
@@ -1,0 +1,15 @@
+package au.com.shiftyjelly.pocketcasts.models.entity
+
+import androidx.room.ColumnInfo
+
+data class NovaLauncherInProgressEpisode(
+    @ColumnInfo(name = "id") val id: String,
+    @ColumnInfo(name = "podcast_id") val podcastId: String,
+    @ColumnInfo(name = "title") val title: String,
+    @ColumnInfo(name = "duration") val duration: Long,
+    @ColumnInfo(name = "current_position") val currentPosition: Long,
+    @ColumnInfo(name = "season_number") val seasonNumber: Int?,
+    @ColumnInfo(name = "episode_number") val episodeNumber: Int?,
+    @ColumnInfo(name = "release_timestamp") val releaseTimestamp: Long,
+    @ColumnInfo(name = "last_used_timestamp") val lastUsedTimestamp: Long?,
+)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManager.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.nova
 
+import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherInProgressEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherNewEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherSubscribedPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
@@ -8,4 +9,5 @@ interface NovaLauncherManager {
     suspend fun getSubscribedPodcasts(): List<NovaLauncherSubscribedPodcast>
     suspend fun getTrendingPodcasts(): List<NovaLauncherTrendingPodcast>
     suspend fun getNewEpisodes(): List<NovaLauncherNewEpisode>
+    suspend fun getInProgressEpisodes(): List<NovaLauncherInProgressEpisode>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
@@ -11,4 +11,5 @@ class NovaLauncherManagerImpl @Inject constructor(
     override suspend fun getSubscribedPodcasts() = podcastDao.getNovaLauncherSubscribedPodcasts()
     override suspend fun getTrendingPodcasts() = podcastDao.getNovaLauncherTrendingPodcasts()
     override suspend fun getNewEpisodes() = episodeDao.getNovaLauncherNewEpisodes()
+    override suspend fun getInProgressEpisodes() = episodeDao.getNovaLauncherInProgressEpisodes()
 }


### PR DESCRIPTION
## Description

This sync in progress episodes with Nova Launcher. Unfortunately, at the moment Nova doesn't support displaying them so the only verification we can do is through the logs. We will revisit testing once we have a Nova build that handles more use cases.

## Testing Instructions

1. Install this version of the Nova Launcher: p1715685124487099-slack-C028JAG44VD
2. Install Pocket Casts.
3. Open the app and play some episodes from different podcasts and make sure they are not archived.
4. Minimize the app.
5. Verify in the logs that in-progress episodes are synced.
```
Nova Launcher sync complete. Success: [Subscribed podcasts: 25, Trending podcasts: 79, New episodes: 56, In progress episodes: 8], Failure: []
```
6. If you notice the message below in the logs. Maximize and minimize the app again. It can happen if Nova fails to fetch verification signatures.
```
Nova Launcher sync failed
java.lang.SecurityException: Failed to verify Source calling package au.com.shiftyjelly.pocketcasts.debug
```

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
