### PR TITLE
Fix podcast title talkback

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderAdapter.kt
@@ -176,7 +176,7 @@ class FolderAdapter(
         val theme: Theme,
     ) : RecyclerView.ViewHolder(view), PodcastTouchCallback.ItemTouchHelperViewHolder {
 
-        val button: View = view.findViewById(R.id.button)
+        val button: View? = view.findViewById(R.id.button)
         val podcastThumbnail: ImageView = view.findViewById(R.id.podcast_artwork)
         val podcastCardView = view.findViewById<CardView>(R.id.podcast_card_view)
         val podcastBackground: View? = view.findViewById(R.id.header_background)
@@ -192,7 +192,7 @@ class FolderAdapter(
         val unplayedCountBadgeView = view.findViewById<ComposeView>(R.id.badge_view)
 
         fun bind(podcast: Podcast, badgeType: BadgeType, podcastUuidToBadge: Map<String, Int>, clickListener: ClickListener) {
-            button.setOnClickListener { clickListener.onPodcastClick(podcast, itemView) }
+            button?.setOnClickListener { clickListener.onPodcastClick(podcast, itemView) }
             podcastCardView?.setOnClickListener { clickListener.onPodcastClick(podcast, itemView) }
             podcastTitle.text = podcast.title
             podcastTitle.show()
@@ -233,7 +233,9 @@ class FolderAdapter(
             }
 
             val badgeCountMessage = if (badgeType == BadgeType.OFF) "" else "$unplayedEpisodeCount new episodes. "
-            button.contentDescription = "${podcast.title}. $badgeCountMessage Open podcast."
+            val contentDescription = "${podcast.title}. $badgeCountMessage Open podcast."
+            button?.contentDescription = contentDescription
+            podcastCardView?.contentDescription = contentDescription
 
             imageRequestFactory
                 .create(podcast, onSuccess = { if (!isListLayout) podcastTitle.hide() })

--- a/modules/features/podcasts/src/main/res/layout/adapter_podcast_grid.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_podcast_grid.xml
@@ -68,13 +68,4 @@
         android:translationZ ="2dp"
         android:visibility="gone"/>
 
-    <View
-        android:id="@+id/button"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="?android:attr/selectableItemBackground"
-        android:foreground="@drawable/focus_border_white"
-        android:clickable="true"
-        android:focusable="true"/>
-
 </au.com.shiftyjelly.pocketcasts.views.component.SquareLayout>


### PR DESCRIPTION
## Description

This fixes podcast title talkback.

Fixes #2294

## Testing Instructions
1. Open the system settings
2. Search for Talkback and turn it on
3. Open Pocket Casts app
4. Drag your finger over the podcast artwork
5. ✅ It should say the podcast title 
6. Smoke test talkback for list view item. It should continue to say the podcast title


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
