### PR TITLE
Fix: Subscribe button is highlighted in green instead of gray in the carousel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.66
 -----
-
+*   Bug Fixes
+    *   Fix: Subscribe button is highlighted in green instead of gray in the carousel
+        ([#2278](https://github.com/Automattic/pocket-casts-android/pull/2278))
 
 7.65
 -----

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.discover.R
 import au.com.shiftyjelly.pocketcasts.discover.extensions.updateSubscribeButtonIcon
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
+import au.com.shiftyjelly.pocketcasts.ui.R.attr.contrast_02
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -71,7 +72,7 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
                 }
             }
             holder.btnSubscribe.setOnClickListener {
-                holder.btnSubscribe.updateSubscribeButtonIcon(subscribed = true)
+                holder.btnSubscribe.updateSubscribeButtonIcon(subscribed = true, colorSubscribed = contrast_02, colorUnsubscribed = contrast_02)
                 onPodcastSubscribe(podcast, null) // no analytics for carousel
 
                 if (podcast.listId != null) {


### PR DESCRIPTION
## Description
- Just fixes the wrong color of subscribe button in discover's carousel 

Fixes #2187 

## Testing Instructions
- Code review should be enough, but you can try to check the subscribe button in carousel from Discover page
- You can try with different themes

## Screenshots or Screencast 

| Before | After |
|--------|--------|
|![Screenshot_20240508_113352](https://github.com/Automattic/pocket-casts-android/assets/42220351/8d8c3815-40e0-474d-bc9a-1623fdbd9938) |![Screenshot_20240508_113047](https://github.com/Automattic/pocket-casts-android/assets/42220351/26e838ed-7c12-40d6-8f4d-2a9663ac0ae8) | 



## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
