### PR TITLE
Adding sleep timer config to general

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
         ([#2244](https://github.com/Automattic/pocket-casts-android/pull/2244))
     *   Add an advanced setting that prioritizes seek accuracy over speed during streaming.
         ([#2265](https://github.com/Automattic/pocket-casts-android/pull/2265))
+    *   Add sleep timer settings that controls the auto restart sleep timer and shake to restart sleep timer
+        ([#2273](https://github.com/Automattic/pocket-casts-android/pull/2273))
 *   Health
     *   Increase minimum SDK version to 24 ([#2262](https://github.com/Automattic/pocket-casts-android/pull/2262))
 *   Bug Fixes

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -290,6 +290,17 @@ class PlaybackSettingsFragment : BaseFragment() {
 
                 item {
                     SettingSection(heading = stringResource(LR.string.settings_general_sleep_timer)) {
+                        AutoSleepTimerRestart(
+                            saved = settings.autoSleepTimerRestart.flow.collectAsState().value,
+                            onSave = {
+                                analyticsTracker.track(
+                                    AnalyticsEvent.SETTINGS_GENERAL_AUTO_SLEEP_TIMER_RESTART_TOGGLED,
+                                    mapOf("enabled" to it),
+                                )
+                                settings.autoSleepTimerRestart.set(it, updateModifiedAt = true)
+                            },
+                        )
+
                         ShakeToResetSleepTimer(
                             saved = settings.shakeToResetSleepTimer.flow.collectAsState().value,
                             onSave = {
@@ -554,6 +565,15 @@ class PlaybackSettingsFragment : BaseFragment() {
         SettingRow(
             primaryText = stringResource(LR.string.settings_sleep_timer_shake_to_reset),
             secondaryText = stringResource(LR.string.settings_sleep_timer_shake_to_reset_summary),
+            toggle = SettingRowToggle.Switch(checked = saved),
+            modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) },
+        )
+
+    @Composable
+    private fun AutoSleepTimerRestart(saved: Boolean, onSave: (Boolean) -> Unit) =
+        SettingRow(
+            primaryText = stringResource(LR.string.settings_sleep_timer_auto_restart),
+            secondaryText = stringResource(LR.string.settings_sleep_timer_auto_restart_summary),
             toggle = SettingRowToggle.Switch(checked = saved),
             modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) },
         )

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -289,6 +289,21 @@ class PlaybackSettingsFragment : BaseFragment() {
                 }
 
                 item {
+                    SettingSection(heading = stringResource(LR.string.settings_general_sleep_timer)) {
+                        ShakeToResetSleepTimer(
+                            saved = settings.shakeToResetSleepTimer.flow.collectAsState().value,
+                            onSave = {
+                                analyticsTracker.track(
+                                    AnalyticsEvent.SETTINGS_GENERAL_SHAKE_TO_RESET_SLEEP_TIMER_TOGGLED,
+                                    mapOf("enabled" to it),
+                                )
+                                settings.shakeToResetSleepTimer.set(it, updateModifiedAt = true)
+                            },
+                        )
+                    }
+                }
+
+                item {
                     // The [scrollToAutoPlay] fragment argument handling depends on this item being last
                     // in the list. If it's position is changed, make sure you update the handling when
                     // we scroll to this item as well.
@@ -530,6 +545,15 @@ class PlaybackSettingsFragment : BaseFragment() {
         SettingRow(
             primaryText = stringResource(LR.string.settings_up_next_tap),
             secondaryText = stringResource(LR.string.settings_up_next_tap_summary),
+            toggle = SettingRowToggle.Switch(checked = saved),
+            modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) },
+        )
+
+    @Composable
+    private fun ShakeToResetSleepTimer(saved: Boolean, onSave: (Boolean) -> Unit) =
+        SettingRow(
+            primaryText = stringResource(LR.string.settings_sleep_timer_shake_to_reset),
+            secondaryText = stringResource(LR.string.settings_sleep_timer_shake_to_reset_summary),
             toggle = SettingRowToggle.Switch(checked = saved),
             modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) },
         )

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -500,6 +500,7 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_GENERAL_INTELLIGENT_PLAYBACK_TOGGLED("settings_general_intelligent_playback_toggled"),
     SETTINGS_GENERAL_PLAY_UP_NEXT_ON_TAP_TOGGLED("settings_general_play_up_next_on_tap_toggled"),
     SETTINGS_GENERAL_SHAKE_TO_RESET_SLEEP_TIMER_TOGGLED("settings_general_shake_to_reset_sleep_timer_toggled"),
+    SETTINGS_GENERAL_AUTO_SLEEP_TIMER_RESTART_TOGGLED("settings_general_auto_sleep_timer_restart_toggled"),
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_SHOWN("settings_general_media_notification_controls_shown"),
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_SHOW_CUSTOM_TOGGLED("settings_general_media_notification_controls_show_custom_toggled"),
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_ORDER_CHANGED("settings_general_media_notification_controls_order_changed"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -499,6 +499,7 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_GENERAL_OPEN_PLAYER_AUTOMATICALLY_TOGGLED("settings_general_open_player_automatically_toggled"),
     SETTINGS_GENERAL_INTELLIGENT_PLAYBACK_TOGGLED("settings_general_intelligent_playback_toggled"),
     SETTINGS_GENERAL_PLAY_UP_NEXT_ON_TAP_TOGGLED("settings_general_play_up_next_on_tap_toggled"),
+    SETTINGS_GENERAL_SHAKE_TO_RESET_SLEEP_TIMER_TOGGLED("settings_general_shake_to_reset_sleep_timer_toggled"),
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_SHOWN("settings_general_media_notification_controls_shown"),
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_SHOW_CUSTOM_TOGGLED("settings_general_media_notification_controls_show_custom_toggled"),
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_ORDER_CHANGED("settings_general_media_notification_controls_order_changed"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1144,6 +1144,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="settings_export_subscriptions">Export subscriptions</string>
     <string name="settings_general_defaults">Defaults</string>
     <string name="settings_general_player">Player</string>
+    <string name="settings_general_sleep_timer">Sleep Timer</string>
     <string name="settings_get_plus_and_more">Get Pocket Casts Plus to unlock this feature and more!</string>
     <string name="settings_headphone_controls_action_next">Next action</string>
     <string name="settings_headphone_controls_action_previous">Previous action</string>
@@ -1319,6 +1320,8 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="settings_up_next_swipe_play_last" translatable="false">@string/play_last</string>
     <string name="settings_up_next_swipe_play_next" translatable="false">@string/play_next</string>
     <string name="settings_up_next_swipe_summary">When swiping from left to right on an episode, the default action will be %s.</string>
+    <string name="settings_sleep_timer_shake_to_reset">Shake to reset Sleep Timer</string>
+    <string name="settings_sleep_timer_shake_to_reset_summary">If on, the sleep timer will restart when you shake your phone.</string>
     <string name="settings_up_next_tap">Play Up Next episode on tap</string>
     <string name="settings_up_next_tap_summary">If on, tapping on an item in your Up Next queue will play it. Long pressing will show the episode options.</string>
     <string name="settings_autoplay">Autoplay</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1320,8 +1320,10 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="settings_up_next_swipe_play_last" translatable="false">@string/play_last</string>
     <string name="settings_up_next_swipe_play_next" translatable="false">@string/play_next</string>
     <string name="settings_up_next_swipe_summary">When swiping from left to right on an episode, the default action will be %s.</string>
-    <string name="settings_sleep_timer_shake_to_reset">Shake to reset Sleep Timer</string>
+    <string name="settings_sleep_timer_shake_to_reset">Shake to restart Sleep Timer</string>
     <string name="settings_sleep_timer_shake_to_reset_summary">If on, the sleep timer will restart when you shake your phone.</string>
+    <string name="settings_sleep_timer_auto_restart">Auto Restart Sleep Timer</string>
+    <string name="settings_sleep_timer_auto_restart_summary">If on, the sleep timer will restart automatically if you play an episode within 5 minutes after the last pause.</string>
     <string name="settings_up_next_tap">Play Up Next episode on tap</string>
     <string name="settings_up_next_tap_summary">If on, tapping on an item in your Up Next queue will play it. Long pressing will show the episode options.</string>
     <string name="settings_autoplay">Autoplay</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -446,6 +446,7 @@ interface Settings {
     val autoPlayNextEpisodeOnEmpty: UserSetting<Boolean>
     val showArchivedDefault: UserSetting<Boolean>
     val mediaControlItems: UserSetting<List<MediaNotificationControls>>
+    val shakeToResetSleepTimer: UserSetting<Boolean>
     fun setMultiSelectItems(items: List<Int>)
     fun setLastPauseTime(date: Date)
     fun getLastPauseTime(): Date?

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -447,6 +447,7 @@ interface Settings {
     val showArchivedDefault: UserSetting<Boolean>
     val mediaControlItems: UserSetting<List<MediaNotificationControls>>
     val shakeToResetSleepTimer: UserSetting<Boolean>
+    val autoSleepTimerRestart: UserSetting<Boolean>
     fun setMultiSelectItems(items: List<Int>)
     fun setLastPauseTime(date: Date)
     fun getLastPauseTime(): Date?

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1026,6 +1026,12 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
+    override val autoSleepTimerRestart = UserSetting.BoolPref(
+        sharedPrefKey = "auto_sleep_timer_restart",
+        defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
+
     override val mediaControlItems = UserSetting.PrefListFromString<MediaNotificationControls>(
         sharedPrefKey = "media_notification_controls_action",
         sharedPrefs = sharedPreferences,

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1020,6 +1020,12 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
+    override val shakeToResetSleepTimer = UserSetting.BoolPref(
+        sharedPrefKey = "shake_to_reset_sleep_timer",
+        defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
+
     override val mediaControlItems = UserSetting.PrefListFromString<MediaNotificationControls>(
         sharedPrefKey = "media_notification_controls_action",
         sharedPrefs = sharedPreferences,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -2115,6 +2115,7 @@ open class PlaybackManager @Inject constructor(
         player?.play(currentTimeMs)
 
         sleepTimer.restartSleepTimerIfApplies(
+            autoSleepTimerEnabled = settings.autoSleepTimerRestart.value,
             currentEpisodeUuid = episode.uuid,
             timerState = SleepTimer.SleepTimerState(
                 isSleepTimerRunning = playbackStateRelay.blockingFirst().isSleepTimerRunning,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
@@ -75,12 +75,15 @@ class SleepTimer @Inject constructor(
     }
 
     fun restartSleepTimerIfApplies(
+        autoSleepTimerEnabled: Boolean,
         currentEpisodeUuid: String,
         timerState: SleepTimerState,
         onRestartSleepAfterTime: () -> Unit,
         onRestartSleepOnEpisodeEnd: () -> Unit,
         onRestartSleepOnChapterEnd: () -> Unit,
     ) {
+        if (!autoSleepTimerEnabled) return
+
         lastTimeSleepTimeHasFinished?.let { lastTimeHasFinished ->
             val diffTime = System.currentTimeMillis().milliseconds - lastTimeHasFinished
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerRestartWhenShakingDevice.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerRestartWhenShakingDevice.kt
@@ -63,22 +63,24 @@ class SleepTimerRestartWhenShakingDevice @Inject constructor(
     }
 
     private fun onDeviceShaken() {
-        val time = sleepTimer.restartTimerIfIsRunning onSuccess@{
-            playbackManager.updateSleepTimerStatus(sleepTimeRunning = true)
+        if (settings.shakeToResetSleepTimer.value) {
+            val time = sleepTimer.restartTimerIfIsRunning onSuccess@{
+                playbackManager.updateSleepTimerStatus(sleepTimeRunning = true)
 
-            if (context.isAppForeground()) {
-                Toast.makeText(
-                    context,
-                    context.getString(R.string.player_sleep_timer_restarted_after_device_shake),
-                    Toast.LENGTH_SHORT,
-                ).show()
-            } else {
-                playbackManager.playSleepTimeTone()
+                if (context.isAppForeground()) {
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.player_sleep_timer_restarted_after_device_shake),
+                        Toast.LENGTH_SHORT,
+                    ).show()
+                } else {
+                    playbackManager.playSleepTimeTone()
+                }
             }
-        }
-        time?.let {
-            LogBuffer.i(SleepTimer.TAG, "Restarted with ${time.inWholeMinutes} minutes set after shaking device")
-            trackSleepTimeRestart(it)
+            time?.let {
+                LogBuffer.i(SleepTimer.TAG, "Restarted with ${time.inWholeMinutes} minutes set after shaking device")
+                trackSleepTimeRestart(it)
+            }
         }
     }
 


### PR DESCRIPTION
## Description
- This PR lets the user disable/enable the auto sleep timer restart and shake device to restart sleep timer
- Adds two events for when toggling the two news sleep timer config
- For context: p1716464798386719-slack-C071416NWE9

````
Tracked: settings_general_shake_to_reset_sleep_timer_toggled, Properties: {“enabled”:boolean
Tracked: settings_general_auto_sleep_timer_restart_toggled, Properties: {“enabled”:boolean
````

## Testing Instructions
1. Go to settings -> General -> Make sure you have `Auto Restart Sleep Timer` enabled
2. Add some episodes to Up Next
3. Play an episode
4. Set Sleep timer. It could be end of episode, end of time or end of chapter
5. If you set to end of time, wait until the sleep timer is triggered
6. When the sleep timer stops the episode you tap to play it again with 5 minutes
7. ✅ Make sure the sleep timer is restarted
8. Go to step 1 and disable the `Auto Restart Sleep Timer` toggle
9. Repeat the steps from 2 to 6
10. ✅ Make sure the sleep timer was not restarted
11. Go to settings -> General -> Make sure you have `Shake to restart Sleep Timer` enabled
12. Play an episode
13. Set sleep timer to 5 minutes
14. Wait a few seconds
15. Shake your device
16. ✅ Make sure the sleep timer was restarted
17. Go to settings -> General -> Make sure you have `Shake to restart Sleep Timer` disabled
18. Repeat the steps from 12 to 15
19. ✅ Make sure the sleep timer was not restarted


## Screenshots or Screencast 

<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/13c79a5e-50d9-46c3-9697-33abacbc9248" width="400">


cc: @leandroalonso 


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack