### PR TITLE
Get Exoplayer cache size from remote config

### DIFF
--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -399,6 +399,7 @@ interface Settings {
     fun getSlumberStudiosPromoCode(): String
     fun getSleepTimerDeviceShakeThreshold(): Long
     fun getRefreshPodcastsBatchSize(): Long
+    fun getExoPlayerCacheSizeInMB(): Long
 
     val podcastGroupingDefault: UserSetting<PodcastGrouping>
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -934,6 +934,10 @@ class SettingsImpl @Inject constructor(
         return getRemoteConfigLong(FirebaseConfig.REFRESH_PODCASTS_BATCH_SIZE)
     }
 
+    override fun getExoPlayerCacheSizeInMB(): Long {
+        return firebaseRemoteConfig.getLong(FirebaseConfig.EXOPLAYER_CACHE_SIZE_IN_MB)
+    }
+
     private fun getRemoteConfigLong(key: String): Long {
         val value = firebaseRemoteConfig.getLong(key)
         return if (value == 0L) (FirebaseConfig.defaults[key] as? Long ?: 0L) else value

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerCacheUtil.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerCacheUtil.kt
@@ -16,7 +16,6 @@ import timber.log.Timber
 
 @OptIn(UnstableApi::class)
 object ExoPlayerCacheUtil {
-    private const val MAX_DEVICE_CACHE_SIZE_BYTES = 50 * 1024 * 1024L
     private const val CACHE_DIR_NAME = "pocketcasts-exoplayer-cache"
     private var simpleCache: SimpleCache? = null
 
@@ -24,15 +23,17 @@ object ExoPlayerCacheUtil {
     @Synchronized
     fun getSimpleCache(
         context: Context,
+        cacheSizeInMB: Long,
         crashLogging: CrashLogging,
     ): SimpleCache? {
         if (FeatureFlag.isEnabled(Feature.CACHE_PLAYING_EPISODE) && simpleCache == null) {
             val cacheDir = File(context.cacheDir, CACHE_DIR_NAME)
+            val cacheSizeInBytes = cacheSizeInMB * 1024 * 1024L
             simpleCache = try {
                 if (BuildConfig.DEBUG) Timber.d("ExoPlayer cache initialized")
                 SimpleCache(
                     cacheDir,
-                    LeastRecentlyUsedCacheEvictor(MAX_DEVICE_CACHE_SIZE_BYTES),
+                    LeastRecentlyUsedCacheEvictor(cacheSizeInBytes),
                     StandaloneDatabaseProvider(context),
                 )
             } catch (e: Exception) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -282,7 +282,11 @@ class SimplePlayer(
             }
         } ?: return
 
-        val sourceFactory = ExoPlayerCacheUtil.getSimpleCache(context, crashLogging)?.let { cache ->
+        val sourceFactory = ExoPlayerCacheUtil.getSimpleCache(
+            context = context,
+            cacheSizeInMB = settings.getExoPlayerCacheSizeInMB(),
+            crashLogging = crashLogging,
+        )?.let { cache ->
             if (location is EpisodeLocation.Stream) {
                 CacheDataSource.Factory()
                     .setCache(cache)

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
@@ -12,6 +12,7 @@ object FirebaseConfig {
     const val SLUMBER_STUDIOS_YEARLY_PROMO_CODE = "slumber_studios_yearly_promo_code"
     const val SLEEP_TIMER_DEVICE_SHAKE_THRESHOLD = "sleep_timer_device_shake_threshold"
     const val REFRESH_PODCASTS_BATCH_SIZE = "refresh_podcasts_batch_size"
+    const val EXOPLAYER_CACHE_SIZE_IN_MB = "exoplayer_cache_size_in_mb"
     val defaults = mapOf(
         PERIODIC_SAVE_TIME_MS to 60000L,
         PLAYER_RELEASE_TIME_OUT_MS to 500L,

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.utils.config
 
+import au.com.shiftyjelly.pocketcasts.helper.BuildConfig
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 
 object FirebaseConfig {
@@ -21,6 +22,7 @@ object FirebaseConfig {
         CLOUD_STORAGE_LIMIT to 10L,
         SLEEP_TIMER_DEVICE_SHAKE_THRESHOLD to 30L,
         REFRESH_PODCASTS_BATCH_SIZE to 200L,
+        EXOPLAYER_CACHE_SIZE_IN_MB to if (BuildConfig.DEBUG) 100L else 0L,
     ) + Feature.values()
         .filter { it.hasFirebaseRemoteFlag }
         .associate { it.key to it.defaultValue }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
@@ -23,6 +23,11 @@ class FirebaseRemoteFeatureProvider @Inject constructor(
             firebaseRemoteConfig
                 .getString(FirebaseConfig.SLUMBER_STUDIOS_YEARLY_PROMO_CODE)
                 .isNotEmpty()
+
+        Feature.CACHE_PLAYING_EPISODE ->
+            firebaseRemoteConfig
+                .getLong(FirebaseConfig.EXOPLAYER_CACHE_SIZE_IN_MB) > 0
+
         else -> firebaseRemoteConfig.getBoolean(feature.key)
     }
 


### PR DESCRIPTION
## Description
This gets the Exoplayer cache size from remote config (increased from 50 to 100 MB).

## Testing Instructions

1. Search for `setMinimumFetchIntervalInSeconds`(...) in the code and set to 5s
2. Add a LogBuffer.i(...) just before line 29 in `ExoPlayerCacheUtil` to print value for `FeatureFlag.isEnabled(Feature.CACHE_PLAYING_EPISODE)` and `firebaseRemoteConfig
                .getLong(FirebaseConfig.EXOPLAYER_CACHE_SIZE_IN_MB)`
4. Install release build
5. Open the app
6. Play an episode
7. Open `Profile` -> `Settings` -> `Help & feedback` -> `Logs`
8. ✅ Notice that correct values are printed
9. Uninstall the build

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
