### PR TITLE
Ignore auto-start playback on automotive app restart

### DIFF
--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
@@ -57,6 +57,8 @@ class AutoPlaybackService : PlaybackService() {
 
     override fun onCreate() {
         super.onCreate()
+        settings.setAutomotiveConnectedToMediaSession(false)
+
         RefreshPodcastsTask.runNow(this, applicationScope)
 
         Log.d(Settings.LOG_TAG_AUTO, "Auto playback service created")

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -127,6 +127,8 @@ interface Settings {
         const val PODCAST_UUID = "podcast_uuid"
 
         const val SOURCE_VIEW = "source_view"
+
+        const val AUTOMOTIVE_CONNECTED_TO_MEDIA_SESSION = "automotive_connected_to_media_session"
     }
 
     enum class NotificationChannel(val id: String) {
@@ -540,4 +542,7 @@ interface Settings {
 
     val bottomInset: Flow<Int>
     fun updateBottomInset(height: Int)
+
+    fun automotiveConnectedToMediaSession(): Boolean
+    fun setAutomotiveConnectedToMediaSession(isLoaded: Boolean)
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1425,4 +1425,14 @@ class SettingsImpl @Inject constructor(
     override fun updateBottomInset(height: Int) {
         _bottomInset.tryEmit(height)
     }
+
+    override fun automotiveConnectedToMediaSession(): Boolean {
+        return sharedPreferences.getBoolean(Settings.AUTOMOTIVE_CONNECTED_TO_MEDIA_SESSION, false)
+    }
+
+    override fun setAutomotiveConnectedToMediaSession(isLoaded: Boolean) {
+        val editor = sharedPreferences.edit()
+        editor.putBoolean(Settings.AUTOMOTIVE_CONNECTED_TO_MEDIA_SESSION, isLoaded)
+        editor.apply()
+    }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -604,6 +604,12 @@ class MediaSessionManager(
         }
 
         override fun onPlay() {
+            if (Util.isAutomotive(context) && !settings.automotiveConnectedToMediaSession()) {
+                // https://developer.android.com/docs/quality-guidelines/car-app-quality#media-autoplay
+                LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Auto start playback ignored just after automotive app restart.")
+                return
+            }
+
             logEvent("play")
             enqueueCommand("play") { playbackManager.playQueueSuspend(sourceView = source) }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -52,6 +52,8 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.Observables
 import io.reactivex.rxkotlin.addTo
 import io.reactivex.rxkotlin.subscribeBy
+import java.util.Timer
+import java.util.TimerTask
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
@@ -380,6 +382,13 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
 
         if (!clientPackageName.contains("au.com.shiftyjelly.pocketcasts")) {
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Client: $clientPackageName connected to media session") // Log things like Android Auto or Assistant connecting
+            if (Util.isAutomotive(applicationContext) && !settings.automotiveConnectedToMediaSession()) {
+                Timer().schedule(object : TimerTask() {
+                    override fun run() {
+                        settings.setAutomotiveConnectedToMediaSession(true)
+                    }
+                }, 1000)
+            }
         }
 
         return if (browserRootHints?.getBoolean(BrowserRoot.EXTRA_RECENT) == true) { // Browser root hints is nullable even though it's not declared as such, come on Google


### PR DESCRIPTION
## Description

This ignores auto-start playback on automotive app restart until 1 sec after connecting to the media session. The last playing episode on the Automotive app is paused which helps transfer over the last playing episode and its playback position from another device. 

This also helps meet the following [car app quality guideline](https://developer.android.com/docs/quality-guidelines/car-app-quality#media-autoplay:~:text=The%20app%20must%20not%20autoplay%20on%20startup%20or%20without%20user%20initiated%20action%20to%20select%20the%20app%20or%20app%20media.):

> The app must not autoplay on startup or without user initiated action to select the app or app media.

Fixes #1649

## Testing Instructions

#### Test.1: Change playing episode's playback position on another device
1. Play an episode (Episode A) in Automotive app
2. Go to the Settings screen 
3. Tap "Refresh now" 
4. While the episode is in playing state, force close the Automotive app
5. Open the phone app and tap "Refresh now" on Profile tab
6. Change progress position of the above playing episode (Episode A) in the phone app
8. Refresh again from Profile tab
9. Open Automotive app
10. ✅ Notice that the last playing episode playback position on the Automotive app is changed to the one received from the phone app

#### Test.2: Change playing episode on another device

1. Play an episode (Episode A) in Automotive app
2. Go to the Settings screen 
3. Tap "Refresh now" 
4. Force close the Automotive app
5. Open the phone app and tap "Refresh now" on Profile tab
6. Complete the above playing episode (Episode A) in the phone app
7. Play another episode (Episode B) on the phone app
8. Refresh again from Profile tab
9. Open Automotive app
10. ✅ Notice that the last playing episode from the phone app is transferred to the Automotive app

## Screenshots or Screencast 

#### Change playing episode's playback positon on another device

https://github.com/Automattic/pocket-casts-android/assets/1405144/3a44b2c5-2da5-40e5-937a-ef0143bff153

#### Change playing episode on another device

https://github.com/Automattic/pocket-casts-android/assets/1405144/5ee4451b-73c2-424c-bc50-983b122a9c72

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md [To be added]
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. [To be added]
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
