### PR TITLE
Move chapter selection to chapter manager

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ChapterDaoSelectionTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ChapterDaoSelectionTest.kt
@@ -1,0 +1,128 @@
+package au.com.shiftyjelly.pocketcasts.models.db
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import au.com.shiftyjelly.pocketcasts.models.db.dao.ChapterDao
+import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
+import au.com.shiftyjelly.pocketcasts.models.db.dao.UserEpisodeDao
+import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import java.util.Date
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ChapterDaoSelectionTest {
+    private lateinit var testDb: AppDatabase
+    private lateinit var chapterDao: ChapterDao
+    private lateinit var episodeDao: EpisodeDao
+    private lateinit var userEpisodeDao: UserEpisodeDao
+
+    @Before
+    fun setupDb() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        chapterDao = testDb.chapterDao()
+        episodeDao = testDb.episodeDao()
+        userEpisodeDao = testDb.userEpisodeDao()
+    }
+
+    @After
+    fun closeDb() {
+        testDb.close()
+    }
+
+    @Test
+    fun deselectPodcastEpisodeChapter() = runTest {
+        episodeDao.insert(PodcastEpisode(uuid = "id", publishedDate = Date()))
+
+        chapterDao.selectChapter("id", 0, select = false)
+
+        val episode = episodeDao.findByUuid("id")!!
+        assertEquals(ChapterIndices(listOf(0)), episode.deselectedChapters)
+    }
+
+    @Test
+    fun deselectUserEpisodeChapter() = runTest {
+        userEpisodeDao.insert(UserEpisode(uuid = "id", publishedDate = Date()))
+
+        chapterDao.selectChapter("id", 0, select = false)
+
+        val episode = userEpisodeDao.findEpisodeByUuid("id")!!
+        assertEquals(ChapterIndices(listOf(0)), episode.deselectedChapters)
+    }
+
+    @Test
+    fun doNotFailWhenDeselectingChapterForNonExistingEpisode() = runTest {
+        chapterDao.selectChapter("id", 0, select = false)
+    }
+
+    @Test
+    fun deselectChapterUsingModificationDate() = runTest {
+        episodeDao.insert(PodcastEpisode(uuid = "id", publishedDate = Date()))
+
+        val now = Date()
+        chapterDao.selectChapter("id", 0, select = false, modifiedAt = now)
+
+        val episode = episodeDao.findByUuid("id")!!
+        assertEquals(now, episode.deselectedChaptersModified)
+    }
+
+    @Test
+    fun selectChapterBack() = runTest {
+        episodeDao.insert(PodcastEpisode(uuid = "id", publishedDate = Date()))
+        chapterDao.selectChapter("id", 0, select = false)
+
+        chapterDao.selectChapter("id", 0, select = true)
+
+        val episode = episodeDao.findByUuid("id")!!
+        assertEquals(ChapterIndices(emptyList()), episode.deselectedChapters)
+    }
+
+    @Test
+    fun deselectedChapterIsAddedOnlyOnce() = runTest {
+        episodeDao.insert(PodcastEpisode(uuid = "id", publishedDate = Date()))
+
+        repeat(10) {
+            chapterDao.selectChapter("id", 0, select = false)
+        }
+
+        val episode = episodeDao.findByUuid("id")!!
+        assertEquals(ChapterIndices(listOf(0)), episode.deselectedChapters)
+    }
+
+    @Test
+    fun deselectMultipleChapters() = runTest {
+        val chapters = List(10) { it }
+        episodeDao.insert(PodcastEpisode(uuid = "id", publishedDate = Date()))
+
+        chapters.forEach {
+            chapterDao.selectChapter("id", it, select = false)
+        }
+
+        val episode = episodeDao.findByUuid("id")!!
+        assertEquals(ChapterIndices(chapters), episode.deselectedChapters)
+    }
+
+    @Test
+    fun selectMultipleChapters() = runTest {
+        val chapters = List(10) { it }
+        episodeDao.insert(PodcastEpisode(uuid = "id", publishedDate = Date()))
+        chapters.forEach {
+            chapterDao.selectChapter("id", it, select = false)
+        }
+
+        chapterDao.selectChapter("id", 9, select = true)
+        chapterDao.selectChapter("id", 8, select = true)
+        chapterDao.selectChapter("id", 7, select = true)
+
+        val episode = episodeDao.findByUuid("id")!!
+        assertEquals(ChapterIndices(List(7) { it }), episode.deselectedChapters)
+    }
+}

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
@@ -49,6 +50,9 @@ class ChaptersViewModelTest {
 
     @get:Rule
     val featureFlagRule = InMemoryFeatureFlagRule()
+
+    @Mock
+    private lateinit var chapterManager: ChapterManager
 
     @Mock
     private lateinit var playbackManager: PlaybackManager
@@ -210,6 +214,7 @@ class ChaptersViewModelTest {
         whenever(settings.cachedSubscriptionStatus).thenReturn(userSetting)
 
         chaptersViewModel = ChaptersViewModel(
+            chapterManager = chapterManager,
             playbackManager = playbackManager,
             settings = settings,
             analyticsTracker = mock(),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -987,45 +987,6 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    fun toggleChapter(select: Boolean, chapter: Chapter) {
-        launch {
-            getCurrentEpisode()?.let { episode ->
-                when (episode) {
-                    is PodcastEpisode -> {
-                        if (select) {
-                            episodeManager.selectChapterIndexForEpisode(chapter.index, episode)
-                        } else {
-                            episodeManager.deselectChapterIndexForEpisode(chapter.index, episode)
-                        }
-                    }
-                    is UserEpisode -> {
-                        if (select) {
-                            userEpisodeManager.selectChapterIndexForEpisode(chapter.index, episode)
-                        } else {
-                            userEpisodeManager.deselectChapterIndexForEpisode(chapter.index, episode)
-                        }
-                    }
-                }
-            }
-            playbackStateRelay.blockingFirst().let { playbackState ->
-                val updatedItems = playbackState.chapters.getList().map {
-                    if (it.index == chapter.index) {
-                        it.copy(selected = select)
-                    } else {
-                        it
-                    }
-                }
-
-                playbackStateRelay.accept(
-                    playbackState.copy(
-                        chapters = playbackState.chapters.copy(items = updatedItems),
-                        lastChangeFrom = LastChangeFrom.OnChapterSelectionToggled.value,
-                    ),
-                )
-            }
-        }
-    }
-
     fun clearUpNextAsync() {
         launch {
             upNextQueue.clearUpNext()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManager.kt
@@ -10,5 +10,11 @@ interface ChapterManager {
         chapters: List<Chapter>,
     )
 
+    suspend fun selectChapter(
+        episodeUuid: String,
+        chapterIndex: Int,
+        select: Boolean,
+    )
+
     fun observerChaptersForEpisode(episodeUuid: String): Flow<Chapters>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
@@ -23,6 +23,10 @@ class ChapterManagerImpl @Inject constructor(
         chapterDao.replaceAllChapters(episodeUuid, chapters)
     }
 
+    override suspend fun selectChapter(episodeUuid: String, chapterIndex: Int, select: Boolean) {
+        chapterDao.selectChapter(episodeUuid, chapterIndex, select)
+    }
+
     override fun observerChaptersForEpisode(episodeUuid: String) = combine(
         episodeManager.observeEpisodeByUuid(episodeUuid).distinctUntilChangedBy(BaseEpisode::deselectedChapters),
         chapterDao.observerChaptersForEpisode(episodeUuid),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -149,8 +149,5 @@ interface EpisodeManager {
 
     suspend fun updateDownloadUrl(episode: PodcastEpisode): String?
 
-    suspend fun selectChapterIndexForEpisode(chapterIndex: Int, episode: PodcastEpisode)
-    suspend fun deselectChapterIndexForEpisode(chapterIndex: Int, episode: PodcastEpisode)
-
     suspend fun getAllPodcastEpisodes(pageLimit: Int): Flow<Pair<PodcastEpisode, Int>>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -16,7 +16,6 @@ import au.com.shiftyjelly.pocketcasts.models.db.helper.ListenedNumbers
 import au.com.shiftyjelly.pocketcasts.models.db.helper.LongestEpisode
 import au.com.shiftyjelly.pocketcasts.models.db.helper.YearOverYearListeningTime
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -1096,22 +1095,6 @@ class EpisodeManagerImpl @Inject constructor(
 
             return@withContext newDownloadUrl ?: episode.downloadUrl
         }
-
-    override suspend fun selectChapterIndexForEpisode(chapterIndex: Int, episode: PodcastEpisode) {
-        val deselectedChapterIndices = episode.deselectedChapters
-        if (!deselectedChapterIndices.contains(chapterIndex)) return
-        episode.deselectedChapters = ChapterIndices(deselectedChapterIndices - chapterIndex)
-        episode.deselectedChaptersModified = Date()
-        episodeDao.update(episode)
-    }
-
-    override suspend fun deselectChapterIndexForEpisode(chapterIndex: Int, episode: PodcastEpisode) {
-        val deselectedChapterIndices = episode.deselectedChapters
-        if (deselectedChapterIndices.contains(chapterIndex)) return
-        episode.deselectedChapters = ChapterIndices(deselectedChapterIndices + chapterIndex)
-        episode.deselectedChaptersModified = Date()
-        episodeDao.update(episode)
-    }
 
     override suspend fun getAllPodcastEpisodes(pageLimit: Int): Flow<Pair<PodcastEpisode, Int>> = flow {
         var offset = 0

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImplTest.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
-import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import java.util.Date
@@ -20,7 +19,6 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturnConsecutively
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.whenever
 
@@ -55,33 +53,6 @@ class EpisodeManagerImplTest {
             ioDispatcher = mock(),
             episodeAnalytics = mock(),
         )
-    }
-
-    @Test
-    fun `select chapter removes element`() = runTest {
-        whenever(episode.deselectedChapters).thenReturn(ChapterIndices(listOf(1, 2, 3)))
-
-        episodeManagerImpl.selectChapterIndexForEpisode(1, episode)
-
-        verify(episode).deselectedChapters = ChapterIndices(listOf(2, 3))
-    }
-
-    @Test
-    fun `deselect chapter adds element`() = runTest {
-        whenever(episode.deselectedChapters).thenReturn(ChapterIndices(listOf(1, 2)))
-
-        episodeManagerImpl.deselectChapterIndexForEpisode(3, episode)
-
-        verify(episode).deselectedChapters = ChapterIndices(listOf(1, 2, 3))
-    }
-
-    @Test
-    fun `deselect chapter is not added twice`() = runTest {
-        whenever(episode.deselectedChapters).thenReturn(ChapterIndices(listOf(1, 2, 3)))
-
-        episodeManagerImpl.deselectChapterIndexForEpisode(3, episode)
-
-        verify(episodeDao, never()).update(any())
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR moves chapter selection from `PlaybackManager` to `ChapterManager` and make it transactional. I'm doing it in a preparation for adding chapters to episode details. 

## Testing Instructions

Test chapter selection. Deselect and select different chapters, check syncing, check skipping chapters in the player, etc.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
