### PR TITLE
Fix discover carousel analytics

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
@@ -53,6 +53,7 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
 
             holder.setTaglineText(tagLineText)
             holder.itemView.setOnClickListener {
+                val isFeatured = podcast.isSponsored || podcast.listId == null
                 onPodcastClicked(podcast, podcast.listId) // no analytics for carousel
 
                 if (podcast.listId != null) {
@@ -62,7 +63,8 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
                         AnalyticsEvent.DISCOVER_LIST_PODCAST_TAPPED,
                         AnalyticsProp.sponsoredPodcastTapped(listId, podcast.uuid),
                     )
-                } else {
+                }
+                if (isFeatured) {
                     FirebaseAnalyticsTracker.openedFeaturedPodcast()
                     analyticsTracker.track(
                         AnalyticsEvent.DISCOVER_FEATURED_PODCAST_TAPPED,

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
@@ -73,6 +73,7 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
                 }
             }
             holder.btnSubscribe.setOnClickListener {
+                val isFeatured = podcast.isSponsored || podcast.listId == null
                 holder.btnSubscribe.updateSubscribeButtonIcon(subscribed = true)
                 onPodcastSubscribe(podcast, null) // no analytics for carousel
 
@@ -83,7 +84,8 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
                         AnalyticsEvent.DISCOVER_LIST_PODCAST_SUBSCRIBED,
                         AnalyticsProp.sponsoredPodcastSubscribed(listId, podcast.uuid),
                     )
-                } else {
+                }
+                if (isFeatured) {
                     FirebaseAnalyticsTracker.subscribedToFeaturedPodcast()
                     analyticsTracker.track(AnalyticsEvent.DISCOVER_FEATURED_PODCAST_SUBSCRIBED, AnalyticsProp.featuredPodcastSubscribed(podcast.uuid))
                 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
@@ -7,7 +7,6 @@ import androidx.recyclerview.widget.ListAdapter
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.analytics.FirebaseAnalyticsTracker
-import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.discover.R
 import au.com.shiftyjelly.pocketcasts.discover.extensions.updateSubscribeButtonIcon
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
@@ -34,7 +33,7 @@ private val differ: DiffUtil.ItemCallback<Any> = object : DiffUtil.ItemCallback<
     }
 }
 
-internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, val onPodcastClicked: ((DiscoverPodcast, String?) -> Unit), val onPodcastSubscribe: ((DiscoverPodcast, String?) -> Unit), private val analyticsTracker: AnalyticsTrackerWrapper) : ListAdapter<Any, CarouselItemViewHolder>(differ) {
+internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, val onPodcastClicked: ((DiscoverPodcast, String?, Boolean) -> Unit), val onPodcastSubscribe: ((DiscoverPodcast, String?) -> Unit), private val analyticsTracker: AnalyticsTrackerWrapper) : ListAdapter<Any, CarouselItemViewHolder>(differ) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CarouselItemViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_carousel, parent, false)
         return CarouselItemViewHolder(theme, view)
@@ -54,7 +53,7 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
             holder.setTaglineText(tagLineText)
             holder.itemView.setOnClickListener {
                 val isFeatured = podcast.isSponsored || podcast.listId == null
-                onPodcastClicked(podcast, podcast.listId) // no analytics for carousel
+                onPodcastClicked(podcast, podcast.listId, isFeatured)
 
                 if (podcast.listId != null) {
                     val listId = podcast.listId as String
@@ -75,7 +74,7 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
             holder.btnSubscribe.setOnClickListener {
                 val isFeatured = podcast.isSponsored || podcast.listId == null
                 holder.btnSubscribe.updateSubscribeButtonIcon(subscribed = true)
-                onPodcastSubscribe(podcast, null) // no analytics for carousel
+                onPodcastSubscribe(podcast, null)
 
                 if (podcast.listId != null) {
                     val listId = podcast.listId as String
@@ -89,7 +88,6 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
                     FirebaseAnalyticsTracker.subscribedToFeaturedPodcast()
                     analyticsTracker.track(AnalyticsEvent.DISCOVER_FEATURED_PODCAST_SUBSCRIBED, AnalyticsProp.featuredPodcastSubscribed(podcast.uuid))
                 }
-                analyticsTracker.track(AnalyticsEvent.PODCAST_SUBSCRIBED, AnalyticsProp.podcastSubscribed(SourceView.DISCOVER, podcast.uuid))
             }
         } else {
             holder.podcast = null
@@ -107,8 +105,6 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
             fun sponsoredPodcastSubscribed(listId: String, uuid: String) = mapOf(LIST_ID_KEY to listId, PODCAST_UUID_KEY to uuid)
             fun featuredPodcastTapped(uuid: String) = mapOf(PODCAST_UUID_KEY to uuid)
             fun featuredPodcastSubscribed(uuid: String) = mapOf(PODCAST_UUID_KEY to uuid)
-            fun podcastSubscribed(source: SourceView, uuid: String) =
-                mapOf(SOURCE_KEY to source.analyticsValue, UUID_KEY to uuid)
         }
     }
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -119,7 +119,7 @@ internal class DiscoverAdapter(
     private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ListAdapter<Any, RecyclerView.ViewHolder>(DiscoverRowDiffCallback()) {
     interface Listener {
-        fun onPodcastClicked(podcast: DiscoverPodcast, listUuid: String?)
+        fun onPodcastClicked(podcast: DiscoverPodcast, listUuid: String?, isFeatured: Boolean = false)
         fun onPodcastSubscribe(podcast: DiscoverPodcast, listUuid: String?)
         fun onPodcastListClicked(list: NetworkLoadableList)
         fun onEpisodeClicked(episode: DiscoverEpisode, listUuid: String?)

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -60,8 +60,8 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
         viewModel.onFragmentPause(activity?.isChangingConfigurations)
     }
 
-    override fun onPodcastClicked(podcast: DiscoverPodcast, listUuid: String?) {
-        val fragment = PodcastFragment.newInstance(podcastUuid = podcast.uuid, fromListUuid = listUuid, sourceView = SourceView.DISCOVER)
+    override fun onPodcastClicked(podcast: DiscoverPodcast, listUuid: String?, isFeatured: Boolean) {
+        val fragment = PodcastFragment.newInstance(podcastUuid = podcast.uuid, fromListUuid = listUuid, sourceView = SourceView.DISCOVER, featuredPodcast = isFeatured)
         (activity as FragmentHostListener).addFragment(fragment)
     }
 


### PR DESCRIPTION
## Description

This includes `Discover` tab carousel's sponsored podcasts in the featured podcast analytics.

Internal ref: p1717644686886349-slack-C028JAG44VD

## Testing Instructions
1. Go to Discover tab
2. Tap on first (sponsored) podcast in the carousel
3. ✅ Notice that `discover_featured_podcast_tapped` is tracked along with `discover_list_podcast_tapped`
4. Subscribe to this sponsored podcast from the podcast details page
5. ✅ Notice that `discover_featured_podcast_subscribed` is tracked along with `discover_list_podcast_subscribed`
6. Unsubscribe the podcast
7. Return to the carousel and subscribe to the same podcast using the plus button for sponsored podcast
8. ✅  Notice that `discover_featured_podcast_subscribed` is tracked along with `discover_list_podcast_subscribed`

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack