### PR TITLE
Add advanced setting to allow more seek accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   New Features
     *   Add a storage setting that attempts to fix missing downloads files.
         ([#2244](https://github.com/Automattic/pocket-casts-android/pull/2244))
+    *   Add an advanced setting that prioritizes seek accuracy over speed during streaming.
+        ([#2265](https://github.com/Automattic/pocket-casts-android/pull/2265))
 *   Health
     *   Increase minimum SDK version to 24 ([#2262](https://github.com/Automattic/pocket-casts-android/pull/2262))
 *   Bug Fixes

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AdvancedSettingsPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AdvancedSettingsPage.kt
@@ -92,6 +92,14 @@ fun AdvancedSettingsView(
                     SyncOnMeteredRow(state.backgroundSyncOnMeteredState)
                 }
             }
+            item {
+                SettingSection(
+                    heading = stringResource(LR.string.settings_storage_section_heading_seek_accuracy),
+                    indent = false,
+                ) {
+                    PrioritizeSeekAccuracydRow(state.prioritizeSeekAccuracyState)
+                }
+            }
         }
     }
 }
@@ -114,6 +122,24 @@ private fun SyncOnMeteredRow(
     )
 }
 
+@Composable
+private fun PrioritizeSeekAccuracydRow(
+    state: AdvancedSettingsViewModel.State.PrioritizeSeekAccuracyState,
+    modifier: Modifier = Modifier,
+) {
+    SettingRow(
+        primaryText = stringResource(LR.string.settings_advanced_prioritize_seek_accuracy),
+        secondaryText = stringResource(LR.string.settings_advanced_prioritize_seek_accuracy_summary),
+        toggle = SettingRowToggle.Switch(state.isChecked),
+        indent = false,
+        modifier = modifier.toggleable(
+            value = state.isChecked,
+            role = Role.Switch,
+            onValueChange = { state.onCheckedChange(it) },
+        ),
+    )
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun AdvancedSettingsPreview(
@@ -125,6 +151,10 @@ private fun AdvancedSettingsPreview(
                 backgroundSyncOnMeteredState = AdvancedSettingsViewModel.State.BackgroundSyncOnMeteredState(
                     isChecked = true,
                     isEnabled = true,
+                    onCheckedChange = {},
+                ),
+                prioritizeSeekAccuracyState = AdvancedSettingsViewModel.State.PrioritizeSeekAccuracyState(
+                    isChecked = true,
                     onCheckedChange = {},
                 ),
             ),

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModel.kt
@@ -38,6 +38,13 @@ class AdvancedSettingsViewModel
                 }
             },
         ),
+        prioritizeSeekAccuracyState = State.PrioritizeSeekAccuracyState(
+            isChecked = settings.prioritizeSeekAccuracy.value,
+            onCheckedChange = {
+                settings.prioritizeSeekAccuracy.set(it, updateModifiedAt = false)
+                updatePrioritizeSeekAccuracyState()
+            },
+        ),
     )
 
     private fun onSyncOnMeteredCheckedChange(isChecked: Boolean) {
@@ -56,17 +63,31 @@ class AdvancedSettingsViewModel
         )
     }
 
+    private fun updatePrioritizeSeekAccuracyState() {
+        mutableState.value = mutableState.value.copy(
+            prioritizeSeekAccuracyState = mutableState.value.prioritizeSeekAccuracyState.copy(
+                isChecked = settings.prioritizeSeekAccuracy.value,
+            ),
+        )
+    }
+
     fun onShown() {
         analyticsTracker.track(AnalyticsEvent.SETTINGS_ADVANCED_SHOWN)
     }
 
     data class State(
         val backgroundSyncOnMeteredState: BackgroundSyncOnMeteredState,
+        val prioritizeSeekAccuracyState: PrioritizeSeekAccuracyState,
     ) {
 
         data class BackgroundSyncOnMeteredState(
             val isChecked: Boolean,
             val isEnabled: Boolean,
+            val onCheckedChange: (Boolean) -> Unit,
+        )
+
+        data class PrioritizeSeekAccuracyState(
+            val isChecked: Boolean,
             val onCheckedChange: (Boolean) -> Unit,
         )
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModel.kt
@@ -43,6 +43,10 @@ class AdvancedSettingsViewModel
             onCheckedChange = {
                 settings.prioritizeSeekAccuracy.set(it, updateModifiedAt = false)
                 updatePrioritizeSeekAccuracyState()
+                analyticsTracker.track(
+                    AnalyticsEvent.SETTINGS_ADVANCED_PRIORITIZE_SEEK_ACCURACY,
+                    mapOf("enabled" to it),
+                )
             },
         ),
     )

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModelTest.kt
@@ -38,6 +38,7 @@ class AdvancedSettingsViewModelTest {
     fun setUp() {
         whenever(settings.syncOnMeteredNetwork()).thenReturn(false)
         whenever(settings.backgroundRefreshPodcasts).thenReturn(UserSetting.Mock(true, mock()))
+        whenever(settings.prioritizeSeekAccuracy).thenReturn(UserSetting.Mock(false, mock()))
         viewModel = AdvancedSettingsViewModel(
             settings,
             analyticsTracker,
@@ -48,5 +49,6 @@ class AdvancedSettingsViewModelTest {
     @Test
     fun `verify settings methods initialize the viewModel state correctly`() {
         TestCase.assertEquals(viewModel.state.value.backgroundSyncOnMeteredState.isChecked, false)
+        TestCase.assertEquals(viewModel.state.value.prioritizeSeekAccuracyState.isChecked, false)
     }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -552,6 +552,7 @@ enum class AnalyticsEvent(val key: String) {
     /* Settings - Advanced */
     SETTINGS_ADVANCED_SHOWN("settings_advanced_shown"),
     SETTINGS_ADVANCED_SYNC_ON_METERED("settings_advanced_sync_on_metered"),
+    SETTINGS_ADVANCED_PRIORITIZE_SEEK_ACCURACY("settings_advanced_prioritize_seek_accuracy"),
 
     /* Search */
     SEARCH_SHOWN("search_shown"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1473,7 +1473,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="settings_advanced_sync_on_metered">Sync on Metered Networks</string>
     <string name="settings_advanced_sync_on_metered_summary">Permits automatic background sync on metered networks. This is enabled by default and has no effect if background refresh is turned off.</string>
     <string name="settings_advanced_prioritize_seek_accuracy">Prioritizing seek accuracy</string>
-    <string name="settings_advanced_prioritize_seek_accuracy_summary">Prioritizing seek accuracy can significantly slow down seek responsiveness and cause Pocket Casts to consume more data</string>
+    <string name="settings_advanced_prioritize_seek_accuracy_summary">Prioritizing seek accuracy can significantly slow down seek responsiveness and cause Pocket Casts to consume more data.</string>
     <!-- Used in a button meaning that the user understood the message. -->
     <string name="whats_new_got_it_button">Got it</string>
     <!-- Button title to upgrade to Plus. Don't translate "Plus" -->

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1275,6 +1275,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="settings_storage_move_podcasts">Moving podcasts&#x2026;</string>
     <string name="settings_storage_section_heading_usage">Usage</string>
     <string name="settings_storage_section_heading_mobile_data">Mobile Data</string>
+    <string name="settings_storage_section_heading_seek_accuracy">Seek Accuracy</string>
     <string name="settings_storage_size_free">%s free</string>
     <string name="settings_storage_sorry">Sorry</string>
     <string name="settings_storage_store_on">Store podcasts on</string>
@@ -1471,6 +1472,8 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
 
     <string name="settings_advanced_sync_on_metered">Sync on Metered Networks</string>
     <string name="settings_advanced_sync_on_metered_summary">Permits automatic background sync on metered networks. This is enabled by default and has no effect if background refresh is turned off.</string>
+    <string name="settings_advanced_prioritize_seek_accuracy">Prioritizing seek accuracy</string>
+    <string name="settings_advanced_prioritize_seek_accuracy_summary">Prioritizing seek accuracy can significantly slow down seek responsiveness and cause Pocket Casts to consume more data</string>
     <!-- Used in a button meaning that the user understood the message. -->
     <string name="whats_new_got_it_button">Got it</string>
     <!-- Button title to upgrade to Plus. Don't translate "Plus" -->

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -279,6 +279,7 @@ interface Settings {
     fun refreshPodcastsOnResume(isUnmetered: Boolean): Boolean
     val backgroundRefreshPodcasts: UserSetting<Boolean>
     val podcastsSortType: UserSetting<PodcastsSortType>
+    val prioritizeSeekAccuracy: UserSetting<Boolean>
 
     fun setSelectPodcastsSortType(sortType: PodcastsSortType)
     fun getSelectPodcastsSortType(): PodcastsSortType

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -188,6 +188,12 @@ class SettingsImpl @Inject constructor(
         toString = { it.clientId.toString() },
     )
 
+    override val prioritizeSeekAccuracy = UserSetting.BoolPref(
+        sharedPrefKey = "prioritizeSeekAccuracy",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
+
     override fun setSelectPodcastsSortType(sortType: PodcastsSortType) {
         sharedPreferences.edit().apply {
             putString(Settings.PREFERENCE_SELECT_PODCAST_LIBRARY_SORT, sortType.clientId.toString())

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -255,7 +255,11 @@ class SimplePlayer(
             .setUserAgent("Pocket Casts")
             .setAllowCrossProtocolRedirects(true)
         val dataSourceFactory = DefaultDataSource.Factory(context, httpDataSourceFactory)
-        val extractorsFactory = DefaultExtractorsFactory().setMp3ExtractorFlags(Mp3Extractor.FLAG_ENABLE_CONSTANT_BITRATE_SEEKING)
+        val extractorsFactory = DefaultExtractorsFactory()
+            .setConstantBitrateSeekingEnabled(true)
+        if (settings.prioritizeSeekAccuracy.value) {
+            extractorsFactory.setMp3ExtractorFlags(Mp3Extractor.FLAG_ENABLE_INDEX_SEEKING)
+        }
         val location = episodeLocation
         if (location == null) {
             onError(PlayerEvent.PlayerError("Episode has no source"))

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -433,6 +433,10 @@ class Support @Inject constructor(
                     Timber.e(e)
                 }
 
+                output.append("Advance Settings").append(eol).append("-------------------").append(eol).append(eol)
+                output.append("Prioritize seek accuracy? ").append(settings.prioritizeSeekAccuracy.value).append(eol)
+                output.append(eol)
+
                 output.append("Episode Issues").append(eol).append("--------------").append(eol).append(eol)
 
                 try {


### PR DESCRIPTION
## Description

Now that we have an `Advanced Settings` section, I'm re-proposing an option to allow more seek accuracy (earlier PR: https://github.com/Automattic/pocket-casts-android/pull/733).

It is not enabled by default, as [more accuracy comes at the cost of slower seeking](https://developer.android.com/media/media3/exoplayer/troubleshooting#why-is-seeking-inaccurate-in-some-mp3-files), particularly for large mp3 files. However, with this advanced setting, and with a stronger warning as advised here: https://github.com/Automattic/pocket-casts-android/pull/733#discussion_r1089262870), users will have a choice to prioritize accuracy over speed.

Fixes #744

## Review Instructions

Requires at least two approvals to merge this PR.

## Testing Instructions

Steps to reproduce

0. Disable `Beta features` -> `Cache playing episode`, kill and restart the app
1. Play a long episode in MP3 format, e.g. https://pca.st/xrfsu987
3. Seek to almost the end of the episode until a few secs are left for it to complete
4. Listen till the end of the episode
5. ✅ Notice that the episode keeps playing for a few more seconds than the original duration.

Test new behavior

7. Go to `Profile` -> `Settings` -> `Advanced Settings`
8. Enable "Prioritize seek accuracy"
9. Reopen the same episode. 
10. Repeat steps 1-3
11. ✅ Notice that the episode ends at the original duration.


## Screenshot

<img width=300 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/3a62682f-80e7-4e24-bbfd-874f2d96feaf"/>




## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md [TO BE ADDED]
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
