### PR TITLE
Add logs to track negative seek on sync

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -166,6 +166,7 @@ class PodcastSyncProcessTest {
                 folderManager = folderManager,
                 syncManager = syncManager,
                 crashLogging = FakeCrashLogging(),
+                analyticsTracker = mock(),
             )
 
             val response = MockResponse()

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -250,6 +250,7 @@ enum class AnalyticsEvent(val key: String) {
     PLAYBACK_EPISODE_AUTOPLAYED("playback_episode_autoplayed"),
     PLAYBACK_EPISODE_DURATION_CHANGED("playback_episode_duration_changed"),
     PLAYBACK_FOREGROUND_SERVICE_ERROR("playback_foreground_service_error"),
+    PLAYBACK_EPISODE_POSITION_CHANGED_ON_SYNC("playback_episode_position_changed_on_sync"),
 
     /* Privacy */
     PRIVACY_SETTINGS_SHOWN("privacy_settings_shown"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -15,6 +15,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.text.HtmlCompat
 import androidx.work.ListenableWorker
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.BuildConfig
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -91,6 +92,7 @@ class RefreshPodcastsThread(
         fun userManager(): UserManager
         fun syncManager(): SyncManager
         fun crashLogging(): CrashLogging
+        fun analyticsTracker(): AnalyticsTrackerWrapper
     }
 
     @Volatile
@@ -254,6 +256,7 @@ class RefreshPodcastsThread(
             folderManager = entryPoint.folderManager(),
             syncManager = entryPoint.syncManager(),
             crashLogging = entryPoint.crashLogging(),
+            analyticsTracker = entryPoint.analyticsTracker(),
         )
         val startTime = SystemClock.elapsedRealtime()
         val syncCompletable = sync.run()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -1061,16 +1061,18 @@ class PodcastSyncProcess(
                     episode.playedUpTo = playedUpTo
                     episode.playedUpToModified = null
                     if (episodeInPlayer) {
-                        val diffSeconds = playedUpTo - currentUpTo
-                        analyticsTracker.track(
-                            AnalyticsEvent.PLAYBACK_EPISODE_POSITION_CHANGED_ON_SYNC,
-                            mapOf(
-                                "position_change" to diffSeconds.roundToInt(),
-                                "is_downloaded" to episode.isDownloaded,
-                                "episode_uuid" to episode.uuid,
-                                "podcast_uuid" to episode.podcastOrSubstituteUuid,
-                            ),
-                        )
+                        val diffSeconds = (playedUpTo - currentUpTo).roundToInt()
+                        if (diffSeconds < 0) {
+                            analyticsTracker.track(
+                                AnalyticsEvent.PLAYBACK_EPISODE_POSITION_CHANGED_ON_SYNC,
+                                mapOf(
+                                    "position_change" to diffSeconds,
+                                    "is_downloaded" to episode.isDownloaded,
+                                    "episode_uuid" to episode.uuid,
+                                    "podcast_uuid" to episode.podcastOrSubstituteUuid,
+                                ),
+                            )
+                        }
                         playbackManager.seekIfPlayingToTimeMs(episode.uuid, (playedUpTo * 1000).toInt())
                     }
                 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.os.Build
 import android.os.SystemClock
 import androidx.annotation.VisibleForTesting
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
@@ -81,6 +83,7 @@ import io.reactivex.schedulers.Schedulers
 import java.time.Instant
 import java.util.Date
 import kotlin.coroutines.CoroutineContext
+import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -109,6 +112,7 @@ class PodcastSyncProcess(
     var folderManager: FolderManager,
     var syncManager: SyncManager,
     val crashLogging: CrashLogging,
+    val analyticsTracker: AnalyticsTrackerWrapper,
 ) : CoroutineScope {
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
@@ -1057,6 +1061,16 @@ class PodcastSyncProcess(
                     episode.playedUpTo = playedUpTo
                     episode.playedUpToModified = null
                     if (episodeInPlayer) {
+                        val diffSeconds = playedUpTo - currentUpTo
+                        analyticsTracker.track(
+                            AnalyticsEvent.PLAYBACK_EPISODE_POSITION_CHANGED_ON_SYNC,
+                            mapOf(
+                                "position_change" to diffSeconds.roundToInt(),
+                                "is_downloaded" to episode.isDownloaded,
+                                "episode_uuid" to episode.uuid,
+                                "podcast_uuid" to episode.podcastOrSubstituteUuid,
+                            ),
+                        )
                         playbackManager.seekIfPlayingToTimeMs(episode.uuid, (playedUpTo * 1000).toInt())
                     }
                 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -1057,7 +1057,7 @@ class PodcastSyncProcess(
 
                 // don't update if times are very close
                 val currentUpTo = episode.playedUpTo
-                if (playedUpTo < currentUpTo - 2 || playedUpTo > currentUpTo + 2) {
+                if (playedUpTo < currentUpTo - 5 || playedUpTo > currentUpTo + 2) {
                     episode.playedUpTo = playedUpTo
                     episode.playedUpToModified = null
                     if (episodeInPlayer) {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -305,6 +305,7 @@ class PodcastSyncProcessTest {
         folderManager = mock(),
         syncManager = mock(),
         crashLogging = FakeCrashLogging(),
+        analyticsTracker = mock(),
     )
 
     private fun mockPodcast(


### PR DESCRIPTION
## Description

Part of https://github.com/Automattic/pocket-casts-android/issues/157

We sync episode progress every minute at `syncEpisodeProgress(playbackState: PlaybackState)`. If the episode is paused before the next progress sync, and there's a background refresh, the playback may skip backward. This is captured below (playback skips 8 secs backward at 00:51):

https://github.com/Automattic/pocket-casts-android/assets/1405144/6608311e-b311-408e-b7fc-87b128392eb9

This PR
- Tracks negative seek on sync
- Increments backward threshold to update time from sync from 2 to 5 seconds 

## Testing Instructions

I confirmed that the analytic event is properly sent:
```
🔵 Tracked: playback_episode_position_changed_on_sync, Properties: {"position_change":-6,"is_downloaded":false,"episode_uuid":"70dd5dc0-bcb1-4343-a1ec-447d08e6c795","podcast_uuid":"e0b82010-83df-012e-3c4d-00163e1b201c"
```

It should be sufficient to just code-review the change. 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
