### PR TITLE
Move fixing downloads to a background task

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/StorageSettingsPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/StorageSettingsPage.kt
@@ -5,25 +5,16 @@ import android.os.StatFs
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.selection.toggleable
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.Card
-import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
-import androidx.compose.material.TextButton
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -32,7 +23,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -45,8 +35,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
@@ -57,9 +45,6 @@ import au.com.shiftyjelly.pocketcasts.compose.components.SettingRadioDialogRow
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRow
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRowToggle
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingSection
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
@@ -133,13 +118,6 @@ fun StorageSettingsPage(
             .collect { message ->
                 Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
             }
-    }
-    if (state.fixDownloadsState.isFixing) {
-        FixingDownloadsDialog(
-            state.fixDownloadsState.currentlyFixed,
-            state.fixDownloadsState.episodeCount,
-            onDismiss = { viewModel.cancelDownloadsFix() },
-        )
     }
 }
 
@@ -414,63 +392,6 @@ private fun AlertDialogView(
     )
 }
 
-@Composable
-private fun FixingDownloadsDialog(
-    currentlyFixed: Int,
-    episodeCount: Int,
-    onDismiss: () -> Unit,
-) {
-    Dialog(
-        properties = DialogProperties(
-            dismissOnClickOutside = false,
-        ),
-        onDismissRequest = { onDismiss() },
-    ) {
-        Card(
-            modifier = Modifier
-                .wrapContentWidth()
-                .wrapContentHeight(),
-            shape = RoundedCornerShape(16.dp),
-        ) {
-            Column(
-                modifier = Modifier
-                    .wrapContentHeight()
-                    .padding(vertical = 8.dp),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.Start,
-            ) {
-                TextH30(
-                    text = stringResource(R.string.settings_storage_fixing_downloads),
-                    modifier = Modifier.padding(16.dp),
-                )
-                TextH50(
-                    text = stringResource(R.string.settings_storage_fixing_progress, currentlyFixed, episodeCount),
-                    modifier = Modifier.padding(16.dp),
-                )
-                LinearProgressIndicator(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                )
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                ) {
-                    TextButton(
-                        onClick = { onDismiss() },
-                        modifier = Modifier.padding(end = 8.dp),
-                    ) {
-                        TextH40(
-                            text = stringResource(R.string.cancel).uppercase(),
-                            color = MaterialTheme.theme.colors.primaryInteractive01,
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
 private fun mapToStringWithStorageSpace(
     option: String,
     path: String?,
@@ -514,9 +435,6 @@ private fun StorageSettingsPreview(
                 ),
                 storageDataWarningState = StorageSettingsViewModel.State.StorageDataWarningState(
                     onCheckedChange = {},
-                ),
-                fixDownloadsState = StorageSettingsViewModel.State.FixDownloadsState(
-                    isFixing = false,
                 ),
             ),
             onBackPressed = {},

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="select_all">Select all</string>
     <string name="select_none">Select none</string>
     <string name="select_all_above">Select all above</string>
+    <string name="stop">Stop</string>
     <string name="deselect_all_above">Deselect all above</string>
     <string name="deselect_all">Deselect all</string>
     <string name="deselect_all_below">Deselect all below</string>
@@ -1170,6 +1171,12 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="settings_import_opml_stop">Stop</string>
     <string name="settings_import_opml_title">Import OPML</string>
     <string name="settings_import_opml_toast">Importing podcasts&#x2026;</string>
+    <string name="settings_fix_downloads_title">Fixing downloads</string>
+    <string name="settings_fix_downloads_progress">%1$d of %2$d episodes</string>
+    <string name="settings_fix_downloads_stop">Stop</string>
+    <string name="settings_fix_downloads_started_message">Downloads fix will start shortly. Check notifications for progress.</string>
+    <string name="settings_fix_downloads_complete_title">Fixing downloads complete</string>
+    <string name="settings_fix_downloads_complete_message">Fixed %d downloads</string>
     <string name="settings_inactive_episodes">Inactive episodes</string>
     <string name="settings_instagram">instagram link</string>
     <string name="settings_keep_screen_awake">Keep screen awake</string>
@@ -1280,8 +1287,6 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="settings_storage_store_on">Store podcasts on</string>
     <string name="settings_storage_fix_downloads">Fix downloads</string>
     <string name="settings_storage_fix_downloads_description">Attempt to restore any downloaded files if they are missing in the Pocket Casts app.</string>
-    <string name="settings_storage_fixing_downloads">Fixing downloads</string>
-    <string name="settings_storage_fixing_progress">Currently fixed: %1$d / %2$d</string>
     <string name="settings_subscribe_to_played">Subscribe to played podcasts</string>
     <string name="settings_show_played">Show played episodes</string>
     <string name="settings_show_played_summary">Episodes that you have finished playing will still be displayed</string>
@@ -1821,6 +1826,8 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="notification_channel_description_podcast_import">Import podcast collections</string>
     <string name="notification_channel_description_sign_in_error">Shows when signed out in background and cannot auto re sign-in</string>
     <string name="notification_channel_description_bookmark">Shows when bookmark is added using headphones</string>
+    <string name="notification_channel_description_fix_downloads">Shows when downloads fix is triggered</string>
+    <string name="notification_channel_description_fix_downloads_complete">Shows when downloads fix is complete</string>
 
     <!-- Bookmarks -->
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -137,6 +137,8 @@ interface Settings {
         NOTIFICATION_CHANNEL_ID_PODCAST("podcastImport"),
         NOTIFICATION_CHANNEL_ID_SIGN_IN_ERROR("signInError"),
         NOTIFICATION_CHANNEL_ID_BOOKMARK("bookmark"),
+        NOTIFICATION_CHANNEL_ID_FIX_DOWNLOADS("fixDownloads"),
+        NOTIFICATION_CHANNEL_ID_FIX_DOWNLOADS_COMPLETE("fixDownloadsComplete"),
     }
 
     enum class NotificationId(val value: Int) {
@@ -145,6 +147,8 @@ interface Settings {
         DOWNLOADING(21483648),
         SIGN_IN_ERROR(21483649),
         BOOKMARK(21483650),
+        FIX_DOWNLOADS(21483651),
+        FIX_DOWNLOADS_COMPLETE(21483652),
     }
 
     enum class UpNextAction(val serverId: Int) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/FixDownloadsWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/FixDownloadsWorker.kt
@@ -1,0 +1,127 @@
+package au.com.shiftyjelly.pocketcasts.repositories.download
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.core.content.getSystemService
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
+import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import java.io.File
+import kotlinx.coroutines.flow.fold
+import kotlinx.coroutines.flow.onEach
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@HiltWorker
+class FixDownloadsWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted parameters: WorkerParameters,
+    private val episodeManager: EpisodeManager,
+    private val fileStorage: FileStorage,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val notificationHelper: NotificationHelper,
+) : CoroutineWorker(context, parameters) {
+    override suspend fun doWork(): Result {
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_STORAGE_FIX_DOWNLOADED_FILES_START)
+
+        val episodeCount = episodeManager.countEpisodes()
+        initializeForegroundInfo(episodeCount)
+        val fixedCount = fixDownloads(episodeCount)
+        showCompleteNotification(fixedCount)
+
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_STORAGE_FIX_DOWNLOADED_FILES_END, mapOf("fixed_count" to fixedCount))
+        return Result.success()
+    }
+
+    private suspend fun fixDownloads(episodeCount: Int) = episodeManager
+        .getAllPodcastEpisodes(pageLimit = 10_000)
+        .onEach { (_, index) -> updateProgressNotification(progress = index + 1, total = episodeCount) }
+        .fold(0) { fixedCount, (episode, _) ->
+            val path = findExpectedDownloadPath(episode)
+            if (path != null && path != episode.downloadedFilePath) {
+                episodeManager.updateDownloadFilePath(episode, path, markAsDownloaded = true)
+                fixedCount + 1
+            } else {
+                fixedCount
+            }
+        }
+
+    private fun findExpectedDownloadPath(episode: PodcastEpisode) = DownloadHelper.pathForEpisode(episode, fileStorage)?.takeIf {
+        val file = File(it)
+        file.exists() && file.isFile
+    }
+
+    private suspend fun initializeForegroundInfo(totalEpisodeCount: Int) {
+        val notificationId = Settings.NotificationId.FIX_DOWNLOADS.value
+        val notification = buildProgressNotification(progress = 0, total = totalEpisodeCount)
+        val foregroundInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(notificationId, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        } else {
+            ForegroundInfo(notificationId, notification)
+        }
+        setForeground(foregroundInfo)
+    }
+
+    private fun updateProgressNotification(progress: Int, total: Int) {
+        // Updating for every episode makes the whole process extremely slow.
+        // It also makes "Stop" button unresponsive because notification is updated so often.
+        // Sampling it makes things easier.
+        if (isStopped || progress % 1_000 != 0) {
+            return
+        }
+        val manager = requireNotNull(applicationContext.getSystemService<NotificationManager>()) {
+            "Notification manager not found"
+        }
+        manager.notify(Settings.NotificationId.FIX_DOWNLOADS.value, buildProgressNotification(progress, total))
+    }
+
+    private fun buildProgressNotification(progress: Int, total: Int): Notification {
+        val cancelIntent = WorkManager.getInstance(applicationContext).createCancelPendingIntent(id)
+        return notificationHelper.downloadsFixChannelBuilder()
+            .setSmallIcon(IR.drawable.notification)
+            .setContentTitle(applicationContext.getString(LR.string.settings_fix_downloads_title))
+            .setContentText(applicationContext.getString(LR.string.settings_fix_downloads_progress, progress, total))
+            .setProgress(total, progress, false)
+            .setOngoing(true)
+            .addAction(IR.drawable.ic_cancel, applicationContext.getString(LR.string.stop), cancelIntent)
+            .build()
+    }
+
+    private fun showCompleteNotification(fixed: Int) {
+        val manager = requireNotNull(applicationContext.getSystemService<NotificationManager>()) {
+            "Notification manager not found"
+        }
+        val notification = notificationHelper.downloadsFixCompleteChannelBuilder()
+            .setSmallIcon(IR.drawable.notification)
+            .setContentTitle(applicationContext.getString(LR.string.settings_fix_downloads_complete_title))
+            .setContentText(applicationContext.getString(LR.string.settings_fix_downloads_complete_message, fixed))
+            .setOngoing(false)
+            .build()
+        manager.notify(Settings.NotificationId.FIX_DOWNLOADS_COMPLETE.value, notification)
+    }
+
+    companion object {
+        private const val TASK_NAME = "fix_downloads_task"
+
+        fun run(context: Context) {
+            val request = OneTimeWorkRequestBuilder<FixDownloadsWorker>().build()
+            WorkManager.getInstance(context).enqueueUniqueWork(TASK_NAME, ExistingWorkPolicy.KEEP, request)
+        }
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelper.kt
@@ -14,6 +14,8 @@ interface NotificationHelper {
     fun playbackErrorChannelBuilder(): NotificationCompat.Builder
     fun podcastImportChannelBuilder(): NotificationCompat.Builder
     fun bookmarkChannelBuilder(): NotificationCompat.Builder
+    fun downloadsFixChannelBuilder(): NotificationCompat.Builder
+    fun downloadsFixCompleteChannelBuilder(): NotificationCompat.Builder
     fun openEpisodeNotificationSettings(activity: Activity?)
     fun isShowing(notificationId: Int): Boolean
     fun removeNotification(intentExtras: Bundle?, notificationId: Int)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelperImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelperImpl.kt
@@ -89,6 +89,22 @@ class NotificationHelperImpl @Inject constructor(@ApplicationContext private val
         }
         channelList.add(bookmarkChannel)
 
+        val fixDownloadsChannel = NotificationChannel(Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_FIX_DOWNLOADS.id, "Fix Downloads", NotificationManager.IMPORTANCE_LOW).apply {
+            description = context.getString(LR.string.notification_channel_description_fix_downloads)
+            setShowBadge(false)
+            enableVibration(false)
+            lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+        }
+        channelList.add(fixDownloadsChannel)
+
+        val fixDownloadsCompleteChannel = NotificationChannel(Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_FIX_DOWNLOADS_COMPLETE.id, "Fix Downloads Complete", NotificationManager.IMPORTANCE_DEFAULT).apply {
+            description = context.getString(LR.string.notification_channel_description_fix_downloads_complete)
+            setShowBadge(false)
+            enableVibration(true)
+            lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+        }
+        channelList.add(fixDownloadsCompleteChannel)
+
         notificationManager.createNotificationChannels(channelList)
     }
 
@@ -114,6 +130,14 @@ class NotificationHelperImpl @Inject constructor(@ApplicationContext private val
 
     override fun bookmarkChannelBuilder(): NotificationCompat.Builder {
         return NotificationCompat.Builder(context, Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_BOOKMARK.id)
+    }
+
+    override fun downloadsFixChannelBuilder(): NotificationCompat.Builder {
+        return NotificationCompat.Builder(context, Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_FIX_DOWNLOADS.id)
+    }
+
+    override fun downloadsFixCompleteChannelBuilder(): NotificationCompat.Builder {
+        return NotificationCompat.Builder(context, Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_FIX_DOWNLOADS_COMPLETE.id)
     }
 
     /**


### PR DESCRIPTION
## Description

A follow up to #2244. After reviewing OPML imports I wanted to move episodes fixing to notifications as well to make it a more familiar experience.

Also, the process is now much faster (about 2 orders of magnitude) because UI updates are less frequent which doesn't block database operations as much.

## Testing Instructions

1. Open the app.
2. Download some episodes.
3. Go to `Profile`/`Downloads` and confirm that you see the episodes.
4. Go back to `Profile`.
5. Execute this query `UPDATE podcast_episodes SET downloaded_file_path = NULL, episode_status = 0`.
6. Go to `Profile`/`Downloads` and confirm that you don't see any episodes.
7. Go to `Settings`/`Storage & data use`.
8. Tap on `Fix downloads`.
9. Wait until process finishes. You should get a notification about it.
10. Go to `Profile`/`Downloads` and confirm that you see the episodes.

## Screenshots or Screencast 

| In progress | Complete |
| - | - |
| ![in-progress](https://github.com/Automattic/pocket-casts-android/assets/30936061/2a10a2dd-9178-4abb-a1cb-50f1ab6b0b8a) | ![complete](https://github.com/Automattic/pocket-casts-android/assets/30936061/2afe02c5-15fa-467d-828f-ae062840e888) |

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
