### PR TITLE
ExoPlayer Cache: Improve error handling

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerCacheUtil.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerCacheUtil.kt
@@ -1,0 +1,47 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import android.content.Context
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.database.StandaloneDatabaseProvider
+import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
+import androidx.media3.datasource.cache.SimpleCache
+import au.com.shiftyjelly.pocketcasts.repositories.BuildConfig
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import com.automattic.android.tracks.crashlogging.CrashLogging
+import java.io.File
+import timber.log.Timber
+
+@OptIn(UnstableApi::class)
+object ExoPlayerCacheUtil {
+    private const val MAX_DEVICE_CACHE_SIZE_BYTES = 50 * 1024 * 1024L
+    private const val CACHE_DIR_NAME = "pocketcasts-exoplayer-cache"
+    private var simpleCache: SimpleCache? = null
+
+    @OptIn(UnstableApi::class)
+    @Synchronized
+    fun getSimpleCache(
+        context: Context,
+        crashLogging: CrashLogging,
+    ): SimpleCache? {
+        if (FeatureFlag.isEnabled(Feature.CACHE_PLAYING_EPISODE) && simpleCache == null) {
+            val cacheDir = File(context.cacheDir, CACHE_DIR_NAME)
+            simpleCache = try {
+                if (BuildConfig.DEBUG) Timber.d("ExoPlayer cache initialized")
+                SimpleCache(
+                    cacheDir,
+                    LeastRecentlyUsedCacheEvictor(MAX_DEVICE_CACHE_SIZE_BYTES),
+                    StandaloneDatabaseProvider(context),
+                )
+            } catch (e: Exception) {
+                val errorMessage = "Failed to instantiate ExoPlayer cache ${e.message}"
+                crashLogging.sendReport(Exception(errorMessage))
+                LogBuffer.e(LogBuffer.TAG_PLAYBACK, errorMessage)
+                null
+            }
+        }
+        return simpleCache
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactoryImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactoryImpl.kt
@@ -3,12 +3,14 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class PlayerFactoryImpl @Inject constructor(
     private val settings: Settings,
     private val statsManager: StatsManager,
+    private val crashLogging: CrashLogging,
     @ApplicationContext private val context: Context,
 ) : PlayerFactory {
 
@@ -20,6 +22,6 @@ class PlayerFactoryImpl @Inject constructor(
     }
 
     override fun createSimplePlayer(onPlayerEvent: (Player, PlayerEvent) -> Unit): Player {
-        return SimplePlayer(settings, statsManager, context, onPlayerEvent)
+        return SimplePlayer(settings, statsManager, context, crashLogging, onPlayerEvent)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -16,12 +16,9 @@ import androidx.media3.common.Player
 import androidx.media3.common.Tracks
 import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.database.StandaloneDatabaseProvider
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.datasource.cache.CacheDataSource
-import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
-import androidx.media3.datasource.cache.SimpleCache
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.hls.HlsMediaSource
@@ -35,19 +32,21 @@ import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.utils.Util
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import java.io.File
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
-class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val context: Context, override val onPlayerEvent: (au.com.shiftyjelly.pocketcasts.repositories.playback.Player, PlayerEvent) -> Unit) : LocalPlayer(onPlayerEvent) {
-    companion object {
-        private const val MAX_DEVICE_CACHE_SIZE_BYTES = 50 * 1024 * 1024
-    }
+class SimplePlayer(
+    val settings: Settings,
+    val statsManager: StatsManager,
+    val context: Context,
+    val crashLogging: CrashLogging,
+    override val onPlayerEvent: (au.com.shiftyjelly.pocketcasts.repositories.playback.Player, PlayerEvent) -> Unit,
+) : LocalPlayer(onPlayerEvent) {
     private val reducedBufferManufacturers = listOf("mercedes-benz")
     private val useReducedBuffer = reducedBufferManufacturers.contains(Build.MANUFACTURER.lowercase()) || Util.isWearOs(context)
     private val bufferTimeMinMillis = TimeUnit.MINUTES.toMillis(2).toInt()
@@ -67,9 +66,6 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
     override var isPip: Boolean = false
 
     private var videoChangedListener: VideoChangedListener? = null
-
-    private var databaseProvider: StandaloneDatabaseProvider? = null
-    private var simpleCache: SimpleCache? = null
 
     @Volatile
     private var prepared = false
@@ -131,8 +127,6 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
 
         player = null
         prepared = false
-        databaseProvider?.close()
-        simpleCache?.release()
 
         videoChangedListener?.videoNeedsReset()
     }
@@ -288,22 +282,14 @@ class SimplePlayer(val settings: Settings, val statsManager: StatsManager, val c
             }
         } ?: return
 
-        if (FeatureFlag.isEnabled(Feature.CACHE_PLAYING_EPISODE) && location is EpisodeLocation.Stream) {
-            databaseProvider ?: run { databaseProvider = StandaloneDatabaseProvider(context) }
-
-            simpleCache ?: run {
-                simpleCache = SimpleCache(
-                    File(context.cacheDir, "podcasts-cache"),
-                    LeastRecentlyUsedCacheEvictor(MAX_DEVICE_CACHE_SIZE_BYTES.toLong()),
-                    databaseProvider!!,
-                )
+        val sourceFactory = ExoPlayerCacheUtil.getSimpleCache(context, crashLogging)?.let { cache ->
+            if (location is EpisodeLocation.Stream) {
+                CacheDataSource.Factory()
+                    .setCache(cache)
+                    .setUpstreamDataSourceFactory(httpDataSourceFactory)
+            } else {
+                dataSourceFactory
             }
-        }
-
-        val sourceFactory = simpleCache?.let {
-            CacheDataSource.Factory()
-                .setCache(it)
-                .setUpstreamDataSourceFactory(httpDataSourceFactory)
         } ?: dataSourceFactory
 
         val mediaItem = MediaItem.fromUri(uri)


### PR DESCRIPTION
## Description

This improves ExoPlayer cache initialization and error handling.

Instead of releasing the `simpleCache` variable every time the player is released, it is stored in a static variable. Considering the current architecture of the app, where `ExoPlayer` can be released and initiated multiple times, this approach is worth using for intermediate caching ([ref](https://rb.gy/vmjs89)).

This resolves the following crash:
https://a8c.sentry.io/share/issue/2f8bcf549be04fb9bcaffd8a223d4681/

I could reproduce the crash by hitting play on a few episodes simultaneously. The cache variable tried to re-initialize while being locked during release, causing the crash.

## Testing Instructions

We are utilizing the built-in caching feature of ExoPlayer. Testing the caching mechanism itself is not required. A few things we can try:

#### Test.1 Using the right cache evictor

1. Reduce `MAX_DEVICE_CACHE_SIZE_BYTES` from 50 to 10 MB
2. Play a large episode
3. Open device explorer
4. ✅ Notice that data is cached at `/data/data/au.com.shiftyjelly.pocketcasts.debug/cache/pocketcasts-exoplayer-cache` in 5 MB chunks
5. Wait till more than 10 MB of data is cached
6. ✅ Notice that the least recently used chunk is replaced by the new data

#### Test.2 Switch to downloaded file

1. Continue from above
2. While the episode is playing, download it
3. ✅ Notice that as soon as the episode download completes, the episode is played from the downloaded location, and intermediate caching stops

#### Test.3 Reproduce the crash 
1. Open a podcast
2. Tap play on multiple episodes
3. ✅ Notice that the app doesn't crash due to this crash: https://a8c.sentry.io/share/issue/2f8bcf549be04fb9bcaffd8a223d4681/
4. Switch to main branch
5. Repeat above steps 
6. App crashes 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
