### PR TITLE
Fix: Sleep timer end of an episode is not pausing before right before the end 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
         ([#2164](https://github.com/Automattic/pocket-casts-android/pull/2164))
     *   Fix cases where podcasts were ignoring 'Never archive' setting in some cases
         ([#2194](https://github.com/Automattic/pocket-casts-android/pull/2194))
+    *   Fix sleep timer end of episode was not keeping the last episode listened
+        ([#2269](https://github.com/Automattic/pocket-casts-android/pull/2269))
 
 7.63
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1312,11 +1312,10 @@ open class PlaybackManager @Inject constructor(
 
         if (hadSleepAfterEpisode) {
             sleepEndOfEpisode(episode)
+            if (!isSleepAfterEpisodeEnabled()) return
         }
 
-        if (!isSleepAfterEpisodeEnabled()) {
-            cancelUpdateTimer()
-        }
+        cancelUpdateTimer()
         cancelBufferUpdateTimer()
 
         if (episode != null) {


### PR DESCRIPTION
## Description
When sleep timer end of episode was triggered the app was moving to the next episode instead of keeping on the last listened one. This PR fixes this issue

End of chapter never had this behavior of keeping on the same chapter. Since the implementation for this a more complicated I won't address this on a beta PR. Also, it needs to be aligned with iOS

Fixes #2266 

## Testing Instructions
1. Add some episodes to up next
2. Set end of episode
3. When the sleep timer stops the episode, make sure the app keep on the same episode

You can also smoke test the Sleep Timer feature

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/42220351/9432ecdc-ec56-4774-ad6f-2171b5e4e8a8



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
