### PR TITLE
Change up next tab position

### DIFF
--- a/modules/services/views/src/main/res/menu/navigation.xml
+++ b/modules/services/views/src/main/res/menu/navigation.xml
@@ -7,11 +7,6 @@
         android:title="@string/podcasts" />
 
     <item
-        android:id="@+id/navigation_upnext"
-        android:icon="@drawable/ic_upnext_tab"
-        android:title="@string/up_next" />
-
-    <item
         android:id="@+id/navigation_filters"
         android:icon="@drawable/ic_filters"
         android:title="@string/filters" />
@@ -20,6 +15,11 @@
         android:id="@+id/navigation_discover"
         android:icon="@drawable/ic_discover"
         android:title="@string/discover" />
+
+    <item
+        android:id="@+id/navigation_upnext"
+        android:icon="@drawable/ic_upnext_tab"
+        android:title="@string/up_next" />
 
     <item
         android:id="@+id/navigation_profile"


### PR DESCRIPTION
## Description
This changes up next tab order.

iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/1803
Internal discussion: p1717555337043659-slack-C029BMLUGRX


## Testing Instructions
1. Open the app
2. ✅ Notice the up-next tab position is updated to match the iOS
3. Install the app from main branch
4. Open the app and select a tab like Filters
5. Kill the app
6. Install the app from this branch
7. Open the app 
8. ✅ Notice that the last selected tab is shown without any crash

## Merge instructions

Merge only when the corresponding iOS PR is merged.


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack