### PR TITLE
Fix/bookmarks episode not found

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
@@ -49,6 +49,7 @@ import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelp
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper.NavigationState
 import java.util.Date
 import java.util.UUID
+import kotlinx.coroutines.flow.collectLatest
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -78,11 +79,6 @@ fun BookmarksPage(
         onRowLongPressed = onRowLongPressed,
         onBookmarksOptionsMenuClicked = { bookmarksViewModel.onOptionsMenuClicked() },
         onPlayClick = { bookmark ->
-            Toast.makeText(
-                context,
-                context.resources.getString(LR.string.playing_bookmark, bookmark.title),
-                Toast.LENGTH_SHORT,
-            ).show()
             bookmarksViewModel.play(bookmark)
         },
         onSearchTextChanged = { bookmarksViewModel.onSearchTextChanged(it) },
@@ -108,6 +104,13 @@ fun BookmarksPage(
                     NavigationState.ShareBookmark -> onShareBookmarkClick()
                     NavigationState.EditBookmark -> onEditBookmarkClick()
                 }
+            }
+    }
+    LaunchedEffect(context) {
+        bookmarksViewModel
+            .message
+            .collectLatest { message ->
+                Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
             }
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
@@ -43,6 +43,7 @@ import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.NoBookmark
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.NoBookmarksView
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.UpsellView
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel
+import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel.BookmarkMessage
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
@@ -110,7 +111,11 @@ fun BookmarksPage(
         bookmarksViewModel
             .message
             .collectLatest { message ->
-                Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                val string = when (message) {
+                    is BookmarkMessage.BookmarkEpisodeNotFound -> context.getString(LR.string.episode_not_found)
+                    is BookmarkMessage.PlayingBookmark -> context.getString(LR.string.playing_bookmark, message.bookmarkTitle)
+                }
+                Toast.makeText(context, string, Toast.LENGTH_SHORT).show()
             }
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -39,6 +39,7 @@ import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectHelper
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -53,6 +54,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
 class BookmarksViewModel
@@ -68,6 +70,7 @@ class BookmarksViewModel
     private val bookmarkFeature: BookmarkFeatureControl,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val bookmarkSearchHandler: BookmarkSearchHandler,
+    @ApplicationContext private val context: Context,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Loading)
@@ -75,6 +78,9 @@ class BookmarksViewModel
 
     private val _showOptionsDialog = MutableSharedFlow<Int>()
     val showOptionsDialog = _showOptionsDialog.asSharedFlow()
+
+    private val _message = MutableSharedFlow<String>()
+    val message = _message.asSharedFlow()
 
     private var isFragmentActive: Boolean = true
 
@@ -315,7 +321,11 @@ class BookmarksViewModel
                 if (shouldLoadOrSwitchEpisode) {
                     playbackManager.playNowSync(it, sourceView = sourceView)
                 }
+            } ?: run {
+                _message.emit(context.getString(LR.string.episode_not_found))
+                return@launch
             }
+            _message.emit(context.getString(LR.string.playing_bookmark, bookmark.title))
             playbackManager.seekToTimeMs(positionMs = bookmark.timeSecs * 1000)
             analyticsTracker.track(
                 AnalyticsEvent.BOOKMARK_PLAY_TAPPED,

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
@@ -126,7 +126,6 @@ class BookmarksViewModelTest {
             bookmarkFeature = bookmarkFeature,
             ioDispatcher = UnconfinedTestDispatcher(),
             bookmarkSearchHandler = bookmarkSearchHandler,
-            context = mock(),
         )
     }
 

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
@@ -126,6 +126,7 @@ class BookmarksViewModelTest {
             bookmarkFeature = bookmarkFeature,
             ioDispatcher = UnconfinedTestDispatcher(),
             bookmarkSearchHandler = bookmarkSearchHandler,
+            context = mock(),
         )
     }
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="downloads">Downloads</string>
     <string name="edit">Edit</string>
     <string name="effects">Effects</string>
+    <string name="episode_not_found">Episode not found</string>
     <string name="go_to_podcast">Go to podcast</string>
     <string name="go_to_files">Go to files</string>
     <string name="in_progress">In progress</string>


### PR DESCRIPTION
## Description
If an episode does not exist for a bookmark, a message is shown that the episode is not found instead of affecting the playing episode.

(Another option is to [filter out such bookmarks](https://github.com/Automattic/pocket-casts-android/compare/fix/bookmarks_unavailable_episodes?expand=1). As they will keep accumulating in the database with no user option to delete them if they want, it might be better to display an appropriate message.)

Fixes #2234

## Testing Instructions
1. Login with a paid account
2. Open an episode and create a bookmark with a unique title
3. Open the bookmarks table in the database inspector and note down the episodeID of this newly created unsynced bookmark
4. Run this query: `DELETE FROM podcast_episodes WHERE uuid = "episodeID noted above>"`
5. Start playing an episode from any podcast
6. Check the `Profile` > `Bookmarks` page, then try to click on the bookmark you created earlier
8. ✅ Notice that a message is shown that the episode is not found and the current playing episode is not affected

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/d85c5230-e021-4aff-abcb-72333514fb90

## Checklist
- [] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
