### PR TITLE
Use correct argument for episode limit string formatting

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -329,11 +329,12 @@ class EpisodeFragment : BaseFragment() {
                         }
 
                         // If we aren't showing another error we can show the episode limit warning
-                        if (!state.episode.isArchived && !binding.errorLayout.isVisible && state.episode.excludeFromEpisodeLimit && state.podcast.autoArchiveEpisodeLimit != null) {
+                        val autoArchiveLimit = state.podcast.autoArchiveEpisodeLimit?.value
+                        if (!state.episode.isArchived && !binding.errorLayout.isVisible && state.episode.excludeFromEpisodeLimit && autoArchiveLimit != null) {
                             binding.errorLayout.isVisible = true
                             binding.lblErrorDetail.isVisible = true
                             binding.lblError.setText(LR.string.podcast_episode_manually_unarchived)
-                            binding.lblErrorDetail.text = getString(LR.string.podcast_episode_manually_unarchived_summary, state.podcast.autoArchiveEpisodeLimit)
+                            binding.lblErrorDetail.text = getString(LR.string.podcast_episode_manually_unarchived_summary, autoArchiveLimit)
                             binding.imgError.setImageResource(IR.drawable.ic_archive)
                         }
 


### PR DESCRIPTION
## Description

There was a crash due to incorrect string formatting as episode limit changed from a number to an enum.

I'll need to investigate why Lint didn't fail on CI because the error was highlighted by it in the IDE.

## Testing Instructions

1. Go to a subscribed podcast.
2. Go to the podcast's settings.
3. Go to the auto archive settings.
4. Change the episode limit to 1 episode.
5. Go back to the podcast episode list.
6. Show unarchived episodes.
7. Open an archived episode details.
8. Unarchive the episode from the details.
9. App should not crash and you should see `It won't be auto archived by your new episode limit of 1` message.

## Screenshots or Screencast 

![Screenshot_20240529-080827](https://github.com/Automattic/pocket-casts-android/assets/30936061/34de0c97-ec54-4807-86de-563684a4c127)

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
