### PR TITLE
Shortcuts ANR

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -552,6 +552,7 @@ class MainActivity :
             force = true,
             coroutineScope = applicationScope,
             context = this,
+            source = PocketCastsShortcuts.Source.REFRESH_APP,
         )
 
         subscriptionManager.refreshPurchases()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -206,6 +206,7 @@ class PlaylistManagerImpl @Inject constructor(
                 force = true,
                 coroutineScope = applicationScope,
                 context = context,
+                source = PocketCastsShortcuts.Source.CREATE_PLAYLIST,
             )
         }
         return id
@@ -311,6 +312,7 @@ class PlaylistManagerImpl @Inject constructor(
                 force = true,
                 coroutineScope = applicationScope,
                 context = context,
+                source = PocketCastsShortcuts.Source.SAVE_PLAYLISTS_ORDER,
             )
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shortcuts/PocketCastsShortcuts.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shortcuts/PocketCastsShortcuts.kt
@@ -12,7 +12,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 object PocketCastsShortcuts {
 
@@ -36,11 +35,10 @@ object PocketCastsShortcuts {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N_MR1) {
             return
         }
+        val shortcutManager = context.getSystemService(ShortcutManager::class.java) ?: return
 
-        coroutineScope.launch(Dispatchers.Main) {
-            val shortcutManager = context.getSystemService(ShortcutManager::class.java) ?: return@launch
-
-            val topPlaylist = withContext(Dispatchers.Default) { playlistManager.findAll().firstOrNull() }
+        coroutineScope.launch(Dispatchers.Default) {
+            val topPlaylist = playlistManager.findAll().firstOrNull()
 
             if (topPlaylist == null) {
                 if (shortcutManager.dynamicShortcuts.size == 1) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shortcuts/PocketCastsShortcuts.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shortcuts/PocketCastsShortcuts.kt
@@ -9,6 +9,7 @@ import android.graphics.drawable.Icon
 import android.os.Build
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.shortcutDrawableId
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -31,6 +32,7 @@ object PocketCastsShortcuts {
         force: Boolean,
         coroutineScope: CoroutineScope,
         context: Context,
+        source: Source,
     ) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N_MR1) {
             return
@@ -46,6 +48,7 @@ object PocketCastsShortcuts {
                 }
                 return@launch
             }
+            LogBuffer.i(PocketCastsShortcuts::class.java.simpleName, "Shortcut update from ${source.value}, top filter title: ${topPlaylist.title}")
 
             if (shortcutManager.dynamicShortcuts.isEmpty() || force) {
                 val filterIntent = context.packageManager.getLaunchIntentForPackage(context.packageName) ?: return@launch
@@ -68,5 +71,12 @@ object PocketCastsShortcuts {
                 }
             }
         }
+    }
+
+    enum class Source(val value: String) {
+        REFRESH_APP("refresh_app"),
+        CREATE_PLAYLIST("create_playlist"),
+        SAVE_PLAYLISTS_ORDER("save_playlists_order"),
+        UPDATE_SHORTCUTS("update_shortcuts"),
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -763,7 +763,13 @@ class PodcastSyncProcess(
     private fun updateShortcuts(playlists: List<Playlist>): Completable {
         // if any playlists have changed update the launcher shortcuts
         if (playlists.isNotEmpty() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-            PocketCastsShortcuts.update(playlistManager, true, applicationScope, context)
+            PocketCastsShortcuts.update(
+                playlistManager = playlistManager,
+                force = true,
+                coroutineScope = applicationScope,
+                context = context,
+                source = PocketCastsShortcuts.Source.UPDATE_SHORTCUTS,
+            )
         }
         return Completable.complete()
     }


### PR DESCRIPTION
## Description



Looking at this ANR in Play console, 
`au.com.shiftyjelly.pocketcasts.repositories.shortcuts.PocketCastsShortcuts$update$1.invokeSuspend`

![image](https://github.com/Automattic/pocket-casts-android/assets/1405144/4caca905-429d-4ce8-af19-ffadb1062b22)

an ANR is triggered at line 52 of `PocketCastsShortcuts`

https://github.com/Automattic/pocket-casts-android/blob/7926889cfad24dc4902bad3640a2355a35fb774e/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shortcuts/PocketCastsShortcuts.kt#L52

While I cannot reproduce this ANR, logging the call source and moving the line outside the main thread, without disrupting the functionality, might help.

This may also explain why there was a freezer binder transaction on 5/18/24, 12:55  in latest logs shared in: https://github.com/Automattic/pocket-casts-android/issues/2225#issuecomment-2119086065 

```
ApplicationExitInfo(timestamp=5/18/24, 12:55 PM pid=6087 realUid=10244 packageUid=10244 definingUid=10244 user=0 process=au.com.shiftyjelly.pocketcasts reason=14 (FREEZER) subreason=20 (FREEZER BINDER TRANSACTION) status=0 importance=400 pss=218MB rss=241MB description=Sync transaction while frozen state=empty trace=null
```

when the app was just opened (maybe through shortcut)

```
I 18/5 12:55:27 App started. 7.63 (9232)
I 18/5 12:55:28 Set up periodic refresh
I 18/5 12:55:28 Playback service created
I 18/5 12:55:29 Running refresh from open app
I 18/5 12:55:29 RefreshPodcastsTask - runNow - Start
I 18/5 12:55:29 Play clicked in player
```

## Testing Instructions

1. Install the app
2. Long press app icon
3. Tap each shortcut
4. ✅ Notice that each shortcut opens properly
5. Go to the `Filters` tab
6. Change filters order
7. Force stop and restart the app
8. Long press the app icon again
9. ✅ Notice that the topmost filter is shown in shortcuts
10. Tap on the updated shortcut
11. ✅ Notice that the shortcut is opened properly
12. Go to Profile -> Help & feedback -> Logs (in toolbar)
13. Notice there is a log entry like "Shortcut update from [source]"

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack