### PR TITLE
Automotive - Add setting to allow overriding current playing on sync

### DIFF
--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsPreferenceFragment.kt
@@ -40,6 +40,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
     private lateinit var preferenceSkipForward: EditTextPreference
     private lateinit var preferenceSkipBackward: EditTextPreference
     private lateinit var preferenceRefreshNow: Preference
+    private lateinit var preferenceOverrideCurrentPlayingOnSync: SwitchPreference
     private lateinit var about: Preference
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -51,6 +52,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
         preferenceRefreshNow = findPreference("refresh_now")!!
         preferenceSkipForward = findPreference(Settings.PREFERENCE_SKIP_FORWARD)!!
         preferenceSkipBackward = findPreference(Settings.PREFERENCE_SKIP_BACKWARD)!!
+        preferenceOverrideCurrentPlayingOnSync = findPreference("overrideCurrentPlayingOnSync")!!
         about = findPreference("about")!!
 
         setupAutoPlay()
@@ -58,6 +60,7 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
         setupAutoShowPlayed()
         setupSkipForward()
         setupSkipBackward()
+        setupOverrideCurrentPlayingOnSync()
         setupRefreshNow()
         setupAbout()
     }
@@ -127,6 +130,16 @@ class AutomotiveSettingsPreferenceFragment : PreferenceFragmentCompat() {
                 preferenceSkipBackward.text = it.toString()
                 preferenceSkipBackward.summary = resources.getStringPluralSeconds(settings.skipBackInSecs.value)
             }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun setupOverrideCurrentPlayingOnSync() {
+        preferenceOverrideCurrentPlayingOnSync.setOnPreferenceChangeListener { _, newValue ->
+            settings.overrideCurrentPlayingOnSync.set(newValue as Boolean, updateModifiedAt = false)
+            true
+        }
+        settings.overrideCurrentPlayingOnSync.flow
+            .onEach { preferenceOverrideCurrentPlayingOnSync.isChecked = it }
             .launchIn(lifecycleScope)
     }
 

--- a/automotive/src/main/res/xml/preferences_auto.xml
+++ b/automotive/src/main/res/xml/preferences_auto.xml
@@ -34,14 +34,24 @@
         android:selectAllOnFocus="true"
         android:summary="@string/settings_skip_back_time_summary"
         android:title="@string/settings_skip_back_time" />
-    <Preference
-        android:key="refresh_now"
-        android:title="@string/profile_refresh_now"
-        android:summary=""
-        android:persistent="false" />
-    <Preference
-        android:key="about"
-        android:title="@string/settings_title_about"
-        android:summary=""
-        android:persistent="false" />
+
+    <PreferenceCategory android:title="@string/refresh">
+        <Preference
+            android:key="refresh_now"
+            android:title="@string/profile_refresh_now"
+            android:summary=""
+            android:persistent="false" />
+        <SwitchPreference
+            android:key="overrideCurrentPlayingOnSync"
+            android:title="@string/settings_override_current_playing_on_sync"
+            android:summary="" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/settings_title_about">
+        <Preference
+            android:key="about"
+            android:title="@string/settings_title_about"
+            android:summary=""
+            android:persistent="false" />
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -74,6 +74,7 @@
     <string name="play_on">Play on&#8230;</string>
     <string name="played">Played</string>
     <string name="podcast_and_episode">Podcast &amp; Episode</string>
+    <string name="refresh">Refresh</string>
     <string name="remove_from_up_next">Remove from Up Next</string>
     <string name="renew_your_subscription">Renew your Subscription</string>
     <string name="removed">Removed</string>
@@ -1223,6 +1224,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="settings_open_player_automatically">Open player automatically</string>
     <string name="settings_open_player_automatically_summary">If on, the full-screen player will open when you start playing a podcast episode.</string>
     <string name="settings_other_media_actions">Other media actions</string>
+    <string name="settings_override_current_playing_on_sync">Override current playing on sync</string>
     <string name="settings_playback_resumption">Intelligent playback resumption</string>
     <string name="settings_playback_resumption_summary">If on, Pocket Casts will go back a little in episodes you resume so you can catch up more comfortably.</string>
     <string name="settings_podcast_artwork">Podcast Artwork</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -127,6 +127,8 @@ interface Settings {
         const val PODCAST_UUID = "podcast_uuid"
 
         const val SOURCE_VIEW = "source_view"
+
+        const val AUTOMOTIVE_UPDATE_CURRENT_PLAYING_ON_SYNC = "automotive_update_current_playing_on_sync"
     }
 
     enum class NotificationChannel(val id: String) {
@@ -540,4 +542,6 @@ interface Settings {
 
     val bottomInset: Flow<Int>
     fun updateBottomInset(height: Int)
+
+    val overrideCurrentPlayingOnSync: UserSetting<Boolean>
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1425,4 +1425,10 @@ class SettingsImpl @Inject constructor(
     override fun updateBottomInset(height: Int) {
         _bottomInset.tryEmit(height)
     }
+
+    override val overrideCurrentPlayingOnSync = UserSetting.BoolPref(
+        sharedPrefKey = "overrideCurrentPlayingOnSync",
+        defaultValue = Util.isAutomotive(context),
+        sharedPrefs = sharedPreferences,
+    )
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/pocket-casts-android/issues/1649

## Description

This adds a setting in the Automotive app to override the current playing episode after sync.

### The problem

On the phone app, if an episode is playing and the app is forced killed, then on restarting the app, it is paused. But in the automotive app, it doesn't.

Phone - Current playing episode is paused after the app restart

https://github.com/Automattic/pocket-casts-android/assets/1405144/41b9baaf-d0e3-4cab-bb21-72870d0e6407 

Automotive - Current playing episode resumes playing after the app restart

https://github.com/Automattic/pocket-casts-android/assets/1405144/f3820602-7c9f-49a7-85e5-3b6426360337

If an episode is playing, it's playback state it is not overridden after sync due to this part of the code:

https://github.com/Automattic/pocket-casts-android/blob/b02dd63d6c87f28f5edc59efd09196d1d652825e/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt#L1034-L1047

There's a setting in Android Auto that allows you to turn off "Start music automatically": https://support.google.com/androidauto/thread/188932983?hl=en&msgid=189045534
but I could not find a similar setting for Android Automotive. 

I tried pausing the playback here when the root items are loaded:

https://github.com/Automattic/pocket-casts-android/blob/00bc449d47a208987cd09c44cc9c93f125e33444/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt#L98

but the timing of the auto-play command was unpredictable in my testing. 

As a workaround, I added a setting only for the Automotive app that overrides the current episode playback state after sync. It is enabled by default for the Automotive app and can be turned off from settings. I found it working in my testing.

## Testing Instructions
1. Play an episode (Episode A) in Automotive app
2. Go to the Settings screen 
3. Tap "Refresh now" 
4. Open the phone app and tap "Refresh now"  on Profile tab
5. Complete the above playing episode (Episode A) in the phone app
6. Play another episode (Episode B) on the phone app
7. Refresh again from Profile tab
8. Refresh the app from Settings in the Automotive app
9. ✅ Notice that the last playing episode from the phone app is shown

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/1405144/b92b9c49-9a9c-4baf-9756-c13086a4b1e4

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md  [To be added]
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.  [To be added]
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
