### PR TITLE
Bump min sdk version to 24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   New Features
     *   Add a storage setting that attempts to fix missing downloads files.
         ([#2244](https://github.com/Automattic/pocket-casts-android/pull/2244))
+*   Health
+    *   Increase minimum SDK version to 24 ([#2262](https://github.com/Automattic/pocket-casts-android/pull/2262))
 *   Bug Fixes
     *   Fix timestamp parameter handling in shared links
         ([#2235](https://github.com/Automattic/pocket-casts-android/pull/2235))

--- a/dependencies.gradle.kts
+++ b/dependencies.gradle.kts
@@ -61,7 +61,7 @@ project.apply {
         set("buildPlatform", getBuildPlatform())
 
         // Android
-        set("minSdkVersion", 23)
+        set("minSdkVersion", 24)
         set("minSdkVersionWear", 26)
         set("targetSdkVersion", 33)
         set("compileSdkVersion", 34)


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR bumps minimum sdk version to `24`. It was discussed here: https://github.com/Automattic/pocket-casts-android/pull/2182#discussion_r1592655462

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->
I don't think testing is necessary.

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
