### PR TITLE
Fix folder flickering

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderViewHolder.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
@@ -27,6 +28,13 @@ class FolderViewHolder(
     val onFolderClick: (Folder) -> Unit,
     val podcastGridLayout: PodcastGridLayoutType,
 ) : RecyclerView.ViewHolder(composeView) {
+
+    init {
+        /* Setting non-default view composition strategy to temporarily fix flickering in folders:
+        https://github.com/Automattic/pocket-casts-android/issues/1661.
+        Folders, used for grouping, should be less in number, it should not cause performance issues. */
+        composeView.setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+    }
 
     fun bind(folder: Folder, podcasts: List<Podcast>, badgeType: BadgeType, podcastUuidToBadge: Map<String, Int>) {
         val badgeCount = calculateFolderBadge(podcasts, badgeType, podcastUuidToBadge)


### PR DESCRIPTION
## Description

This temporarily fixes folder flickering when switching between tabs.

Fixes #1661

## Testing Instructions
1. Login with a paid account
2. Create two folders of different colors and add podcasts to them. 
3. Switch between Podcasts tab and another tab
4. ✅  Notice there's no flickering in the folders

## Screenshots or Screencast 

**Before**

https://github.com/Automattic/pocket-casts-android/assets/1405144/5d152c36-c9a2-4c8c-a535-ccc65883b556

**After**

https://github.com/Automattic/pocket-casts-android/assets/1405144/9b62551d-b5bf-4d40-bb83-acb02d617f9f


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
