### PR TITLE
Update bottom inset on application start

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -391,6 +391,7 @@ class MainActivity :
 
         val showMiniPlayerImmediately = savedInstanceState?.getBoolean(SAVEDSTATE_MINIPLAYER_SHOWN, false) ?: false
         binding.playerBottomSheet.isVisible = showMiniPlayerImmediately
+        settings.updateBottomInset(if (showMiniPlayerImmediately) resources.getDimension(R.dimen.miniPlayerHeight).toInt() else 0)
 
         setupPlayerViews(showMiniPlayerImmediately)
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -13,9 +13,7 @@ import androidx.core.os.bundleOf
 import androidx.core.view.updatePadding
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -194,19 +192,6 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
             }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                settings.bottomInset.collect {
-                    if (FeatureFlag.isEnabled(Feature.PODCASTS_GRID_VIEW_DESIGN_CHANGES)) {
-                        val gridOuterPadding = if (settings.podcastGridLayout.value == PodcastGridLayoutType.LIST_VIEW) 0 else gridOuterPadding
-                        realBinding?.recyclerView?.updatePadding(gridOuterPadding, gridOuterPadding, gridOuterPadding, gridOuterPadding + it)
-                    } else {
-                        realBinding?.recyclerView?.updatePadding(bottom = it)
-                    }
-                }
-            }
-        }
-
         if (!viewModel.isFragmentChangingConfigurations) {
             folderUuid?.let { viewModel.trackFolderShown(it) } ?: viewModel.trackPodcastsListShown()
         }
@@ -368,6 +353,17 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         ) {
             adapter?.badgeType = badgeType
             realBinding?.recyclerView?.adapter = adapter
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            settings.bottomInset.collect {
+                if (FeatureFlag.isEnabled(Feature.PODCASTS_GRID_VIEW_DESIGN_CHANGES)) {
+                    val gridOuterPadding = if (settings.podcastGridLayout.value == PodcastGridLayoutType.LIST_VIEW) 0 else gridOuterPadding
+                    realBinding?.recyclerView?.updatePadding(gridOuterPadding, gridOuterPadding, gridOuterPadding, gridOuterPadding + it)
+                } else {
+                    realBinding?.recyclerView?.updatePadding(bottom = it)
+                }
+            }
         }
 
         realBinding?.recyclerView?.layoutManager = layoutManager


### PR DESCRIPTION
## Description

Applies podcasts grid padding when the user installs the app for the first time and has not interacted with the mini-player yet.

Fixes https://github.com/Automattic/pocket-casts-android/issues/2248

## Testing Instructions

1. Checkout 7.64 tag
2. Put a breakpoint at line 202
3. Fresh install the app
4. Go to Podcasts tab
5. ✅ Notice that breakpoint is not hit
6. Go to Discover tab and subscribe to a few podcasts
7. Go to Podcasts tab
8. ✅ Notice that breakpoint is still not hit and out grid padding is not applied
9. Checkout this branch
10. Put a breakpoint at line 362
11. Fresh install the app
12. Go to Podcasts tab
13. ✅ Notice that breakpoint is hit
14. Repeat steps 6-7
15. ✅ Notice that breakpoint is hit and outer grid padding is applied
16. Switch between grid and list view
17. ✅ Notice that the outer padding for the layout is correct

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/7ca824d5-88f5-493b-9602-922f04a4d6b5

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
