### PR TITLE
Constraint episode archive limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@
     *   Fix the Google Podcasts OPML file import and include an error message if parsing fails.
         ([#2260](https://github.com/Automattic/pocket-casts-android/pull/2260))
     *   Improve intermediate caching of playing episode 
-        ([#2242](https://github.com/Automattic/pocket-casts-android/pull/2242))
+        ([#2242](https://github.com/Automattic/pocket-casts-android/pull/2242))    
+    *   Fix 'No limit' episode archive setting not being respected 
+        ([#2270](https://github.com/Automattic/pocket-casts-android/pull/2270))
 
 7.64
 -----

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
@@ -160,6 +160,7 @@ class AppDatabaseTest {
                 AppDatabase.MIGRATION_91_92,
                 AppDatabase.MIGRATION_92_93,
                 AppDatabase.MIGRATION_93_94,
+                AppDatabase.MIGRATION_94_95,
             )
             .build()
         // close the database and release any stream resources when the test finishes

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -486,7 +486,7 @@ class PodcastAdapter(
                     episodeCount = episodeCount,
                     archivedCount = archivedCount,
                     searchTerm = searchTerm,
-                    episodeLimit = if (podcast.overrideGlobalArchive) podcast.autoArchiveEpisodeLimit else null,
+                    episodeLimit = podcast.autoArchiveEpisodeLimit?.value,
                 ),
             )
             addAll(episodesPlusLimit)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveFragment.kt
@@ -38,6 +38,7 @@ import au.com.shiftyjelly.pocketcasts.compose.dialogs.RadioOptionsDialog
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveInactive
+import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveLimit
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.ToolbarColors
@@ -220,7 +221,7 @@ class PodcastAutoArchiveFragment : BaseFragment() {
 
     @Composable
     private fun EpisodeLimitSection(
-        limit: Int?,
+        limit: AutoArchiveLimit,
         modifier: Modifier = Modifier,
     ) {
         var openEpisodeLimitDialog by remember { mutableStateOf(false) }
@@ -231,7 +232,7 @@ class PodcastAutoArchiveFragment : BaseFragment() {
         ) {
             SettingRow(
                 primaryText = stringResource(LR.string.settings_auto_archive_episode_limit),
-                secondaryText = stringResource(EpisodeLimits[limit] ?: LR.string.settings_auto_archive_limit_none),
+                secondaryText = stringResource(limit.stringRes),
                 toggle = SettingRowToggle.None,
                 modifier = Modifier.clickable { openEpisodeLimitDialog = true },
             )
@@ -291,16 +292,16 @@ class PodcastAutoArchiveFragment : BaseFragment() {
 
     @Composable
     private fun EpisodeLimitDialog(
-        limit: Int?,
+        limit: AutoArchiveLimit,
         modifier: Modifier = Modifier,
-        onConfirm: (Int?) -> Unit,
+        onConfirm: (AutoArchiveLimit) -> Unit,
         onDismiss: () -> Unit,
     ) {
         RadioOptionsDialog(
             title = stringResource(LR.string.settings_auto_archive_episode_limit),
             selectedOption = limit,
-            allOptions = EpisodeLimits.keys.toList(),
-            optionName = { option -> stringResource(EpisodeLimits[option] ?: LR.string.settings_auto_archive_limit_none) },
+            allOptions = AutoArchiveLimit.entries,
+            optionName = { option -> stringResource(option.stringRes) },
             onSelectOption = onConfirm,
             onDismiss = onDismiss,
             modifier = modifier,
@@ -322,14 +323,6 @@ class PodcastAutoArchiveFragment : BaseFragment() {
     companion object {
         private const val NEW_INSTANCE_ARGS = "PodcastAutoArchiveFragmentArg"
         private const val PODCAST_TINT_KEY = "PodcastTintKey"
-
-        private val EpisodeLimits = mapOf(
-            null to LR.string.settings_auto_archive_limit_none,
-            1 to LR.string.settings_auto_archive_limit_1,
-            2 to LR.string.settings_auto_archive_limit_2,
-            5 to LR.string.settings_auto_archive_limit_5,
-            10 to LR.string.settings_auto_archive_limit_10,
-        )
 
         fun newInstance(
             podcastUuid: String,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveViewModel.kt
@@ -7,6 +7,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveInactive
+import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveLimit
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import dagger.assisted.Assisted
@@ -34,7 +35,7 @@ class PodcastAutoArchiveViewModel @AssistedInject constructor(
             overrideAutoArchiveSettings = podcast.overrideGlobalArchive,
             archiveAfterPlaying = podcast.autoArchiveAfterPlaying ?: archiveAfterPlaying,
             archiveInactive = podcast.autoArchiveInactive ?: archiveInactive,
-            episodeLimit = podcast.autoArchiveEpisodeLimit,
+            episodeLimit = podcast.autoArchiveEpisodeLimit ?: AutoArchiveLimit.None,
             podcast = podcast,
         )
     }.shareIn(viewModelScope, SharingStarted.Lazily, replay = 1)
@@ -74,11 +75,11 @@ class PodcastAutoArchiveViewModel @AssistedInject constructor(
         }
     }
 
-    fun updateEpisodeLimit(value: Int?) {
+    fun updateEpisodeLimit(value: AutoArchiveLimit) {
         viewModelScope.launch {
             analyticsTracker.track(
                 AnalyticsEvent.PODCAST_SETTINGS_AUTO_ARCHIVE_EPISODE_LIMIT_CHANGED,
-                mapOf("value" to (value?.toString() ?: "none")),
+                mapOf("value" to value.analyticsValue),
             )
             podcastManager.updateArchiveEpisodeLimit(podcastUuid, value)
         }
@@ -93,7 +94,7 @@ class PodcastAutoArchiveViewModel @AssistedInject constructor(
         val overrideAutoArchiveSettings: Boolean = false,
         val archiveAfterPlaying: AutoArchiveAfterPlaying = AutoArchiveAfterPlaying.Never,
         val archiveInactive: AutoArchiveInactive = AutoArchiveInactive.Never,
-        val episodeLimit: Int? = null,
+        val episodeLimit: AutoArchiveLimit = AutoArchiveLimit.None,
         val podcast: Podcast? = null,
     )
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -675,7 +675,7 @@ private fun Flowable<CombinedEpisodeAndBookmarkData>.loadEpisodesAndBookmarks(
             val showArchivedWithSearch = episodeSearchResults.searchUuids != null || showArchived
             val filteredList =
                 if (showArchivedWithSearch) searchList else searchList.filter { !it.isArchived }
-            val episodeLimit = podcast.autoArchiveEpisodeLimit
+            val episodeLimit = podcast.autoArchiveEpisodeLimit?.value
             val episodeLimitIndex: Int?
             // if the episode limit is on, the following texting is shown the episode list 'Limited to x most recent episodes'
             if (episodeLimit != null && filteredList.isNotEmpty() && podcast.overrideGlobalArchive) {
@@ -708,7 +708,7 @@ private fun Flowable<CombinedEpisodeAndBookmarkData>.loadEpisodesAndBookmarks(
                 archivedCount = archivedCount,
                 searchTerm = episodeSearchResults.searchTerm,
                 searchBookmarkTerm = bookmarkSearchResults.searchTerm,
-                episodeLimit = podcast.autoArchiveEpisodeLimit,
+                episodeLimit = podcast.autoArchiveEpisodeLimit?.value,
                 episodeLimitIndex = episodeLimitIndex,
             )
             state

--- a/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/95.json
+++ b/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/95.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 94,
+    "version": 95,
     "identityHash": "cff6935134e3adb543e070f9d2c0aa05",
     "entities": [
       {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/AutoArchiveLimitTypeConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/AutoArchiveLimitTypeConverter.kt
@@ -1,0 +1,16 @@
+package au.com.shiftyjelly.pocketcasts.models.converter
+
+import androidx.room.TypeConverter
+import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveLimit
+
+class AutoArchiveLimitTypeConverter {
+    @TypeConverter
+    fun fromInt(value: Int): AutoArchiveLimit {
+        return AutoArchiveLimit.fromServerId(value) ?: AutoArchiveLimit.None
+    }
+
+    @TypeConverter
+    fun toInt(value: AutoArchiveLimit): Int {
+        return value.serverId
+    }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -15,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.TrendingPodcast
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveInactive
+import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveLimit
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
@@ -389,7 +390,7 @@ abstract class PodcastDao {
     abstract suspend fun updateArchiveAfterInactive(uuid: String, value: AutoArchiveInactive, modified: Date = Date())
 
     @Query("UPDATE podcasts SET auto_archive_episode_limit = :value, auto_archive_episode_limit_modified = :modified, sync_status = 0 WHERE uuid = :uuid")
-    abstract suspend fun updateArchiveEpisodeLimit(uuid: String, value: Int?, modified: Date = Date())
+    abstract suspend fun updateArchiveEpisodeLimit(uuid: String, value: AutoArchiveLimit, modified: Date = Date())
 
     @Query("DELETE FROM trending_podcasts")
     protected abstract suspend fun deleteAllTrendingPodcasts()

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.localization.helper.tryToLocalise
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveInactive
+import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveLimit
 import au.com.shiftyjelly.pocketcasts.models.to.Bundle
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
@@ -92,7 +93,7 @@ data class Podcast(
         level = DeprecationLevel.ERROR,
         replaceWith = ReplaceWith(expression = "autoArchiveEpisodeLimit"),
     )
-    @ColumnInfo(name = "auto_archive_episode_limit") internal var rawAutoArchiveEpisodeLimit: Int? = null,
+    @ColumnInfo(name = "auto_archive_episode_limit") internal var rawAutoArchiveEpisodeLimit: AutoArchiveLimit = AutoArchiveLimit.None,
     @ColumnInfo(name = "auto_archive_episode_limit_modified") var autoArchiveEpisodeLimitModified: Date? = null,
     @ColumnInfo(name = "estimated_next_episode") var estimatedNextEpisode: Date? = null,
     @ColumnInfo(name = "episode_frequency") var episodeFrequency: String? = null,
@@ -207,10 +208,12 @@ data class Podcast(
         }
 
     @Suppress("DEPRECATION_ERROR")
-    var autoArchiveEpisodeLimit: Int?
+    var autoArchiveEpisodeLimit: AutoArchiveLimit?
         get() = rawAutoArchiveEpisodeLimit.takeIf { overrideGlobalArchive }
         set(value) {
-            rawAutoArchiveEpisodeLimit = value
+            if (value != null) {
+                rawAutoArchiveEpisodeLimit = value
+            }
         }
 
     enum class Licensing {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/AutoArchiveLimit.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/AutoArchiveLimit.kt
@@ -1,0 +1,47 @@
+package au.com.shiftyjelly.pocketcasts.models.to
+
+import androidx.annotation.StringRes
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+enum class AutoArchiveLimit(
+    val value: Int?,
+    val serverId: Int,
+    val analyticsValue: String,
+    @StringRes val stringRes: Int,
+) {
+    None(
+        value = null,
+        serverId = 0,
+        analyticsValue = "none",
+        stringRes = LR.string.settings_auto_archive_limit_none,
+    ),
+    One(
+        value = 1,
+        serverId = 1,
+        analyticsValue = "1",
+        stringRes = LR.string.settings_auto_archive_limit_1,
+    ),
+    Two(
+        value = 2,
+        serverId = 2,
+        analyticsValue = "2",
+        stringRes = LR.string.settings_auto_archive_limit_2,
+    ),
+    Five(
+        value = 5,
+        serverId = 5,
+        analyticsValue = "5",
+        stringRes = LR.string.settings_auto_archive_limit_5,
+    ),
+    Ten(
+        value = 10,
+        serverId = 10,
+        analyticsValue = "10",
+        stringRes = LR.string.settings_auto_archive_limit_10,
+    ),
+    ;
+
+    companion object {
+        fun fromServerId(id: Int) = entries.find { it.serverId == id }
+    }
+}

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/converter/AutoArchiveLimitTypeConverterTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/converter/AutoArchiveLimitTypeConverterTest.kt
@@ -1,0 +1,48 @@
+package au.com.shiftyjelly.pocketcasts.models.converter
+
+import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveLimit
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AutoArchiveLimitTypeConverterTest {
+    private val converter = AutoArchiveLimitTypeConverter()
+
+    @Test
+    fun `podcast limits are encoded correctly`() {
+        val expected = mapOf(
+            AutoArchiveLimit.None to 0,
+            AutoArchiveLimit.One to 1,
+            AutoArchiveLimit.Two to 2,
+            AutoArchiveLimit.Five to 5,
+            AutoArchiveLimit.Ten to 10,
+        )
+
+        val databaseValues = AutoArchiveLimit.entries.associateWith { limit ->
+            converter.toInt(limit)
+        }
+
+        assertEquals(expected, databaseValues)
+    }
+
+    @Test
+    fun `podcast groupings are decoded correctly`() {
+        val expected = mapOf(
+            0 to AutoArchiveLimit.None,
+            1 to AutoArchiveLimit.One,
+            2 to AutoArchiveLimit.Two,
+            5 to AutoArchiveLimit.Five,
+            10 to AutoArchiveLimit.Ten,
+        )
+
+        val databaseValues = AutoArchiveLimit.entries.associate { it.serverId to converter.fromInt(it.serverId) }
+
+        assertEquals(expected, databaseValues)
+    }
+
+    @Test
+    fun `decode unknown value`() {
+        val limit = converter.fromInt(Int.MIN_VALUE)
+
+        assertEquals(AutoArchiveLimit.None, limit)
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -947,14 +947,12 @@ class EpisodeManagerImpl @Inject constructor(
     }
 
     override fun checkPodcastForEpisodeLimit(podcast: Podcast, playbackManager: PlaybackManager?) {
-        if (!podcast.overrideGlobalArchive) return
-
-        val episodeLimit = podcast.autoArchiveEpisodeLimit
+        val episodeLimit = podcast.autoArchiveEpisodeLimit?.value
 
         if (episodeLimit != null) {
             val allEpisodes = episodeDao.findByPodcastOrderPublishedDateDesc(podcast.uuid).filter { !it.excludeFromEpisodeLimit }
             if (allEpisodes.isNotEmpty() && episodeLimit < allEpisodes.size) {
-                val episodesToRemove = allEpisodes.subList(episodeLimit, allEpisodes.size)
+                val episodesToRemove = allEpisodes.drop(episodeLimit)
                     .filter { !it.isArchived }
                     .filter { (settings.autoArchiveIncludesStarred.value && it.isStarred) || !it.isStarred }
                     .filter { playbackManager?.getCurrentEpisode()?.uuid != it.uuid }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -8,6 +8,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.TrendingPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveInactive
+import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveLimit
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
@@ -151,5 +152,5 @@ interface PodcastManager {
     suspend fun updateArchiveSettings(uuid: String, enable: Boolean, afterPlaying: AutoArchiveAfterPlaying, inactive: AutoArchiveInactive)
     suspend fun updateArchiveAfterPlaying(uuid: String, value: AutoArchiveAfterPlaying)
     suspend fun updateArchiveAfterInactive(uuid: String, value: AutoArchiveInactive)
-    suspend fun updateArchiveEpisodeLimit(uuid: String, value: Int?)
+    suspend fun updateArchiveEpisodeLimit(uuid: String, value: AutoArchiveLimit)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.TrendingPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveInactive
+import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveLimit
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
@@ -808,7 +809,7 @@ class PodcastManagerImpl @Inject constructor(
         podcastDao.updateArchiveAfterInactive(uuid, value)
     }
 
-    override suspend fun updateArchiveEpisodeLimit(uuid: String, value: Int?) {
+    override suspend fun updateArchiveEpisodeLimit(uuid: String, value: AutoArchiveLimit) {
         podcastDao.updateArchiveEpisodeLimit(uuid, value)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -12,6 +12,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveInactive
+import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveLimit
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.to.StatsBundle
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
@@ -961,7 +962,7 @@ class PodcastSyncProcess(
             podcast.autoArchiveInactive = AutoArchiveInactive.fromIndex(it) ?: AutoArchiveInactive.Default
         }
         withSyncValue(podcast.autoArchiveEpisodeLimitModified, podcastSync.autoArchiveEpisodeLimitModified, podcastSync.autoArchiveEpisodeLimit) {
-            podcast.autoArchiveEpisodeLimit = it
+            podcast.autoArchiveEpisodeLimit = AutoArchiveLimit.fromServerId(it) ?: AutoArchiveLimit.None
         }
         withSyncValue(podcast.groupingModified, podcastSync.episodeGroupingModified, podcastSync.episodeGrouping) {
             podcast.grouping = PodcastGrouping.fromServerId(it) ?: PodcastGrouping.None
@@ -1167,7 +1168,7 @@ class PodcastSyncProcess(
                             }
                         }
                         autoArchiveEpisodeLimit = int32Setting {
-                            value = int32Value { value = podcast.autoArchiveEpisodeLimit ?: 0 }
+                            value = int32Value { value = podcast.autoArchiveEpisodeLimit?.serverId ?: AutoArchiveLimit.None.serverId }
                             modifiedAt = podcast.autoArchiveEpisodeLimitModified.toProtobufTimestampOrFallback()
                         }
                         episodeGrouping = int32Setting {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -6,6 +6,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveInactive
+import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveLimit
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
@@ -322,7 +323,7 @@ class PodcastSyncProcessTest {
         overrideGlobalArchive: Boolean = false,
         autoArchiveAfterPlaying: AutoArchiveAfterPlaying = AutoArchiveAfterPlaying.Never,
         autoArchiveInactive: AutoArchiveInactive = AutoArchiveInactive.Never,
-        autoArchiveEpisodeLimit: Int = 0,
+        autoArchiveEpisodeLimit: AutoArchiveLimit = AutoArchiveLimit.None,
         podcastGrouping: PodcastGrouping = PodcastGrouping.None,
         episodesSortType: EpisodesSortType = EpisodesSortType.EPISODES_SORT_BY_TITLE_ASC,
     ) = mock<Podcast> {


### PR DESCRIPTION
## Description

Episode archive limit is another setting that got hit by sync test. In the app we used `null` to represent `No episode limit`. A sync value for this state is `0`.

Internal ref: p1716451879995699-slack-C02A333D8LQ

## Testing Instructions

1. Install the app from 201c539b50c42a0ff918a72b557e921a2dfb2f88
2. Subscribe to at least 6 podcasts.
3. Execute this query: `UPDATE podcasts SET auto_archive_episode_limit = 0, override_global_archive = 1`.
4. Open one of the podcasts.
5. You should see `Limited to 0 most recent episodes`.
6. Go to podcast settings and change auto archive episode limit to `No limit`.
7. Go to other 4 podcasts and select other limits. Leave one podcast in the state from the query.
8. Install the app from this branch.
9. Check podcasts settings and make sure that these the setting you set are still there.
10. The last podcast you didn't change should have `No limit` and should not display `Limited to 0 most recent episodes` in the episode listing.
11. Execute this query: `UPDATE podcasts SET auto_archive_episode_limit = 0, override_global_archive = 1`.
12. All podcasts should be set to `No limit` setting and should not display `Limited to 0 most recent episodes`.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~