### PR TITLE
Fix Tesla artwork issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
     *   Add a storage setting that attempts to fix missing downloads files.
         ([#2244](https://github.com/Automattic/pocket-casts-android/pull/2244))
 *   Bug Fixes
+    *   Fix Tesla podcast artwork not loading
+        ([#2254](https://github.com/Automattic/pocket-casts-android/pull/2254))
     *   Fix timestamp parameter handling in shared links
         ([#2235](https://github.com/Automattic/pocket-casts-android/pull/2235))
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -408,8 +408,11 @@ class MediaSessionManager(
             if (Util.isAutomotive(context)) nowPlayingBuilder = nowPlayingBuilder.putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_ICON_URI, bitmapUri)
 
             // Send the bitmap, as some devices don't support URLs, such as a Tesla.
-            AutoConverter.getPodcastArtworkBitmap(episode, context, useEpisodeArtwork)?.let { bitmap ->
-                nowPlayingBuilder = nowPlayingBuilder.putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, bitmap)
+            // Don't do this for Wear OS or Automotive to reduce the amount memory used.
+            if (!Util.isWearOs(context) && !Util.isAutomotive(context)) {
+                AutoConverter.getPodcastArtworkBitmap(episode, context, useEpisodeArtwork)?.let { bitmap ->
+                    nowPlayingBuilder = nowPlayingBuilder.putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, bitmap)
+                }
             }
             Timber.i("MediaSession metadata. With artwork.")
         }


### PR DESCRIPTION
## Description

The podcast or episode artwork doesn't show in Tesla cars when only the artwork URL is set in the media session metadata. If the artwork is set in a bitmap it's displayed. 

Fixes https://github.com/Automattic/pocket-casts-android/issues/2237

## Testing Instructions
This is a hard one to test without a car but it would be good to check that using the bitmap doesn't break other places where we use the artwork. 

1. Tap play on an episode
2. ✅ Verify the notification shade artwork is correct and not low-resolution
3. Start an Android Auto head unit
```
cd /Applications/android-sdk/extras/google/auto/ (or wherever your Android SDK folder is located)
# first time add the execute permission
chmod +x ./desktop-head-unit
./desktop-head-unit --usb
```
4. ✅ Verify the playing screen has the correct artwork

## Screenshots 

![20240520_145201](https://github.com/Automattic/pocket-casts-android/assets/308331/e83e8741-e3a4-4e0d-a834-efc1595a9a6c)
