### PR TITLE
Fix latest badge disappearing on podcasts list view 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
         ([#2242](https://github.com/Automattic/pocket-casts-android/pull/2242))    
     *   Fix 'No limit' episode archive setting not being respected 
         ([#2270](https://github.com/Automattic/pocket-casts-android/pull/2270))
+    *   Fix badges visibility on the Podcasts tab
+        ([#2284](https://github.com/Automattic/pocket-casts-android/pull/2284))
 
 7.64
 -----

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderAdapter.kt
@@ -44,6 +44,7 @@ import au.com.shiftyjelly.pocketcasts.views.adapter.PodcastTouchCallback
 import au.com.shiftyjelly.pocketcasts.views.extensions.hide
 import au.com.shiftyjelly.pocketcasts.views.extensions.inflate
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
+import au.com.shiftyjelly.pocketcasts.views.extensions.showIf
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import kotlin.math.min
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
@@ -210,7 +211,7 @@ class FolderAdapter(
                 unplayedText.hide()
                 unplayedCountBadgeView?.let {
                     it.setBadgeContent(displayBadgeCount, badgeType)
-                    it.show()
+                    it.showIf(displayBadgeCount > 0)
                 }
                 podcastCardView?.elevation = cardElevation
                 podcastCardView?.radius = cardCornerRadius


### PR DESCRIPTION
## Description
This fixes latest badge disappearing on podcasts list view 

Fixes #2281

## Testing Instructions

1. Login with an account subscribed to many podcasts
2. Arrange podcasts by release date in the Podcasts tab
3. Tap more options in the app bar and select list layout
4. Scroll the list forward and backward
5. ✅  Notice that the latest badges doesn't disappear on scrolling backward
6. Smoke test latest/ unfinished badge visibility on grid/ list layouts, inside and outside folder
7. ✅  Notice that badges visibility is as expected

## Screenshots or Screencast 

Before 


https://github.com/Automattic/pocket-casts-android/assets/1405144/3ebf3df4-464a-4c1f-a64a-55165388957b


After


https://github.com/Automattic/pocket-casts-android/assets/1405144/c7f1b677-18a8-43bc-9496-26f07ef6ae23


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
