### PR TITLE
Add unit tests for pre process OPML file

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
@@ -28,14 +28,7 @@ import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshServerManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import java.io.BufferedReader
-import java.io.BufferedWriter
-import java.io.File
-import java.io.FileInputStream
-import java.io.FileOutputStream
 import java.io.InputStream
-import java.io.InputStreamReader
-import java.io.OutputStreamWriter
 import java.io.StringReader
 import java.net.URL
 import java.util.Scanner
@@ -235,7 +228,7 @@ class OpmlImportTask @AssistedInject constructor(
         val resolver = applicationContext.contentResolver
         try {
             resolver.openInputStream(uri)?.use { inputStream ->
-                val modifiedInputStream = replaceInvalidXmlCharacter(inputStream)
+                val modifiedInputStream = PreProcessOpmlFile().replaceInvalidXmlCharacter(inputStream)
                 urls = readOpmlUrlsSax(modifiedInputStream)
             }
         } catch (e: SAXException) {
@@ -246,37 +239,6 @@ class OpmlImportTask @AssistedInject constructor(
 
         processUrls(urls)
         return urls.size
-    }
-
-    private fun replaceInvalidXmlCharacter(inputStream: InputStream): InputStream {
-        val tempFile = File.createTempFile("output", ".xml")
-        tempFile.deleteOnExit()
-
-        BufferedReader(InputStreamReader(inputStream, Charsets.UTF_8)).use { reader ->
-            BufferedWriter(OutputStreamWriter(FileOutputStream(tempFile), Charsets.UTF_8)).use { writer ->
-                reader.lineSequence().forEach { line ->
-                    val modifiedLine = line
-                        .replace("<outline", "\n<outline")
-                        .replace("&(?!amp;|quot;|gt;|lt;)".toRegex(), "&amp;")
-                        .replace("’", "&apos;")
-
-                    val textRegex = """(?<=text=")(.*?)(?="\s*(?:/>|\s+xmlUrl|\s+type))""".toRegex()
-                    val finalLine = textRegex.replace(modifiedLine) { matchResult ->
-                        val text = matchResult.groupValues[1]
-                        val fixedText = text
-                            .replace("\"", "&quot;")
-                            .replace(">", "&gt;")
-                            .replace("<", "&lt;")
-                        matchResult.value.replace(text, fixedText)
-                    }
-
-                    writer.write(finalLine)
-                    writer.newLine()
-                }
-            }
-        }
-
-        return FileInputStream(tempFile)
     }
 
     private suspend fun processUrls(urls: List<String>) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/PreProcessOpmlFile.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/PreProcessOpmlFile.kt
@@ -1,0 +1,43 @@
+package au.com.shiftyjelly.pocketcasts.repositories.opml
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+
+class PreProcessOpmlFile {
+    fun replaceInvalidXmlCharacter(inputStream: InputStream): InputStream {
+        val tempFile = File.createTempFile("output", ".xml")
+        tempFile.deleteOnExit()
+
+        BufferedReader(InputStreamReader(inputStream, Charsets.UTF_8)).use { reader ->
+            BufferedWriter(OutputStreamWriter(FileOutputStream(tempFile), Charsets.UTF_8)).use { writer ->
+                reader.lineSequence().forEach { line ->
+                    val modifiedLine = line
+                        .replace("<outline", "\n<outline")
+                        .replace("&(?!amp;|quot;|gt;|lt;)".toRegex(), "&amp;")
+                        .replace("’", "&apos;")
+
+                    val textRegex = """(?<=text=")(.*?)(?="\s*(?:/>|\s+xmlUrl|\s+type))""".toRegex()
+                    val finalLine = textRegex.replace(modifiedLine) { matchResult ->
+                        val text = matchResult.groupValues[1]
+                        val fixedText = text
+                            .replace("\"", "&quot;")
+                            .replace(">", "&gt;")
+                            .replace("<", "&lt;")
+                        matchResult.value.replace(text, fixedText)
+                    }
+
+                    writer.write(finalLine)
+                    writer.newLine()
+                }
+            }
+        }
+
+        return FileInputStream(tempFile)
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/opml/PreProcessOpmlFileTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/opml/PreProcessOpmlFileTest.kt
@@ -1,0 +1,89 @@
+package au.com.shiftyjelly.pocketcasts.repositories.opml
+
+import au.com.shiftyjelly.pocketcasts.utils.extensions.removeNewLines
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.nio.charset.StandardCharsets
+import java.util.Scanner
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PreProcessOpmlFileTest {
+    @Test
+    fun preProcessValidOpmlFileWithoutEspecialCharacters() {
+        val xmlString = "<outline xmlUrl=\"https://feeds.simplecast.com\" type=\"rss\" text=\"valid text\" />"
+        val inputStream: InputStream = ByteArrayInputStream(xmlString.toByteArray(StandardCharsets.UTF_8))
+        val processedStream: InputStream = PreProcessOpmlFile().replaceInvalidXmlCharacter(inputStream)
+
+        val processedString = Scanner(processedStream).useDelimiter("\\A").next()
+        processedStream.close()
+
+        assertEquals(xmlString, processedString.toString().removeNewLines())
+    }
+
+    @Test
+    fun preProcessOpmlFileWithInvalidXmlCharacterInElementText() {
+        val xmlString = "<outline xmlUrl=\"https://feeds.simplecast.com\" type=\"rss\" text=\"This has <special> characters\" />"
+        val inputStream: InputStream = ByteArrayInputStream(xmlString.toByteArray(StandardCharsets.UTF_8))
+        val processedStream: InputStream = PreProcessOpmlFile().replaceInvalidXmlCharacter(inputStream)
+
+        val processedString = Scanner(processedStream).useDelimiter("\\A").next()
+        processedStream.close()
+
+        val expected = "<outline xmlUrl=\"https://feeds.simplecast.com\" type=\"rss\" text=\"This has &lt;special&gt; characters\" />"
+        assertEquals(expected, processedString.removeNewLines())
+    }
+
+    @Test
+    fun preProcessOpmlFileWithInvalidXmlCharacterInElementTextWhenElementXmlUrlIsLocatedAtTheEnd() {
+        val xmlString = "<outline type=\"rss\" text=\"This has <special> characters\" xmlUrl=\"https://feeds.simplecast.com\" />"
+        val inputStream: InputStream = ByteArrayInputStream(xmlString.toByteArray(StandardCharsets.UTF_8))
+        val processedStream: InputStream = PreProcessOpmlFile().replaceInvalidXmlCharacter(inputStream)
+
+        val processedString = Scanner(processedStream).useDelimiter("\\A").next()
+        processedStream.close()
+
+        val expected = "<outline type=\"rss\" text=\"This has &lt;special&gt; characters\" xmlUrl=\"https://feeds.simplecast.com\" />"
+        assertEquals(expected, processedString.removeNewLines())
+    }
+
+    @Test
+    fun preProcessOpmlFileWithInvalidXmlCharacterInElementXmlUrl() {
+        val xmlString = "<outline xmlUrl=\"https://feeds.simplecast.com/sz&W8tJ16\" type=\"rss\" text=\"Text\" />"
+        val inputStream: InputStream = ByteArrayInputStream(xmlString.toByteArray(StandardCharsets.UTF_8))
+        val processedStream: InputStream = PreProcessOpmlFile().replaceInvalidXmlCharacter(inputStream)
+
+        val processedString = Scanner(processedStream).useDelimiter("\\A").next()
+        processedStream.close()
+
+        val expected = "<outline xmlUrl=\"https://feeds.simplecast.com/sz&amp;W8tJ16\" type=\"rss\" text=\"Text\" />"
+        assertEquals(expected, processedString.removeNewLines())
+    }
+
+    @Test
+    fun preProcessOpmlFileWithMultipleInvalidXmlCharacterInElementText() {
+        val xmlString =
+            "<outline xmlUrl=\"https://feeds.simplecast.com/\" type=\"rss\" text=\"<special>\" /> <outline xmlUrl=\"https://feeds.simplecast.com/szW8tJ16\" type=\"rss\" text=\"CNBC’s\" />"
+        val inputStream: InputStream = ByteArrayInputStream(xmlString.toByteArray(StandardCharsets.UTF_8))
+        val processedStream: InputStream = PreProcessOpmlFile().replaceInvalidXmlCharacter(inputStream)
+
+        val processedString = Scanner(processedStream).useDelimiter("\\A").next()
+        processedStream.close()
+
+        val expected = "<outline xmlUrl=\"https://feeds.simplecast.com/\" type=\"rss\" text=\"&lt;special&gt;\" /> <outline xmlUrl=\"https://feeds.simplecast.com/szW8tJ16\" type=\"rss\" text=\"CNBC&apos;s\" />"
+        assertEquals(expected, processedString.removeNewLines())
+    }
+
+    @Test
+    fun preProcessAnAlreadyPreProcessedOpmlFile() {
+        val xmlString = "<outline xmlUrl=\"https://feeds.simplecast.com\" type=\"rss\" text=\"This has &lt;special&gt; characters\" />"
+        val inputStream: InputStream = ByteArrayInputStream(xmlString.toByteArray(StandardCharsets.UTF_8))
+        val processedStream: InputStream = PreProcessOpmlFile().replaceInvalidXmlCharacter(inputStream)
+
+        val processedString = Scanner(processedStream).useDelimiter("\\A").next()
+        processedStream.close()
+
+        val expected = "<outline xmlUrl=\"https://feeds.simplecast.com\" type=\"rss\" text=\"This has &lt;special&gt; characters\" />"
+        assertEquals(expected, processedString.removeNewLines())
+    }
+}


### PR DESCRIPTION
## Description
- Add missing uni tests for #2260

## Testing Instructions
- Code review should be enough 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
