### PR TITLE
Sync recently played podcasts with the Nova Launcher

### DIFF
--- a/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
+++ b/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherInProgressEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherNewEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherRecentlyPlayedPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherSubscribedPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -19,6 +20,25 @@ internal class CatalogFactory(
     fun subscribedPodcasts(data: List<NovaLauncherSubscribedPodcast>) = Catalog(
         id = "SubscribedPodcasts",
         label = context.getString(LR.string.nova_launcher_subscribed_podcasts),
+        items = data.map { podcast ->
+            CatalogItem.Base(
+                id = podcast.id,
+                intent = podcast.intent,
+                lastUsedTimestamp = podcast.lastUsedTimestamp,
+                typeData = TypeData.Podcast(
+                    name = podcast.title,
+                    iconUrl = podcast.coverUrl,
+                    originalReleaseTimestamp = podcast.initialReleaseTimestamp,
+                    latestReleaseTimestamp = podcast.latestReleaseTimestamp,
+                ),
+            )
+        },
+    )
+
+    fun recentlyPlayedPodcasts(data: List<NovaLauncherRecentlyPlayedPodcast>) = Catalog(
+        id = "RecentlyPlayed",
+        label = context.getString(LR.string.nova_launcher_recently_played),
+        type = CatalogType.CONTINUE,
         items = data.map { podcast ->
             CatalogItem.Base(
                 id = podcast.id,
@@ -98,6 +118,13 @@ internal class CatalogFactory(
     private val NovaLauncherSubscribedPodcast.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$id.webp"
 
     private val NovaLauncherSubscribedPodcast.intent get() = context.launcherIntent
+        .setAction(Settings.INTENT_OPEN_APP_PODCAST_UUID)
+        .putExtra(Settings.PODCAST_UUID, id)
+        .putExtra(Settings.SOURCE_VIEW, SourceView.NOVA_LAUNCHER.analyticsValue)
+
+    private val NovaLauncherRecentlyPlayedPodcast.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$id.webp"
+
+    private val NovaLauncherRecentlyPlayedPodcast.intent get() = context.launcherIntent
         .setAction(Settings.INTENT_OPEN_APP_PODCAST_UUID)
         .putExtra(Settings.PODCAST_UUID, id)
         .putExtra(Settings.SOURCE_VIEW, SourceView.NOVA_LAUNCHER.analyticsValue)

--- a/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/NovaLauncherSyncWorker.kt
+++ b/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/NovaLauncherSyncWorker.kt
@@ -46,12 +46,14 @@ internal class NovaLauncherSyncWorker @AssistedInject constructor(
 
         return coroutineScope {
             val subscribedPodcasts = async { catalogFactory.subscribedPodcasts(manager.getSubscribedPodcasts()) }
+            val recentlyPlayedPodcast = async { catalogFactory.recentlyPlayedPodcasts(manager.getRecentlyPlayedPodcasts()) }
             val trendingPodcasts = async { catalogFactory.trendingPodcasts(manager.getTrendingPodcasts()) }
             val newEpisodes = async { catalogFactory.newEpisodes(manager.getNewEpisodes()) }
             val inProgressEpisodes = async { catalogFactory.inProgressEpisodes(manager.getInProgressEpisodes()) }
 
             try {
                 val isUserDataSubmitted = launcherBridge.submitUserData(listOf(subscribedPodcasts.await())).isSuccess
+                val isUsageHistorySubmitted = launcherBridge.submitUsageHistory(listOf(recentlyPlayedPodcast.await())).isSuccess
                 val isRecommendationsSubmitted = launcherBridge.submitRecommendations(listOf(trendingPodcasts.await(), newEpisodes.await(), inProgressEpisodes.await())).isSuccess
 
                 val results = listOf(
@@ -59,6 +61,11 @@ internal class NovaLauncherSyncWorker @AssistedInject constructor(
                         isUserDataSubmitted,
                         "Subscribed podcasts",
                         subscribedPodcasts.await().items.size,
+                    ),
+                    SubmissionResult(
+                        isUsageHistorySubmitted,
+                        "Recently played podcasts",
+                        recentlyPlayedPodcast.await().items.size,
                     ),
                     SubmissionResult(
                         isRecommendationsSubmitted,

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1932,6 +1932,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
 
     <!-- Nova Launcher -->
     <string name="nova_launcher_subscribed_podcasts">Subscribed Podcasts</string>
+    <string name="nova_launcher_recently_played">Recently Played</string>
     <string name="nova_launcher_new_releases">New Releases</string>
 <string name="nova_launcher_trending" translatable="false">@string/discover_trending</string>
     <string name="nova_launcher_continue_listening">Continue listening</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -447,12 +447,12 @@ abstract class PodcastDao {
           podcasts
         WHERE
         -- Select only episodes that were used at most 2 months ago
-          last_used_timestamp >= (UNIXEPOCH() - 5184000)
+          last_used_timestamp * 1000 >= (:currentTime - 5184000000)
         ORDER BY
           last_used_timestamp DESC
         LIMIT
           200
         """,
     )
-    abstract suspend fun getNovaLauncherRecentlyPlayedPodcasts(): List<NovaLauncherRecentlyPlayedPodcast>
+    abstract suspend fun getNovaLauncherRecentlyPlayedPodcasts(currentTime: Long = System.currentTimeMillis()): List<NovaLauncherRecentlyPlayedPodcast>
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/NovaLauncherRecentlyPlayedPodcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/NovaLauncherRecentlyPlayedPodcast.kt
@@ -1,0 +1,11 @@
+package au.com.shiftyjelly.pocketcasts.models.entity
+
+import androidx.room.ColumnInfo
+
+data class NovaLauncherRecentlyPlayedPodcast(
+    @ColumnInfo(name = "id") val id: String,
+    @ColumnInfo(name = "title") val title: String,
+    @ColumnInfo(name = "initial_release_timestamp") val initialReleaseTimestamp: Long?,
+    @ColumnInfo(name = "latest_release_timestamp") val latestReleaseTimestamp: Long?,
+    @ColumnInfo(name = "last_used_timestamp") val lastUsedTimestamp: Long,
+)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManager.kt
@@ -2,11 +2,13 @@ package au.com.shiftyjelly.pocketcasts.repositories.nova
 
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherInProgressEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherNewEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherRecentlyPlayedPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherSubscribedPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
 
 interface NovaLauncherManager {
     suspend fun getSubscribedPodcasts(): List<NovaLauncherSubscribedPodcast>
+    suspend fun getRecentlyPlayedPodcasts(): List<NovaLauncherRecentlyPlayedPodcast>
     suspend fun getTrendingPodcasts(): List<NovaLauncherTrendingPodcast>
     suspend fun getNewEpisodes(): List<NovaLauncherNewEpisode>
     suspend fun getInProgressEpisodes(): List<NovaLauncherInProgressEpisode>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
@@ -9,6 +9,7 @@ class NovaLauncherManagerImpl @Inject constructor(
     private val episodeDao: EpisodeDao,
 ) : NovaLauncherManager {
     override suspend fun getSubscribedPodcasts() = podcastDao.getNovaLauncherSubscribedPodcasts()
+    override suspend fun getRecentlyPlayedPodcasts() = podcastDao.getNovaLauncherRecentlyPlayedPodcasts()
     override suspend fun getTrendingPodcasts() = podcastDao.getNovaLauncherTrendingPodcasts()
     override suspend fun getNewEpisodes() = episodeDao.getNovaLauncherNewEpisodes()
     override suspend fun getInProgressEpisodes() = episodeDao.getNovaLauncherInProgressEpisodes()


### PR DESCRIPTION
## Description

This recently played podcasts with Nova Launcher. Unfortunately, at the moment Nova doesn't support displaying them so the only verification we can do is through the logs. We will revisit testing once we have a Nova build that handles more use cases.

## Testing Instructions

1. Install this version of the Nova Launcher: p1715685124487099-slack-C028JAG44VD
2. Install Pocket Casts.
3. Open the app and play some episodes from different podcasts.
4. Minimize the app.
5. Verify in the logs that recently played poccasts are synced.
```
Nova Launcher sync complete. Success: [Subscribed podcasts: 25, Recently played podcasts: 38, Trending podcasts: 79, New episodes: 56, In progress episodes: 8], Failure: []
```
6. If you notice the message below in the logs. Maximize and minimize the app again. It can happen if Nova fails to fetch verification signatures.
```
Nova Launcher sync failed
java.lang.SecurityException: Failed to verify Source calling package au.com.shiftyjelly.pocketcasts.debug
```

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
