### PR TITLE
Enable dynamic widget colors by default

### DIFF
--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1403,7 +1403,7 @@ class SettingsImpl @Inject constructor(
     ) {
         override fun get(): Boolean {
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                sharedPrefs.getBoolean(sharedPrefKey, false)
+                sharedPrefs.getBoolean(sharedPrefKey, true)
             } else {
                 false
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
@@ -169,6 +169,10 @@ class VersionMigrationsJob : JobService() {
         if (previousVersionCode < 9230 && previousVersionCode != 9227) {
             migrateToGranularEpisodeArtworkSettings(applicationContext)
         }
+
+        if (previousVersionCode < 9235) {
+            enableDynamicColors()
+        }
     }
 
     private fun removeOldTempPodcastDirectory() {
@@ -260,5 +264,9 @@ class VersionMigrationsJob : JobService() {
             val useEpisodeArtwork = settings.getBooleanForKey("useEpisodeArtwork", false)
             settings.artworkConfiguration.set(ArtworkConfiguration((useEpisodeArtwork)), updateModifiedAt = true)
         }
+    }
+
+    private fun enableDynamicColors() {
+        settings.useDynamicColorsForWidget.set(true, updateModifiedAt = true)
     }
 }


### PR DESCRIPTION
## Description

This enabled dynamic colors for widgets by default.

## Testing Instructions

> [!note]
> Test this with Android 12+

1. Clean install the app.
2. Add large widget.
3. Notice that it is themed to your home screen palette.
4. Go to settings and disable dynamic colors for widgets.
5. Close the app.
6. The widget should not be themed.
7. Apply [this patch](https://github.com/Automattic/pocket-casts-android/files/15339429/dynamic.patch).
8. Install the app with the patch.
9. The widget should be themed.
10. Go to settings and disable dynamic colors.
11. Close the app.
12. The widget should not be themed.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
