### PR TITLE
Change cache playing episode feature flag key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 *   Bug Fixes
     *   Fix timestamp parameter handling in shared links
         ([#2235](https://github.com/Automattic/pocket-casts-android/pull/2235))
+    *   Improve intermediate caching of playing episode 
+        ([#2242](https://github.com/Automattic/pocket-casts-android/pull/2242))
 
 7.64
 -----

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -68,12 +68,12 @@ enum class Feature(
         hasDevToggle = true,
     ),
     CACHE_PLAYING_EPISODE(
-        key = "cache_playing_episode",
+        key = "cache_playing_episode_enabled",
         title = "Cache playing episode",
-        defaultValue = BuildConfig.DEBUG,
+        defaultValue = true,
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
-        hasDevToggle = false,
+        hasDevToggle = true,
     ),
     CATEGORIES_REDESIGN(
         key = "CATEGORIES_REDESIGN",


### PR DESCRIPTION
Parent PR: https://github.com/Automattic/pocket-casts-android/pull/2242

## Description
This changes the "Cache playing episode" feature flag key so that enabling the flag does not enable the feature for previous versions, and sets the default value to true. It can be turned off through the Firebase remote config.

## Testing Instructions
Ensure that values updated are correct.

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
